### PR TITLE
fix: improve context overflow error messages and docs

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -541,7 +541,7 @@ export async function runAgentTurnWithFallback(params: {
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isContextOverflow
-        ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
+        ? "⚠️ Context overflow — prompt too large for this model. Try /reset or /new for a fresh session, reduce workspace files, or switch to a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
           : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;


### PR DESCRIPTION
## Summary

Improves the user experience when hitting context overflow errors (#5771).

### Changes

**Error messages (src)**
- Include context window size, source, and message count in the overflow error so users can diagnose the issue
- Add actionable suggestions: reduce workspace files, lower `bootstrapMaxChars`, use `/reset`
- Improve diagnostic logging with `contextWindow` and `contextSource` fields

**Documentation (docs)**
- Document `agents.defaults.compaction` config with full example (mode, reserveTokensFloor, memoryFlush)
- Document related settings: `contextTokens`, `bootstrapMaxChars`, `bootstrapTotalMaxChars`
- Clarify that `autoCompact` is NOT a config key (common user confusion from the issue)
- Add troubleshooting section for context overflow

### Before
```
Context overflow: prompt too large for the model. Try again with less input or a larger-context model.
```

### After
```
Context overflow: prompt too large for the model. Context window: 200,000 tokens (source: default). Messages in session: 3. Try /reset (or /new) to start a fresh session, reduce workspace files (AGENTS.md, SOUL.md, etc.), lower `agents.defaults.bootstrapMaxChars`, or switch to a larger-context model.
```

### Testing
- [x] `pnpm build` passes
- [x] Existing unit tests pass (`run.overflow-compaction.test.ts`, `config.compaction-settings.test.ts`)
- [x] AI-assisted (Claude via OpenClaw)

Closes #5771

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves context overflow error messages with actionable diagnostic information (context window size, source, message count) and adds comprehensive compaction documentation including config examples, related settings, and a troubleshooting section.

- `run.ts`: Error message now includes dynamic context info (window size, source, message count) and specific remediation steps
- `agent-runner-execution.ts`: Catch-all fallback message updated with consistent suggestions (/reset, reduce workspace files, switch model)
- `compaction.md`: Added YAML config example, related settings table, `autoCompact` clarification, and troubleshooting section — all verified against source code
- **Issue found**: The e2e test in `reply.triggers.trigger-handling.ignores-inline-elevated-directive-unapproved-sender.e2e.test.ts` (line 140-142) uses `toBe()` exact match against the old fallback message from `agent-runner-execution.ts` and was not updated in this PR — this test will fail

<h3>Confidence Score: 3/5</h3>

- Low-risk changes to error messages and docs, but an existing e2e test will break due to an exact string match on the old message.
- The code changes are straightforward improvements to error messages and logging, and the documentation additions are accurate. However, the e2e test `reply.triggers.trigger-handling.ignores-inline-elevated-directive-unapproved-sender.e2e.test.ts` expects the old message string via `toBe()` and was not updated, which will cause a test failure. Score of 3 reflects that the functional changes are sound but the PR is not merge-ready until the test is fixed.
- Pay close attention to `src/auto-reply/reply/agent-runner-execution.ts` — the updated error message at line 544 breaks an e2e test that was not included in this PR's changes.

<sub>Last reviewed commit: 1eef057</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->