### PR TITLE
fix(config): block destructive config writes instead of only logging them (#19065)

### DIFF
--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -369,4 +369,107 @@ describe("config io write", () => {
       expect(last.watchCommand).toBe("gateway --force");
     });
   });
+
+  it("blocks and rejects a write that reduces config size by more than 50%", async () => {
+    await withTempHome("openclaw-config-io-", async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const rejectedPath = `${configPath}.rejected`;
+      // Write a large initial config (>512 bytes) so the size-drop check triggers.
+      // Use env.vars for bulk — these are valid schema fields.
+      const bigConfig = {
+        gateway: { mode: "local", port: 18789 },
+        env: {
+          vars: Object.fromEntries(
+            Array.from({ length: 30 }, (_, i) => [`PADDING_VAR_${i}`, "x".repeat(20)]),
+          ),
+        },
+      };
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, JSON.stringify(bigConfig, null, 2), "utf-8");
+
+      const errorFn = vi.fn();
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: { warn: vi.fn(), error: errorFn },
+      });
+
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.valid).toBe(true);
+
+      // A tiny config — triggers the >50% size-drop safeguard.
+      await expect(io.writeConfigFile({ gateway: { mode: "local" } })).rejects.toThrow(
+        "Config write blocked",
+      );
+
+      // Original file must be untouched.
+      const remaining = JSON.parse(await fs.readFile(configPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+      expect((remaining as { gateway?: { port?: number } }).gateway?.port).toBe(18789);
+
+      // Rejected payload must be saved for debugging.
+      const rejectedExists = await fs
+        .access(rejectedPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(rejectedExists).toBe(true);
+
+      // Error must be logged.
+      expect(errorFn).toHaveBeenCalledWith(expect.stringContaining("Config write blocked"));
+    });
+  });
+
+  it("blocks and rejects a write that removes gateway.mode from an existing config", async () => {
+    await withTempHome("openclaw-config-io-", async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const rejectedPath = `${configPath}.rejected`;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { mode: "local", port: 18789 } }, null, 2),
+        "utf-8",
+      );
+
+      const errorFn = vi.fn();
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: { warn: vi.fn(), error: errorFn },
+      });
+
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.valid).toBe(true);
+
+      // Strip gateway.mode — triggers the gateway-mode-removed safeguard.
+      const next = structuredClone(snapshot.config);
+      if (next.gateway) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper
+        delete (next.gateway as any).mode;
+      }
+
+      await expect(io.writeConfigFile(next)).rejects.toThrow("Config write blocked");
+
+      // Original file must be untouched.
+      const remaining = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        gateway?: { mode?: string };
+      };
+      expect(remaining.gateway?.mode).toBe("local");
+
+      // Rejected payload saved.
+      const rejectedExists = await fs
+        .access(rejectedPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(rejectedExists).toBe(true);
+
+      // Audit log must contain a "rejected" entry.
+      const auditPath = path.join(home, ".openclaw", "logs", "config-audit.jsonl");
+      const auditLines = (await fs.readFile(auditPath, "utf-8")).trim().split("\n").filter(Boolean);
+      const last = JSON.parse(auditLines.at(-1) ?? "{}") as Record<string, unknown>;
+      expect(last.result).toBe("rejected");
+      expect(Array.isArray(last.suspicious) && (last.suspicious as string[]).length > 0).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Fixes #19065

The gateway's config write audit correctly detected destructive writes (>50% size drop, `gateway.mode` removed), but only logged them as warnings and allowed the write through. This has caused production outages when a truncated or corrupted config was silently persisted.

## Solution

After computing suspicious reasons, filter to the hard-blocking ones (`size-drop:*` and `gateway-mode-removed`). If any are present:

1. **Block the write** — the original `openclaw.json` is left untouched
2. **Save rejected payload** to `openclaw.json.rejected` for debugging
3. **Log a clear error** message identifying the reason(s)
4. **Append a `rejected` audit record** to `config-audit.jsonl` for forensics
5. **Throw** so the caller is informed

The informational `missing-meta-before-write` reason is intentionally excluded from the blocking set — it is diagnostic, not destructive, and fires on all pre-meta configs.

## Changes

- `src/config/io.ts`: Add `"rejected"` to `ConfigWriteAuditResult`; add blocking guard after suspicious-reason computation
- `src/config/io.write-config.test.ts`: Two new test cases — size-drop block and gateway-mode-removed block

## Testing

All 363 unit tests in `src/config/` pass:

```
Test Files  47 passed (47)
Tests      363 passed (363)
```

New tests cover:
- Write blocked + original file untouched + `.rejected` file created + error logged (size-drop)
- Write blocked + original file untouched + audit record has `result: "rejected"` (gateway-mode-removed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the config write audit system from warning-only to hard-blocking for destructive writes. Previously, the system detected dangerous config writes (>50% size drops and `gateway.mode` removal) but only logged warnings, leading to production outages when corrupted configs were persisted. Now, when blocking reasons are detected, the write is rejected, the original file remains untouched, and the rejected payload is saved to `.rejected` for debugging with a full audit trail.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The implementation is well-designed with proper error handling, the blocking logic is conservative and only targets truly destructive scenarios, comprehensive test coverage validates all the blocking behaviors, and the change transforms a critical production issue into a preventive safeguard
- No files require special attention

<sub>Last reviewed commit: be4f245</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->