### PR TITLE
fix(extensions): add peerDependencies to resolve workspace:* for npm consumers

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -19,6 +19,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -11,6 +11,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/google-antigravity-auth/package.json
+++ b/extensions/google-antigravity-auth/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -11,7 +11,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.1.26"
+    "openclaw": ">=2026.2.14"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -13,6 +13,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -8,7 +8,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.1.26"
+    "openclaw": ">=2026.2.14"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -12,6 +12,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/minimax-portal-auth/package.json
+++ b/extensions/minimax-portal-auth/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -12,6 +12,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -10,6 +10,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -10,6 +10,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -13,6 +13,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -11,6 +11,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -9,6 +9,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -9,6 +9,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"


### PR DESCRIPTION
## Problem

All 31 extensions in `extensions/` declare `"openclaw": "workspace:*"` in `devDependencies`. While this is correct for local development within the pnpm workspace, when extensions are published or installed via npm as standalone packages, `workspace:*` cannot resolve — npm/yarn have no knowledge of pnpm workspace protocol.

Extensions should declare `openclaw` as a `peerDependency` so that npm consumers know the host must provide it.

## Previous attempts

This issue has been identified and attempted before, but never merged:

- **#8387** — Fixed only `nextcloud-talk`; closed as duplicate of #15034
- **#15034** — Fixed all extensions; closed as superseded by #15889
- **#15889** — Fixed all extensions; closed due to noisy branch (>20 labels)

This PR is a fresh, clean fix from `upstream/main` with a single commit.

## Changes

Add `peerDependencies: { "openclaw": ">=2026.2.14" }` to all 31 extensions that have `workspace:*` in `devDependencies`:

- **29 extensions**: Add new `peerDependencies` block
- **googlechat, memory-core**: Update existing `peerDependencies` version from `>=2026.1.26` to `>=2026.2.14`

`devDependencies` are left unchanged — `workspace:*` is correct for local development within the pnpm monorepo.

## Verification

- ✅ `pnpm install` — lockfile is happy (no resolution changes needed)
- ✅ `pnpm run build` — builds successfully
- ✅ All 31 extension `package.json` files are valid JSON
- ✅ Single commit, minimal mechanical change — only adds/updates `peerDependencies`

Fixes #14042

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `peerDependencies` declaration to all 31 extensions to resolve `workspace:*` protocol incompatibility when extensions are published to npm as standalone packages. The change is mechanical and consistent across all extensions:

- **29 extensions**: Added new `peerDependencies: { "openclaw": ">=2026.2.14" }` block
- **2 extensions** (`googlechat`, `memory-core`): Updated existing `peerDependencies` from `>=2026.1.26` to `>=2026.2.14`

The `devDependencies: { "openclaw": "workspace:*" }` declarations are correctly preserved for local pnpm workspace development. This aligns with repository guidelines in `AGENTS.md:12` which specifies that extensions should put `openclaw` in `peerDependencies` to avoid npm install breakage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a mechanical, well-understood change that adds peer dependency declarations to extension packages. The modifications are consistent across all 31 files, use proper semver ranges, preserve existing workspace protocol for local development, and align with documented repository guidelines. The PR author has verified the change with `pnpm install` and `pnpm run build`.
- No files require special attention

<sub>Last reviewed commit: 16d8950</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->