### PR TITLE
fix(sessions): sync display fields on model switch

### DIFF
--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -91,8 +91,63 @@ describe("gateway sessions patch", () => {
     }
     expect(res.entry.providerOverride).toBe("openai");
     expect(res.entry.modelOverride).toBe("gpt-5.2");
+    expect(res.entry.modelProvider).toBe("openai");
+    expect(res.entry.model).toBe("gpt-5.2");
     expect(res.entry.authProfileOverride).toBeUndefined();
     expect(res.entry.authProfileOverrideSource).toBeUndefined();
     expect(res.entry.authProfileOverrideCompactionCount).toBeUndefined();
+  });
+
+  test("model patch updates display fields for immediate visibility (issue #18603)", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess",
+        updatedAt: 1,
+        modelProvider: "anthropic",
+        model: "claude-opus-4-5",
+      } as SessionEntry,
+    };
+    const res = await applySessionsPatchToStore({
+      cfg: {} as OpenClawConfig,
+      store,
+      storeKey: "agent:main:main",
+      patch: { model: "openai/gpt-5.2" },
+      loadGatewayModelCatalog: async () => [{ provider: "openai", id: "gpt-5.2" }],
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.entry.providerOverride).toBe("openai");
+    expect(res.entry.modelOverride).toBe("gpt-5.2");
+    expect(res.entry.modelProvider).toBe("openai");
+    expect(res.entry.model).toBe("gpt-5.2");
+  });
+
+  test("clearing model (null) clears display fields", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess",
+        updatedAt: 1,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.2",
+        modelProvider: "openai",
+        model: "gpt-5.2",
+      } as SessionEntry,
+    };
+    const res = await applySessionsPatchToStore({
+      cfg: {} as OpenClawConfig,
+      store,
+      storeKey: "agent:main:main",
+      patch: { model: null },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.entry.providerOverride).toBeUndefined();
+    expect(res.entry.modelOverride).toBeUndefined();
+    expect(res.entry.modelProvider).toBeUndefined();
+    expect(res.entry.model).toBeUndefined();
   });
 });

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import { applyModelOverrideToSessionEntry } from "./model-overrides.js";
+
+function makeEntry(overrides?: Partial<SessionEntry>): SessionEntry {
+  return {
+    sessionId: "test-session",
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+describe("applyModelOverrideToSessionEntry", () => {
+  describe("non-default selection (switching to a specific model)", () => {
+    test("sets both override and display fields", () => {
+      const entry = makeEntry();
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "openai", model: "gpt-5.2" },
+      });
+
+      expect(updated).toBe(true);
+      expect(entry.providerOverride).toBe("openai");
+      expect(entry.modelOverride).toBe("gpt-5.2");
+      expect(entry.modelProvider).toBe("openai");
+      expect(entry.model).toBe("gpt-5.2");
+    });
+
+    test("updates display fields when override fields already match but display fields are stale", () => {
+      const entry = makeEntry({
+        providerOverride: "openai",
+        modelOverride: "gpt-5.2",
+        modelProvider: "anthropic",
+        model: "claude-opus-4-5",
+      });
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "openai", model: "gpt-5.2" },
+      });
+
+      expect(updated).toBe(true);
+      expect(entry.modelProvider).toBe("openai");
+      expect(entry.model).toBe("gpt-5.2");
+    });
+
+    test("returns updated=false when all fields already match", () => {
+      const entry = makeEntry({
+        providerOverride: "openai",
+        modelOverride: "gpt-5.2",
+        modelProvider: "openai",
+        model: "gpt-5.2",
+      });
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "openai", model: "gpt-5.2" },
+      });
+
+      expect(updated).toBe(false);
+    });
+
+    test("switches from one model to another, updating all fields", () => {
+      const entry = makeEntry({
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-5",
+        modelProvider: "anthropic",
+        model: "claude-opus-4-5",
+      });
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "openai", model: "gpt-5.2" },
+      });
+
+      expect(updated).toBe(true);
+      expect(entry.providerOverride).toBe("openai");
+      expect(entry.modelOverride).toBe("gpt-5.2");
+      expect(entry.modelProvider).toBe("openai");
+      expect(entry.model).toBe("gpt-5.2");
+    });
+  });
+
+  describe("default selection (reverting to configured default)", () => {
+    test("clears both override and display fields", () => {
+      const entry = makeEntry({
+        providerOverride: "openai",
+        modelOverride: "gpt-5.2",
+        modelProvider: "openai",
+        model: "gpt-5.2",
+      });
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "anthropic", model: "claude-opus-4-5", isDefault: true },
+      });
+
+      expect(updated).toBe(true);
+      expect(entry.providerOverride).toBeUndefined();
+      expect(entry.modelOverride).toBeUndefined();
+      expect(entry.modelProvider).toBeUndefined();
+      expect(entry.model).toBeUndefined();
+    });
+
+    test("returns updated=false when entry is already clean", () => {
+      const entry = makeEntry();
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "anthropic", model: "claude-opus-4-5", isDefault: true },
+      });
+
+      expect(updated).toBe(false);
+    });
+
+    test("clears display fields even when override fields were already absent", () => {
+      const entry = makeEntry({
+        modelProvider: "openai",
+        model: "gpt-5.2",
+      });
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "anthropic", model: "claude-opus-4-5", isDefault: true },
+      });
+
+      expect(updated).toBe(true);
+      expect(entry.modelProvider).toBeUndefined();
+      expect(entry.model).toBeUndefined();
+    });
+  });
+
+  describe("auth profile override handling", () => {
+    test("sets auth profile alongside model override", () => {
+      const entry = makeEntry();
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "openai", model: "gpt-5.2" },
+        profileOverride: "openai:custom",
+      });
+
+      expect(updated).toBe(true);
+      expect(entry.authProfileOverride).toBe("openai:custom");
+      expect(entry.authProfileOverrideSource).toBe("user");
+    });
+
+    test("clears auth profile when switching model without profile", () => {
+      const entry = makeEntry({
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-5",
+        modelProvider: "anthropic",
+        model: "claude-opus-4-5",
+        authProfileOverride: "anthropic:default",
+        authProfileOverrideSource: "user" as const,
+        authProfileOverrideCompactionCount: 3,
+      });
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "openai", model: "gpt-5.2" },
+      });
+
+      expect(updated).toBe(true);
+      expect(entry.authProfileOverride).toBeUndefined();
+      expect(entry.authProfileOverrideSource).toBeUndefined();
+      expect(entry.authProfileOverrideCompactionCount).toBeUndefined();
+    });
+  });
+
+  describe("updatedAt timestamp", () => {
+    test("updates timestamp when changes are made", () => {
+      const entry = makeEntry({ updatedAt: 1000 });
+      applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "openai", model: "gpt-5.2" },
+      });
+
+      expect(entry.updatedAt).toBeGreaterThan(1000);
+    });
+
+    test("does not update timestamp when no changes are made", () => {
+      const entry = makeEntry({
+        updatedAt: 1000,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.2",
+        modelProvider: "openai",
+        model: "gpt-5.2",
+      });
+      applyModelOverrideToSessionEntry({
+        entry,
+        selection: { provider: "openai", model: "gpt-5.2" },
+      });
+
+      expect(entry.updatedAt).toBe(1000);
+    });
+  });
+
+  test("regression: session list shows new model immediately after switch (issue #18603)", () => {
+    // Simulate the exact bug scenario: user switches model, then session list
+    // returns stale display fields because only override fields were updated.
+    const entry = makeEntry({
+      modelProvider: "anthropic",
+      model: "claude-opus-4-5",
+    });
+
+    // User switches to gpt-5.2
+    applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider: "openai", model: "gpt-5.2" },
+    });
+
+    // Session list reads entry.model and entry.modelProvider (the display fields).
+    // Before the fix, these would still show the old model.
+    expect(entry.model).toBe("gpt-5.2");
+    expect(entry.modelProvider).toBe("openai");
+
+    // Also verify override fields for runtime model resolution
+    expect(entry.modelOverride).toBe("gpt-5.2");
+    expect(entry.providerOverride).toBe("openai");
+  });
+});

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -25,6 +25,14 @@ export function applyModelOverrideToSessionEntry(params: {
       delete entry.modelOverride;
       updated = true;
     }
+    if (entry.modelProvider) {
+      delete entry.modelProvider;
+      updated = true;
+    }
+    if (entry.model) {
+      delete entry.model;
+      updated = true;
+    }
   } else {
     if (entry.providerOverride !== selection.provider) {
       entry.providerOverride = selection.provider;
@@ -32,6 +40,14 @@ export function applyModelOverrideToSessionEntry(params: {
     }
     if (entry.modelOverride !== selection.model) {
       entry.modelOverride = selection.model;
+      updated = true;
+    }
+    if (entry.modelProvider !== selection.provider) {
+      entry.modelProvider = selection.provider;
+      updated = true;
+    }
+    if (entry.model !== selection.model) {
+      entry.model = selection.model;
       updated = true;
     }
   }


### PR DESCRIPTION
## Summary

Fixes #18603

`applyModelOverrideToSessionEntry()` updated `providerOverride`/`modelOverride` but left the display fields (`model`/`modelProvider`) stale. Every UI surface — session list, CLI status, TUI — reads the display fields, so a switched model appeared unchanged until the next message was actually sent.

- On model switch: write display fields alongside override fields
- On revert-to-default: clear display fields so consumers fall back to configured defaults
- Added `model-overrides.test.ts` (12 tests) covering set, clear, idempotency, stale display sync, auth profile handling, and timestamp behavior
- Extended `sessions-patch.test.ts` with display field assertions and two new test cases

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed model switch display bug where UI surfaces showed stale model info. The function `applyModelOverrideToSessionEntry()` now syncs display fields (`model`/`modelProvider`) alongside override fields (`modelOverride`/`providerOverride`), ensuring session lists, CLI status, and TUI reflect changes immediately.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean bug fix with comprehensive test coverage (12 new unit tests in model-overrides.test.ts plus 2 integration tests in sessions-patch.test.ts). The fix is straightforward: syncing display fields alongside override fields. All edge cases are tested including idempotency, stale display sync, clearing on default, and the exact regression scenario from issue #18603. No breaking changes or risky refactoring.
- No files require special attention

<sub>Last reviewed commit: 653c915</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->