### PR TITLE
feat: Auto-configure Z.AI MCP tools during onboard

### DIFF
--- a/skills/zai-vision/SKILL.md
+++ b/skills/zai-vision/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: zai-vision
+description: AI Agent's "eyes" for processing visual information. Specialized for frontend development and bug debugging. Convert UI to code, OCR optimization, error diagnosis, diagram understanding, and data visualization analysis.
+metadata:
+  openclaw:
+    emoji: 👁️
+    priority: high
+    triggers:
+      - "分析图片"
+      - "看图"
+      - "这个截图"
+      - "UI 设计"
+      - "错误截图"
+      - "架构图"
+      - "流程图"
+      - "视频分析"
+      - "OCR"
+      - "识别文字"
+      - "前端还原"
+      - "UI 转代码"
+---
+
+# Vision Assistant - AI Agent 的"眼睛"
+
+**弥补传统 LLM 只能处理文本的短板** - 将视觉感知与可执行动作无缝链接
+
+## 核心优势
+
+- ✅ **前端还原** - UI 截图直接生成可运行代码
+- ✅ **自动化错误排查** - 分析报错截图，给出具体修复建议
+- ✅ **优化的 OCR** - 专门针对代码、终端输出、技术文档
+- ✅ **图表理解** - 从数据可视化中提取趋势和洞察
+
+## 核心应用场景
+
+1. **前端开发** - UI 设计稿 → 可运行代码
+2. **Bug 调试** - 错误截图 → 修复方案
+3. **代码审查** - 截图 OCR → 提取代码
+4. **架构理解** - 技术图表 → 系统分析
+5. **数据分析** - 图表仪表盘 → 趋势洞察
+
+## Important Rules
+
+### ⚠️ File Path Requirement
+- **MUST use local file path**: `/path/to/image.png`
+- **NEVER use URLs**: Will cause 400 error
+- If user provides URL, download to `/tmp/` first
+
+### File Format Support
+- **Images**: JPG, PNG, WebP
+- **Videos**: MP4, MOV, M4V (max 8MB)
+
+## Automatic Tool Selection
+
+### 1. UI to Code (前端还原神器)
+**工具**: `zai-vision.ui_to_artifact`
+**能力**: 直接将 UI 截图转换为可运行的代码、提示词或技术规格
+
+**输出类型**:
+- `code`: 生成可运行的前端代码
+- `prompt`: 生成 AI 提示词（用于重新创建 UI）
+- `spec`: 生成技术规格说明
+- `description`: 自然语言描述
+
+**示例**:
+```
+User: "把这个设计稿转成 React 代码 /tmp/design.png"
+→ Call: mcporter call zai-vision.ui_to_artifact
+         image_source="/tmp/design.png"
+         output_type="code"
+         prompt="生成 React 组件"
+→ Result: 可直接运行的 React 代码
+```
+
+### 2. Optimized OCR (代码/终端/文档专用)
+**工具**: `zai-vision.extract_text_from_screenshot`
+**能力**: 专门优化针对以下场景的 OCR 识别
+- 💻 代码截图
+- 🖥️ 终端输出
+- 📄 技术文档
+
+**示例**:
+```
+User: "提取这个终端输出的文字 /tmp/terminal.png"
+→ Call: mcporter call zai-vision.extract_text_from_screenshot
+         image_source="/tmp/terminal.png"
+         prompt="提取终端输出内容"
+         programming_language="python"  # 可选
+→ Result: 格式化的代码/文本
+```
+
+### 3. Error Diagnosis (开发者利器)
+**工具**: `zai-vision.diagnose_error_screenshot`
+**能力**: 分析报错截图并给出**具体的修复建议**
+
+**示例**:
+```
+User: "看看这个错误怎么解决 /tmp/error.png"
+→ Call: mcporter call zai-vision.diagnose_error_screenshot
+         image_source="/tmp/error.png"
+         prompt="分析错误原因并给出修复方案"
+         context="运行 npm install 时出现"
+→ Result: 错误原因 + 具体修复步骤
+```
+
+### 4. Technical Diagram Understanding (架构图理解)
+**工具**: `zai-vision.understand_technical_diagram`
+**能力**: 理解复杂的技术图表
+- 🏗️ 系统架构图
+- 🔄 流程图
+- 📐 UML 图
+- 🗃️ ER 图
+
+**示例**:
+```
+User: "解释这个系统架构 /tmp/architecture.png"
+→ Call: mcporter call zai-vision.understand_technical_diagram
+         image_source="/tmp/architecture.png"
+         prompt="详细解释这个架构的组成部分和数据流"
+         diagram_type="architecture"
+→ Result: 架构解析 + 组件说明 + 数据流分析
+```
+
+### 5. Data Visualization Analysis (图表洞察)
+**工具**: `zai-vision.analyze_data_visualization`
+**能力**: 从图表和仪表盘中提取数据趋势和洞察
+
+**分析重点**:
+- 📈 趋势识别
+- ⚠️ 异常检测
+- 🔍 对比分析
+- 📊 性能指标
+
+**示例**:
+```
+User: "分析这个仪表盘 /tmp/dashboard.png"
+→ Call: mcporter call zai-vision.analyze_data_visualization
+         image_source="/tmp/dashboard.png"
+         prompt="提取关键指标和趋势"
+         analysis_focus="performance metrics"
+→ Result: 关键指标 + 趋势分析 + 异常提醒
+```
+
+## Workflow
+
+1. **Detect file path** in user message
+2. **Download if URL** (save to `/tmp/`)
+3. **Determine tool** based on user intent
+4. **Call via mcporter**
+5. **Present results** in Chinese
+
+## Error Handling
+
+### If user provides URL:
+1. Download to `/tmp/`: `curl -o /tmp/image.png "URL"`
+2. Then analyze local file
+
+### If file not found:
+1. Ask user to verify path
+2. Suggest checking file exists: `ls -la /path/to/file`
+
+### If 400 error:
+1. Confirm using local path (not URL)
+2. Check file format (JPG/PNG)
+3. For video: check size ≤ 8MB
+
+## Integration Tips
+
+- Always expand `~` to full path
+- Timeout: 60 seconds default
+- Present results in user's language (Chinese if asked in Chinese)

--- a/skills/zai-vision/SKILL.md
+++ b/skills/zai-vision/SKILL.md
@@ -42,27 +42,32 @@ metadata:
 ## Important Rules
 
 ### ⚠️ File Path Requirement
+
 - **MUST use local file path**: `/path/to/image.png`
 - **NEVER use URLs**: Will cause 400 error
 - If user provides URL, download to `/tmp/` first
 
 ### File Format Support
+
 - **Images**: JPG, PNG, WebP
 - **Videos**: MP4, MOV, M4V (max 8MB)
 
 ## Automatic Tool Selection
 
 ### 1. UI to Code (前端还原神器)
+
 **工具**: `zai-vision.ui_to_artifact`
 **能力**: 直接将 UI 截图转换为可运行的代码、提示词或技术规格
 
 **输出类型**:
+
 - `code`: 生成可运行的前端代码
 - `prompt`: 生成 AI 提示词（用于重新创建 UI）
 - `spec`: 生成技术规格说明
 - `description`: 自然语言描述
 
 **示例**:
+
 ```
 User: "把这个设计稿转成 React 代码 /tmp/design.png"
 → Call: mcporter call zai-vision.ui_to_artifact
@@ -73,13 +78,16 @@ User: "把这个设计稿转成 React 代码 /tmp/design.png"
 ```
 
 ### 2. Optimized OCR (代码/终端/文档专用)
+
 **工具**: `zai-vision.extract_text_from_screenshot`
 **能力**: 专门优化针对以下场景的 OCR 识别
+
 - 💻 代码截图
 - 🖥️ 终端输出
 - 📄 技术文档
 
 **示例**:
+
 ```
 User: "提取这个终端输出的文字 /tmp/terminal.png"
 → Call: mcporter call zai-vision.extract_text_from_screenshot
@@ -90,10 +98,12 @@ User: "提取这个终端输出的文字 /tmp/terminal.png"
 ```
 
 ### 3. Error Diagnosis (开发者利器)
+
 **工具**: `zai-vision.diagnose_error_screenshot`
 **能力**: 分析报错截图并给出**具体的修复建议**
 
 **示例**:
+
 ```
 User: "看看这个错误怎么解决 /tmp/error.png"
 → Call: mcporter call zai-vision.diagnose_error_screenshot
@@ -104,14 +114,17 @@ User: "看看这个错误怎么解决 /tmp/error.png"
 ```
 
 ### 4. Technical Diagram Understanding (架构图理解)
+
 **工具**: `zai-vision.understand_technical_diagram`
 **能力**: 理解复杂的技术图表
+
 - 🏗️ 系统架构图
 - 🔄 流程图
 - 📐 UML 图
 - 🗃️ ER 图
 
 **示例**:
+
 ```
 User: "解释这个系统架构 /tmp/architecture.png"
 → Call: mcporter call zai-vision.understand_technical_diagram
@@ -122,16 +135,19 @@ User: "解释这个系统架构 /tmp/architecture.png"
 ```
 
 ### 5. Data Visualization Analysis (图表洞察)
