### PR TITLE
feat(skill): add mindgardener — file-based memory with surprise-driven consolidation

### DIFF
--- a/skills/mindgardener/SKILL.md
+++ b/skills/mindgardener/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mindgardener
-description: Persistent memory layer for AI agents — wiki-style knowledge graph with surprise-driven consolidation.
+description: Long-term memory for AI agents. Reads chat logs and builds a wiki of people, projects & events. No database — just text files.
 homepage: https://github.com/widingmarcus-cyber/mindgardener
 metadata:
   {
@@ -24,9 +24,9 @@ metadata:
 
 # MindGardener
 
-Persistent memory for AI agents. Extracts entities from daily logs, builds a wiki-style knowledge graph, and uses surprise scoring to decide what's worth remembering.
+Long-term memory for AI agents. Reads your agent's daily logs and automatically builds a wiki of everyone and everything it encounters. No database needed — just text files.
 
-"Memory isn't a hard drive — it's a garden."
+"Your agent forgets everything between sessions. MindGardener fixes that."
 
 ## Setup
 

--- a/skills/mindgardener/SKILL.md
+++ b/skills/mindgardener/SKILL.md
@@ -24,9 +24,22 @@ metadata:
 
 # MindGardener
 
-Your AI agent's personal Wikipedia — automatically built and updated from daily conversations. Every chat adds to a growing wiki of people, projects, and events. No database needed, just text files.
+**Your AI agent's personal Wikipedia — automatically built and updated from daily conversations.**
 
-"Your agent forgets everything between sessions. MindGardener fixes that."
+Every time you chat with your agent, it mentions people, projects, tools, and events. MindGardener turns those conversations into a personal wiki — one markdown file per entity — that grows over time. Your agent remembers what happened last week, who you talked about, and what matters.
+
+No database needed. Just text files.
+
+## How It Stays Manageable
+
+You might wonder: won't this create thousands of files? No. MindGardener is opinionated about what it remembers:
+
+- **One file per entity.** A person, a company, a project each gets one `.md` file. Mentions across different days get merged into the same file — not duplicated.
+- **Surprise scoring decides what's worth keeping.** Not everything is interesting. MindGardener predicts what _should_ have happened based on what it already knows, then compares with what _actually_ happened. Only surprising things get promoted to long-term memory. Routine stuff fades.
+- **Automatic pruning.** Entities that haven't been mentioned in 30+ days get archived. Your wiki stays focused on what's active and relevant.
+- **You can edit it.** It's just markdown files in a folder. Open them in VS Code, Obsidian, or `vim`. Add facts, fix mistakes, delete things. Run `garden reindex` and the system catches up.
+
+A typical agent running for a month has 30-80 entity files. That's it — a small, browsable wiki, not a data dump.
 
 ## Setup
 
@@ -69,27 +82,32 @@ garden consolidate
 
 ## How It Works
 
-1. **Extract**: LLM reads daily log → entities + relationships (JSON)
-2. **Store**: Wiki pages per entity with `[[wikilinks]]` in Markdown
-3. **Graph**: Triplets in JSONL (`subject → predicate → object`)
-4. **Surprise**: Two-stage prediction error (predict THEN compare)
-5. **Consolidate**: High-surprise → MEMORY.md
-6. **Prune**: Archive unreferenced entities
+1. **Extract**: LLM reads your daily log → finds people, projects, events
+2. **Store**: Creates one wiki page per entity with `[[wikilinks]]` between them
+3. **Surprise**: Predicts what should happen, compares with reality, scores the difference
+4. **Consolidate**: High-surprise items get promoted to long-term memory (MEMORY.md)
+5. **Prune**: Inactive entities get archived automatically
 
-All storage is Markdown + JSONL. No database. `cat`, `grep`, `git` compatible.
+All storage is Markdown + JSONL. Readable with `cat`, searchable with `grep`, versionable with `git`.
 
 ## Integration
 
-### Nightly cron
+### Nightly cron (set it and forget it)
 
 ```bash
 garden extract && garden surprise && garden consolidate
 ```
 
-### Context retrieval
+### Before responding to a user (context retrieval)
 
 ```bash
 garden recall "topic from user message"
+```
+
+### After manually editing wiki pages
+
+```bash
+garden reindex
 ```
 
 ## Config
@@ -103,3 +121,5 @@ consolidation:
   surprise_threshold: 0.5
   decay_days: 30
 ```
+
+Supports 5 LLM providers: Google Gemini, OpenAI, Anthropic, Ollama (local/free), and any OpenAI-compatible API.

--- a/skills/mindgardener/SKILL.md
+++ b/skills/mindgardener/SKILL.md
@@ -35,6 +35,7 @@ Persistent memory for AI agents. Extracts entities from daily logs, builds a wik
 3. Initialize: `garden init`
 
 For local models (zero cost, no API key):
+
 ```bash
 garden init --provider ollama
 ```
@@ -51,20 +52,20 @@ garden consolidate
 
 ## Commands
 
-| Command | What it does |
-|---------|-------------|
-| `garden init` | Initialize workspace (config, dirs, daily file) |
-| `garden extract` | Extract entities from daily logs → wiki pages |
-| `garden surprise` | Two-stage prediction error scoring |
-| `garden consolidate` | Promote high-surprise events to MEMORY.md |
-| `garden recall "query"` | Fuzzy search with graph traversal |
-| `garden entities` | List all known entities by type |
-| `garden prune` | Archive stale entities |
-| `garden merge "a" "b"` | Merge duplicate entities |
-| `garden fix type "X" "tool"` | Fix LLM extraction mistakes |
-| `garden reindex` | Rebuild graph after manual edits |
-| `garden viz` | Mermaid knowledge graph |
-| `garden stats` | Overview statistics |
+| Command                      | What it does                                    |
+| ---------------------------- | ----------------------------------------------- |
+| `garden init`                | Initialize workspace (config, dirs, daily file) |
+| `garden extract`             | Extract entities from daily logs → wiki pages   |
+| `garden surprise`            | Two-stage prediction error scoring              |
+| `garden consolidate`         | Promote high-surprise events to MEMORY.md       |
+| `garden recall "query"`      | Fuzzy search with graph traversal               |
+| `garden entities`            | List all known entities by type                 |
+| `garden prune`               | Archive stale entities                          |
+| `garden merge "a" "b"`       | Merge duplicate entities                        |
+| `garden fix type "X" "tool"` | Fix LLM extraction mistakes                     |
+| `garden reindex`             | Rebuild graph after manual edits                |
+| `garden viz`                 | Mermaid knowledge graph                         |
+| `garden stats`               | Overview statistics                             |
 
 ## How It Works
 
@@ -80,11 +81,13 @@ All storage is Markdown + JSONL. No database. `cat`, `grep`, `git` compatible.
 ## Integration
 
 ### Nightly cron
+
 ```bash
 garden extract && garden surprise && garden consolidate
 ```
 
 ### Context retrieval
+
 ```bash
 garden recall "topic from user message"
 ```
@@ -94,7 +97,7 @@ garden recall "topic from user message"
 ```yaml
 # garden.yaml
 extraction:
-  provider: google    # google, openai, anthropic, ollama, compatible
+  provider: google # google, openai, anthropic, ollama, compatible
   model: gemini-2.0-flash
 consolidation:
   surprise_threshold: 0.5

--- a/skills/mindgardener/SKILL.md
+++ b/skills/mindgardener/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mindgardener
-description: Long-term memory for AI agents. Reads chat logs and builds a wiki of people, projects & events. No database — just text files.
+description: "Your AI agent's personal Wikipedia — automatically built and updated from daily conversations. No database, just files."
 homepage: https://github.com/widingmarcus-cyber/mindgardener
 metadata:
   {
@@ -24,7 +24,7 @@ metadata:
 
 # MindGardener
 
-Long-term memory for AI agents. Reads your agent's daily logs and automatically builds a wiki of everyone and everything it encounters. No database needed — just text files.
+Your AI agent's personal Wikipedia — automatically built and updated from daily conversations. Every chat adds to a growing wiki of people, projects, and events. No database needed, just text files.
 
 "Your agent forgets everything between sessions. MindGardener fixes that."
 

--- a/skills/mindgardener/SKILL.md
+++ b/skills/mindgardener/SKILL.md
@@ -11,11 +11,11 @@ metadata:
         "install":
           [
             {
-              "id": "pip",
-              "kind": "pip",
+              "id": "uv",
+              "kind": "uv",
               "package": "mindgardener",
               "bins": ["garden"],
-              "label": "Install mindgardener (pip)",
+              "label": "Install mindgardener (uv/pip)",
             },
           ],
       },
@@ -30,12 +30,11 @@ Persistent memory for AI agents. Extracts entities from daily logs, builds a wik
 
 ## Setup
 
-1. Install: `pip install mindgardener`
+1. Install: `uv tool install mindgardener` (or `pip install mindgardener`)
 2. Set LLM provider key: `export GEMINI_API_KEY=your-key` (or `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
 3. Initialize: `garden init`
 
 For local models (zero cost, no API key):
-
 ```bash
 garden init --provider ollama
 ```
@@ -52,20 +51,20 @@ garden consolidate
 
 ## Commands
 
-| Command                      | What it does                                    |
-| ---------------------------- | ----------------------------------------------- |
-| `garden init`                | Initialize workspace (config, dirs, daily file) |
-| `garden extract`             | Extract entities from daily logs → wiki pages   |
-| `garden surprise`            | Two-stage prediction error scoring              |
-| `garden consolidate`         | Promote high-surprise events to MEMORY.md       |
-| `garden recall "query"`      | Fuzzy search with graph traversal               |
-| `garden entities`            | List all known entities by type                 |
-| `garden prune`               | Archive stale entities                          |
-| `garden merge "a" "b"`       | Merge duplicate entities                        |
-| `garden fix type "X" "tool"` | Fix LLM extraction mistakes                     |
-| `garden reindex`             | Rebuild graph after manual edits                |
-| `garden viz`                 | Mermaid knowledge graph                         |
-| `garden stats`               | Overview statistics                             |
+| Command | What it does |
+|---------|-------------|
+| `garden init` | Initialize workspace (config, dirs, daily file) |
+| `garden extract` | Extract entities from daily logs → wiki pages |
+| `garden surprise` | Two-stage prediction error scoring |
+| `garden consolidate` | Promote high-surprise events to MEMORY.md |
+| `garden recall "query"` | Fuzzy search with graph traversal |
+| `garden entities` | List all known entities by type |
+| `garden prune` | Archive stale entities |
+| `garden merge "a" "b"` | Merge duplicate entities |
+| `garden fix type "X" "tool"` | Fix LLM extraction mistakes |
+| `garden reindex` | Rebuild graph after manual edits |
+| `garden viz` | Mermaid knowledge graph |
+| `garden stats` | Overview statistics |
 
 ## How It Works
 
@@ -81,13 +80,11 @@ All storage is Markdown + JSONL. No database. `cat`, `grep`, `git` compatible.
 ## Integration
 
 ### Nightly cron
-
 ```bash
 garden extract && garden surprise && garden consolidate
 ```
 
 ### Context retrieval
-
 ```bash
 garden recall "topic from user message"
 ```
@@ -97,7 +94,7 @@ garden recall "topic from user message"
 ```yaml
 # garden.yaml
 extraction:
-  provider: google # google, openai, anthropic, ollama, compatible
+  provider: google    # google, openai, anthropic, ollama, compatible
   model: gemini-2.0-flash
 consolidation:
   surprise_threshold: 0.5

--- a/skills/mindgardener/SKILL.md
+++ b/skills/mindgardener/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: mindgardener
+description: Persistent memory layer for AI agents — wiki-style knowledge graph with surprise-driven consolidation.
+homepage: https://github.com/widingmarcus-cyber/mindgardener
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🌱",
+        "requires": { "bins": ["garden"] },
+        "install":
+          [
+            {
+              "id": "pip",
+              "kind": "pip",
+              "package": "mindgardener",
+              "bins": ["garden"],
+              "label": "Install mindgardener (pip)",
+            },
+          ],
+      },
+  }
+---
+
+# MindGardener
+
+Persistent memory for AI agents. Extracts entities from daily logs, builds a wiki-style knowledge graph, and uses surprise scoring to decide what's worth remembering.
+
+"Memory isn't a hard drive — it's a garden."
+
+## Setup
+
+1. Install: `pip install mindgardener`
+2. Set LLM provider key: `export GEMINI_API_KEY=your-key` (or `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
+3. Initialize: `garden init`
+
+For local models (zero cost, no API key):
+
+```bash
+garden init --provider ollama
+```
+
+## Quick Start
+
+```bash
+garden init
+garden extract
+garden recall "topic"
+garden surprise
+garden consolidate
+```
+
+## Commands
+
+| Command                      | What it does                                    |
+| ---------------------------- | ----------------------------------------------- |
+| `garden init`                | Initialize workspace (config, dirs, daily file) |
+| `garden extract`             | Extract entities from daily logs → wiki pages   |
+| `garden surprise`            | Two-stage prediction error scoring              |
+| `garden consolidate`         | Promote high-surprise events to MEMORY.md       |
+| `garden recall "query"`      | Fuzzy search with graph traversal               |
+| `garden entities`            | List all known entities by type                 |
+| `garden prune`               | Archive stale entities                          |
+| `garden merge "a" "b"`       | Merge duplicate entities                        |
+| `garden fix type "X" "tool"` | Fix LLM extraction mistakes                     |
+| `garden reindex`             | Rebuild graph after manual edits                |
+| `garden viz`                 | Mermaid knowledge graph                         |
+| `garden stats`               | Overview statistics                             |
+
+## How It Works
+
+1. **Extract**: LLM reads daily log → entities + relationships (JSON)
+2. **Store**: Wiki pages per entity with `[[wikilinks]]` in Markdown
+3. **Graph**: Triplets in JSONL (`subject → predicate → object`)
+4. **Surprise**: Two-stage prediction error (predict THEN compare)
+5. **Consolidate**: High-surprise → MEMORY.md
+6. **Prune**: Archive unreferenced entities
+
+All storage is Markdown + JSONL. No database. `cat`, `grep`, `git` compatible.
+
+## Integration
+
+### Nightly cron
+
+```bash
+garden extract && garden surprise && garden consolidate
+```
+
+### Context retrieval
+
+```bash
+garden recall "topic from user message"
+```
+
+## Config
+
+```yaml
+# garden.yaml
+extraction:
+  provider: google # google, openai, anthropic, ollama, compatible
+  model: gemini-2.0-flash
+consolidation:
+  surprise_threshold: 0.5
+  decay_days: 30
+```


### PR DESCRIPTION
## New Skill: MindGardener 🌱

**A file-based memory layer for AI agents.**

> "Memory isn't a hard drive — it's a garden."

### What it does
- Extracts entities from daily markdown logs into wiki-style pages with `[[wikilinks]]`
- Builds a knowledge graph with JSONL triplets
- Uses **two-stage prediction error scoring** to decide what to remember
- Fuzzy recall with Levenshtein distance, initials, and aliases
- Sleep cycle consolidation (high-surprise → MEMORY.md)
- Temporal decay + pruning for stale entities

### 12 CLI Commands
`garden init`, `extract`, `surprise`, `consolidate`, `recall`, `entities`, `prune`, `merge`, `fix`, `reindex`, `viz`, `stats`

### Zero Infrastructure
No vector DB, no server, no account. All storage is Markdown + JSONL.

### 5 LLM Providers
Google Gemini, OpenAI, Anthropic, Ollama (local/free), any OpenAI-compatible API.

### Install
```bash
pip install mindgardener
garden init
```

**Homepage:** https://github.com/widingmarcus-cyber/mindgardener
**Tests:** 96 passing | **LOC:** 4124 | **Deps:** 1 (pyyaml)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `mindgardener` skill that registers a Python-based CLI tool (`garden`) for file-based memory management with wiki-style knowledge graphs. The skill uses the `uv` install kind, matching the existing `nano-pdf` skill pattern and the `SkillInstallSpec` type definition.

- Skill metadata is correctly structured with `kind: "uv"`, `package: "mindgardener"`, and `bins: ["garden"]`
- The `garden` binary name does not conflict with any existing skill
- Documentation covers setup, commands, integration patterns, and configuration
- No code changes to core — this is a skill definition file only

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a single skill definition file with no changes to core code.
- The PR adds only a SKILL.md file following established patterns (mirrors `nano-pdf` exactly). The `kind: "uv"` install spec is valid per `SkillInstallSpec` types. The previously flagged `pip` kind issue has been fixed. No executable code is introduced into the repository.
- No files require special attention.

<sub>Last reviewed commit: ed09dc9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->