### PR TITLE
googlechat: fix runtime.error signature in startup error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ USER.md
 !.agent/workflows/
 /local/
 package-lock.json
+
+.fake

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -538,7 +538,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
     startAccount: async (ctx) => {
       const account = ctx.account;
       ctx.log?.info(`[${account.accountId}] starting Google Chat webhook`);
-      
+
       try {
         ctx.setStatus({
           accountId: account.accountId,
@@ -548,7 +548,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
           audienceType: account.config.audienceType,
           audience: account.config.audience,
         });
-        
+
         const unregister = await startGoogleChatMonitor({
           account,
           config: ctx.cfg,
@@ -558,9 +558,9 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
           webhookUrl: account.config.webhookUrl,
           statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
         });
-        
+
         ctx.log?.info(`[${account.accountId}] Google Chat webhook started successfully`);
-        
+
         return () => {
           unregister?.();
           ctx.setStatus({
@@ -572,19 +572,19 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         const errorStack = err instanceof Error ? err.stack : undefined;
-        
-        ctx.log?.error(
-          `[${account.accountId}] Google Chat channel startup failed: ${errorMsg}`,
-          errorStack ? { stack: errorStack } : undefined,
-        );
-        
+        const fullMessage = errorStack
+          ? `[${account.accountId}] Google Chat channel startup failed: ${errorMsg}\n${errorStack}`
+          : `[${account.accountId}] Google Chat channel startup failed: ${errorMsg}`;
+
+        ctx.log?.error(fullMessage);
+
         ctx.setStatus({
           accountId: account.accountId,
           running: false,
           lastStopAt: Date.now(),
           lastError: errorMsg,
         });
-        
+
         // Return a no-op cleanup function so the gateway doesn't crash
         return () => {
           ctx.log?.info(`[${account.accountId}] Google Chat cleanup (failed startup)`);

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -943,19 +943,19 @@ export function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): ()
 
     const audienceType = normalizeAudienceType(options.account.config.audienceType);
     const audience = options.account.config.audience?.trim();
-    
+
     if (!audienceType) {
       const errMsg = `[${options.account.accountId}] audienceType is required (app-url or project-number)`;
       options.runtime.error?.(errMsg);
       throw new Error(errMsg);
     }
-    
+
     if (!audience) {
       const errMsg = `[${options.account.accountId}] audience is required`;
       options.runtime.error?.(errMsg);
       throw new Error(errMsg);
     }
-    
+
     const mediaMaxMb = options.account.config.mediaMaxMb ?? 20;
 
     const unregister = registerGoogleChatWebhookTarget({
@@ -974,10 +974,10 @@ export function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): ()
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
     const errorStack = err instanceof Error ? err.stack : undefined;
-    options.runtime.error?.(
-      `[${options.account.accountId}] Failed to initialize Google Chat monitor: ${errorMsg}`,
-      errorStack ? { stack: errorStack } : undefined,
-    );
+    const fullMessage = errorStack
+      ? `[${options.account.accountId}] Failed to initialize Google Chat monitor: ${errorMsg}\n${errorStack}`
+      : `[${options.account.accountId}] Failed to initialize Google Chat monitor: ${errorMsg}`;
+    options.runtime.error?.(fullMessage);
     // Re-throw so startAccount can handle it
     throw err;
   }
@@ -992,10 +992,10 @@ export async function startGoogleChatMonitor(
     // Log and re-throw so the caller (startAccount) can handle it
     const errorMsg = err instanceof Error ? err.message : String(err);
     const errorStack = err instanceof Error ? err.stack : undefined;
-    params.runtime.error?.(
-      `[${params.account.accountId}] startGoogleChatMonitor failed: ${errorMsg}`,
-      errorStack ? { stack: errorStack } : undefined,
-    );
+    const fullMessage = errorStack
+      ? `[${params.account.accountId}] startGoogleChatMonitor failed: ${errorMsg}\n${errorStack}`
+      : `[${params.account.accountId}] startGoogleChatMonitor failed: ${errorMsg}`;
+    params.runtime.error?.(fullMessage);
     throw err;
   }
 }

--- a/hs_err_pid37672.log
+++ b/hs_err_pid37672.log
@@ -1,0 +1,358 @@
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (malloc) failed to allocate 1048576 bytes. Error detail: AllocateHeap
+# Possible reasons:
+#   The system is out of physical RAM or swap space
+#   This process is running with CompressedOops enabled, and the Java Heap may be blocking the growth of the native heap
+# Possible solutions:
+#   Reduce memory load on the system
+#   Increase physical memory or swap space
+#   Check if swap backing store is full
+#   Decrease Java heap size (-Xmx/-Xms)
+#   Decrease number of Java threads
+#   Decrease Java thread stack sizes (-Xss)
+#   Set larger code cache with -XX:ReservedCodeCacheSize=
+#   JVM is running with Unscaled Compressed Oops mode in which the Java heap is
+#     placed in the first 4GB address space. The Java Heap base address is the
+#     maximum limit for the native heap growth. Please use -XX:HeapBaseMinAddress
+#     to set the Java Heap base and to place the Java Heap above 4GB virtual address.
+# This output file may be truncated or incomplete.
+#
+#  Out of Memory Error (allocation.cpp:44), pid=37672, tid=48180
+#
+# JRE version:  (21.0.9+10) (build )
+# Java VM: OpenJDK 64-Bit Server VM (21.0.9+10-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, parallel gc, windows-amd64)
+# No core dump will be written. Minidumps are not enabled by default on client versions of Windows
+#
+
+---------------  S U M M A R Y ------------
+
+Command Line: --add-modules=ALL-SYSTEM --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Djava.import.generatesMetadataFilesAtProjectRoot=false -DDetectVMInstallationsJob.disabled=true -Dfile.encoding=utf8 -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable -javaagent:d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\lombok\lombok-1.18.39-4050.jar -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=d:\Apps\VSCode\data\user-data\User\workspaceStorage\6757c41021d0bb3bb0ebe045b38cf3cb\redhat.java -Daether.dependencyCollector.impl=bf d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\server\plugins\org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar -configuration d:\Apps\VSCode\data\user-data\User\globalStorage\redhat.java\1.52.0\config_win -data d:\Apps\VSCode\data\user-data\User\workspaceStorage\6757c41021d0bb3bb0ebe045b38cf3cb\redhat.java\jdt_ws --pipe=\\.\pipe\lsp-68f201defebcdf987cf934c9d0db98c9-sock
+
+Host: 12th Gen Intel(R) Core(TM) i7-12650H, 16 cores, 39G,  Windows 11 , 64 bit Build 26100 (10.0.26100.7705)
+Time: Sun Feb 15 05:16:09 2026 Pacific Standard Time elapsed time: 1.186375 seconds (0d 0h 0m 1s)
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x000001405a521980):  JavaThread "Unknown thread" [_thread_in_vm, id=48180, stack(0x000000022ca00000,0x000000022cb00000) (1024K)]
+
+Stack: [0x000000022ca00000,0x000000022cb00000]
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+V  [jvm.dll+0x6d6e29]
+V  [jvm.dll+0x8b4b76]
+V  [jvm.dll+0x8b712e]
+V  [jvm.dll+0x8b7813]
+V  [jvm.dll+0x283d86]
+V  [jvm.dll+0xc1277]
+V  [jvm.dll+0x71457d]
+V  [jvm.dll+0x714c3c]
+V  [jvm.dll+0x6e59c8]
+V  [jvm.dll+0x87e58c]
+V  [jvm.dll+0x3c42fc]
+V  [jvm.dll+0x86727b]
+V  [jvm.dll+0x457391]
+V  [jvm.dll+0x458f81]
+C  [jli.dll+0x52d0]
+C  [ucrtbase.dll+0x37b0]
+C  [KERNEL32.DLL+0x2e8d7]
+C  [ntdll.dll+0x8c40c]
+
+
+---------------  P R O C E S S  ---------------
+
+Threads class SMR info:
+_java_thread_list=0x000001405a54ab10, length=1, elements={
+0x000001405a521980
+}
+
+Java Threads: ( => current thread )
+=>0x000001405a521980 JavaThread "Unknown thread"             [_thread_in_vm, id=48180, stack(0x000000022ca00000,0x000000022cb00000) (1024K)]
+Total: 1
+
+Other Threads:
+  0x000001405a3aca00 WatcherThread "VM Periodic Task Thread"        [id=46328, stack(0x000000022cc00000,0x000000022cd00000) (1024K)]
+  0x000001405a53ef40 WorkerThread "GC Thread#0"                     [id=26388, stack(0x000000022cb00000,0x000000022cc00000) (1024K)]
+Total: 2
+
+Threads with active compile tasks:
+Total: 0
+
+VM state: not at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread: None
+
+Heap address: 0x0000000080000000, size: 2048 MB, Compressed Oops mode: 32-bit
+
+CDS archive(s) mapped at: [0x0000014000000000-0x0000014000ba0000-0x0000014000ba0000), size 12189696, SharedBaseAddress: 0x0000014000000000, ArchiveRelocationMode: 1.
+Compressed class space mapped at: 0x0000014001000000-0x0000014041000000, reserved size: 1073741824
+Narrow klass base: 0x0000014000000000, Narrow klass shift: 0, Narrow klass range: 0x100000000
+
+GC Precious Log:
+ CardTable entry size: 512
+ CPUs: 16 total, 16 available
+ Memory: 40581M
+ Large Page Support: Disabled
+ NUMA Support: Disabled
+ Compressed Oops: Enabled (32-bit)
+ Alignments: Space 512K, Generation 512K, Heap 2M
+ Heap Min Capacity: 100M
+ Heap Initial Capacity: 100M
+ Heap Max Capacity: 2G
+ Pre-touch: Disabled
+ Parallel Workers: 13
+
+Heap:
+ PSYoungGen      total 29696K, used 512K [0x00000000d5580000, 0x00000000d7680000, 0x0000000100000000)
+  eden space 25600K, 2% used [0x00000000d5580000,0x00000000d5600020,0x00000000d6e80000)
+  from space 4096K, 0% used [0x00000000d7280000,0x00000000d7280000,0x00000000d7680000)
+  to   space 4096K, 0% used [0x00000000d6e80000,0x00000000d6e80000,0x00000000d7280000)
+ ParOldGen       total 68608K, used 0K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 0% used [0x0000000080000000,0x0000000080000000,0x0000000084300000)
+ Metaspace       used 0K, committed 0K, reserved 1048576K
+  class space    used 0K, committed 0K, reserved 1048576K
+
+Card table byte_map: [0x0000014059ec0000,0x000001405a2d0000] _byte_map_base: 0x0000014059ac0000
+
+Marking Bits: (ParMarkBitMap*) 0x00007fffa5b02460
+ Begin Bits: [0x000001406c9d0000, 0x000001406e9d0000)
+ End Bits:   [0x000001406e9d0000, 0x00000140709d0000)
+
+Polling page: 0x0000014058140000
+
+Metaspace:
+
+Usage:
+  Non-class:      0 bytes used.
+      Class:      0 bytes used.
+       Both:      0 bytes used.
+
+Virtual space:
+  Non-class space:        0 bytes reserved,       0 bytes (  ?%) committed,  0 nodes.
+      Class space:        1.00 GB reserved,       0 bytes (  0%) committed,  1 nodes.
+             Both:        1.00 GB reserved,       0 bytes (  0%) committed. 
+
+Chunk freelists:
+   Non-Class:  0 bytes
+       Class:  16.00 MB
+        Both:  16.00 MB
+
+MaxMetaspaceSize: unlimited
+CompressedClassSpaceSize: 1.00 GB
+Initial GC threshold: 21.00 MB
+Current GC threshold: 17179869184.00 GB
+CDS: on
+ - commit_granule_bytes: 65536.
+ - commit_granule_words: 8192.
+ - virtual_space_node_default_size: 8388608.
+ - enlarge_chunks_in_place: 1.
+ - use_allocation_guard: 0.
+
+
+Internal statistics:
+
+num_allocs_failed_limit: 0.
+num_arena_births: 0.
+num_arena_deaths: 0.
+num_vsnodes_births: 1.
+num_vsnodes_deaths: 0.
+num_space_committed: 0.
+num_space_uncommitted: 0.
+num_chunks_returned_to_freelist: 0.
+num_chunks_taken_from_freelist: 1.
+num_chunk_merges: 0.
+num_chunk_splits: 1.
+num_chunks_enlarged: 0.
+num_inconsistent_stats: 0.
+
+CodeHeap 'non-profiled nmethods': size=119168Kb used=0Kb max_used=0Kb free=119168Kb
+ bounds [0x00000140652c0000, 0x0000014065530000, 0x000001406c720000]
+CodeHeap 'profiled nmethods': size=119104Kb used=0Kb max_used=0Kb free=119104Kb
+ bounds [0x000001405d720000, 0x000001405d990000, 0x0000014064b70000]
+CodeHeap 'non-nmethods': size=7488Kb used=194Kb max_used=342Kb free=7293Kb
+ bounds [0x0000014064b70000, 0x0000014064de0000, 0x00000140652c0000]
+CodeCache: size=245760Kb, used=194Kb, max_used=342Kb, free=245565Kb
+ total_blobs=70, nmethods=0, adapters=48, full_count=0
+Compilation: enabled, stopped_count=0, restarted_count=0
+
+Compilation events (0 events):
+No events
+
+GC Heap History (0 events):
+No events
+
+Dll operation events (1 events):
+Event: 0.084 Loaded shared library d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\java.dll
+
+Deoptimization events (0 events):
+No events
+
+Classes loaded (0 events):
+No events
+
+Classes unloaded (0 events):
+No events
+
+Classes redefined (0 events):
+No events
+
+Internal exceptions (0 events):
+No events
+
+ZGC Phase Switch (0 events):
+No events
+
+VM Operations (0 events):
+No events
+
+Memory protections (0 events):
+No events
+
+Nmethod flushes (0 events):
+No events
+
+Events (1 events):
+Event: 0.095 Thread 0x000001405a521980 Thread added: 0x000001405a521980
+
+
+Dynamic libraries:
+0x00007ff721930000 - 0x00007ff72193e000 	d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\java.exe
+0x00007ff89f9c0000 - 0x00007ff89fc28000 	C:\WINDOWS\SYSTEM32\ntdll.dll
+0x00007ff89e920000 - 0x00007ff89e9e9000 	C:\WINDOWS\System32\KERNEL32.DLL
+0x00007ff89c380000 - 0x00007ff89c771000 	C:\WINDOWS\System32\KERNELBASE.dll
+0x00007ff89c830000 - 0x00007ff89c97b000 	C:\WINDOWS\System32\ucrtbase.dll
+0x00007ff8634d0000 - 0x00007ff8634e8000 	d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\jli.dll
+0x00007ff8634f0000 - 0x00007ff86350e000 	d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\VCRUNTIME140.dll
+0x00007ff89f2c0000 - 0x00007ff89f486000 	C:\WINDOWS\System32\USER32.dll
+0x00007ff883ef0000 - 0x00007ff884183000 	C:\WINDOWS\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.7824_none_3e0870b2e3345462\COMCTL32.dll
+0x00007ff89c2a0000 - 0x00007ff89c2c7000 	C:\WINDOWS\System32\win32u.dll
+0x00007ff89f210000 - 0x00007ff89f2b9000 	C:\WINDOWS\System32\msvcrt.dll
+0x00007ff89e8e0000 - 0x00007ff89e90b000 	C:\WINDOWS\System32\GDI32.dll
+0x00007ff89d570000 - 0x00007ff89d69b000 	C:\WINDOWS\System32\gdi32full.dll
+0x00007ff89c780000 - 0x00007ff89c823000 	C:\WINDOWS\System32\msvcp_win.dll
+0x00007ff89f760000 - 0x00007ff89f791000 	C:\WINDOWS\System32\IMM32.DLL
+0x00007ff86f8d0000 - 0x00007ff86f8dc000 	d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\vcruntime140_1.dll
+0x00007ff863000000 - 0x00007ff86308d000 	d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\msvcp140.dll
+0x00007fffa4e40000 - 0x00007fffa5be0000 	d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\server\jvm.dll
+0x00007ff89dd10000 - 0x00007ff89ddc4000 	C:\WINDOWS\System32\ADVAPI32.dll
+0x00007ff89f5b0000 - 0x00007ff89f656000 	C:\WINDOWS\System32\sechost.dll
+0x00007ff89f490000 - 0x00007ff89f5a8000 	C:\WINDOWS\System32\RPCRT4.dll
+0x00007ff89e760000 - 0x00007ff89e7d4000 	C:\WINDOWS\System32\WS2_32.dll
+0x00007ff89ae70000 - 0x00007ff89aece000 	C:\WINDOWS\SYSTEM32\POWRPROF.dll
+0x00007ff88fc70000 - 0x00007ff88fca5000 	C:\WINDOWS\SYSTEM32\WINMM.dll
+0x00007ff891f40000 - 0x00007ff891f4b000 	C:\WINDOWS\SYSTEM32\VERSION.dll
+0x00007ff89ae50000 - 0x00007ff89ae64000 	C:\WINDOWS\SYSTEM32\UMPDC.dll
+0x00007ff89b120000 - 0x00007ff89b13b000 	C:\WINDOWS\SYSTEM32\kernel.appcore.dll
+0x00007ff86cb40000 - 0x00007ff86cb4a000 	d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\jimage.dll
+0x00007ff89a160000 - 0x00007ff89a3a2000 	C:\WINDOWS\SYSTEM32\DBGHELP.DLL
+0x00007ff89deb0000 - 0x00007ff89e236000 	C:\WINDOWS\System32\combase.dll
+0x00007ff89ddd0000 - 0x00007ff89dea7000 	C:\WINDOWS\System32\OLEAUT32.dll
+0x00007ff883880000 - 0x00007ff8838bb000 	C:\WINDOWS\SYSTEM32\dbgcore.DLL
+0x00007ff89c2d0000 - 0x00007ff89c375000 	C:\WINDOWS\System32\bcryptPrimitives.dll
+0x00007ff863460000 - 0x00007ff86346f000 	d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\instrument.dll
+0x00007ff8634b0000 - 0x00007ff8634d0000 	d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\java.dll
+
+JVMTI agents:
+d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\lombok\lombok-1.18.39-4050.jar path:none, loaded, not initialized, instrumentlib options:none
+
+dbghelp: loaded successfully - version: 4.0.5 - missing functions: none
+symbol engine: initialized successfully - sym options: 0x614 - pdb path: .;d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin;C:\WINDOWS\SYSTEM32;C:\WINDOWS\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.7824_none_3e0870b2e3345462;d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\jre\21.0.9-win32-x86_64\bin\server
+
+VM Arguments:
+jvm_args: --add-modules=ALL-SYSTEM --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Djava.import.generatesMetadataFilesAtProjectRoot=false -DDetectVMInstallationsJob.disabled=true -Dfile.encoding=utf8 -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable -javaagent:d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\lombok\lombok-1.18.39-4050.jar -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=d:\Apps\VSCode\data\user-data\User\workspaceStorage\6757c41021d0bb3bb0ebe045b38cf3cb\redhat.java -Daether.dependencyCollector.impl=bf 
+java_command: d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\server\plugins\org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar -configuration d:\Apps\VSCode\data\user-data\User\globalStorage\redhat.java\1.52.0\config_win -data d:\Apps\VSCode\data\user-data\User\workspaceStorage\6757c41021d0bb3bb0ebe045b38cf3cb\redhat.java\jdt_ws --pipe=\\.\pipe\lsp-68f201defebcdf987cf934c9d0db98c9-sock
+java_class_path (initial): d:\Apps\VSCode\data\extensions\redhat.java-1.52.0-win32-x64\server\plugins\org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar
+Launcher Type: SUN_STANDARD
+
+[Global flags]
+    uintx AdaptiveSizePolicyWeight                 = 90                                        {product} {command line}
+     intx CICompilerCount                          = 12                                        {product} {ergonomic}
+    uintx GCTimeRatio                              = 4                                         {product} {command line}
+     bool HeapDumpOnOutOfMemoryError               = true                                   {manageable} {command line}
+    ccstr HeapDumpPath                             = d:\Apps\VSCode\data\user-data\User\workspaceStorage\6757c41021d0bb3bb0ebe045b38cf3cb\redhat.java         {manageable} {command line}
+   size_t InitialHeapSize                          = 104857600                                 {product} {command line}
+   size_t MaxHeapSize                              = 2147483648                                {product} {command line}
+   size_t MaxNewSize                               = 715653120                                 {product} {ergonomic}
+   size_t MinHeapDeltaBytes                        = 524288                                    {product} {ergonomic}
+   size_t MinHeapSize                              = 104857600                                 {product} {command line}
+   size_t NewSize                                  = 34603008                                  {product} {ergonomic}
+    uintx NonNMethodCodeHeapSize                   = 7602480                                {pd product} {ergonomic}
+    uintx NonProfiledCodeHeapSize                  = 122027880                              {pd product} {ergonomic}
+   size_t OldSize                                  = 70254592                                  {product} {ergonomic}
+    uintx ProfiledCodeHeapSize                     = 122027880                              {pd product} {ergonomic}
+    uintx ReservedCodeCacheSize                    = 251658240                              {pd product} {ergonomic}
+     bool SegmentedCodeCache                       = true                                      {product} {ergonomic}
+   size_t SoftMaxHeapSize                          = 2147483648                             {manageable} {ergonomic}
+     bool UseCompressedOops                        = true                           {product lp64_product} {ergonomic}
+     bool UseLargePagesIndividualAllocation        = false                                  {pd product} {ergonomic}
+     bool UseParallelGC                            = true                                      {product} {command line}
+
+Logging:
+Log output configuration:
+ #0: stdout all=off uptime,level,tags foldmultilines=false
+ #1: stderr all=off uptime,level,tags foldmultilines=false
+
+Release file:
+<release file has not been read>
+Environment Variables:
+JAVA_HOME=C:\Program Files\Java\jdk-1.8
+PATH=D:\Program Files\Python314\Scripts\;D:\Program Files\Python314\;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\libnvvp;C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin;D::\Python312\Scripts\;D:\Python312\;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\libnvvp;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn\;C:\Program Files\Microsoft SQL Server\150\Tools\Binn\;C:\Program Files\dotnet\;C:\Program Files\Git\cmd;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Program Files\NVIDIA Corporation\NVIDIA NvDLISR;C:\ProgramData\chocolatey\bin;C:\Program Files\Maven\apache-maven-3.9.6\bin;C:\Program Files\Java\jdk-1.8\bin;C:\Python27;C:\Users\Mark\AppData\Roaming\nvm;C:\Program Files\nodejs;c:\Users\Mark\AppData\Local\Programs\cursor\resources\app\bin;C:\Program Files\PuTTY\;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Amazon\AWSCLI\bin\;C:\Program Files\GitHub CLI\;C:\Program Files\Docker\Docker\resources\bin;D:\Apps\Java17\bin;C:\Users\Mark\.console-ninja\.bin;C:\Users\Mark\scoop\shims;C:\Users\Mark\.dotnet\tools;C:\Users\Mark\AppData\Local\Programs\Microsoft VS Code\bin;D:\Python312\Lib\site-packages\numpy\f2py;C:\Users\Mark\AppData\Local\Programs\Ollama;C:\Users\Mark\AppData\Local\GitHubDesktop\bin;C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2024.1.1\bin;C:\Program Files (x86)\mongosh-2.2.6-win32-x64\bin;C:\Program Files\Maven\apache-maven-3.9.6\apache-maven\src\bin;C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.2\bin;C:\Program Files\JetBrains\WebStorm 2024.1.3\bin;C:\Users\Mark\AppData\Roaming\nvm;C:\Program Files\nodejs;C:\Users\Mark\AppData\Local\Microsoft\WinGet\Links;C:\Program Files (x86)\chromedriver-win64;C:\Users\Mark\.deno\bin;C:\Users\Mark\.bun\bin;C:\Users\Mark\AppData\Local\Microsoft\WindowsApps;D:\Python312;c:\users\mark\.local\bin;c:\users\mark\.local\bin;C:\Users\Mark\AppData\Local\Pandoc\;d:\python312\Scripts;
+USERNAME=Mark
+OS=Windows_NT
+PROCESSOR_IDENTIFIER=Intel64 Family 6 Model 154 Stepping 3, GenuineIntel
+TMP=C:\Users\Mark\AppData\Local\Temp
+TEMP=C:\Users\Mark\AppData\Local\Temp
+
+
+
+
+Periodic native trim disabled
+
+---------------  S Y S T E M  ---------------
+
+OS:
+ Windows 11 , 64 bit Build 26100 (10.0.26100.7705)
+OS uptime: 4 days 2:41 hours
+Hyper-V role detected
+
+CPU: total 16 (initial active 16) (8 cores per cpu, 2 threads per core) family 6 model 154 stepping 3 microcode 0x41c, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, sha, fma, vzeroupper, clflush, clflushopt, clwb, hv, serialize, rdtscp, rdpid, fsrm, f16c, cet_ibt, cet_ss
+Processor Information for processor 0
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 1
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 2
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 3
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 4
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 5
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 6
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 7
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 8
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 9
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 10
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 11
+  Max Mhz: 2300, Current Mhz: 2300, Mhz Limit: 2300
+Processor Information for processor 12
+  Max Mhz: 2300, Current Mhz: 1500, Mhz Limit: 1679
+Processor Information for processor 13
+  Max Mhz: 2300, Current Mhz: 1500, Mhz Limit: 1679
+Processor Information for processor 14
+  Max Mhz: 2300, Current Mhz: 1700, Mhz Limit: 1679
+Processor Information for processor 15
+  Max Mhz: 2300, Current Mhz: 1700, Mhz Limit: 1679
+
+Memory: 4k page, system-wide physical 40581M (9501M free)
+TotalPageFile size 50581M (AvailPageFile size 132M)
+current process WorkingSet (physical memory assigned to process): 26M, peak: 26M
+current process commit charge ("private bytes"): 226M, peak: 227M
+
+vm_info: OpenJDK 64-Bit Server VM (21.0.9+10-LTS) for windows-amd64 JRE (21.0.9+10-LTS), built on 2025-10-21T00:00:00Z by "admin" with unknown MS VC++:1942
+
+END.


### PR DESCRIPTION
## Summary

Fixes #18975 - Google Chat channel startup crash due to incorrect error logging signature.

## Changes

Updated error logging calls in Google Chat monitor and channel modules to use the correct single-argument signature for `runtime.error()` and `ctx.log.error()`. Previously, these methods were being called with a second argument containing stack trace metadata, which is not supported by the logging interface.

### Modified Files
- `extensions/googlechat/src/monitor.ts` - Fixed 2 error logging calls in startup error handlers
- `extensions/googlechat/src/channel.ts` - Fixed 1 error logging call in channel startup  

## Testing

- Built and type-checked successfully (`pnpm build`, `pnpm tsgo`)
- All tests passing (`pnpm test extensions/googlechat`)
- Lint/format checks passing (`pnpm check`)
- Gateway starts without errors on local dev environment
- Google Chat webhooks working correctly

## Root Cause

The `RuntimeLogger.error()` type signature only accepts `(message: string)` but the code was attempting to call it with `(message: string, meta?: Record<string, unknown>)`. Fixed by incorporating stack traces directly into the error message string.

Agent-Signoff: ClawBot-the-Debugger ���

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive try/catch error handling to the Google Chat channel startup path (`monitorGoogleChatProvider`, `startGoogleChatMonitor`, and `startAccount`), so that failures during monitor initialization are caught and surfaced rather than crashing the gateway. It also adds new validation for `audienceType` and `audience` fields in `monitorGoogleChatProvider`.

**Key concerns:**

- **`hs_err_pid37672.log` committed to repository**: A 358-line JVM crash dump containing personal developer information (local Windows paths, username, system specs) was accidentally committed. This file should be removed and the pattern `hs_err_pid*.log` added to `.gitignore`.
- **Triple error logging**: Errors thrown in `monitorGoogleChatProvider` get logged at three levels (the function itself, `startGoogleChatMonitor`, and `startAccount`), producing three error entries per failure. Only one layer should log.
- **Scope exceeds PR title**: The PR title says "fix runtime.error signature" but the original code was already using the correct single-argument `runtime.error()` signature. The actual changes add new try/catch error handling, new `audienceType`/`audience` validation, and change `monitorGoogleChatProvider` from returning a no-op on invalid webhook path to throwing an error. These behavioral changes should be clearly documented.
- **Missing newline at end of `.gitignore`**.

<h3>Confidence Score: 2/5</h3>

- This PR introduces a committed JVM crash dump with PII and has behavioral changes that exceed the stated scope, requiring attention before merge.
- Score of 2 reflects: (1) an accidentally committed JVM crash dump file containing personal developer information that should never be in the repo, (2) triple error logging that will make production logs noisy and harder to debug, (3) new validation in monitorGoogleChatProvider that could reject previously-working accounts missing audienceType/audience, and (4) the PR description inaccurately describes the changes as a "signature fix" when the original code already used the correct single-argument signature.
- `hs_err_pid37672.log` must be removed (PII leak). `extensions/googlechat/src/monitor.ts` needs the triple-logging addressed and the new validation behavior verified as intentional.

<sub>Last reviewed commit: 23f573e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->