### PR TITLE
fix: remove message_id from system prompt to preserve prompt caching

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -25,8 +25,6 @@ describe("buildInboundMetaSystemPrompt", () => {
 
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["schema"]).toBe("openclaw.inbound_meta.v1");
-    expect(payload["message_id"]).toBe("123");
-    expect(payload["message_id_full"]).toBeUndefined();
     expect(payload["reply_to_id"]).toBe("99");
     expect(payload["chat_id"]).toBe("telegram:5494292670");
     expect(payload["channel"]).toBe("telegram");
@@ -61,21 +59,6 @@ describe("buildInboundMetaSystemPrompt", () => {
     expect(payload["sender_id"]).toBeUndefined();
   });
 
-  it("keeps message_id_full only when it differs from message_id", () => {
-    const prompt = buildInboundMetaSystemPrompt({
-      MessageSid: "short-id",
-      MessageSidFull: "full-provider-message-id",
-      OriginatingTo: "channel:C1",
-      OriginatingChannel: "slack",
-      Provider: "slack",
-      Surface: "slack",
-      ChatType: "group",
-    } as TemplateContext);
-
-    const payload = parseInboundMetaPayload(prompt);
-    expect(payload["message_id"]).toBe("short-id");
-    expect(payload["message_id_full"]).toBe("full-provider-message-id");
-  });
 });
 
 describe("buildInboundUserContextPrefix", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -13,8 +13,6 @@ function safeTrim(value: unknown): string | undefined {
 export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
-  const messageId = safeTrim(ctx.MessageSid);
-  const messageIdFull = safeTrim(ctx.MessageSidFull);
   const replyToId = safeTrim(ctx.ReplyToId);
   const chatId = safeTrim(ctx.OriginatingTo);
 
@@ -22,8 +20,6 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   // Those belong in the user-role "untrusted context" blocks.
   const payload = {
     schema: "openclaw.inbound_meta.v1",
-    message_id: messageId,
-    message_id_full: messageIdFull && messageIdFull !== messageId ? messageIdFull : undefined,
     sender_id: safeTrim(ctx.SenderId),
     chat_id: chatId,
     reply_to_id: replyToId,


### PR DESCRIPTION
## Summary

- Remove `message_id` and `message_id_full` from the inbound metadata system prompt payload — they are unique UUIDs per inbound message, guaranteeing the system prompt changes on every run and defeating prompt caching across all providers
- The IDs remain available in user-role context via the envelope, so tool actions that need them are unaffected

## Test plan

- [x] `inbound-meta.test.ts` updated and passing (5 tests)
- [x] Tested locally — system prompt hash stays stable across consecutive messages

AI-assisted (Claude Code), fully tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `message_id` and `message_id_full` from the system prompt to enable prompt caching. These are unique UUIDs that change on every message, preventing cache hits across providers.

Key changes:
- Removed `message_id` and `message_id_full` from `buildInboundMetaSystemPrompt` payload in `src/auto-reply/reply/inbound-meta.ts:13-52`
- Updated tests to reflect removal: removed assertions for `message_id` and deleted test case for `message_id_full` in `src/auto-reply/reply/inbound-meta.test.ts:14-61`
- No functional impact: message IDs remain available via envelope/user context for tool actions that need them
- Tests updated and passing, confirming system prompt stability

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects a well-scoped performance optimization with comprehensive test coverage. The change removes unique identifiers from the system prompt without affecting tool functionality, as message IDs remain accessible via envelope context. Tests are updated and passing, confirming the prompt hash stabilizes across messages while preserving all required functionality.
- No files require special attention

<sub>Last reviewed commit: 983e85c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->