### PR TITLE
Fix Telegram per-message link preview override

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -194,6 +194,9 @@ function buildSendSchema(options: {
     threadId: Type.Optional(Type.String()),
     asVoice: Type.Optional(Type.Boolean()),
     silent: Type.Optional(Type.Boolean()),
+    linkPreview: Type.Optional(
+      Type.Boolean({ description: "Controls whether link previews are shown for URLs in messages" }),
+    ),
     quoteText: Type.Optional(
       Type.String({ description: "Quote text for Telegram reply_parameters" }),
     ),

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -188,6 +188,7 @@ export async function handleTelegramAction(
       integer: true,
     });
     const quoteText = readStringParam(params, "quoteText");
+    const linkPreview = typeof params.linkPreview === "boolean" ? params.linkPreview : undefined;
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(
@@ -204,6 +205,7 @@ export async function handleTelegramAction(
       quoteText: quoteText ?? undefined,
       asVoice: typeof params.asVoice === "boolean" ? params.asVoice : undefined,
       silent: typeof params.silent === "boolean" ? params.silent : undefined,
+      linkPreview,
     });
     return jsonResult({
       ok: true,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -60,6 +60,8 @@ type TelegramSendOpts = {
   messageThreadId?: number;
   /** Inline keyboard buttons (reply markup). */
   buttons?: TelegramInlineButtons;
+  /** Controls whether link previews are shown. Defaults to account config. */
+  linkPreview?: boolean;
 };
 
 type TelegramSendResult = {
@@ -466,8 +468,8 @@ export async function sendMessageTelegram(
   });
   const renderHtmlText = (value: string) => renderTelegramHtmlText(value, { textMode, tableMode });
 
-  // Resolve link preview setting from config (default: enabled).
-  const linkPreviewEnabled = account.config.linkPreview ?? true;
+  // Resolve link preview setting: per-message > account config > default enabled.
+  const linkPreviewEnabled = opts.linkPreview ?? account.config.linkPreview ?? true;
   const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
 
   const sendTelegramText = async (


### PR DESCRIPTION
## Description
Telegram's sendMessage defaults to the account-level `linkPreview` setting, ignoring per-message overrides requested via the tool interface.

## Fix
- Added `linkPreview` parameter reading in `telegram-actions.ts` and pass it through to `sendMessageTelegram`
- Added `linkPreview` to the `TelegramSendOpts` type
- Updated priority chain: per-message > account config > default (enabled)

This is a minimal, targeted fix extracted from a previous multi-feature PR (#18224).

## AI Transparency
- **Assisted by**: OpenClaw Agent (Claude Opus)
- **Testing level**: Type check verification
- **Prompt strategy**: Extracted targeted fix from multi-feature PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-message `linkPreview` override support to Telegram's `sendMessage` action, fixing an issue where the account-level setting couldn't be overridden for individual messages.

**Changes made:**
- Added `linkPreview` parameter reading in `telegram-actions.ts` (line 190)
- Passed the parameter through to `sendMessageTelegram` (line 207)
- Added `linkPreview` to the `TelegramSendOpts` type definition (line 64 in `send.ts`)
- Implemented proper priority chain: per-message > account config > default (enabled) on line 472

**Issue found:**
- The `linkPreview` parameter is missing from the tool schema definition in `message-tool.ts` (around line 196), which means agents won't have visibility into this parameter through the schema. The parameter will work at runtime since it's read directly from params, but it won't be documented in the tool interface.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor schema definition issue that should be addressed
- The implementation is clean and correct, with proper type safety and a well-implemented priority chain. The code follows existing patterns and doesn't introduce security vulnerabilities. However, the missing tool schema definition means agents won't have formal visibility into the new parameter, which reduces the score from 5 to 4. The functionality will work at runtime, but the schema incompleteness is a gap in the API contract.
- Pay attention to `src/agents/tools/message-tool.ts` - needs the `linkPreview` parameter added to the schema definition (around line 196)

<sub>Last reviewed commit: decbe33</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->