### PR TITLE
fix(web-search): normalize bare ui_lang codes to full Brave locales

### DIFF
--- a/src/agents/tools/web-search.brave-locale.test.ts
+++ b/src/agents/tools/web-search.brave-locale.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./web-search.js";
+
+const { normalizeBraveUiLang } = __testing;
+
+describe("normalizeBraveUiLang", () => {
+  it("maps bare language codes to full Brave locales", () => {
+    expect(normalizeBraveUiLang("en")).toBe("en-US");
+    expect(normalizeBraveUiLang("de")).toBe("de-DE");
+    expect(normalizeBraveUiLang("ja")).toBe("ja-JP");
+    expect(normalizeBraveUiLang("zh")).toBe("zh-CN");
+  });
+
+  it("is case-insensitive for bare codes", () => {
+    expect(normalizeBraveUiLang("EN")).toBe("en-US");
+    expect(normalizeBraveUiLang("Fr")).toBe("fr-FR");
+  });
+
+  it("passes through full hyphenated locales with normalized case", () => {
+    expect(normalizeBraveUiLang("en-US")).toBe("en-US");
+    expect(normalizeBraveUiLang("pt-BR")).toBe("pt-BR");
+  });
+
+  it("normalizes case of hyphenated locales", () => {
+    expect(normalizeBraveUiLang("en-us")).toBe("en-US");
+    expect(normalizeBraveUiLang("EN-US")).toBe("en-US");
+    expect(normalizeBraveUiLang("PT-br")).toBe("pt-BR");
+  });
+
+  it("converts underscore-separated locales to hyphenated form", () => {
+    expect(normalizeBraveUiLang("en_US")).toBe("en-US");
+    expect(normalizeBraveUiLang("pt_BR")).toBe("pt-BR");
+    expect(normalizeBraveUiLang("zh_cn")).toBe("zh-CN");
+  });
+
+  it("returns undefined for unknown bare codes", () => {
+    expect(normalizeBraveUiLang("xx")).toBeUndefined();
+    expect(normalizeBraveUiLang("zzz")).toBeUndefined();
+  });
+
+  it("returns undefined for empty/undefined input", () => {
+    expect(normalizeBraveUiLang(undefined)).toBeUndefined();
+    expect(normalizeBraveUiLang("")).toBeUndefined();
+    expect(normalizeBraveUiLang("  ")).toBeUndefined();
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeBraveUiLang("  en  ")).toBe("en-US");
+    expect(normalizeBraveUiLang(" en-US ")).toBe("en-US");
+  });
+});


### PR DESCRIPTION
## Summary

Based on #18931 by @arosstale, with fixes for review feedback:

- Maps bare language codes (e.g. `en`) to full Brave locales (`en-US`) to prevent 422 validation errors
- **Normalizes hyphenated locale case** to `language-REGION` format (e.g. `en-us` → `en-US`, `EN-US` → `en-US`) to satisfy Brave's strict enum validation
- **Converts underscore-separated locales** (e.g. `en_US`, `zh_cn`) to hyphenated form before lookup, preventing them from being silently dropped
- Unknown bare codes are silently dropped (Brave falls back to its own default)

## Test plan

- [x] Unit tests for `normalizeBraveUiLang` (8 tests):
  - Bare language codes → full Brave locale
  - Case-insensitive bare codes
  - Full hyphenated locales pass through with normalized case
  - Mixed-case hyphenated locales normalized (`en-us` → `en-US`)
  - Underscore locales converted (`en_US` → `en-US`)
  - Unknown codes → undefined
  - Empty/undefined → undefined
  - Whitespace trimming
- [x] Lint and format clean

Fixes #18795  
Supersedes #18931

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds locale normalization for Brave Search `ui_lang` parameter to prevent 422 validation errors when LLMs send bare language codes. The implementation maps bare codes like `en` to full Brave locales (`en-US`), normalizes case to `language-REGION` format, and converts underscore separators to hyphens. Test coverage includes 8 unit tests covering all edge cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks identified
- The changes are well-isolated to locale normalization logic with comprehensive test coverage (8 tests), proper edge case handling, and clear implementation that directly addresses the 422 validation error issue. The normalization function is pure, side-effect free, and only affects the Brave Search API parameter formatting.
- No files require special attention

<sub>Last reviewed commit: 065c148</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->