### PR TITLE
feat(ui): treat 'btw' as addendum while chat is busy

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { handleSendChat, type ChatHost } from "./app-chat.ts";
+
+function createHost(overrides: Partial<ChatHost> = {}): ChatHost {
+  return {
+    connected: true,
+    chatMessage: "",
+    chatAttachments: [],
+    chatQueue: [],
+    chatRunId: null,
+    chatSending: false,
+    sessionKey: "main",
+    basePath: "",
+    hello: null,
+    chatAvatarUrl: null,
+    refreshSessionsAfterChat: new Set(),
+    ...overrides,
+  };
+}
+
+describe("chat addendum queue", () => {
+  it("queues 'btw' messages as addendums (front of queue) when busy", async () => {
+    const host = createHost({
+      chatRunId: "run-1",
+      chatMessage: "btw: also, it is in vlan 66",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatQueue).toHaveLength(1);
+    expect(host.chatQueue[0]?.kind).toBe("addendum");
+    expect(host.chatQueue[0]?.text).toBe("also, it is in vlan 66");
+    expect(host.chatMessage).toBe("");
+    expect(host.chatAttachments).toEqual([]);
+  });
+
+  it("inserts addendums ahead of already-queued normal messages", async () => {
+    const host = createHost({
+      chatRunId: "run-1",
+      chatQueue: [
+        {
+          id: "q-1",
+          kind: "message",
+          text: "next question",
+          createdAt: 1,
+        },
+      ],
+      chatMessage: "btw - one more detail",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatQueue).toHaveLength(2);
+    expect(host.chatQueue[0]?.kind).toBe("addendum");
+    expect(host.chatQueue[0]?.text).toBe("one more detail");
+    expect(host.chatQueue[1]?.text).toBe("next question");
+  });
+
+  it("merges consecutive addendums into a single queued addendum", async () => {
+    const host = createHost({
+      chatRunId: "run-1",
+      chatQueue: [
+        {
+          id: "a-1",
+          kind: "addendum",
+          text: "first addendum",
+          createdAt: 1,
+        },
+      ],
+      chatMessage: "btw second addendum",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatQueue).toHaveLength(1);
+    expect(host.chatQueue[0]?.kind).toBe("addendum");
+    expect(host.chatQueue[0]?.text).toBe("first addendum\n\nsecond addendum");
+  });
+});

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -4,10 +4,13 @@ export type ChatAttachment = {
   mimeType: string;
 };
 
+export type ChatQueueItemKind = "message" | "addendum";
+
 export type ChatQueueItem = {
   id: string;
   text: string;
   createdAt: number;
+  kind?: ChatQueueItemKind;
   attachments?: ChatAttachment[];
   refreshSessions?: boolean;
 };

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -330,10 +330,15 @@ export function renderChat(props: ChatProps) {
                   (item) => html`
                     <div class="chat-queue__item">
                       <div class="chat-queue__text">
-                        ${
-                          item.text ||
-                          (item.attachments?.length ? `Image (${item.attachments.length})` : "")
-                        }
+                        ${(() => {
+                          const label =
+                            item.text ||
+                            (item.attachments?.length ? `Image (${item.attachments.length})` : "");
+                          if (!label) {
+                            return "";
+                          }
+                          return item.kind === "addendum" ? `Addendum: ${label}` : label;
+                        })()}
                       </div>
                       <button
                         class="btn chat-queue__remove"


### PR DESCRIPTION
## What
When the control UI already has an active run in progress, messages that start with "btw" are treated as *addenda* to the in-flight request instead of being queued as a new independent message.

## Behavior
- Recognizes case-insensitive prefixes: `btw`, `btw:`, `btw,`, `btw -`
- Strips the prefix + optional punctuation
- Enqueues the addendum at the **front** of the queue (ahead of already-queued normal messages) so context arrives before any later questions
- Merges consecutive addendums into a single queue item (separated by a blank line)
- Labels addendum queue items as `Addendum: ...` in the queue widget
- If not busy, or the message is just `btw` with no body (and no attachments), falls back to normal enqueue behavior

## Notes
- Adds `ChatQueueItemKind = 'message' | 'addendum'` (optional `kind` for backwards compatibility)
- Adds unit tests for the addendum queue logic

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an addendum queue feature that treats messages starting with "btw" as context additions to in-flight chat requests rather than separate messages. When the chat is busy, `btw`-prefixed messages are inserted at the front of the queue and consecutive addendums are merged with blank line separators. The UI labels these as "Addendum: ..." in the queue widget.

Key changes:
- Added `ChatQueueItemKind` type (`'message' | 'addendum'`) with optional `kind` field for backwards compatibility
- Implemented `parseBtwAddendum()` to detect `btw`, `btw:`, `btw,`, `btw -` prefixes (case-insensitive)
- Implemented `enqueueChatAddendum()` to insert at queue front and merge consecutive addendums
- Updated queue rendering to display "Addendum:" prefix for addendum items
- Added comprehensive unit tests covering main scenarios

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one known issue already identified
- The implementation is clean, well-tested, and follows existing patterns. The multiline regex issue was already identified in previous review threads. The feature adds new functionality without breaking existing behavior due to the optional `kind` field for backwards compatibility. Type definitions are properly updated and the UI changes are minimal and focused.
- No files require special attention beyond the already-noted multiline regex issue in `ui/src/ui/app-chat.ts`

<sub>Last reviewed commit: 46b7749</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->