### PR TITLE
feat: macOS TCC permission error detection + permctl skill

### DIFF
--- a/skills/permctl/SKILL.md
+++ b/skills/permctl/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: permctl
+description: Check and manage macOS TCC permissions for AI agents. Use when tools fail with permission errors, after installing new CLI tools, or after Node.js upgrades.
+metadata: { "openclaw": { "emoji": "🔐", "os": ["darwin"], "requires": { "bins": ["osascript"] } } }
+---
+
+# permctl — macOS TCC Permission Checker
+
+Self-contained bash script. No dependencies beyond macOS builtins.
+
+## Location
+
+The script is bundled at `permctl.sh` next to this file. Resolve the path relative to this SKILL.md.
+
+## Commands
+
+All output is JSON. Parse with `jq` or inline.
+
+### Check permissions (agent-relevant)
+
+```bash
+bash <SKILL_DIR>/permctl.sh status
+```
+
+Returns:
+
+```json
+{
+  "binary": "/opt/homebrew/Cellar/node/25.4.0/bin/node",
+  "permissions": [
+    { "kind": "screen-recording", "status": "granted" },
+    { "kind": "accessibility", "status": "granted" },
+    { "kind": "automation", "status": "granted" },
+    { "kind": "full-disk-access", "status": "granted" }
+  ]
+}
+```
+
+Status values: `granted` | `denied` | `unknown`
+
+### Check all permissions (including calendar, reminders)
+
+```bash
+bash <SKILL_DIR>/permctl.sh status --all
+```
+
+### Trigger popup for a missing permission
+
+```bash
+bash <SKILL_DIR>/permctl.sh request screen-recording
+```
+
+Returns `{"kind":"screen-recording","triggered":true}` or `{"triggered":false,"opened_settings":true}` for permissions that require manual setup.
+
+### Batch-request all missing
+
+```bash
+bash <SKILL_DIR>/permctl.sh request
+```
+
+Checks all agent permissions, triggers popups for denied ones, opens System Settings for manual-only ones.
+
+### Open System Settings panel
+
+```bash
+bash <SKILL_DIR>/permctl.sh guide accessibility
+```
+
+Available permission names: `screen-recording`, `accessibility`, `automation`, `full-disk-access`, `camera`, `microphone`, `calendar`, `reminders`, `contacts`, `input-monitoring`
+
+## Decision Logic for Agents
+
+```
+1. Tool fails with permission error
+2. Run: bash permctl.sh status
+3. Parse JSON → find denied/unknown permissions
+4. For each denied:
+   a. Run: bash permctl.sh request <permission>
+   b. If triggered=false → tell user to grant manually in System Settings
+5. Retry the original tool
+```
+
+## Why Permissions Break
+
+macOS TCC is per-binary. The **node binary** needs permissions, not CLI tools.
+After `brew upgrade node`, the path changes → permissions invalidated → run `permctl.sh status` to diagnose.
+
+## Related Tools
+
+| Tool                | Needs                           |
+| ------------------- | ------------------------------- |
+| Peekaboo            | screen-recording, accessibility |
+| macos-automator-mcp | automation, accessibility       |
+| camsnap             | camera                          |
+| whisper / sag       | microphone                      |

