### PR TITLE
fix(feishu): keep chunked messages in topic/thread context

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -170,7 +170,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               cfg,
               to: chatId,
               text: chunk,
-              replyToMessageId,
+              replyToMessageId: first ? replyToMessageId : undefined,
               mentions: first ? mentionTargets : undefined,
               accountId,
             });
@@ -187,7 +187,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               cfg,
               to: chatId,
               text: chunk,
-              replyToMessageId,
+              replyToMessageId: first ? replyToMessageId : undefined,
               mentions: first ? mentionTargets : undefined,
               accountId,
             });


### PR DESCRIPTION
# fix(feishu): keep message chunks in topic/thread context

## Summary

Fixes an issue where long message responses in Feishu topics/threads would have 
their subsequent chunks sent to the main chat instead of staying within the 
topic context.

## Problem

When responding to messages in a Feishu topic (thread), if the response is long 
and needs to be chunked, only the first chunk stays in the topic. Subsequent 
chunks appear in the main group chat, breaking the conversation flow.

### Root Cause

In `reply-dispatcher.ts`, when sending chunked messages, all chunks use the same 
`replyToMessageId`. This causes Feishu to interpret subsequent chunks as replies 
to the first chunk rather than part of the same topic thread.

**Code location:** `extensions/feishu/src/reply-dispatcher.ts` (lines ~144-154)

```typescript
// BEFORE (problematic)
for (const chunk of core.channel.text.chunkTextWithMode(text, textChunkLimit, chunkMode)) {
  await sendMarkdownCardFeishu({
    cfg,
    to: chatId,
    text: chunk,
    replyToMessageId,  // ❌ Used for ALL chunks
    mentions: first ? mentionTargets : undefined,
  });
  first = false;
}
```

## Solution

Only use `replyToMessageId` for the **first chunk**. Subsequent chunks should 
omit this parameter to stay within the topic/thread context.

```typescript
// AFTER (fixed)
for (const chunk of core.channel.text.chunkTextWithMode(text, textChunkLimit, chunkMode)) {
  await sendMarkdownCardFeishu({
    cfg,
    to: chatId,
    text: chunk,
    replyToMessageId: first ? replyToMessageId : undefined,  // ✅ Only first chunk
    mentions: first ? mentionTargets : undefined,
  });
  first = false;
}
```

### Technical Details

- **File:** `extensions/feishu/src/reply-dispatcher.ts`
- **Function:** `createFeishuReplyDispatcher` → `deliver` callback
- **Applies to:** Both card messages (`sendMarkdownCardFeishu`) and text messages (`sendMessageFeishu`)

## Changes

- Modified `reply-dispatcher.ts` to conditionally set `replyToMessageId` based on 
  the `first` flag in both card and text message sending paths

## Testing

- [ ] Long messages in topics stay within the topic context
- [ ] First chunk correctly replies to the original message
- [ ] Subsequent chunks appear in sequence within the topic
- [ ] Non-topic messages continue to work as expected

## Related

- Feishu API behavior: Messages with `replyToMessageId` are treated as replies, 
  which in topic contexts can cause them to appear in the main chat
- This fix ensures chunked messages behave as a single logical response

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes chunked message behavior in Feishu topics/threads by conditionally applying `replyToMessageId` only to the first chunk. Previously, all chunks used `replyToMessageId`, causing subsequent chunks to appear in the main chat rather than staying within the topic context. The fix applies to both card messages (`sendMarkdownCardFeishu`) and text messages (`sendMessageFeishu`) in `reply-dispatcher.ts:173` and `reply-dispatcher.ts:190`.

- Applied `replyToMessageId: first ? replyToMessageId : undefined` pattern to both message sending paths
- Maintains consistency with existing `mentions` field which already uses this pattern
- Preserves first chunk as a reply to maintain conversation context
- Subsequent chunks omit `replyToMessageId` to remain in the same thread

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-understood, and follows existing patterns in the codebase. The fix mirrors the existing pattern used for the `mentions` field, applies consistently to both message sending paths, and directly addresses the described bug without introducing new logic or side effects
- No files require special attention

<sub>Last reviewed commit: 478bbed</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->