### PR TITLE
fix(web-search): normalize ui_lang parameter for Brave Search API

### DIFF
--- a/src/agents/tools/web-search.e2e.test.ts
+++ b/src/agents/tools/web-search.e2e.test.ts
@@ -8,6 +8,7 @@ const {
   isDirectPerplexityBaseUrl,
   resolvePerplexityRequestModel,
   normalizeFreshness,
+  normalizeBraveUiLang,
   freshnessToPerplexityRecency,
   resolveGrokApiKey,
   resolveGrokModel,
@@ -103,6 +104,40 @@ describe("web_search freshness normalization", () => {
     expect(normalizeFreshness("2024-13-01to2024-01-31")).toBeUndefined();
     expect(normalizeFreshness("2024-02-30to2024-03-01")).toBeUndefined();
     expect(normalizeFreshness("2024-03-10to2024-03-01")).toBeUndefined();
+  });
+});
+
+describe("normalizeBraveUiLang", () => {
+  it("passes through valid locale codes unchanged", () => {
+    expect(normalizeBraveUiLang("en-US")).toBe("en-US");
+    expect(normalizeBraveUiLang("de-DE")).toBe("de-DE");
+    expect(normalizeBraveUiLang("ja-JP")).toBe("ja-JP");
+    expect(normalizeBraveUiLang("zh-CN")).toBe("zh-CN");
+  });
+
+  it("maps bare language codes to default locales", () => {
+    expect(normalizeBraveUiLang("en")).toBe("en-US");
+    expect(normalizeBraveUiLang("de")).toBe("de-DE");
+    expect(normalizeBraveUiLang("fr")).toBe("fr-FR");
+    expect(normalizeBraveUiLang("ja")).toBe("ja-JP");
+    expect(normalizeBraveUiLang("zh")).toBe("zh-CN");
+  });
+
+  it("returns undefined for unrecognized values", () => {
+    expect(normalizeBraveUiLang("xx")).toBeUndefined();
+    expect(normalizeBraveUiLang("en-XX")).toBeUndefined();
+    expect(normalizeBraveUiLang("not-a-lang")).toBeUndefined();
+  });
+
+  it("returns undefined for empty/undefined input", () => {
+    expect(normalizeBraveUiLang(undefined)).toBeUndefined();
+    expect(normalizeBraveUiLang("")).toBeUndefined();
+    expect(normalizeBraveUiLang("  ")).toBeUndefined();
+  });
+
+  it("trims whitespace before matching", () => {
+    expect(normalizeBraveUiLang(" en-US ")).toBe("en-US");
+    expect(normalizeBraveUiLang(" en ")).toBe("en-US");
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -655,7 +655,7 @@ async function runWebSearch(params: {
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
-      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
+      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${normalizeBraveUiLang(params.ui_lang) || "default"}:${params.freshness || "default"}`
       : params.provider === "perplexity"
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}:${params.freshness || "default"}`
         : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -36,6 +36,69 @@ const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
 const BRAVE_FRESHNESS_RANGE = /^(\d{4}-\d{2}-\d{2})to(\d{4}-\d{2}-\d{2})$/;
 
+const BRAVE_UI_LANGS = new Set([
+  "es-AR",
+  "en-AU",
+  "de-AT",
+  "nl-BE",
+  "fr-BE",
+  "pt-BR",
+  "en-CA",
+  "fr-CA",
+  "es-CL",
+  "da-DK",
+  "fi-FI",
+  "fr-FR",
+  "de-DE",
+  "el-GR",
+  "zh-HK",
+  "en-IN",
+  "en-ID",
+  "it-IT",
+  "ja-JP",
+  "ko-KR",
+  "en-MY",
+  "es-MX",
+  "nl-NL",
+  "en-NZ",
+  "no-NO",
+  "zh-CN",
+  "pl-PL",
+  "en-PH",
+  "ru-RU",
+  "en-ZA",
+  "es-ES",
+  "sv-SE",
+  "fr-CH",
+  "de-CH",
+  "zh-TW",
+  "tr-TR",
+  "en-GB",
+  "en-US",
+  "es-US",
+]);
+
+const BRAVE_LANG_TO_DEFAULT_LOCALE: Record<string, string> = {
+  en: "en-US",
+  es: "es-ES",
+  fr: "fr-FR",
+  de: "de-DE",
+  pt: "pt-BR",
+  nl: "nl-NL",
+  da: "da-DK",
+  fi: "fi-FI",
+  el: "el-GR",
+  it: "it-IT",
+  ja: "ja-JP",
+  ko: "ko-KR",
+  no: "no-NO",
+  pl: "pl-PL",
+  ru: "ru-RU",
+  sv: "sv-SE",
+  tr: "tr-TR",
+  zh: "zh-CN",
+};
+
 const WebSearchSchema = Type.Object({
   query: Type.String({ description: "Search query string." }),
   count: Type.Optional(
@@ -58,7 +121,8 @@ const WebSearchSchema = Type.Object({
   ),
   ui_lang: Type.Optional(
     Type.String({
-      description: "ISO language code for UI elements.",
+      description:
+        "Locale code for UI elements (e.g., 'en-US', 'de-DE', 'fr-FR'). Must be a language-country pair, not a bare language code.",
     }),
   ),
   freshness: Type.Optional(
@@ -404,6 +468,28 @@ function normalizeFreshness(value: string | undefined): string | undefined {
 }
 
 /**
+ * Normalize a ui_lang value for the Brave Search API.
+ * Accepts full locale codes (e.g. "en-US") or bare language codes (e.g. "en")
+ * and maps them to a valid Brave locale. Returns undefined for unrecognized values.
+ */
+function normalizeBraveUiLang(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (BRAVE_UI_LANGS.has(trimmed)) {
+    return trimmed;
+  }
+
+  const lower = trimmed.toLowerCase();
+  return BRAVE_LANG_TO_DEFAULT_LOCALE[lower];
+}
+
+/**
  * Map normalized freshness values (pd/pw/pm/py) to Perplexity's
  * search_recency_filter values (day/week/month/year).
  */
@@ -651,7 +737,10 @@ async function runWebSearch(params: {
     url.searchParams.set("search_lang", params.search_lang);
   }
   if (params.ui_lang) {
-    url.searchParams.set("ui_lang", params.ui_lang);
+    const normalized = normalizeBraveUiLang(params.ui_lang);
+    if (normalized) {
+      url.searchParams.set("ui_lang", normalized);
+    }
   }
   if (params.freshness) {
     url.searchParams.set("freshness", params.freshness);
@@ -798,6 +887,7 @@ export const __testing = {
   isDirectPerplexityBaseUrl,
   resolvePerplexityRequestModel,
   normalizeFreshness,
+  normalizeBraveUiLang,
   freshnessToPerplexityRecency,
   resolveGrokApiKey,
   resolveGrokModel,

--- a/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
@@ -111,11 +111,21 @@ describe("web_search country and language parameters", () => {
   it.each([
     { key: "country", value: "DE" },
     { key: "search_lang", value: "de" },
-    { key: "ui_lang", value: "de" },
+    { key: "ui_lang", value: "de-DE" },
     { key: "freshness", value: "pw" },
   ])("passes $key parameter to Brave API", async ({ key, value }) => {
     const url = await runBraveSearchAndGetUrl({ [key]: value });
     expect(url.searchParams.get(key)).toBe(value);
+  });
+
+  it("normalizes bare ui_lang codes to full locale for Brave API", async () => {
+    const url = await runBraveSearchAndGetUrl({ ui_lang: "en" });
+    expect(url.searchParams.get("ui_lang")).toBe("en-US");
+  });
+
+  it("drops unrecognized ui_lang values", async () => {
+    const url = await runBraveSearchAndGetUrl({ ui_lang: "xx" });
+    expect(url.searchParams.has("ui_lang")).toBe(false);
   });
 
   it("rejects invalid freshness values", async () => {


### PR DESCRIPTION
## Problem

The `web_search` tool sends bare language codes (e.g. `en`) as the `ui_lang` parameter to the Brave Search API, which only accepts locale codes (e.g. `en-US`). This causes a 422 validation error, completely breaking web search for Brave users.

Reported in #18795.

## Solution

- Add `normalizeBraveUiLang()` that validates `ui_lang` against Brave's accepted locale set
- Map bare language codes to their default locale (e.g. `en` → `en-US`, `de` → `de-DE`)
- Silently drop unrecognized values instead of forwarding them to cause API errors
- Update the tool schema description to clarify the expected format (locale code, not bare language code)

## Test Plan

- Added unit tests for `normalizeBraveUiLang`: valid locales pass through, bare codes get mapped, unrecognized values return undefined, whitespace is trimmed
- Updated integration test: verified bare `ui_lang` codes are normalized in the actual Brave API URL, and unrecognized values are omitted
- All 57 tests pass (`npx vitest run --config vitest.e2e.config.ts src/agents/tools/web-search.e2e.test.ts src/agents/tools/web-tools.enabled-defaults.e2e.test.ts`)

Closes #18795

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Brave Search API 422 errors caused by sending bare language codes (e.g., `en`) as `ui_lang` instead of required locale codes (e.g., `en-US`). Adds a `normalizeBraveUiLang()` function that validates against Brave's accepted locale set, maps common bare language codes to default locales, and silently drops unrecognized values.

- Adds `BRAVE_UI_LANGS` set (38 valid locales) and `BRAVE_LANG_TO_DEFAULT_LOCALE` mapping (18 bare codes → locales) as module-level constants
- Applies normalization at the Brave API call site, only setting `ui_lang` when a valid locale is resolved
- Updates schema description to clarify the expected locale format
- Comprehensive unit and integration tests covering pass-through, mapping, rejection, and edge cases
- Minor optimization opportunity: the cache key at line 658 uses the raw `ui_lang` rather than the normalized value, which can cause redundant API calls for equivalent inputs (e.g., `"en"` and `"en-US"` produce different cache keys despite resolving to the same request)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a real API validation error with a well-tested normalization function.
- The fix is focused and correct: it adds input normalization that prevents 422 errors from the Brave Search API. The locale set and bare-code mapping are accurate. Tests are thorough. The only minor issue is that the cache key uses the raw ui_lang value, which is a small optimization miss rather than a correctness bug.
- `src/agents/tools/web-search.ts` — cache key construction at line 658 uses raw `ui_lang` instead of normalized value.

<sub>Last reviewed commit: 80117a0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->