### PR TITLE
test(discord): add unit tests for presence cache module

### DIFF
--- a/src/discord/monitor/presence-cache.test.ts
+++ b/src/discord/monitor/presence-cache.test.ts
@@ -1,0 +1,85 @@
+import { type GatewayPresenceUpdate, PresenceUpdateStatus } from "discord-api-types/v10";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearPresences, getPresence, presenceCacheSize, setPresence } from "./presence-cache.js";
+
+function makePresence(
+  userId: string,
+  status: PresenceUpdateStatus = PresenceUpdateStatus.Online,
+): GatewayPresenceUpdate {
+  return {
+    user: { id: userId },
+    status,
+    activities: [],
+    client_status: {},
+  } as unknown as GatewayPresenceUpdate;
+}
+
+describe("presence-cache", () => {
+  afterEach(() => {
+    clearPresences();
+  });
+
+  it("stores and retrieves presence by account and user", () => {
+    const presence = makePresence("u1");
+    setPresence("acc1", "u1", presence);
+    expect(getPresence("acc1", "u1")).toBe(presence);
+  });
+
+  it("returns undefined for unknown user", () => {
+    expect(getPresence("acc1", "u1")).toBeUndefined();
+  });
+
+  it("returns undefined for unknown account", () => {
+    setPresence("acc1", "u1", makePresence("u1"));
+    expect(getPresence("acc2", "u1")).toBeUndefined();
+  });
+
+  it("uses 'default' key when accountId is undefined", () => {
+    const presence = makePresence("u1");
+    setPresence(undefined, "u1", presence);
+    expect(getPresence(undefined, "u1")).toBe(presence);
+  });
+
+  it("overwrites existing presence for the same user", () => {
+    setPresence("acc1", "u1", makePresence("u1", PresenceUpdateStatus.Online));
+    const updated = makePresence("u1", PresenceUpdateStatus.Idle);
+    setPresence("acc1", "u1", updated);
+    expect(getPresence("acc1", "u1")).toBe(updated);
+    expect(presenceCacheSize()).toBe(1);
+  });
+
+  it("tracks total cache size across accounts", () => {
+    setPresence("acc1", "u1", makePresence("u1"));
+    setPresence("acc1", "u2", makePresence("u2"));
+    setPresence("acc2", "u3", makePresence("u3"));
+    expect(presenceCacheSize()).toBe(3);
+  });
+
+  it("clears all presences when no accountId given", () => {
+    setPresence("acc1", "u1", makePresence("u1"));
+    setPresence("acc2", "u2", makePresence("u2"));
+    clearPresences();
+    expect(presenceCacheSize()).toBe(0);
+  });
+
+  it("clears only the specified account", () => {
+    setPresence("acc1", "u1", makePresence("u1"));
+    setPresence("acc2", "u2", makePresence("u2"));
+    clearPresences("acc1");
+    expect(getPresence("acc1", "u1")).toBeUndefined();
+    expect(getPresence("acc2", "u2")).toBeDefined();
+    expect(presenceCacheSize()).toBe(1);
+  });
+
+  it("evicts oldest entry when exceeding max cache size", () => {
+    const limit = 5000;
+    for (let i = 0; i < limit + 1; i++) {
+      setPresence("acc1", `u${i}`, makePresence(`u${i}`));
+    }
+    // First entry should have been evicted
+    expect(getPresence("acc1", "u0")).toBeUndefined();
+    // Last entry should exist
+    expect(getPresence("acc1", `u${limit}`)).toBeDefined();
+    expect(presenceCacheSize()).toBe(limit);
+  });
+});


### PR DESCRIPTION
The presence cache module (`src/discord/monitor/presence-cache.ts`) had zero test coverage.

Adds 9 unit tests covering:
- Store and retrieve presence data
- Undefined accountId fallback behavior
- Overwrites for same user+account
- Per-account clearing
- Global clearing
- Cross-account size tracking
- Max-size eviction (5000 cap)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a comprehensive unit test suite for the Discord presence cache module (`src/discord/monitor/presence-cache.ts`), which previously had zero test coverage. The 9 tests cover the full public API surface: `setPresence`, `getPresence`, `clearPresences`, and `presenceCacheSize`, including edge cases like the `undefined` accountId fallback to `"default"` key and the 5000-entry per-account eviction cap.

- Tests follow project conventions: colocated `*.test.ts`, vitest framework, proper `afterEach` cleanup of module-level state
- Eviction test correctly verifies FIFO eviction behavior at the 5000-entry boundary
- No issues found — clean, focused test addition with no production code changes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds a new test file with no changes to production code.
- Score of 5 reflects that this is a pure test addition with no production code changes. The tests are correctly written, properly isolated, and follow project conventions. No logical errors or issues found.
- No files require special attention.

<sub>Last reviewed commit: 7a61b28</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->