### PR TITLE
fix(gateway): use loopback for local CLI connections when bind=lan

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -113,7 +113,7 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.url).toBe("ws://100.64.0.1:18800");
   });
 
-  it("uses LAN IP when bind is lan and LAN IP is available", async () => {
+  it("uses loopback when bind is lan (server on 0.0.0.0 accepts loopback)", async () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
@@ -121,7 +121,7 @@ describe("callGateway url resolution", () => {
 
     await callGateway({ method: "health" });
 
-    expect(lastClientOptions?.url).toBe("ws://192.168.1.42:18800");
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
   });
 
   it("falls back to loopback when bind is lan but no LAN IP found", async () => {
@@ -198,7 +198,7 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.message).toContain("Gateway target: ws://127.0.0.1:18789");
   });
 
-  it("uses LAN IP and reports lan source when bind is lan", () => {
+  it("uses loopback URL but reports lan source when bind is lan", () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "local", bind: "lan" },
     });
@@ -208,7 +208,7 @@ describe("buildGatewayConnectionDetails", () => {
 
     const details = buildGatewayConnectionDetails();
 
-    expect(details.url).toBe("ws://10.0.0.5:18800");
+    expect(details.url).toBe("ws://127.0.0.1:18800");
     expect(details.urlSource).toBe("local lan 10.0.0.5");
     expect(details.bindDetail).toBe("Bind: lan");
   });

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -105,12 +105,14 @@ export function buildGatewayConnectionDetails(
   const preferLan = bindMode === "lan";
   const lanIPv4 = preferLan ? pickPrimaryLanIPv4() : undefined;
   const scheme = tlsEnabled ? "wss" : "ws";
+  // Always use loopback for local CLI connections. When bind=lan the server
+  // listens on 0.0.0.0 which accepts loopback traffic, and using a LAN IP
+  // would cause the gateway to treat same-host CLI calls as remote (requiring
+  // device pairing). Tailnet genuinely needs its own IP for cross-host routing.
   const localUrl =
     preferTailnet && tailnetIPv4
       ? `${scheme}://${tailnetIPv4}:${localPort}`
-      : preferLan && lanIPv4
-        ? `${scheme}://${lanIPv4}:${localPort}`
-        : `${scheme}://127.0.0.1:${localPort}`;
+      : `${scheme}://127.0.0.1:${localPort}`;
   const urlOverride =
     typeof options.url === "string" && options.url.trim().length > 0
       ? options.url.trim()


### PR DESCRIPTION
## Summary

When `gateway.bind=lan`, the CLI constructed its WebSocket URL using the host's LAN IP (e.g. `ws://10.0.0.5:18789`) instead of `ws://127.0.0.1:18789`. This caused the gateway to treat same-host CLI calls as remote connections, requiring device pairing instead of auto-approving via the `isLocalClient` path.

## Fix

Always use `127.0.0.1` for local CLI connections regardless of bind mode. When `bind=lan` the server listens on `0.0.0.0`, which accepts loopback traffic. The LAN IP is still reported in `urlSource` for diagnostics.

Tailnet bind mode is unaffected — it genuinely needs a non-loopback IP for cross-host routing.

## Changes

- `src/gateway/call.ts`: Remove the `preferLan` branch from `localUrl` construction
- `src/gateway/call.test.ts`: Update 2 tests to expect loopback URL with bind=lan

## Testing

All 21 tests in `call.test.ts` pass.

Closes #19004

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed local CLI connections incorrectly requiring device pairing when `gateway.bind=lan`. The CLI was constructing WebSocket URLs using the host's LAN IP instead of `127.0.0.1`, causing the gateway to treat same-host connections as remote. 

The fix removes the `preferLan` branch from `localUrl` construction in `src/gateway/call.ts:108-115`, ensuring loopback is always used for local CLI connections. When `bind=lan`, the server listens on `0.0.0.0` which accepts loopback traffic, so this works correctly. The LAN IP is still reported in `urlSource` for diagnostics.

Two test expectations were updated to reflect the new behavior: the URL now uses `127.0.0.1` while `urlSource` still reports the LAN IP for transparency.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a targeted correction that removes a problematic code branch causing incorrect behavior. The change is well-documented with an inline comment, all test cases have been updated appropriately, and the logic is sound: when bind=lan the server listens on 0.0.0.0 which accepts loopback connections. The tailnet bind mode remains correctly handled with its own IP for cross-host routing.
- No files require special attention

<sub>Last reviewed commit: 94bbe54</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->