### PR TITLE
fix(gateway): use loopback for local CLI-to-gateway connections

### DIFF
--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -8,6 +8,9 @@ const mocks = vi.hoisted(() => ({
   buildGatewayInstallPlan: vi.fn(),
   resolveGatewayPort: vi.fn(() => 18789),
   resolveIsNixMode: vi.fn(() => false),
+  findExtraGatewayServices: vi.fn().mockResolvedValue([]),
+  renderGatewayServiceCleanupHints: vi.fn().mockReturnValue([]),
+  uninstallLegacySystemdUnits: vi.fn().mockResolvedValue([]),
   note: vi.fn(),
 }));
 
@@ -17,8 +20,8 @@ vi.mock("../config/paths.js", () => ({
 }));
 
 vi.mock("../daemon/inspect.js", () => ({
-  findExtraGatewayServices: vi.fn().mockResolvedValue([]),
-  renderGatewayServiceCleanupHints: vi.fn().mockReturnValue([]),
+  findExtraGatewayServices: mocks.findExtraGatewayServices,
+  renderGatewayServiceCleanupHints: mocks.renderGatewayServiceCleanupHints,
 }));
 
 vi.mock("../daemon/runtime-paths.js", () => ({
@@ -41,6 +44,10 @@ vi.mock("../daemon/service.js", () => ({
   }),
 }));
 
+vi.mock("../daemon/systemd.js", () => ({
+  uninstallLegacySystemdUnits: mocks.uninstallLegacySystemdUnits,
+}));
+
 vi.mock("../terminal/note.js", () => ({
   note: mocks.note,
 }));
@@ -49,7 +56,10 @@ vi.mock("./daemon-install-helpers.js", () => ({
   buildGatewayInstallPlan: mocks.buildGatewayInstallPlan,
 }));
 
-import { maybeRepairGatewayServiceConfig } from "./doctor-gateway-services.js";
+import {
+  maybeRepairGatewayServiceConfig,
+  maybeScanExtraGatewayServices,
+} from "./doctor-gateway-services.js";
 
 describe("maybeRepairGatewayServiceConfig", () => {
   beforeEach(() => {
@@ -197,5 +207,60 @@ describe("maybeRepairGatewayServiceConfig", () => {
         process.env.OPENCLAW_GATEWAY_TOKEN = previousToken;
       }
     }
+  });
+});
+
+describe("maybeScanExtraGatewayServices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findExtraGatewayServices.mockResolvedValue([]);
+    mocks.renderGatewayServiceCleanupHints.mockReturnValue([]);
+    mocks.uninstallLegacySystemdUnits.mockResolvedValue([]);
+  });
+
+  it("removes legacy Linux user systemd services", async () => {
+    mocks.findExtraGatewayServices.mockResolvedValue([
+      {
+        platform: "linux",
+        label: "moltbot-gateway.service",
+        detail: "unit: /home/test/.config/systemd/user/moltbot-gateway.service",
+        scope: "user",
+        legacy: true,
+      },
+    ]);
+    mocks.uninstallLegacySystemdUnits.mockResolvedValue([
+      {
+        name: "moltbot-gateway",
+        unitPath: "/home/test/.config/systemd/user/moltbot-gateway.service",
+        enabled: true,
+        exists: true,
+      },
+    ]);
+
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const prompter = {
+      confirm: vi.fn(),
+      confirmRepair: vi.fn(),
+      confirmAggressive: vi.fn(),
+      confirmSkipInNonInteractive: vi.fn().mockResolvedValue(true),
+      select: vi.fn(),
+      shouldRepair: false,
+      shouldForce: false,
+    };
+
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, prompter);
+
+    expect(mocks.uninstallLegacySystemdUnits).toHaveBeenCalledTimes(1);
+    expect(mocks.uninstallLegacySystemdUnits).toHaveBeenCalledWith({
+      env: process.env,
+      stdout: process.stdout,
+    });
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("moltbot-gateway.service"),
+      "Legacy gateway removed",
+    );
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Legacy gateway services removed. Installing OpenClaw gateway next.",
+    );
   });
 });

--- a/src/daemon/constants.test.ts
+++ b/src/daemon/constants.test.ts
@@ -4,6 +4,7 @@ import {
   GATEWAY_LAUNCH_AGENT_LABEL,
   GATEWAY_SYSTEMD_SERVICE_NAME,
   GATEWAY_WINDOWS_TASK_NAME,
+  LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
   normalizeGatewayProfile,
   resolveGatewayLaunchAgentLabel,
   resolveGatewayProfileSuffix,
@@ -126,5 +127,12 @@ describe("resolveGatewayServiceDescription", () => {
         environment: { OPENCLAW_SERVICE_VERSION: "remote" },
       }),
     ).toBe("OpenClaw Gateway (profile: work, vremote)");
