### PR TITLE
chore(test): fix TS2345 in before_tool_call abort-dedup test

### DIFF
--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -177,7 +177,14 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     const withAbort = wrapToolWithAbortSignal(wrapped, abortController.signal);
     const [def] = toToolDefinitions([withAbort]);
 
-    await def.execute("call-abort-dedup", { command: "ls" }, undefined, undefined, undefined);
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
+    await def.execute(
+      "call-abort-dedup",
+      { command: "ls" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
 
     expect(hookRunner.runBeforeToolCall).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Follows up on 116f5afe ("Fix types in tests 31/N") — one remaining `TS2345` in the same file.

```
src/agents/pi-tools.before-tool-call.e2e.test.ts(180,84): error TS2345:
  Argument of type 'undefined' is not assignable to parameter of type 'ExtensionContext'.
```

Uses the same pattern established in that commit: cast an empty object to `Parameters<typeof def.execute>[4]` instead of passing `undefined`.

1 file, 1 line change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the final remaining `TS2345` TypeScript error in the `before_tool_call` abort-dedup test by applying the same pattern established in commit 116f5afe: instead of passing `undefined` for the extension context parameter, the code now casts an empty object to `Parameters<typeof def.execute>[4]`. This ensures type safety while maintaining the same runtime behavior, as the extension context is not actually used in this particular test case.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a trivial TypeScript type fix following an established pattern from a previous commit. The change only affects test code, doesn't alter runtime behavior, and TypeScript compilation now passes without errors. The fix correctly applies the same pattern used throughout the file for handling the extension context parameter.
- No files require special attention

<sub>Last reviewed commit: 3e07e2a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->