### PR TITLE
fix(gateway): specify utf-8 encoding on SSE res.write() calls

### DIFF
--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -77,7 +77,7 @@ export async function readJsonBodyOrError(
 }
 
 export function writeDone(res: ServerResponse) {
-  res.write("data: [DONE]\n\n");
+  res.write("data: [DONE]\n\n", "utf-8");
 }
 
 export function setSseHeaders(res: ServerResponse) {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -37,7 +37,7 @@ type OpenAiChatCompletionRequest = {
 };
 
 function writeSse(res: ServerResponse, data: unknown) {
-  res.write(`data: ${JSON.stringify(data)}\n\n`);
+  res.write(`data: ${JSON.stringify(data)}\n\n`, "utf-8");
 }
 
 function asMessages(val: unknown): OpenAiChatMessage[] {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -62,8 +62,8 @@ const DEFAULT_BODY_BYTES = 20 * 1024 * 1024;
 const DEFAULT_MAX_URL_PARTS = 8;
 
 function writeSseEvent(res: ServerResponse, event: StreamingEvent) {
-  res.write(`event: ${event.type}\n`);
-  res.write(`data: ${JSON.stringify(event)}\n\n`);
+  res.write(`event: ${event.type}\n`, "utf-8");
+  res.write(`data: ${JSON.stringify(event)}\n\n`, "utf-8");
 }
 
 function extractTextContent(content: string | ContentPart[]): string {


### PR DESCRIPTION
## Problem

Fixes #18897

Node.js `ServerResponse.write(string)` defaults to Latin-1 (binary) encoding. When an LLM response contains a character outside the Latin-1 range — such as ◆ (U+25C6, code point 9670) — the runtime throws:

```
TypeError: Cannot convert argument to a ByteString
```

This silently kills the SSE stream and returns no response to the client, breaking all subsequent gateway replies for that request.

## Fix

Pass `"utf-8"` as the second argument to every `res.write()` call in the gateway SSE path:

| File | Change |
|------|--------|
| `src/gateway/openai-http.ts` | `writeSse` helper |
| `src/gateway/openresponses-http.ts` | `writeSseEvent` helper (both writes) |
| `src/gateway/http-common.ts` | `writeDone` helper |

4-line change, no logic altered.

## Testing

Reproduce by asking the model to produce a response containing ◆ (U+25C6). Before this fix the stream errors; after, it streams correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `"utf-8"` encoding parameter to all `res.write()` calls in SSE streaming helpers to prevent Node.js from defaulting to Latin-1 encoding. This fixes stream crashes when LLM responses contain characters outside the Latin-1 range (e.g., ◆ U+25C6).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical (4 lines changed across 3 files), addresses a specific encoding bug with no logic changes, and all SSE write paths have been consistently updated
- No files require special attention

<sub>Last reviewed commit: 4304165</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->