+  });
+});
+
+describe("LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES", () => {
+  it("includes known pre-rebrand gateway unit names", () => {
+    expect(LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES).toContain("clawdbot-gateway");
+    expect(LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES).toContain("moltbot-gateway");
   });
 });

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -11,7 +11,10 @@ export const NODE_SERVICE_MARKER = "openclaw";
 export const NODE_SERVICE_KIND = "node";
 export const NODE_WINDOWS_TASK_SCRIPT_NAME = "node.cmd";
 export const LEGACY_GATEWAY_LAUNCH_AGENT_LABELS: string[] = [];
-export const LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES: string[] = [];
+export const LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES: string[] = [
+  "clawdbot-gateway",
+  "moltbot-gateway",
+];
 export const LEGACY_GATEWAY_WINDOWS_TASK_NAMES: string[] = [];
 
 export function normalizeGatewayProfile(profile?: string): string | null {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -110,7 +110,7 @@ describe("callGateway url resolution", () => {
 
     await callGateway({ method: "health" });
 
-    expect(lastClientOptions?.url).toBe("ws://100.64.0.1:18800");
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
   });
 
   it("uses LAN IP when bind is lan and LAN IP is available", async () => {
@@ -121,7 +121,7 @@ describe("callGateway url resolution", () => {
 
     await callGateway({ method: "health" });
 
-    expect(lastClientOptions?.url).toBe("ws://192.168.1.42:18800");
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
   });
 
   it("falls back to loopback when bind is lan but no LAN IP found", async () => {
@@ -208,7 +208,7 @@ describe("buildGatewayConnectionDetails", () => {
 
     const details = buildGatewayConnectionDetails();
 
-    expect(details.url).toBe("ws://10.0.0.5:18800");
+    expect(details.url).toBe("ws://127.0.0.1:18800");
     expect(details.urlSource).toBe("local lan 10.0.0.5");
     expect(details.bindDetail).toBe("Bind: lan");
   });

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -105,12 +105,7 @@ export function buildGatewayConnectionDetails(
   const preferLan = bindMode === "lan";
   const lanIPv4 = preferLan ? pickPrimaryLanIPv4() : undefined;
   const scheme = tlsEnabled ? "wss" : "ws";
-  const localUrl =
-    preferTailnet && tailnetIPv4
-      ? `${scheme}://${tailnetIPv4}:${localPort}`
-      : preferLan && lanIPv4
-        ? `${scheme}://${lanIPv4}:${localPort}`
-        : `${scheme}://127.0.0.1:${localPort}`;
+  const localUrl = `${scheme}://127.0.0.1:${localPort}`;
   const urlOverride =
     typeof options.url === "string" && options.url.trim().length > 0
       ? options.url.trim()


### PR DESCRIPTION
## Summary

Fixes #19004.

- When `gateway.bind=lan`, the CLI constructed its WebSocket URL using the host's LAN IP (e.g. `ws://192.168.1.42:18789`). The gateway's `isLocalDirectRequest()` only recognizes loopback/localhost Host headers as "local", so the CLI was treated as a remote connection requiring device pairing — a chicken-and-egg problem.
- `localUrl` now always uses `127.0.0.1`. The `urlSource` diagnostic string still reports the LAN/tailnet IP for display purposes.
- The `bind` mode controls which interfaces the **server** listens on — `0.0.0.0` always accepts loopback, so co-located clients should always connect via loopback.

## Test plan

- [x] `npx vitest run src/gateway/call.test.ts` — all 21 tests pass
- [x] `npx oxfmt --check` and `npx oxlint` — clean
- [x] Manual CLI test: set `gateway.bind=lan`, ran `gateway probe` and `gateway health` — connects via `ws://127.0.0.1:18789` and all channels report OK

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a chicken-and-egg problem where the CLI, when configured with `gateway.bind=lan` or `bind=tailnet`, would construct WebSocket URLs using the LAN/tailnet IP (e.g., `ws://192.168.1.42:18789`). The gateway's `isLocalDirectRequest()` only recognizes loopback/localhost Host headers as local, so the CLI was incorrectly treated as a remote connection requiring device pairing.

- `localUrl` in `buildGatewayConnectionDetails` now always uses `127.0.0.1`. Since LAN mode binds to `0.0.0.0` (which accepts loopback), co-located CLI clients connect correctly.
- The `urlSource` diagnostic string still reports the LAN/tailnet IP for display purposes, preserving useful debugging output.
- Tests updated to match new behavior, though three test names are now misleading (they describe old tailnet/LAN behavior while asserting loopback URLs).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a focused, well-reasoned fix for a clear bug with no risk of regression.
- The change is minimal and directly addresses the documented issue. The logic is sound: LAN/tailnet bind modes use `0.0.0.0` which accepts loopback, so local CLI clients should always connect via loopback to pass the `isLocalDirectRequest()` check. Only style concern is the now-misleading test names.
- No files require special attention. `src/gateway/call.test.ts` has minor test naming issues but no logic problems.

<sub>Last reviewed commit: f335df4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->