### PR TITLE
feat(usage): add default model costs for session_status

### DIFF
--- a/src/utils/usage-format.cost-defaults.test.ts
+++ b/src/utils/usage-format.cost-defaults.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { resolveModelCostConfig } from "./usage-format.js";
+
+describe("resolveModelCostConfig", () => {
+  it("returns cost for exact match (gpt-4o)", () => {
+    const cost = resolveModelCostConfig({ model: "gpt-4o" });
+    expect(cost).toBeDefined();
+    expect(cost?.input).toBe(2.5);
+  });
+
+  it("returns cost for fuzzy match (claude-3-5-sonnet)", () => {
+    const cost = resolveModelCostConfig({ model: "anthropic/claude-3-5-sonnet-20240620" });
+    expect(cost).toBeDefined();
+    expect(cost?.input).toBe(3);
+  });
+
+  it("returns undefined for unknown model", () => {
+    const cost = resolveModelCostConfig({ model: "unknown-model" });
+    expect(cost).toBeUndefined();
+  });
+
+  it("prioritizes config override", () => {
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            models: [
+              {
+                id: "gpt-4o",
+                cost: { input: 100, output: 200, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const cost = resolveModelCostConfig({
+      provider: "openai",
+      model: "gpt-4o",
+      config: config as unknown as Record<string, unknown>,
+    });
+    expect(cost?.input).toBe(100);
+  });
+});

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -43,6 +43,30 @@ export function formatUsd(value?: number): string | undefined {
   return `$${value.toFixed(4)}`;
 }
 
+const toNumber = (value: number | undefined): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : 0;
+
+// Cost per 1M tokens (USD)
+const DEFAULT_MODEL_COSTS: Record<string, ModelCostConfig> = {
+  // OpenAI
+  "gpt-4o": { input: 2.5, output: 10, cacheRead: 1.25, cacheWrite: 2.5 }, // 2024-08 pricing
+  "gpt-4o-mini": { input: 0.15, output: 0.6, cacheRead: 0.075, cacheWrite: 0.15 },
+  "gpt-4-turbo": { input: 10, output: 30, cacheRead: 10, cacheWrite: 10 },
+
+  // Anthropic
+  "claude-3-5-sonnet-20240620": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  "claude-3-5-sonnet-latest": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  "claude-3-5-haiku-20241022": { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+  "claude-3-opus-20240229": { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+
+  // Google
+  "gemini-1.5-pro": { input: 3.5, output: 10.5, cacheRead: 0.875, cacheWrite: 3.5 }, // approximate
+  "gemini-1.5-flash": { input: 0.075, output: 0.3, cacheRead: 0.01875, cacheWrite: 0.075 },
+
+  // DeepSeek (approx)
+  "deepseek-chat": { input: 0.14, output: 0.28, cacheRead: 0.014, cacheWrite: 0.14 },
+};
+
 export function resolveModelCostConfig(params: {
   provider?: string;
   model?: string;
@@ -50,16 +74,35 @@ export function resolveModelCostConfig(params: {
 }): ModelCostConfig | undefined {
   const provider = params.provider?.trim();
   const model = params.model?.trim();
-  if (!provider || !model) {
+  if (!model) {
     return undefined;
   }
-  const providers = params.config?.models?.providers ?? {};
-  const entry = providers[provider]?.models?.find((item) => item.id === model);
-  return entry?.cost;
-}
 
-const toNumber = (value: number | undefined): number =>
-  typeof value === "number" && Number.isFinite(value) ? value : 0;
+  // 1. Check user config overrides
+  if (provider && params.config?.models?.providers) {
+    const providers = params.config.models.providers;
+    const entry = providers[provider]?.models?.find((item) => item.id === model);
+    if (entry?.cost) {
+      return entry.cost;
+    }
+  }
+
+  // 2. Check default costs map
+  const normalized = model.toLowerCase();
+  for (const [key, cost] of Object.entries(DEFAULT_MODEL_COSTS)) {
+    if (normalized === key) {
+      return cost;
+    }
+  }
+  // Fuzzy match: if config model is "anthropic/claude-3-5-sonnet-20240620"
+  for (const [key, cost] of Object.entries(DEFAULT_MODEL_COSTS)) {
+    if (normalized.endsWith(key)) {
+      return cost;
+    }
+  }
+
+  return undefined;
+}
 
 export function estimateUsageCost(params: {
   usage?: NormalizedUsage | UsageTotals | null;


### PR DESCRIPTION
Add built-in cost defaults for common models so session_status can show cost estimates without manual configuration.

Recreated from #18138 with only relevant files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added built-in default cost configurations for common AI models (OpenAI GPT-4o/mini/turbo, Anthropic Claude 3.5 Sonnet/Haiku/Opus, Google Gemini 1.5 Pro/Flash, DeepSeek Chat) to enable cost estimation in `session_status` without requiring manual configuration.

- Enhanced `resolveModelCostConfig` to fallback to default costs when user config is not available
- Removed requirement for provider parameter (now works with model name alone)
- Implemented fuzzy matching to handle model names with provider prefixes (e.g., `anthropic/claude-3-5-sonnet-20240620`)
- Added comprehensive test coverage for exact match, fuzzy match, unknown models, and config override priority
- User config overrides still take precedence over defaults

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no significant risks
- The implementation is straightforward and low-risk: adds default cost data, enhances fallback logic, and includes comprehensive tests. The changes preserve backward compatibility (user config overrides still work), don't modify any runtime behavior beyond adding defaults, and follow existing code patterns. The fuzzy matching logic is simple and defensive.
- No files require special attention

<sub>Last reviewed commit: 17e5da8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->