### PR TITLE
fix(hooks): reject path traversal in hook pack manifest entries during install

### DIFF
--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -235,6 +235,40 @@ describe("installHooksFromPath", () => {
     expect(result.targetDir).toBe(path.join(stateDir, "hooks", "my-hook"));
     expect(fs.existsSync(path.join(result.targetDir, "HOOK.md"))).toBe(true);
   });
+
+  it("rejects hook pack with path traversal in openclaw.hooks entries", async () => {
+    const workDir = makeTempDir();
+    const stateDir = makeTempDir();
+    const pkgDir = path.join(workDir, "package");
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    // Create an outside-root hook directory
+    const outsideDir = path.join(workDir, "outside");
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(outsideDir, "HOOK.md"), "---\nname: outside\n---\n# Outside\n");
+    fs.writeFileSync(path.join(outsideDir, "handler.js"), "export default async () => {};\n");
+
+    // Package manifest references a path that escapes the package directory
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "traversal-pack",
+        openclaw: { hooks: ["../outside"] },
+      }),
+      "utf-8",
+    );
+
+    const result = await installHooksFromPath({
+      path: pkgDir,
+      hooksDir: path.join(stateDir, "hooks"),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("path traversal");
+  });
 });
 
 describe("installHooksFromNpmSpec", () => {

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -213,6 +213,13 @@ async function installHookPackageFromDir(params: {
   const resolvedHooks = [] as string[];
   for (const entry of hookEntries) {
     const hookDir = path.resolve(params.packageDir, entry);
+    const relative = path.relative(params.packageDir, hookDir);
+    if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+      return {
+        ok: false,
+        error: `hook path "${entry}" escapes package directory (path traversal rejected)`,
+      };
+    }
     await validateHookDir(hookDir);
     const hookName = await resolveHookNameFromDir(hookDir);
     resolvedHooks.push(hookName);


### PR DESCRIPTION
## Problem

The `installHookPackageFromDir` function in `src/hooks/install.ts` resolves `openclaw.hooks[]` entries from the package manifest via `path.resolve(params.packageDir, entry)` without verifying the resolved path stays within the package directory. A crafted hook pack can reference `../outside` or absolute paths to load and execute arbitrary code from outside the package root.

This is a path traversal vulnerability (CWE-22) with CVSS 7.8 (High).

Note: `src/hooks/workspace.ts` already has a `resolveContainedDir` guard for the same pattern — this fix closes the gap in the install path.

Closes #18922

## Solution

Added a path containment check in `installHookPackageFromDir` that validates each resolved hook entry stays within `params.packageDir` using `path.relative`. Entries that escape the package directory are rejected with a clear error message.

## Test Plan

- Added regression test in `install.test.ts`: creates a hook pack with `../outside` in `openclaw.hooks[]` and verifies the install is rejected with "path traversal" error
- All 12 tests in `install.test.ts` pass
- All 2 tests in `workspace.test.ts` pass (no regression)
- Verified with `npx vitest run src/hooks/install.test.ts src/hooks/workspace.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added path traversal validation to `installHookPackageFromDir` in `src/hooks/install.ts:216-222` to prevent malicious hook packs from loading code outside the package directory. The fix validates each `openclaw.hooks[]` entry using `path.relative` to ensure the resolved path stays within `params.packageDir`, matching the existing pattern from `resolveContainedDir` in `workspace.ts:55-63`.

- Closes a CWE-22 path traversal vulnerability where crafted manifests could reference `../outside` or absolute paths
- Added regression test validating the fix rejects traversal attempts with clear error messages
- Implementation is consistent with existing security patterns across the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix correctly addresses a path traversal vulnerability using a well-established pattern from workspace.ts, includes comprehensive test coverage, and has no logical flaws or edge case issues
- No files require special attention

<sub>Last reviewed commit: 72af1ff</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->