### PR TITLE
fix(completion): initialize compinit before compdef

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -381,6 +381,11 @@ function generateZshCompletion(program: Command): string {
   const script = `
 #compdef ${rootCmd}
 
+if ! command -v compdef >/dev/null 2>&1; then
+  autoload -Uz compinit
+  compinit
+fi
+
 _${rootCmd}_root_completion() {
   local -a commands
   local -a options


### PR DESCRIPTION
If compdef is not loaded, the zsh completion script fails silently.

Fix: Check for compdef and initialize compinit if needed.

Recreated from #17922 with only the relevant file.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds initialization guard for zsh completion system to prevent silent failures. The PR adds a check for `compdef` availability and initializes `compinit` if needed before defining completions, ensuring the completion script works even when run before the shell's completion system is loaded. Also includes a minor import reordering (commander imports moved to top).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-scoped, fixes a real issue with zsh completion initialization, follows standard zsh completion patterns, and only modifies the generated completion script. The implementation is defensive (checks for compdef before calling compinit) and will not break existing working setups.
- No files require special attention

<sub>Last reviewed commit: 4b8f457</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->