### PR TITLE
CI/macOS: disable Vitest vmForks for TS tests to stop mock-state leakage flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,6 +436,7 @@ jobs:
       - name: TS tests (macOS)
         env:
           NODE_OPTIONS: --max-old-space-size=4096
+          OPENCLAW_TEST_VM_FORKS: "0"
         run: pnpm test
 
       # --- Xcode/Swift setup ---


### PR DESCRIPTION
## Summary
This PR stabilizes the macOS TypeScript CI job by disabling Vitest `vmForks` for that job only.

The macOS workflow currently runs:
- `pnpm test`

On CI, `scripts/test-parallel.mjs` enables `vmForks` by default. In that mode, we observed cross-file mock/module-state contamination leading to order-dependent false negatives (for example, `vi.fn()` call-count assertions unexpectedly at 0, missing mocked exports, and unrelated suites failing together).

## Root Cause
The failures are caused by test-runner isolation behavior under `CI + vmForks`, not by the feature code in the failing PRs.

Evidence from reproduction:
- `CI=true pnpm test` -> reproducible random mock-related failures across unrelated suites.
- `CI=true pnpm test -- src/web/inbound/send-api.test.ts src/process/supervisor/adapters/child.test.ts` -> both pass in isolation.
- `CI=true OPENCLAW_TEST_VM_FORKS=0 pnpm test` -> full suite passes.

## Change
In `.github/workflows/ci.yml`, for `macos` -> `TS tests (macOS)`:
- Add `OPENCLAW_TEST_VM_FORKS: "0"`

This keeps the fix narrowly scoped to the flaky job while preserving existing behavior elsewhere.

## Why This Scope
- The observed blocker is the macOS CI TS job.
- This patch avoids broad test runner policy changes and minimizes risk.
- We can evaluate broader `vmForks` policy separately if needed.

## Validation
- Reproduced CI-only flake locally with `CI=true`.
- Verified deterministic pass with `OPENCLAW_TEST_VM_FORKS=0`.
- Confirmed targeted failing tests pass in isolation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Disabled Vitest `vmForks` for macOS CI to prevent cross-file mock-state contamination causing flaky test failures. The change sets `OPENCLAW_TEST_VM_FORKS: "0"` which `scripts/test-parallel.mjs` respects to fall back to standard forks-based test execution. This is a targeted fix for observed CI-only flakes without affecting other platforms or local development.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line config change that disables a specific test runner feature for one CI job. The environment variable is explicitly supported by the test infrastructure (test-parallel.mjs:55-57), fallback behavior is well-tested, and the scope is narrowly limited to macOS CI without affecting other platforms or local development
- No files require special attention

<sub>Last reviewed commit: 4a46bcd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->