### PR TITLE
fix(config): warn on numeric IDs that lose precision

### DIFF
--- a/src/config/validation-numeric-ids.test.ts
+++ b/src/config/validation-numeric-ids.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { warnUnsafeNumericIds } from "./validation-numeric-ids.js";
+
+describe("warnUnsafeNumericIds", () => {
+  it("returns no warnings for safe integers", () => {
+    const raw = { channels: { discord: { guilds: { test: { users: [123, "456"] } } } } };
+    expect(warnUnsafeNumericIds(raw)).toEqual([]);
+  });
+
+  it("warns about numeric values exceeding MAX_SAFE_INTEGER", () => {
+    // Simulate what JSON.parse does to large unquoted numbers
+    const raw = JSON.parse(
+      '{"channels":{"discord":{"guilds":{"s":{"users":[233734246190153728]}}}}}',
+    );
+    const warnings = warnUnsafeNumericIds(raw);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("channels.discord.guilds.s.users[0]");
+    expect(warnings[0].message).toContain("MAX_SAFE_INTEGER");
+    expect(warnings[0].message).toContain("quotes");
+  });
+
+  it("warns about multiple unsafe IDs", () => {
+    const raw = JSON.parse('{"users":[233734246190153728, 804620549493620756]}');
+    const warnings = warnUnsafeNumericIds(raw);
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("ignores strings, booleans, and null", () => {
+    const raw = { a: "big number 99999999999999999", b: true, c: null };
+    expect(warnUnsafeNumericIds(raw)).toEqual([]);
+  });
+
+  it("ignores NaN and Infinity", () => {
+    const raw = { a: NaN, b: Infinity, c: -Infinity };
+    expect(warnUnsafeNumericIds(raw)).toEqual([]);
+  });
+
+  it("handles deeply nested structures", () => {
+    const raw = JSON.parse('{"a":{"b":{"c":{"d":233734246190153728}}}}');
+    const warnings = warnUnsafeNumericIds(raw);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("a.b.c.d");
+  });
+});

--- a/src/config/validation-numeric-ids.ts
+++ b/src/config/validation-numeric-ids.ts
@@ -1,0 +1,39 @@
+import type { ConfigValidationIssue } from "./types.js";
+
+/**
+ * Scan the raw (pre-Zod) config for numeric values that exceed
+ * Number.MAX_SAFE_INTEGER. These are almost always Discord/Slack/Telegram
+ * snowflake IDs that lost precision during JSON.parse because they were
+ * written without quotes.
+ *
+ * Example: `"users": [233734246190153728]` silently becomes
+ *          `233734246190153730` after parsing.
+ */
+export function warnUnsafeNumericIds(raw: unknown): ConfigValidationIssue[] {
+  const warnings: ConfigValidationIssue[] = [];
+  walk(raw, "", warnings);
+  return warnings;
+}
+
+function walk(value: unknown, path: string, out: ConfigValidationIssue[]): void {
+  if (typeof value === "number" && !Number.isSafeInteger(value) && Number.isFinite(value)) {
+    out.push({
+      path: path || "(root)",
+      message:
+        `Numeric value ${value} exceeds Number.MAX_SAFE_INTEGER and lost precision during JSON parsing. ` +
+        `Wrap it in quotes (e.g. "${value}") to preserve the exact value.`,
+    });
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      walk(value[i], path ? `${path}[${i}]` : `[${i}]`, out);
+    }
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      walk(child, path ? `${path}.${key}` : key, out);
+    }
+  }
+}

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -20,6 +20,7 @@ import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-di
 import { applyAgentDefaults, applyModelDefaults, applySessionDefaults } from "./defaults.js";
 import { findLegacyConfigIssues } from "./legacy.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
+import { warnUnsafeNumericIds } from "./validation-numeric-ids.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth"]);
@@ -258,6 +259,9 @@ function validateConfigObjectWithPluginsBase(
       }
     }
   }
+
+  // Warn about numeric IDs that lose precision after JSON.parse (e.g. Discord snowflakes).
+  warnings.push(...warnUnsafeNumericIds(raw));
 
   const heartbeatChannelIds = new Set<string>();
   for (const channelId of CHANNEL_IDS) {


### PR DESCRIPTION
Large numeric IDs (e.g. Telegram chat IDs) can lose precision when parsed as JavaScript numbers.

Fix: Add validation that warns when numeric IDs exceed safe integer range.

Recreated from #16934 with only relevant files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a config validation utility that warns users when numeric values in their config exceed `Number.MAX_SAFE_INTEGER`, which causes silent precision loss during `JSON.parse`. This is a targeted fix for a real issue with Discord/Telegram snowflake IDs that lose precision when written without quotes in JSON config files. The implementation is clean — a recursive `walk` function scans the raw pre-Zod config object and produces warnings (not errors), and it's integrated at the right location in the plugin-aware validation path.

- New `validation-numeric-ids.ts` module with `warnUnsafeNumericIds()` function that recursively detects unsafe numeric values
- Comprehensive test suite covering safe integers, unsafe integers, multiple warnings, edge cases (NaN, Infinity), and deep nesting
- Integration into `validateConfigObjectWithPluginsBase` in `validation.ts`, appending warnings to the existing warnings array
- **Issue found**: The warning message's suggested fix (`e.g. "${value}"`) interpolates the *already-corrupted* value, which could mislead users into quoting the wrong number

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it only adds non-blocking warnings and does not alter config parsing or validation logic.
- The implementation is well-structured with good test coverage. The only issue is a misleading warning message that suggests quoting the already-corrupted value. The change is additive (warnings only), doesn't affect existing validation behavior, and is properly scoped to the plugin-aware validation path.
- `src/config/validation-numeric-ids.ts` — warning message suggests the corrupted value as the fix

<sub>Last reviewed commit: 012a98e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->