### PR TITLE
docs: add tip for smaller models during bootstrap ritual

### DIFF
--- a/docs/start/bootstrapping.md
+++ b/docs/start/bootstrapping.md
@@ -24,6 +24,12 @@ On the first agent run, OpenClaw bootstraps the workspace (default
 - Writes identity + preferences to `IDENTITY.md`, `USER.md`, `SOUL.md`.
 - Removes `BOOTSTRAP.md` when finished so it only runs once.
 
+<Tip>
+Smaller or local models may struggle with the bootstrapping ritual. If the agent
+stalls or skips steps, give all the details upfront in a single conversational
+message and explicitly ask it to consult the `BOOTSTRAP.md`, write the files and delete `BOOTSTRAP.md`.
+</Tip>
+
 ## Where it runs
 
 Bootstrapping always runs on the **gateway host**. If the macOS app connects to


### PR DESCRIPTION
## Summary

- **Problem:** Smaller or local LLMs (e.g. 14B-parameter models) frequently fail the open-ended bootstrap ritual — stalling, skipping file writes, or not deleting `BOOTSTRAP.md`. Users hitting this have no guidance in the docs.
- **Why it matters:** Bootstrapping is the first agent interaction. A broken first run is a bad first impression, especially for users running local models via Ollama or similar.
- **What changed:** Added a single `<Tip>` callout to `docs/start/bootstrapping.md` advising users to front-load all identity details in one conversational message and explicitly ask the agent to write the files and delete `BOOTSTRAP.md`.
- **What did NOT change:** No code, prompts, or templates were modified. The `BOOTSTRAP.md` template and TUI/macOS kickoff messages remain unchanged.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Related: https://github.com/giosullutrone/Openclaw-Bootstrapping-Benchmark (external benchmark showing the failure pattern)

## User-visible / Behavior Changes

A new `<Tip>` callout appears on the [Agent Bootstrapping](https://docs.openclaw.ai/start/bootstrapping) docs page, directly after the "What bootstrapping does" section.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime/container: N/A (docs only)
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. Open https://docs.openclaw.ai/start/bootstrapping
2. Scroll to "What bootstrapping does"
3. See the new tip below the bullet list

### Expected

- Tip callout renders correctly in Mintlify

### Actual

- Matches expected

## Evidence

- [x] The [OpenClaw Bootstrapping Benchmark](https://github.com/giosullutrone/Openclaw-Bootstrapping-Benchmark) tested 7 local models across 4 prompt variants (5 runs each). The "natural-guided" variant (all details upfront, explicit file names) achieved 100% success on 5/7 models. The "natural-unguided" variant (same data, no explicit instructions) achieved 0/7 perfect scores. This tip documents the guided approach as a workaround.

## Human Verification (required)

- Verified Scenarios: (1) That the tip would have been not need -> Created an automated benchmark to test the bootstrapping process on different user answer styles (2) That the "change files and remove the bootstrap" would be redundant with the hatching prompt itself -> From what I have seen by asking the model to peruse the prompts, it isn't with only the macos app being the closest but still useful for the end user
- Edge cases checked: Some models do not need the additional guidance in the user answer but I think it's still fine to bring it up as it only costs a couple of tokens if the user still decides to follow the tip
- What I did **not** verify: Whether it break something in the closed high-performance models but I don't see why it should as we are only suggesting to the user to remind them to do the hatching corrrectly

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit or remove the `<Tip>` block.
- Files/config to restore: `docs/start/bootstrapping.md`
- Known bad symptoms: None (docs-only change).

## Risks and Mitigations

None.

---

> AI-assisted: This PR was authored with AI assistance (GitHub Copilot). The change was fully reviewed and verified by the contributor.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `<Tip>` callout to `docs/start/bootstrapping.md` advising users of smaller or local LLMs (e.g., 14B-parameter models via Ollama) to front-load all identity details in a single message and explicitly ask the agent to consult `BOOTSTRAP.md`, write the identity files, and delete `BOOTSTRAP.md`. This addresses a documented failure pattern where smaller models stall, skip file writes, or fail to complete the bootstrap ritual.

- The tip is placed logically after the "What bootstrapping does" bullet list, where users first learn the expected flow
- Content is accurate: it aligns with the `BOOTSTRAP.md` template's instructions to write `IDENTITY.md`, `USER.md`, `SOUL.md`, and then delete `BOOTSTRAP.md`
- Formatting follows existing `<Tip>` callout conventions used across the docs
- No code, prompts, or templates were modified — purely a docs change

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds only a documentation tip with no code or configuration changes.
- This is a minimal, docs-only change that adds a single `<Tip>` callout. The content is factually accurate, the formatting matches existing conventions, and there is no risk of breaking anything. The tip is backed by external benchmarking data showing it helps smaller models succeed at bootstrapping.
- No files require special attention.

<sub>Last reviewed commit: fbb904b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->