### PR TITLE
fix(voice-call): replace console.log with runtime logging

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -43,13 +43,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (!replyToMessageId) {
         return;
       }
-      typingState = await addTypingIndicator({ cfg, messageId: replyToMessageId, accountId });
+      typingState = await addTypingIndicator({
+        cfg,
+        messageId: replyToMessageId,
+        accountId,
+        runtime: params.runtime,
+      });
     },
     stop: async () => {
       if (!typingState) {
         return;
       }
-      await removeTypingIndicator({ cfg, state: typingState, accountId });
+      await removeTypingIndicator({ cfg, state: typingState, accountId, runtime: params.runtime });
       typingState = null;
     },
     onStartError: (err) =>

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -1,6 +1,7 @@
-import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { getFeishuRuntime } from "./runtime.js";
 
 // Feishu emoji types for typing indicator
 // See: https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
@@ -19,8 +20,9 @@ export async function addTypingIndicator(params: {
   cfg: ClawdbotConfig;
   messageId: string;
   accountId?: string;
+  runtime?: RuntimeEnv;
 }): Promise<TypingIndicatorState> {
-  const { cfg, messageId, accountId } = params;
+  const { cfg, messageId, accountId, runtime } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     return { messageId, reactionId: null };
@@ -41,7 +43,9 @@ export async function addTypingIndicator(params: {
     return { messageId, reactionId };
   } catch (err) {
     // Silently fail - typing indicator is not critical
-    console.log(`[feishu] failed to add typing indicator: ${err}`);
+    if (getFeishuRuntime().logging.shouldLogVerbose()) {
+      runtime?.log?.(`[feishu] failed to add typing indicator: ${String(err)}`);
+    }
     return { messageId, reactionId: null };
   }
 }
@@ -53,8 +57,9 @@ export async function removeTypingIndicator(params: {
   cfg: ClawdbotConfig;
   state: TypingIndicatorState;
   accountId?: string;
+  runtime?: RuntimeEnv;
 }): Promise<void> {
-  const { cfg, state, accountId } = params;
+  const { cfg, state, accountId, runtime } = params;
   if (!state.reactionId) {
     return;
   }
@@ -75,6 +80,8 @@ export async function removeTypingIndicator(params: {
     });
   } catch (err) {
     // Silently fail - cleanup is not critical
-    console.log(`[feishu] failed to remove typing indicator: ${err}`);
+    if (getFeishuRuntime().logging.shouldLogVerbose()) {
+      runtime?.log?.(`[feishu] failed to remove typing indicator: ${String(err)}`);
+    }
   }
 }

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -56,7 +56,9 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
     normalizeAllowEntry: (entry) =>
       entry.replace(/^(nextcloud-talk|nc-talk|nc):/i, "").toLowerCase(),
     notifyApproval: async ({ id }) => {
-      console.log(`[nextcloud-talk] User ${id} approved for pairing`);
+      getNextcloudTalkRuntime()
+        .logging.getChildLogger()
+        .info(`[nextcloud-talk] User ${id} approved for pairing`);
     },
   },
   capabilities: {

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -156,8 +156,10 @@ export async function sendMessageNextcloudTalk(
     // Response parsing failed, but message was sent.
   }
 
-  if (opts.verbose) {
-    console.log(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
+  if (opts.verbose || getNextcloudTalkRuntime().logging.shouldLogVerbose()) {
+    getNextcloudTalkRuntime()
+      .logging.getChildLogger()
+      .info(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
   }
 
   getNextcloudTalkRuntime().channel.activity.record({

--- a/extensions/voice-call/src/manager.test.ts
+++ b/extensions/voice-call/src/manager.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { VoiceCallConfigSchema } from "./config.js";
 import { CallManager } from "./manager.js";
+import type { Logger } from "./manager/context.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import type {
   HangupCallInput,
@@ -46,6 +47,12 @@ class FakeProvider implements VoiceCallProvider {
   }
 }
 
+const logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Logger;
+
 describe("CallManager", () => {
   it("upgrades providerCallId mapping when provider ID changes", async () => {
     const config = VoiceCallConfigSchema.parse({
@@ -55,7 +62,7 @@ describe("CallManager", () => {
     });
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(new FakeProvider(), "https://example.com/voice/webhook");
 
     const { callId, success, error } = await manager.initiateCall("+15550000001");
@@ -89,7 +96,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     const { callId, success } = await manager.initiateCall("+15550000002", undefined, {
@@ -123,7 +130,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     manager.processEvent({
@@ -152,7 +159,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     manager.processEvent({
@@ -182,7 +189,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     manager.processEvent({
@@ -211,7 +218,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     manager.processEvent({
@@ -251,7 +258,7 @@ describe("CallManager", () => {
     });
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(new FakeProvider(), "https://example.com/voice/webhook");
 
     manager.processEvent({
@@ -278,7 +285,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     const started = await manager.initiateCall("+15550000003");
@@ -332,7 +339,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     const started = await manager.initiateCall("+15550000004");
@@ -378,7 +385,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     const started = await manager.initiateCall("+15550000005");
@@ -445,7 +452,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     const started = await manager.initiateCall("+15550000006");

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { VoiceCallConfig } from "./config.js";
-import type { CallManagerContext } from "./manager/context.js";
+import type { CallManagerContext, Logger } from "./manager/context.js";
 import { processEvent as processManagerEvent } from "./manager/events.js";
 import { getCallByProviderCallId as getCallByProviderCallIdFromMaps } from "./manager/lookup.js";
 import {
@@ -46,6 +46,7 @@ export class CallManager {
   private provider: VoiceCallProvider | null = null;
   private config: VoiceCallConfig;
   private storePath: string;
+  private logger: Logger;
   private webhookUrl: string | null = null;
   private activeTurnCalls = new Set<CallId>();
   private transcriptWaiters = new Map<
@@ -58,8 +59,9 @@ export class CallManager {
   >();
   private maxDurationTimers = new Map<CallId, NodeJS.Timeout>();
 
-  constructor(config: VoiceCallConfig, storePath?: string) {
+  constructor(config: VoiceCallConfig, logger: Logger, storePath?: string) {
     this.config = config;
+    this.logger = logger;
     this.storePath = resolveDefaultStoreBase(config, storePath);
   }
 
@@ -139,6 +141,7 @@ export class CallManager {
       storePath: this.storePath,
       webhookUrl: this.webhookUrl,
       activeTurnCalls: this.activeTurnCalls,
+      logger: this.logger,
       transcriptWaiters: this.transcriptWaiters,
       maxDurationTimers: this.maxDurationTimers,
       onCallAnswered: (call) => {

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -16,11 +16,19 @@ export type CallManagerRuntimeState = {
   rejectedProviderCallIds: Set<string>;
 };
 
+export type Logger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+  debug?: (message: string) => void;
+};
+
 export type CallManagerRuntimeDeps = {
   provider: VoiceCallProvider | null;
   config: VoiceCallConfig;
   storePath: string;
   webhookUrl: string | null;
+  logger: Logger;
 };
 
 export type CallManagerTransientState = {

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -25,6 +25,12 @@ function createContext(overrides: Partial<CallManagerContext> = {}): CallManager
     storePath,
     webhookUrl: null,
     activeTurnCalls: new Set(),
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    },
     transcriptWaiters: new Map(),
     maxDurationTimers: new Map(),
     ...overrides,

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -124,7 +124,7 @@ export async function createVoiceCallRuntime(params: {
   }
 
   const provider = resolveProvider(config);
-  const manager = new CallManager(config);
+  const manager = new CallManager(config, log);
   const webhookServer = new VoiceCallWebhookServer(config, manager, provider, coreConfig);
 
   const localUrl = await webhookServer.start();

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -218,7 +218,7 @@ function startPollingLoop(params: {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
         // no updates
       } else if (!isStopped() && !abortSignal.aborted) {
-        console.error(`[${account.accountId}] Zalo polling error:`, err);
+        runtime.error?.(`[${account.accountId}] Zalo polling error: ${String(err)}`);
         await new Promise((resolve) => setTimeout(resolve, 5000));
       }
     }
@@ -265,10 +265,12 @@ async function processUpdate(
       );
       break;
     case "message.sticker.received":
-      console.log(`[${account.accountId}] Received sticker from ${message.from.id}`);
+      logVerbose(core, runtime, `[${account.accountId}] Received sticker from ${message.from.id}`);
       break;
     case "message.unsupported.received":
-      console.log(
+      logVerbose(
+        core,
+        runtime,
         `[${account.accountId}] Received unsupported message type from ${message.from.id}`,
       );
       break;
@@ -334,7 +336,7 @@ async function handleImageMessage(
       mediaPath = saved.path;
       mediaType = saved.contentType;
     } catch (err) {
-      console.error(`[${account.accountId}] Failed to download Zalo image:`, err);
+      runtime.error?.(`[${account.accountId}] Failed to download Zalo image: ${String(err)}`);
     }
   }
 


### PR DESCRIPTION
Voice call events and outbound logging were using console methods, bypassing structured logs.

Injected logger into CallManager and event contexts, updated tests to mock logger.
Also replaced console.log/error in feishu, nextcloud-talk, and zalo extensions.

Recreated from #18879 with only relevant files (no import reordering noise).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces `console.log`/`console.error`/`console.warn` with structured runtime logging across voice-call, feishu, nextcloud-talk, and zalo extensions. In the voice-call extension, a `Logger` type is introduced in `manager/context.ts` and injected into `CallManager` via constructor, then threaded through `CallManagerContext` to `events.ts`. Feishu, nextcloud-talk, and zalo extensions use their existing runtime logging patterns (`runtime?.log`, `getNextcloudTalkRuntime().logging.getChildLogger()`, `logVerbose()`). Tests are properly updated with mock loggers.

- The voice-call `manager/events.ts` is fully migrated, but sibling files in the same `manager/` directory (`outbound.ts`, `timers.ts`, `store.ts`) still use `console.*` calls. This is noted in inline comments — it may be intentional scoping for this PR but worth addressing in a follow-up.
- Import reordering in several files is cosmetic (type imports before value imports).
- All changes are backwards-compatible: `runtime.ts` provides a console-based fallback logger when none is supplied.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — changes are straightforward logging replacements with no behavioral or logic changes.
- Score of 4 reflects clean, well-tested logging migration with one minor gap: several files in the same `manager/` directory still use `console.*` instead of the newly introduced logger. No logic or security issues.
- `extensions/voice-call/src/manager/outbound.ts` and `extensions/voice-call/src/manager/timers.ts` still use `console.*` and should be converted in a follow-up.

<sub>Last reviewed commit: 04f6429</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->