--- a/skills/permctl/permctl.sh
+++ b/skills/permctl/permctl.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# permctl.sh — macOS TCC permission checker for AI agents
+# Usage: bash permctl.sh [status|request|guide] [permission]
+# Output: JSON (machine-readable)
+set -euo pipefail
+
+NODE_BIN=$(cd "$(dirname "$(which node)")" && pwd -P)/$(basename "$(which node)")
+# Follow symlinks manually (macOS BSD readlink lacks -f)
+while [ -L "$NODE_BIN" ]; do
+  LINK_TARGET=$(readlink "$NODE_BIN")
+  case "$LINK_TARGET" in
+    /*) NODE_BIN="$LINK_TARGET" ;;
+    *)  NODE_BIN="$(dirname "$NODE_BIN")/$LINK_TARGET" ;;
+  esac
+done
+
+check_screen_recording() {
+  # Prefer peekaboo if available (most reliable)
+  if command -v peekaboo &>/dev/null; then
+    local out
+    out=$(peekaboo permissions status 2>&1) || true
+    if echo "$out" | grep -q "Screen Recording.*Granted"; then
+      echo "granted"; return
+    elif echo "$out" | grep -q "Screen Recording.*Not Granted"; then
+      echo "denied"; return
+    fi
+  fi
+  # Fallback: screencapture (may fail in non-TTY)
+  /usr/sbin/screencapture -x /tmp/.permctl_sr_test.png 2>/dev/null || true
+  if [ -f /tmp/.permctl_sr_test.png ]; then
+    rm -f /tmp/.permctl_sr_test.png
+    echo "granted"
+  else
+    # screencapture can fail in non-TTY without meaning denied
+    # Check via TCC database as last resort
+    local count
+    count=$(sqlite3 "$HOME/Library/Application Support/com.apple.TCC/TCC.db" \
+      "SELECT allowed FROM access WHERE service='kTCCServiceScreenCapture' AND indirect_object_identifier='com.apple.screencaptureui' LIMIT 1" 2>/dev/null) || true
+    if [ "$count" = "1" ]; then
+      echo "granted"
+    elif [ "$count" = "0" ]; then
+      echo "denied"
+    else
+      echo "unknown"
+    fi
+  fi
+}
+
+check_accessibility() {
+  local out
+  out=$(osascript \
+    -e 'with timeout of 5 seconds' \
+    -e 'tell application "System Events" to get name of first process' \
+    -e 'end timeout' 2>&1) || true
+  if echo "$out" | grep -qi "not allowed"; then
+    echo "denied"
+  elif [ -n "$out" ] && ! echo "$out" | grep -qi "error"; then
+    echo "granted"
+  else
+    echo "unknown"
+  fi
+}
+
+check_automation() {
+  local out
+  out=$(osascript \
+    -e 'with timeout of 5 seconds' \
+    -e 'tell application "Finder" to get name' \
+    -e 'end timeout' 2>&1) || true
+  if echo "$out" | grep -qi "not allowed\|not authorized"; then
+    echo "denied"
+  elif [ "$out" = "Finder" ]; then
+    echo "granted"
+  else
+    echo "unknown"
+  fi
+}
+
+check_full_disk_access() {
+  if [ ! -e "$HOME/Library/Mail" ]; then
+    # Directory doesn't exist — can't determine FDA status
+    echo "unknown"
+  elif ls "$HOME/Library/Mail" >/dev/null 2>&1; then
+    echo "granted"
+  else
+    echo "denied"
+  fi
+}
+
+check_calendar() {
+  local out
+  out=$(osascript \
+    -e 'with timeout of 5 seconds' \
+    -e 'tell application "Calendar" to get name of first calendar' \
+    -e 'end timeout' 2>&1) || true
+  if echo "$out" | grep -qi "not allowed"; then
+    echo "denied"
+  elif [ -n "$out" ] && ! echo "$out" | grep -qi "error"; then
+    echo "granted"
+  else
+    echo "unknown"
+  fi
+}
+
+check_reminders() {
+  local out
+  out=$(osascript \
+    -e 'with timeout of 5 seconds' \
+    -e 'tell application "Reminders" to get name of first list' \
+    -e 'end timeout' 2>&1) || true
+  if echo "$out" | grep -qi "not allowed\|denied"; then
+    echo "denied"
+  elif [ -n "$out" ] && ! echo "$out" | grep -qi "error"; then
+    echo "granted"
+  else
+    echo "unknown"
+  fi
+}
+
+# ── Settings URLs ────────────────────────────────────────────────────
+settings_url() {
+  case "$1" in
+    screen-recording) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture" ;;
+    accessibility) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" ;;
+    automation) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation" ;;
+    full-disk-access) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles" ;;
+    camera) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera" ;;
+    microphone) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone" ;;
+    calendar) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars" ;;
+    reminders) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_Reminders" ;;
+    contacts) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts" ;;
+    input-monitoring) echo "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent" ;;
+    *) echo "" ;;
+  esac
+}
+
+# ── Trigger permission popup ────────────────────────────────────────
+trigger_permission() {
+  case "$1" in
+    screen-recording)
+      /usr/sbin/screencapture -x /tmp/.permctl_trigger.png 2>/dev/null || true
+      rm -f /tmp/.permctl_trigger.png
+      echo '{"kind":"screen-recording","triggered":true}'
+      ;;
+    accessibility)
+      osascript -e 'tell application "System Events" to get name of first process' 2>/dev/null || true
+      echo '{"kind":"accessibility","triggered":true}'
+      ;;
+    automation)
+      osascript -e 'tell application "Finder" to get name' 2>/dev/null || true
+      echo '{"kind":"automation","triggered":true}'
+      ;;
+    calendar)
+      osascript -e 'tell application "Calendar" to get name of first calendar' 2>/dev/null || true
+      echo '{"kind":"calendar","triggered":true}'
+      ;;
+    contacts)
+      osascript -e 'tell application "Contacts" to get name of first person' 2>/dev/null || true
+      echo '{"kind":"contacts","triggered":true}'
+      ;;
+    reminders)
+      osascript -e 'tell application "Reminders" to get name of first list' 2>/dev/null || true
+      echo '{"kind":"reminders","triggered":true}'
+      ;;
+    full-disk-access|camera|microphone|input-monitoring)
+      local url
+      url=$(settings_url "$1")
+      open "$url" 2>/dev/null || true
+      echo "{\"kind\":\"$1\",\"triggered\":false,\"opened_settings\":true}"
+      ;;
+    *)
+      echo "{\"error\":\"unknown permission: $1\"}"
+      ;;
+  esac
+}
+
+# ── Commands ─────────────────────────────────────────────────────────
+cmd_status() {
+  local perms=("screen-recording" "accessibility" "automation" "full-disk-access")
+  if [ "${1:-}" = "--all" ]; then
+    perms+=("calendar" "reminders")
+  fi
+
+  local items=()
+  for p in "${perms[@]}"; do
+    local fn="check_${p//-/_}"
+    local st
+    st=$($fn 2>/dev/null || echo "unknown")
+    items+=("{\"kind\":\"$p\",\"status\":\"$st\"}")
+  done
+
+  local json
+  json=$(printf '%s,' "${items[@]}")
+  json="[${json%,}]"
+  echo "{\"binary\":\"$NODE_BIN\",\"permissions\":$json}"
+}
+
+cmd_request() {
+  if [ -n "${1:-}" ]; then
+    trigger_permission "$1"
+    return
+  fi
+  # Batch: trigger all denied
+  local status_json
+  status_json=$(cmd_status)
+  local results=()
+  for p in screen-recording accessibility automation full-disk-access; do
+    local st
+    st=$(echo "$status_json" | grep -o "\"kind\":\"$p\",\"status\":\"[^\"]*\"" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
+    if [ "$st" != "granted" ]; then
+      local r
+      r=$(trigger_permission "$p")
+      results+=("$r")
+    fi
+  done
+  if [ ${#results[@]} -eq 0 ]; then
+    echo '{"message":"all permissions granted","results":[]}'
+  else
+    local json
+    json=$(printf '%s,' "${results[@]}")
+    echo "{\"results\":[${json%,}]}"
+  fi
+}
+
+cmd_guide() {
+  local perm="${1:-}"
+  if [ -z "$perm" ]; then
+    echo '{"error":"usage: permctl.sh guide <permission>"}'
+    return 1
+  fi
+  local url
+  url=$(settings_url "$perm")
+  if [ -z "$url" ]; then
+    echo "{\"error\":\"unknown permission: $perm\"}"
+    return 1
+  fi
+  open "$url" 2>/dev/null || true
+  echo "{\"kind\":\"$perm\",\"opened\":true,\"url\":\"$url\",\"binary\":\"$NODE_BIN\"}"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────
+case "${1:-status}" in
+  status) cmd_status "${2:-}" ;;
+  request|req) cmd_request "${2:-}" ;;
+  guide) cmd_guide "${2:-}" ;;
+  *)
+    echo '{"error":"unknown command","usage":"permctl.sh [status|request|guide] [permission]"}'
+    exit 1
+    ;;
+esac

--- a/src/agents/tcc-detect.test.ts
+++ b/src/agents/tcc-detect.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { detectTccError } from "./tcc-detect.js";
+
+describe("detectTccError", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  function setDarwin() {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+  }
+
+  function setLinux() {
+    Object.defineProperty(process, "platform", { value: "linux" });
+  }
+
+  it("returns null on non-darwin", () => {
+    setLinux();
+    expect(detectTccError("osascript is not allowed assistive access", 1)).toBeNull();
+  });
+
+  it("returns null on empty output", () => {
+    setDarwin();
+    expect(detectTccError("", 1)).toBeNull();
+  });
+
+  it("returns null on exit code 0", () => {
+    setDarwin();
+    expect(detectTccError("osascript is not allowed assistive access", 0)).toBeNull();
+  });
+
+  it("detects accessibility error", () => {
+    setDarwin();
+    const output = "System Events got an error: osascript is not allowed assistive access.";
+    const hint = detectTccError(output, 1);
+    expect(hint).toContain("macOS permission error detected");
+    expect(hint).toContain("accessibility");
+    expect(hint).toContain("permctl.sh");
+  });
+
+  it("detects screen recording error", () => {
+    setDarwin();
+    const output = "screen recording permission is required";
+    const hint = detectTccError(output, 1);
+    expect(hint).toContain("screen-recording");
+  });
+
+  it("detects automation error", () => {
+    setDarwin();
+    const output = "Not authorized to send Apple events to Finder.";
+    const hint = detectTccError(output, 1);
+    expect(hint).toContain("automation");
+  });
+
+  it("detects full disk access error", () => {
+    setDarwin();
+    const output = "ls: /Users/test/Library/Mail: Operation not permitted";
+    const hint = detectTccError(output, 1);
+    expect(hint).toContain("macOS permission error detected");
+  });
+
+  it("ignores generic EPERM unrelated to TCC", () => {
+    setDarwin();
+    expect(detectTccError("chown: /tmp/foo: Operation not permitted", 1)).toBeNull();
+    expect(detectTccError("bind: Operation not permitted", 1)).toBeNull();
+  });
+
+  it("detects kTCCService pattern", () => {
+    setDarwin();
+    const output = "tccd deny kTCCServiceCamera for pid 1234";
+    const hint = detectTccError(output, 1);
+    expect(hint).toContain("camera");
+  });
+
+  it("returns null for normal errors", () => {
+    setDarwin();
+    expect(detectTccError("command not found: foo", 127)).toBeNull();
+    expect(detectTccError("segmentation fault", 139)).toBeNull();
+    expect(detectTccError("No such file or directory", 1)).toBeNull();
+  });
+});

--- a/src/agents/tcc-detect.ts
+++ b/src/agents/tcc-detect.ts
@@ -1,0 +1,87 @@
+/**
+ * macOS TCC permission error detector for exec output.
+ *
+ * When a command fails with a macOS permission-related error,
+ * appends a hint pointing the agent to the permctl skill.
+ * This runs at the tool layer so agents cannot bypass it.
+ */
+
+// Patterns that indicate macOS TCC permission denials
+const TCC_ERROR_PATTERNS = [
+  /not allowed to send keystrokes/i,
+  /not authorized to send apple events/i,
+  /(?:Library|TCC|Privacy).*operation not permitted|operation not permitted.*(?:Library|TCC|Privacy)/i,
+  /tccd.*deny/i,
+  /assistive access/i,
+  /screen.?recording/i,
+  /not allowed assistive access/i,
+  /osascript is not allowed/i,
+  /System Events got an error.*not allowed/i,
+  /is not authorized to/i,
+  /kTCCService/i,
+  /user denied/i,
+  /requires? the accessibility/i,
+  /This app is not authorized/i,
+  /AXError/i,
+];
+
+// Map error patterns to likely permission kinds
+const PERMISSION_HINTS: Array<{ pattern: RegExp; permission: string }> = [
+  {
+    pattern: /screen.?recording|screencapture|kTCCServiceScreenCapture/i,
+    permission: "screen-recording",
+  },
+  {
+    pattern: /assistive access|accessibility|AXError|kTCCServiceAccessibility/i,
+    permission: "accessibility",
+  },
+  {
+    pattern: /apple events|not authorized to send|automation|kTCCServiceAppleEvents/i,
+    permission: "automation",
+  },
+  {
+    pattern: /operation not permitted.*Library|full.?disk|kTCCServiceSystemPolicyAllFiles/i,
+    permission: "full-disk-access",
+  },
+  { pattern: /camera|kTCCServiceCamera/i, permission: "camera" },
+  { pattern: /microphone|audio input|kTCCServiceMicrophone/i, permission: "microphone" },
+];
+
+/**
+ * Detect if exec output contains macOS TCC permission errors.
+ * Returns null if no permission error detected, or a hint string to append.
+ */
+export function detectTccError(output: string, exitCode: number | null): string | null {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  if (!output) {
+    return null;
+  }
+  // Only check failed commands (non-zero exit or signal kill)
+  if (exitCode === 0) {
+    return null;
+  }
+
+  const matched = TCC_ERROR_PATTERNS.some((p) => p.test(output));
+  if (!matched) {
+    return null;
+  }
+
+  // Try to identify which permission
+  const permissions: string[] = [];
+  for (const { pattern, permission } of PERMISSION_HINTS) {
+    if (pattern.test(output) && !permissions.includes(permission)) {
+      permissions.push(permission);
+    }
+  }
+
+  const permHint = permissions.length > 0 ? `Likely missing: ${permissions.join(", ")}\n` : "";
+
+  return (
+    `\n\n⚠️ macOS permission error detected.\n` +
+    permHint +
+    `Run: bash <permctl_skill_dir>/permctl.sh status\n` +
+    `Then: bash <permctl_skill_dir>/permctl.sh request ${permissions[0] || "<permission>"}`
+  );
+}


