### PR TITLE
fix(agents): prune excess images from conversation history (#19099)

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.prunes-history-images.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.prunes-history-images.test.ts
@@ -115,10 +115,7 @@ describe("sanitizeSessionMessagesImages – maxHistoryImages pruning", () => {
   });
 
   it("removes all images when maxHistoryImages is 0", async () => {
-    const messages = [
-      makeUserMessageWithImage("a"),
-      makeUserMessageWithImage("b"),
-    ];
+    const messages = [makeUserMessageWithImage("a"), makeUserMessageWithImage("b")];
     const out = await sanitizeSessionMessagesImages(messages, "test", { maxHistoryImages: 0 });
     expect(countImageBlocks(out)).toBe(0);
     expect(collectPlaceholders(out)).toHaveLength(2);

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.prunes-history-images.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.prunes-history-images.test.ts
@@ -44,7 +44,9 @@ function countImageBlocks(messages: AgentMessage[]): number {
   let count = 0;
   for (const msg of messages) {
     const content = (msg as { content?: unknown }).content;
-    if (!Array.isArray(content)) { continue; }
+    if (!Array.isArray(content)) {
+      continue;
+    }
     for (const block of content) {
       if (block && typeof block === "object" && (block as { type?: string }).type === "image") {
         count++;
@@ -58,7 +60,9 @@ function collectPlaceholders(messages: AgentMessage[]): string[] {
   const placeholders: string[] = [];
   for (const msg of messages) {
     const content = (msg as { content?: unknown }).content;
-    if (!Array.isArray(content)) { continue; }
+    if (!Array.isArray(content)) {
+      continue;
+    }
     for (const block of content) {
       if (block && typeof block === "object") {
         const rec = block as { type?: string; text?: string };

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.prunes-history-images.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.prunes-history-images.test.ts
@@ -44,7 +44,7 @@ function countImageBlocks(messages: AgentMessage[]): number {
   let count = 0;
   for (const msg of messages) {
     const content = (msg as { content?: unknown }).content;
-    if (!Array.isArray(content)) continue;
+    if (!Array.isArray(content)) { continue; }
     for (const block of content) {
       if (block && typeof block === "object" && (block as { type?: string }).type === "image") {
         count++;
@@ -58,7 +58,7 @@ function collectPlaceholders(messages: AgentMessage[]): string[] {
   const placeholders: string[] = [];
   for (const msg of messages) {
     const content = (msg as { content?: unknown }).content;
-    if (!Array.isArray(content)) continue;
+    if (!Array.isArray(content)) { continue; }
     for (const block of content) {
       if (block && typeof block === "object") {
         const rec = block as { type?: string; text?: string };

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.prunes-history-images.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.prunes-history-images.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the maxHistoryImages pruning feature added to
+ * sanitizeSessionMessagesImages.
+ *
+ * Scenario: a long-running chat session accumulates more than the provider's
+ * image limit in its history.  Without pruning, every new request – even a
+ * plain-text one – would carry all accumulated images and trigger an HTTP 400
+ * "Max images exceeded" error.
+ *
+ * With maxHistoryImages set the oldest images are replaced by a placeholder
+ * text block so the payload stays within the provider cap.
+ */
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { sanitizeSessionMessagesImages } from "./pi-embedded-helpers.js";
+
+// Minimal 1×1 transparent PNG (67 bytes, valid base64).
+// Using a real image keeps sanitizeContentBlocksImages happy so it doesn't
+// replace our test blocks with error-text placeholders.
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk" +
+  "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+function makeImageBlock(_id = "img") {
+  return { type: "image" as const, data: TINY_PNG_BASE64, mimeType: "image/png" };
+}
+
+function makeUserMessageWithImage(id: string): AgentMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text: `Look at this, image ${id}` }, makeImageBlock(id)],
+  } as unknown as AgentMessage;
+}
+
+function makeUserMessageText(text: string): AgentMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+  } as unknown as AgentMessage;
+}
+
+function countImageBlocks(messages: AgentMessage[]): number {
+  let count = 0;
+  for (const msg of messages) {
+    const content = (msg as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block && typeof block === "object" && (block as { type?: string }).type === "image") {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+function collectPlaceholders(messages: AgentMessage[]): string[] {
+  const placeholders: string[] = [];
+  for (const msg of messages) {
+    const content = (msg as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block && typeof block === "object") {
+        const rec = block as { type?: string; text?: string };
+        if (rec.type === "text" && rec.text?.includes("image removed from history")) {
+          placeholders.push(rec.text);
+        }
+      }
+    }
+  }
+  return placeholders;
+}
+
+describe("sanitizeSessionMessagesImages – maxHistoryImages pruning", () => {
+  it("keeps all images when count is within the limit", async () => {
+    const messages = [
+      makeUserMessageWithImage("a"),
+      makeUserMessageWithImage("b"),
+      makeUserMessageWithImage("c"),
+    ];
+    const out = await sanitizeSessionMessagesImages(messages, "test", { maxHistoryImages: 5 });
+    expect(countImageBlocks(out)).toBe(3);
+    expect(collectPlaceholders(out)).toHaveLength(0);
+  });
+
+  it("replaces oldest images when count exceeds the limit", async () => {
+    const messages = [
+      makeUserMessageWithImage("1"), // oldest – should be pruned
+      makeUserMessageWithImage("2"), // should be pruned
+      makeUserMessageWithImage("3"), // should be kept
+    ];
+    const out = await sanitizeSessionMessagesImages(messages, "test", { maxHistoryImages: 1 });
+    expect(countImageBlocks(out)).toBe(1);
+    expect(collectPlaceholders(out)).toHaveLength(2);
+  });
+
+  it("does not prune when maxHistoryImages is undefined (disabled)", async () => {
+    const messages = [
+      makeUserMessageWithImage("1"),
+      makeUserMessageWithImage("2"),
+      makeUserMessageWithImage("3"),
+      makeUserMessageWithImage("4"),
+      makeUserMessageWithImage("5"),
+      makeUserMessageWithImage("6"),
+      makeUserMessageWithImage("7"),
+      makeUserMessageWithImage("8"),
+      makeUserMessageWithImage("9"), // would exceed default limit if enabled
+    ];
+    // Explicitly undefined means pruning is off
+    const out = await sanitizeSessionMessagesImages(messages, "test", {
+      maxHistoryImages: undefined,
+    });
+    expect(countImageBlocks(out)).toBe(9);
+    expect(collectPlaceholders(out)).toHaveLength(0);
+  });
+
+  it("removes all images when maxHistoryImages is 0", async () => {
+    const messages = [
+      makeUserMessageWithImage("a"),
+      makeUserMessageWithImage("b"),
+    ];
+    const out = await sanitizeSessionMessagesImages(messages, "test", { maxHistoryImages: 0 });
+    expect(countImageBlocks(out)).toBe(0);
+    expect(collectPlaceholders(out)).toHaveLength(2);
+  });
+
+  it("plain-text messages are unaffected by image pruning", async () => {
+    const messages = [
+      makeUserMessageWithImage("1"),
+      makeUserMessageWithImage("2"),
+      makeUserMessageText("no images here"),
+    ];
+    const out = await sanitizeSessionMessagesImages(messages, "test", { maxHistoryImages: 1 });
+    // Only 1 image kept (the most recent), 1 replaced
+    expect(countImageBlocks(out)).toBe(1);
+    // Text-only message is fully preserved
+    const lastMsg = out[out.length - 1] as { content?: unknown };
+    const lastContent = lastMsg.content as Array<{ type?: string; text?: string }>;
+    expect(lastContent.some((b) => b.type === "text" && b.text === "no images here")).toBe(true);
+  });
+
+  it("preserves N most recent images (newest are kept)", async () => {
+    // Create 5 messages, each with one image – we want to keep only last 2
+    const messages = [
+      makeUserMessageWithImage("first"),
+      makeUserMessageWithImage("second"),
+      makeUserMessageWithImage("third"),
+      makeUserMessageWithImage("fourth"),
+      makeUserMessageWithImage("fifth"), // most recent
+    ];
+    const out = await sanitizeSessionMessagesImages(messages, "test", { maxHistoryImages: 2 });
+    expect(countImageBlocks(out)).toBe(2);
+    // The 3 oldest should have been replaced with placeholders
+    expect(collectPlaceholders(out)).toHaveLength(3);
+    // The last two messages should still have their image intact
+    const fourthMsg = out[3] as { content?: unknown };
+    const fourthContent = fourthMsg.content as Array<{ type?: string }>;
+    expect(fourthContent.some((b) => b.type === "image")).toBe(true);
+    const fifthMsg = out[4] as { content?: unknown };
+    const fifthContent = fifthMsg.content as Array<{ type?: string }>;
+    expect(fifthContent.some((b) => b.type === "image")).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -42,6 +42,7 @@ export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-help
 
 export { downgradeOpenAIReasoningBlocks } from "./pi-embedded-helpers/openai.js";
 export {
+  DEFAULT_MAX_HISTORY_IMAGES,
   isEmptyAssistantMessageContent,
   sanitizeSessionMessagesImages,
 } from "./pi-embedded-helpers/images.js";

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -163,7 +163,9 @@ export async function sanitizeSessionMessagesImages(
     const role = (msg as { role?: unknown }).role;
     if (role === "toolResult") {
       const toolMsg = msg as Extract<AgentMessage, { role: "toolResult" }>;
-      const rawContent = Array.isArray(toolMsg.content) ? (toolMsg.content as unknown as ContentBlock[]) : [];
+      const rawContent = Array.isArray(toolMsg.content)
+        ? (toolMsg.content as unknown as ContentBlock[])
+        : [];
       const prunedContent = dropOldestImageBlocks(rawContent, toDropRef, label);
       const nextContent = (await sanitizeContentBlocksImages(
         prunedContent,

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -438,6 +438,7 @@ export async function sanitizeSessionHistory(params: {
       toolCallIdMode: policy.toolCallIdMode,
       preserveSignatures: policy.preserveSignatures,
       sanitizeThoughtSignatures: policy.sanitizeThoughtSignatures,
+      maxHistoryImages: policy.maxHistoryImages,
     },
   );
   const sanitizedThinking = policy.normalizeAntigravityThinkingBlocks

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -1,6 +1,6 @@
 import { normalizeProviderId } from "./model-selection.js";
-import { DEFAULT_MAX_HISTORY_IMAGES } from "./pi-embedded-helpers/images.js";
 import { isAntigravityClaude, isGoogleModelApi } from "./pi-embedded-helpers/google.js";
+import { DEFAULT_MAX_HISTORY_IMAGES } from "./pi-embedded-helpers/images.js";
 import type { ToolCallIdMode } from "./tool-call-id.js";
 
 export type TranscriptSanitizeMode = "full" | "images-only";

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "./model-selection.js";
+import { DEFAULT_MAX_HISTORY_IMAGES } from "./pi-embedded-helpers/images.js";
 import { isAntigravityClaude, isGoogleModelApi } from "./pi-embedded-helpers/google.js";
 import type { ToolCallIdMode } from "./tool-call-id.js";
 
@@ -19,6 +20,15 @@ export type TranscriptPolicy = {
   validateGeminiTurns: boolean;
   validateAnthropicTurns: boolean;
   allowSyntheticToolResults: boolean;
+  /**
+   * Maximum number of images to retain across the entire conversation history
+   * when building a request payload.  Oldest images beyond this cap are
+   * replaced with a placeholder text block so providers that enforce a
+   * per-request image limit (commonly 8) do not return HTTP 400 errors.
+   *
+   * Defaults to DEFAULT_MAX_HISTORY_IMAGES (8).  Set to undefined to disable.
+   */
+  maxHistoryImages?: number;
 };
 
 const MISTRAL_MODEL_HINTS = [
@@ -119,5 +129,6 @@ export function resolveTranscriptPolicy(params: {
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && isAnthropic,
     allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+    maxHistoryImages: DEFAULT_MAX_HISTORY_IMAGES,
   };
 }

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -77,7 +77,7 @@ export async function readJsonBodyOrError(
 }
 
 export function writeDone(res: ServerResponse) {
-  res.write("data: [DONE]\n\n");
+  res.write("data: [DONE]\n\n", "utf-8");
 }
 
 export function setSseHeaders(res: ServerResponse) {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -37,7 +37,7 @@ type OpenAiChatCompletionRequest = {
 };
 
 function writeSse(res: ServerResponse, data: unknown) {
-  res.write(`data: ${JSON.stringify(data)}\n\n`);
+  res.write(`data: ${JSON.stringify(data)}\n\n`, "utf-8");
 }
 
 function asMessages(val: unknown): OpenAiChatMessage[] {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -62,8 +62,8 @@ const DEFAULT_BODY_BYTES = 20 * 1024 * 1024;
 const DEFAULT_MAX_URL_PARTS = 8;
 
 function writeSseEvent(res: ServerResponse, event: StreamingEvent) {
-  res.write(`event: ${event.type}\n`);
-  res.write(`data: ${JSON.stringify(event)}\n\n`);
+  res.write(`event: ${event.type}\n`, "utf-8");
+  res.write(`data: ${JSON.stringify(event)}\n\n`, "utf-8");
 }
 
 function extractTextContent(content: string | ContentPart[]): string {


### PR DESCRIPTION
## Problem

In long sessions, every image sent by the user or returned by a tool accumulates in the conversation history. Providers that enforce a per-request image cap (commonly **8 images**) then reject subsequent requests with:

```
HTTP 400 – Max images exceeded
```

Fixes #19099

## Solution

Rather than letting images pile up indefinitely, we now keep only the **8 most recent** image blocks across the full conversation history. Older image blocks are replaced with a lightweight text placeholder (`[session:history] image removed from history`) so the message structure stays valid for all providers.

The limit is controlled by the new `DEFAULT_MAX_HISTORY_IMAGES = 8` constant in `images.ts` and is surfaced through `TranscriptPolicy.maxHistoryImages`. It can be overridden per-provider if needed.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-helpers/images.ts` | Add `DEFAULT_MAX_HISTORY_IMAGES`, `countHistoryImages`, `dropOldestImageBlocks` helpers; extend `sanitizeSessionMessagesImages()` with `maxHistoryImages` option |
| `src/agents/transcript-policy.ts` | Add `maxHistoryImages` field to `TranscriptPolicy`; default to `DEFAULT_MAX_HISTORY_IMAGES` in `resolveTranscriptPolicy()` |
| `src/agents/pi-embedded-runner/google.ts` | Forward `policy.maxHistoryImages` into `sanitizeSessionHistory()` |
| `src/agents/pi-embedded-helpers.ts` | Re-export `DEFAULT_MAX_HISTORY_IMAGES` |
| `src/agents/pi-embedded-helpers.sanitize-session-messages-images.prunes-history-images.test.ts` | Unit tests for the new pruning logic |

## Testing

- New unit tests verify that images beyond the cap are replaced with placeholders and that the N most recent images are always preserved.
- TypeScript compiles without errors (`npx tsc --noEmit`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds image-count pruning to conversation history to prevent HTTP 400 "Max images exceeded" errors from providers that cap per-request images (commonly 8). When the total image count exceeds `maxHistoryImages` (default 8), the oldest image blocks are replaced with lightweight text placeholders (`[session:history] image removed from history`), preserving message structure while staying within provider limits.

- Adds `DEFAULT_MAX_HISTORY_IMAGES = 8` constant, `countHistoryImages`, and `dropOldestImageBlocks` helper functions in `images.ts`
- Extends `sanitizeSessionMessagesImages()` with a `maxHistoryImages` option that prunes oldest images using a shared mutable counter across all messages
- Adds `maxHistoryImages` field to `TranscriptPolicy` type, defaulting to 8 for all providers via `resolveTranscriptPolicy()`
- Forwards the option through both the `google.ts` runner and the main `attempt.ts` runner paths (via `sanitizeSessionHistory`)
- Includes 6 unit tests covering within-limit, over-limit, disabled, zero, text-only, and newest-preserved scenarios
- Separately, adds explicit `"utf-8"` encoding to SSE `res.write()` calls in the gateway HTTP handlers (defensive improvement)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk; the pruning logic is well-structured, properly tested, and correctly integrated into all existing code paths.
- The implementation is clean, well-documented, and follows existing patterns. The mutable counter approach for tracking drops across messages is correct. Tests cover key edge cases. The universal 8-image cap for all providers is a conservative safe default. The gateway UTF-8 changes are trivially correct. No logic bugs or security issues found.
- No files require special attention. The core logic in `src/agents/pi-embedded-helpers/images.ts` has been thoroughly reviewed and the pruning approach is sound.

<sub>Last reviewed commit: 236f287</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->