### PR TITLE
fix(security): tighten permissions for cron/, browser/, settings/ in doctor --fix

### DIFF
--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -242,4 +242,41 @@ describe("security fix", () => {
     expectPerms((await fs.stat(transcriptPath)).mode & 0o777, 0o600);
     expectPerms((await fs.stat(includePath)).mode & 0o777, 0o600);
   });
+
+  it("tightens perms for cron, browser, and settings directories", async () => {
+    const stateDir = await createStateDir("sensitive-dirs");
+    await fs.chmod(stateDir, 0o755);
+
+    const configPath = path.join(stateDir, "openclaw.json");
+    await writeJsonConfig(configPath, {});
+    await fs.chmod(configPath, 0o644);
+
+    const cronDir = path.join(stateDir, "cron");
+    await fs.mkdir(cronDir, { recursive: true });
+    await fs.chmod(cronDir, 0o755);
+    const jobsPath = path.join(cronDir, "jobs.json");
+    await fs.writeFile(jobsPath, "{}\n", "utf-8");
+    await fs.chmod(jobsPath, 0o644);
+    const jobsBakPath = path.join(cronDir, "jobs.json.bak");
+    await fs.writeFile(jobsBakPath, "{}\n", "utf-8");
+    await fs.chmod(jobsBakPath, 0o644);
+
+    const browserDir = path.join(stateDir, "browser");
+    await fs.mkdir(browserDir, { recursive: true });
+    await fs.chmod(browserDir, 0o755);
+
+    const settingsDir = path.join(stateDir, "settings");
+    await fs.mkdir(settingsDir, { recursive: true });
+    await fs.chmod(settingsDir, 0o755);
+
+    const env = createFixEnv(stateDir, configPath);
+    const res = await fixSecurityFootguns({ env, stateDir, configPath });
+    expect(res.ok).toBe(true);
+
+    expectPerms((await fs.stat(cronDir)).mode & 0o777, 0o700);
+    expectPerms((await fs.stat(jobsPath)).mode & 0o777, 0o600);
+    expectPerms((await fs.stat(jobsBakPath)).mode & 0o777, 0o600);
+    expectPerms((await fs.stat(browserDir)).mode & 0o777, 0o700);
+    expectPerms((await fs.stat(settingsDir)).mode & 0o777, 0o700);
+  });
 });

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -451,6 +451,17 @@ export async function fixSecurityFootguns(opts?: {
     }
   }
 
+  for (const dir of ["cron", "browser", "settings"]) {
+    // eslint-disable-next-line no-await-in-loop
+    actions.push(await applyPerms({ path: path.join(stateDir, dir), mode: 0o700, require: "dir" }));
+  }
+  for (const file of ["cron/jobs.json", "cron/jobs.json.bak"]) {
+    // eslint-disable-next-line no-await-in-loop
+    actions.push(
+      await applyPerms({ path: path.join(stateDir, file), mode: 0o600, require: "file" }),
+    );
+  }
+
   await chmodCredentialsAndAgentState({
     env,
     stateDir,


### PR DESCRIPTION
## Problem

`openclaw doctor --fix` secures `stateDir`, `configPath`, `credentials/`, and `agents/*/sessions/` but misses `cron/`, `browser/`, and `settings/` directories. These contain sensitive data:

- `cron/jobs.json` — scheduled task details including payload/message content
- `browser/` — session state and cookies
- `settings/` — user settings

These directories are created with default permissions (755/644) and never tightened, leaving them world-readable even after running `doctor --fix`.

Reported in #18866, root cause confirmed by community analysis in the comments.

## Solution

Add `applyPerms` calls in `fixSecurityFootguns` for:
- `cron/` → 700
- `cron/jobs.json` → 600
- `cron/jobs.json.bak` → 600
- `browser/` → 700
- `settings/` → 700

Uses the existing `applyPerms` closure which handles both Unix (`chmod`) and Windows (`icacls`) platforms, and gracefully skips missing paths.

## Test Plan

- Added test case "tightens perms for cron, browser, and settings directories" that creates all three directories with 755 and files with 644, runs `fixSecurityFootguns`, and asserts directories are 700 and files are 600
- All 6 tests pass (`npx vitest run src/security/fix.test.ts`)

Closes #18866

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds permission tightening for `cron/`, `browser/`, and `settings/` directories in `openclaw doctor --fix`. These directories contain sensitive data (scheduled task details, browser session state/cookies, and user settings) that were previously left world-readable with default permissions (755/644).

The implementation uses the existing `applyPerms` closure pattern, which handles both Unix (`chmod`) and Windows (`icacls`) platforms and gracefully skips missing paths. Test coverage validates that directories are set to 700 and files to 600 after running the security fix.

**Changes:**
- Secures `cron/`, `browser/`, and `settings/` directories (700)
- Secures `cron/jobs.json` and `cron/jobs.json.bak` files (600)
- Adds comprehensive test coverage for the new permission fixes

This is a targeted security hardening fix that closes a gap in the existing `doctor --fix` security tooling.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security improvement
- Score reflects that the implementation is clean, follows established patterns, and includes proper test coverage. The main concern is the incomplete coverage mentioned in the previous thread (`cron/runs/` subdirectory is not secured), but this doesn't introduce new vulnerabilities - it's an incremental improvement that addresses part of the security gap reported in #18866
- No files require special attention - the implementation is straightforward and follows existing patterns

<sub>Last reviewed commit: bc5aae0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->