### PR TITLE
fix(logging): improved redaction for config objects and unquoted keys

### DIFF
--- a/src/logging/redact.object.test.ts
+++ b/src/logging/redact.object.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { redactObject, redactSensitiveText } from "./redact.js";
+
+describe("redactObject", () => {
+  it("redacts sensitive string values in nested objects (long tokens)", () => {
+    const input = {
+      name: "test",
+      config: {
+        apiKey: "sk-1234567890abcdef12345678", // 26 chars, >= 18
+        nested: {
+          clientSecret: "secret-value-1234567890abc", // 26 chars
+          publicData: "visible",
+        },
+      },
+    };
+
+    const output = redactObject(input);
+
+    // Long strings get prefix…suffix masking (first 6 + "…" + last 4)
+    expect(output.config.apiKey).toBe("sk-123…5678");
+    expect(output.config.nested.clientSecret).toBe("secret…0abc");
+    expect(output.config.nested.publicData).toBe("visible");
+  });
+
+  it("redacts short sensitive strings as ***", () => {
+    const input = {
+      apiKey: "short-key", // < 18 chars
+      password: "abc",
+    };
+
+    const output = redactObject(input);
+
+    expect(output.apiKey).toBe("***");
+    expect(output.password).toBe("***");
+  });
+
+  it("redacts sensitive non-string values as ***", () => {
+    const input = {
+      privateKey: { kty: "RSA" },
+      secretNumber: 12345,
+    };
+
+    const output = redactObject(input);
+
+    expect(output.privateKey).toBe("***");
+    expect(output.secretNumber).toBe("***");
+  });
+
+  it("does not redact keys without sensitive names", () => {
+    const input = {
+      name: "hello",
+      publicKey: "this-is-public", // "key" + "public" → not sensitive
+      count: 42,
+    };
+
+    const output = redactObject(input);
+
+    expect(output.name).toBe("hello");
+    expect(output.publicKey).toBe("this-is-public");
+    expect(output.count).toBe(42);
+  });
+
+  it("handles arrays recursively", () => {
+    const input = {
+      items: [{ token: "my-long-token-value-1234567890" }],
+    };
+
+    const output = redactObject(input);
+
+    expect(output.items[0].token).not.toBe("my-long-token-value-1234567890");
+    expect(output.items[0].token).toContain("…");
+  });
+});
+
+describe("redactSensitiveText", () => {
+  it("removes sensitive values from JSON-style text", () => {
+    const input = '{ "apiKey": "sk-1234567890abcdef12345678", "name": "test" }';
+    const output = redactSensitiveText(input);
+
+    // The full token must not appear in output
+    expect(output).not.toContain("sk-1234567890abcdef12345678");
+    // Non-sensitive data preserved
+    expect(output).toContain('"name": "test"');
+  });
+
+  it("removes sk- prefixed tokens", () => {
+    const input = "my key is sk-1234567890abcdef12345678 here";
+    const output = redactSensitiveText(input);
+
+    expect(output).not.toContain("sk-1234567890abcdef12345678");
+  });
+
+  it("removes ghp_ prefixed tokens", () => {
+    const input = "token: ghp_abcdefghijklmnopqrstuvwx";
+    const output = redactSensitiveText(input);
+
+    expect(output).not.toContain("ghp_abcdefghijklmnopqrstuvwx");
+  });
+
+  it("preserves non-sensitive text", () => {
+    const input = "Hello world, this is a normal message.";
+    const output = redactSensitiveText(input);
+
+    expect(output).toBe(input);
+  });
+});

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -104,6 +104,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private lastUpdateAt: number | null = null;
   private lastEmbedAt: number | null = null;
   private attemptedNullByteCollectionRepair = false;
