### PR TITLE
fix(edit): allow empty string newText for line deletion

### DIFF
--- a/src/agents/pi-tools.read.edit-empty-newtext.test.ts
+++ b/src/agents/pi-tools.read.edit-empty-newtext.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { assertRequiredParams, CLAUDE_PARAM_GROUPS } from "./pi-tools.read.js";
+
+describe("edit tool: empty newText", () => {
+  it("should accept empty string newText (deletion use case)", () => {
+    expect(() =>
+      assertRequiredParams(
+        { path: "file.ts", oldText: "line to delete\n", newText: "" },
+        CLAUDE_PARAM_GROUPS.edit,
+        "Edit",
+      ),
+    ).not.toThrow();
+  });
+
+  it("should accept whitespace-only newText", () => {
+    expect(() =>
+      assertRequiredParams(
+        { path: "file.ts", oldText: "old\n", newText: "\n" },
+        CLAUDE_PARAM_GROUPS.edit,
+        "Edit",
+      ),
+    ).not.toThrow();
+  });
+
+  it("should still reject missing newText entirely", () => {
+    expect(() =>
+      assertRequiredParams({ path: "file.ts", oldText: "old\n" }, CLAUDE_PARAM_GROUPS.edit, "Edit"),
+    ).toThrow(/newText/);
+  });
+
+  it("should still reject missing oldText", () => {
+    expect(() =>
+      assertRequiredParams({ path: "file.ts", newText: "new" }, CLAUDE_PARAM_GROUPS.edit, "Edit"),
+    ).toThrow(/oldText/);
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -1,10 +1,10 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
-import type { AnyAgentTool } from "./pi-tools.types.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
-import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
 
 // NOTE(steipete): Upstream read now does file-magic MIME detection; we keep the wrapper
@@ -108,6 +108,7 @@ export const CLAUDE_PARAM_GROUPS = {
     {
       keys: ["newText", "new_string"],
       label: "newText (newText or new_string)",
+      allowEmpty: true,
     },
   ],
 } as const;


### PR DESCRIPTION
## Summary

Fixes #19085 — the edit tool rejects empty string `newText` as a missing required parameter, preventing line deletion via `newText: ""`.

## Root Cause

The `assertRequiredParams` validation uses `value.trim().length > 0` for the newText parameter group, which treats empty strings and whitespace-only strings as missing. The `allowEmpty` guard exists but wasn't set for newText.

## Fix

Add `allowEmpty: true` to the newText/new_string parameter group in `CLAUDE_PARAM_GROUPS.edit`. This is the same pattern used elsewhere (e.g., in common.ts line 190).

## Changes

- `src/agents/pi-tools.read.ts`: Add `allowEmpty: true` to newText param group
- `src/agents/pi-tools.read.edit-empty-newtext.test.ts`: 4 unit tests covering empty string, whitespace, missing newText, and missing oldText

## Testing

- [x] All 4 new tests pass
- [x] `pnpm build` succeeds
- [x] Lint passes (0 warnings, 0 errors)

AI-assisted (Claude/HAL). Fully tested locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed validation to allow empty string `newText` in the edit tool for line deletion. Previously, `assertRequiredParams` rejected empty strings using `value.trim().length > 0`, preventing deletion via `newText: ""`. Added `allowEmpty: true` to the newText parameter group, matching the pattern used elsewhere in the codebase (e.g., `src/agents/tools/common.ts:190`).

- Added `allowEmpty: true` to newText parameter validation in `CLAUDE_PARAM_GROUPS.edit`
- Added comprehensive test coverage with 4 unit tests covering empty strings, whitespace, and missing parameter validation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-targeted, and follows existing patterns. It adds a single boolean flag to enable empty strings for a specific use case. The change is covered by comprehensive unit tests that verify both the new behavior (allowing empty strings) and the existing behavior (rejecting missing parameters). The implementation matches the same pattern used elsewhere in the codebase for similar validation scenarios.
- No files require special attention

<sub>Last reviewed commit: e52c834</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->