### PR TITLE
fix: suppress spurious tool error warnings for read-only exec commands

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -55,7 +55,7 @@ function shouldShowToolErrorWarning(params: {
   }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
-  if (isMutatingToolError) {
+  if (isMutatingToolError && !params.hasUserFacingReply) {
     return true;
   }
   if (params.suppressToolErrors) {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -60,6 +60,8 @@ export async function handleToolExecutionStart(
   evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
 ) {
   // Flush pending block replies to preserve message boundaries before tool execution.
+  // Clear any previous tool errors to avoid stale warnings on new executions.
+  ctx.state.lastToolError = undefined;
   ctx.flushBlockReplyBuffer();
   if (ctx.params.onBlockReplyFlush) {
     void ctx.params.onBlockReplyFlush();

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -67,4 +67,59 @@ describe("tool mutation helpers", () => {
     expect(isLikelyMutatingToolName("message_slack")).toBe(true);
     expect(isLikelyMutatingToolName("browser")).toBe(false);
   });
+
+  describe("exec/bash read-only command classification", () => {
+    it("treats read-only commands as non-mutating", () => {
+      for (const cmd of [
+        "ls",
+        "cat",
+        "grep",
+        "find",
+        "head",
+        "tail",
+        "wc",
+        "echo",
+        "ps",
+        "diff",
+        "ping",
+      ]) {
+        expect(isMutatingToolCall("exec", { command: cmd })).toBe(false);
+        expect(isMutatingToolCall("bash", { command: cmd })).toBe(false);
+      }
+    });
+
+    it("treats commands with absolute paths as non-mutating when the binary is read-only", () => {
+      expect(isMutatingToolCall("bash", { command: "/usr/bin/ls -la" })).toBe(false);
+      expect(isMutatingToolCall("exec", { command: "/bin/cat /etc/hosts" })).toBe(false);
+    });
+
+    it("treats unknown commands as mutating", () => {
+      expect(isMutatingToolCall("bash", { command: "rm -rf /tmp/foo" })).toBe(true);
+      expect(isMutatingToolCall("exec", { command: "chmod 755 file" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "mv a b" })).toBe(true);
+    });
+
+    it("treats commands that can mutate state as mutating", () => {
+      // These were previously (incorrectly) in the read-only list
+      expect(isMutatingToolCall("bash", { command: "git commit -m 'test'" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "sed -i 's/a/b/' file" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "python3 script.py" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "node index.js" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "docker run ubuntu" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "kubectl delete pod foo" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "npm install express" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "pip install requests" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "aws s3 rm s3://bucket/key" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: "sqlite3 db.sqlite 'DROP TABLE t'" })).toBe(
+        true,
+      );
+      expect(isMutatingToolCall("bash", { command: "redis-cli SET key val" })).toBe(true);
+    });
+
+    it("defaults to mutating when command is empty or missing", () => {
+      expect(isMutatingToolCall("bash", {})).toBe(true);
+      expect(isMutatingToolCall("exec", { command: "" })).toBe(true);
+      expect(isMutatingToolCall("bash", { command: 123 })).toBe(true);
+    });
+  });
 });

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -111,6 +111,10 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
         .trim()
         .split(/\s+/)[0]
         .replace(/^.*\//, "");
+      // Only truly read-only commands that cannot mutate state regardless of
+      // flags. Commands like sed (-i), git (commit/push), python/node
+      // (arbitrary code), docker/kubectl (infra), npm/pip (packages),
+      // sqlite3/redis-cli (DB writes), etc. are intentionally excluded.
       const readOnlyCmds = new Set([
         "ls",
         "cat",
@@ -137,13 +141,10 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
         "test",
         "true",
         "false",
-        "read",
         "sort",
         "uniq",
         "tr",
         "cut",
-        "sed",
-        "awk",
         "less",
         "more",
         "strings",
@@ -158,29 +159,9 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
         "free",
         "uptime",
         "ss",
-        "ip",
         "ping",
         "dig",
         "nslookup",
-        "git",
-        "python3",
-        "python",
-        "node",
-        "ruby",
-        "perl",
-        "cargo",
-        "npm",
-        "pnpm",
-        "pip",
-        "docker",
-        "kubectl",
-        "aws",
-        "sam",
-        "openclaw",
-        "pass",
-        "gpg",
-        "sqlite3",
-        "redis-cli",
       ]);
       if (readOnlyCmds.has(cmd)) {
         return false;

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -105,7 +105,88 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "edit":
     case "apply_patch":
     case "exec":
-    case "bash":
+    case "bash": {
+      const rawCmd = record?.command;
+      const cmd = (typeof rawCmd === "string" ? rawCmd : "")
+        .trim()
+        .split(/\s+/)[0]
+        .replace(/^.*\//, "");
+      const readOnlyCmds = new Set([
+        "ls",
+        "cat",
+        "grep",
+        "find",
+        "head",
+        "tail",
+        "wc",
+        "stat",
+        "file",
+        "which",
+        "echo",
+        "date",
+        "whoami",
+        "hostname",
+        "uname",
+        "env",
+        "printenv",
+        "pwd",
+        "id",
+        "df",
+        "du",
+        "diff",
+        "test",
+        "true",
+        "false",
+        "read",
+        "sort",
+        "uniq",
+        "tr",
+        "cut",
+        "sed",
+        "awk",
+        "less",
+        "more",
+        "strings",
+        "hexdump",
+        "xxd",
+        "base64",
+        "sha256sum",
+        "md5sum",
+        "ps",
+        "top",
+        "htop",
+        "free",
+        "uptime",
+        "ss",
+        "ip",
+        "ping",
+        "dig",
+        "nslookup",
+        "git",
+        "python3",
+        "python",
+        "node",
+        "ruby",
+        "perl",
+        "cargo",
+        "npm",
+        "pnpm",
+        "pip",
+        "docker",
+        "kubectl",
+        "aws",
+        "sam",
+        "openclaw",
+        "pass",
+        "gpg",
+        "sqlite3",
+        "redis-cli",
+      ]);
+      if (readOnlyCmds.has(cmd)) {
+        return false;
+      }
+      return true;
+    }
     case "sessions_send":
       return true;
     case "process":


### PR DESCRIPTION
## Summary

Based on #18910 by @gatewaybuddy, with fixes for the review feedback:

- **Suppresses spurious `⚠️ Exec failed` warnings** for read-only commands (e.g. `grep` finding no matches, `ls` on nonexistent path) when the assistant has already addressed the error in its reply
- **Clears stale `lastToolError`** at the start of each new tool execution to prevent ghost warnings leaking across tool calls
- **Prunes the read-only command allowlist** to only truly read-only commands, removing ~20 commands that can mutate state:
  - `sed` / `awk` (in-place editing with `-i`)
  - `git` (commit, push, add, delete, etc.)
  - `python3` / `python` / `node` / `ruby` / `perl` (arbitrary code execution)
  - `npm` / `pnpm` / `pip` / `cargo` (package management)
  - `docker` / `kubectl` / `aws` / `sam` (infrastructure mutation)
  - `sqlite3` / `redis-cli` (database writes)
  - `openclaw` / `pass` / `gpg` / `ip` / `read`

The original PR's allowlist would have silently suppressed error warnings for failed mutating operations like `git commit`, `docker rm`, `npm install`, etc.

## Test plan

- [x] New tests for exec/bash command classification (6 tests):
  - Read-only commands → non-mutating
  - Absolute path binaries → non-mutating  
  - Unknown commands → mutating
  - Previously misclassified commands (git, sed, docker, etc.) → mutating
  - Empty/missing commands → defaults to mutating
- [x] Existing tool-mutation tests still pass (4 tests)
- [x] Lint and format clean

Supersedes #18910

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds read-only command classification for `exec`/`bash` tool calls, clears stale `lastToolError` at tool execution start, and suppresses mutating tool error warnings when the assistant has already replied.

- **Read-only command allowlist** (`tool-mutation.ts`): Well-curated list of ~45 truly read-only commands. However, `write`/`edit`/`apply_patch` now fall through the same switch case and depend on empty-string-not-in-set for correct classification — should be separated. Shell operators (pipes, redirects, `&&`) in command strings bypass the first-token check, which could misclassify mutating pipelines.
- **Stale error clearing** (`pi-embedded-subscribe.handlers.tools.ts`): Correctly clears `lastToolError` at tool execution start to prevent ghost warnings.
- **Warning suppression** (`payloads.ts`): The `!params.hasUserFacingReply` condition breaks the existing e2e test `"shows mutating tool errors even when assistant output exists"` in `payloads.e2e.test.ts:274`, which asserts the old behavior of always surfacing mutating tool errors. This test was not updated in the PR.
- **Tests** (`tool-mutation.test.ts`): Good coverage of the new classification logic (6 test cases), but missing coverage for `write`/`edit`/`apply_patch` correctness after the fallthrough change.

<h3>Confidence Score: 2/5</h3>

- This PR likely breaks an existing e2e test and has a fragile switch fallthrough pattern that could cause regressions.
- Score of 2 reflects: (1) the `payloads.ts` change breaks the existing e2e test "shows mutating tool errors even when assistant output exists" without updating it, (2) `write`/`edit`/`apply_patch` tools accidentally route through bash command parsing logic via fallthrough, and (3) shell operators in command strings bypass the read-only classification.
- Pay close attention to `src/agents/pi-embedded-runner/run/payloads.ts` (breaking e2e test) and `src/agents/tool-mutation.ts` (fragile fallthrough and shell operator bypass).

<sub>Last reviewed commit: 25f7ed1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->