### PR TITLE
memory: support per-agent QMD collection paths

### DIFF
--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -7,6 +7,7 @@ import type {
   SandboxDockerSettings,
   SandboxPruneSettings,
 } from "./types.sandbox.js";
+import type { MemoryQmdIndexPath } from "./types.memory.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
 export type AgentModelConfig =
@@ -28,6 +29,8 @@ export type AgentConfig = {
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];
   memorySearch?: MemorySearchConfig;
+  /** Per-agent QMD collection paths (appended to global `memory.qmd.paths`). */
+  qmd?: { paths?: MemoryQmdIndexPath[] };
   /** Human-like delay between block replies for this agent. */
   humanDelay?: HumanDelayConfig;
   /** Optional per-agent heartbeat overrides. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -614,6 +614,22 @@ export const AgentEntrySchema = z
       .optional(),
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
+    qmd: z
+      .object({
+        paths: z
+          .array(
+            z
+              .object({
+                path: z.string(),
+                name: z.string().optional(),
+                pattern: z.string().optional(),
+              })
+              .strict(),
+          )
+          .optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -273,9 +273,15 @@ export function resolveMemoryBackendConfig(params: {
   const qmdCfg = params.cfg.memory?.qmd;
   const includeDefaultMemory = qmdCfg?.includeDefaultMemory !== false;
   const nameSet = new Set<string>();
+
+  // Per-agent QMD paths from agents.list[].qmd.paths (appended after global paths).
+  const agentCfg = params.cfg.agents?.list?.find((a) => a.id === params.agentId);
+  const perAgentPaths = agentCfg?.qmd?.paths;
+
   const collections = [
     ...resolveDefaultCollections(includeDefaultMemory, workspaceDir, nameSet, params.agentId),
     ...resolveCustomPaths(qmdCfg?.paths, workspaceDir, nameSet, params.agentId),
+    ...resolveCustomPaths(perAgentPaths, workspaceDir, nameSet, params.agentId),
   ];
 
   const rawCommand = qmdCfg?.command?.trim() || "qmd";


### PR DESCRIPTION
## Summary

- **Problem:** QMD backend resolves custom collection paths from global `memory.qmd.paths` only — all agents share the same collections in multi-agent setups.
- **Why it matters:** Agent-specific knowledge leaks into unrelated agents' search results, reducing relevance. The builtin backend already supports per-agent scoping via `memorySearch.extraPaths`, but QMD has no equivalent.
- **What changed:** Added optional `qmd.paths` to per-agent config (`AgentConfig`). `resolveMemoryBackendConfig()` now appends per-agent paths after global paths.
- **What did NOT change:** Global `memory.qmd.paths` behavior is untouched. Default memory paths (`MEMORY.md`, `memory/*.md`) remain workspace-scoped as before. No changes to builtin backend or `memorySearch.extraPaths`.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #19005

## User-visible / Behavior Changes

New optional config key `agents.list[].qmd.paths` (array of `MemoryQmdIndexPath`). Per-agent paths are appended to global `memory.qmd.paths`. No behavior change for existing configs without the new key.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- Runtime: Node 22+ / Bun

### Steps

1. Configure two agents with different `qmd.paths` in config
2. Run `resolveMemoryBackendConfig` for each agent
3. Verify collections include global + agent-specific paths

### Expected

- Each agent's resolved collections contain global paths plus only their own per-agent paths

### Actual

- Confirmed via unit test

## Evidence

- [x] Failing test/log before + passing after — new test `merges per-agent qmd.paths with global paths` (8/8 passing)

## Human Verification (required)

- Verified scenarios: new test covers merge behavior for agent with per-agent paths and agent without
- Edge cases checked: agent with no `qmd` config gets only global paths; collection name deduplication still works
- What you did **not** verify: live gateway with real QMD command

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (additive optional key)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: remove `qmd` key from agent configs; behavior reverts to global-only paths
- Known bad symptoms: unexpected collections in agent search results

## Risks and Mitigations

None — additive config key with no impact on existing setups.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds per-agent QMD collection paths (`agents.list[].qmd.paths`) that are appended after global `memory.qmd.paths` during resolution, enabling agent-specific knowledge scoping in multi-agent setups.

- The core resolution logic in `backend-config.ts` is clean and reuses the existing `resolveCustomPaths` helper — collection name deduplication via `nameSet` is preserved.
- The new test covers the key scenarios (agent with per-agent paths, agent without).
- **Critical issue:** The `qmd` field was added to the `AgentConfig` TypeScript type but **not** to the `AgentEntrySchema` Zod schema in `src/config/zod-schema.agent-runtime.ts`. That schema uses `.strict()`, which means any config that uses the new `agents.list[].qmd.paths` key will fail validation with an "unrecognized key" error at runtime. The Zod schema must be updated for this feature to work.

<h3>Confidence Score: 2/5</h3>

- This PR will not work as intended due to a missing Zod schema update — configs using the new key will be rejected at runtime.
- The implementation logic is correct and the test passes, but the Zod validation schema for agent entries uses `.strict()` and was not updated to include the new `qmd` field. This means the feature is dead on arrival: any user config that sets `agents.list[].qmd.paths` will fail config validation before the resolution code ever runs.
- Pay close attention to `src/config/zod-schema.agent-runtime.ts` — the `AgentEntrySchema` needs a `qmd` field added to match the TypeScript type change in `types.agents.ts`.

<sub>Last reviewed commit: 80f4a45</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->