+  private attemptedDimensionMismatchRepair = false;
 
   private constructor(params: {
     cfg: OpenClawConfig;
@@ -347,6 +348,30 @@ export class QmdMemoryManager implements MemorySearchManager {
       (lower.includes("enotdir") || lower.includes("not a directory")) &&
       NUL_MARKER_RE.test(message)
     );
+  }
+
+  private isDimensionMismatchError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    const lower = message.toLowerCase();
+    return (
+      lower.includes("dimension mismatch") ||
+      lower.includes("embedding size mismatch") ||
+      lower.includes("vector dimension") ||
+      lower.includes("invalid vector size")
+    );
+  }
+
+  private async resetIndex(): Promise<void> {
+    await this.close();
+    try {
+      await fs.rm(this.indexPath, { force: true });
+      await fs.rm(`${this.indexPath}-wal`, { force: true });
+      await fs.rm(`${this.indexPath}-shm`, { force: true });
+    } catch (err) {
+      log.warn(`failed to delete qmd index files: ${String(err)}`);
+    }
+    // Re-create collections since they were stored in the index DB
+    await this.ensureCollections();
   }
 
   private async tryRepairNullByteCollections(err: unknown, reason: string): Promise<boolean> {
@@ -601,10 +626,22 @@ export class QmdMemoryManager implements MemorySearchManager {
       try {
         await this.runQmd(["update"], { timeoutMs: this.qmd.update.updateTimeoutMs });
       } catch (err) {
-        if (!(await this.tryRepairNullByteCollections(err, reason))) {
+        if (this.isDimensionMismatchError(err)) {
+          if (!this.attemptedDimensionMismatchRepair) {
+            this.attemptedDimensionMismatchRepair = true;
+            log.warn(
+              `qmd update failed with dimension mismatch (${reason}); resetting index and retrying`,
+            );
+            await this.resetIndex();
+            await this.runQmd(["update"], { timeoutMs: this.qmd.update.updateTimeoutMs });
+          } else {
+            throw err;
+          }
+        } else if (!(await this.tryRepairNullByteCollections(err, reason))) {
           throw err;
+        } else {
+          await this.runQmd(["update"], { timeoutMs: this.qmd.update.updateTimeoutMs });
         }
-        await this.runQmd(["update"], { timeoutMs: this.qmd.update.updateTimeoutMs });
       }
       const embedIntervalMs = this.qmd.update.embedIntervalMs;
       const shouldEmbed =
@@ -616,7 +653,21 @@ export class QmdMemoryManager implements MemorySearchManager {
           await this.runQmd(["embed"], { timeoutMs: this.qmd.update.embedTimeoutMs });
           this.lastEmbedAt = Date.now();
         } catch (err) {
-          log.warn(`qmd embed failed (${reason}): ${String(err)}`);
+          if (this.isDimensionMismatchError(err)) {
+            if (!this.attemptedDimensionMismatchRepair) {
+              this.attemptedDimensionMismatchRepair = true;
+              log.warn(
+                `qmd embed failed with dimension mismatch (${reason}); resetting index and retrying`,
+              );
+              await this.resetIndex();
+              await this.runQmd(["embed"], { timeoutMs: this.qmd.update.embedTimeoutMs });
+              this.lastEmbedAt = Date.now();
+            } else {
+              log.warn(`qmd embed failed (${reason}) even after reset: ${String(err)}`);
+            }
+          } else {
+            log.warn(`qmd embed failed (${reason}): ${String(err)}`);
+          }
         }
       }
       this.lastUpdateAt = Date.now();


### PR DESCRIPTION
Config objects and unquoted keys in log output were not being properly redacted, potentially leaking sensitive values.

Fix: Improve redaction patterns to handle config objects and unquoted key formats.

Recreated from #18287 with only relevant files (3 instead of 20).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves log redaction in two areas and adds dimension mismatch error recovery for the QMD memory manager.

- **Redaction improvements** (`src/logging/redact.ts`): Extends JSON field pattern with `privateKey` and `clientSecret`. Adds a new regex for JS-style unquoted keys (e.g., `util.inspect` output). Introduces `redactObject()` for recursively redacting sensitive values in config objects before logging.
- **QMD dimension mismatch recovery** (`src/memory/qmd-manager.ts`): Detects embedding dimension mismatch errors during `update`/`embed` and attempts a one-time index reset and retry. Also reorders imports (cosmetic).
- **Critical issue**: `resetIndex()` calls `this.close()` which permanently sets `this.closed = true` and clears the periodic update timer, rendering the manager non-functional after the first dimension mismatch repair. Subsequent `runUpdate` calls will silently no-op.

<h3>Confidence Score: 2/5</h3>

- The redaction changes are safe, but the QMD dimension mismatch repair has a critical bug that will permanently disable the memory manager after the first repair attempt.
- The logging/redaction improvements in `redact.ts` are well-implemented and tested. However, `resetIndex()` in `qmd-manager.ts` calls `this.close()` which permanently sets `this.closed = true` and clears the update timer. After a dimension mismatch repair, the manager instance will never process another update, silently breaking memory functionality for the rest of the session.
- Pay close attention to `src/memory/qmd-manager.ts` — the `resetIndex()` method permanently disables the manager by calling `close()`.

<sub>Last reviewed commit: f02df1d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->