### PR TITLE
feat(plugins): add Agentic Workflow (Mesh) orchestration plugin

### DIFF
--- a/extensions/mesh/README.md
+++ b/extensions/mesh/README.md
@@ -1,0 +1,87 @@
+# Mesh Plugin for OpenClaw
+
+Mesh is a workflow orchestration plugin for OpenClaw.
+
+It adds deterministic multi-step execution on top of existing OpenClaw agents:
+- explicit workflow plans (DAG)
+- step dependencies
+- run status tracking
+- targeted retries
+
+## Features
+
+Gateway methods:
+- `mesh.plan`
+- `mesh.plan.auto`
+- `mesh.run`
+- `mesh.status`
+- `mesh.retry`
+
+Chat command:
+- `/mesh <goal>`
+- `/mesh plan <goal>`
+- `/mesh run <goal|mesh-plan-id>`
+- `/mesh status <runId>`
+- `/mesh retry <runId> [step1,step2,...]`
+
+## Install
+
+### From a local OpenClaw checkout
+
+```bash
+openclaw plugins install ./extensions/mesh
+openclaw plugins enable mesh
+```
+
+### From a linked local path
+
+```bash
+openclaw plugins install --link ./extensions/mesh
+openclaw plugins enable mesh
+```
+
+If this plugin is bundled in your build, you still need to enable it:
+
+```bash
+openclaw plugins enable mesh
+```
+
+## Config
+
+Current plugin config schema is empty (no required settings):
+
+```json5
+{
+  plugins: {
+    entries: {
+      mesh: {
+        enabled: true
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after install/enable/config changes.
+
+## Usage
+
+In chat:
+
+```text
+/mesh Build a landing page animation, test mobile, then write release notes
+```
+
+Or step-by-step:
+
+```text
+/mesh plan Build a landing page animation, test mobile, then write release notes
+/mesh run mesh-plan-<id>
+/mesh status mesh-run-<id>
+/mesh retry mesh-run-<id> test-mobile
+```
+
+## Notes
+
+- run state is in-memory today (not persisted across gateway restarts)
+- plan cache for `/mesh run <mesh-plan-id>` is in-memory and scoped to chat sender/channel

--- a/extensions/mesh/README.md
+++ b/extensions/mesh/README.md
@@ -3,6 +3,7 @@
 Mesh is a workflow orchestration plugin for OpenClaw.
 
 It adds deterministic multi-step execution on top of existing OpenClaw agents:
+
 - explicit workflow plans (DAG)
 - step dependencies
 - run status tracking
@@ -11,6 +12,7 @@ It adds deterministic multi-step execution on top of existing OpenClaw agents:
 ## Features
 
 Gateway methods:
+
 - `mesh.plan`
 - `mesh.plan.auto`
 - `mesh.run`
@@ -18,6 +20,7 @@ Gateway methods:
 - `mesh.retry`
 
 Chat command:
+
 - `/mesh <goal>`
 - `/mesh plan <goal>`
 - `/mesh run <goal|mesh-plan-id>`
@@ -55,10 +58,10 @@ Current plugin config schema is empty (no required settings):
   plugins: {
     entries: {
       mesh: {
-        enabled: true
-      }
-    }
-  }
+        enabled: true,
+      },
+    },
+  },
 }
 ```
 

--- a/extensions/mesh/index.ts
+++ b/extensions/mesh/index.ts
@@ -1,0 +1,15 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { registerMeshCommand } from "./src/mesh-command.js";
+import { registerMeshGatewayMethods } from "./src/mesh-gateway.js";
+
+const meshPlugin = {
+  id: "mesh",
+  name: "Mesh",
+  description: "Workflow orchestration plugin with DAG planning, runs, and retries.",
+  register(api: OpenClawPluginApi) {
+    registerMeshGatewayMethods(api);
+    registerMeshCommand(api);
+  },
+};
+
+export default meshPlugin;

--- a/extensions/mesh/openclaw.plugin.json
+++ b/extensions/mesh/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "mesh",
+  "name": "Mesh",
+  "description": "Workflow orchestration plugin with DAG planning, runs, and retries.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/mesh/src/mesh-command.test.ts
+++ b/extensions/mesh/src/mesh-command.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { registerMeshCommand } from "./mesh-command.js";
+
+const callGatewayMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/gateway/call.js", () => ({
+  callGateway: callGatewayMock,
+}));
+
+type RegisteredCommand = {
+  name: string;
+  description: string;
+  acceptsArgs?: boolean;
+  handler: (ctx: {
+    senderId?: string;
+    channel: string;
+    isAuthorizedSender: boolean;
+    args?: string;
+    commandBody: string;
+    config: Record<string, unknown>;
+  }) => Promise<{ text?: string }>;
+};
+
+function captureCommand() {
+  let command: RegisteredCommand | null = null;
+  const api = {
+    registerCommand: (def: RegisteredCommand) => {
+      command = def;
+    },
+  } as unknown as OpenClawPluginApi;
+  registerMeshCommand(api);
+  if (!command) {
+    throw new Error("mesh command was not registered");
+  }
+  return command;
+}
+
+describe("mesh plugin command", () => {
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+  });
+
+  it("registers /mesh command", () => {
+    const command = captureCommand();
+    expect(command.name).toBe("mesh");
+    expect(command.acceptsArgs).toBe(true);
+  });
+
+  it("returns usage for bare /mesh", async () => {
+    const command = captureCommand();
+    const result = await command.handler({
+      channel: "whatsapp",
+      senderId: "user-1",
+      isAuthorizedSender: true,
+      commandBody: "/mesh",
+      config: {},
+    });
+    expect(result.text).toContain("Mesh command");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("runs /mesh plan <goal>", async () => {
+    const command = captureCommand();
+    callGatewayMock.mockResolvedValueOnce({
+      plan: {
+        planId: "mesh-plan-1",
+        goal: "build animation",
+        createdAt: Date.now(),
+        steps: [{ id: "s1", prompt: "do thing" }],
+      },
+      source: "llm",
+    });
+
+    const result = await command.handler({
+      channel: "whatsapp",
+      senderId: "user-1",
+      isAuthorizedSender: true,
+      commandBody: "/mesh plan build animation",
+      config: {},
+    });
+
+    expect(result.text).toContain("Run exact plan: /mesh run mesh-plan-1");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "mesh.plan.auto",
+      }),
+    );
+  });
+
+  it("runs cached plan id without re-planning", async () => {
+    const command = captureCommand();
+    callGatewayMock
+      .mockResolvedValueOnce({
+        plan: {
+          planId: "mesh-plan-cache",
+          goal: "cached goal",
+          createdAt: Date.now(),
+          steps: [{ id: "s1", prompt: "do thing" }],
+        },
+      })
+      .mockResolvedValueOnce({
+        runId: "mesh-run-1",
+        status: "completed",
+        stats: { total: 1, succeeded: 1, failed: 0, skipped: 0, running: 0, pending: 0 },
+      });
+
+    await command.handler({
+      channel: "whatsapp",
+      senderId: "user-1",
+      isAuthorizedSender: true,
+      commandBody: "/mesh plan cached goal",
+      config: {},
+    });
+
+    callGatewayMock.mockClear();
+
+    const result = await command.handler({
+      channel: "whatsapp",
+      senderId: "user-1",
+      isAuthorizedSender: true,
+      commandBody: "/mesh run mesh-plan-cache",
+      config: {},
+    });
+
+    expect(result.text).toContain("Mesh Run");
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "mesh.run",
+      }),
+    );
+  });
+
+  it("blocks unauthorized sender", async () => {
+    const command = captureCommand();
+    const result = await command.handler({
+      channel: "whatsapp",
+      senderId: "user-1",
+      isAuthorizedSender: false,
+      commandBody: "/mesh status mesh-run-1",
+      config: {},
+    });
+    expect(result.text).toContain("requires authorization");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/mesh/src/mesh-command.test.ts
+++ b/extensions/mesh/src/mesh-command.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { describe, expect, it, beforeEach, vi } from "vitest";
 import { registerMeshCommand } from "./mesh-command.js";
 
 const callGatewayMock = vi.hoisted(() => vi.fn());

--- a/extensions/mesh/src/mesh-command.test.ts
+++ b/extensions/mesh/src/mesh-command.test.ts
@@ -22,14 +22,15 @@ type RegisteredCommand = {
   }) => Promise<{ text?: string }>;
 };
 
