### PR TITLE
fix(llm-task): fall back to dist/ path for runEmbeddedPiAgent import

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -24,12 +24,17 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
     // ignore
   }
 
-  // Bundled install (built)
-  const mod = await import("../../../src/agents/pi-embedded-runner.js");
-  if (typeof mod.runEmbeddedPiAgent !== "function") {
-    throw new Error("Internal error: runEmbeddedPiAgent not available");
+  // Bundled install (built) — src/ tree doesn't exist, try dist/.
+  try {
+    const mod = await import("../../../dist/agents/pi-embedded-runner.js");
+    if (typeof (mod as any).runEmbeddedPiAgent === "function") {
+      return (mod as any).runEmbeddedPiAgent;
+    }
+  } catch {
+    // ignore
   }
-  return mod.runEmbeddedPiAgent as RunEmbeddedPiAgentFn;
+
+  throw new Error("Internal error: runEmbeddedPiAgent not available (tried src/ and dist/)");
 }
 
 function stripCodeFences(s: string): string {

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -1,8 +1,8 @@
+import { Type } from "@sinclair/typebox";
+import Ajv from "ajv";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { Type } from "@sinclair/typebox";
-import Ajv from "ajv";
 // NOTE: This extension is intended to be bundled with OpenClaw.
 // When running from source (tests/dev), OpenClaw internals live under src/.
 // When running from a built install, internals live under dist/ (no src/ tree).
@@ -25,16 +25,22 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
   }
 
   // Bundled install (built) — src/ tree doesn't exist, try dist/.
+  let distError: unknown;
   try {
+    // @ts-expect-error — dist/ path only exists at runtime in packaged installs
     const mod = await import("../../../dist/agents/pi-embedded-runner.js");
+    // oxlint-disable-next-line typescript/no-explicit-any
     if (typeof (mod as any).runEmbeddedPiAgent === "function") {
+      // oxlint-disable-next-line typescript/no-explicit-any
       return (mod as any).runEmbeddedPiAgent;
     }
-  } catch {
-    // ignore
+  } catch (err) {
+    distError = err;
   }
 
-  throw new Error("Internal error: runEmbeddedPiAgent not available (tried src/ and dist/)");
+  throw new Error("Internal error: runEmbeddedPiAgent not available (tried src/ and dist/)", {
+    cause: distError,
+  });
 }
 
 function stripCodeFences(s: string): string {


### PR DESCRIPTION
## Summary

Based on #18946 by @arosstale, with fixes for CI failure and review feedback:

- Fixes copy-paste bug where the bundled-install fallback imported from `src/` (same as the dev path) instead of `dist/`, causing `runEmbeddedPiAgent` to fail in packaged installs where `src/` doesn't exist
- **Adds `@ts-expect-error`** to suppress TS2307 for the `dist/` import path that only exists at runtime in packaged installs (this was causing the CI type-check failure)
- **Adds `oxlint-disable` comments** for `as any` casts in the `dist/` block, matching the existing `src/` block style
- **Captures the underlying import error** and attaches it via `Error({ cause })` so callers can see why each import attempt failed, rather than getting a generic "not available" message

## Test plan

- [x] `tsgo --noEmit` passes (no TS2307 error)
- [x] `oxfmt --check` passes
- [x] `oxlint` passes (no `no-explicit-any` errors)

Fixes #18846
Supersedes #18946

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a copy-paste bug in `loadRunEmbeddedPiAgent()` where the bundled-install fallback path was importing from `src/` (identical to the dev path) instead of `dist/`, causing `runEmbeddedPiAgent` to fail in packaged installs where `src/` doesn't exist.

- Corrects the fallback import path from `../../../src/` to `../../../dist/` for packaged installs
- Wraps the `dist/` import in a `try/catch` block (matching the `src/` block pattern) with `@ts-expect-error` to suppress TS2307 since the path only exists at runtime
- Captures and attaches the underlying import error via `Error({ cause })` for better debugging
- Import reorder is oxfmt auto-sorting (no logic change)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a clear copy-paste bug with a minimal, well-structured change.
- The change is small and targeted: it fixes an obvious copy-paste bug (both paths importing from src/ instead of src/ then dist/), follows the existing code patterns, and adds proper error handling. The import reorder is purely formatter-driven. No new logic complexity or risk introduced.
- No files require special attention.

<sub>Last reviewed commit: 55437c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->