### PR TITLE
fix: prevent duplicated text after tag stripping

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -237,14 +237,29 @@ function stripFinalTagsFromText(text: string): string {
   return text.replace(FINAL_TAG_RE, "");
 }
 
+/**
+ * Detect and remove same-line duplicates that appear when tags like `</final>`
+ * are stripped, leaving the same text concatenated with itself.
+ * For example: "Hello there!Hello there!More text" → "Hello there!More text"
+ */
+function collapseSameLineDuplicates(text: string): string {
+  // Only try this for lines that might have duplicated content (at least 10 chars
+  // to avoid false positives on short strings like "ok ok" or "no no").
+  return text.replace(/(.{10,}?[.!?])\1/g, "$1");
+}
+
 function collapseConsecutiveDuplicateBlocks(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) {
     return text;
   }
-  const blocks = trimmed.split(/\n{2,}/);
+
+  // First pass: same-line duplicate sentences (from stripped tags joining text)
+  const deinlined = collapseSameLineDuplicates(trimmed);
+
+  const blocks = deinlined.split(/\n{2,}/);
   if (blocks.length < 2) {
-    return text;
+    return deinlined;
   }
 
   const normalizeBlock = (value: string) => value.trim().replace(/\s+/g, " ");
@@ -261,7 +276,7 @@ function collapseConsecutiveDuplicateBlocks(text: string): string {
   }
 
   if (result.length === blocks.length) {
-    return text;
+    return deinlined;
   }
   return result.join("\n\n");
 }

--- a/src/agents/pi-embedded-helpers/same-line-dedup.test.ts
+++ b/src/agents/pi-embedded-helpers/same-line-dedup.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
+
+describe("same-line duplicate collapse", () => {
+  it("removes duplicated sentences joined after tag stripping", () => {
+    const input = "Running on Opus 4.6. What do you need?Running on Opus 4.6. What do you need?";
+    expect(sanitizeUserFacingText(input)).toBe("Running on Opus 4.6. What do you need?");
+  });
+
+  it("keeps trailing different text after duplicate", () => {
+    const input =
+      "Atlas here, Dion. What do you need?Atlas here, Dion. What do you need?Fair point.";
+    expect(sanitizeUserFacingText(input)).toBe("Atlas here, Dion. What do you need?Fair point.");
+  });
+
+  it("does not touch short repeated words like ok ok", () => {
+    expect(sanitizeUserFacingText("ok ok")).toBe("ok ok");
+    expect(sanitizeUserFacingText("no no no")).toBe("no no no");
+  });
+
+  it("still collapses paragraph-level duplicates", () => {
+    expect(sanitizeUserFacingText("Hello!\n\nHello!")).toBe("Hello!");
+  });
+
+  it("does not affect normal text", () => {
+    const normal = "This is a perfectly normal response. Nothing weird here.";
+    expect(sanitizeUserFacingText(normal)).toBe(normal);
+  });
+});


### PR DESCRIPTION
When HTML-like tags are stripped from assistant output, the remaining text could be duplicated on the same line.

Fix: Improve the deduplication logic to handle tag-stripped content correctly.

Recreated from #16813 with only relevant files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds same-line duplicate text detection to prevent duplicated assistant output after HTML-like tags (e.g., `</final>`) are stripped. The fix introduces a new `collapseSameLineDuplicates` function that uses a regex pattern to detect and remove sentence-level duplicates that occur on the same line.

**Key changes:**
- New `collapseSameLineDuplicates` function with regex `/(.{10,}?[.!?])\1/g` to detect duplicated sentences (minimum 10 characters, ending in `.`, `!`, or `?`)
- Modified `collapseConsecutiveDuplicateBlocks` to apply same-line deduplication before paragraph-level deduplication
- Updated return statements to preserve same-line deduplication results
- Added comprehensive test coverage for the new behavior
- Minor import reordering (type imports before regular imports)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with appropriate safeguards (10-char minimum to avoid false positives), comprehensive test coverage, and correct integration into the existing deduplication pipeline. The regex pattern correctly uses non-greedy matching and backreferences, and the changes preserve the original text when no duplicates are found
- No files require special attention

<sub>Last reviewed commit: 5981e3d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->