### PR TITLE
fix(voice-call): handle EADDRINUSE crash on webhook server start

### DIFF
--- a/extensions/voice-call/src/webhook-eaddrinuse.test.ts
+++ b/extensions/voice-call/src/webhook-eaddrinuse.test.ts
@@ -1,0 +1,92 @@
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VoiceCallConfig } from "./config.js";
+import type { CallManager } from "./manager.js";
+import type { VoiceCallProvider } from "./providers/base.js";
+import { VoiceCallWebhookServer } from "./webhook.js";
+
+function makeConfig(port: number): VoiceCallConfig {
+  return {
+    serve: { port, bind: "127.0.0.1", path: "/voice/webhook" },
+  } as unknown as VoiceCallConfig;
+}
+
+const stubManager = {} as CallManager;
+const stubProvider = {} as VoiceCallProvider;
+
+/**
+ * Create an EADDRINUSE error matching what Node emits.
+ */
+function eaddrinuse(port: number): NodeJS.ErrnoException {
+  const err = new Error(
+    `listen EADDRINUSE: address already in use 127.0.0.1:${port}`,
+  ) as NodeJS.ErrnoException;
+  err.code = "EADDRINUSE";
+  return err;
+}
+
+describe("VoiceCallWebhookServer EADDRINUSE retry", () => {
+  let webhook: VoiceCallWebhookServer | null = null;
+  // Track the real listen so we can restore it
+  const realListen = http.Server.prototype.listen;
+
+  afterEach(async () => {
+    // Restore listen
+    http.Server.prototype.listen = realListen;
+    vi.restoreAllMocks();
+    if (webhook) {
+      await webhook.stop();
+      webhook = null;
+    }
+  });
+
+  /**
+   * Patch http.Server.prototype.listen to simulate EADDRINUSE for specific ports.
+   * The server "error" event fires asynchronously with EADDRINUSE for blocked ports.
+   * For other ports, the real listen is called.
+   */
+  function blockPorts(blocked: Set<number>): void {
+    http.Server.prototype.listen = function patchedListen(
+      this: http.Server,
+      ...args: unknown[]
+    ): http.Server {
+      const port = typeof args[0] === "number" ? args[0] : undefined;
+      if (port !== undefined && blocked.has(port)) {
+        // Simulate async EADDRINUSE
+        setImmediate(() => {
+          this.emit("error", eaddrinuse(port));
+        });
+        return this;
+      }
+      // Call real listen
+      return realListen.apply(this, args as Parameters<typeof realListen>);
+    } as typeof realListen;
+  }
+
+  it("falls back to next port when configured port is occupied", async () => {
+    blockPorts(new Set([40000]));
+    webhook = new VoiceCallWebhookServer(makeConfig(40000), stubManager, stubProvider);
+    const url = await webhook.start();
+    expect(url).toBe("http://127.0.0.1:40001/voice/webhook");
+  });
+
+  it("skips multiple occupied ports", async () => {
+    blockPorts(new Set([40010, 40011]));
+    webhook = new VoiceCallWebhookServer(makeConfig(40010), stubManager, stubProvider);
+    const url = await webhook.start();
+    expect(url).toBe("http://127.0.0.1:40012/voice/webhook");
+  });
+
+  it("throws after exhausting retries", async () => {
+    blockPorts(new Set([40020, 40021, 40022, 40023]));
+    webhook = new VoiceCallWebhookServer(makeConfig(40020), stubManager, stubProvider);
+    await expect(webhook.start()).rejects.toThrow("EADDRINUSE");
+  });
+
+  it("starts on configured port when available", async () => {
+    blockPorts(new Set()); // nothing blocked
+    webhook = new VoiceCallWebhookServer(makeConfig(40030), stubManager, stubProvider);
+    const url = await webhook.start();
+    expect(url).toBe("http://127.0.0.1:40030/voice/webhook");
+  });
+});

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -184,7 +184,37 @@ export class VoiceCallWebhookServer {
   async start(): Promise<string> {
     const { port, bind, path: webhookPath } = this.config.serve;
     const streamPath = this.config.streaming?.streamPath || "/voice/stream";
+    const maxRetries = 3;
 
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const tryPort = port + attempt;
+      try {
+        const url = await this.tryListen(tryPort, bind, webhookPath, streamPath);
+        if (attempt > 0) {
+          console.log(`[voice-call] Port ${port} was in use, fell back to ${tryPort}`);
+        }
+        return url;
+      } catch (err) {
+        const isAddrInUse =
+          err instanceof Error &&
+          "code" in err &&
+          (err as NodeJS.ErrnoException).code === "EADDRINUSE";
+        if (!isAddrInUse || attempt === maxRetries) {
+          throw err;
+        }
+        console.warn(`[voice-call] Port ${tryPort} in use (EADDRINUSE), trying ${tryPort + 1}…`);
+      }
+    }
+    // Unreachable, but satisfies TypeScript
+    throw new Error(`[voice-call] Failed to bind after ${maxRetries + 1} attempts`);
+  }
+
+  private tryListen(
+    port: number,
+    bind: string,
+    webhookPath: string,
+    streamPath: string,
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
       this.server = http.createServer((req, res) => {
         this.handleRequest(req, res, webhookPath).catch((err) => {
@@ -207,7 +237,10 @@ export class VoiceCallWebhookServer {
         });
       }
 
-      this.server.on("error", reject);
+      this.server.on("error", (err) => {
+        this.server = null;
+        reject(err);
+      });
 
       this.server.listen(port, bind, () => {
         const url = `http://${bind}:${port}${webhookPath}`;


### PR DESCRIPTION
When the webhook port is already in use, the server crashes with an unhandled EADDRINUSE error.

Fix: Catch the error and retry with a fallback port, or surface a clear error message.

Recreated from #17050 with only relevant files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds EADDRINUSE error handling to the voice-call webhook server by retrying on sequential ports (up to 3 fallback attempts). The core retry logic in `webhook.ts` is sound — it correctly detects `EADDRINUSE`, increments the port, and re-throws non-EADDRINUSE errors. The `this.server = null` cleanup on error is a good defensive addition.

However, two issues need attention:

- **Test constructor mismatch**: The test file constructs `VoiceCallWebhookServer` with a single config-like object (`{ serve, providers }`), but the actual constructor expects four positional parameters `(config, manager, provider, coreConfig?)`. This will fail TypeScript type-checking. The `providers` key (plural) also doesn't exist on `VoiceCallConfig`.
- **Port fallback not visible to callers**: When the server falls back to a different port, `runtime.ts` still reads `config.serve.port` (the original port) for tunnel and Tailscale setup. This means tunnels would forward to the wrong port after a fallback, silently breaking webhook delivery.

<h3>Confidence Score: 2/5</h3>

- This PR has a test that won't compile and a logic gap where port fallback breaks tunnel configuration.
- Score of 2 reflects two concrete issues: (1) the test file uses an incorrect constructor signature that won't pass type-checking, and (2) when the server falls back to a different port, the tunnel/tailscale setup in runtime.ts still references the original (occupied) port, which would silently break webhook delivery in production.
- `extensions/voice-call/src/webhook-eaddrinuse.test.ts` needs constructor calls fixed. `extensions/voice-call/src/webhook.ts` and `extensions/voice-call/src/runtime.ts` need the fallback port to be propagated to tunnel callers.

<sub>Last reviewed commit: 8559c80</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->