### PR TITLE
fix: Fix normalise toolid

### DIFF
--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { TextContent } from "@mariozechner/pi-ai";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import { createHash } from "node:crypto";
 import type {
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
@@ -13,6 +14,31 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 const GUARD_TRUNCATION_SUFFIX =
   "\n\n⚠️ [Content truncated during persistence — original exceeded size limit. " +
   "Use offset/limit parameters or request specific sections for large content.]";
+
+// Session transcripts should be resilient across providers. Some OpenAI-compatible APIs
+// generate tool call ids like `functions.exec:0` (or include whitespace), which can
+// break strict parsers / validators on reload. Normalize ids before persistence and
+// apply a stable mapping to corresponding toolResult messages.
+const PERSISTED_TOOL_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+function shortHash(text: string, length = 8): string {
+  return createHash("sha1").update(text).digest("hex").slice(0, length);
+}
+
+function normalizePersistedToolCallId(raw: string): string {
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  if (!trimmed) {
+    return "tool";
+  }
+  if (PERSISTED_TOOL_ID_RE.test(trimmed)) {
+    return trimmed;
+  }
+
+  // Keep only safe chars for on-disk transcripts.
+  const replaced = trimmed.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const collapsed = replaced.replace(/_+/g, "_").replace(/^_+|_+$/g, "");
+  return collapsed || `tool_${shortHash(trimmed)}`;
+}
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -111,15 +137,133 @@ export function installSessionToolResultGuard(
 } {
   const originalAppend = sessionManager.appendMessage.bind(sessionManager);
   const pending = new Map<string, string | undefined>();
+
+  const persistedIdMap = new Map<string, string>();
+  const usedPersistedIds = new Set<string>();
+
+  const resolvePersistedId = (id: string): string => {
+    const raw = typeof id === "string" ? id : "";
+    const canonical = raw.trim();
+    if (!canonical) {
+      return "tool";
+    }
+
+    const existing = persistedIdMap.get(canonical);
+    if (existing) {
+      return existing;
+    }
+
+    // Idempotence: if we've already emitted this id (e.g. a toolResult message
+    // has already been mapped once), don't remap it again.
+    if (PERSISTED_TOOL_ID_RE.test(canonical) && usedPersistedIds.has(canonical)) {
+      return canonical;
+    }
+
+    const base = normalizePersistedToolCallId(canonical);
+    if (!usedPersistedIds.has(base)) {
+      persistedIdMap.set(canonical, base);
+      usedPersistedIds.add(base);
+      return base;
+    }
+
+    const candidate = `${base}_${shortHash(canonical)}`;
+    if (!usedPersistedIds.has(candidate)) {
+      persistedIdMap.set(canonical, candidate);
+      usedPersistedIds.add(candidate);
+      return candidate;
+    }
+
+    for (let i = 2; i < 1000; i += 1) {
+      const next = `${base}_${i}`;
+      if (!usedPersistedIds.has(next)) {
+        persistedIdMap.set(canonical, next);
+        usedPersistedIds.add(next);
+        return next;
+      }
+    }
+
+    const fallback = `tool_${shortHash(`${canonical}:${Date.now()}`)}`;
+    persistedIdMap.set(canonical, fallback);
+    usedPersistedIds.add(fallback);
+    return fallback;
+  };
+
+  const applyPersistedIdMapping = (message: AgentMessage): AgentMessage => {
+    if (!message || typeof message !== "object") {
+      return message;
+    }
+
+    const role = (message as { role?: unknown }).role;
+
+    if (role === "assistant") {
+      const content = (message as { content?: unknown }).content;
+      if (!Array.isArray(content)) {
+        return message;
+      }
+      let changed = false;
+      const nextContent = content.map((block: unknown) => {
+        if (!block || typeof block !== "object") {
+          return block;
+        }
+        const rec = block as { type?: unknown; id?: unknown };
+        const type = rec.type;
+        const id = rec.id;
+        if (
+          (type !== "functionCall" && type !== "toolUse" && type !== "toolCall") ||
+          typeof id !== "string" ||
+          !id
+        ) {
+          return block;
+        }
+        const nextId = resolvePersistedId(id);
+        if (nextId === id) {
+          return block;
+        }
+        changed = true;
+        return { ...(block as unknown as Record<string, unknown>), id: nextId };
+      });
+      return changed
+        ? ({
+            ...(message as unknown as Record<string, unknown>),
+            content: nextContent,
+          } as AgentMessage)
+        : message;
+    }
+
+    if (role === "toolResult") {
+      const toolCallId = (message as { toolCallId?: unknown }).toolCallId;
+      const toolUseId = (message as { toolUseId?: unknown }).toolUseId;
+      const toolCallIdStr = typeof toolCallId === "string" && toolCallId ? toolCallId : undefined;
+      const toolUseIdStr = typeof toolUseId === "string" && toolUseId ? toolUseId : undefined;
+      const nextToolCallId = toolCallIdStr ? resolvePersistedId(toolCallIdStr) : undefined;
+      const nextToolUseId = toolUseIdStr ? resolvePersistedId(toolUseIdStr) : undefined;
+
+      if (nextToolCallId === toolCallIdStr && nextToolUseId === toolUseIdStr) {
+        return message;
+      }
+
+      return {
+        ...(message as unknown as Record<string, unknown>),
+        ...(nextToolCallId !== undefined ? { toolCallId: nextToolCallId } : null),
+        ...(nextToolUseId !== undefined ? { toolUseId: nextToolUseId } : null),
+      } as AgentMessage;
+    }
+
+    return message;
+  };
+
   const persistMessage = (message: AgentMessage) => {
+    const mapped = applyPersistedIdMapping(message);
     const transformer = opts?.transformMessageForPersistence;
-    return transformer ? transformer(message) : message;
+    return transformer ? transformer(mapped) : mapped;
   };
 
   const persistToolResult = (
     message: AgentMessage,
     meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean },
   ) => {
+    // `persistMessage` already applies the persisted tool id mapping; keep this focused
+    // on the optional tool-result persistence hook.
     const transformer = opts?.transformToolResultForPersistence;
     return transformer ? transformer(message, meta) : message;
   };
@@ -183,11 +327,15 @@ export function installSessionToolResultGuard(
     const nextRole = (nextMessage as { role?: unknown }).role;
 
     if (nextRole === "toolResult") {
-      const id = extractToolResultId(nextMessage as Extract<AgentMessage, { role: "toolResult" }>);
+      const idRaw = extractToolResultId(
+        nextMessage as Extract<AgentMessage, { role: "toolResult" }>,
+      );
+      const id = idRaw ? resolvePersistedId(idRaw) : null;
       const toolName = id ? pending.get(id) : undefined;
       if (id) {
         pending.delete(id);
       }
+
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
       const capped = capToolResultSize(persistMessage(nextMessage));
@@ -235,7 +383,7 @@ export function installSessionToolResultGuard(
 
     if (toolCalls.length > 0) {
       for (const call of toolCalls) {
-        pending.set(call.id, call.name);
+        pending.set(resolvePersistedId(call.id), call.name);
       }
     }
 

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -244,8 +244,8 @@ export function installSessionToolResultGuard(
 
       return {
         ...(message as unknown as Record<string, unknown>),
-        ...(nextToolCallId !== undefined ? { toolCallId: nextToolCallId } : null),
-        ...(nextToolUseId !== undefined ? { toolUseId: nextToolUseId } : null),
+        ...(nextToolCallId !== undefined ? { toolCallId: nextToolCallId } : {}),
+        ...(nextToolUseId !== undefined ? { toolUseId: nextToolUseId } : {}),
       } as AgentMessage;
     }
 


### PR DESCRIPTION
Summary

Problem: Session transcripts can contain tool call IDs like functions.exec:0 (and sometimes leading whitespace), which can violate strict tool-id validation on reload.
Why it matters: Can make sessions fail to load / appear “corrupted”, breaking recovery and usability.
What changed: Normalize tool call IDs at persistence time to safe ^[a-zA-Z0-9_-]+$ IDs and apply a stable mapping so toolResults remain paired.
What did NOT change (scope boundary): No change to tool execution logic, provider APIs, or runtime tool-calling behavior—only transcript persistence normalization.
Change Type (select all)

Bug fix
Scope (select all touched areas)

Gateway / orchestration
Skills / tool execution
Auth / tokens
Memory / storage
Integrations
API / contracts
UI / DX
CI/CD / infra
Linked Issue/PR

Closes https://github.com/openclaw/openclaw/issues/18484
User-visible / Behavior Changes

Session transcripts persist tool call IDs in a normalized safe format; sessions should reload reliably even if upstream tool IDs contain : / . / whitespace.
Security Impact (required)

New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No
Data access scope changed? No
If any Yes, explain risk + mitigation: N/A
Repro + Verification

Environment
OS: ubuntu 22.04
Runtime/container: local
Model/provider: OpenAI-compatible APIs that emit tool ids like functions.exec:0
Integration/channel (if any): N/A
Relevant config (redacted): N/A
Steps
Run a tool-calling turn where the provider emits a tool call id like " functions.exec:0".
Persist to session transcript.
Reload/parse session transcript.
Expected
Session loads successfully; toolResult entries remain paired with their toolCalls.
Actual (before)
Session parser/validator can reject tool IDs that don’t match strict patterns, causing reload failure / session corruption.
Evidence

Failing test/log before + passing after
Added e2e test: src/agents/session-tool-result-guard.e2e.test.ts (“normalizes invalid tool call IDs…”)
Ran: vitest -c vitest.e2e.config.ts run src/agents/session-tool-result-guard.e2e.test.ts
Human Verification (required)

Verified scenarios:
Persisting an assistant toolCall with id " functions.exec:0" results in a normalized persisted id matching ^[a-zA-Z0-9_-]+$.
Matching toolResult toolCallId remains paired to the normalized toolCall id.
Edge cases checked:
Whitespace trimming; collision handling via stable mapping; idempotence (avoid re-mapping already-normalized ids).
What you did not verify:
End-to-end reproduction with a live OpenAI-compatible provider (manual session reload) beyond the e2e test harness.
Compatibility / Migration

Backward compatible? Yes
Config/env changes? No
Migration needed? No
If yes, exact upgrade steps: N/A
Greptile Summary
Adds ID normalization for session transcript persistence to prevent reload failures when tool call IDs contain invalid characters like :, ., or whitespace. The fix applies a stable mapping that normalizes tool call IDs before persistence and ensures toolResult entries remain paired with their corresponding toolCall entries.

Normalizes tool call IDs to match ^[a-zA-Z0-9_-]+$ pattern before persisting to session transcripts
Uses stable mapping (persistedIdMap) to ensure toolResult messages remain paired with normalized toolCall IDs
Handles collision detection via usedPersistedIds set with fallback strategies (hash suffix, numeric suffix, timestamp-based)
Includes comprehensive test coverage for the new normalization logic
Previous reviewer feedback addressed: removed duplicate shortHash function and eliminated double ID mapping in persistToolResult
Confidence Score: 5/5
Safe to merge - well-tested bug fix with no breaking changes
The fix correctly addresses a specific session reload failure by normalizing tool call IDs at persistence time. The implementation includes proper collision handling, idempotence checks, and maintains backward compatibility. Previous reviewer feedback has been addressed (duplicate shortHash removed, double mapping eliminated). Test coverage validates the normalization logic and pairing behavior.
No files require special attention
Last reviewed commit: https://github.com/openclaw/openclaw/commit/f20736a3a59916e6620bcaf9b8b3c46e2d81c6c9

Greptile Summary
Fixes session reload failures caused by tool call IDs containing invalid characters (:, ., whitespace) from OpenAI-compatible APIs. The implementation normalizes tool call IDs to match ^[a-zA-Z0-9_-]+$ before persisting to session transcripts while maintaining proper pairing between toolCall and toolResult messages through a stable ID mapping.

Adds normalizePersistedToolCallId function that strips invalid characters and collapses underscores
Implements resolvePersistedId with collision handling using hash suffixes, numeric suffixes, and timestamp-based fallbacks
Applies normalization to both assistant messages (toolCall/toolUse/functionCall blocks) and toolResult messages (toolCallId/toolUseId fields)
Includes comprehensive test coverage for the normalization logic
Test file changes add default suppressToolErrorWarnings: false value to heartbeat test expectations (unrelated fix)
Confidence Score: 5/5
Safe to merge - well-tested bug fix with no breaking changes
The implementation correctly addresses session reload failures through ID normalization at persistence time. The logic includes proper collision handling with multiple fallback strategies, maintains backward compatibility, and has comprehensive test coverage. The PR description indicates previous reviewer feedback was addressed (duplicate shortHash removed, double mapping eliminated). The heartbeat test changes are unrelated but benign test fixes.
No files require special attention
Last reviewed commit: https://github.com/openclaw/openclaw/commit/c4a4777f31420418194467348d2aa4dc20665cd8

(3/5) Reply to the agent's comments like "Can you suggest a fix for this https://github.com/greptileai?" or ask follow-up questions!

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds ID normalization for session transcript persistence to prevent reload failures when tool call IDs from OpenAI-compatible APIs contain invalid characters (`:`, `.`, whitespace). The implementation applies a stable mapping that normalizes tool call IDs before persistence while maintaining proper pairing between `toolCall` and `toolResult` entries.

- Normalizes tool call IDs to match `^[a-zA-Z0-9_-]+$` pattern before persisting
- Uses stable ID mapping (`persistedIdMap`, `usedPersistedIds`) to ensure `toolResult` messages remain paired with normalized `toolCall` IDs
- Implements collision handling via hash suffix, numeric suffix, and timestamp-based fallbacks
- Includes comprehensive test coverage validating normalization logic and pairing behavior
- One critical logical error found in spread operator usage (line 247-248) that will cause runtime errors

<h3>Confidence Score: 3/5</h3>

- This PR contains a critical logical error that will cause runtime failures
- The implementation correctly addresses session reload failures through ID normalization, but contains a critical bug at lines 247-248 where spreading `null` will throw a runtime error. This bug affects the core functionality of persisting toolResult messages with normalized IDs
- src/agents/session-tool-result-guard.ts requires immediate fix for the spread operator bug at lines 247-248

<sub>Last reviewed commit: 4ec4beb</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->