### PR TITLE
Implement check for empty Gmail events in hooks mapping

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -150,13 +150,14 @@ export async function applyHookMappings(
   if (mappings.length === 0) {
     return null;
   }
+
+  if (isEmptyGmailEvent(ctx)) {
+    return { ok: true, action: null, skipped: true };
+  }
+  
   for (const mapping of mappings) {
     if (!mappingMatches(mapping, ctx)) {
       continue;
-    }
-
-    if (isEmptyGmailEvent(ctx)) {
-      return { ok: true, action: null, skipped: true };
     }
 
     const base = buildActionFromMapping(mapping, ctx);

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -155,6 +155,10 @@ export async function applyHookMappings(
       continue;
     }
 
+    if (isEmptyGmailEvent(ctx)) {
+      return { ok: true, action: null, skipped: true };
+    }
+
     const base = buildActionFromMapping(mapping, ctx);
     if (!base.ok) {
       return base;
@@ -179,6 +183,14 @@ export async function applyHookMappings(
     return merged;
   }
   return null;
+}
+
+function isEmptyGmailEvent(ctx: HookMappingContext): boolean {
+  if (ctx.path !== "gmail") {
+    return false;
+  }
+  const messages = (ctx.payload as Record<string, unknown>).messages;
+  return !Array.isArray(messages) || messages.length === 0;
 }
 
 function normalizeHookMapping(


### PR DESCRIPTION
Add isEmptyGmailEvent function to check for empty Gmail events.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: When deleting e-mails in gmail, empty notifications are sent, which cause problems.
- Why it matters: The agent reacts to the empty messages and repeats old notifications.
- What changed: in src/gateway/hooks-mapping.ts a check for empty gmail-messages was introduced.
- What did NOT change (scope boundary): everything else

## Change Type (select all)

- [ x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

Empty gmail-notifications are ignored, which prevents from repeating old gmail-notifications.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: n/a

## Repro + Verification

Manual test.

### Environment

- OS: ubuntu
- Runtime/container: docker
- Model/provider: openai-gpt-5-2
- Integration/channel (if any): Telegram and Gmail
- Relevant config (redacted): none

### Steps

1. delete an e-mail from the gmail inbox

### Expected

- after fix: nothing happens in OpenClaw

### Actual

- before fix: the agent gets an empty notification and tries to resolve it, usually by repeating the last notification.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: arriving e-mail in gmail, and deleting e-mail in gmail
- Edge cases checked: none
- What you did **not** verify: n/a

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: n/a

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: restore original src/gateway/hooks-mapping.ts
- Files/config to restore: src/gateway/hooks-mapping.ts
- Known bad symptoms reviewers should watch for: none

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: I don't see any.
  - Mitigation: n/a

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an early-exit guard in `applyHookMappings` to skip empty Gmail webhook events (where `messages` is missing or an empty array). When Gmail sends delete-notification webhooks with no message content, the agent previously attempted to process them — rendering near-empty templates and repeating old notifications. The new `isEmptyGmailEvent` check runs once before the mapping loop and returns a `skipped` result, which the HTTP handler in `server-http.ts` correctly handles as a 204 No Content response.

- Added `isEmptyGmailEvent` helper function in `src/gateway/hooks-mapping.ts` that gates on `ctx.path === "gmail"` and checks for a missing/empty `messages` array
- The check is placed before the mapping loop, so it executes once per request regardless of how many mappings match
- Return type matches the existing `HookMappingResult` discriminated union (`{ ok: true, action: null, skipped: true }`)
- No test coverage was added for the new function

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a narrowly scoped early-exit guard for a known edge case with minimal risk of regression.
- The change is small, well-placed, and correctly typed. It only affects Gmail webhook paths with missing/empty messages, leaving all other hook processing untouched. The return type matches the existing discriminated union and the caller already handles the skipped case. The only concern is the lack of test coverage for the new function, but the logic is straightforward enough that the risk is low.
- No files require special attention.

<sub>Last reviewed commit: 88a30b3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->