### PR TITLE
fix(telegram): skip message_thread_id for private chats to prevent silent message drops (v2)

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -850,7 +850,7 @@ describe("sendMessageTelegram", () => {
     });
   });
 
-  it("keeps message_thread_id for private chat topic sends (#18974)", async () => {
+  it("skips opts-level message_thread_id for private chats (#17242)", async () => {
     const chatId = "123456789";
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 56,
@@ -866,7 +866,30 @@ describe("sendMessageTelegram", () => {
       messageThreadId: 271,
     });
 
+    // opts.messageThreadId is skipped for private chats — it comes from
+    // reply context that plain DMs don't support.
     expect(sendMessage).toHaveBeenCalledWith(chatId, "hello private", {
+      parse_mode: "HTML",
+    });
+  });
+
+  it("preserves target-embedded message_thread_id for DM topics (#18974)", async () => {
+    const chatId = "123456789";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 57,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    // Topic embedded in target address — used for DM topic routing (Bot API 9.3)
+    await sendMessageTelegram(`${chatId}:topic:271`, "hello topic", {
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "hello topic", {
       parse_mode: "HTML",
       message_thread_id: 271,
     });
@@ -925,16 +948,12 @@ describe("sendMessageTelegram", () => {
     expect(res.messageId).toBe("58");
   });
 
-  it("retries private chat sends without message_thread_id on thread-not-found", async () => {
+  it("private chat sends skip opts message_thread_id so thread-not-found retry is unnecessary (#17242)", async () => {
     const chatId = "123456789";
-    const threadErr = new Error("400: Bad Request: message thread not found");
-    const sendMessage = vi
-      .fn()
-      .mockRejectedValueOnce(threadErr)
-      .mockResolvedValueOnce({
-        message_id: 59,
-        chat: { id: chatId },
-      });
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 59,
+      chat: { id: chatId },
+    });
     const api = { sendMessage } as unknown as {
       sendMessage: typeof sendMessage;
     };
@@ -945,11 +964,10 @@ describe("sendMessageTelegram", () => {
       messageThreadId: 271,
     });
 
-    expect(sendMessage).toHaveBeenNthCalledWith(1, chatId, "hello private", {
-      parse_mode: "HTML",
-      message_thread_id: 271,
-    });
-    expect(sendMessage).toHaveBeenNthCalledWith(2, chatId, "hello private", {
+    // Private chat sends skip opts-level message_thread_id entirely,
+    // so the thread-not-found fallback is never needed.
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "hello private", {
       parse_mode: "HTML",
     });
     expect(res.messageId).toBe("59");
@@ -973,7 +991,7 @@ describe("sendMessageTelegram", () => {
   });
 
   it("does not retry without message_thread_id on chat-not-found", async () => {
-    const chatId = "123456789";
+    const chatId = "-1001234567890";
     const chatErr = new Error("400: Bad Request: chat not found");
     const sendMessage = vi.fn().mockRejectedValueOnce(chatErr);
     const api = { sendMessage } as unknown as {
@@ -981,7 +999,7 @@ describe("sendMessageTelegram", () => {
     };
 
     await expect(
-      sendMessageTelegram(chatId, "hello private", {
+      sendMessageTelegram(chatId, "hello group", {
         token: "tok",
         api,
         messageThreadId: 271,
@@ -989,7 +1007,7 @@ describe("sendMessageTelegram", () => {
     ).rejects.toThrow(/chat not found/i);
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledWith(chatId, "hello private", {
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "hello group", {
       parse_mode: "HTML",
       message_thread_id: 271,
     });
@@ -1262,6 +1280,27 @@ describe("sendStickerTelegram", () => {
     });
 
     expect(sendSticker).toHaveBeenCalledWith(chatId, "fileId123", undefined);
+  });
+
+  it("skips opts-level message_thread_id for sticker sends to private chats (#17242)", async () => {
+    const chatId = "123456789";
+    const sendSticker = vi.fn().mockResolvedValue({
+      message_id: 110,
+      chat: { id: chatId },
+    });
+    const api = { sendSticker } as unknown as {
+      sendSticker: typeof sendSticker;
+    };
+
+    const res = await sendStickerTelegram(chatId, "fileId123", {
+      token: "tok",
+      api,
+      messageThreadId: 271,
+    });
+
+    // opts.messageThreadId is skipped for private chats.
+    expect(sendSticker).toHaveBeenCalledWith(chatId, "fileId123", undefined);
+    expect(res.messageId).toBe("110");
   });
 });
 


### PR DESCRIPTION
## Improved v2 of #17252 — Fixes #17242

Closes #17242

### Problem

When sending messages to Telegram **private chats** (positive chatId), the opts-level `messageThreadId` — typically derived from reply-context — is passed as `message_thread_id` to the Telegram API.  Private chats don't support forum topics, so the API rejects with:

```
400: Bad Request: message thread not found
```

Messages are **silently dropped**, affecting:
- Sub-agent announce notifications (`sessions_spawn`)
- Cron job deliveries to private chats
- Proactive `message` tool sends

### Root cause

`buildTelegramThreadReplyParams` unconditionally merges `opts.messageThreadId` into the thread spec for all chat types, including private chats where `message_thread_id` is invalid.

### Fix

In `buildTelegramThreadReplyParams`, private chats (`chatType === "direct"`) now **only honour the thread ID embedded in the target address** (e.g., `123456789:topic:42`) and **ignore the opts-level `messageThreadId`**.

This is a single-point fix that covers **all send paths**: text messages, media, stickers, and polls — addressing the reviewer feedback on #17252 about missing sticker/poll checks.

### Why not blanket-strip?

[Previous #17252 was rejected](https://github.com/openclaw/openclaw/pull/17252) because blanket-suppressing `message_thread_id` for all private chats would break **DM topic routing** (Bot API 9.3, #18974).  This v2 distinguishes between:

| Source | Private chat behaviour | Rationale |
|--------|----------------------|-----------|
| Target address (`123456789:topic:42`) | ✅ **Kept** | Intentional DM topic routing |
| `opts.messageThreadId` (reply context) | ❌ **Skipped** | Reply-context thread IDs don't apply to plain DMs |

### Changes

- **`src/telegram/send.ts`** — `buildTelegramThreadReplyParams`: for private chats, use only `targetMessageThreadId` (from target string), ignore `opts.messageThreadId`
- **`src/telegram/send.test.ts`** — Updated/added tests:
  - Verifies opts-level `messageThreadId` is skipped for private chat text sends
  - Verifies target-embedded thread IDs are preserved for DM topics
  - Verifies opts-level `messageThreadId` is skipped for private chat sticker sends
  - Updated chat-not-found test to use group chatId (was using private chatId with now-skipped thread param)

### Test results

All 38 telegram test files pass (469 tests).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes silent message drops when sending to Telegram private chats with a reply-context `messageThreadId` (#17242). The root cause was `buildTelegramThreadReplyParams` unconditionally forwarding `opts.messageThreadId` (from reply context) to the API as `message_thread_id`, which private chats reject with `400: Bad Request: message thread not found`.

The fix is a single-point change in `buildTelegramThreadReplyParams`:
- **Private chats** (`chatType === "direct"`): only use the thread ID embedded in the target address (e.g., `123456789:topic:42`), ignoring the opts-level `messageThreadId`
- **Group/unknown chats**: preserve the existing precedence (`opts.messageThreadId` takes priority, falls back to `targetMessageThreadId`)

This covers all send paths (text, media, stickers, polls) since they all flow through `buildTelegramThreadReplyParams`.

- Tests updated to verify opts-level thread ID is skipped for private text and sticker sends
- New test verifies target-embedded thread IDs are preserved for DM topic routing (Bot API 9.3)
- Existing chat-not-found test updated to use group chat ID (since private chats now skip opts thread ID, the old assertion was invalid)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a well-scoped fix with correct logic and thorough test coverage.
- The change is minimal (6 lines of logic in one function), the fix is correct based on Telegram API semantics, it preserves existing behavior for non-private chats, and the tests comprehensively cover the key scenarios: opts-level thread ID skipped for private chats, target-embedded thread ID preserved for DM topics, and group chat behavior unchanged. The `??` operator is semantically equivalent to the previous `!= null` ternary for the non-private path.
- No files require special attention.

<sub>Last reviewed commit: 3cd7e0d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->