### PR TITLE
fix(agents): trigger model failover on connection-refused and network-unreachable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Model fallback: classify additional network transport errors (`ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, `EAI_AGAIN`) as failover-worthy so fallback chains advance when primary providers are unreachable. Landed from contributor PR #19077 by @ayanesakura. Thanks @ayanesakura.
 - CLI/Cron run exit code: return exit code `0` only when `cron run` reports `{ ok: true, ran: true }`, and `1` for non-run/error outcomes so scripting/debugging reflects actual execution status. Landed from contributor PR #31121 by @Sid-Qin. Thanks @Sid-Qin.
 - Nodes/Screen recording guardrails: cap `nodes` tool `screen_record` `durationMs` to 5 minutes at both schema-validation and runtime invocation layers to prevent long-running blocking captures from unbounded durations. Landed from contributor PR #31106 by @BlueBirdBack. Thanks @BlueBirdBack.
 - Telegram/Empty final replies: skip outbound send for null/undefined final text payloads without media so Telegram typing indicators do not linger on `text must be non-empty` errors. Landed from contributor PR #30969 by @haosenwang1018. Thanks @haosenwang1018.

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -183,7 +183,19 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   }
 
   const code = (getErrorCode(err) ?? "").toUpperCase();
-  if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
+  if (
+    [
+      "ETIMEDOUT",
+      "ESOCKETTIMEDOUT",
+      "ECONNRESET",
+      "ECONNABORTED",
+      "ECONNREFUSED",
+      "ENETUNREACH",
+      "EHOSTUNREACH",
+      "ENETRESET",
+      "EAI_AGAIN",
+    ].includes(code)
+  ) {
     return "timeout";
   }
   if (isTimeoutError(err)) {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -787,6 +787,14 @@ describe("runWithModelFallback", () => {
     });
   });
 
+  it("falls back on ENETRESET (connection reset by network)", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("connect ENETRESET"), { code: "ENETRESET" }),
+    });
+  });
+
   it("falls back on provider abort errors with request-aborted messages", async () => {
     await expectFallsBackToHaiku({
       provider: "openai",

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -751,6 +751,42 @@ describe("runWithModelFallback", () => {
     });
   });
 
+  it("falls back on ECONNREFUSED (local server down or remote unreachable)", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:11434"), {
+        code: "ECONNREFUSED",
+      }),
+    });
+  });
+
+  it("falls back on ENETUNREACH (network disconnected)", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("connect ENETUNREACH"), { code: "ENETUNREACH" }),
+    });
+  });
+
+  it("falls back on EHOSTUNREACH (host unreachable)", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("connect EHOSTUNREACH"), { code: "EHOSTUNREACH" }),
+    });
+  });
+
+  it("falls back on EAI_AGAIN (DNS resolution failure)", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("getaddrinfo EAI_AGAIN api.openai.com"), {
+        code: "EAI_AGAIN",
+      }),
+    });
+  });
+
   it("falls back on provider abort errors with request-aborted messages", async () => {
     await expectFallsBackToHaiku({
       provider: "openai",


### PR DESCRIPTION
## Summary

Closes #18868

Network connection errors (`ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, `EAI_AGAIN`) were not recognized as failover-worthy errors, so the fallback chain was never advanced when the primary provider was unreachable due to a network outage or a stopped local server.

This is especially impactful when a **local fallback model** (e.g. Ollama on localhost) is configured alongside a remote primary: if the network goes down, the gateway should seamlessly fall back to the local model instead of surfacing an error to the user.

### Changes

- **`src/agents/failover-error.ts`** — Added `ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, and `EAI_AGAIN` to the error-code list in `resolveFailoverReasonFromError()` that triggers failover (categorized as `"timeout"`, consistent with the existing `ETIMEDOUT` / `ECONNRESET` / `ECONNABORTED` handling).
- **`src/agents/model-fallback.e2e.test.ts`** — Added 4 e2e tests covering each new error code scenario.

### Why these specific codes

| Code | When it fires |
|------|--------------|
| `ECONNREFUSED` | Target port not listening (e.g. Ollama/vLLM stopped, or remote server down) |
| `ENETUNREACH` | No route to network (e.g. Wi-Fi/Ethernet disconnected) |
| `EHOSTUNREACH` | Specific host unreachable (e.g. VPN down, firewall block) |
| `ENETRESET` | Connection reset by network (e.g. NAT timeout, ISP reset) |
| `EAI_AGAIN` | DNS resolution temporarily failed (e.g. DNS server unreachable) |

## Test plan

- [x] All 4 new e2e tests pass (`pnpm test:e2e -- src/agents/model-fallback.e2e.test.ts`)
- [x] Existing failover tests unaffected (the one pre-existing flaky test `skips providers when all profiles are in cooldown` fails on `main` as well)
- [x] `oxfmt` and `oxlint` pass on changed files

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds network connection error codes to the failover mechanism so the agent can gracefully fall back to alternative models when the primary provider is unreachable due to network issues.

- Extended the error code list in `resolveFailoverReasonFromError()` to include `ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, and `EAI_AGAIN`, categorized as timeout errors
- Added 4 e2e tests covering the new error scenarios (missing test for `ENETRESET`)
- Consistent with existing network error handling in `src/telegram/network-errors.ts`
- Enables seamless failover to local models (e.g., Ollama) when remote providers are down

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one test case addition recommended
- The change is well-implemented and consistent with existing patterns in the codebase. The new error codes are already recognized elsewhere (telegram network errors), and the categorization as timeout errors makes sense. Test coverage is good but missing one case for ENETRESET. The impact is localized to failover logic with clear benefits for resilience.
- Add test case for `ENETRESET` in `model-fallback.e2e.test.ts` for complete coverage

<sub>Last reviewed commit: 43c1c9a</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->