### PR DESCRIPTION
## Summary

When exec commands fail with macOS TCC (Transparency, Consent, and Control) permission errors, OpenClaw now automatically detects the error pattern and injects a remediation hint pointing the agent to the `permctl` skill.

## Problem

On macOS, agents frequently hit TCC permission walls (screen recording, accessibility, automation, full disk access, camera, microphone). Without tool-layer detection:
- Prompt-level instructions can be bypassed or ignored by agents
- Each skill would need its own permission error handling (doesn't scale)
- Agents waste turns guessing what went wrong

## Solution

**Tool-layer interception** in `bash-tools.exec.ts` — agents cannot bypass it.

### New files
- `src/agents/tcc-detect.ts` — Pattern matcher for 15+ TCC error signatures, maps to 6 permission kinds
- `src/agents/tcc-detect.test.ts` — 9 unit tests
- `skills/permctl/permctl.sh` — Zero-dependency bash script for permission diagnosis/remediation (JSON output, agent-friendly)
- `skills/permctl/SKILL.md` — Agent-oriented documentation

### Modified
- `src/agents/bash-tools.exec.ts` — 3 injection points: sync completion, failure rejection, background notification

## Detection covers
- Screen recording (`kTCCServiceScreenCapture`)
- Accessibility (`AXError`, assistive access)
- Automation (Apple Events authorization)
- Full disk access (`Operation not permitted` on protected paths)
- Camera / Microphone (`kTCCServiceCamera`, `kTCCServiceMicrophone`)

## Testing
- `tsc --noEmit`: clean (0 errors)
- 13 existing exec tests: all pass
- 9 new tcc-detect tests: all pass
- Manual: `permctl.sh status --all` verified on macOS 15 (Sequoia)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds macOS TCC (Transparency, Consent, and Control) permission error detection to the exec tool layer, along with a new `permctl` bash skill for diagnosing and remediating permission issues. The approach intercepts TCC errors at the tool layer (in `bash-tools.exec.ts`) so agents cannot bypass it, which is architecturally sound.

- **`tcc-detect.ts`**: Two-stage detection (pattern match → permission classification) with sensible guards (`darwin`-only, `exitCode !== 0`). However, two Stage 1 patterns (`/is not authorized to/i` and `/user denied/i`) are generic English phrases that will false-positive on non-TCC authorization errors from tools like AWS CLI, kubectl, Docker, and OAuth flows — misdirecting the agent to run `permctl.sh` for unrelated failures.
- **`bash-tools.exec.ts`**: Minimal, clean integration at two injection points (failure rejection and background notification). Previous review feedback about the redundant success-path call and the `readlink -f` issue have been addressed.
- **`permctl.sh`**: Well-structured zero-dependency script. The `check_full_disk_access` false-positive when `~/Library/Mail` doesn't exist has been fixed. However, `trigger_permission` unconditionally reports `"triggered":true` for osascript-based permissions, even when the trigger silently fails — this can mislead the agent into waiting for a user action that never appeared.
- **`tcc-detect.test.ts`**: Good coverage of happy paths and basic negative cases, but lacks tests for the false-positive scenarios (HTTP auth errors, OAuth denials) that the broad patterns would match.

<h3>Confidence Score: 3/5</h3>

- Functional but has false-positive risks in TCC detection patterns that will misdirect agents on non-TCC authorization errors
- The architecture is sound and the exec integration is clean, but two overly-broad Stage 1 patterns (`/is not authorized to/i` and `/user denied/i`) will produce false-positive TCC hints for common non-TCC failures (AWS CLI, kubectl, OAuth, Docker auth errors). These false positives cause the agent to waste turns running `permctl.sh` for unrelated issues. Additionally, `trigger_permission` in `permctl.sh` always reports `triggered:true` regardless of whether the trigger actually succeeded, which can mislead agent decision-making. The test suite lacks coverage for these false-positive scenarios.
- `src/agents/tcc-detect.ts` needs the broadest attention — the two overly-generic patterns should be tightened or removed before merge. `skills/permctl/permctl.sh` has a lower-severity issue with `trigger_permission` always reporting success.

<sub>Last reviewed commit: 600de87</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->