### PR TITLE
feat(discord): expose source message metadata in component interactions

### DIFF
--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -727,6 +727,8 @@ async function dispatchDiscordComponentEvent(params: {
   guildInfo: ReturnType<typeof resolveDiscordGuildEntry>;
   eventText: string;
   replyToId?: string;
+  /** The message ID that the component (button/select) belongs to */
+  sourceMessageId?: string;
   routeOverrides?: { sessionKey?: string; agentId?: string; accountId?: string };
 }): Promise<void> {
   const { ctx, interaction, interactionCtx, channelCtx, guildInfo, eventText } = params;
@@ -824,6 +826,7 @@ async function dispatchDiscordComponentEvent(params: {
     CommandAuthorized: true,
     CommandSource: "text" as const,
     MessageSid: interaction.rawData.id,
+    ReplyToId: params.sourceMessageId,
     Timestamp: timestamp,
     OriginatingChannel: "discord" as const,
     OriginatingTo: `channel:${interactionCtx.channelId}`,
@@ -1031,6 +1034,8 @@ async function handleDiscordComponentEvent(params: {
     logError(`${params.label}: failed to acknowledge interaction: ${String(err)}`);
   }
 
+  const sourceMessageId = consumed.messageId ?? params.interaction.message?.id;
+
   await dispatchDiscordComponentEvent({
     ctx: params.ctx,
     interaction: params.interaction,
@@ -1038,7 +1043,8 @@ async function handleDiscordComponentEvent(params: {
     channelCtx,
     guildInfo,
     eventText,
-    replyToId: consumed.messageId ?? params.interaction.message?.id,
+    replyToId: sourceMessageId,
+    sourceMessageId,
     routeOverrides: {
       sessionKey: consumed.sessionKey,
       agentId: consumed.agentId,


### PR DESCRIPTION
## Summary

When a user clicks a Discord component button (e.g. a "Mark as read" button on an article card), the agent receives only the button label (`Clicked "Read"`) with no context about *which message* contained the button.

This PR adds `ReplyToId` to the inbound event envelope — the message ID of the message containing the clicked component. The agent can then use this ID to fetch the message content if needed.

### Problem

Discord component interactions do not include the parent message ID in the event payload. When an agent sends multiple messages with identical buttons (e.g. article digest with per-article "Lu" buttons), clicking any button produces the same event text, making it impossible to know which article was acted upon.

### Solution

- Extract `sourceMessageId` from either the component registry (`consumed.messageId`) or the interaction data (`interaction.message?.id`)
- Wire it through the dispatch pipeline as both `replyToId` and `sourceMessageId`
- Set `ReplyToId` in the inbound envelope

### Files changed (1)

| File | Change |
|------|--------|
| `src/discord/monitor/agent-components.ts` | Add `sourceMessageId` extraction + wire `ReplyToId` into event dispatch (+10/-4 lines) |

### Testing

- [x] Build passes
- [x] Backward-compatible
- [x] Rebased on latest main

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `sourceMessageId` extraction to Discord component interactions and wires it to the `ReplyToId` field in the inbound event envelope. The implementation extracts the message ID from either the component registry (`consumed.messageId`) or the interaction's message object (`params.interaction.message?.id`), enabling agents to identify which message contained a clicked button or select menu.

Changes:
- Added `sourceMessageId` parameter to `dispatchDiscordComponentEvent` function
- Set `ReplyToId: params.sourceMessageId` in the event payload (line 829)
- Extract `sourceMessageId` from `consumed.messageId ?? params.interaction.message?.id` in `handleDiscordComponentEvent` (line 1037)
- Pass `sourceMessageId` to both `replyToId` and `sourceMessageId` parameters

The implementation is consistent with how Discord message handlers set `ReplyToId` (from `replyContext?.id`) and follows the existing pattern. Note that `ReplyToBody` is not set here (unlike message handlers), which is expected since component interactions don't provide message body context — agents would need to fetch it separately using the ID.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues identified
- Clean implementation that follows existing patterns, is backward-compatible, properly handles fallback cases, and solves the stated problem without introducing side effects
- No files require special attention

<sub>Last reviewed commit: eb80d07</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->