+
 **工具**: `zai-vision.analyze_data_visualization`
 **能力**: 从图表和仪表盘中提取数据趋势和洞察
 
 **分析重点**:
+
 - 📈 趋势识别
 - ⚠️ 异常检测
 - 🔍 对比分析
 - 📊 性能指标
 
 **示例**:
+
 ```
 User: "分析这个仪表盘 /tmp/dashboard.png"
 → Call: mcporter call zai-vision.analyze_data_visualization
@@ -152,14 +168,17 @@ User: "分析这个仪表盘 /tmp/dashboard.png"
 ## Error Handling
 
 ### If user provides URL:
+
 1. Download to `/tmp/`: `curl -o /tmp/image.png "URL"`
 2. Then analyze local file
 
 ### If file not found:
+
 1. Ask user to verify path
 2. Suggest checking file exists: `ls -la /path/to/file`
 
 ### If 400 error:
+
 1. Confirm using local path (not URL)
 2. Check file format (JPG/PNG)
 3. For video: check size ≤ 8MB

--- a/skills/zread/SKILL.md
+++ b/skills/zread/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: zread
+description: Deep analysis of GitHub repositories using Zread MCP (GLM Coding Plan exclusive). Search docs/issues/PRs, analyze structure, and read source code in real-time.
+metadata:
+  openclaw:
+    emoji: 📦
+    priority: high
+    triggers:
+      - "分析仓库"
+      - "查看仓库"
+      - "了解项目"
+      - "GitHub 仓库"
+      - "repo structure"
+      - "how does this repo work"
+      - "源码分析"
+      - "依赖库调研"
+      - "Issue"
+      - "PR"
+---
+
+# GitHub Repository Analyzer (Zread MCP)
+
+**GLM Coding Plan 专属能力** - 为智能体工程（Agentic Engineering）量身定制
+
+## 核心优势
+
+- ✅ **实时调取真实代码和文档** - AI 不再"盲猜"
+- ✅ **搜索 Issue/PR/贡献者** - 快速掌握项目背景
+- ✅ **深度源码分析** - 读取完整代码实现
+- ✅ **加速学习曲线** - 快速理解新库
+
+## When to Use
+
+**Trigger automatically when user says:**
+- "分析 [某个] 仓库"
+- "查看 [owner/repo] 的结构"
+- "帮我了解 [project] 项目"
+- "这个 GitHub 仓库怎么用"
+- "Read the README of [repo]"
+- "Explain how [repo] works"
+- "源码分析 [repo]"
+- "调研 [repo] 依赖库"
+- "查看 [repo] 的 Issue/PR"
+
+## Automatic Workflow
+
+1. **Extract repo name** from user message (format: `owner/repo`)
+2. **Choose appropriate tool:**
+   - For structure/exploration → `zread.get_repo_structure`
+   - For specific questions → `zread.search_doc`
+   - For specific files → `zread.read_file`
+3. **Call via mcporter** and present results
+
+## Example Triggers
+
+### Structure Analysis
+```
+User: "分析 facebook/react 仓库"
+→ Call: zread.get_repo_structure repo_name="facebook/react"
+→ Present: directory tree + key files
+```
+
+### Documentation Search
+```
+User: "vuejs/core 的响应式原理是什么"
+→ Call: zread.search_doc repo_name="vuejs/core" query="reactivity principle" language="zh"
+→ Present: relevant docs + code snippets
+```
+
+### File Reading
+```
+User: "读取 openclaw/openclaw 的 README.md"
+→ Call: zread.read_file repo_name="openclaw/openclaw" file_path="README.md"
+→ Present: file content
+```
+
+## Tool Reference
+
+### zread.search_doc
+**不只是搜索代码** - 全方位检索项目知识
+- **参数**: `repo_name`, `query`, `language` (zh/en)
+- **搜索范围**:
+  - 📚 仓库知识文档
+  - 🐛 近期 Issue
+  - 🔀 Pull Request
+  - 👥 贡献者信息
+- **用途**: 快速掌握项目背景、查找解决方案、了解项目动态
+- **示例**: `mcporter call zread.search_doc repo_name="owner/repo" query="installation" language="zh"`
+
+### zread.get_repo_structure
+**一键获取项目全貌**
+- **参数**: `repo_name` (required), `dir_path` (optional)
+- **返回**: 完整目录树 + 文件列表
+- **用途**: 快速理解模块划分、逻辑布局、项目架构
+- **示例**: `mcporter call zread.get_repo_structure repo_name="owner/repo"`
+
+### zread.read_file
+**深度源码分析**
+- **参数**: `repo_name`, `file_path`
+- **返回**: 完整代码内容
+- **用途**: 理解实现逻辑、学习代码风格、调试问题
+- **示例**: `mcporter call zread.read_file repo_name="owner/repo" file_path="src/index.js"`
+
+## Notes
+
+- **GLM Coding Plan 专属** - 需要 GLM Coding Plan 订阅
+- Only works with **public** GitHub repositories
+- Format must be `owner/repo`
+- Timeout: up to 60 seconds
+- Always provide Chinese response when user asks in Chinese
+
+## Typical Use Cases
+
+### 1. 学习新库
+```
+User: "我想学 React，帮我看看 facebook/react 的结构"
+→ get_repo_structure → 展示项目布局
+→ search_doc "getting started" → 查找入门文档
+→ read_file "README.md" → 读取完整说明
+```
+
+### 2. 依赖库调研
+```
+User: "调研一下 vuejs/core 的响应式系统实现"
+→ search_doc "reactivity implementation"
+→ read_file "packages/reactivity/src/reactive.ts"
+→ 解释核心实现逻辑
+```
+
+### 3. Bug 修复
+```
+User: "这个库有个问题，看看最近的 Issue"
+→ search_doc "recent issues"
+→ 分析 Issue 中的解决方案
+→ read_file 相关代码文件
+```
+
+### 4. 贡献代码
+```
+User: "我想给 openclaw/openclaw 提 PR，看看贡献者指南"
+→ search_doc "contributing"
+→ read_file "CONTRIBUTING.md"
+→ 展示贡献流程
+```
+
+## Error Handling
+
+If repo not found or timeout:
+1. Check if repo is public
+2. Verify format is `owner/repo`
+3. Suggest alternative: use `gh` CLI or `web_fetch`

--- a/skills/zread/SKILL.md
+++ b/skills/zread/SKILL.md
@@ -32,6 +32,7 @@ metadata:
 ## When to Use
 
 **Trigger automatically when user says:**
+
 - "分析 [某个] 仓库"
 - "查看 [owner/repo] 的结构"
 - "帮我了解 [project] 项目"
@@ -54,6 +55,7 @@ metadata:
 ## Example Triggers
 
 ### Structure Analysis
+
 ```
 User: "分析 facebook/react 仓库"
 → Call: zread.get_repo_structure repo_name="facebook/react"
@@ -61,6 +63,7 @@ User: "分析 facebook/react 仓库"
 ```
 
 ### Documentation Search
+
 ```
 User: "vuejs/core 的响应式原理是什么"
 → Call: zread.search_doc repo_name="vuejs/core" query="reactivity principle" language="zh"
@@ -68,6 +71,7 @@ User: "vuejs/core 的响应式原理是什么"
 ```
 
 ### File Reading
+
 ```
 User: "读取 openclaw/openclaw 的 README.md"
 → Call: zread.read_file repo_name="openclaw/openclaw" file_path="README.md"
@@ -77,7 +81,9 @@ User: "读取 openclaw/openclaw 的 README.md"
 ## Tool Reference
 
 ### zread.search_doc
+
 **不只是搜索代码** - 全方位检索项目知识
+
 - **参数**: `repo_name`, `query`, `language` (zh/en)
 - **搜索范围**:
   - 📚 仓库知识文档
@@ -88,14 +94,18 @@ User: "读取 openclaw/openclaw 的 README.md"
 - **示例**: `mcporter call zread.search_doc repo_name="owner/repo" query="installation" language="zh"`
 
 ### zread.get_repo_structure
+
 **一键获取项目全貌**
+
 - **参数**: `repo_name` (required), `dir_path` (optional)
 - **返回**: 完整目录树 + 文件列表
 - **用途**: 快速理解模块划分、逻辑布局、项目架构
 - **示例**: `mcporter call zread.get_repo_structure repo_name="owner/repo"`
 
 ### zread.read_file
+
 **深度源码分析**
+
 - **参数**: `repo_name`, `file_path`
 - **返回**: 完整代码内容
 - **用途**: 理解实现逻辑、学习代码风格、调试问题
@@ -112,6 +122,7 @@ User: "读取 openclaw/openclaw 的 README.md"
 ## Typical Use Cases
 
 ### 1. 学习新库
+
 ```
 User: "我想学 React，帮我看看 facebook/react 的结构"
 → get_repo_structure → 展示项目布局
@@ -120,6 +131,7 @@ User: "我想学 React，帮我看看 facebook/react 的结构"
 ```
 
 ### 2. 依赖库调研
