### PR TITLE
fix(discord): remove any type usage in exec approval tests

### DIFF
--- a/src/discord/monitor/exec-approvals.test.ts
+++ b/src/discord/monitor/exec-approvals.test.ts
@@ -165,10 +165,8 @@ describe("parseExecApprovalData", () => {
   });
 
   it("rejects null/undefined input", () => {
-    // oxlint-disable-next-line typescript/no-explicit-any
-    expect(parseExecApprovalData(null as any)).toBeNull();
-    // oxlint-disable-next-line typescript/no-explicit-any
-    expect(parseExecApprovalData(undefined as any)).toBeNull();
+    expect(parseExecApprovalData(null as unknown as Record<string, string>)).toBeNull();
+    expect(parseExecApprovalData(undefined as unknown as Record<string, string>)).toBeNull();
   });
 
   it("accepts all valid actions", () => {


### PR DESCRIPTION
Using 'any' to test null/undefined inputs triggers lint warnings.

Fix: Use 'unknown as Record<string, string>' for safer type casting in tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `any` type casts and their associated `oxlint-disable-next-line typescript/no-explicit-any` suppressions in `parseExecApprovalData` test cases. Replaces them with the safer `unknown as Record<string, string>` double-cast pattern, which satisfies the linter without losing test intent.

- Eliminates two `oxlint-disable-next-line` comments and two `as any` casts in the "rejects null/undefined input" test
- Aligns with the project's coding guidelines ("Prefer strict typing; avoid `any`" and "do not disable `no-explicit-any`")
- No runtime behavior change — the test still validates that `parseExecApprovalData` correctly handles null/undefined inputs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only affects test type annotations with no runtime impact.
- The change is a minimal, test-only lint fix that replaces `as any` casts with `as unknown as Record<string, string>`. It has zero runtime behavioral changes, affects only two lines in a single test file, and follows established TypeScript best practices for type-safe test casting.
- No files require special attention.

<sub>Last reviewed commit: 0a997a5</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->