### PR TITLE
feat(web-search): add baseUrl option for Brave Search provider

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -234,7 +234,8 @@ function resolveBraveBaseUrl(search?: WebSearchConfig): string | undefined {
   if (!search || typeof search !== "object") {
     return undefined;
   }
-  const baseUrl = "baseUrl" in search && typeof search.baseUrl === "string" ? search.baseUrl : undefined;
+  const baseUrl =
+    "baseUrl" in search && typeof search.baseUrl === "string" ? search.baseUrl : undefined;
   return baseUrl?.trim() || undefined;
 }
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -22,7 +22,8 @@ const SEARCH_PROVIDERS = ["brave", "perplexity", "grok"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
-const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
+const BRAVE_SEARCH_BASE_URL = "https://api.search.brave.com";
+const BRAVE_SEARCH_PATH = "/res/v1/web/search";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
@@ -227,6 +228,14 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
     return "brave";
   }
   return "brave";
+}
+
+function resolveBraveBaseUrl(search?: WebSearchConfig): string | undefined {
+  if (!search || typeof search !== "object") {
+    return undefined;
+  }
+  const baseUrl = "baseUrl" in search && typeof search.baseUrl === "string" ? search.baseUrl : undefined;
+  return baseUrl?.trim() || undefined;
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
@@ -562,6 +571,7 @@ async function runWebSearch(params: {
   search_lang?: string;
   ui_lang?: string;
   freshness?: string;
+  braveBaseUrl?: string;
   perplexityBaseUrl?: string;
   perplexityModel?: string;
   grokModel?: string;
@@ -569,7 +579,7 @@ async function runWebSearch(params: {
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
-      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
+      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.braveBaseUrl ?? BRAVE_SEARCH_BASE_URL}`
       : params.provider === "perplexity"
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}:${params.freshness || "default"}`
         : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
@@ -641,7 +651,8 @@ async function runWebSearch(params: {
     throw new Error("Unsupported web search provider.");
   }
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  const braveBaseUrl = (params.braveBaseUrl ?? BRAVE_SEARCH_BASE_URL).replace(/\/$/, "");
+  const url = new URL(braveBaseUrl + BRAVE_SEARCH_PATH);
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {
@@ -715,6 +726,7 @@ export function createWebSearchTool(options?: {
   }
 
   const provider = resolveSearchProvider(search);
+  const braveBaseUrl = resolveBraveBaseUrl(search);
   const perplexityConfig = resolvePerplexityConfig(search);
   const grokConfig = resolveGrokConfig(search);
 
@@ -778,6 +790,7 @@ export function createWebSearchTool(options?: {
         search_lang,
         ui_lang,
         freshness,
+        braveBaseUrl,
         perplexityBaseUrl: resolvePerplexityBaseUrl(
           perplexityConfig,
           perplexityAuth?.source,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -107,6 +107,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
+  "tools.web.search.baseUrl":
+    "Brave Search API base URL override (default: https://api.search.brave.com). Useful for routing through a proxy.",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
   "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -402,6 +402,8 @@ export type ToolsConfig = {
       provider?: "brave" | "perplexity" | "grok";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
+      /** Base URL for Brave Search API requests (defaults to https://api.search.brave.com). Useful for proxies. */
+      baseUrl?: string;
       /** Default search results count (1-10). */
       maxResults?: number;
       /** Timeout in seconds for search requests. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -229,6 +229,7 @@ export const ToolsWebSearchSchema = z
     enabled: z.boolean().optional(),
     provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("grok")]).optional(),
     apiKey: z.string().optional().register(sensitive),
+    baseUrl: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     cacheTtlMinutes: z.number().nonnegative().optional(),


### PR DESCRIPTION
## Summary

Adds a `baseUrl` config option to the Brave Search provider, allowing users to route requests through a local proxy or custom endpoint.

Closes #19075

## Motivation

The Brave Search provider had a hardcoded API endpoint (`https://api.search.brave.com/res/v1/web/search`). Users who want to route through a proxy or a compatible local server have no way to override it. The Perplexity provider already supports `baseUrl` — this PR brings the same feature to Brave.

## Changes

- **`src/agents/tools/web-search.ts`**: Split `BRAVE_SEARCH_ENDPOINT` into `BRAVE_SEARCH_BASE_URL` + `BRAVE_SEARCH_PATH`. Added `resolveBraveBaseUrl()` helper and wired `braveBaseUrl` through `runWebSearch`. Cache key updated to include the base URL so different endpoints don't share cached results.
- **`src/config/zod-schema.agent-runtime.ts`**: Added `baseUrl: z.string().optional()` to `ToolsWebSearchSchema`.
- **`src/config/types.tools.ts`**: Added `baseUrl?: string` to the search config type with JSDoc.
- **`src/config/schema.help.ts`**: Added help text for `tools.web.search.baseUrl`.

## Config example

```json
{
  "tools": {
    "web": {
      "search": {
        "provider": "brave",
        "baseUrl": "http://localhost:9100/brave",
        "apiKey": "BSA..."
      }
    }
  }
}
```

## Backwards compatibility

The default value is `https://api.search.brave.com`, so existing configs are unaffected.

## Related

- Issue #19075
- PR #19084 bundles this with an unrelated "Inter-session Message Role" change — this PR is the focused, standalone fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `baseUrl` configuration option to the Brave Search provider, enabling users to route requests through proxies or custom endpoints. Implementation follows similar pattern to existing Perplexity `baseUrl` support.

**Key changes:**
- Split `BRAVE_SEARCH_ENDPOINT` constant into `BRAVE_SEARCH_BASE_URL` + `BRAVE_SEARCH_PATH` for flexibility
- Added `resolveBraveBaseUrl()` helper function to extract and normalize the base URL from config
- Updated cache key generation to include `braveBaseUrl` to prevent cross-contamination between different endpoints
- Added config schema support across TypeScript types, Zod validation, and help text
- Maintains backward compatibility with default value of `https://api.search.brave.com`

**Minor architectural note:**
The `baseUrl` field is placed at the top level of `tools.web.search` (Brave-specific), while Perplexity uses nested `tools.web.search.perplexity.baseUrl`. This works functionally but creates a slight inconsistency in config structure. Future work could consider moving to `brave.baseUrl` for better symmetry.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with low risk - straightforward feature addition with backward compatibility maintained
- Implementation is clean and follows existing patterns from Perplexity provider. Cache key properly includes baseUrl to prevent cross-contamination. URL construction correctly strips trailing slashes. Default value ensures backward compatibility. Only minor architectural inconsistency noted (top-level vs nested config), which doesn't affect functionality.
- No files require special attention - all changes are straightforward

<sub>Last reviewed commit: 338b0b3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->