+
 ```
 User: "调研一下 vuejs/core 的响应式系统实现"
 → search_doc "reactivity implementation"
@@ -128,6 +140,7 @@ User: "调研一下 vuejs/core 的响应式系统实现"
 ```
 
 ### 3. Bug 修复
+
 ```
 User: "这个库有个问题，看看最近的 Issue"
 → search_doc "recent issues"
@@ -136,6 +149,7 @@ User: "这个库有个问题，看看最近的 Issue"
 ```
 
 ### 4. 贡献代码
+
 ```
 User: "我想给 openclaw/openclaw 提 PR，看看贡献者指南"
 → search_doc "contributing"
@@ -146,6 +160,7 @@ User: "我想给 openclaw/openclaw 提 PR，看看贡献者指南"
 ## Error Handling
 
 If repo not found or timeout:
+
 1. Check if repo is public
 2. Verify format is `owner/repo`
 3. Suggest alternative: use `gh` CLI or `web_fetch`

--- a/src/commands/__tests__/zai-mcp-tools-config.test.ts
+++ b/src/commands/__tests__/zai-mcp-tools-config.test.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { configureZaiMcpTools } from "../zai-mcp-tools-config.js";
+
+describe("configureZaiMcpTools", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "zai-mcp-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("should create mcporter.json with all Z.AI MCP tools", async () => {
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const configPath = path.join(tempDir, "config", "mcporter.json");
+    const content = await fs.readFile(configPath, "utf-8");
+    const config = JSON.parse(content);
+
+    expect(config.mcpServers).toBeDefined();
+    expect(config.mcpServers.zread).toBeDefined();
+    expect(config.mcpServers["zai-vision"]).toBeDefined();
+    expect(config.mcpServers["zai-web-search"]).toBeDefined();
+  });
+
+  it("should configure zread with correct HTTP settings", async () => {
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const configPath = path.join(tempDir, "config", "mcporter.json");
+    const content = await fs.readFile(configPath, "utf-8");
+    const config = JSON.parse(content);
+
+    expect(config.mcpServers.zread.baseUrl).toBe("https://api.z.ai/api/mcp/zread/mcp");
+    expect(config.mcpServers.zread.headers.Authorization).toBe(`Bearer ${apiKey}`);
+  });
+
+  it("should configure zai-vision with stdio mode", async () => {
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const configPath = path.join(tempDir, "config", "mcporter.json");
+    const content = await fs.readFile(configPath, "utf-8");
+    const config = JSON.parse(content);
+
+    expect(config.mcpServers["zai-vision"].command).toBe("npx -y @z_ai/mcp-server");
+    expect(config.mcpServers["zai-vision"].env.Z_AI_API_KEY).toBe(apiKey);
+  });
+
+  it("should preserve existing mcpServers when merging", async () => {
+    // Create existing config
+    const configDir = path.join(tempDir, "config");
+    await fs.mkdir(configDir, { recursive: true });
+    const existingConfig = {
+      mcpServers: {
+        "existing-tool": {
+          command: "existing-command",
+        },
+      },
+    };
+    await fs.writeFile(path.join(configDir, "mcporter.json"), JSON.stringify(existingConfig));
+
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const content = await fs.readFile(path.join(configDir, "mcporter.json"), "utf-8");
+    const config = JSON.parse(content);
+
+    // Existing tool should be preserved
+    expect(config.mcpServers["existing-tool"]).toBeDefined();
+    expect(config.mcpServers["existing-tool"].command).toBe("existing-command");
+    // New tools should be added
+    expect(config.mcpServers.zread).toBeDefined();
+  });
+
+  it("should handle config without mcpServers field", async () => {
+    // Create existing config without mcpServers
+    const configDir = path.join(tempDir, "config");
+    await fs.mkdir(configDir, { recursive: true });
+    const existingConfig = {
+      otherField: "someValue",
+    };
+    await fs.writeFile(path.join(configDir, "mcporter.json"), JSON.stringify(existingConfig));
+
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const content = await fs.readFile(path.join(configDir, "mcporter.json"), "utf-8");
+    const config = JSON.parse(content);
+
+    // mcpServers should be created
+    expect(config.mcpServers).toBeDefined();
+    expect(config.mcpServers.zread).toBeDefined();
+    // Other fields should be preserved
+    expect(config.otherField).toBe("someValue");
+  });
+
+  it("should handle invalid JSON in existing config", async () => {
+    const configDir = path.join(tempDir, "config");
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(path.join(configDir, "mcporter.json"), "invalid json {{{");
+
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const content = await fs.readFile(path.join(configDir, "mcporter.json"), "utf-8");
+    const config = JSON.parse(content);
+
+    // Should create valid config
+    expect(config.mcpServers).toBeDefined();
+    expect(config.mcpServers.zread).toBeDefined();
+  });
+});

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -646,7 +646,7 @@ export async function applyAuthChoiceApiProviders(
 
     // Auto-configure Z.AI MCP tools (zread, vision, web-search)
     try {
-      if (apiKey) {
+      if (apiKey && params.agentDir) {
         await configureZaiMcpTools(apiKey, params.agentDir);
         await params.prompter.note(
           "Z.AI MCP tools (zread, vision, web-search) auto-configured.",

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -653,7 +653,10 @@ export async function applyAuthChoiceApiProviders(
     // Auto-configure Z.AI MCP tools (zread, vision, web-search)
     try {
       await configureZaiMcpTools(apiKey, params.agentDir);
-      await params.prompter.note("Z.AI MCP tools (zread, vision, web-search) auto-configured.", "MCP Tools");
+      await params.prompter.note(
+        "Z.AI MCP tools (zread, vision, web-search) auto-configured.",
+        "MCP Tools",
+      );
     } catch (e) {
       // Non-fatal, just log and continue
       console.warn("Failed to auto-configure Z.AI MCP tools:", e);

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -79,6 +79,7 @@ import {
 import type { AuthChoice } from "./onboard-types.js";
 import { OPENCODE_ZEN_DEFAULT_MODEL } from "./opencode-zen-model-default.js";
 import { detectZaiEndpoint } from "./zai-endpoint-detect.js";
+import { configureZaiMcpTools } from "./zai-mcp-tools-config.js";
 
 const API_KEY_TOKEN_PROVIDER_AUTH_CHOICE: Record<string, AuthChoice> = {
   openrouter: "openrouter-api-key",
@@ -648,6 +649,15 @@ export async function applyAuthChoiceApiProviders(
         }),
       noteDefault: defaultModel,
     });
+
+    // Auto-configure Z.AI MCP tools (zread, vision, web-search)
+    try {
+      await configureZaiMcpTools(apiKey, params.agentDir);
+      await params.prompter.note("Z.AI MCP tools (zread, vision, web-search) auto-configured.", "MCP Tools");
+    } catch (e) {
+      // Non-fatal, just log and continue
+      console.warn("Failed to auto-configure Z.AI MCP tools:", e);
+    }
 
     return { config: nextConfig, agentModelOverride };
   }

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -549,7 +549,7 @@ export async function applyAuthChoiceApiProviders(
 
     // Input API key
     let hasCredential = false;
-    let apiKey = "";
+    let apiKey: string = "";
 
     if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "zai") {
       apiKey = normalizeApiKeyInput(params.opts.token);

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -5,16 +5,10 @@ import {
   normalizeApiKeyInput,
   validateApiKeyInput,
 } from "./auth-choice.api-key.js";
-import {
-  createAuthChoiceAgentModelNoter,
-  createAuthChoiceDefaultModelApplier,
-  createAuthChoiceModelStateBridge,
-  ensureApiKeyFromOptionEnvOrPrompt,
-  normalizeTokenProviderInput,
-} from "./auth-choice.apply-helpers.js";
 import { applyAuthChoiceHuggingface } from "./auth-choice.apply.huggingface.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyAuthChoiceOpenRouter } from "./auth-choice.apply.openrouter.js";
+import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
 import {
   applyGoogleGeminiModelDefault,
   GOOGLE_GEMINI_DEFAULT_MODEL,
@@ -29,8 +23,6 @@ import {
   applyKimiCodeProviderConfig,
   applyLitellmConfig,
   applyLitellmProviderConfig,
-  applyMistralConfig,
-  applyMistralProviderConfig,
   applyMoonshotConfig,
   applyMoonshotConfigCn,
   applyMoonshotProviderConfig,
@@ -54,7 +46,6 @@ import {
   QIANFAN_DEFAULT_MODEL_REF,
   KIMI_CODING_MODEL_REF,
   MOONSHOT_DEFAULT_MODEL_REF,
-  MISTRAL_DEFAULT_MODEL_REF,
   SYNTHETIC_DEFAULT_MODEL_REF,
   TOGETHER_DEFAULT_MODEL_REF,
   VENICE_DEFAULT_MODEL_REF,
@@ -65,7 +56,6 @@ import {
   setGeminiApiKey,
   setLitellmApiKey,
   setKimiCodingApiKey,
-  setMistralApiKey,
   setMoonshotApiKey,
   setOpencodeZenApiKey,
   setSyntheticApiKey,
@@ -76,314 +66,95 @@ import {
   setZaiApiKey,
   ZAI_DEFAULT_MODEL_REF,
 } from "./onboard-auth.js";
-import type { AuthChoice } from "./onboard-types.js";
 import { OPENCODE_ZEN_DEFAULT_MODEL } from "./opencode-zen-model-default.js";
 import { detectZaiEndpoint } from "./zai-endpoint-detect.js";
 import { configureZaiMcpTools } from "./zai-mcp-tools-config.js";
-
-const API_KEY_TOKEN_PROVIDER_AUTH_CHOICE: Record<string, AuthChoice> = {
-  openrouter: "openrouter-api-key",
-  litellm: "litellm-api-key",
-  "vercel-ai-gateway": "ai-gateway-api-key",
-  "cloudflare-ai-gateway": "cloudflare-ai-gateway-api-key",
-  moonshot: "moonshot-api-key",
-  "kimi-code": "kimi-code-api-key",
-  "kimi-coding": "kimi-code-api-key",
-  google: "gemini-api-key",
-  zai: "zai-api-key",
-  xiaomi: "xiaomi-api-key",
-  synthetic: "synthetic-api-key",
-  venice: "venice-api-key",
-  together: "together-api-key",
-  huggingface: "huggingface-api-key",
-  mistral: "mistral-api-key",
-  opencode: "opencode-zen",
-  qianfan: "qianfan-api-key",
-};
-
-const ZAI_AUTH_CHOICE_ENDPOINT: Partial<
-  Record<AuthChoice, "global" | "cn" | "coding-global" | "coding-cn">
-> = {
-  "zai-coding-global": "coding-global",
-  "zai-coding-cn": "coding-cn",
-  "zai-global": "global",
-  "zai-cn": "cn",
-};
-
-type ApiKeyProviderConfigApplier = (
-  config: ApplyAuthChoiceParams["config"],
-) => ApplyAuthChoiceParams["config"];
-
-type SimpleApiKeyProviderFlow = {
-  provider: Parameters<typeof ensureApiKeyFromOptionEnvOrPrompt>[0]["provider"];
-  profileId: string;
-  expectedProviders: string[];
-  envLabel: string;
-  promptMessage: string;
-  setCredential: (apiKey: string, agentDir?: string) => void | Promise<void>;
-  defaultModel: string;
-  applyDefaultConfig: ApiKeyProviderConfigApplier;
-  applyProviderConfig: ApiKeyProviderConfigApplier;
-  tokenProvider?: string;
-  normalize?: (value: string) => string;
-  validate?: (value: string) => string | undefined;
-  noteDefault?: string;
-  noteMessage?: string;
-  noteTitle?: string;
-};
-
-const SIMPLE_API_KEY_PROVIDER_FLOWS: Partial<Record<AuthChoice, SimpleApiKeyProviderFlow>> = {
-  "ai-gateway-api-key": {
-    provider: "vercel-ai-gateway",
-    profileId: "vercel-ai-gateway:default",
-    expectedProviders: ["vercel-ai-gateway"],
-    envLabel: "AI_GATEWAY_API_KEY",
-    promptMessage: "Enter Vercel AI Gateway API key",
-    setCredential: setVercelAiGatewayApiKey,
-    defaultModel: VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applyVercelAiGatewayConfig,
-    applyProviderConfig: applyVercelAiGatewayProviderConfig,
-    noteDefault: VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
-  },
-  "moonshot-api-key": {
-    provider: "moonshot",
-    profileId: "moonshot:default",
-    expectedProviders: ["moonshot"],
-    envLabel: "MOONSHOT_API_KEY",
-    promptMessage: "Enter Moonshot API key",
-    setCredential: setMoonshotApiKey,
-    defaultModel: MOONSHOT_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applyMoonshotConfig,
-    applyProviderConfig: applyMoonshotProviderConfig,
-  },
-  "moonshot-api-key-cn": {
-    provider: "moonshot",
-    profileId: "moonshot:default",
-    expectedProviders: ["moonshot"],
-    envLabel: "MOONSHOT_API_KEY",
-    promptMessage: "Enter Moonshot API key (.cn)",
-    setCredential: setMoonshotApiKey,
-    defaultModel: MOONSHOT_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applyMoonshotConfigCn,
-    applyProviderConfig: applyMoonshotProviderConfigCn,
-  },
-  "kimi-code-api-key": {
-    provider: "kimi-coding",
-    profileId: "kimi-coding:default",
-    expectedProviders: ["kimi-code", "kimi-coding"],
-    envLabel: "KIMI_API_KEY",
-    promptMessage: "Enter Kimi Coding API key",
-    setCredential: setKimiCodingApiKey,
-    defaultModel: KIMI_CODING_MODEL_REF,
-    applyDefaultConfig: applyKimiCodeConfig,
-    applyProviderConfig: applyKimiCodeProviderConfig,
-    noteDefault: KIMI_CODING_MODEL_REF,
-    noteMessage: [
-      "Kimi Coding uses a dedicated endpoint and API key.",
-      "Get your API key at: https://www.kimi.com/code/en",
-    ].join("\n"),
-    noteTitle: "Kimi Coding",
-  },
-  "xiaomi-api-key": {
-    provider: "xiaomi",
-    profileId: "xiaomi:default",
-    expectedProviders: ["xiaomi"],
-    envLabel: "XIAOMI_API_KEY",
-    promptMessage: "Enter Xiaomi API key",
-    setCredential: setXiaomiApiKey,
-    defaultModel: XIAOMI_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applyXiaomiConfig,
-    applyProviderConfig: applyXiaomiProviderConfig,
-    noteDefault: XIAOMI_DEFAULT_MODEL_REF,
-  },
-  "mistral-api-key": {
-    provider: "mistral",
-    profileId: "mistral:default",
-    expectedProviders: ["mistral"],
-    envLabel: "MISTRAL_API_KEY",
-    promptMessage: "Enter Mistral API key",
-    setCredential: setMistralApiKey,
-    defaultModel: MISTRAL_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applyMistralConfig,
-    applyProviderConfig: applyMistralProviderConfig,
-    noteDefault: MISTRAL_DEFAULT_MODEL_REF,
-  },
-  "venice-api-key": {
-    provider: "venice",
-    profileId: "venice:default",
-    expectedProviders: ["venice"],
-    envLabel: "VENICE_API_KEY",
-    promptMessage: "Enter Venice AI API key",
-    setCredential: setVeniceApiKey,
-    defaultModel: VENICE_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applyVeniceConfig,
-    applyProviderConfig: applyVeniceProviderConfig,
-    noteDefault: VENICE_DEFAULT_MODEL_REF,
-    noteMessage: [
-      "Venice AI provides privacy-focused inference with uncensored models.",
-      "Get your API key at: https://venice.ai/settings/api",
-      "Supports 'private' (fully private) and 'anonymized' (proxy) modes.",
-    ].join("\n"),
-    noteTitle: "Venice AI",
-  },
-  "opencode-zen": {
-    provider: "opencode",
-    profileId: "opencode:default",
-    expectedProviders: ["opencode"],
-    envLabel: "OPENCODE_API_KEY",
-    promptMessage: "Enter OpenCode Zen API key",
-    setCredential: setOpencodeZenApiKey,
-    defaultModel: OPENCODE_ZEN_DEFAULT_MODEL,
-    applyDefaultConfig: applyOpencodeZenConfig,
-    applyProviderConfig: applyOpencodeZenProviderConfig,
-    noteDefault: OPENCODE_ZEN_DEFAULT_MODEL,
-    noteMessage: [
-      "OpenCode Zen provides access to Claude, GPT, Gemini, and more models.",
-      "Get your API key at: https://opencode.ai/auth",
-      "OpenCode Zen bills per request. Check your OpenCode dashboard for details.",
-    ].join("\n"),
-    noteTitle: "OpenCode Zen",
-  },
-  "together-api-key": {
-    provider: "together",
-    profileId: "together:default",
-    expectedProviders: ["together"],
-    envLabel: "TOGETHER_API_KEY",
-    promptMessage: "Enter Together AI API key",
-    setCredential: setTogetherApiKey,
-    defaultModel: TOGETHER_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applyTogetherConfig,
-    applyProviderConfig: applyTogetherProviderConfig,
-    noteDefault: TOGETHER_DEFAULT_MODEL_REF,
-    noteMessage: [
-      "Together AI provides access to leading open-source models including Llama, DeepSeek, Qwen, and more.",
-      "Get your API key at: https://api.together.xyz/settings/api-keys",
-    ].join("\n"),
-    noteTitle: "Together AI",
-  },
-  "qianfan-api-key": {
-    provider: "qianfan",
-    profileId: "qianfan:default",
-    expectedProviders: ["qianfan"],
-    envLabel: "QIANFAN_API_KEY",
-    promptMessage: "Enter QIANFAN API key",
-    setCredential: setQianfanApiKey,
-    defaultModel: QIANFAN_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applyQianfanConfig,
-    applyProviderConfig: applyQianfanProviderConfig,
-    noteDefault: QIANFAN_DEFAULT_MODEL_REF,
-    noteMessage: [
-      "Get your API key at: https://console.bce.baidu.com/qianfan/ais/console/apiKey",
-      "API key format: bce-v3/ALTAK-...",
-    ].join("\n"),
-    noteTitle: "QIANFAN",
-  },
-  "synthetic-api-key": {
-    provider: "synthetic",
-    profileId: "synthetic:default",
-    expectedProviders: ["synthetic"],
-    envLabel: "SYNTHETIC_API_KEY",
-    promptMessage: "Enter Synthetic API key",
-    setCredential: setSyntheticApiKey,
-    defaultModel: SYNTHETIC_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applySyntheticConfig,
-    applyProviderConfig: applySyntheticProviderConfig,
-    normalize: (value) => String(value ?? "").trim(),
-    validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
-  },
-};
 
 export async function applyAuthChoiceApiProviders(
   params: ApplyAuthChoiceParams,
 ): Promise<ApplyAuthChoiceResult | null> {
   let nextConfig = params.config;
   let agentModelOverride: string | undefined;
-  const noteAgentModel = createAuthChoiceAgentModelNoter(params);
-  const applyProviderDefaultModel = createAuthChoiceDefaultModelApplier(
-    params,
-    createAuthChoiceModelStateBridge({
-      getConfig: () => nextConfig,
-      setConfig: (config) => (nextConfig = config),
-      getAgentModelOverride: () => agentModelOverride,
-      setAgentModelOverride: (model) => (agentModelOverride = model),
-    }),
-  );
+  const noteAgentModel = async (model: string) => {
+    if (!params.agentId) {
+      return;
+    }
+    await params.prompter.note(
+      `Default model set to ${model} for agent "${params.agentId}".`,
+      "Model configured",
+    );
+  };
 
   let authChoice = params.authChoice;
-  const normalizedTokenProvider = normalizeTokenProviderInput(params.opts?.tokenProvider);
-  if (authChoice === "apiKey" && params.opts?.tokenProvider) {
-    if (normalizedTokenProvider !== "anthropic" && normalizedTokenProvider !== "openai") {
-      authChoice = API_KEY_TOKEN_PROVIDER_AUTH_CHOICE[normalizedTokenProvider ?? ""] ?? authChoice;
+  if (
+    authChoice === "apiKey" &&
+    params.opts?.tokenProvider &&
+    params.opts.tokenProvider !== "anthropic" &&
+    params.opts.tokenProvider !== "openai"
+  ) {
+    if (params.opts.tokenProvider === "openrouter") {
+      authChoice = "openrouter-api-key";
+    } else if (params.opts.tokenProvider === "litellm") {
+      authChoice = "litellm-api-key";
+    } else if (params.opts.tokenProvider === "vercel-ai-gateway") {
+      authChoice = "ai-gateway-api-key";
+    } else if (params.opts.tokenProvider === "cloudflare-ai-gateway") {
+      authChoice = "cloudflare-ai-gateway-api-key";
+    } else if (params.opts.tokenProvider === "moonshot") {
+      authChoice = "moonshot-api-key";
+    } else if (
+      params.opts.tokenProvider === "kimi-code" ||
+      params.opts.tokenProvider === "kimi-coding"
+    ) {
+      authChoice = "kimi-code-api-key";
+    } else if (params.opts.tokenProvider === "google") {
+      authChoice = "gemini-api-key";
+    } else if (params.opts.tokenProvider === "zai") {
+      authChoice = "zai-api-key";
+    } else if (params.opts.tokenProvider === "xiaomi") {
+      authChoice = "xiaomi-api-key";
+    } else if (params.opts.tokenProvider === "synthetic") {
+      authChoice = "synthetic-api-key";
+    } else if (params.opts.tokenProvider === "venice") {
+      authChoice = "venice-api-key";
+    } else if (params.opts.tokenProvider === "together") {
+      authChoice = "together-api-key";
+    } else if (params.opts.tokenProvider === "huggingface") {
+      authChoice = "huggingface-api-key";
+    } else if (params.opts.tokenProvider === "opencode") {
+      authChoice = "opencode-zen";
+    } else if (params.opts.tokenProvider === "qianfan") {
+      authChoice = "qianfan-api-key";
     }
   }
 
-  async function applyApiKeyProviderWithDefaultModel({
-    provider,
-    profileId,
-    expectedProviders,
-    envLabel,
-    promptMessage,
-    setCredential,
-    defaultModel,
-    applyDefaultConfig,
-    applyProviderConfig,
-    noteMessage,
-    noteTitle,
-    tokenProvider = normalizedTokenProvider,
-    normalize = normalizeApiKeyInput,
-    validate = validateApiKeyInput,
-    noteDefault = defaultModel,
-  }: {
-    provider: Parameters<typeof ensureApiKeyFromOptionEnvOrPrompt>[0]["provider"];
-    profileId: string;
-    expectedProviders: string[];
-    envLabel: string;
-    promptMessage: string;
-    setCredential: (apiKey: string) => void | Promise<void>;
-    defaultModel: string;
-    applyDefaultConfig: (
-      config: ApplyAuthChoiceParams["config"],
-    ) => ApplyAuthChoiceParams["config"];
-    applyProviderConfig: (
-      config: ApplyAuthChoiceParams["config"],
-    ) => ApplyAuthChoiceParams["config"];
-    noteMessage?: string;
-    noteTitle?: string;
-    tokenProvider?: string;
-    normalize?: (value: string) => string;
-    validate?: (value: string) => string | undefined;
-    noteDefault?: string;
-  }): Promise<ApplyAuthChoiceResult> {
-    await ensureApiKeyFromOptionEnvOrPrompt({
-      token: params.opts?.token,
-      provider,
-      tokenProvider,
-      expectedProviders,
-      envLabel,
-      promptMessage,
-      setCredential: async (apiKey) => {
-        await setCredential(apiKey);
-      },
-      noteMessage,
-      noteTitle,
-      normalize,
-      validate,
-      prompter: params.prompter,
-    });
+  async function ensureMoonshotApiKeyCredential(promptMessage: string): Promise<void> {
+    let hasCredential = false;
 
-    nextConfig = applyAuthProfileConfig(nextConfig, {
-      profileId,
-      provider,
-      mode: "api_key",
-    });
-    await applyProviderDefaultModel({
-      defaultModel,
-      applyDefaultConfig,
-      applyProviderConfig,
-      noteDefault,
-    });
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "moonshot") {
+      await setMoonshotApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
 
-    return { config: nextConfig, agentModelOverride };
+    const envKey = resolveEnvApiKey("moonshot");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing MOONSHOT_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        await setMoonshotApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: promptMessage,
+        validate: validateApiKeyInput,
+      });
+      await setMoonshotApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+    }
   }
 
   if (authChoice === "openrouter-api-key") {
@@ -396,30 +167,41 @@ export async function applyAuthChoiceApiProviders(
     const existingProfileId = profileOrder.find((profileId) => Boolean(store.profiles[profileId]));
     const existingCred = existingProfileId ? store.profiles[existingProfileId] : undefined;
     let profileId = "litellm:default";
-    let hasCredential = Boolean(existingProfileId && existingCred?.type === "api_key");
-    if (hasCredential && existingProfileId) {
-      profileId = existingProfileId;
-    }
+    let hasCredential = false;
 
-    if (!hasCredential) {
-      await ensureApiKeyFromOptionEnvOrPrompt({
-        token: params.opts?.token,
-        tokenProvider: normalizedTokenProvider,
-        expectedProviders: ["litellm"],
-        provider: "litellm",
-        envLabel: "LITELLM_API_KEY",
-        promptMessage: "Enter LiteLLM API key",
-        normalize: normalizeApiKeyInput,
-        validate: validateApiKeyInput,
-        prompter: params.prompter,
-        setCredential: async (apiKey) => setLitellmApiKey(apiKey, params.agentDir),
-        noteMessage:
-          "LiteLLM provides a unified API to 100+ LLM providers.\nGet your API key from your LiteLLM proxy or https://litellm.ai\nDefault proxy runs on http://localhost:4000",
-        noteTitle: "LiteLLM",
-      });
+    if (existingProfileId && existingCred?.type === "api_key") {
+      profileId = existingProfileId;
       hasCredential = true;
     }
-
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "litellm") {
+      await setLitellmApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+    if (!hasCredential) {
+      await params.prompter.note(
+        "LiteLLM provides a unified API to 100+ LLM providers.\nGet your API key from your LiteLLM proxy or https://litellm.ai\nDefault proxy runs on http://localhost:4000",
+        "LiteLLM",
+      );
+      const envKey = resolveEnvApiKey("litellm");
+      if (envKey) {
+        const useExisting = await params.prompter.confirm({
+          message: `Use existing LITELLM_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+          initialValue: true,
+        });
+        if (useExisting) {
+          await setLitellmApiKey(envKey.apiKey, params.agentDir);
+          hasCredential = true;
+        }
+      }
+      if (!hasCredential) {
+        const key = await params.prompter.text({
+          message: "Enter LiteLLM API key",
+          validate: validateApiKeyInput,
+        });
+        await setLitellmApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+        hasCredential = true;
+      }
+    }
     if (hasCredential) {
       nextConfig = applyAuthProfileConfig(nextConfig, {
         profileId,
@@ -427,38 +209,75 @@ export async function applyAuthChoiceApiProviders(
         mode: "api_key",
       });
     }
-    await applyProviderDefaultModel({
+    const applied = await applyDefaultModelChoice({
+      config: nextConfig,
+      setDefaultModel: params.setDefaultModel,
       defaultModel: LITELLM_DEFAULT_MODEL_REF,
       applyDefaultConfig: applyLitellmConfig,
       applyProviderConfig: applyLitellmProviderConfig,
       noteDefault: LITELLM_DEFAULT_MODEL_REF,
+      noteAgentModel,
+      prompter: params.prompter,
     });
+    nextConfig = applied.config;
+    agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
     return { config: nextConfig, agentModelOverride };
   }
 
-  const simpleApiKeyProviderFlow = SIMPLE_API_KEY_PROVIDER_FLOWS[authChoice];
-  if (simpleApiKeyProviderFlow) {
-    return await applyApiKeyProviderWithDefaultModel({
-      provider: simpleApiKeyProviderFlow.provider,
-      profileId: simpleApiKeyProviderFlow.profileId,
-      expectedProviders: simpleApiKeyProviderFlow.expectedProviders,
-      envLabel: simpleApiKeyProviderFlow.envLabel,
-      promptMessage: simpleApiKeyProviderFlow.promptMessage,
-      setCredential: async (apiKey) =>
-        simpleApiKeyProviderFlow.setCredential(apiKey, params.agentDir),
-      defaultModel: simpleApiKeyProviderFlow.defaultModel,
-      applyDefaultConfig: simpleApiKeyProviderFlow.applyDefaultConfig,
-      applyProviderConfig: simpleApiKeyProviderFlow.applyProviderConfig,
-      noteDefault: simpleApiKeyProviderFlow.noteDefault,
-      noteMessage: simpleApiKeyProviderFlow.noteMessage,
-      noteTitle: simpleApiKeyProviderFlow.noteTitle,
-      tokenProvider: simpleApiKeyProviderFlow.tokenProvider,
-      normalize: simpleApiKeyProviderFlow.normalize,
-      validate: simpleApiKeyProviderFlow.validate,
+  if (authChoice === "ai-gateway-api-key") {
+    let hasCredential = false;
+
+    if (
+      !hasCredential &&
+      params.opts?.token &&
+      params.opts?.tokenProvider === "vercel-ai-gateway"
+    ) {
+      await setVercelAiGatewayApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+
+    const envKey = resolveEnvApiKey("vercel-ai-gateway");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing AI_GATEWAY_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        await setVercelAiGatewayApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter Vercel AI Gateway API key",
+        validate: validateApiKeyInput,
+      });
+      await setVercelAiGatewayApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "vercel-ai-gateway:default",
+      provider: "vercel-ai-gateway",
+      mode: "api_key",
     });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
+        applyDefaultConfig: applyVercelAiGatewayConfig,
+        applyProviderConfig: applyVercelAiGatewayProviderConfig,
+        noteDefault: VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
   }
 
   if (authChoice === "cloudflare-ai-gateway-api-key") {
+    let hasCredential = false;
     let accountId = params.opts?.cloudflareAiGatewayAccountId?.trim() ?? "";
     let gatewayId = params.opts?.cloudflareAiGatewayGatewayId?.trim() ?? "";
 
@@ -480,73 +299,215 @@ export async function applyAuthChoiceApiProviders(
     };
 
     const optsApiKey = normalizeApiKeyInput(params.opts?.cloudflareAiGatewayApiKey ?? "");
-    let resolvedApiKey = "";
-    if (accountId && gatewayId && optsApiKey) {
-      resolvedApiKey = optsApiKey;
+    if (!hasCredential && accountId && gatewayId && optsApiKey) {
+      await setCloudflareAiGatewayConfig(accountId, gatewayId, optsApiKey, params.agentDir);
+      hasCredential = true;
     }
 
     const envKey = resolveEnvApiKey("cloudflare-ai-gateway");
-    if (!resolvedApiKey && envKey) {
+    if (!hasCredential && envKey) {
       const useExisting = await params.prompter.confirm({
         message: `Use existing CLOUDFLARE_AI_GATEWAY_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
         initialValue: true,
       });
       if (useExisting) {
         await ensureAccountGateway();
-        resolvedApiKey = normalizeApiKeyInput(envKey.apiKey);
+        await setCloudflareAiGatewayConfig(
+          accountId,
+          gatewayId,
+          normalizeApiKeyInput(envKey.apiKey),
+          params.agentDir,
+        );
+        hasCredential = true;
       }
     }
 
-    if (!resolvedApiKey && optsApiKey) {
+    if (!hasCredential && optsApiKey) {
       await ensureAccountGateway();
-      resolvedApiKey = optsApiKey;
+      await setCloudflareAiGatewayConfig(accountId, gatewayId, optsApiKey, params.agentDir);
+      hasCredential = true;
     }
 
-    if (!resolvedApiKey) {
+    if (!hasCredential) {
       await ensureAccountGateway();
       const key = await params.prompter.text({
         message: "Enter Cloudflare AI Gateway API key",
         validate: validateApiKeyInput,
       });
-      resolvedApiKey = normalizeApiKeyInput(String(key ?? ""));
+      await setCloudflareAiGatewayConfig(
+        accountId,
+        gatewayId,
+        normalizeApiKeyInput(String(key ?? "")),
+        params.agentDir,
+      );
+      hasCredential = true;
     }
 
-    await setCloudflareAiGatewayConfig(accountId, gatewayId, resolvedApiKey, params.agentDir);
+    if (hasCredential) {
+      nextConfig = applyAuthProfileConfig(nextConfig, {
+        profileId: "cloudflare-ai-gateway:default",
+        provider: "cloudflare-ai-gateway",
+        mode: "api_key",
+      });
+    }
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
+        applyDefaultConfig: (cfg) =>
+          applyCloudflareAiGatewayConfig(cfg, {
+            accountId: accountId || params.opts?.cloudflareAiGatewayAccountId,
+            gatewayId: gatewayId || params.opts?.cloudflareAiGatewayGatewayId,
+          }),
+        applyProviderConfig: (cfg) =>
+          applyCloudflareAiGatewayProviderConfig(cfg, {
+            accountId: accountId || params.opts?.cloudflareAiGatewayAccountId,
+            gatewayId: gatewayId || params.opts?.cloudflareAiGatewayGatewayId,
+          }),
+        noteDefault: CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
+  }
+
+  if (authChoice === "moonshot-api-key") {
+    await ensureMoonshotApiKeyCredential("Enter Moonshot API key");
     nextConfig = applyAuthProfileConfig(nextConfig, {
-      profileId: "cloudflare-ai-gateway:default",
-      provider: "cloudflare-ai-gateway",
+      profileId: "moonshot:default",
+      provider: "moonshot",
       mode: "api_key",
     });
-    await applyProviderDefaultModel({
-      defaultModel: CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
-      applyDefaultConfig: (cfg) =>
-        applyCloudflareAiGatewayConfig(cfg, {
-          accountId: accountId || params.opts?.cloudflareAiGatewayAccountId,
-          gatewayId: gatewayId || params.opts?.cloudflareAiGatewayGatewayId,
-        }),
-      applyProviderConfig: (cfg) =>
-        applyCloudflareAiGatewayProviderConfig(cfg, {
-          accountId: accountId || params.opts?.cloudflareAiGatewayAccountId,
-          gatewayId: gatewayId || params.opts?.cloudflareAiGatewayGatewayId,
-        }),
-      noteDefault: CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: MOONSHOT_DEFAULT_MODEL_REF,
+        applyDefaultConfig: applyMoonshotConfig,
+        applyProviderConfig: applyMoonshotProviderConfig,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
+  }
+
+  if (authChoice === "moonshot-api-key-cn") {
+    await ensureMoonshotApiKeyCredential("Enter Moonshot API key (.cn)");
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "moonshot:default",
+      provider: "moonshot",
+      mode: "api_key",
     });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: MOONSHOT_DEFAULT_MODEL_REF,
+        applyDefaultConfig: applyMoonshotConfigCn,
+        applyProviderConfig: applyMoonshotProviderConfigCn,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
+  }
+
+  if (authChoice === "kimi-code-api-key") {
+    let hasCredential = false;
+    const tokenProvider = params.opts?.tokenProvider?.trim().toLowerCase();
+    if (
+      !hasCredential &&
+      params.opts?.token &&
+      (tokenProvider === "kimi-code" || tokenProvider === "kimi-coding")
+    ) {
+      await setKimiCodingApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+
+    if (!hasCredential) {
+      await params.prompter.note(
+        [
+          "Kimi Coding uses a dedicated endpoint and API key.",
+          "Get your API key at: https://www.kimi.com/code/en",
+        ].join("\n"),
+        "Kimi Coding",
+      );
+    }
+    const envKey = resolveEnvApiKey("kimi-coding");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing KIMI_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        await setKimiCodingApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter Kimi Coding API key",
+        validate: validateApiKeyInput,
+      });
+      await setKimiCodingApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "kimi-coding:default",
+      provider: "kimi-coding",
+      mode: "api_key",
+    });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: KIMI_CODING_MODEL_REF,
+        applyDefaultConfig: applyKimiCodeConfig,
+        applyProviderConfig: applyKimiCodeProviderConfig,
+        noteDefault: KIMI_CODING_MODEL_REF,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
     return { config: nextConfig, agentModelOverride };
   }
 
   if (authChoice === "gemini-api-key") {
-    await ensureApiKeyFromOptionEnvOrPrompt({
-      token: params.opts?.token,
-      provider: "google",
-      tokenProvider: normalizedTokenProvider,
-      expectedProviders: ["google"],
-      envLabel: "GEMINI_API_KEY",
-      promptMessage: "Enter Gemini API key",
-      normalize: normalizeApiKeyInput,
-      validate: validateApiKeyInput,
-      prompter: params.prompter,
-      setCredential: async (apiKey) => setGeminiApiKey(apiKey, params.agentDir),
-    });
+    let hasCredential = false;
+
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "google") {
+      await setGeminiApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+
+    const envKey = resolveEnvApiKey("google");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing GEMINI_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        await setGeminiApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter Gemini API key",
+        validate: validateApiKeyInput,
+      });
+      await setGeminiApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+    }
     nextConfig = applyAuthProfileConfig(nextConfig, {
       profileId: "google:default",
       provider: "google",
@@ -575,20 +536,47 @@ export async function applyAuthChoiceApiProviders(
     authChoice === "zai-global" ||
     authChoice === "zai-cn"
   ) {
-    let endpoint = ZAI_AUTH_CHOICE_ENDPOINT[authChoice];
+    let endpoint: "global" | "cn" | "coding-global" | "coding-cn" | undefined;
+    if (authChoice === "zai-coding-global") {
+      endpoint = "coding-global";
+    } else if (authChoice === "zai-coding-cn") {
+      endpoint = "coding-cn";
+    } else if (authChoice === "zai-global") {
+      endpoint = "global";
+    } else if (authChoice === "zai-cn") {
+      endpoint = "cn";
+    }
 
-    const apiKey = await ensureApiKeyFromOptionEnvOrPrompt({
-      token: params.opts?.token,
-      provider: "zai",
-      tokenProvider: normalizedTokenProvider,
-      expectedProviders: ["zai"],
-      envLabel: "ZAI_API_KEY",
-      promptMessage: "Enter Z.AI API key",
-      normalize: normalizeApiKeyInput,
-      validate: validateApiKeyInput,
-      prompter: params.prompter,
-      setCredential: async (apiKey) => setZaiApiKey(apiKey, params.agentDir),
-    });
+    // Input API key
+    let hasCredential = false;
+    let apiKey = "";
+
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "zai") {
+      apiKey = normalizeApiKeyInput(params.opts.token);
+      await setZaiApiKey(apiKey, params.agentDir);
+      hasCredential = true;
+    }
+
+    const envKey = resolveEnvApiKey("zai");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing ZAI_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        apiKey = envKey.apiKey ?? "";
+        await setZaiApiKey(apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter Z.AI API key",
+        validate: validateApiKeyInput,
+      });
+      apiKey = normalizeApiKeyInput(String(key ?? ""));
+      await setZaiApiKey(apiKey, params.agentDir);
+    }
 
     // zai-api-key: auto-detect endpoint + choose a working default model.
     let modelIdOverride: string | undefined;
@@ -635,7 +623,9 @@ export async function applyAuthChoiceApiProviders(
     });
 
     const defaultModel = modelIdOverride ? `zai/${modelIdOverride}` : ZAI_DEFAULT_MODEL_REF;
-    await applyProviderDefaultModel({
+    const applied = await applyDefaultModelChoice({
+      config: nextConfig,
+      setDefaultModel: params.setDefaultModel,
       defaultModel,
       applyDefaultConfig: (config) =>
         applyZaiConfig(config, {
@@ -648,7 +638,11 @@ export async function applyAuthChoiceApiProviders(
           ...(modelIdOverride ? { modelId: modelIdOverride } : {}),
         }),
       noteDefault: defaultModel,
+      noteAgentModel,
+      prompter: params.prompter,
     });
+    nextConfig = applied.config;
+    agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
 
     // Auto-configure Z.AI MCP tools (zread, vision, web-search)
     try {
@@ -667,8 +661,318 @@ export async function applyAuthChoiceApiProviders(
     return { config: nextConfig, agentModelOverride };
   }
 
+  if (authChoice === "xiaomi-api-key") {
+    let hasCredential = false;
+
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "xiaomi") {
+      await setXiaomiApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+
+    const envKey = resolveEnvApiKey("xiaomi");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing XIAOMI_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        await setXiaomiApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter Xiaomi API key",
+        validate: validateApiKeyInput,
+      });
+      await setXiaomiApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "xiaomi:default",
+      provider: "xiaomi",
+      mode: "api_key",
+    });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: XIAOMI_DEFAULT_MODEL_REF,
+        applyDefaultConfig: applyXiaomiConfig,
+        applyProviderConfig: applyXiaomiProviderConfig,
+        noteDefault: XIAOMI_DEFAULT_MODEL_REF,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
+  }
+
+  if (authChoice === "synthetic-api-key") {
+    if (params.opts?.token && params.opts?.tokenProvider === "synthetic") {
+      await setSyntheticApiKey(String(params.opts.token ?? "").trim(), params.agentDir);
+    } else {
+      const key = await params.prompter.text({
+        message: "Enter Synthetic API key",
+        validate: (value) => (value?.trim() ? undefined : "Required"),
+      });
+      await setSyntheticApiKey(String(key ?? "").trim(), params.agentDir);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "synthetic:default",
+      provider: "synthetic",
+      mode: "api_key",
+    });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: SYNTHETIC_DEFAULT_MODEL_REF,
+        applyDefaultConfig: applySyntheticConfig,
+        applyProviderConfig: applySyntheticProviderConfig,
+        noteDefault: SYNTHETIC_DEFAULT_MODEL_REF,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
+  }
+
+  if (authChoice === "venice-api-key") {
+    let hasCredential = false;
+
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "venice") {
+      await setVeniceApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+
+    if (!hasCredential) {
+      await params.prompter.note(
+        [
+          "Venice AI provides privacy-focused inference with uncensored models.",
+          "Get your API key at: https://venice.ai/settings/api",
+          "Supports 'private' (fully private) and 'anonymized' (proxy) modes.",
+        ].join("\n"),
+        "Venice AI",
+      );
+    }
+
+    const envKey = resolveEnvApiKey("venice");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing VENICE_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        await setVeniceApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter Venice AI API key",
+        validate: validateApiKeyInput,
+      });
+      await setVeniceApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "venice:default",
+      provider: "venice",
+      mode: "api_key",
+    });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: VENICE_DEFAULT_MODEL_REF,
+        applyDefaultConfig: applyVeniceConfig,
+        applyProviderConfig: applyVeniceProviderConfig,
+        noteDefault: VENICE_DEFAULT_MODEL_REF,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
+  }
+
+  if (authChoice === "opencode-zen") {
+    let hasCredential = false;
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "opencode") {
+      await setOpencodeZenApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+
+    if (!hasCredential) {
+      await params.prompter.note(
+        [
+          "OpenCode Zen provides access to Claude, GPT, Gemini, and more models.",
+          "Get your API key at: https://opencode.ai/auth",
+          "OpenCode Zen bills per request. Check your OpenCode dashboard for details.",
+        ].join("\n"),
+        "OpenCode Zen",
+      );
+    }
+    const envKey = resolveEnvApiKey("opencode");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing OPENCODE_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        await setOpencodeZenApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter OpenCode Zen API key",
+        validate: validateApiKeyInput,
+      });
+      await setOpencodeZenApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "opencode:default",
+      provider: "opencode",
+      mode: "api_key",
+    });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: OPENCODE_ZEN_DEFAULT_MODEL,
+        applyDefaultConfig: applyOpencodeZenConfig,
+        applyProviderConfig: applyOpencodeZenProviderConfig,
+        noteDefault: OPENCODE_ZEN_DEFAULT_MODEL,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
+  }
+
+  if (authChoice === "together-api-key") {
+    let hasCredential = false;
+
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "together") {
+      await setTogetherApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+
+    if (!hasCredential) {
+      await params.prompter.note(
+        [
+          "Together AI provides access to leading open-source models including Llama, DeepSeek, Qwen, and more.",
+          "Get your API key at: https://api.together.xyz/settings/api-keys",
+        ].join("\n"),
+        "Together AI",
+      );
+    }
+
+    const envKey = resolveEnvApiKey("together");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing TOGETHER_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        await setTogetherApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter Together AI API key",
+        validate: validateApiKeyInput,
+      });
+      await setTogetherApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "together:default",
+      provider: "together",
+      mode: "api_key",
+    });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: TOGETHER_DEFAULT_MODEL_REF,
+        applyDefaultConfig: applyTogetherConfig,
+        applyProviderConfig: applyTogetherProviderConfig,
+        noteDefault: TOGETHER_DEFAULT_MODEL_REF,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
+  }
+
   if (authChoice === "huggingface-api-key") {
     return applyAuthChoiceHuggingface({ ...params, authChoice });
+  }
+
+  if (authChoice === "qianfan-api-key") {
+    let hasCredential = false;
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "qianfan") {
+      setQianfanApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+
+    if (!hasCredential) {
+      await params.prompter.note(
+        [
+          "Get your API key at: https://console.bce.baidu.com/qianfan/ais/console/apiKey",
+          "API key format: bce-v3/ALTAK-...",
+        ].join("\n"),
+        "QIANFAN",
+      );
+    }
+    const envKey = resolveEnvApiKey("qianfan");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing QIANFAN_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        setQianfanApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter QIANFAN API key",
+        validate: validateApiKeyInput,
+      });
+      setQianfanApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "qianfan:default",
+      provider: "qianfan",
+      mode: "api_key",
+    });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: QIANFAN_DEFAULT_MODEL_REF,
+        applyDefaultConfig: applyQianfanConfig,
+        applyProviderConfig: applyQianfanProviderConfig,
+        noteDefault: QIANFAN_DEFAULT_MODEL_REF,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
   }
 
   return null;

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -652,11 +652,13 @@ export async function applyAuthChoiceApiProviders(
 
     // Auto-configure Z.AI MCP tools (zread, vision, web-search)
     try {
-      await configureZaiMcpTools(apiKey, params.agentDir);
-      await params.prompter.note(
-        "Z.AI MCP tools (zread, vision, web-search) auto-configured.",
-        "MCP Tools",
-      );
+      if (apiKey) {
+        await configureZaiMcpTools(apiKey, params.agentDir);
+        await params.prompter.note(
+          "Z.AI MCP tools (zread, vision, web-search) auto-configured.",
+          "MCP Tools",
+        );
+      }
     } catch (e) {
       // Non-fatal, just log and continue
       console.warn("Failed to auto-configure Z.AI MCP tools:", e);

--- a/src/commands/zai-mcp-tools-config.ts
+++ b/src/commands/zai-mcp-tools-config.ts
@@ -17,10 +17,7 @@ export interface ZaiMcpToolsConfig {
  * @param apiKey - Z.AI API key
  * @param workspaceDir - Workspace directory path
  */
-export async function configureZaiMcpTools(
-  apiKey: string,
-  workspaceDir: string,
-): Promise<void> {
+export async function configureZaiMcpTools(apiKey: string, workspaceDir: string): Promise<void> {
   const configDir = path.join(workspaceDir, "config");
   const configPath = path.join(configDir, "mcporter.json");
 

--- a/src/commands/zai-mcp-tools-config.ts
+++ b/src/commands/zai-mcp-tools-config.ts
@@ -25,12 +25,18 @@ export async function configureZaiMcpTools(apiKey: string, workspaceDir: string)
   await fs.mkdir(configDir, { recursive: true });
 
   // Read existing config or create new one
-  let config: ZaiMcpToolsConfig = { mcpServers: {} };
+  let config: ZaiMcpToolsConfig;
   try {
     const existing = await fs.readFile(configPath, "utf-8");
-    config = { mcpServers: {}, ...JSON.parse(existing) };
+    const parsed = JSON.parse(existing);
+    // Ensure mcpServers exists (robust merging)
+    config = {
+      ...parsed,
+      mcpServers: parsed.mcpServers || {},
+    };
   } catch {
-    // File doesn't exist, create new config
+    // File doesn't exist or invalid JSON, create new config
+    config = { mcpServers: {} };
   }
 
   // Configure MCP tools

--- a/src/commands/zai-mcp-tools-config.ts
+++ b/src/commands/zai-mcp-tools-config.ts
@@ -31,7 +31,7 @@ export async function configureZaiMcpTools(
   let config: ZaiMcpToolsConfig = { mcpServers: {} };
   try {
     const existing = await fs.readFile(configPath, "utf-8");
-    config = JSON.parse(existing);
+    config = { mcpServers: {}, ...JSON.parse(existing) };
   } catch {
     // File doesn't exist, create new config
   }

--- a/src/commands/zai-mcp-tools-config.ts
+++ b/src/commands/zai-mcp-tools-config.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface ZaiMcpToolsConfig {
+  mcpServers: Record<string, any>;
+}
+
+/**
+ * Configure Z.AI MCP tools in mcporter.json
+ *
+ * When user chooses Z.AI provider during onboard, this function automatically
+ * configures the following MCP tools:
+ * - zread: GitHub repo analysis
+ * - zai-vision: Image/video analysis
+ * - zai-web-search: Web search
+ *
+ * @param apiKey - Z.AI API key
+ * @param workspaceDir - Workspace directory path
+ */
+export async function configureZaiMcpTools(
+  apiKey: string,
+  workspaceDir: string,
+): Promise<void> {
+  const configDir = path.join(workspaceDir, "config");
+  const configPath = path.join(configDir, "mcporter.json");
+
+  // Ensure config directory exists
+  await fs.mkdir(configDir, { recursive: true });
+
+  // Read existing config or create new one
+  let config: ZaiMcpToolsConfig = { mcpServers: {} };
+  try {
+    const existing = await fs.readFile(configPath, "utf-8");
+    config = JSON.parse(existing);
+  } catch {
+    // File doesn't exist, create new config
+  }
+
+  // Configure MCP tools
+  const authHeader = `Bearer ${apiKey}`;
+
+  config.mcpServers = {
+    ...config.mcpServers,
+    // zread: GitHub repo analysis
+    zread: {
+      baseUrl: "https://api.z.ai/api/mcp/zread/mcp",
+      headers: {
+        Authorization: authHeader,
+      },
+    },
+    // zai-vision: Image/video analysis (stdio mode)
+    "zai-vision": {
+      command: "npx -y @z_ai/mcp-server",
+      env: {
+        Z_AI_API_KEY: apiKey,
+      },
+    },
+    // zai-web-search: Web search
+    "zai-web-search": {
+      baseUrl: "https://api.z.ai/api/mcp/web_search_prime/mcp",
+      headers: {
+        Authorization: authHeader,
+        Accept: "application/json, text/event-stream",
+      },
+    },
+  };
+
+  // Write config
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+}

--- a/src/commands/zai-mcp-tools-config.ts
+++ b/src/commands/zai-mcp-tools-config.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 export interface ZaiMcpToolsConfig {
-  mcpServers: Record<string, any>;
+  mcpServers: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Auto-configure Z.AI MCP tools (zread, zai-vision, zai-web-search) during the onboard flow when user selects Z.AI provider.

## Changes

- Added `configureZaiMcpTools` function to automatically configure MCP tools
- Integrated into Z.AI auth choice flow in `auth-choice.apply.api-providers.ts`
- Creates/updates `~/.openclaw/workspace/config/mcporter.json` with MCP tool configs

## Tools Configured

| Tool | Transport | Purpose |
|------|-----------|---------|
| zread | HTTP | GitHub repo analysis |
| zai-vision | stdio | Image/video analysis |
| zai-web-search | HTTP | Web search |

## Benefits

- **Better DX**: Users get all Z.AI tools working immediately after onboard
- **GLM Coding Plan value**: Highlights exclusive features
- **Reduced friction**: No manual JSON editing required

## Related

- Closes #18741
- Related to #18173 (Z.AI tool_stream support)

## Testing

- [ ] Tested locally with `openclaw onboard` and Z.AI provider
- [ ] Verified mcporter.json is created/updated correctly
- [ ] Verified MCP tools are usable after onboard

## AI Assistance

🤖 This implementation was written with Claude assistance (OpenClaw agent).

## Checklist

- [x] Mark as AI-assisted
- [x] I understand what the code does
- [x] Follows CONTRIBUTING.md guidelines

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Auto-configures Z.AI MCP tools (zread, zai-vision, zai-web-search) during onboarding when users select Z.AI as their provider. Creates/updates `mcporter.json` in the agent directory with authentication headers and environment variables for the three MCP tools.

**Key Changes:**
- Added `configureZaiMcpTools` function to handle MCP tool configuration
- Integrated into Z.AI auth flow with non-fatal error handling
- Configures HTTP-based tools (zread, web-search) with Bearer auth and stdio-based tool (vision) with API key env var

**Issues Found:**
- Missing test coverage for the new functionality
- Config merging could be more robust (doesn't explicitly ensure `mcpServers` exists in parsed JSON)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor improvements recommended
- Implementation is straightforward and follows existing patterns in the codebase. Error handling is appropriate (non-fatal try/catch). The main concerns are lack of test coverage and slightly fragile config merging, but these don't prevent the feature from working correctly in typical scenarios.
- Consider adding tests for `src/commands/zai-mcp-tools-config.ts` to verify config creation and merging behavior

<sub>Last reviewed commit: 4ac2318</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->