### PR TITLE
fix(agents): expand ~ in tool paths and add Brave Search baseUrl override

### DIFF
--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 
 export type RequiredParamGroup = {
@@ -95,6 +97,13 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   if ("file_path" in normalized && !("path" in normalized)) {
     normalized.path = normalized.file_path;
     delete normalized.file_path;
+  }
+  // Expand ~ to the OS account home dir. Must use OS home (HOME/USERPROFILE/os.homedir)
+  // rather than resolveEffectiveHomeDir, which prefers OPENCLAW_HOME and would send
+  // tool file paths into the app-state directory instead of the user's home.
+  if (typeof normalized.path === "string" && normalized.path.startsWith("~")) {
+    const osHome = process.env.HOME || process.env.USERPROFILE || os.homedir();
+    normalized.path = expandHomePrefix(normalized.path, { home: osHome });
   }
   // old_string → oldText (edit)
   if ("old_string" in normalized && !("oldText" in normalized)) {

--- a/src/agents/tilde-expansion.test.ts
+++ b/src/agents/tilde-expansion.test.ts
@@ -1,0 +1,31 @@
+import os from "node:os";
+import { describe, expect, it } from "vitest";
+import { normalizeToolParams } from "./pi-tools.params.js";
+
+describe("normalizeToolParams tilde expansion", () => {
+  it("expands ~ in path parameter", () => {
+    const home = os.homedir();
+    const params = { path: "~/.ssh/config" };
+    const normalized = normalizeToolParams(params);
+    expect(normalized?.path).toBe(`${home}/.ssh/config`);
+  });
+
+  it("expands ~ in file_path parameter (aliased to path)", () => {
+    const home = os.homedir();
+    const params = { file_path: "~/Documents/notes.txt" };
+    const normalized = normalizeToolParams(params);
+    expect(normalized?.path).toBe(`${home}/Documents/notes.txt`);
+  });
+
+  it("does not expand ~ if it is not at the start of the path", () => {
+    const params = { path: "/some/path/~middle" };
+    const normalized = normalizeToolParams(params);
+    expect(normalized?.path).toBe("/some/path/~middle");
+  });
+
+  it("handles paths without tilde", () => {
+    const params = { path: "/etc/hosts" };
+    const normalized = normalizeToolParams(params);
+    expect(normalized?.path).toBe("/etc/hosts");
+  });
+});

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -309,6 +309,7 @@ type BraveLlmContextResponse = {
 
 type BraveConfig = {
   mode?: string;
+  baseUrl?: string;
 };
 
 type PerplexityConfig = {
@@ -1603,18 +1604,21 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   braveMode?: "web" | "llm-context";
+  braveBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
   const providerSpecificKey =
-    params.provider === "perplexity"
-      ? `${params.perplexityTransport ?? "search_api"}:${params.perplexityBaseUrl ?? PERPLEXITY_DIRECT_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
-      : params.provider === "grok"
-        ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
-        : params.provider === "gemini"
-          ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
-          : params.provider === "kimi"
-            ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-            : "";
+    params.provider === "brave"
+      ? (params.braveBaseUrl?.trim() ?? "")
+      : params.provider === "perplexity"
+        ? `${params.perplexityTransport ?? "search_api"}:${params.perplexityBaseUrl ?? PERPLEXITY_DIRECT_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
+        : params.provider === "grok"
+          ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
+          : params.provider === "gemini"
+            ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
+            : params.provider === "kimi"
+              ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
+              : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
       ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
@@ -1809,7 +1813,8 @@ async function runWebSearch(params: {
     return payload;
   }
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  const braveEndpoint = (params.braveBaseUrl?.trim() || BRAVE_SEARCH_ENDPOINT).replace(/\/$/, "");
+  const url = new URL(braveEndpoint);
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {
@@ -2186,6 +2191,7 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         braveMode,
+        braveBaseUrl: braveConfig.baseUrl?.trim() || undefined,
       });
       return jsonResult(result);
     },

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -471,6 +471,8 @@ export type ToolsConfig = {
       brave?: {
         /** Brave Search mode: "web" (standard results) or "llm-context" (pre-extracted page content). Default: "web". */
         mode?: "web" | "llm-context";
+        /** Base URL override for Brave Search API (optional; useful for proxies or custom endpoints). */
+        baseUrl?: string;
       };
       /** Gemini-specific configuration (used when provider="gemini"). */
       gemini?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -311,6 +311,7 @@ export const ToolsWebSearchSchema = z
     brave: z
       .object({
         mode: z.union([z.literal("web"), z.literal("llm-context")]).optional(),
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Changes

### 1. Tilde (`~`) expansion in filesystem tool paths

`normalizeToolParams` now expands `~` in `path`/`file_path` to the OS account home directory. Uses `HOME`/`USERPROFILE`/`os.homedir()` explicitly to avoid `OPENCLAW_HOME`, which is used for app-state isolation and would otherwise redirect tool file paths to the wrong directory.

Fixes: #30669

### 2. Brave Search `baseUrl` override

Adds `tools.web.search.brave.baseUrl` config option, following the same per-provider nested config pattern used by kimi/perplexity. Useful for routing requests through a proxy or custom endpoint.

- Type definition added inside `brave?: { ... }` in `types.tools.ts`
- Zod schema updated in `zod-schema.agent-runtime.ts`  
- Cache key includes `braveBaseUrl` to prevent collisions across endpoints

## Testing

- 4 new unit tests in `src/agents/tilde-expansion.test.ts` covering `~` expansion, `file_path` alias, non-leading `~`, and plain paths
- `pnpm build` passes
- `pnpm check` passes (lint/format)

## Notes

Rebased on current `main`. Drops the inter-session role rewrite from the earlier version — that change was incomplete (callers in `session-memory/handler.ts` and `google.ts` were not updated) and will be addressed separately.