-function captureCommand() {
-  let command: RegisteredCommand | null = null;
+function captureCommand(): RegisteredCommand {
+  const registered: RegisteredCommand[] = [];
   const api = {
     registerCommand: (def: RegisteredCommand) => {
-      command = def;
+      registered.push(def);
     },
   } as unknown as OpenClawPluginApi;
   registerMeshCommand(api);
+  const command = registered[0];
   if (!command) {
     throw new Error("mesh command was not registered");
   }

--- a/extensions/mesh/src/mesh-command.ts
+++ b/extensions/mesh/src/mesh-command.ts
@@ -1,0 +1,338 @@
+import type { OpenClawPluginApi, ReplyPayload } from "openclaw/plugin-sdk";
+import type { PluginCommandContext } from "../../../src/plugins/types.js";
+import { callGateway } from "../../../src/gateway/call.js";
+import { logVerbose } from "../../../src/globals.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../../src/utils/message-channel.js";
+
+type MeshPlanShape = {
+  planId: string;
+  goal: string;
+  createdAt: number;
+  steps: Array<{ id: string; name?: string; prompt: string; dependsOn?: string[] }>;
+};
+
+type CachedMeshPlan = { plan: MeshPlanShape; createdAt: number };
+
+type ParsedMeshCommand =
+  | { ok: true; action: "help" }
+  | { ok: true; action: "run" | "plan"; target: string }
+  | { ok: true; action: "status"; runId: string }
+  | { ok: true; action: "retry"; runId: string; stepIds?: string[] }
+  | { ok: false; message: string }
+  | null;
+
+const meshPlanCache = new Map<string, CachedMeshPlan>();
+const MAX_CACHED_MESH_PLANS = 200;
+const MESH_PLAN_CALL_TIMEOUT_MS = 120_000;
+const MESH_RUN_CALL_TIMEOUT_MS = 15 * 60_000;
+const MESH_STATUS_CALL_TIMEOUT_MS = 15_000;
+const MESH_RETRY_CALL_TIMEOUT_MS = 15 * 60_000;
+
+function trimMeshPlanCache() {
+  if (meshPlanCache.size <= MAX_CACHED_MESH_PLANS) {
+    return;
+  }
+  const oldest = [...meshPlanCache.entries()]
+    .sort((a, b) => a[1].createdAt - b[1].createdAt)
+    .slice(0, meshPlanCache.size - MAX_CACHED_MESH_PLANS);
+  for (const [key] of oldest) {
+    meshPlanCache.delete(key);
+  }
+}
+
+function parseMeshCommand(commandBody: string): ParsedMeshCommand {
+  const trimmed = commandBody.trim();
+  if (!/^\/mesh\b/i.test(trimmed)) {
+    return null;
+  }
+  const rest = trimmed.replace(/^\/mesh\b:?/i, "").trim();
+  if (!rest || /^help$/i.test(rest)) {
+    return { ok: true, action: "help" };
+  }
+
+  const tokens = rest.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return { ok: true, action: "help" };
+  }
+
+  const actionCandidate = tokens[0]?.toLowerCase() ?? "";
+  const explicitAction =
+    actionCandidate === "run" ||
+    actionCandidate === "plan" ||
+    actionCandidate === "status" ||
+    actionCandidate === "retry"
+      ? actionCandidate
+      : null;
+
+  if (!explicitAction) {
+    // Shorthand: `/mesh <goal>` => auto plan + run
+    return { ok: true, action: "run", target: rest };
+  }
+
+  const actionArgs = rest.slice(tokens[0]?.length ?? 0).trim();
+  if (explicitAction === "plan" || explicitAction === "run") {
+    if (!actionArgs) {
+      return { ok: false, message: `Usage: /mesh ${explicitAction} <goal>` };
+    }
+    return { ok: true, action: explicitAction, target: actionArgs };
+  }
+
+  if (explicitAction === "status") {
+    if (!actionArgs) {
+      return { ok: false, message: "Usage: /mesh status <runId>" };
+    }
+    return { ok: true, action: "status", runId: actionArgs.split(/\s+/)[0] };
+  }
+
+  const argsTokens = actionArgs.split(/\s+/).filter(Boolean);
+  if (argsTokens.length === 0) {
+    return { ok: false, message: "Usage: /mesh retry <runId> [step1,step2,...]" };
+  }
+  const runId = argsTokens[0];
+  const stepArg = argsTokens.slice(1).join(" ").trim();
+  const stepIds =
+    stepArg.length > 0
+      ? stepArg
+          .split(",")
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+      : undefined;
+  return { ok: true, action: "retry", runId, stepIds };
+}
+
+function cacheKeyForPlan(ctx: PluginCommandContext, planId: string) {
+  const sender = ctx.senderId ?? "unknown";
+  const channel = ctx.channel || "unknown";
+  return `${channel}:${sender}:${planId}`;
+}
+
+function putCachedPlan(ctx: PluginCommandContext, plan: MeshPlanShape) {
+  meshPlanCache.set(cacheKeyForPlan(ctx, plan.planId), { plan, createdAt: Date.now() });
+  trimMeshPlanCache();
+}
+
+function getCachedPlan(ctx: PluginCommandContext, planId: string): MeshPlanShape | null {
+  return meshPlanCache.get(cacheKeyForPlan(ctx, planId))?.plan ?? null;
+}
+
+function looksLikeMeshPlanId(value: string) {
+  return /^mesh-plan-[a-z0-9-]+$/i.test(value.trim());
+}
+
+function formatPlanSummary(plan: {
+  goal: string;
+  steps: Array<{ id: string; name?: string; prompt: string; dependsOn?: string[] }>;
+}) {
+  const lines = ["🕸️ Mesh Plan", `Goal: ${plan.goal}`, "", `Steps (${plan.steps.length}):`];
+  for (const step of plan.steps) {
+    const dependsOn = Array.isArray(step.dependsOn) && step.dependsOn.length > 0;
+    const depLine = dependsOn ? ` (depends on: ${step.dependsOn?.join(", ")})` : "";
+    lines.push(`- ${step.id}${step.name ? ` — ${step.name}` : ""}${depLine}`);
+    lines.push(`  ${step.prompt}`);
+  }
+  return lines.join("\n");
+}
+
+function formatRunSummary(payload: {
+  runId: string;
+  status: string;
+  stats?: {
+    total?: number;
+    succeeded?: number;
+    failed?: number;
+    skipped?: number;
+    running?: number;
+    pending?: number;
+  };
+}) {
+  const stats = payload.stats ?? {};
+  return [
+    "🕸️ Mesh Run",
+    `Run: ${payload.runId}`,
+    `Status: ${payload.status}`,
+    `Steps: total=${stats.total ?? 0}, ok=${stats.succeeded ?? 0}, failed=${stats.failed ?? 0}, skipped=${stats.skipped ?? 0}, running=${stats.running ?? 0}, pending=${stats.pending ?? 0}`,
+  ].join("\n");
+}
+
+function meshUsageText() {
+  return [
+    "🕸️ Mesh command",
+    "Usage:",
+    "- /mesh <goal>  (auto plan + run)",
+    "- /mesh plan <goal>",
+    "- /mesh run <goal|mesh-plan-id>",
+    "- /mesh status <runId>",
+    "- /mesh retry <runId> [step1,step2,...]",
+  ].join("\n");
+}
+
+function resolveMeshClientLabel(ctx: PluginCommandContext) {
+  const channel = ctx.channel;
+  const sender = ctx.senderId ?? "unknown";
+  return `Chat mesh (${channel}:${sender})`;
+}
+
+async function runMeshCommand(ctx: PluginCommandContext): Promise<ReplyPayload> {
+  const parsed = parseMeshCommand(ctx.commandBody);
+  if (!parsed) {
+    return { text: meshUsageText() };
+  }
+  if (!ctx.isAuthorizedSender) {
+    logVerbose(`Ignoring /mesh from unauthorized sender: ${ctx.senderId || "<unknown>"}`);
+    return { text: "⚠️ This command requires authorization." };
+  }
+  if (!parsed.ok) {
+    return { text: parsed.message };
+  }
+  if (parsed.action === "help") {
+    return { text: meshUsageText() };
+  }
+
+  const clientDisplayName = resolveMeshClientLabel(ctx);
+  const commonGateway = {
+    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+    clientDisplayName,
+    mode: GATEWAY_CLIENT_MODES.BACKEND,
+  } as const;
+
+  if (parsed.action === "plan") {
+    const planResp = await callGateway<{
+      plan: MeshPlanShape;
+      order?: string[];
+      source?: string;
+    }>({
+      method: "mesh.plan.auto",
+      params: {
+        goal: parsed.target,
+        agentId: "main",
+      },
+      ...commonGateway,
+      timeoutMs: MESH_PLAN_CALL_TIMEOUT_MS,
+    });
+    putCachedPlan(ctx, planResp.plan);
+    const sourceLine = planResp.source ? `\nPlanner source: ${planResp.source}` : "";
+    return {
+      text: `${formatPlanSummary(planResp.plan)}${sourceLine}\n\nRun exact plan: /mesh run ${planResp.plan.planId}`,
+    };
+  }
+
+  if (parsed.action === "run") {
+    let runPlan: MeshPlanShape;
+    if (looksLikeMeshPlanId(parsed.target)) {
+      const cached = getCachedPlan(ctx, parsed.target.trim());
+      if (!cached) {
+        return {
+          text: `Plan ${parsed.target.trim()} not found in this chat.\nCreate one first: /mesh plan <goal>`,
+        };
+      }
+      runPlan = cached;
+    } else {
+      const planResp = await callGateway<{
+        plan: MeshPlanShape;
+        order?: string[];
+        source?: string;
+      }>({
+        method: "mesh.plan.auto",
+        params: {
+          goal: parsed.target,
+          agentId: "main",
+        },
+        ...commonGateway,
+        timeoutMs: MESH_PLAN_CALL_TIMEOUT_MS,
+      });
+      putCachedPlan(ctx, planResp.plan);
+      runPlan = planResp.plan;
+    }
+
+    const runResp = await callGateway<{
+      runId: string;
+      status: string;
+      stats?: {
+        total?: number;
+        succeeded?: number;
+        failed?: number;
+        skipped?: number;
+        running?: number;
+        pending?: number;
+      };
+    }>({
+      method: "mesh.run",
+      params: {
+        plan: runPlan,
+      },
+      ...commonGateway,
+      timeoutMs: MESH_RUN_CALL_TIMEOUT_MS,
+    });
+
+    return {
+      text: `${formatPlanSummary(runPlan)}\n\n${formatRunSummary(runResp)}`,
+    };
+  }
+
+  if (parsed.action === "status") {
+    const statusResp = await callGateway<{
+      runId: string;
+      status: string;
+      stats?: {
+        total?: number;
+        succeeded?: number;
+        failed?: number;
+        skipped?: number;
+        running?: number;
+        pending?: number;
+      };
+    }>({
+      method: "mesh.status",
+      params: { runId: parsed.runId },
+      ...commonGateway,
+      timeoutMs: MESH_STATUS_CALL_TIMEOUT_MS,
+    });
+    return {
+      text: formatRunSummary(statusResp),
+    };
+  }
+
+  if (parsed.action === "retry") {
+    const retryResp = await callGateway<{
+      runId: string;
+      status: string;
+      stats?: {
+        total?: number;
+        succeeded?: number;
+        failed?: number;
+        skipped?: number;
+        running?: number;
+        pending?: number;
+      };
+    }>({
+      method: "mesh.retry",
+      params: {
+        runId: parsed.runId,
+        ...(parsed.stepIds && parsed.stepIds.length > 0 ? { stepIds: parsed.stepIds } : {}),
+      },
+      ...commonGateway,
+      timeoutMs: MESH_RETRY_CALL_TIMEOUT_MS,
+    });
+    return {
+      text: `🔁 Retry submitted\n${formatRunSummary(retryResp)}`,
+    };
+  }
+
+  return { text: meshUsageText() };
+}
+
+export function registerMeshCommand(api: OpenClawPluginApi) {
+  api.registerCommand({
+    name: "mesh",
+    description: "Plan and run multi-step workflows.",
+    acceptsArgs: true,
+    handler: async (ctx) => {
+      try {
+        return await runMeshCommand(ctx);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { text: `❌ Mesh command failed: ${message}` };
+      }
+    },
+  });
+}

--- a/extensions/mesh/src/mesh-command.ts
+++ b/extensions/mesh/src/mesh-command.ts
@@ -1,7 +1,7 @@
 import type { OpenClawPluginApi, ReplyPayload } from "openclaw/plugin-sdk";
-import type { PluginCommandContext } from "../../../src/plugins/types.js";
 import { callGateway } from "../../../src/gateway/call.js";
 import { logVerbose } from "../../../src/globals.js";
+import type { PluginCommandContext } from "../../../src/plugins/types.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../../src/utils/message-channel.js";
 
 type MeshPlanShape = {

--- a/extensions/mesh/src/mesh-gateway.test.ts
+++ b/extensions/mesh/src/mesh-gateway.test.ts
@@ -34,6 +34,13 @@ type GatewayCallResult = {
   meta?: Record<string, unknown>;
 };
 
+type TestRespond = (
+  ok: boolean,
+  payload?: unknown,
+  error?: unknown,
+  meta?: Record<string, unknown>,
+) => void;
+
 function setupHandlers() {
   const handlers: Record<string, GatewayRequestHandler> = {};
   const api = {
@@ -54,7 +61,8 @@ async function callHandler(
     void handler({
       req: { type: "req", id: `test-${method}`, method, params },
       params,
-      respond: (ok, payload, error, meta) => resolve({ ok, payload, error, meta }),
+      respond: (ok: boolean, payload?: unknown, error?: unknown, meta?: Record<string, unknown>) =>
+        resolve({ ok, payload, error, meta }),
       client: null,
       isWebchatConnect: false,
       context: { deps: {} },
@@ -124,10 +132,10 @@ describe("mesh plugin gateway", () => {
   it("runs mesh workflow and returns completed status", async () => {
     const handlers = setupHandlers();
 
-    agentMethodMock.mockImplementation(({ respond }) => {
+    agentMethodMock.mockImplementation(({ respond }: { respond: TestRespond }) => {
       respond(true, { runId: "agent-run-1" });
     });
-    agentWaitMethodMock.mockImplementation(({ respond }) => {
+    agentWaitMethodMock.mockImplementation(({ respond }: { respond: TestRespond }) => {
       respond(true, { status: "ok" });
     });
 

--- a/extensions/mesh/src/mesh-gateway.test.ts
+++ b/extensions/mesh/src/mesh-gateway.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayRequestHandler, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const agentCommandMock = vi.hoisted(() => vi.fn());
 const normalizeAgentIdMock = vi.hoisted(() => vi.fn((value: string) => value));
@@ -141,7 +141,10 @@ describe("mesh plugin gateway", () => {
     });
 
     expect(res.ok).toBe(true);
-    const payload = res.payload as { status?: string; stats?: { succeeded?: number; total?: number } };
+    const payload = res.payload as {
+      status?: string;
+      stats?: { succeeded?: number; total?: number };
+    };
     expect(payload.status).toBe("completed");
     expect(payload.stats?.total).toBe(1);
     expect(payload.stats?.succeeded).toBe(1);

--- a/extensions/mesh/src/mesh-gateway.test.ts
+++ b/extensions/mesh/src/mesh-gateway.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayRequestHandler, OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+const agentCommandMock = vi.hoisted(() => vi.fn());
+const normalizeAgentIdMock = vi.hoisted(() => vi.fn((value: string) => value));
+const agentMethodMock = vi.hoisted(() => vi.fn());
+const agentWaitMethodMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/commands/agent.js", () => ({
+  agentCommand: agentCommandMock,
+}));
+
+vi.mock("../../../src/routing/session-key.js", () => ({
+  normalizeAgentId: normalizeAgentIdMock,
+}));
+
+vi.mock("../../../src/runtime.js", () => ({
+  defaultRuntime: {},
+}));
+
+vi.mock("../../../src/gateway/server-methods/agent.js", () => ({
+  agentHandlers: {
+    agent: agentMethodMock,
+    "agent.wait": agentWaitMethodMock,
+  },
+}));
+
+import { registerMeshGatewayMethods } from "./mesh-gateway.js";
+
+type GatewayCallResult = {
+  ok: boolean;
+  payload?: unknown;
+  error?: unknown;
+  meta?: Record<string, unknown>;
+};
+
+function setupHandlers() {
+  const handlers: Record<string, GatewayRequestHandler> = {};
+  const api = {
+    registerGatewayMethod: (method: string, handler: GatewayRequestHandler) => {
+      handlers[method] = handler;
+    },
+  } as unknown as OpenClawPluginApi;
+  registerMeshGatewayMethods(api);
+  return handlers;
+}
+
+async function callHandler(
+  handler: GatewayRequestHandler,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<GatewayCallResult> {
+  return await new Promise<GatewayCallResult>((resolve) => {
+    void handler({
+      req: { type: "req", id: `test-${method}`, method, params },
+      params,
+      respond: (ok, payload, error, meta) => resolve({ ok, payload, error, meta }),
+      client: null,
+      isWebchatConnect: false,
+      context: { deps: {} },
+    } as never);
+  });
+}
+
+describe("mesh plugin gateway", () => {
+  beforeEach(() => {
+    agentCommandMock.mockReset();
+    normalizeAgentIdMock.mockReset();
+    normalizeAgentIdMock.mockImplementation((value: string) => value);
+    agentMethodMock.mockReset();
+    agentWaitMethodMock.mockReset();
+  });
+
+  it("registers all mesh gateway methods", () => {
+    const handlers = setupHandlers();
+    expect(Object.keys(handlers).sort()).toEqual([
+      "mesh.plan",
+      "mesh.plan.auto",
+      "mesh.retry",
+      "mesh.run",
+      "mesh.status",
+    ]);
+  });
+
+  it("returns validation error for invalid mesh.plan", async () => {
+    const handlers = setupHandlers();
+    const res = await callHandler(handlers["mesh.plan"], "mesh.plan", { goal: "" });
+    expect(res.ok).toBe(false);
+  });
+
+  it("plans and returns topological order", async () => {
+    const handlers = setupHandlers();
+    const res = await callHandler(handlers["mesh.plan"], "mesh.plan", {
+      goal: "build",
+      steps: [
+        { id: "a", prompt: "first" },
+        { id: "b", prompt: "second", dependsOn: ["a"] },
+      ],
+    });
+    expect(res.ok).toBe(true);
+    const payload = res.payload as { order?: string[]; plan?: { steps?: Array<{ id: string }> } };
+    expect(payload.order).toEqual(["a", "b"]);
+    expect(payload.plan?.steps?.length).toBe(2);
+  });
+
+  it("falls back to single-step plan when auto planner fails", async () => {
+    const handlers = setupHandlers();
+    agentCommandMock.mockRejectedValueOnce(new Error("planner unavailable"));
+
+    const res = await callHandler(handlers["mesh.plan.auto"], "mesh.plan.auto", {
+      goal: "ship release",
+      agentId: "main",
+    });
+
+    expect(res.ok).toBe(true);
+    const payload = res.payload as {
+      source?: string;
+      plan?: { steps?: Array<{ prompt: string }> };
+    };
+    expect(payload.source).toBe("fallback");
+    expect(payload.plan?.steps?.[0]?.prompt).toBe("ship release");
+  });
+
+  it("runs mesh workflow and returns completed status", async () => {
+    const handlers = setupHandlers();
+
+    agentMethodMock.mockImplementation(({ respond }) => {
+      respond(true, { runId: "agent-run-1" });
+    });
+    agentWaitMethodMock.mockImplementation(({ respond }) => {
+      respond(true, { status: "ok" });
+    });
+
+    const res = await callHandler(handlers["mesh.run"], "mesh.run", {
+      plan: {
+        planId: "mesh-plan-1",
+        goal: "do one thing",
+        createdAt: Date.now(),
+        steps: [{ id: "s1", prompt: "do one thing" }],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    const payload = res.payload as { status?: string; stats?: { succeeded?: number; total?: number } };
+    expect(payload.status).toBe("completed");
+    expect(payload.stats?.total).toBe(1);
+    expect(payload.stats?.succeeded).toBe(1);
+  });
+});

--- a/extensions/mesh/src/mesh-gateway.ts
+++ b/extensions/mesh/src/mesh-gateway.ts
@@ -6,7 +6,9 @@ import { defaultRuntime } from "../../../src/runtime.js";
 import {
   ErrorCodes,
   errorShape,
-  formatValidationErrors,
+} from "../../../src/gateway/protocol/index.js";
+import { agentHandlers } from "../../../src/gateway/server-methods/agent.js";
+import {
   validateMeshPlanAutoParams,
   validateMeshPlanParams,
   validateMeshRetryParams,
@@ -15,8 +17,7 @@ import {
   type MeshPlanAutoParams,
   type MeshRunParams,
   type MeshWorkflowPlan,
-} from "../../../src/gateway/protocol/index.js";
-import { agentHandlers } from "../../../src/gateway/server-methods/agent.js";
+} from "./mesh-schema.js";
 
 type MeshStepStatus = "pending" | "running" | "succeeded" | "failed" | "skipped";
 type MeshRunStatus = "pending" | "running" | "completed" | "failed";
@@ -696,7 +697,7 @@ const meshHandlers: Record<
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          `invalid mesh.plan params: ${formatValidationErrors(validateMeshPlanParams.errors)}`,
+          "invalid mesh.plan params",
         ),
       );
       return;
@@ -729,7 +730,7 @@ const meshHandlers: Record<
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          `invalid mesh.plan.auto params: ${formatValidationErrors(validateMeshPlanAutoParams.errors)}`,
+          "invalid mesh.plan.auto params",
         ),
       );
       return;
@@ -780,7 +781,7 @@ const meshHandlers: Record<
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          `invalid mesh.run params: ${formatValidationErrors(validateMeshRunParams.errors)}`,
+          "invalid mesh.run params",
         ),
       );
       return;
@@ -824,7 +825,7 @@ const meshHandlers: Record<
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          `invalid mesh.status params: ${formatValidationErrors(validateMeshStatusParams.errors)}`,
+          "invalid mesh.status params",
         ),
       );
       return;
@@ -844,7 +845,7 @@ const meshHandlers: Record<
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          `invalid mesh.retry params: ${formatValidationErrors(validateMeshRetryParams.errors)}`,
+          "invalid mesh.retry params",
         ),
       );
       return;

--- a/extensions/mesh/src/mesh-gateway.ts
+++ b/extensions/mesh/src/mesh-gateway.ts
@@ -1,0 +1,899 @@
+import { randomUUID } from "node:crypto";
+import type { GatewayRequestHandlerOptions, OpenClawPluginApi, RespondFn } from "openclaw/plugin-sdk";
+import { agentCommand } from "../../../src/commands/agent.js";
+import { normalizeAgentId } from "../../../src/routing/session-key.js";
+import { defaultRuntime } from "../../../src/runtime.js";
+import {
+  ErrorCodes,
+  errorShape,
+  formatValidationErrors,
+  validateMeshPlanAutoParams,
+  validateMeshPlanParams,
+  validateMeshRetryParams,
+  validateMeshRunParams,
+  validateMeshStatusParams,
+  type MeshPlanAutoParams,
+  type MeshRunParams,
+  type MeshWorkflowPlan,
+} from "../../../src/gateway/protocol/index.js";
+import { agentHandlers } from "../../../src/gateway/server-methods/agent.js";
+
+type MeshStepStatus = "pending" | "running" | "succeeded" | "failed" | "skipped";
+type MeshRunStatus = "pending" | "running" | "completed" | "failed";
+
+type MeshStepRuntime = {
+  id: string;
+  name?: string;
+  prompt: string;
+  dependsOn: string[];
+  agentId?: string;
+  sessionKey?: string;
+  thinking?: string;
+  timeoutMs?: number;
+  status: MeshStepStatus;
+  attempts: number;
+  startedAt?: number;
+  endedAt?: number;
+  agentRunId?: string;
+  error?: string;
+};
+
+type MeshRunRecord = {
+  runId: string;
+  plan: MeshWorkflowPlan;
+  status: MeshRunStatus;
+  startedAt: number;
+  endedAt?: number;
+  continueOnError: boolean;
+  maxParallel: number;
+  defaultStepTimeoutMs: number;
+  lane?: string;
+  stepOrder: string[];
+  steps: Record<string, MeshStepRuntime>;
+  history: Array<{ ts: number; type: string; stepId?: string; data?: Record<string, unknown> }>;
+};
+
+type MeshAutoStep = {
+  id?: string;
+  name?: string;
+  prompt: string;
+  dependsOn?: string[];
+  agentId?: string;
+  sessionKey?: string;
+  thinking?: string;
+  timeoutMs?: number;
+};
+
+type MeshAutoPlanShape = {
+  steps?: MeshAutoStep[];
+};
+
+const meshRuns = new Map<string, MeshRunRecord>();
+const MAX_KEEP_RUNS = 200;
+const AUTO_PLAN_TIMEOUT_MS = 90_000;
+const PLANNER_MAIN_KEY = "mesh-planner";
+
+function trimMap() {
+  if (meshRuns.size <= MAX_KEEP_RUNS) {
+    return;
+  }
+  const sorted = [...meshRuns.values()].sort((a, b) => a.startedAt - b.startedAt);
+  const overflow = meshRuns.size - MAX_KEEP_RUNS;
+  for (const stale of sorted.slice(0, overflow)) {
+    meshRuns.delete(stale.runId);
+  }
+}
+
+function normalizeDependsOn(dependsOn: string[] | undefined): string[] {
+  if (!Array.isArray(dependsOn)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const raw of dependsOn) {
+    const trimmed = String(raw ?? "").trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function normalizePlan(plan: MeshWorkflowPlan): MeshWorkflowPlan {
+  return {
+    planId: plan.planId.trim(),
+    goal: plan.goal.trim(),
+    createdAt: plan.createdAt,
+    steps: plan.steps.map((step) => ({
+      id: step.id.trim(),
+      name: typeof step.name === "string" ? step.name.trim() || undefined : undefined,
+      prompt: step.prompt.trim(),
+      dependsOn: normalizeDependsOn(step.dependsOn),
+      agentId: typeof step.agentId === "string" ? step.agentId.trim() || undefined : undefined,
+      sessionKey:
+        typeof step.sessionKey === "string" ? step.sessionKey.trim() || undefined : undefined,
+      thinking: typeof step.thinking === "string" ? step.thinking : undefined,
+      timeoutMs:
+        typeof step.timeoutMs === "number" && Number.isFinite(step.timeoutMs)
+          ? Math.max(1_000, Math.floor(step.timeoutMs))
+          : undefined,
+    })),
+  };
+}
+
+function createPlanFromParams(params: {
+  goal: string;
+  steps?: MeshAutoStep[];
+}): MeshWorkflowPlan {
+  const now = Date.now();
+  const goal = params.goal.trim();
+  const sourceSteps = params.steps?.length
+    ? params.steps
+    : [
+        {
+          id: "step-1",
+          name: "Primary Task",
+          prompt: goal,
+        },
+      ];
+
+  const steps = sourceSteps.map((step, index) => {
+    const stepId = step.id?.trim() || `step-${index + 1}`;
+    return {
+      id: stepId,
+      name: step.name?.trim() || undefined,
+      prompt: step.prompt.trim(),
+      dependsOn: normalizeDependsOn(step.dependsOn),
+      agentId: step.agentId?.trim() || undefined,
+      sessionKey: step.sessionKey?.trim() || undefined,
+      thinking: typeof step.thinking === "string" ? step.thinking : undefined,
+      timeoutMs:
+        typeof step.timeoutMs === "number" && Number.isFinite(step.timeoutMs)
+          ? Math.max(1_000, Math.floor(step.timeoutMs))
+          : undefined,
+    };
+  });
+
+  return {
+    planId: `mesh-plan-${randomUUID()}`,
+    goal,
+    createdAt: now,
+    steps,
+  };
+}
+
+function validatePlanGraph(plan: MeshWorkflowPlan): { ok: true; order: string[] } | { ok: false; error: string } {
+  const ids = new Set<string>();
+  for (const step of plan.steps) {
+    if (ids.has(step.id)) {
+      return { ok: false, error: `duplicate step id: ${step.id}` };
+    }
+    ids.add(step.id);
+  }
+
+  for (const step of plan.steps) {
+    for (const depId of step.dependsOn ?? []) {
+      if (!ids.has(depId)) {
+        return { ok: false, error: `unknown dependency "${depId}" on step "${step.id}"` };
+      }
+      if (depId === step.id) {
+        return { ok: false, error: `step "${step.id}" cannot depend on itself` };
+      }
+    }
+  }
+
+  const inDegree = new Map<string, number>();
+  const outgoing = new Map<string, string[]>();
+  for (const step of plan.steps) {
+    inDegree.set(step.id, 0);
+    outgoing.set(step.id, []);
+  }
+  for (const step of plan.steps) {
+    for (const dep of step.dependsOn ?? []) {
+      inDegree.set(step.id, (inDegree.get(step.id) ?? 0) + 1);
+      const list = outgoing.get(dep);
+      if (list) {
+        list.push(step.id);
+      }
+    }
+  }
+
+  const queue = plan.steps.filter((step) => (inDegree.get(step.id) ?? 0) === 0).map((s) => s.id);
+  const order: string[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
+    order.push(current);
+    const targets = outgoing.get(current) ?? [];
+    for (const next of targets) {
+      const degree = (inDegree.get(next) ?? 0) - 1;
+      inDegree.set(next, degree);
+      if (degree === 0) {
+        queue.push(next);
+      }
+    }
+  }
+
+  if (order.length !== plan.steps.length) {
+    return { ok: false, error: "workflow contains a dependency cycle" };
+  }
+  return { ok: true, order };
+}
+
+async function callGatewayHandler(
+  handler: (opts: GatewayRequestHandlerOptions) => Promise<void> | void,
+  opts: GatewayRequestHandlerOptions,
+): Promise<{ ok: boolean; payload?: unknown; error?: unknown; meta?: Record<string, unknown> }> {
+  return await new Promise((resolve) => {
+    let settled = false;
+    const settle = (result: { ok: boolean; payload?: unknown; error?: unknown; meta?: Record<string, unknown> }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(result);
+    };
+    const respond: RespondFn = (ok, payload, error, meta) => {
+      settle({ ok, payload, error, meta });
+    };
+    void Promise.resolve(
+      handler({
+        ...opts,
+        respond,
+      }),
+    ).catch((err) => {
+      settle({ ok: false, error: err });
+    });
+  });
+}
+
+function buildStepPrompt(step: MeshStepRuntime, run: MeshRunRecord): string {
+  if (step.dependsOn.length === 0) {
+    return step.prompt;
+  }
+  const lines = step.dependsOn.map((depId) => {
+    const dep = run.steps[depId];
+    const details = dep.agentRunId ? ` runId=${dep.agentRunId}` : "";
+    return `- ${depId}: ${dep.status}${details}`;
+  });
+  return `${step.prompt}\n\nDependency context:\n${lines.join("\n")}`;
+}
+
+function resolveStepTimeoutMs(step: MeshStepRuntime, run: MeshRunRecord): number {
+  if (typeof step.timeoutMs === "number" && Number.isFinite(step.timeoutMs)) {
+    return Math.max(1_000, Math.floor(step.timeoutMs));
+  }
+  return run.defaultStepTimeoutMs;
+}
+
+async function executeStep(params: {
+  run: MeshRunRecord;
+  step: MeshStepRuntime;
+  opts: GatewayRequestHandlerOptions;
+}) {
+  const { run, step, opts } = params;
+  step.status = "running";
+  step.startedAt = Date.now();
+  step.endedAt = undefined;
+  step.error = undefined;
+  step.attempts += 1;
+  run.history.push({ ts: Date.now(), type: "step.start", stepId: step.id });
+
+  const agentRequestId = `${run.runId}:${step.id}:${step.attempts}`;
+  const prompt = buildStepPrompt(step, run);
+  const timeoutMs = resolveStepTimeoutMs(step, run);
+  const timeoutSeconds = Math.ceil(timeoutMs / 1000);
+
+  const accepted = await callGatewayHandler(agentHandlers.agent, {
+    ...opts,
+    req: {
+      type: "req",
+      id: `${agentRequestId}:agent`,
+      method: "agent",
+      params: {},
+    },
+    params: {
+      message: prompt,
+      idempotencyKey: agentRequestId,
+      ...(step.agentId ? { agentId: step.agentId } : {}),
+      ...(step.sessionKey ? { sessionKey: step.sessionKey } : {}),
+      ...(step.thinking ? { thinking: step.thinking } : {}),
+      ...(run.lane ? { lane: run.lane } : {}),
+      timeout: timeoutSeconds,
+      deliver: false,
+    },
+  });
+
+  if (!accepted.ok) {
+    step.status = "failed";
+    step.endedAt = Date.now();
+    step.error = String(accepted.error ?? "agent request failed");
+    run.history.push({
+      ts: Date.now(),
+      type: "step.error",
+      stepId: step.id,
+      data: { error: step.error },
+    });
+    return;
+  }
+
+  const runId = (() => {
+    const candidate = accepted.payload as { runId?: unknown } | undefined;
+    return typeof candidate?.runId === "string" ? candidate.runId : undefined;
+  })();
+  step.agentRunId = runId;
+
+  if (!runId) {
+    step.status = "failed";
+    step.endedAt = Date.now();
+    step.error = "agent did not return runId";
+    run.history.push({
+      ts: Date.now(),
+      type: "step.error",
+      stepId: step.id,
+      data: { error: step.error },
+    });
+    return;
+  }
+
+  const waited = await callGatewayHandler(agentHandlers["agent.wait"], {
+    ...opts,
+    req: {
+      type: "req",
+      id: `${agentRequestId}:wait`,
+      method: "agent.wait",
+      params: {},
+    },
+    params: {
+      runId,
+      timeoutMs,
+    },
+  });
+
+  const waitPayload = waited.payload as { status?: unknown; error?: unknown } | undefined;
+  const waitStatus = typeof waitPayload?.status === "string" ? waitPayload.status : "error";
+  if (waited.ok && waitStatus === "ok") {
+    step.status = "succeeded";
+    step.endedAt = Date.now();
+    run.history.push({ ts: Date.now(), type: "step.ok", stepId: step.id, data: { runId } });
+    return;
+  }
+
+  step.status = "failed";
+  step.endedAt = Date.now();
+  step.error =
+    typeof waitPayload?.error === "string"
+      ? waitPayload.error
+      : String(waited.error ?? `agent.wait returned status ${waitStatus}`);
+  run.history.push({
+    ts: Date.now(),
+    type: "step.error",
+    stepId: step.id,
+    data: { runId, status: waitStatus, error: step.error },
+  });
+}
+
+function createRunRecord(params: {
+  runId: string;
+  plan: MeshWorkflowPlan;
+  order: string[];
+  continueOnError: boolean;
+  maxParallel: number;
+  defaultStepTimeoutMs: number;
+  lane?: string;
+}): MeshRunRecord {
+  const steps: Record<string, MeshStepRuntime> = {};
+  for (const step of params.plan.steps) {
+    steps[step.id] = {
+      id: step.id,
+      name: step.name,
+      prompt: step.prompt,
+      dependsOn: step.dependsOn ?? [],
+      agentId: step.agentId,
+      sessionKey: step.sessionKey,
+      thinking: step.thinking,
+      timeoutMs: step.timeoutMs,
+      status: "pending",
+      attempts: 0,
+    };
+  }
+  return {
+    runId: params.runId,
+    plan: params.plan,
+    status: "pending",
+    startedAt: Date.now(),
+    continueOnError: params.continueOnError,
+    maxParallel: params.maxParallel,
+    defaultStepTimeoutMs: params.defaultStepTimeoutMs,
+    lane: params.lane,
+    stepOrder: params.order,
+    steps,
+    history: [],
+  };
+}
+
+function findReadySteps(run: MeshRunRecord): MeshStepRuntime[] {
+  const ready: MeshStepRuntime[] = [];
+  for (const stepId of run.stepOrder) {
+    const step = run.steps[stepId];
+    if (!step || step.status !== "pending") {
+      continue;
+    }
+    const deps = step.dependsOn.map((depId) => run.steps[depId]).filter(Boolean);
+    if (deps.some((dep) => dep.status === "failed" || dep.status === "skipped")) {
+      step.status = "skipped";
+      step.endedAt = Date.now();
+      step.error = "dependency failed";
+      continue;
+    }
+    if (deps.every((dep) => dep.status === "succeeded")) {
+      ready.push(step);
+    }
+  }
+  return ready;
+}
+
+async function runWorkflow(run: MeshRunRecord, opts: GatewayRequestHandlerOptions) {
+  run.status = "running";
+  run.history.push({ ts: Date.now(), type: "run.start" });
+
+  const inFlight = new Set<Promise<void>>();
+  let stopScheduling = false;
+
+  while (true) {
+    const failed = Object.values(run.steps).some((step) => step.status === "failed");
+    if (failed && !run.continueOnError) {
+      stopScheduling = true;
+    }
+
+    if (!stopScheduling) {
+      const ready = findReadySteps(run);
+      for (const step of ready) {
+        if (inFlight.size >= run.maxParallel) {
+          break;
+        }
+        const task = executeStep({ run, step, opts }).finally(() => {
+          inFlight.delete(task);
+        });
+        inFlight.add(task);
+      }
+    }
+
+    if (inFlight.size > 0) {
+      await Promise.race(inFlight);
+      continue;
+    }
+
+    const pending = Object.values(run.steps).filter((step) => step.status === "pending");
+    if (pending.length === 0) {
+      break;
+    }
+
+    for (const step of pending) {
+      step.status = "skipped";
+      step.endedAt = Date.now();
+      step.error = stopScheduling ? "cancelled after failure" : "unresolvable dependencies";
+    }
+    break;
+  }
+
+  const hasFailure = Object.values(run.steps).some((step) => step.status === "failed");
+  run.status = hasFailure ? "failed" : "completed";
+  run.endedAt = Date.now();
+  run.history.push({
+    ts: Date.now(),
+    type: "run.end",
+    data: { status: run.status },
+  });
+}
+
+function resolveStepIdsForRetry(run: MeshRunRecord, requested?: string[]): string[] {
+  if (Array.isArray(requested) && requested.length > 0) {
+    return requested.map((stepId) => stepId.trim()).filter(Boolean);
+  }
+  return Object.values(run.steps)
+    .filter((step) => step.status === "failed" || step.status === "skipped")
+    .map((step) => step.id);
+}
+
+function descendantsOf(run: MeshRunRecord, roots: Set<string>): Set<string> {
+  const descendants = new Set<string>();
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
+    for (const step of Object.values(run.steps)) {
+      if (!step.dependsOn.includes(current) || descendants.has(step.id)) {
+        continue;
+      }
+      descendants.add(step.id);
+      queue.push(step.id);
+    }
+  }
+  return descendants;
+}
+
+function resetStepsForRetry(run: MeshRunRecord, stepIds: string[]) {
+  const rootSet = new Set(stepIds);
+  const descendants = descendantsOf(run, rootSet);
+  const resetIds = new Set([...rootSet, ...descendants]);
+  for (const stepId of resetIds) {
+    const step = run.steps[stepId];
+    if (!step) {
+      continue;
+    }
+    if (step.status === "succeeded" && !rootSet.has(stepId)) {
+      continue;
+    }
+    step.status = "pending";
+    step.startedAt = undefined;
+    step.endedAt = undefined;
+    step.error = undefined;
+    if (rootSet.has(stepId)) {
+      step.agentRunId = undefined;
+    }
+  }
+}
+
+function summarizeRun(run: MeshRunRecord) {
+  return {
+    runId: run.runId,
+    plan: run.plan,
+    status: run.status,
+    startedAt: run.startedAt,
+    endedAt: run.endedAt,
+    stats: {
+      total: Object.keys(run.steps).length,
+      succeeded: Object.values(run.steps).filter((step) => step.status === "succeeded").length,
+      failed: Object.values(run.steps).filter((step) => step.status === "failed").length,
+      skipped: Object.values(run.steps).filter((step) => step.status === "skipped").length,
+      running: Object.values(run.steps).filter((step) => step.status === "running").length,
+      pending: Object.values(run.steps).filter((step) => step.status === "pending").length,
+    },
+    steps: run.stepOrder.map((stepId) => run.steps[stepId]),
+    history: run.history,
+  };
+}
+
+function extractTextFromAgentResult(result: unknown): string {
+  const payloads = (result as { payloads?: Array<{ text?: unknown }> } | undefined)?.payloads;
+  if (!Array.isArray(payloads)) {
+    return "";
+  }
+  const texts: string[] = [];
+  for (const payload of payloads) {
+    if (typeof payload?.text === "string" && payload.text.trim()) {
+      texts.push(payload.text.trim());
+    }
+  }
+  return texts.join("\n\n");
+}
+
+function parseJsonObjectFromText(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    // keep trying
+  }
+
+  const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  if (fenceMatch?.[1]) {
+    try {
+      const parsed = JSON.parse(fenceMatch[1]);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      // keep trying
+    }
+  }
+
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    const candidate = trimmed.slice(start, end + 1);
+    try {
+      const parsed = JSON.parse(candidate);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function buildAutoPlannerPrompt(params: { goal: string; maxSteps: number }) {
+  return [
+    "You are a workflow planner. Convert the user's goal into executable workflow steps.",
+    "Return STRICT JSON only, no markdown, no prose.",
+    'JSON schema: {"steps": [{"id": string, "name"?: string, "prompt": string, "dependsOn"?: string[]}]}',
+    "Rules:",
+    `- Use 2 to ${params.maxSteps} steps.`,
+    "- Keep ids short, lowercase, kebab-case.",
+    "- dependsOn must reference earlier step ids when needed.",
+    "- prompts must be concrete and executable by an AI coding assistant.",
+    "- Do not include extra fields.",
+    `Goal: ${params.goal}`,
+  ].join("\n");
+}
+
+async function generateAutoPlan(params: {
+  goal: string;
+  maxSteps: number;
+  agentId?: string;
+  sessionKey?: string;
+  thinking?: string;
+  timeoutMs?: number;
+  lane?: string;
+  opts: GatewayRequestHandlerOptions;
+}): Promise<{ plan: MeshWorkflowPlan; source: "llm" | "fallback"; plannerText?: string }> {
+  const prompt = buildAutoPlannerPrompt({ goal: params.goal, maxSteps: params.maxSteps });
+  const timeoutSeconds = Math.ceil((params.timeoutMs ?? AUTO_PLAN_TIMEOUT_MS) / 1000);
+  const resolvedAgentId = normalizeAgentId(params.agentId ?? "main");
+  const plannerSessionKey = params.sessionKey?.trim() || `agent:${resolvedAgentId}:${PLANNER_MAIN_KEY}`;
+
+  try {
+    const runResult = await agentCommand(
+      {
+        message: prompt,
+        deliver: false,
+        timeout: String(timeoutSeconds),
+        agentId: resolvedAgentId,
+        sessionKey: plannerSessionKey,
+        ...(params.thinking ? { thinking: params.thinking } : {}),
+        ...(params.lane ? { lane: params.lane } : {}),
+      },
+      defaultRuntime,
+      params.opts.context.deps,
+    );
+
+    const text = extractTextFromAgentResult(runResult);
+    const parsed = parseJsonObjectFromText(text) as MeshAutoPlanShape | null;
+    const rawSteps = Array.isArray(parsed?.steps) ? parsed.steps : [];
+    if (rawSteps.length > 0) {
+      const plan = normalizePlan(
+        createPlanFromParams({
+          goal: params.goal,
+          steps: rawSteps.slice(0, params.maxSteps),
+        }),
+      );
+      return { plan, source: "llm", plannerText: text };
+    }
+
+    const fallbackPlan = normalizePlan(createPlanFromParams({ goal: params.goal }));
+    return { plan: fallbackPlan, source: "fallback", plannerText: text };
+  } catch {
+    const fallbackPlan = normalizePlan(createPlanFromParams({ goal: params.goal }));
+    return { plan: fallbackPlan, source: "fallback" };
+  }
+}
+
+const meshHandlers: Record<
+  string,
+  (opts: GatewayRequestHandlerOptions) => Promise<void> | void
+> = {
+  "mesh.plan": ({ params, respond }: GatewayRequestHandlerOptions) => {
+    if (!validateMeshPlanParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid mesh.plan params: ${formatValidationErrors(validateMeshPlanParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params;
+    const plan = normalizePlan(
+      createPlanFromParams({
+        goal: p.goal,
+        steps: p.steps,
+      }),
+    );
+    const graph = validatePlanGraph(plan);
+    if (!graph.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, graph.error));
+      return;
+    }
+    respond(
+      true,
+      {
+        plan,
+        order: graph.order,
+      },
+      undefined,
+    );
+  },
+  "mesh.plan.auto": async ({ params, respond, ...rest }: GatewayRequestHandlerOptions) => {
+    if (!validateMeshPlanAutoParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid mesh.plan.auto params: ${formatValidationErrors(validateMeshPlanAutoParams.errors)}`,
+        ),
+      );
+      return;
+    }
+
+    const p = params as MeshPlanAutoParams;
+    const maxSteps =
+      typeof p.maxSteps === "number" && Number.isFinite(p.maxSteps)
+        ? Math.max(1, Math.min(16, Math.floor(p.maxSteps)))
+        : 6;
+    const auto = await generateAutoPlan({
+      goal: p.goal,
+      maxSteps,
+      agentId: p.agentId,
+      sessionKey: p.sessionKey,
+      thinking: p.thinking,
+      timeoutMs: p.timeoutMs,
+      lane: p.lane,
+      opts: {
+        ...rest,
+        params,
+        respond,
+      },
+    });
+
+    const graph = validatePlanGraph(auto.plan);
+    if (!graph.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, graph.error));
+      return;
+    }
+
+    respond(
+      true,
+      {
+        plan: auto.plan,
+        order: graph.order,
+        source: auto.source,
+        plannerText: auto.plannerText,
+      },
+      undefined,
+    );
+  },
+  "mesh.run": async (opts: GatewayRequestHandlerOptions) => {
+    const { params, respond } = opts;
+    if (!validateMeshRunParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid mesh.run params: ${formatValidationErrors(validateMeshRunParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params as MeshRunParams;
+    const plan = normalizePlan(p.plan);
+    const graph = validatePlanGraph(plan);
+    if (!graph.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, graph.error));
+      return;
+    }
+
+    const maxParallel =
+      typeof p.maxParallel === "number" && Number.isFinite(p.maxParallel)
+        ? Math.min(16, Math.max(1, Math.floor(p.maxParallel)))
+        : 2;
+    const defaultStepTimeoutMs =
+      typeof p.defaultStepTimeoutMs === "number" && Number.isFinite(p.defaultStepTimeoutMs)
+        ? Math.max(1_000, Math.floor(p.defaultStepTimeoutMs))
+        : 120_000;
+    const runId = `mesh-run-${randomUUID()}`;
+    const record = createRunRecord({
+      runId,
+      plan,
+      order: graph.order,
+      continueOnError: p.continueOnError === true,
+      maxParallel,
+      defaultStepTimeoutMs,
+      lane: typeof p.lane === "string" ? p.lane : undefined,
+    });
+    meshRuns.set(runId, record);
+    trimMap();
+
+    await runWorkflow(record, opts);
+    respond(true, summarizeRun(record), undefined);
+  },
+  "mesh.status": ({ params, respond }: GatewayRequestHandlerOptions) => {
+    if (!validateMeshStatusParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid mesh.status params: ${formatValidationErrors(validateMeshStatusParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const run = meshRuns.get(params.runId.trim());
+    if (!run) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "mesh run not found"));
+      return;
+    }
+    respond(true, summarizeRun(run), undefined);
+  },
+  "mesh.retry": async (opts: GatewayRequestHandlerOptions) => {
+    const { params, respond } = opts;
+    if (!validateMeshRetryParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid mesh.retry params: ${formatValidationErrors(validateMeshRetryParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const runId = params.runId.trim();
+    const run = meshRuns.get(runId);
+    if (!run) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "mesh run not found"));
+      return;
+    }
+    if (run.status === "running") {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "mesh run is currently running"));
+      return;
+    }
+    const stepIds = resolveStepIdsForRetry(run, params.stepIds);
+    if (stepIds.length === 0) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "no failed or skipped steps available to retry"),
+      );
+      return;
+    }
+    for (const stepId of stepIds) {
+      if (!run.steps[stepId]) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, `unknown retry step id: ${stepId}`),
+        );
+        return;
+      }
+    }
+
+    resetStepsForRetry(run, stepIds);
+    run.status = "pending";
+    run.endedAt = undefined;
+    run.history.push({
+      ts: Date.now(),
+      type: "run.retry",
+      data: { stepIds },
+    });
+    await runWorkflow(run, opts);
+    respond(true, summarizeRun(run), undefined);
+  },
+};
+
+export function registerMeshGatewayMethods(api: OpenClawPluginApi) {
+  for (const [method, handler] of Object.entries(meshHandlers)) {
+    api.registerGatewayMethod(method, handler);
+  }
+}

--- a/extensions/mesh/src/mesh-gateway.ts
+++ b/extensions/mesh/src/mesh-gateway.ts
@@ -1,9 +1,9 @@
+import { randomUUID } from "node:crypto";
 import type {
   GatewayRequestHandlerOptions,
   OpenClawPluginApi,
   RespondFn,
 } from "openclaw/plugin-sdk";
-import { randomUUID } from "node:crypto";
 import { agentCommand } from "../../../src/commands/agent.js";
 import { ErrorCodes, errorShape } from "../../../src/gateway/protocol/index.js";
 import { agentHandlers } from "../../../src/gateway/server-methods/agent.js";

--- a/extensions/mesh/src/mesh-schema.ts
+++ b/extensions/mesh/src/mesh-schema.ts
@@ -1,0 +1,195 @@
+type MeshPlanStep = {
+  id: string;
+  name?: string;
+  prompt: string;
+  dependsOn?: string[];
+  agentId?: string;
+  sessionKey?: string;
+  thinking?: string;
+  timeoutMs?: number;
+};
+
+export type MeshWorkflowPlan = {
+  planId: string;
+  goal: string;
+  createdAt: number;
+  steps: MeshPlanStep[];
+};
+
+export type MeshPlanParams = {
+  goal: string;
+  steps?: Array<{
+    id?: string;
+    name?: string;
+    prompt: string;
+    dependsOn?: string[];
+    agentId?: string;
+    sessionKey?: string;
+    thinking?: string;
+    timeoutMs?: number;
+  }>;
+};
+
+export type MeshRunParams = {
+  plan: MeshWorkflowPlan;
+  continueOnError?: boolean;
+  maxParallel?: number;
+  defaultStepTimeoutMs?: number;
+  lane?: string;
+};
+
+export type MeshPlanAutoParams = {
+  goal: string;
+  maxSteps?: number;
+  agentId?: string;
+  sessionKey?: string;
+  thinking?: string;
+  timeoutMs?: number;
+  lane?: string;
+};
+
+export type MeshStatusParams = {
+  runId: string;
+};
+
+export type MeshRetryParams = {
+  runId: string;
+  stepIds?: string[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalInt(value: unknown): value is number | undefined {
+  return value === undefined || (typeof value === "number" && Number.isFinite(value));
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isPlanStep(value: unknown): value is MeshPlanStep {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (!isNonEmptyString(value.id) || !isNonEmptyString(value.prompt)) {
+    return false;
+  }
+  if (!isOptionalString(value.name) || !isOptionalString(value.agentId)) {
+    return false;
+  }
+  if (!isOptionalString(value.sessionKey) || !isOptionalString(value.thinking)) {
+    return false;
+  }
+  if (!isOptionalInt(value.timeoutMs)) {
+    return false;
+  }
+  if (value.dependsOn !== undefined && !isStringArray(value.dependsOn)) {
+    return false;
+  }
+  return true;
+}
+
+export function validateMeshPlanParams(value: unknown): value is MeshPlanParams {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (!isNonEmptyString(value.goal)) {
+    return false;
+  }
+  if (value.steps === undefined) {
+    return true;
+  }
+  if (!Array.isArray(value.steps) || value.steps.length < 1 || value.steps.length > 128) {
+    return false;
+  }
+  return value.steps.every((step) => {
+    if (!isRecord(step) || !isNonEmptyString(step.prompt)) {
+      return false;
+    }
+    if (!isOptionalString(step.id) || !isOptionalString(step.name)) {
+      return false;
+    }
+    if (!isOptionalString(step.agentId) || !isOptionalString(step.sessionKey)) {
+      return false;
+    }
+    if (!isOptionalString(step.thinking) || !isOptionalInt(step.timeoutMs)) {
+      return false;
+    }
+    if (step.dependsOn !== undefined && !isStringArray(step.dependsOn)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function validateMeshWorkflowPlan(value: unknown): value is MeshWorkflowPlan {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (!isNonEmptyString(value.planId) || !isNonEmptyString(value.goal)) {
+    return false;
+  }
+  if (typeof value.createdAt !== "number" || !Number.isFinite(value.createdAt)) {
+    return false;
+  }
+  if (!Array.isArray(value.steps) || value.steps.length < 1 || value.steps.length > 128) {
+    return false;
+  }
+  return value.steps.every((step) => isPlanStep(step));
+}
+
+export function validateMeshRunParams(value: unknown): value is MeshRunParams {
+  if (!isRecord(value) || !validateMeshWorkflowPlan(value.plan)) {
+    return false;
+  }
+  if (value.continueOnError !== undefined && typeof value.continueOnError !== "boolean") {
+    return false;
+  }
+  if (!isOptionalInt(value.maxParallel) || !isOptionalInt(value.defaultStepTimeoutMs)) {
+    return false;
+  }
+  if (!isOptionalString(value.lane)) {
+    return false;
+  }
+  return true;
+}
+
+export function validateMeshPlanAutoParams(value: unknown): value is MeshPlanAutoParams {
+  if (!isRecord(value) || !isNonEmptyString(value.goal)) {
+    return false;
+  }
+  if (!isOptionalInt(value.maxSteps) || !isOptionalInt(value.timeoutMs)) {
+    return false;
+  }
+  if (!isOptionalString(value.agentId) || !isOptionalString(value.sessionKey)) {
+    return false;
+  }
+  if (!isOptionalString(value.thinking) || !isOptionalString(value.lane)) {
+    return false;
+  }
+  return true;
+}
+
+export function validateMeshStatusParams(value: unknown): value is MeshStatusParams {
+  return isRecord(value) && isNonEmptyString(value.runId);
+}
+
+export function validateMeshRetryParams(value: unknown): value is MeshRetryParams {
+  if (!isRecord(value) || !isNonEmptyString(value.runId)) {
+    return false;
+  }
+  if (value.stepIds === undefined) {
+    return true;
+  }
+  return isStringArray(value.stepIds) && value.stepIds.length > 0;
+}


### PR DESCRIPTION
## What is Mesh?

Mesh is an **agentic workflow orchestration layer** for OpenClaw.

Instead of treating a complex task as one large run, Mesh models work as:

1. A goal
2. A dependency-aware step graph (DAG)
3. A tracked run with step-level state and retry controls

Mesh does not replace OpenClaw agents. It coordinates them.

## Summary

This PR re-architects Mesh as an optional plugin under `extensions/mesh`, aligned with maintainer guidance to keep workflow orchestration out of stock core.

Mesh behavior remains available when the plugin is enabled:

- `mesh.plan`
- `mesh.plan.auto`
- `mesh.run`
- `mesh.status`
- `mesh.retry`
- `/mesh` chat command family

## Why

- Aligns with maintainer direction to ship Mesh as plugin architecture.
- Keeps core lean while preserving deterministic orchestration capabilities.
- Enables faster, safer iteration on Mesh without core coupling.

## What changed

Added plugin files:

- `extensions/mesh/index.ts`
- `extensions/mesh/openclaw.plugin.json`
- `extensions/mesh/README.md`
- `extensions/mesh/src/mesh-command.ts`
- `extensions/mesh/src/mesh-gateway.ts`
- `extensions/mesh/src/mesh-schema.ts`
- `extensions/mesh/src/mesh-command.test.ts`
- `extensions/mesh/src/mesh-gateway.test.ts`

Notes:

- Plugin now owns Mesh schema/validation (`mesh-schema.ts`) instead of importing removed core Mesh protocol validators.
- Existing gateway auth/scope policy for `mesh.*` methods still applies in core gateway method authorization.

## Install / enable

```bash
openclaw plugins install ./extensions/mesh
openclaw plugins enable mesh
```

Then restart gateway.

## Validation

Typecheck:

```bash
pnpm -C repos/openclaw exec tsc -p tsconfig.json --noEmit
```

Targeted tests:

```bash
pnpm -C repos/openclaw exec vitest run \
  extensions/mesh/src/mesh-gateway.test.ts \
  extensions/mesh/src/mesh-command.test.ts \
  src/gateway/server-methods/server-methods.test.ts \
  src/auto-reply/reply/commands.test.ts
```

Formatting:

```bash
pnpm -C repos/openclaw run format:check
```

Result: targeted suites are passing on this branch (`100` tests), plus formatting check is green.

## Known limitations

- Mesh run store is in-memory.
- Plan-id cache for `/mesh run <mesh-plan-id>` is in-memory and scoped by sender/channel.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Mesh workflow orchestration plugin under `extensions/mesh/`, implementing DAG-based multi-step workflow planning, execution, status tracking, and retry capabilities as a plugin rather than in core.

**Key changes:**
- Plugin entry point (`index.ts`) and config (`openclaw.plugin.json`) follow established plugin conventions
- Gateway methods (`mesh.plan`, `mesh.plan.auto`, `mesh.run`, `mesh.status`, `mesh.retry`) provide the orchestration API
- Chat command (`/mesh`) provides a user-facing interface for planning and running workflows
- Schema validation (`mesh-schema.ts`) with hand-written type guards for all method params
- Tests cover command parsing, gateway method registration, plan validation, auto-plan fallback, and workflow execution

**Architecture observations:**
- Run and plan state are in-memory (module-level `Map`s), as documented in known limitations
- Workflow execution uses topological sort + parallel step scheduling with configurable concurrency
- Auto-planning delegates to an LLM agent with JSON parsing fallback
- The plugin uses relative imports to core modules (`../../../src/...`), consistent with other deeply-integrated bundled plugins like `llm-task` and `lobster`
- `mesh-gateway.ts` is 900 LOC, above the repo's ~500 LOC guideline — could benefit from splitting helpers into separate files

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it adds an isolated optional plugin with no modifications to existing core code.
- Score of 4 reflects that this is a purely additive change (no existing code modified), the plugin follows established patterns, and the code logic is sound with proper validation and error handling. Deducted 1 point for the 900-LOC file exceeding repo guidelines and the in-memory-only state store being a production limitation.
- `extensions/mesh/src/mesh-gateway.ts` is the most complex file at 900 LOC and contains the core orchestration logic — deserves careful review of the workflow scheduling loop and retry reset logic.

<sub>Last reviewed commit: f40618b</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->