### PR TITLE
feat(claude-code): implement spawn mode for Claude Code sub-agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.2.24",
+  "version": "2026.2.24-cc-spawn-v2",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.2.24-cc-spawn-v2",
+  "version": "2026.2.24-cc-spawn-v3",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.2.24-cc-spawn-v3",
+  "version": "2026.2.24-cc-spawn-v4",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/src/agents/claude-code/binary.ts
+++ b/src/agents/claude-code/binary.ts
@@ -1,0 +1,60 @@
+/**
+ * Resolve the `claude` CLI binary path.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+/**
+ * Resolves the Claude Code CLI binary.
+ *
+ * Resolution order:
+ * 1. Explicit path from config (`binaryPath`)
+ * 2. `which claude` from PATH
+ * 3. Throw with install instructions
+ */
+export function resolveClaudeBinary(binaryPath?: string | null): string {
+  // 1. Explicit path from config
+  if (binaryPath) {
+    if (!fs.existsSync(binaryPath)) {
+      throw new Error(`Claude Code binary not found at configured path: ${binaryPath}`);
+    }
+    return binaryPath;
+  }
+
+  // 2. Resolve from PATH
+  try {
+    const resolved = execFileSync("which", ["claude"], {
+      encoding: "utf8",
+      timeout: 5_000,
+    }).trim();
+    if (resolved) {
+      return resolved;
+    }
+  } catch {
+    // Fall through on Windows or missing `which`
+  }
+
+  // Windows fallback
+  if (process.platform === "win32") {
+    try {
+      const resolved = execFileSync("where", ["claude"], {
+        encoding: "utf8",
+        timeout: 5_000,
+      })
+        .trim()
+        .split(/\r?\n/)[0];
+      if (resolved) {
+        return resolved;
+      }
+    } catch {
+      // Fall through
+    }
+  }
+
+  // 3. Fail with helpful message
+  throw new Error(
+    "Claude Code CLI not found. Install it with: npm install -g @anthropic-ai/claude-code\n" +
+      "Or set agents.defaults.subagents.claudeCode.binaryPath in openclaw.json",
+  );
+}

--- a/src/agents/claude-code/claude-code.test.ts
+++ b/src/agents/claude-code/claude-code.test.ts
@@ -1,0 +1,680 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, afterEach } from "vitest";
+import { resolveClaudeBinary } from "./binary.js";
+import type {
+  CCSystemStatusMessage,
+  CCSystemInitMessage,
+  CCAssistantMessage,
+  CCResultMessage,
+  CCAuthStatusMessage,
+  CCControlResponse,
+} from "./protocol.js";
+import { parseOutboundMessage } from "./protocol.js";
+import {
+  registryKey,
+  resolveSession,
+  saveSession,
+  updateSessionStats,
+  deleteSession,
+  listSessions,
+  listAllSessions,
+  peekSessionHistory,
+} from "./sessions.js";
+import type { ClaudeCodeProgressEvent } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Binary resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveClaudeBinary", () => {
+  it("throws when binaryPath does not exist", () => {
+    expect(() => resolveClaudeBinary("/nonexistent/path/claude")).toThrow(
+      "Claude Code binary not found at configured path",
+    );
+  });
+
+  it("returns binaryPath when it exists", () => {
+    // Use node binary as a stand-in (guaranteed to exist)
+    const nodePath = process.execPath;
+    expect(resolveClaudeBinary(nodePath)).toBe(nodePath);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Protocol parsing
+// ---------------------------------------------------------------------------
+
+describe("parseOutboundMessage", () => {
+  it("parses a system status message", () => {
+    const raw = JSON.stringify({
+      type: "system",
+      subtype: "status",
+      status: null,
+      permissionMode: "bypassPermissions",
+      uuid: "abc",
+      session_id: "sess-1",
+    });
+    const msg = parseOutboundMessage(raw);
+    expect(msg).toBeTruthy();
+    expect(msg!.type).toBe("system");
+    const sys = msg as CCSystemStatusMessage;
+    expect(sys.subtype).toBe("status");
+    expect(sys.permissionMode).toBe("bypassPermissions");
+  });
+
+  it("parses a system init message", () => {
+    const raw = JSON.stringify({
+      type: "system",
+      subtype: "init",
+      cwd: "/home/user/project",
+      session_id: "sess-init-1",
+      tools: ["Read", "Write", "Bash"],
+      mcp_servers: [],
+      model: "claude-opus-4-6",
+      permissionMode: "bypassPermissions",
+      uuid: "abc",
+    });
+    const msg = parseOutboundMessage(raw) as CCSystemInitMessage;
+    expect(msg.type).toBe("system");
+    expect(msg.subtype).toBe("init");
+    expect(msg.session_id).toBe("sess-init-1");
+    expect(msg.model).toBe("claude-opus-4-6");
+    expect(msg.tools).toEqual(["Read", "Write", "Bash"]);
+  });
+
+  it("parses an assistant message", () => {
+    const raw = JSON.stringify({
+      type: "assistant",
+      message: {
+        model: "claude-opus-4-6",
+        id: "msg_01",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 50 },
+      },
+      session_id: "sess-1",
+      uuid: "abc",
+    });
+    const msg = parseOutboundMessage(raw) as CCAssistantMessage;
+    expect(msg.type).toBe("assistant");
+    expect(msg.message.content[0]).toEqual({ type: "text", text: "Hello" });
+    expect(msg.message.usage?.input_tokens).toBe(100);
+  });
+
+  it("parses an assistant message with tool_use blocks", () => {
+    const raw = JSON.stringify({
+      type: "assistant",
+      message: {
+        model: "claude-opus-4-6",
+        id: "msg_02",
+        type: "message",
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me read that file." },
+          { type: "tool_use", id: "tu_01", name: "Read", input: { file_path: "/test.ts" } },
+        ],
+        stop_reason: "tool_use",
+      },
+      session_id: "sess-1",
+      uuid: "abc",
+    });
+    const msg = parseOutboundMessage(raw) as CCAssistantMessage;
+    expect(msg.message.content).toHaveLength(2);
+    expect(msg.message.content[1].type).toBe("tool_use");
+    expect((msg.message.content[1] as unknown as { name: string }).name).toBe("Read");
+  });
+
+  it("parses a result message", () => {
+    const raw = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      duration_ms: 5000,
+      is_error: false,
+      num_turns: 3,
+      session_id: "sess-1",
+      total_cost_usd: 0.42,
+      usage: { input_tokens: 1000, output_tokens: 500 },
+      result: "Task completed.",
+      uuid: "abc",
+    });
+    const msg = parseOutboundMessage(raw) as CCResultMessage;
+    expect(msg.type).toBe("result");
+    expect(msg.subtype).toBe("success");
+    expect(msg.total_cost_usd).toBe(0.42);
+    expect(msg.result).toBe("Task completed.");
+  });
+
+  it("parses result with error subtypes", () => {
+    for (const subtype of ["error_during_execution", "error_max_turns", "error_max_budget_usd"]) {
+      const raw = JSON.stringify({
+        type: "result",
+        subtype,
+        is_error: true,
+        session_id: "sess-1",
+        uuid: "abc",
+      });
+      const msg = parseOutboundMessage(raw) as CCResultMessage;
+      expect(msg.subtype).toBe(subtype);
+    }
+  });
+
+  it("parses auth_status message", () => {
+    const raw = JSON.stringify({
+      type: "auth_status",
+      isAuthenticating: false,
+      error: "token expired",
+      uuid: "abc",
+      session_id: "sess-1",
+    });
+    const msg = parseOutboundMessage(raw) as CCAuthStatusMessage;
+    expect(msg.type).toBe("auth_status");
+    expect(msg.error).toBe("token expired");
+  });
+
+  it("parses control_response message", () => {
+    const raw = JSON.stringify({
+      type: "control_response",
+      response: {
+        subtype: "success",
+        request_id: "req_01",
+      },
+    });
+    const msg = parseOutboundMessage(raw) as CCControlResponse;
+    expect(msg.type).toBe("control_response");
+    expect(msg.response.subtype).toBe("success");
+  });
+
+  it("returns null for non-JSON", () => {
+    expect(parseOutboundMessage("not json")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseOutboundMessage("")).toBeNull();
+    expect(parseOutboundMessage("  ")).toBeNull();
+  });
+
+  it("returns null for JSON without type field", () => {
+    expect(parseOutboundMessage('{"foo": "bar"}')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session registry
+// ---------------------------------------------------------------------------
+
+describe("session registry", () => {
+  const testAgentId = `test-agent-${Date.now()}`;
+  const testRepo = `/tmp/test-repo-${Date.now()}`;
+
+  afterEach(() => {
+    // Clean up test registry files
+    const dir = path.join(os.homedir(), ".openclaw", "agents", testAgentId);
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it("returns undefined for unknown repo", () => {
+    const result = resolveSession(testAgentId, testRepo);
+    expect(result).toBeUndefined();
+  });
+
+  it("saves and retrieves a session", () => {
+    saveSession(testAgentId, testRepo, "session-123", {
+      task: "Test task",
+      costUsd: 0.5,
+    });
+
+    // resolveSession won't find the CC session file, so it should clean up and return undefined.
+    // This is expected — in a real environment, the CC session file would exist.
+    const result = resolveSession(testAgentId, testRepo);
+    expect(result).toBeUndefined(); // CC session file doesn't exist in test env
+
+    // But listSessions should be empty since resolveSession cleaned up
+    // Let's verify saveSession works by listing before resolveSession cleans up.
+  });
+
+  it("listSessions returns saved entries", () => {
+    saveSession(testAgentId, testRepo, "session-456", {
+      task: "Another task",
+      costUsd: 1.0,
+    });
+
+    const sessions = listSessions(testAgentId);
+    expect(sessions[testRepo]).toBeTruthy();
+    expect(sessions[testRepo].sessionId).toBe("session-456");
+    expect(sessions[testRepo].totalCostUsd).toBe(1.0);
+    expect(sessions[testRepo].taskHistory).toHaveLength(1);
+    expect(sessions[testRepo].taskHistory[0].task).toBe("Another task");
+  });
+
+  it("updateSessionStats accumulates cost and turns", () => {
+    saveSession(testAgentId, testRepo, "session-789", {
+      task: "Initial task",
+      costUsd: 0.5,
+    });
+
+    updateSessionStats(testAgentId, testRepo, { turns: 5, costUsd: 0.3 });
+
+    const sessions = listSessions(testAgentId);
+    // totalCostUsd from saveSession + updateSessionStats
+    expect(sessions[testRepo].totalCostUsd).toBe(0.8);
+    expect(sessions[testRepo].totalTurns).toBe(5);
+  });
+
+  it("deleteSession removes an entry", () => {
+    saveSession(testAgentId, testRepo, "session-del", {
+      task: "To be deleted",
+    });
+
+    const deleted = deleteSession(testAgentId, testRepo);
+    expect(deleted).toBe(true);
+
+    const sessions = listSessions(testAgentId);
+    expect(sessions[testRepo]).toBeUndefined();
+  });
+
+  it("deleteSession returns false for non-existent entry", () => {
+    expect(deleteSession(testAgentId, "/nonexistent")).toBe(false);
+  });
+
+  it("saveSession updates existing entry on re-save with same sessionId", () => {
+    saveSession(testAgentId, testRepo, "session-update", {
+      task: "Task 1",
+      costUsd: 0.5,
+    });
+    saveSession(testAgentId, testRepo, "session-update", {
+      task: "Task 2",
+      costUsd: 0.3,
+    });
+
+    const sessions = listSessions(testAgentId);
+    expect(sessions[testRepo].sessionId).toBe("session-update");
+    // Cost is accumulated via the existing entry path: 0.5 (initial) + 0.3 (update)
+    expect(sessions[testRepo].totalCostUsd).toBe(0.8);
+    expect(sessions[testRepo].taskHistory).toHaveLength(2);
+  });
+
+  it("listAllSessions aggregates across agents", () => {
+    const agentA = `test-listall-a-${Date.now()}`;
+    const agentB = `test-listall-b-${Date.now()}`;
+    const repoA = `/tmp/test-repo-a-${Date.now()}`;
+    const repoB = `/tmp/test-repo-b-${Date.now()}`;
+
+    try {
+      saveSession(agentA, repoA, "sess-a", { task: "Task A", costUsd: 1.0 });
+      saveSession(agentB, repoB, "sess-b", { task: "Task B", costUsd: 2.0 });
+
+      const all = listAllSessions();
+      const foundA = all.find((s) => s.sessionId === "sess-a");
+      const foundB = all.find((s) => s.sessionId === "sess-b");
+
+      expect(foundA).toBeTruthy();
+      expect(foundA?.agentId).toBe(agentA);
+      expect(foundA?.repoPath).toBe(repoA);
+      expect(foundB).toBeTruthy();
+      expect(foundB?.agentId).toBe(agentB);
+    } finally {
+      // Cleanup
+      for (const agent of [agentA, agentB]) {
+        const dir = path.join(os.homedir(), ".openclaw", "agents", agent);
+        try {
+          fs.rmSync(dir, { recursive: true, force: true });
+        } catch {}
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Named sessions (label support)
+// ---------------------------------------------------------------------------
+
+describe("registryKey", () => {
+  it("returns repoPath when no label", () => {
+    expect(registryKey("/home/user/project")).toBe("/home/user/project");
+  });
+
+  it("returns repoPath::label when label provided", () => {
+    expect(registryKey("/home/user/project", "dashboard-refactor")).toBe(
+      "/home/user/project::dashboard-refactor",
+    );
+  });
+});
+
+describe("named sessions", () => {
+  const testAgentId = `test-named-${Date.now()}`;
+  const testRepo = `/tmp/test-named-repo-${Date.now()}`;
+
+  afterEach(() => {
+    const dir = path.join(os.homedir(), ".openclaw", "agents", testAgentId);
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it("saveSession with label does not overwrite unlabeled session", () => {
+    // Save an unlabeled session
+    saveSession(testAgentId, testRepo, "sess-default", {
+      task: "Default task",
+      costUsd: 1.0,
+    });
+
+    // Save a labeled session on the same repo
+    saveSession(testAgentId, testRepo, "sess-labeled", {
+      task: "Labeled task",
+      costUsd: 2.0,
+      label: "dashboard-refactor",
+    });
+
+    const sessions = listSessions(testAgentId);
+
+    // Unlabeled session is keyed by repoPath
+    expect(sessions[testRepo]).toBeTruthy();
+    expect(sessions[testRepo].sessionId).toBe("sess-default");
+    expect(sessions[testRepo].totalCostUsd).toBe(1.0);
+
+    // Labeled session is keyed by repoPath::label
+    const labeledKey = `${testRepo}::dashboard-refactor`;
+    expect(sessions[labeledKey]).toBeTruthy();
+    expect(sessions[labeledKey].sessionId).toBe("sess-labeled");
+    expect(sessions[labeledKey].totalCostUsd).toBe(2.0);
+    expect(sessions[labeledKey].label).toBe("dashboard-refactor");
+  });
+
+  it("multiple sessions on same repo with different labels coexist", () => {
+    saveSession(testAgentId, testRepo, "sess-a", {
+      task: "Feature A",
+      costUsd: 0.5,
+      label: "feature-a",
+    });
+    saveSession(testAgentId, testRepo, "sess-b", {
+      task: "Feature B",
+      costUsd: 0.7,
+      label: "feature-b",
+    });
+    saveSession(testAgentId, testRepo, "sess-default", {
+      task: "Default",
+      costUsd: 0.3,
+    });
+
+    const sessions = listSessions(testAgentId);
+
+    // All three coexist under different keys
+    expect(sessions[`${testRepo}::feature-a`].sessionId).toBe("sess-a");
+    expect(sessions[`${testRepo}::feature-b`].sessionId).toBe("sess-b");
+    expect(sessions[testRepo].sessionId).toBe("sess-default");
+
+    // Labels are stored on the entries
+    expect(sessions[`${testRepo}::feature-a`].label).toBe("feature-a");
+    expect(sessions[`${testRepo}::feature-b`].label).toBe("feature-b");
+    expect(sessions[testRepo].label).toBeUndefined();
+  });
+
+  it("updateSessionStats with label targets the correct entry", () => {
+    saveSession(testAgentId, testRepo, "sess-default", {
+      task: "Default",
+      costUsd: 1.0,
+    });
+    saveSession(testAgentId, testRepo, "sess-labeled", {
+      task: "Labeled",
+      costUsd: 1.0,
+      label: "my-label",
+    });
+
+    // Update only the labeled session
+    updateSessionStats(testAgentId, testRepo, { turns: 10, costUsd: 0.5 }, "my-label");
+
+    const sessions = listSessions(testAgentId);
+    // Labeled session got the update
+    expect(sessions[`${testRepo}::my-label`].totalTurns).toBe(10);
+    expect(sessions[`${testRepo}::my-label`].totalCostUsd).toBe(1.5);
+    // Default session is untouched
+    expect(sessions[testRepo].totalTurns).toBe(0);
+    expect(sessions[testRepo].totalCostUsd).toBe(1.0);
+  });
+
+  it("deleteSession with label only removes the labeled entry", () => {
+    saveSession(testAgentId, testRepo, "sess-default", { task: "Default" });
+    saveSession(testAgentId, testRepo, "sess-labeled", {
+      task: "Labeled",
+      label: "to-delete",
+    });
+
+    const deleted = deleteSession(testAgentId, testRepo, "to-delete");
+    expect(deleted).toBe(true);
+
+    const sessions = listSessions(testAgentId);
+    // Labeled entry is gone
+    expect(sessions[`${testRepo}::to-delete`]).toBeUndefined();
+    // Default entry still exists
+    expect(sessions[testRepo]).toBeTruthy();
+    expect(sessions[testRepo].sessionId).toBe("sess-default");
+  });
+
+  it("resolveSession with and without label are independent", () => {
+    // Both will return undefined (CC session files don't exist in test env),
+    // but they should look up different registry keys.
+    saveSession(testAgentId, testRepo, "sess-default", { task: "Default" });
+    saveSession(testAgentId, testRepo, "sess-labeled", {
+      task: "Labeled",
+      label: "independent",
+    });
+
+    // resolveSession cleans up entries whose CC session files don't exist.
+    // Call for labeled — it should clean only the labeled entry.
+    const labeled = resolveSession(testAgentId, testRepo, "independent");
+    expect(labeled).toBeUndefined(); // CC session file doesn't exist
+
+    // The default entry should still be in the registry (not yet resolved/cleaned).
+    const sessions = listSessions(testAgentId);
+    expect(sessions[testRepo]).toBeTruthy();
+    expect(sessions[testRepo].sessionId).toBe("sess-default");
+    // The labeled entry was cleaned up by resolveSession
+    expect(sessions[`${testRepo}::independent`]).toBeUndefined();
+  });
+
+  it("listAllSessions extracts repoPath from labeled keys", () => {
+    saveSession(testAgentId, testRepo, "sess-labeled", {
+      task: "Labeled",
+      costUsd: 1.0,
+      label: "my-feature",
+    });
+
+    const all = listAllSessions();
+    const found = all.find((s) => s.sessionId === "sess-labeled");
+    expect(found).toBeTruthy();
+    expect(found?.repoPath).toBe(testRepo); // repoPath, not repoPath::label
+    expect(found?.agentId).toBe(testAgentId);
+    expect(found?.label).toBe("my-feature");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP bridge script generation
+// ---------------------------------------------------------------------------
+
+describe("MCP bridge", () => {
+  it("startMcpBridge creates script and config", async () => {
+    const { startMcpBridge } = await import("./mcp-bridge.js");
+
+    const handle = await startMcpBridge({
+      task: "Test task",
+      repo: "/tmp/test-repo",
+      agentId: "test-agent",
+    });
+
+    expect(handle.mcpConfig).toBeTruthy();
+    expect(handle.mcpConfig.type).toBe("stdio");
+    expect(handle.mcpConfig.command).toBe(process.execPath);
+    expect((handle.mcpConfig.args as string[])[0]).toMatch(/\.cjs$/);
+    expect(handle.announceQueuePath).toMatch(/announce\.ndjson$/);
+
+    // Verify script was written
+    const scriptPath = (handle.mcpConfig.args as string[])[0];
+    expect(fs.existsSync(scriptPath)).toBe(true);
+
+    // drainAnnouncements on empty file returns empty
+    expect(handle.drainAnnouncements()).toEqual([]);
+
+    // Write a fake announcement and drain it
+    fs.writeFileSync(
+      handle.announceQueuePath,
+      JSON.stringify({ message: "Hello from bridge", timestamp: new Date().toISOString() }) + "\n",
+    );
+    const announcements = handle.drainAnnouncements();
+    expect(announcements).toEqual(["Hello from bridge"]);
+    // Second drain should be empty
+    expect(handle.drainAnnouncements()).toEqual([]);
+
+    // Stop and verify cleanup
+    await handle.stop();
+    expect(fs.existsSync(scriptPath)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Progress event types
+// ---------------------------------------------------------------------------
+
+describe("progress events", () => {
+  it("covers all event kinds", () => {
+    const events: ClaudeCodeProgressEvent[] = [
+      { kind: "status", permissionMode: "bypassPermissions", sessionId: "sess-1" },
+      { kind: "tool_use", toolName: "Read", input: { file_path: "/test.ts" } },
+      { kind: "text", text: "Hello" },
+      { kind: "hook_failed", hookName: "pre-commit", exitCode: 1, output: "failed" },
+      { kind: "task_notification", taskId: "task-1", status: "completed", summary: "Done" },
+      { kind: "auth_error", error: "expired" },
+      { kind: "progress_summary", summary: "[kyo] Working... (30s, $0.10, 2 turns)" },
+      {
+        kind: "permission_request",
+        toolName: "Bash",
+        description: "Run: npm test",
+        requestId: "tu_01",
+      },
+    ];
+
+    // All events should be valid (TypeScript ensures this)
+    expect(events).toHaveLength(8);
+    for (const event of events) {
+      expect(event.kind).toBeTruthy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session history peek
+// ---------------------------------------------------------------------------
+
+describe("peekSessionHistory", () => {
+  const tmpDir = path.join(os.tmpdir(), `cc-peek-test-${Date.now()}`);
+  const fakeRepo = "/home/user/myproject";
+  const sessionId = "peek-test-session";
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeSessionFile(lines: object[]) {
+    const sessionDir = path.join(tmpDir, ".claude", "projects", "myproject");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const sessionFile = path.join(sessionDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(sessionFile, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+    return sessionFile;
+  }
+
+  it("returns empty string when session file not found", () => {
+    const result = peekSessionHistory("/nonexistent/repo", "no-such-session");
+    expect(result).toBe("");
+  });
+
+  it("extracts text content from assistant and user messages", () => {
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      writeSessionFile([
+        { message: { role: "user", content: "Fix the bug in auth.ts" } },
+        {
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "I'll fix the authentication bug." },
+              { type: "tool_use", id: "t1", name: "Edit", input: {} },
+            ],
+          },
+        },
+        {
+          type: "user",
+          message: {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "t1", content: "OK" }],
+          },
+        },
+        {
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "The bug is fixed. I updated the token validation." }],
+          },
+        },
+      ]);
+
+      const result = peekSessionHistory(fakeRepo, sessionId);
+      expect(result).toContain("[User]: Fix the bug in auth.ts");
+      expect(result).toContain("[CC]: I'll fix the authentication bug.");
+      expect(result).toContain("[CC]: The bug is fixed.");
+      expect(result).not.toContain("tool_result");
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+
+  it("respects maxMessages limit", () => {
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      writeSessionFile([
+        { message: { role: "user", content: "Message 1" } },
+        { message: { role: "assistant", content: [{ type: "text", text: "Reply 1" }] } },
+        { message: { role: "user", content: "Message 2" } },
+        { message: { role: "assistant", content: [{ type: "text", text: "Reply 2" }] } },
+        { message: { role: "user", content: "Message 3" } },
+        { message: { role: "assistant", content: [{ type: "text", text: "Reply 3" }] } },
+      ]);
+
+      const result = peekSessionHistory(fakeRepo, sessionId, { maxMessages: 2 });
+      expect(result).not.toContain("Message 1");
+      expect(result).not.toContain("Reply 1");
+      expect(result).toContain("[User]: Message 3");
+      expect(result).toContain("[CC]: Reply 3");
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+
+  it("truncates when exceeding maxChars", () => {
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      const longText = "A".repeat(3000);
+      writeSessionFile([
+        { message: { role: "user", content: longText } },
+        { message: { role: "assistant", content: [{ type: "text", text: longText }] } },
+      ]);
+
+      const result = peekSessionHistory(fakeRepo, sessionId, { maxChars: 500 });
+      expect(result.length).toBeLessThan(600);
+      expect(result).toContain("…");
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+});

--- a/src/agents/claude-code/index.ts
+++ b/src/agents/claude-code/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Claude Code spawn mode — barrel export.
+ */
+
+export { resolveClaudeBinary } from "./binary.js";
+export { spawnClaudeCode, sendFollowUp, respondToPermission } from "./runner.js";
+export {
+  killClaudeCode,
+  killAllClaudeCode,
+  isClaudeCodeRunning,
+  getLiveSession,
+  getAllLiveSessions,
+} from "./live-state.js";
+export type { LiveSession } from "./live-state.js";
+export {
+  registryKey,
+  resolveSession,
+  saveSession,
+  updateSessionStats,
+  deleteSession,
+  listSessions,
+  listAllSessions,
+} from "./sessions.js";
+export { startMcpBridge } from "./mcp-bridge.js";
+export type { McpBridgeHandle } from "./mcp-bridge.js";
+export type {
+  ClaudeCodeSubagentConfig,
+  ClaudeCodePermissionMode,
+  ClaudeCodeSpawnOptions,
+  ClaudeCodeProgressEvent,
+  ClaudeCodeResult,
+  ClaudeCodeSessionEntry,
+  ClaudeCodeSessionRegistry,
+  ClaudeCodeTaskHistoryEntry,
+} from "./types.js";
+export type {
+  CCOutboundMessage,
+  CCInboundMessage,
+  CCResultMessage,
+  CCAssistantMessage,
+  CCSystemMessage,
+} from "./protocol.js";

--- a/src/agents/claude-code/index.ts
+++ b/src/agents/claude-code/index.ts
@@ -14,14 +14,32 @@ export {
 export type { LiveSession } from "./live-state.js";
 export {
   registryKey,
+  repoPathToSlug,
   resolveSession,
   saveSession,
   updateSessionStats,
   deleteSession,
   listSessions,
   listAllSessions,
+  parseJsonlHeader,
+  discoverSessions,
 } from "./sessions.js";
 export { startMcpBridge } from "./mcp-bridge.js";
+export { gatherProjectStatus } from "./project-status.js";
+export type { ProjectStatus } from "./project-status.js";
+export {
+  selectSession,
+  assessTaskRelevance,
+  keywordFallback,
+  scoreSession,
+  DEFAULT_SESSION_SELECTION_CONFIG,
+} from "./session-selection.js";
+export type {
+  SessionSelection,
+  SessionScore,
+  ScoreFactors,
+  TaskRelevanceResult,
+} from "./session-selection.js";
 export type { McpBridgeHandle } from "./mcp-bridge.js";
 export type {
   ClaudeCodeSubagentConfig,
@@ -32,6 +50,9 @@ export type {
   ClaudeCodeSessionEntry,
   ClaudeCodeSessionRegistry,
   ClaudeCodeTaskHistoryEntry,
+  DiscoveredSession,
+  JsonlHeader,
+  SessionSelectionConfig,
 } from "./types.js";
 export type {
   CCOutboundMessage,

--- a/src/agents/claude-code/live-state.ts
+++ b/src/agents/claude-code/live-state.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared live-session state for Claude Code spawn mode.
+ *
+ * This module holds the in-memory maps for active spawns and live sessions,
+ * plus lightweight query/kill functions. It's kept separate from runner.ts
+ * so that CLI modules (cc-cli) can inspect state without pulling in the
+ * heavy spawn machinery (mcp-bridge, protocol, subsystem logger).
+ */
+
+import type { ChildProcess } from "node:child_process";
+import path from "node:path";
+import type { ClaudeCodeResult, ClaudeCodeSpawnOptions } from "./types.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type LiveSession = {
+  child: ChildProcess;
+  sessionId: string | undefined;
+  repoPath: string;
+  startedAt: number;
+  accumulatedCostUsd: number;
+  accumulatedTurns: number;
+  lastToolName: string | undefined;
+  lastActivityText: string;
+  /** Persistent spawn fields. */
+  results: ClaudeCodeResult[];
+  persistent: boolean;
+  pendingFollowUp: { resolve: (r: ClaudeCodeResult) => void; reject: (e: Error) => void } | null;
+  persistentIdleTimer: ReturnType<typeof setTimeout> | null;
+};
+
+export type RepoQueueEntry = {
+  resolve: (value: ClaudeCodeResult) => void;
+  reject: (reason: unknown) => void;
+  options: ClaudeCodeSpawnOptions;
+};
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+/** Active child processes keyed by resolved repo path. */
+export const activeSpawns = new Map<string, ChildProcess>();
+export const queuedSpawns = new Map<string, RepoQueueEntry>();
+export const liveSessions = new Map<string, LiveSession>();
+
+// ── Query/Kill ───────────────────────────────────────────────────────────────
+
+/**
+ * Kill a running Claude Code session for a repo.
+ */
+export function killClaudeCode(repoPath: string): boolean {
+  const resolved = path.resolve(repoPath);
+  const child = activeSpawns.get(resolved);
+  if (!child) {
+    return false;
+  }
+  child.kill("SIGTERM");
+  setTimeout(() => {
+    if (!child.killed) {
+      child.kill("SIGKILL");
+    }
+  }, 5_000);
+  activeSpawns.delete(resolved);
+  liveSessions.delete(resolved);
+  return true;
+}
+
+/**
+ * Check if a Claude Code session is running for a repo.
+ */
+export function isClaudeCodeRunning(repoPath: string): boolean {
+  return activeSpawns.has(path.resolve(repoPath));
+}
+
+/**
+ * Get the live session for a repo (if running).
+ */
+export function getLiveSession(repoPath: string): LiveSession | undefined {
+  return liveSessions.get(path.resolve(repoPath));
+}
+
+/**
+ * Get all live sessions.
+ */
+export function getAllLiveSessions(): Map<string, LiveSession> {
+  return liveSessions;
+}
+
+/**
+ * Kill ALL running Claude Code sessions.
+ * Used during gateway shutdown/restart to prevent orphaned child processes.
+ * Returns the number of sessions killed.
+ */
+export function killAllClaudeCode(): number {
+  let killed = 0;
+  for (const [repoPath, child] of activeSpawns) {
+    try {
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        try {
+          if (!child.killed) {
+            child.kill("SIGKILL");
+          }
+        } catch {
+          // ignore — process may have already exited
+        }
+      }, 5_000);
+      killed++;
+    } catch {
+      // ignore — process may have already exited
+    }
+    liveSessions.delete(repoPath);
+  }
+  activeSpawns.clear();
+  // Reject any queued spawns
+  for (const [, entry] of queuedSpawns) {
+    try {
+      entry.reject(new Error("Gateway shutting down"));
+    } catch {
+      // ignore
+    }
+  }
+  queuedSpawns.clear();
+  return killed;
+}

--- a/src/agents/claude-code/mcp-bridge.ts
+++ b/src/agents/claude-code/mcp-bridge.ts
@@ -1,0 +1,376 @@
+/**
+ * MCP bridge server for Claude Code spawn mode.
+ *
+ * Exposes OpenClaw context tools to the spawned CC session via a stdio-based
+ * MCP server. This follows the same pattern as the VS Code extension which
+ * injects `claude-vscode` as an MCP server.
+ *
+ * Phase 3: stateful bridge with budget tracking, announce relay, and all 4 tools.
+ *
+ * Transport: The bridge is a self-contained Node.js script written to a temp
+ * file and referenced in `--mcp-config`. CC's MCP client spawns it and
+ * communicates via stdin/stdout JSON-RPC.
+ *
+ * Announce relay: The bridge writes announce messages to a temp file. The
+ * runner polls this file and relays announcements to the gateway.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ClaudeCodeSpawnOptions } from "./types.js";
+
+export type McpBridgeHandle = {
+  /** MCP config object for `--mcp-config` injection. */
+  mcpConfig: Record<string, unknown>;
+  /** Path to the announce queue file (NDJSON). */
+  announceQueuePath: string;
+  /** Read and drain pending announce messages. */
+  drainAnnouncements(): string[];
+  /** Stop the bridge server and clean up. */
+  stop(): Promise<void>;
+};
+
+// ---------------------------------------------------------------------------
+// Bridge server script generator
+// ---------------------------------------------------------------------------
+
+function generateBridgeScript(options: {
+  task: string;
+  agentId?: string;
+  repo: string;
+  maxBudgetUsd?: number;
+  announceQueuePath: string;
+  workspaceDir?: string;
+}): string {
+  const taskJson = JSON.stringify(options.task);
+  const agentIdJson = JSON.stringify(options.agentId ?? "default");
+  const repoJson = JSON.stringify(options.repo);
+  const budgetJson = JSON.stringify(options.maxBudgetUsd ?? null);
+  const announcePathJson = JSON.stringify(options.announceQueuePath);
+  const workspaceDirJson = JSON.stringify(
+    options.workspaceDir ??
+      path.join(os.homedir(), ".openclaw", "agents", options.agentId ?? "default"),
+  );
+
+  return `
+"use strict";
+const readline = require("readline");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const rl = readline.createInterface({ input: process.stdin });
+
+// Stateful budget tracking
+let totalCostUsd = 0;
+const maxBudgetUsd = ${budgetJson};
+
+const TOOLS = [
+  {
+    name: "openclaw_conversation_context",
+    description: "Returns context about the OpenClaw conversation that triggered this Claude Code session. Call this to understand why you were invoked and what task you should accomplish.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
+  {
+    name: "openclaw_memory_search",
+    description: "Search OpenClaw memory files for relevant context. Returns matching content from the agent's memory and workspace memory directories.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query (case-insensitive substring match)" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "openclaw_announce",
+    description: "Send a progress message back to the user's chat channel. Use this to keep the user informed about significant progress milestones. Messages are delivered asynchronously.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        message: { type: "string", description: "Message to send to the user" },
+      },
+      required: ["message"],
+    },
+  },
+  {
+    name: "openclaw_session_info",
+    description: "Returns metadata about the current OpenClaw session: agent ID, repo path, task description, cost budget remaining.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
+];
+
+function respond(id, result) {
+  const msg = JSON.stringify({ jsonrpc: "2.0", id, result });
+  process.stdout.write(msg + "\\n");
+}
+
+function respondError(id, code, message) {
+  const msg = JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+  process.stdout.write(msg + "\\n");
+}
+
+function searchMemoryFiles(query) {
+  const lowerQuery = query.toLowerCase();
+  const results = [];
+  const searchDirs = [
+    path.join(${workspaceDirJson}, "memory"),
+    // Also search the workspace root for MEMORY.md
+    ${workspaceDirJson},
+  ];
+
+  for (const dir of searchDirs) {
+    try {
+      if (!fs.existsSync(dir)) continue;
+      const entries = fs.readdirSync(dir);
+      for (const file of entries) {
+        if (!file.endsWith(".md")) continue;
+        const filePath = path.join(dir, file);
+        try {
+          const stat = fs.statSync(filePath);
+          if (!stat.isFile()) continue;
+          const content = fs.readFileSync(filePath, "utf8");
+          if (content.toLowerCase().includes(lowerQuery)) {
+            results.push({
+              file: path.relative(${workspaceDirJson}, filePath),
+              content: content.slice(0, 3000),
+            });
+          }
+        } catch {}
+      }
+    } catch {}
+  }
+  return results;
+}
+
+function handleRequest(parsed) {
+  const { id, method, params } = parsed;
+
+  if (method === "initialize") {
+    return respond(id, {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: {} },
+      serverInfo: { name: "openclaw-bridge", version: "2.0.0" },
+    });
+  }
+
+  if (method === "notifications/initialized") {
+    return; // No response needed
+  }
+
+  if (method === "tools/list") {
+    return respond(id, { tools: TOOLS });
+  }
+
+  if (method === "tools/call") {
+    const toolName = params?.name;
+    const toolArgs = params?.arguments ?? {};
+
+    // Budget gate: refuse all tools if budget exhausted
+    if (maxBudgetUsd !== null && totalCostUsd >= maxBudgetUsd) {
+      return respond(id, {
+        content: [{
+          type: "text",
+          text: "Budget exhausted ($" + totalCostUsd.toFixed(2) + " / $" + maxBudgetUsd.toFixed(2) + "). Tool call refused.",
+        }],
+        isError: true,
+      });
+    }
+
+    switch (toolName) {
+      case "openclaw_conversation_context":
+        return respond(id, {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              task: ${taskJson},
+              agentId: ${agentIdJson},
+              repo: ${repoJson},
+              note: "You were spawned by OpenClaw to handle this task. Complete it and return your findings.",
+              budgetRemaining: maxBudgetUsd !== null
+                ? "$" + (maxBudgetUsd - totalCostUsd).toFixed(2)
+                : "unlimited",
+            }, null, 2),
+          }],
+        });
+
+      case "openclaw_memory_search": {
+        const query = toolArgs.query || "";
+        if (!query.trim()) {
+          return respond(id, {
+            content: [{ type: "text", text: "Please provide a non-empty search query." }],
+            isError: true,
+          });
+        }
+        const results = searchMemoryFiles(query);
+        return respond(id, {
+          content: [{
+            type: "text",
+            text: results.length > 0
+              ? JSON.stringify(results, null, 2)
+              : "No matching memory files found for query: " + JSON.stringify(query),
+          }],
+        });
+      }
+
+      case "openclaw_announce": {
+        const message = toolArgs.message || "";
+        if (!message.trim()) {
+          return respond(id, {
+            content: [{ type: "text", text: "Please provide a non-empty message." }],
+            isError: true,
+          });
+        }
+        // Write to announce queue file — the runner picks these up
+        try {
+          const entry = JSON.stringify({ message, timestamp: new Date().toISOString() });
+          fs.appendFileSync(${announcePathJson}, entry + "\\n", "utf8");
+        } catch (err) {
+          process.stderr.write("[openclaw-bridge] announce write error: " + err.message + "\\n");
+        }
+        return respond(id, {
+          content: [{ type: "text", text: "Message queued for delivery to user's chat." }],
+        });
+      }
+
+      case "openclaw_session_info":
+        return respond(id, {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              agentId: ${agentIdJson},
+              repo: ${repoJson},
+              task: ${taskJson},
+              costAccumulatedUsd: totalCostUsd,
+              budgetMaxUsd: maxBudgetUsd,
+              budgetRemainingUsd: maxBudgetUsd !== null
+                ? maxBudgetUsd - totalCostUsd
+                : null,
+            }, null, 2),
+          }],
+        });
+
+      default:
+        return respondError(id, -32601, "Unknown tool: " + toolName);
+    }
+  }
+
+  if (method === "ping") {
+    return respond(id, {});
+  }
+
+  // Unknown method
+  if (id !== undefined) {
+    respondError(id, -32601, "Method not found: " + method);
+  }
+}
+
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  try {
+    const parsed = JSON.parse(line);
+    handleRequest(parsed);
+  } catch (err) {
+    process.stderr.write("[openclaw-bridge] parse error: " + err.message + "\\n");
+  }
+});
+
+process.on("SIGTERM", () => process.exit(0));
+process.on("SIGINT", () => process.exit(0));
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the MCP bridge server as a subprocess.
+ * Returns a handle with the MCP config for `--mcp-config` and a stop function.
+ */
+export async function startMcpBridge(options: ClaudeCodeSpawnOptions): Promise<McpBridgeHandle> {
+  const tmpDir = path.join(os.tmpdir(), "openclaw-mcp-bridge");
+  fs.mkdirSync(tmpDir, { recursive: true });
+
+  const bridgeId = `bridge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const scriptPath = path.join(tmpDir, `${bridgeId}.cjs`);
+  const announceQueuePath = path.join(tmpDir, `${bridgeId}-announce.ndjson`);
+
+  // Resolve workspace dir for memory search
+  const agentId = options.agentId ?? "default";
+  const workspaceDir = path.join(os.homedir(), ".openclaw", "agents", agentId);
+
+  const script = generateBridgeScript({
+    task: options.task,
+    agentId: options.agentId,
+    repo: options.repo,
+    maxBudgetUsd: options.maxBudgetUsd,
+    announceQueuePath,
+    workspaceDir,
+  });
+
+  fs.writeFileSync(scriptPath, script, "utf8");
+
+  const mcpConfig: Record<string, unknown> = {
+    type: "stdio",
+    command: process.execPath,
+    args: [scriptPath],
+  };
+
+  let stopped = false;
+
+  return {
+    mcpConfig,
+    announceQueuePath,
+
+    drainAnnouncements(): string[] {
+      try {
+        if (!fs.existsSync(announceQueuePath)) {
+          return [];
+        }
+        const content = fs.readFileSync(announceQueuePath, "utf8").trim();
+        if (!content) {
+          return [];
+        }
+        // Clear the file
+        fs.writeFileSync(announceQueuePath, "", "utf8");
+        // Parse NDJSON
+        const messages: string[] = [];
+        for (const line of content.split("\n")) {
+          if (!line.trim()) {
+            continue;
+          }
+          try {
+            const parsed = JSON.parse(line);
+            if (typeof parsed.message === "string") {
+              messages.push(parsed.message);
+            }
+          } catch {
+            // Skip malformed lines
+          }
+        }
+        return messages;
+      } catch {
+        return [];
+      }
+    },
+
+    async stop() {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      try {
+        fs.unlinkSync(scriptPath);
+      } catch {
+        // ignore
+      }
+      try {
+        fs.unlinkSync(announceQueuePath);
+      } catch {
+        // ignore
+      }
+    },
+  };
+}

--- a/src/agents/claude-code/project-status.ts
+++ b/src/agents/claude-code/project-status.ts
@@ -1,0 +1,221 @@
+/**
+ * Project status gathering for Claude Code session intelligence.
+ *
+ * Collects git state, GitHub PR/CI info, session data, and docs presence
+ * for a repository. Used both as pre-flight before spawning CC and as
+ * data source for the MCP bridge `openclaw_project_status` tool.
+ */
+
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import { discoverSessions } from "./sessions.js";
+import type { DiscoveredSession } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ProjectStatus = {
+  repo: { path: string; name: string; isGitRepo: boolean };
+  git: {
+    currentBranch: string;
+    headCommitSha: string;
+    headCommitMessage: string;
+    uncommittedChanges: string[];
+    stagedChanges: string[];
+    stashCount: number;
+    recentCommits: Array<{ sha: string; message: string; author: string; date: string }>;
+  };
+  github?: {
+    openPrs: Array<{ number: number; title: string; branch: string; state: string }>;
+    failingChecks: Array<{ name: string; status: string }>;
+  };
+  sessions: {
+    active: DiscoveredSession[];
+    recent: DiscoveredSession[];
+    ownRecent: DiscoveredSession[];
+  };
+  docs: {
+    hasClaudeMd: boolean;
+    hasSpecs: boolean;
+    specFiles: string[];
+    hasTodo: boolean;
+    hasReadme: boolean;
+  };
+  timestamp: string;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CMD_TIMEOUT_MS = 5_000;
+
+async function runGit(args: string[], cwd: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd,
+      timeout: CMD_TIMEOUT_MS,
+    });
+    return stdout.trim();
+  } catch {
+    return "";
+  }
+}
+
+async function runGh(args: string[], cwd: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("gh", args, {
+      cwd,
+      timeout: CMD_TIMEOUT_MS,
+    });
+    return stdout.trim();
+  } catch {
+    return "";
+  }
+}
+
+function parseSettled<T>(result: PromiseSettledResult<T>, fallback: T): T {
+  return result.status === "fulfilled" ? result.value : fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Gather a structured project status for a repository.
+ * Runs git commands in parallel with 5s timeout each.
+ * `gh` CLI commands are optional (gracefully fails if gh not installed).
+ */
+export async function gatherProjectStatus(
+  repoPath: string,
+  agentId?: string,
+): Promise<ProjectStatus> {
+  const resolved = path.resolve(repoPath);
+  const isGitRepo = fs.existsSync(path.join(resolved, ".git"));
+
+  // Parallel execution — all commands are independent
+  const [branch, headInfo, statusShort, stashList, recentLog, ghPrs, ghChecks, sessions] =
+    await Promise.allSettled([
+      runGit(["branch", "--show-current"], resolved),
+      runGit(["log", "-1", "--format=%h %s"], resolved),
+      runGit(["status", "--short"], resolved),
+      runGit(["stash", "list"], resolved),
+      runGit(["log", "--oneline", "-10", "--format=%h|%s|%an|%ar"], resolved),
+      runGh(["pr", "list", "--json", "number,title,headRefName,state", "--limit", "5"], resolved),
+      runGh(["pr", "checks", "--json", "name,state"], resolved),
+      discoverSessions(resolved),
+    ]);
+
+  // Parse git status lines
+  const statusLines = parseSettled(statusShort, "").split("\n").filter(Boolean);
+  const staged = statusLines.filter((l) => /^[MADRC]/.test(l));
+  const unstaged = statusLines.filter((l) => /^.[MADRC?]/.test(l));
+
+  // Parse recent commits
+  const commits = parseSettled(recentLog, "")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split("|");
+      return {
+        sha: parts[0] ?? "",
+        message: parts[1] ?? "",
+        author: parts[2] ?? "",
+        date: parts[3] ?? "",
+      };
+    });
+
+  // Parse GitHub data
+  let github: ProjectStatus["github"] | undefined;
+  const prsRaw = parseSettled(ghPrs, "");
+  const checksRaw = parseSettled(ghChecks, "");
+  if (prsRaw || checksRaw) {
+    let openPrs: Array<{ number: number; title: string; branch: string; state: string }> = [];
+    let failingChecks: Array<{ name: string; status: string }> = [];
+    try {
+      if (prsRaw) {
+        const parsed = JSON.parse(prsRaw) as Array<{
+          number: number;
+          title: string;
+          headRefName: string;
+          state: string;
+        }>;
+        openPrs = parsed.map((p) => ({
+          number: p.number,
+          title: p.title,
+          branch: p.headRefName,
+          state: p.state,
+        }));
+      }
+    } catch {
+      // ignore parse errors
+    }
+    try {
+      if (checksRaw) {
+        const parsed = JSON.parse(checksRaw) as Array<{ name: string; state: string }>;
+        failingChecks = parsed
+          .filter((c) => c.state === "FAILURE" || c.state === "failure")
+          .map((c) => ({ name: c.name, status: c.state }));
+      }
+    } catch {
+      // ignore parse errors
+    }
+    if (openPrs.length > 0 || failingChecks.length > 0) {
+      github = { openPrs, failingChecks };
+    }
+  }
+
+  // Parse sessions
+  const allSessions = parseSettled(sessions, [] as DiscoveredSession[]);
+  const active = allSessions.filter((s) => s.isRunning);
+  const recent = allSessions.slice(0, 5);
+  const ownRecent = agentId ? allSessions.filter((s) => s.agentId === agentId).slice(0, 3) : [];
+
+  // Check docs
+  const hasClaudeMd = fs.existsSync(path.join(resolved, "CLAUDE.md"));
+  const specsDir = path.join(resolved, ".specs");
+  const hasSpecs = fs.existsSync(specsDir);
+  let specFiles: string[] = [];
+  if (hasSpecs) {
+    try {
+      specFiles = fs.readdirSync(specsDir).filter((f) => f.endsWith(".md"));
+    } catch {
+      // ignore
+    }
+  }
+
+  // Parse head commit
+  const headRaw = parseSettled(headInfo, "");
+  const headParts = headRaw.split(" ");
+  const headSha = headParts[0] ?? "";
+  const headMessage = headParts.slice(1).join(" ");
+
+  return {
+    repo: { path: resolved, name: path.basename(resolved), isGitRepo },
+    git: {
+      currentBranch: parseSettled(branch, "unknown"),
+      headCommitSha: headSha,
+      headCommitMessage: headMessage,
+      uncommittedChanges: unstaged.map((l) => l.trim()),
+      stagedChanges: staged.map((l) => l.trim()),
+      stashCount: parseSettled(stashList, "").split("\n").filter(Boolean).length,
+      recentCommits: commits,
+    },
+    github,
+    sessions: { active, recent, ownRecent },
+    docs: {
+      hasClaudeMd,
+      hasSpecs,
+      specFiles,
+      hasTodo: fs.existsSync(path.join(resolved, "TODO.md")),
+      hasReadme: fs.existsSync(path.join(resolved, "README.md")),
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/src/agents/claude-code/protocol.ts
+++ b/src/agents/claude-code/protocol.ts
@@ -1,0 +1,273 @@
+/**
+ * Stream-JSON protocol types for Claude Code CLI (v2.1.41+).
+ *
+ * The CLI uses NDJSON (newline-delimited JSON) over stdin/stdout when invoked
+ * with `-p --output-format stream-json --input-format stream-json --verbose`.
+ *
+ * These types are derived from empirical analysis of the CLI source. The npm
+ * package does not export protocol types — only tool input schemas.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared
+// ---------------------------------------------------------------------------
+
+export type ClaudeCodeUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Messages FROM Claude Code (stdout)
+// ---------------------------------------------------------------------------
+
+/** System message — session init, status, hooks, task notifications. */
+export type CCSystemMessage =
+  | CCSystemInitMessage
+  | CCSystemStatusMessage
+  | CCSystemHookStartedMessage
+  | CCSystemHookProgressMessage
+  | CCSystemHookResponseMessage
+  | CCSystemTaskNotificationMessage;
+
+export type CCSystemInitMessage = {
+  type: "system";
+  subtype: "init";
+  cwd: string;
+  session_id: string;
+  tools: string[];
+  mcp_servers: unknown[];
+  model: string;
+  permissionMode?: string;
+  claude_code_version?: string;
+  agents?: string[];
+  skills?: string[];
+  plugins?: string[];
+  uuid: string;
+};
+
+export type CCSystemStatusMessage = {
+  type: "system";
+  subtype: "status";
+  status: string | null;
+  permissionMode?: string;
+  uuid: string;
+  session_id: string;
+};
+
+export type CCSystemHookStartedMessage = {
+  type: "system";
+  subtype: "hook_started";
+  hook_id: string;
+  hook_name: string;
+  hook_event: string;
+  uuid: string;
+  session_id: string;
+};
+
+export type CCSystemHookProgressMessage = {
+  type: "system";
+  subtype: "hook_progress";
+  hook_id: string;
+  hook_name: string;
+  hook_event: string;
+  output?: string;
+  uuid: string;
+  session_id: string;
+};
+
+export type CCSystemHookResponseMessage = {
+  type: "system";
+  subtype: "hook_response";
+  hook_id: string;
+  hook_name: string;
+  hook_event: string;
+  output?: string;
+  stdout?: string;
+  stderr?: string;
+  exit_code?: number;
+  outcome?: string;
+  uuid: string;
+  session_id: string;
+};
+
+export type CCSystemTaskNotificationMessage = {
+  type: "system";
+  subtype: "task_notification";
+  task_id: string;
+  status: "completed" | "failed" | "stopped";
+  output_file?: string;
+  summary?: string;
+  uuid: string;
+  session_id: string;
+};
+
+/** Assistant message — Claude's response with text and tool_use blocks. */
+export type CCAssistantMessage = {
+  type: "assistant";
+  message: {
+    model: string;
+    id: string;
+    type: "message";
+    role: "assistant";
+    content: CCContentBlock[];
+    stop_reason: "end_turn" | "tool_use" | null;
+    usage?: ClaudeCodeUsage;
+  };
+  session_id: string;
+  uuid: string;
+};
+
+export type CCContentBlock = CCTextBlock | CCToolUseBlock;
+
+export type CCTextBlock = {
+  type: "text";
+  text: string;
+};
+
+export type CCToolUseBlock = {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+};
+
+/** User message — tool results echoed back. */
+export type CCUserMessage = {
+  type: "user";
+  message: {
+    role: "user";
+    content: CCToolResultBlock[];
+  };
+  uuid: string;
+  session_id: string;
+};
+
+export type CCToolResultBlock = {
+  tool_use_id: string;
+  type: "tool_result";
+  content: string;
+};
+
+/** Result message — terminal, always the last message. */
+export type CCResultMessage = {
+  type: "result";
+  subtype: CCResultSubtype;
+  duration_ms?: number;
+  duration_api_ms?: number;
+  is_error: boolean;
+  num_turns?: number;
+  stop_reason?: string;
+  session_id: string;
+  total_cost_usd?: number;
+  usage?: ClaudeCodeUsage;
+  modelUsage?: Record<string, unknown>;
+  permission_denials?: string[];
+  uuid: string;
+  result?: string;
+  errors?: string[];
+};
+
+export type CCResultSubtype =
+  | "success"
+  | "error_during_execution"
+  | "error_max_turns"
+  | "error_max_budget_usd";
+
+/** Stream event — partial deltas for real-time display. */
+export type CCStreamEvent = {
+  type: "stream_event";
+  // Contains content_block_delta with text_delta fragments (high-frequency).
+  event?: { type?: string; [key: string]: unknown };
+  [key: string]: unknown;
+};
+
+/** Auth status — emitted when auth state changes. */
+export type CCAuthStatusMessage = {
+  type: "auth_status";
+  isAuthenticating: boolean;
+  output?: string;
+  error?: string | null;
+  uuid: string;
+  session_id: string;
+};
+
+/** Control response — response to a control_request we sent. */
+export type CCControlResponse = {
+  type: "control_response";
+  response: {
+    subtype: "success" | "error";
+    request_id: string;
+    response?: Record<string, unknown>;
+    error?: string;
+    pending_permission_requests?: unknown[];
+  };
+};
+
+/** Union of all outbound (stdout) message types. */
+export type CCOutboundMessage =
+  | CCSystemMessage
+  | CCAssistantMessage
+  | CCUserMessage
+  | CCResultMessage
+  | CCStreamEvent
+  | CCAuthStatusMessage
+  | CCControlResponse;
+
+// ---------------------------------------------------------------------------
+// Messages TO Claude Code (stdin)
+// ---------------------------------------------------------------------------
+
+/** User message — send a prompt or follow-up. */
+export type CCUserInput = {
+  type: "user";
+  message: {
+    role: "user";
+    content: string;
+  };
+  uuid: string;
+};
+
+/** Control request — change settings mid-session. */
+export type CCControlRequest = {
+  type: "control_request";
+  request: CCControlRequestPayload;
+  request_id: string;
+};
+
+export type CCControlRequestPayload =
+  | { subtype: "set_permission_mode"; permissionMode: string }
+  | { subtype: "set_model"; model: string }
+  | { subtype: "initialize" }
+  | { subtype: "mcp_status" };
+
+/** Keep-alive — prevent stdin EOF. */
+export type CCKeepAlive = {
+  type: "keep_alive";
+};
+
+/** Union of all inbound (stdin) message types. */
+export type CCInboundMessage = CCUserInput | CCControlRequest | CCKeepAlive;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Type guard for outbound messages. */
+export function parseOutboundMessage(raw: string): CCOutboundMessage | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed === "object" && parsed !== null && typeof parsed.type === "string") {
+      return parsed as CCOutboundMessage;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/agents/claude-code/runner.ts
+++ b/src/agents/claude-code/runner.ts
@@ -1,0 +1,1121 @@
+/**
+ * Claude Code streaming NDJSON runner.
+ *
+ * Spawns the Claude Code CLI as a child process with bidirectional stream-json
+ * I/O, parses the NDJSON protocol, and returns a structured result.
+ *
+ * Phase 2: bidirectional stream-json with progress relay and cost tracking.
+ */
+
+import { execSync, spawn } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveClaudeBinary } from "./binary.js";
+import { activeSpawns, queuedSpawns, liveSessions, type LiveSession } from "./live-state.js";
+import { startMcpBridge, type McpBridgeHandle } from "./mcp-bridge.js";
+import type { CCAssistantMessage } from "./protocol.js";
+import { parseOutboundMessage } from "./protocol.js";
+import { peekSessionHistory, resolveSession, saveSession, updateSessionStats } from "./sessions.js";
+import type {
+  ClaudeCodePermissionMode,
+  ClaudeCodeResult,
+  ClaudeCodeSpawnOptions,
+} from "./types.js";
+
+const log = createSubsystemLogger("agent/claude-code");
+
+// ---------------------------------------------------------------------------
+// NDJSON debug logger — writes all stdin/stdout messages to a per-spawn file
+// ---------------------------------------------------------------------------
+
+const NDJSON_LOG_DIR = path.join(
+  process.env.HOME ?? "/tmp",
+  ".openclaw",
+  "logs",
+  "claude-code-ndjson",
+);
+
+function createNdjsonLogger(repoPath: string): {
+  logStdin: (data: string) => void;
+  logStdout: (data: string) => void;
+  logStderr: (data: string) => void;
+  close: () => void;
+} {
+  try {
+    fs.mkdirSync(NDJSON_LOG_DIR, { recursive: true });
+  } catch {
+    // best-effort
+  }
+  const repoLabel = path.basename(repoPath);
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const filePath = path.join(NDJSON_LOG_DIR, `${repoLabel}_${ts}.ndjson`);
+  const stream = fs.createWriteStream(filePath, { flags: "a" });
+  log.info(`NDJSON debug log: ${filePath}`);
+
+  return {
+    logStdin(data: string) {
+      stream.write(`${JSON.stringify({ dir: "stdin", ts: Date.now(), data })}\n`);
+    },
+    logStdout(data: string) {
+      stream.write(`${JSON.stringify({ dir: "stdout", ts: Date.now(), data })}\n`);
+    },
+    logStderr(data: string) {
+      stream.write(`${JSON.stringify({ dir: "stderr", ts: Date.now(), data })}\n`);
+    },
+    close() {
+      stream.end();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Idle debounce — instead of specifically waiting for a `result` message
+// (which CC CLI sometimes fails to emit — see anthropics/claude-code#3187,
+// anthropics/claude-code#1920), we use
+// a simple inactivity timer. Every NDJSON message resets the timer. When no
+// messages arrive for IDLE_DEBOUNCE_MS, we assume the turn is done, kill the
+// process, and synthesize a result from whatever we've captured.
+//
+// The `result` message is still handled as the happy path (instant return),
+// but we no longer depend on it.
+// ---------------------------------------------------------------------------
+
+const IDLE_DEBOUNCE_MS = 30_000; // 30s of silence WHILE IDLE (not waiting for API)
+export const PERSISTENT_IDLE_MS = 30 * 60 * 1_000; // 30 minutes default for persistent sessions
+
+// ---------------------------------------------------------------------------
+// Process tree check
+// ---------------------------------------------------------------------------
+
+/** Check if a process has active child processes (tool execution signal). */
+function hasActiveChildren(pid: number | undefined): boolean {
+  if (!pid) {
+    return false;
+  }
+  try {
+    // pgrep --parent returns 0 if children exist, 1 if none
+    execSync(`pgrep --parent ${pid}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Arg builder
+// ---------------------------------------------------------------------------
+
+function buildArgs(options: ClaudeCodeSpawnOptions): string[] {
+  const args = [
+    "-p", // REQUIRED: non-interactive mode
+    "--output-format",
+    "stream-json", // NDJSON output
+    "--input-format",
+    "stream-json", // NDJSON input
+    "--verbose", // REQUIRED for stream-json output
+    "--setting-sources",
+    "user,project,local",
+    "--include-partial-messages",
+  ];
+
+  // Permission handling
+  const mode: ClaudeCodePermissionMode = options.permissionMode ?? "bypassPermissions";
+  if (mode === "bypassPermissions") {
+    args.push("--dangerously-skip-permissions");
+  } else if (mode === "default" || mode === "delegate") {
+    // Phase 4: permission relay via stdio
+    args.push("--permission-prompt-tool", "stdio");
+  } else {
+    args.push("--permission-mode", mode);
+  }
+
+  if (options.model) {
+    args.push("--model", options.model);
+  }
+  if (options.resume) {
+    args.push("--resume", options.resume);
+  } else if (options.continueSession) {
+    args.push("--continue");
+  }
+  if (options.sessionId) {
+    args.push("--session-id", options.sessionId);
+  }
+  if (options.maxBudgetUsd != null) {
+    args.push("--max-budget-usd", String(options.maxBudgetUsd));
+  }
+
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// Progress relay — assembles periodic progress summaries
+// ---------------------------------------------------------------------------
+
+type ProgressState = {
+  lastRelayAt: number;
+  intervalMs: number;
+  enabled: boolean;
+  includeToolUse: boolean;
+  lastToolName: string | undefined;
+  lastActivityText: string;
+  accumulatedCostUsd: number;
+  accumulatedTurns: number;
+  timer: ReturnType<typeof setInterval> | null;
+};
+
+function createProgressState(options: ClaudeCodeSpawnOptions): ProgressState {
+  const relay = options.progressRelay;
+  const intervalSeconds = relay?.intervalSeconds ?? 30;
+  return {
+    lastRelayAt: Date.now(),
+    intervalMs: intervalSeconds * 1_000,
+    enabled: relay?.enabled !== false,
+    includeToolUse: relay?.includeToolUse !== false,
+    lastToolName: undefined,
+    lastActivityText: "",
+    accumulatedCostUsd: 0,
+    accumulatedTurns: 0,
+    timer: null,
+  };
+}
+
+function buildProgressSummary(
+  progress: ProgressState,
+  repoPath: string,
+  startedAt: number,
+): string {
+  const elapsedSec = Math.round((Date.now() - startedAt) / 1_000);
+  const elapsed = formatDuration(elapsedSec);
+  const cost =
+    progress.accumulatedCostUsd > 0 ? `, $${progress.accumulatedCostUsd.toFixed(2)}` : "";
+  const turns = progress.accumulatedTurns > 0 ? `, ${progress.accumulatedTurns} turns` : "";
+  const repoLabel = path.basename(repoPath);
+  const lastAction =
+    progress.includeToolUse && progress.lastToolName
+      ? `\n   Last action: ${progress.lastToolName}`
+      : "";
+  return `[${repoLabel}] Claude Code working... (${elapsed}${cost}${turns})${lastAction}`;
+}
+
+function formatDuration(totalSeconds: number): string {
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds}s`;
+}
+
+// ---------------------------------------------------------------------------
+// Core spawn function
+// ---------------------------------------------------------------------------
+
+async function executeSpawn(options: ClaudeCodeSpawnOptions): Promise<ClaudeCodeResult> {
+  // 1. Validate repo path
+  const repoPath = path.resolve(options.repo);
+  if (!fs.existsSync(path.join(repoPath, ".git"))) {
+    throw new Error(`Not a git repository: ${repoPath}`);
+  }
+
+  // 2. Resolve binary
+  const binaryPath = resolveClaudeBinary(options.binaryPath);
+
+  // 3. Resolve session for resume — only when explicitly requested
+  const agentId = options.agentId ?? "default";
+  const sessionToResume = options.resume;
+  if (sessionToResume) {
+    options = { ...options, resume: sessionToResume };
+  }
+
+  // 3b. Peek at previous session history for context when resuming/continuing
+  let sessionContext = "";
+  if (sessionToResume || options.continueSession) {
+    const peekSessionId = sessionToResume ?? resolveSession(agentId, repoPath, options.label);
+    if (peekSessionId) {
+      sessionContext = peekSessionHistory(repoPath, peekSessionId, {
+        maxMessages: 8,
+        maxChars: 4000,
+      });
+      if (sessionContext) {
+        log.info(`peeked session ${peekSessionId}: ${sessionContext.length} chars of context`);
+      }
+    }
+  }
+
+  // 4. Build args
+  const args = buildArgs(options);
+
+  // 5. Start MCP bridge server (if enabled)
+  let bridge: McpBridgeHandle | null = null;
+  if (options.mcpBridge?.enabled !== false) {
+    try {
+      bridge = await startMcpBridge(options);
+      args.push(
+        "--mcp-config",
+        JSON.stringify({
+          mcpServers: {
+            "openclaw-bridge": bridge.mcpConfig,
+          },
+        }),
+      );
+    } catch (err) {
+      log.warn(`MCP bridge failed to start: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // 6. Spawn child process
+  const env: Record<string, string | undefined> = { ...process.env };
+  delete env.CLAUDECODE; // CRITICAL: prevents nested session detection
+  delete env.ANTHROPIC_API_KEY;
+
+  log.info(
+    `spawning claude-code: repo=${repoPath} ${options.continueSession ? "continue=true" : `resume=${sessionToResume ?? "none"}`} model=${options.model ?? "default"}`,
+  );
+  log.info(`claude-code args: ${JSON.stringify(args)}`);
+  log.info(`claude-code binary: ${binaryPath}`);
+
+  const child = spawn(binaryPath, args, {
+    cwd: repoPath,
+    stdio: ["pipe", "pipe", "pipe"],
+    env: env as NodeJS.ProcessEnv,
+  });
+
+  child.on("error", (err) => {
+    log.error(`claude-code spawn error: ${err.message}`);
+  });
+
+  child.on("exit", (code, signal) => {
+    log.info(`claude-code process exited: code=${code} signal=${signal}`);
+  });
+
+  activeSpawns.set(repoPath, child);
+
+  const startedAt = Date.now();
+  const ndjsonLog = createNdjsonLogger(repoPath);
+
+  // 7. Send initial task on stdin — keep stdin OPEN for multi-turn
+  // When resuming, prepend previous session context so CC knows what happened
+  let taskContent = options.task;
+  if (sessionContext) {
+    taskContent = [
+      "<previous_session_context>",
+      sessionContext,
+      "</previous_session_context>",
+      "",
+      taskContent,
+    ].join("\n");
+  }
+  const initMessage = JSON.stringify({
+    type: "user",
+    message: { role: "user", content: taskContent },
+    uuid: crypto.randomUUID(),
+  });
+  child.stdin.write(initMessage + "\n");
+  ndjsonLog.logStdin(initMessage);
+  log.info(`claude-code stdin message sent (stdin kept open), pid=${child.pid}`);
+
+  // 8. Set up timeout
+  const timeoutSeconds = options.timeoutSeconds ?? 600;
+  const timeoutMs = timeoutSeconds * 1_000;
+  let timedOut = false;
+  const timeoutHandler = () => {
+    // Last-chance: check if CC has active child processes
+    if (hasActiveChildren(child.pid)) {
+      log.info(
+        `spawn timeout: ${timeoutSeconds}s elapsed but CC has active children — extending by 5m`,
+      );
+      timeout = setTimeout(timeoutHandler, 5 * 60 * 1_000);
+      return;
+    }
+    timedOut = true;
+    log.warn(`claude-code timeout after ${timeoutSeconds}s, sending SIGTERM`);
+    child.kill("SIGTERM");
+    setTimeout(() => {
+      if (!child.killed) {
+        child.kill("SIGKILL");
+      }
+    }, 5_000);
+  };
+  // Persistent mode relies on the 30-min idle timeout instead
+  let timeout: ReturnType<typeof setTimeout> | null = options.persistent
+    ? null
+    : setTimeout(timeoutHandler, timeoutMs);
+
+  // 9. Collect stderr + handle spawn errors
+  let stderrBuf = "";
+  child.stderr?.on("data", (d: Buffer) => {
+    const chunk = d.toString();
+    stderrBuf += chunk;
+    ndjsonLog.logStderr(chunk);
+    if (chunk.trim()) {
+      log.warn(`CC stderr: ${chunk.trim()}`);
+    }
+  });
+  child.on("error", (err) => {
+    log.error(`CC spawn error: ${err.message}`);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    liveSessions.delete(repoPath);
+    activeSpawns.delete(repoPath);
+    ndjsonLog.close();
+  });
+
+  // 10. Set up progress relay
+  const progress = createProgressState(options);
+
+  // Register live session
+  const persistent = options.persistent === true;
+  const liveSession: LiveSession = {
+    child,
+    sessionId: undefined,
+    repoPath,
+    startedAt,
+    accumulatedCostUsd: 0,
+    accumulatedTurns: 0,
+    lastToolName: undefined,
+    lastActivityText: "",
+    results: [],
+    persistent,
+    pendingFollowUp: null,
+    persistentIdleTimer: null,
+  };
+  liveSessions.set(repoPath, liveSession);
+
+  // Start periodic progress relay + announce drain
+  if (progress.enabled && options.onProgress) {
+    progress.timer = setInterval(() => {
+      // Relay progress summary
+      const summary = buildProgressSummary(progress, repoPath, startedAt);
+      options.onProgress?.({ kind: "progress_summary", summary });
+
+      // Drain bridge announcements (from openclaw_announce MCP tool)
+      if (bridge) {
+        const announcements = bridge.drainAnnouncements();
+        for (const msg of announcements) {
+          options.onProgress?.({ kind: "text", text: msg });
+        }
+      }
+    }, progress.intervalMs);
+  }
+
+  // 11. Parse NDJSON stream
+  let result: ClaudeCodeResult | null = null;
+  let capturedSessionId: string | undefined;
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  let idleFired = false;
+  // Track whether CC is waiting for an API response (between message_stop/user and
+  // message_start). During this window, silence is expected — don't idle-kill.
+  let waitingForApiResponse = false;
+  // Track whether CC is executing a tool locally (between stop_reason="tool_use" on
+  // assistant/message_delta and the next `user` tool_result). Silence is expected.
+  let executingTool = false;
+
+  // Persistent mode: promise plumbing for the first result
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- assigned synchronously inside Promise constructor
+  let resolveFirstResult: ((r: ClaudeCodeResult) => void) | undefined;
+  let rejectFirstResult: ((e: Error) => void) | undefined;
+  let firstResultResolved = false;
+  const firstResultPromise = persistent
+    ? new Promise<ClaudeCodeResult>((resolve, reject) => {
+        resolveFirstResult = resolve;
+        rejectFirstResult = reject;
+      })
+    : null;
+
+  /** Reset the long persistent idle timer (30 min). */
+  const resetPersistentIdleTimer = () => {
+    if (liveSession.persistentIdleTimer) {
+      clearTimeout(liveSession.persistentIdleTimer);
+    }
+    liveSession.persistentIdleTimer = setTimeout(() => {
+      log.warn(`persistent session idle for ${PERSISTENT_IDLE_MS}ms — killing process`);
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!child.killed) {
+          child.kill("SIGKILL");
+        }
+      }, 5_000);
+    }, PERSISTENT_IDLE_MS);
+  };
+
+  const resetIdleTimer = () => {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+    // Persistent sessions don't get killed by the short idle debounce
+    if (persistent) {
+      return;
+    }
+    // Don't start idle timer while CC is waiting for an API response or
+    // executing a tool — silence is expected during those windows.
+    if (waitingForApiResponse || executingTool) {
+      return;
+    }
+    idleTimer = setTimeout(() => {
+      // Last-chance check: does CC have active child processes?
+      if (hasActiveChildren(child.pid)) {
+        log.info(
+          `idle debounce: ${IDLE_DEBOUNCE_MS}ms silence but CC has active children — extending`,
+        );
+        idleTimer = null;
+        resetIdleTimer(); // will re-check flags and children next time
+        return;
+      }
+      idleFired = true;
+      log.warn(
+        `idle debounce: no messages for ${IDLE_DEBOUNCE_MS}ms — assuming turn complete. ` +
+          `Sending SIGTERM (workaround for CC CLI bug anthropics/claude-code#3187 / #1920).`,
+      );
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!child.killed) {
+          child.kill("SIGKILL");
+        }
+      }, 5_000);
+    }, IDLE_DEBOUNCE_MS);
+  };
+
+  const clearIdleTimer = () => {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+  };
+
+  const rl = readline.createInterface({ input: child.stdout });
+  let gotResult = false;
+
+  for await (const line of rl) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    ndjsonLog.logStdout(line);
+
+    const msg = parseOutboundMessage(line);
+    if (!msg) {
+      log.debug(`non-JSON on stdout: ${line.slice(0, 200)}`);
+      continue;
+    }
+
+    // Every valid message resets the idle debounce
+    resetIdleTimer();
+
+    switch (msg.type) {
+      case "system": {
+        if (msg.subtype === "init") {
+          capturedSessionId = msg.session_id;
+          liveSession.sessionId = msg.session_id;
+          log.info(`claude-code session init: sessionId=${msg.session_id} model=${msg.model}`);
+          options.onProgress?.({
+            kind: "status",
+            permissionMode: msg.permissionMode,
+            sessionId: msg.session_id,
+          });
+        } else if (msg.subtype === "status") {
+          capturedSessionId = capturedSessionId ?? msg.session_id;
+          options.onProgress?.({
+            kind: "status",
+            permissionMode: msg.permissionMode,
+            sessionId: msg.session_id,
+          });
+        } else if (msg.subtype === "hook_started") {
+          log.debug(`hook started: ${msg.hook_name}`);
+        } else if (msg.subtype === "hook_response") {
+          if (msg.exit_code != null && msg.exit_code !== 0) {
+            options.onProgress?.({
+              kind: "hook_failed",
+              hookName: msg.hook_name,
+              exitCode: msg.exit_code,
+              output: msg.stderr || msg.output || "",
+            });
+          }
+        } else if (msg.subtype === "task_notification") {
+          options.onProgress?.({
+            kind: "task_notification",
+            taskId: msg.task_id,
+            status: msg.status,
+            summary: msg.summary,
+          });
+        }
+        break;
+      }
+
+      case "assistant": {
+        capturedSessionId = capturedSessionId ?? msg.session_id;
+        // Track cost from assistant message usage
+        if (msg.message.usage) {
+          // Rough cost estimate: input_tokens * $3/MTok + output_tokens * $15/MTok (Opus pricing)
+          // The actual cost comes from the result message; this is for progress display.
+        }
+        progress.accumulatedTurns += 1;
+        liveSession.accumulatedTurns = progress.accumulatedTurns;
+        // Track tool execution state from stop_reason
+        if (msg.message.stop_reason === "tool_use") {
+          executingTool = true;
+        }
+        // Reset spawn timeout — proof of real activity
+        if (timeout) {
+          if (timeout) {
+            clearTimeout(timeout);
+          }
+          timeout = setTimeout(timeoutHandler, timeoutMs);
+        }
+        handleAssistantMessage(msg, options, progress, liveSession);
+        break;
+      }
+
+      case "user": {
+        // Tool results echoed back — CC finished executing tool, will make another API call.
+        executingTool = false;
+        waitingForApiResponse = true;
+        break;
+      }
+
+      case "stream_event": {
+        // Track API response state for idle timer
+        if (msg.event?.type === "message_start") {
+          // API response started streaming — no longer waiting
+          waitingForApiResponse = false;
+          executingTool = false;
+        } else if (msg.event?.type === "message_stop") {
+          // API response complete — CC will now execute tools or finish.
+          waitingForApiResponse = false;
+        } else if (msg.event?.type === "message_delta") {
+          // message_delta arrives before assistant message — has early stop_reason
+          const delta = (msg.event as Record<string, unknown>).delta as
+            | Record<string, unknown>
+            | undefined;
+          if (delta?.stop_reason === "tool_use") {
+            executingTool = true;
+          }
+        }
+        // Partial deltas — extract text for progress display
+        handleStreamEvent(msg, progress, liveSession);
+        break;
+      }
+
+      case "auth_status": {
+        if (msg.error) {
+          child.kill("SIGTERM");
+          throw new Error(
+            "Claude Code authentication failed. " +
+              "Run `claude` in a terminal to re-authenticate.",
+          );
+        }
+        break;
+      }
+
+      case "control_response": {
+        log.info(`control response: ${msg.response.subtype} for ${msg.response.request_id}`);
+        break;
+      }
+
+      case "result": {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        clearIdleTimer();
+        waitingForApiResponse = false;
+        const resultObj: ClaudeCodeResult = {
+          success: msg.subtype === "success",
+          sessionId: msg.session_id,
+          result: msg.result ?? "",
+          totalCostUsd: msg.total_cost_usd ?? 0,
+          durationMs: msg.duration_ms ?? 0,
+          durationApiMs: msg.duration_api_ms ?? 0,
+          numTurns: msg.num_turns ?? 0,
+          usage: msg.usage ?? { input_tokens: 0, output_tokens: 0 },
+          permissionDenials: msg.permission_denials ?? [],
+          errors: msg.errors ?? [],
+        };
+        // Update accumulated cost from the definitive result
+        progress.accumulatedCostUsd = resultObj.totalCostUsd;
+        liveSession.accumulatedCostUsd = resultObj.totalCostUsd;
+
+        if (persistent) {
+          // Push to results array
+          liveSession.results.push(resultObj);
+          // Resolve any pending follow-up promise
+          if (liveSession.pendingFollowUp) {
+            liveSession.pendingFollowUp.resolve(resultObj);
+            liveSession.pendingFollowUp = null;
+          }
+          // Notify via progress callback
+          options.onProgress?.({ kind: "result", result: resultObj });
+          // First result? Resolve the initial spawn promise
+          if (!firstResultResolved) {
+            firstResultResolved = true;
+            resolveFirstResult?.(resultObj);
+          }
+          // Reset idle timer for persistent keepalive
+          resetPersistentIdleTimer();
+          // DON'T break out of for-await — keep listening
+        } else {
+          // Existing one-shot behavior
+          result = resultObj;
+          gotResult = true;
+        }
+        break;
+      }
+
+      default: {
+        log.debug(`unknown CC message type: ${(msg as { type: string }).type}`);
+        break;
+      }
+    }
+
+    // Break out of the for-await loop once we have a result.
+    // Without this, readline keeps waiting for more stdout lines
+    // (the process may linger), and the progress timer keeps firing.
+    if (gotResult) {
+      rl.close();
+      break;
+    }
+  }
+
+  // 12. Cleanup — persistent sessions handle cleanup differently
+  const cleanupOneShot = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    clearIdleTimer();
+    ndjsonLog.close();
+    if (progress.timer) {
+      clearInterval(progress.timer);
+    }
+    liveSessions.delete(repoPath);
+  };
+
+  if (persistent) {
+    // For persistent mode, the for-await loop only exits when the process
+    // dies (stdin closed by remote, SIGTERM, etc.). When that happens, clean up.
+    // But first: return the first result to the caller while the loop is still running.
+
+    // Set up background cleanup when the process eventually exits.
+    const cleanupPersistent = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      clearIdleTimer();
+      if (liveSession.persistentIdleTimer) {
+        clearTimeout(liveSession.persistentIdleTimer);
+      }
+      ndjsonLog.close();
+      if (progress.timer) {
+        clearInterval(progress.timer);
+      }
+      liveSessions.delete(repoPath);
+      activeSpawns.delete(repoPath);
+      if (bridge) {
+        bridge.stop().catch(() => {});
+      }
+      // Reject any pending follow-up
+      if (liveSession.pendingFollowUp) {
+        liveSession.pendingFollowUp.reject(new Error("Persistent session ended"));
+        liveSession.pendingFollowUp = null;
+      }
+      // Reject first result if never received
+      if (!firstResultResolved) {
+        firstResultResolved = true;
+        const stderr = stderrBuf.trim();
+        rejectFirstResult?.(
+          new Error(
+            `Claude Code process exited without a result message.${stderr ? ` stderr: ${stderr}` : ""}`,
+          ),
+        );
+      }
+      drainQueue(repoPath);
+    };
+
+    child.on("close", cleanupPersistent);
+
+    // Return the first result — the readline loop continues in the background
+    return firstResultPromise!;
+  }
+
+  // --- One-shot cleanup path (unchanged) ---
+  cleanupOneShot();
+
+  // Kill the process if it's still running (e.g. after receiving result or idle debounce)
+  if (!child.killed && child.exitCode === null) {
+    child.kill("SIGTERM");
+    setTimeout(() => {
+      if (!child.killed) {
+        child.kill("SIGKILL");
+      }
+    }, 5_000);
+  }
+
+  if (bridge) {
+    try {
+      await bridge.stop();
+    } catch {
+      // ignore
+    }
+  }
+  activeSpawns.delete(repoPath);
+
+  await new Promise<void>((resolve) => {
+    if (child.exitCode !== null) {
+      resolve();
+    } else {
+      child.on("close", () => resolve());
+    }
+  });
+
+  // 13. Handle missing result
+  if (!result) {
+    if (idleFired || progress.accumulatedTurns > 0) {
+      // Either idle debounce fired, or CC did some work but exited without a result.
+      // Synthesize a success result from what we captured.
+      const durationMs = Date.now() - startedAt;
+      const reason = idleFired
+        ? `idle debounce (${IDLE_DEBOUNCE_MS}ms silence)`
+        : "process exited without result message";
+      log.warn(`synthesizing result: ${reason}`);
+      return {
+        success: true,
+        sessionId: capturedSessionId ?? "",
+        result: progress.lastActivityText || "(completed — result message missing from CC CLI)",
+        totalCostUsd: progress.accumulatedCostUsd,
+        durationMs,
+        durationApiMs: 0,
+        numTurns: progress.accumulatedTurns,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        permissionDenials: [],
+        errors: [`CC CLI did not emit result message. Synthesized via ${reason}.`],
+      };
+    }
+
+    if (timedOut) {
+      return {
+        success: false,
+        sessionId: capturedSessionId ?? "",
+        result: "",
+        totalCostUsd: 0,
+        durationMs: timeoutSeconds * 1_000,
+        durationApiMs: 0,
+        numTurns: 0,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        permissionDenials: [],
+        errors: [`Timed out after ${timeoutSeconds}s`],
+      };
+    }
+
+    const stderr = stderrBuf.trim();
+    throw new Error(
+      `Claude Code process exited without a result message.${stderr ? ` stderr: ${stderr}` : ""}`,
+    );
+  }
+
+  // 14. Persist session
+  const sessionId = result.sessionId || capturedSessionId || "";
+  if (sessionId) {
+    saveSession(agentId, repoPath, sessionId, {
+      task: options.task,
+      costUsd: result.totalCostUsd,
+      label: options.label,
+    });
+    updateSessionStats(
+      agentId,
+      repoPath,
+      { turns: result.numTurns, costUsd: result.totalCostUsd },
+      options.label,
+    );
+  }
+
+  // Drain queued spawn for this repo
+  drainQueue(repoPath);
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Assistant message handler
+// ---------------------------------------------------------------------------
+
+function handleAssistantMessage(
+  msg: CCAssistantMessage,
+  options: ClaudeCodeSpawnOptions,
+  progress: ProgressState,
+  liveSession: LiveSession,
+): void {
+  for (const block of msg.message.content) {
+    if (block.type === "text" && block.text.trim()) {
+      progress.lastActivityText = block.text.slice(0, 200);
+      liveSession.lastActivityText = progress.lastActivityText;
+      options.onProgress?.({ kind: "text", text: block.text });
+    }
+    if (block.type === "tool_use") {
+      const toolBlock = block;
+      progress.lastToolName = toolBlock.name;
+      liveSession.lastToolName = toolBlock.name;
+
+      // Phase 4: detect permission prompt tool_use and relay
+      if (toolBlock.name === "permission_prompt" || toolBlock.name === "__permission_prompt") {
+        const input = toolBlock.input;
+        const toolName = typeof input.tool_name === "string" ? input.tool_name : toolBlock.name;
+        const description =
+          typeof input.description === "string"
+            ? input.description
+            : typeof input.command === "string"
+              ? `Run: ${String(input.command)}`
+              : `Tool: ${toolName}`;
+        options.onProgress?.({
+          kind: "permission_request",
+          toolName,
+          description,
+          requestId: toolBlock.id,
+        });
+        options.onPermissionRequest?.({
+          toolName,
+          description,
+          requestId: toolBlock.id,
+        });
+      } else {
+        options.onProgress?.({
+          kind: "tool_use",
+          toolName: toolBlock.name,
+          input: toolBlock.input,
+        });
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stream event handler — extract partial text for progress
+// ---------------------------------------------------------------------------
+
+function handleStreamEvent(
+  msg: Record<string, unknown>,
+  progress: ProgressState,
+  liveSession: LiveSession,
+): void {
+  // stream_event messages contain content_block_delta with text fragments.
+  // We extract the text for the "last activity" progress display.
+  try {
+    const blockDelta = msg.content_block_delta as Record<string, unknown> | undefined;
+    const delta = blockDelta?.delta as Record<string, unknown> | undefined;
+    if (delta?.type === "text_delta" && typeof delta.text === "string") {
+      const text = delta.text.trim();
+      if (text) {
+        progress.lastActivityText = text.slice(0, 200);
+        liveSession.lastActivityText = progress.lastActivityText;
+      }
+    }
+  } catch {
+    // Non-critical — ignore parse failures on stream events.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Queue management
+// ---------------------------------------------------------------------------
+
+function drainQueue(repoPath: string): void {
+  const queued = queuedSpawns.get(repoPath);
+  if (!queued) {
+    return;
+  }
+  queuedSpawns.delete(repoPath);
+
+  executeSpawn(queued.options).then(queued.resolve, queued.reject);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn a Claude Code CLI session.
+ *
+ * Enforces per-repo concurrency: max 1 running + 1 queued. The 3rd request is rejected.
+ */
+export async function spawnClaudeCode(options: ClaudeCodeSpawnOptions): Promise<ClaudeCodeResult> {
+  const repoPath = path.resolve(options.repo);
+
+  // Check active spawns
+  if (activeSpawns.has(repoPath)) {
+    // One is already running — check if we can queue
+    if (queuedSpawns.has(repoPath)) {
+      throw new Error(
+        `Claude Code is already running and queued for ${repoPath}. ` +
+          "Wait for the current run to finish.",
+      );
+    }
+
+    log.info(`claude-code already running for ${repoPath}, queuing request`);
+    return new Promise<ClaudeCodeResult>((resolve, reject) => {
+      queuedSpawns.set(repoPath, { resolve, reject, options });
+    });
+  }
+
+  return executeSpawn(options);
+}
+
+/**
+ * Send a follow-up message to a persistent Claude Code session and wait for the result.
+ * Returns a promise that resolves when the next `result` message arrives.
+ */
+export function sendFollowUpAndWait(
+  repoPath: string,
+  message: string,
+  timeoutMs?: number,
+): Promise<ClaudeCodeResult> {
+  const resolved = path.resolve(repoPath);
+  const session = liveSessions.get(resolved);
+  if (!session || !session.persistent) {
+    return Promise.reject(new Error(`No persistent session for ${resolved}`));
+  }
+  if (!session.child.stdin?.writable) {
+    return Promise.reject(new Error(`Session stdin not writable for ${resolved}`));
+  }
+  if (session.pendingFollowUp) {
+    return Promise.reject(new Error("A follow-up is already pending"));
+  }
+
+  const promise = new Promise<ClaudeCodeResult>((resolve, reject) => {
+    session.pendingFollowUp = { resolve, reject };
+
+    // Optional timeout
+    if (timeoutMs != null && timeoutMs > 0) {
+      const timer = setTimeout(() => {
+        if (session.pendingFollowUp?.reject === reject) {
+          session.pendingFollowUp = null;
+          reject(new Error(`Follow-up timed out after ${timeoutMs}ms`));
+        }
+      }, timeoutMs);
+      // Clear timeout when resolved
+      const origResolve = resolve;
+      const origReject = reject;
+      session.pendingFollowUp = {
+        resolve: (r) => {
+          clearTimeout(timer);
+          origResolve(r);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          origReject(e);
+        },
+      };
+    }
+  });
+
+  // Send the follow-up message
+  const followUp = JSON.stringify({
+    type: "user",
+    message: { role: "user", content: message },
+    uuid: crypto.randomUUID(),
+  });
+  session.child.stdin.write(followUp + "\n");
+  log.info(`follow-up (with wait) sent to persistent session on ${resolved}`);
+
+  return promise;
+}
+
+/**
+ * Stop a persistent Claude Code session. Sends SIGTERM, cleans up state.
+ */
+export function stopPersistentSession(repoPath: string): boolean {
+  const resolved = path.resolve(repoPath);
+  const session = liveSessions.get(resolved);
+  if (!session) {
+    return false;
+  }
+  if (session.persistentIdleTimer) {
+    clearTimeout(session.persistentIdleTimer);
+    session.persistentIdleTimer = null;
+  }
+  // Reject any pending follow-up
+  if (session.pendingFollowUp) {
+    session.pendingFollowUp.reject(new Error("Persistent session stopped"));
+    session.pendingFollowUp = null;
+  }
+  // SIGTERM the process — the child 'close' handler in executeSpawn will clean up
+  // liveSessions and activeSpawns.
+  if (!session.child.killed && session.child.exitCode === null) {
+    session.child.kill("SIGTERM");
+    setTimeout(() => {
+      if (!session.child.killed) {
+        session.child.kill("SIGKILL");
+      }
+    }, 5_000);
+  }
+  return true;
+}
+
+/**
+ * Send a follow-up message to a running Claude Code session.
+ * Returns true if the message was sent, false if no active session.
+ */
+export function sendFollowUp(repoPath: string, message: string): boolean {
+  const resolved = path.resolve(repoPath);
+  const session = liveSessions.get(resolved);
+  if (!session || !session.child.stdin?.writable) {
+    return false;
+  }
+
+  const followUp = JSON.stringify({
+    type: "user",
+    message: { role: "user", content: message },
+    uuid: crypto.randomUUID(),
+  });
+  session.child.stdin.write(followUp + "\n");
+  log.info(`follow-up message sent to session on ${resolved}`);
+  // Note: follow-up NDJSON logging not available here (logger is scoped to executeSpawn)
+  return true;
+}
+
+/**
+ * Respond to a permission request from a running Claude Code session.
+ * Used by the permission relay (Phase 4) to send allow/deny responses.
+ *
+ * @param repoPath - Repo path of the running session
+ * @param requestId - The tool_use ID from the permission_prompt block
+ * @param allow - Whether to allow the action
+ * @returns true if the response was sent
+ */
+export function respondToPermission(repoPath: string, requestId: string, allow: boolean): boolean {
+  const resolved = path.resolve(repoPath);
+  const session = liveSessions.get(resolved);
+  if (!session || !session.child.stdin?.writable) {
+    return false;
+  }
+
+  // Permission responses are sent as tool_result messages on stdin
+  const response = JSON.stringify({
+    type: "user",
+    message: {
+      role: "user",
+      content: [
+        {
+          tool_use_id: requestId,
+          type: "tool_result",
+          content: JSON.stringify({
+            approved: allow,
+            // When denied, CC will log the denial
+          }),
+        },
+      ],
+    },
+    uuid: crypto.randomUUID(),
+  });
+  session.child.stdin.write(response + "\n");
+  log.info(`permission response sent: requestId=${requestId} allow=${allow}`);
+  return true;
+}
+
+// Query/kill functions re-exported from live-state for barrel compatibility.
+export {
+  killClaudeCode,
+  isClaudeCodeRunning,
+  getLiveSession,
+  getAllLiveSessions,
+} from "./live-state.js";

--- a/src/agents/claude-code/runner.ts
+++ b/src/agents/claude-code/runner.ts
@@ -309,15 +309,19 @@ async function executeSpawn(options: ClaudeCodeSpawnOptions): Promise<ClaudeCode
 
   // 7b. Send initial task on stdin — keep stdin OPEN for multi-turn
   // CC processes stdin in order: initialize will be handled before this message.
+  // Prepend source attribution marker so JSONL scanners can identify OpenClaw sessions
+  const marker = `[openclaw:agent=${agentId}]`;
   // When resuming, prepend previous session context so CC knows what happened
-  let taskContent = options.task;
+  let taskContent = `${marker}\n\n${options.task}`;
   if (sessionContext) {
     taskContent = [
+      marker,
+      "",
       "<previous_session_context>",
       sessionContext,
       "</previous_session_context>",
       "",
-      taskContent,
+      options.task,
     ].join("\n");
   }
   const initMessage = JSON.stringify({

--- a/src/agents/claude-code/session-selection.ts
+++ b/src/agents/claude-code/session-selection.ts
@@ -1,0 +1,515 @@
+/**
+ * Intelligent session selection for Claude Code spawns.
+ *
+ * Replaces naive `resolveSession()` registry lookup with a 5-factor scoring
+ * model that considers branch match, recency, task relevance (LLM-scored),
+ * session health, and context capacity.
+ */
+
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { ProjectStatus } from "./project-status.js";
+import { resolveSession } from "./sessions.js";
+import type { DiscoveredSession, SessionSelectionConfig } from "./types.js";
+
+const log = createSubsystemLogger("agent/claude-code/session-selection");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_SESSION_SELECTION_CONFIG: SessionSelectionConfig = {
+  relevanceModel: "claude-haiku",
+  relevanceMaxTokens: 500,
+  relevanceTimeoutMs: 3000,
+  resumeThreshold: 0.6,
+  enabled: true,
+};
+
+const HARD_CEILING_COMPACTIONS = 3;
+const HARD_CEILING_BUDGET_PCT = 0.7;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TaskRelevanceResult = {
+  sessionId: string;
+  relevance: number;
+  reasoning: string;
+};
+
+export type ScoreFactors = {
+  branchMatch: number;
+  recency: number;
+  taskRelevance: number;
+  sessionHealth: number;
+  contextCapacity: number;
+};
+
+export type SessionScore = {
+  sessionId: string;
+  score: number;
+  factors: ScoreFactors;
+  recommendation: "resume" | "fresh";
+  reason: string;
+};
+
+export type SessionSelection = {
+  action: "resume" | "fresh" | "queue";
+  sessionId?: string;
+  reason: string;
+  scores?: SessionScore[];
+};
+
+// ---------------------------------------------------------------------------
+// LLM-based task relevance
+// ---------------------------------------------------------------------------
+
+/** Map friendly model names to actual API model IDs. */
+function resolveModelId(model: string): string {
+  const aliases: Record<string, string> = {
+    "claude-haiku": "claude-haiku-4-5-20251001",
+    "claude-sonnet": "claude-sonnet-4-6-20250514",
+    "claude-opus": "claude-opus-4-6-20250514",
+  };
+  return aliases[model] ?? model;
+}
+
+/**
+ * Call Anthropic Messages API for task relevance scoring.
+ * Uses ANTHROPIC_API_KEY from environment. Falls back to keyword matching
+ * if no API key is available.
+ */
+async function callAnthropicApi(prompt: string, config: SessionSelectionConfig): Promise<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error("ANTHROPIC_API_KEY not available");
+  }
+
+  const modelId = resolveModelId(config.relevanceModel);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.relevanceTimeoutMs);
+
+  try {
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: modelId,
+        max_tokens: config.relevanceMaxTokens,
+        temperature: 0,
+        messages: [{ role: "user", content: prompt }],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Anthropic API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    const text = data.content?.find((b) => b.type === "text")?.text;
+    if (!text) {
+      throw new Error("No text in API response");
+    }
+    return text;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Extract JSON array from LLM response text, handling markdown code fences. */
+function extractJson(text: string): string {
+  // Try to extract JSON from markdown code fences
+  const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) {
+    return fenceMatch[1].trim();
+  }
+  // Try to find a JSON array directly
+  const arrayMatch = text.match(/\[[\s\S]*\]/);
+  if (arrayMatch) {
+    return arrayMatch[0];
+  }
+  return text;
+}
+
+/**
+ * Score task relevance for all candidate sessions in one batched LLM call.
+ * Falls back to keyword Jaccard if LLM is disabled or fails.
+ */
+export async function assessTaskRelevance(
+  task: string,
+  sessions: DiscoveredSession[],
+  config: SessionSelectionConfig = DEFAULT_SESSION_SELECTION_CONFIG,
+): Promise<TaskRelevanceResult[]> {
+  if (sessions.length === 0) {
+    return [];
+  }
+
+  if (!config.enabled) {
+    return sessions.map((s) => keywordFallback(task, s));
+  }
+
+  const sessionDescriptions = sessions
+    .map((s, i) => {
+      const desc = s.lastTask ?? s.firstMessage ?? "(no description)";
+      const branch = s.branch ?? "unknown";
+      return `${i + 1}. [branch: ${branch}] ${desc}`;
+    })
+    .join("\n");
+
+  const prompt = `You are scoring task relevance for session selection.
+
+NEW TASK: ${task}
+
+EXISTING SESSIONS:
+${sessionDescriptions}
+
+For each session, rate how relevant its previous work is to the new task.
+Consider: same feature area? same files likely touched? shared context valuable?
+A session about "refactor webhook handler" IS relevant to "fix webhook error handling".
+A session about "add OAuth" is NOT relevant to "update README formatting".
+
+Return JSON array: [{"index": 1, "relevance": 0.0-1.0, "reasoning": "one line"}]
+Relevance scale: 0.0 = unrelated, 0.3 = tangentially related, 0.6 = related work, 0.9 = same feature/task, 1.0 = exact continuation.`;
+
+  try {
+    const response = await callAnthropicApi(prompt, config);
+    const scores = JSON.parse(extractJson(response)) as Array<{
+      index: number;
+      relevance: number;
+      reasoning: string;
+    }>;
+
+    return scores.map((s) => ({
+      sessionId: sessions[s.index - 1]?.sessionId ?? "",
+      relevance: Math.min(Math.max(s.relevance, 0), 1),
+      reasoning: s.reasoning,
+    }));
+  } catch (err) {
+    log.warn(
+      `Task relevance LLM call failed, falling back to keyword matching: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return sessions.map((s) => keywordFallback(task, s));
+  }
+}
+
+/**
+ * Keyword Jaccard similarity fallback when LLM is disabled or fails.
+ */
+export function keywordFallback(task: string, session: DiscoveredSession): TaskRelevanceResult {
+  const taskWords = new Set(
+    task
+      .toLowerCase()
+      .split(/\W+/)
+      .filter((w) => w.length > 3),
+  );
+  const sessionText = session.lastTask ?? session.firstMessage ?? "";
+  const sessionWords = new Set(
+    sessionText
+      .toLowerCase()
+      .split(/\W+/)
+      .filter((w) => w.length > 3),
+  );
+  const intersection = [...taskWords].filter((w) => sessionWords.has(w));
+  const union = new Set([...taskWords, ...sessionWords]);
+  const jaccard = union.size > 0 ? intersection.length / union.size : 0;
+  return {
+    sessionId: session.sessionId,
+    relevance: Math.min(jaccard * 2, 1),
+    reasoning: `keyword overlap: ${intersection.length}/${union.size} words`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scoring function
+// ---------------------------------------------------------------------------
+
+/**
+ * Score a single session against a task using 5 factors.
+ * Total max 1.0, clamped to minimum 0.
+ */
+export function scoreSession(
+  session: DiscoveredSession,
+  _task: string,
+  currentBranch: string,
+  relevance: TaskRelevanceResult,
+  _maxBudgetUsd?: number,
+): SessionScore {
+  // Hard ceiling: 3+ compactions = context too degraded
+  if (session.compactionCount >= HARD_CEILING_COMPACTIONS) {
+    return {
+      sessionId: session.sessionId,
+      score: 0,
+      factors: {
+        branchMatch: 0,
+        recency: 0,
+        taskRelevance: 0,
+        sessionHealth: 0,
+        contextCapacity: 0,
+      },
+      recommendation: "fresh",
+      reason: `Force fresh — session compacted ${session.compactionCount} times (context too degraded)`,
+    };
+  }
+
+  // Hard ceiling: 70%+ budget consumed
+  if (session.budgetUsedPct != null && session.budgetUsedPct >= HARD_CEILING_BUDGET_PCT) {
+    return {
+      sessionId: session.sessionId,
+      score: 0,
+      factors: {
+        branchMatch: 0,
+        recency: 0,
+        taskRelevance: 0,
+        sessionHealth: 0,
+        contextCapacity: 0,
+      },
+      recommendation: "fresh",
+      reason: `Force fresh — session used ${(session.budgetUsedPct * 100).toFixed(0)}% of budget`,
+    };
+  }
+
+  // Soft ceiling: unrelated task + large session
+  if (relevance.relevance < 0.1 && session.messageCount > 200) {
+    return {
+      sessionId: session.sessionId,
+      score: 0,
+      factors: {
+        branchMatch: 0,
+        recency: 0,
+        taskRelevance: 0,
+        sessionHealth: 0,
+        contextCapacity: 0,
+      },
+      recommendation: "fresh",
+      reason: `Force fresh — unrelated task (${relevance.reasoning}) + large session (${session.messageCount} messages)`,
+    };
+  }
+
+  const factors: ScoreFactors = {
+    branchMatch: 0,
+    recency: 0,
+    taskRelevance: 0,
+    sessionHealth: 0,
+    contextCapacity: 0,
+  };
+
+  // 1. Branch match (0.25)
+  if (session.branch === currentBranch) {
+    factors.branchMatch = 0.25;
+  }
+
+  // 2. Recency (0.0 - 0.20) — exponential decay
+  const ageHours = (Date.now() - session.lastModified.getTime()) / (1000 * 60 * 60);
+  if (ageHours < 1) {
+    factors.recency = 0.2;
+  } else if (ageHours < 6) {
+    factors.recency = 0.16;
+  } else if (ageHours < 24) {
+    factors.recency = 0.12;
+  } else if (ageHours < 72) {
+    factors.recency = 0.08;
+  } else if (ageHours < 168) {
+    factors.recency = 0.04;
+  } else {
+    factors.recency = 0;
+  }
+
+  // 3. Task relevance (-0.15 to 0.25)
+  if (relevance.relevance >= 0.6) {
+    factors.taskRelevance = 0.25;
+  } else if (relevance.relevance >= 0.3) {
+    factors.taskRelevance = 0.1 + (relevance.relevance - 0.3) * 0.5;
+  } else if (relevance.relevance >= 0.1) {
+    factors.taskRelevance = 0;
+  } else {
+    factors.taskRelevance = -0.15;
+  }
+
+  // 4. Session health (0.0 - 0.15)
+  let health = 0.15;
+  if (session.messageCount > 500) {
+    health -= 0.07;
+  }
+  if (session.fileSizeBytes > 5_000_000) {
+    health -= 0.04;
+  }
+  if (ageHours > 168) {
+    health -= 0.04;
+  }
+  factors.sessionHealth = Math.max(health, 0);
+
+  // 5. Context capacity (0.0 - 0.15)
+  let capacity = 0.15;
+  if (session.compactionCount === 1) {
+    capacity -= 0.04;
+  } else if (session.compactionCount === 2) {
+    capacity -= 0.09;
+  }
+  if (session.budgetUsedPct != null) {
+    if (session.budgetUsedPct > 0.5) {
+      capacity -= 0.04;
+    } else if (session.budgetUsedPct > 0.3) {
+      capacity -= 0.02;
+    }
+  }
+  const totalTokens = session.totalInputTokens + session.totalOutputTokens;
+  const tokensPerMessage = session.messageCount > 0 ? totalTokens / session.messageCount : 0;
+  if (tokensPerMessage > 4000) {
+    capacity -= 0.03;
+  }
+  factors.contextCapacity = Math.max(capacity, 0);
+
+  const score = Math.max(
+    0,
+    factors.branchMatch +
+      factors.recency +
+      factors.taskRelevance +
+      factors.sessionHealth +
+      factors.contextCapacity,
+  );
+
+  const threshold = DEFAULT_SESSION_SELECTION_CONFIG.resumeThreshold;
+  return {
+    sessionId: session.sessionId,
+    score,
+    factors,
+    recommendation: score >= threshold ? "resume" : "fresh",
+    reason: buildReason(factors, score, session, relevance, threshold),
+  };
+}
+
+function buildReason(
+  factors: ScoreFactors,
+  score: number,
+  session: DiscoveredSession,
+  relevance: TaskRelevanceResult,
+  threshold: number,
+): string {
+  const parts: string[] = [];
+  if (factors.branchMatch > 0) {
+    parts.push("same branch");
+  }
+  if (factors.recency >= 0.16) {
+    parts.push("recent");
+  } else if (factors.recency === 0) {
+    parts.push("stale (>1 week)");
+  }
+  if (factors.taskRelevance >= 0.15) {
+    parts.push(`related: ${relevance.reasoning}`);
+  } else if (factors.taskRelevance < 0) {
+    parts.push(`unrelated: ${relevance.reasoning}`);
+  }
+  if (factors.sessionHealth < 0.08) {
+    parts.push("large/unhealthy session");
+  }
+  if (factors.contextCapacity < 0.08) {
+    parts.push("low context capacity");
+  }
+  if (session.compactionCount > 0) {
+    parts.push(`${session.compactionCount}x compacted`);
+  }
+  if (session.budgetUsedPct != null && session.budgetUsedPct > 0.3) {
+    parts.push(`${(session.budgetUsedPct * 100).toFixed(0)}% budget used`);
+  }
+
+  const action = score >= threshold ? "Resume" : "Start fresh";
+  return `${action} (score: ${score.toFixed(2)}) — ${parts.join(", ") || "no strong signals"}`;
+}
+
+// ---------------------------------------------------------------------------
+// Decision function
+// ---------------------------------------------------------------------------
+
+/**
+ * Select the best session strategy for a new task.
+ *
+ * Decision tree:
+ * 1. Label provided → direct resolveSession() lookup
+ * 2. Active session on repo → queue (existing behavior)
+ * 3. No own sessions → fresh
+ * 4. Score all own sessions → best above threshold = resume, otherwise fresh
+ */
+export async function selectSession(
+  task: string,
+  repoPath: string,
+  agentId: string,
+  projectStatus: ProjectStatus,
+  label?: string,
+  maxBudgetUsd?: number,
+  config?: Partial<SessionSelectionConfig>,
+): Promise<SessionSelection> {
+  const selectionConfig: SessionSelectionConfig = {
+    ...DEFAULT_SESSION_SELECTION_CONFIG,
+    ...config,
+  };
+
+  // Labeled sessions: direct lookup (preserved from existing behavior)
+  if (label) {
+    const existing = resolveSession(agentId, repoPath, label);
+    if (existing) {
+      return { action: "resume", sessionId: existing, reason: `Labeled session "${label}"` };
+    }
+    return { action: "fresh", reason: `New labeled session "${label}"` };
+  }
+
+  // Active session: queue (existing behavior)
+  if (projectStatus.sessions.active.length > 0) {
+    return { action: "queue", reason: "Active session running on this repo" };
+  }
+
+  // Score all own sessions
+  const ownSessions = projectStatus.sessions.recent.filter((s) => s.agentId === agentId);
+  if (ownSessions.length === 0) {
+    return { action: "fresh", reason: "No previous sessions found" };
+  }
+
+  // LLM-based semantic relevance — one call for all candidates
+  let relevanceResults: TaskRelevanceResult[];
+  try {
+    relevanceResults = await assessTaskRelevance(task, ownSessions, selectionConfig);
+  } catch (err) {
+    log.warn(
+      `Task relevance scoring failed, falling back to keyword matching: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    relevanceResults = ownSessions.map((s) => keywordFallback(task, s));
+  }
+
+  const relevanceMap = new Map(relevanceResults.map((r) => [r.sessionId, r]));
+
+  const scores = ownSessions.map((s) =>
+    scoreSession(
+      s,
+      task,
+      projectStatus.git.currentBranch,
+      relevanceMap.get(s.sessionId) ?? {
+        sessionId: s.sessionId,
+        relevance: 0.5,
+        reasoning: "unknown",
+      },
+      maxBudgetUsd,
+    ),
+  );
+  scores.sort((a, b) => b.score - a.score);
+
+  const best = scores[0];
+  if (best.score >= selectionConfig.resumeThreshold) {
+    log.info(`Session selection: resume ${best.sessionId} — ${best.reason}`);
+    return {
+      action: "resume",
+      sessionId: best.sessionId,
+      reason: best.reason,
+      scores,
+    };
+  }
+
+  log.info(`Session selection: fresh — ${best.reason}`);
+  return { action: "fresh", reason: best.reason, scores };
+}

--- a/src/agents/claude-code/sessions.ts
+++ b/src/agents/claude-code/sessions.ts
@@ -8,7 +8,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { ClaudeCodeSessionEntry, ClaudeCodeSessionRegistry } from "./types.js";
+import readline from "node:readline";
+import { isClaudeCodeRunning } from "./live-state.js";
+import type {
+  ClaudeCodeSessionEntry,
+  ClaudeCodeSessionRegistry,
+  DiscoveredSession,
+  JsonlHeader,
+} from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Registry file path
@@ -65,37 +72,33 @@ function saveRegistry(agentId: string, registry: ClaudeCodeSessionRegistry): voi
 // ---------------------------------------------------------------------------
 
 /**
- * Attempt to locate the CC session file in `~/.claude/projects/`.
- *
- * Claude Code slugifies the project path. The exact algorithm is internal to CC,
- * so we try the most common patterns. If we can't find the file, the session is
- * assumed to have been cleaned up.
+ * Convert a repo path to CC's project directory slug.
+ * CC uses the full path with `/` replaced by `-`.
+ * e.g. `/home/fonz/Projects/openclaw` → `-home-fonz-Projects-openclaw`
  */
+export function repoPathToSlug(repoPath: string): string {
+  return repoPath.replace(/\//g, "-");
+}
+
 /**
  * Locate the CC session JSONL file path, or return undefined if not found.
+ * Uses the confirmed slug algorithm as the primary path,
+ * with a broad-search fallback as safety net.
  */
-function findCcSessionFile(repoPath: string, sessionId: string): string | undefined {
+function findSessionJsonlPath(repoPath: string, sessionId: string): string | undefined {
   const claudeDir = path.join(os.homedir(), ".claude", "projects");
   if (!fs.existsSync(claudeDir)) {
     return undefined;
   }
 
-  // CC uses the project path as a directory slug. Try a few variants.
-  const candidates = [
-    // Most common: the base directory name
-    path.basename(repoPath),
-    // Full path with slashes replaced
-    repoPath.replace(/^\//, "").replace(/\//g, "-"),
-  ];
-
-  for (const slug of candidates) {
-    const sessionFile = path.join(claudeDir, slug, `${sessionId}.jsonl`);
-    if (fs.existsSync(sessionFile)) {
-      return sessionFile;
-    }
+  // Primary path
+  const primarySlug = repoPathToSlug(repoPath);
+  const primaryFile = path.join(claudeDir, primarySlug, `${sessionId}.jsonl`);
+  if (fs.existsSync(primaryFile)) {
+    return primaryFile;
   }
 
-  // Broad search: look through all subdirs for a matching session file.
+  // Broad search fallback
   try {
     const dirs = fs.readdirSync(claudeDir, { withFileTypes: true });
     for (const dir of dirs) {
@@ -112,6 +115,11 @@ function findCcSessionFile(repoPath: string, sessionId: string): string | undefi
   }
 
   return undefined;
+}
+
+/** Back-compat alias. */
+function findCcSessionFile(repoPath: string, sessionId: string): string | undefined {
+  return findSessionJsonlPath(repoPath, sessionId);
 }
 
 function ccSessionFileExists(repoPath: string, sessionId: string): boolean {
@@ -354,18 +362,13 @@ export function peekSessionHistory(
     return "";
   }
 
-  // Take the last N messages
   const recent = messages.slice(-maxMessages);
-
-  // Build a compact summary
   const parts: string[] = [];
   let totalChars = 0;
 
   for (const msg of recent) {
     const prefix = msg.role === "assistant" ? "CC" : "User";
     let content = msg.text;
-
-    // Truncate individual messages if needed
     const remaining = maxChars - totalChars;
     if (remaining <= 0) {
       break;
@@ -373,10 +376,211 @@ export function peekSessionHistory(
     if (content.length > remaining) {
       content = content.slice(0, remaining) + "…";
     }
-
     parts.push(`[${prefix}]: ${content}`);
     totalChars += content.length;
   }
 
   return parts.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// JSONL header parsing (streaming)
+// ---------------------------------------------------------------------------
+
+const ORIGIN_MARKER_RE = /\[openclaw:agent=([^\]]+)\]/;
+
+/**
+ * Extract metadata from a CC JSONL session file using streaming readline.
+ * Constant memory regardless of file size.
+ */
+export async function parseJsonlHeader(filePath: string): Promise<JsonlHeader> {
+  const result: JsonlHeader = {
+    lineCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    compactionCount: 0,
+  };
+
+  const stream = fs.createReadStream(filePath, { encoding: "utf8" });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) {
+        continue;
+      }
+      result.lineCount++;
+
+      try {
+        const msg = JSON.parse(line);
+
+        // Extract metadata from first 10 lines
+        if (result.lineCount <= 10) {
+          if (!result.gitBranch && msg.gitBranch) {
+            result.gitBranch = msg.gitBranch;
+          }
+          if (!result.slug && msg.slug) {
+            result.slug = msg.slug;
+          }
+          if (!result.version && msg.version) {
+            result.version = msg.version;
+          }
+        }
+
+        // Extract first user message as "title" + origin marker
+        if (!result.firstUserMessage && msg.type === "user" && msg.message?.content) {
+          const text =
+            typeof msg.message.content === "string"
+              ? msg.message.content
+              : Array.isArray(msg.message.content)
+                ? (msg.message.content as Array<{ type?: string; text?: string }>).find(
+                    (b) => b.type === "text",
+                  )?.text
+                : undefined;
+          if (text) {
+            result.firstUserMessage = text.slice(0, 200);
+            const markerMatch = text.match(ORIGIN_MARKER_RE);
+            if (markerMatch) {
+              result.originMarker = markerMatch[1];
+            }
+          }
+        }
+
+        // Accumulate token usage from assistant messages
+        if (msg.message?.usage) {
+          result.totalInputTokens += msg.message.usage.input_tokens ?? 0;
+          result.totalOutputTokens += msg.message.usage.output_tokens ?? 0;
+        }
+
+        // Detect auto-compaction events
+        if (msg.type === "system" && msg.message?.content) {
+          const text =
+            typeof msg.message.content === "string"
+              ? msg.message.content
+              : JSON.stringify(msg.message.content);
+          if (text.includes("compress") || text.includes("compact") || text.includes("summary")) {
+            result.compactionCount++;
+          }
+        }
+      } catch {
+        // Skip non-JSON lines
+      }
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Session discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover all CC sessions for a repository, merging OpenClaw registries
+ * with native CC JSONL storage. Deduplicates by sessionId.
+ */
+export async function discoverSessions(repoPath: string): Promise<DiscoveredSession[]> {
+  const resolved = path.resolve(repoPath);
+  const results: DiscoveredSession[] = [];
+  const seen = new Set<string>();
+
+  // 1. OpenClaw registries (rich metadata)
+  const allRegistrySessions = listAllSessions();
+  for (const entry of allRegistrySessions) {
+    if (path.resolve(entry.repoPath) !== resolved) {
+      continue;
+    }
+    seen.add(entry.sessionId);
+
+    // Try to parse JSONL for branch/message/capacity info
+    const jsonlPath = findSessionJsonlPath(resolved, entry.sessionId);
+    let header: JsonlHeader | undefined;
+    let fileStat: fs.Stats | undefined;
+    if (jsonlPath) {
+      try {
+        header = await parseJsonlHeader(jsonlPath);
+        fileStat = fs.statSync(jsonlPath);
+      } catch {
+        // JSONL file may be gone or corrupt
+      }
+    }
+
+    results.push({
+      sessionId: entry.sessionId,
+      source: "openclaw",
+      agentId: entry.agentId,
+      repoPath: resolved,
+      branch: header?.gitBranch ?? "unknown",
+      firstMessage: header?.firstUserMessage ?? "(no message)",
+      lastModified: new Date(entry.lastResumedAt),
+      messageCount: header?.lineCount ?? 0,
+      fileSizeBytes: fileStat?.size ?? 0,
+      totalCostUsd: entry.totalCostUsd,
+      totalTurns: entry.totalTurns,
+      lastTask: entry.taskHistory.length > 0 ? entry.taskHistory.at(-1)?.task : undefined,
+      label: entry.label,
+      slug: header?.slug,
+      isRunning: isClaudeCodeRunning(resolved),
+      originMarker: header?.originMarker,
+      totalInputTokens: header?.totalInputTokens ?? 0,
+      totalOutputTokens: header?.totalOutputTokens ?? 0,
+      compactionCount: header?.compactionCount ?? 0,
+    });
+  }
+
+  // 2. CC native storage (sessions not in any OpenClaw registry)
+  const slug = repoPathToSlug(resolved);
+  const sessionDir = path.join(os.homedir(), ".claude", "projects", slug);
+  if (fs.existsSync(sessionDir)) {
+    let files: string[];
+    try {
+      files = fs.readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"));
+    } catch {
+      files = [];
+    }
+
+    for (const file of files) {
+      const sessionId = path.basename(file, ".jsonl");
+      if (seen.has(sessionId)) {
+        continue;
+      }
+
+      const filePath = path.join(sessionDir, file);
+      try {
+        const stat = fs.statSync(filePath);
+        const header = await parseJsonlHeader(filePath);
+        results.push({
+          sessionId,
+          source: "native-only",
+          repoPath: resolved,
+          branch: header.gitBranch ?? "unknown",
+          firstMessage: header.firstUserMessage ?? "(no message)",
+          lastModified: stat.mtime,
+          messageCount: header.lineCount,
+          fileSizeBytes: stat.size,
+          slug: header.slug,
+          isRunning: false,
+          originMarker: header.originMarker,
+          totalInputTokens: header.totalInputTokens,
+          totalOutputTokens: header.totalOutputTokens,
+          compactionCount: header.compactionCount,
+        });
+      } catch {
+        // Skip files we can't read
+      }
+    }
+  }
+
+  // Sort: running sessions first, then by lastModified descending
+  results.sort((a, b) => {
+    if (a.isRunning !== b.isRunning) {
+      return a.isRunning ? -1 : 1;
+    }
+    return b.lastModified.getTime() - a.lastModified.getTime();
+  });
+
+  return results;
 }

--- a/src/agents/claude-code/sessions.ts
+++ b/src/agents/claude-code/sessions.ts
@@ -85,7 +85,7 @@ export function repoPathToSlug(repoPath: string): string {
  * Uses the confirmed slug algorithm as the primary path,
  * with a broad-search fallback as safety net.
  */
-function findSessionJsonlPath(repoPath: string, sessionId: string): string | undefined {
+export function findSessionJsonlPath(repoPath: string, sessionId: string): string | undefined {
   const claudeDir = path.join(os.homedir(), ".claude", "projects");
   if (!fs.existsSync(claudeDir)) {
     return undefined;

--- a/src/agents/claude-code/sessions.ts
+++ b/src/agents/claude-code/sessions.ts
@@ -1,0 +1,382 @@
+/**
+ * Session registry for Claude Code spawn mode.
+ *
+ * Maintains a simple `(agentId, repoPath[, label]) → sessionId` mapping persisted to disk.
+ * Session files live in Claude Code's native store at `~/.claude/projects/`.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ClaudeCodeSessionEntry, ClaudeCodeSessionRegistry } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Registry file path
+// ---------------------------------------------------------------------------
+
+function registryDir(agentId: string): string {
+  return path.join(os.homedir(), ".openclaw", "agents", agentId);
+}
+
+function registryPath(agentId: string): string {
+  return path.join(registryDir(agentId), "claude-code-sessions.json");
+}
+
+// ---------------------------------------------------------------------------
+// Registry key helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the registry key for a session.
+ * Without a label, this is just the repoPath (backwards compatible).
+ * With a label, it's `repoPath::label` — allowing parallel named sessions
+ * on the same repo.
+ */
+export function registryKey(repoPath: string, label?: string): string {
+  return label ? `${repoPath}::${label}` : repoPath;
+}
+
+// ---------------------------------------------------------------------------
+// Load / save
+// ---------------------------------------------------------------------------
+
+function loadRegistry(agentId: string): ClaudeCodeSessionRegistry {
+  const filePath = registryPath(agentId);
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && parsed.sessions) {
+      return parsed as ClaudeCodeSessionRegistry;
+    }
+  } catch {
+    // File missing or corrupt — start fresh.
+  }
+  return { sessions: {} };
+}
+
+function saveRegistry(agentId: string, registry: ClaudeCodeSessionRegistry): void {
+  const dir = registryDir(agentId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(registryPath(agentId), JSON.stringify(registry, null, 2), "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// CC session file resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to locate the CC session file in `~/.claude/projects/`.
+ *
+ * Claude Code slugifies the project path. The exact algorithm is internal to CC,
+ * so we try the most common patterns. If we can't find the file, the session is
+ * assumed to have been cleaned up.
+ */
+/**
+ * Locate the CC session JSONL file path, or return undefined if not found.
+ */
+function findCcSessionFile(repoPath: string, sessionId: string): string | undefined {
+  const claudeDir = path.join(os.homedir(), ".claude", "projects");
+  if (!fs.existsSync(claudeDir)) {
+    return undefined;
+  }
+
+  // CC uses the project path as a directory slug. Try a few variants.
+  const candidates = [
+    // Most common: the base directory name
+    path.basename(repoPath),
+    // Full path with slashes replaced
+    repoPath.replace(/^\//, "").replace(/\//g, "-"),
+  ];
+
+  for (const slug of candidates) {
+    const sessionFile = path.join(claudeDir, slug, `${sessionId}.jsonl`);
+    if (fs.existsSync(sessionFile)) {
+      return sessionFile;
+    }
+  }
+
+  // Broad search: look through all subdirs for a matching session file.
+  try {
+    const dirs = fs.readdirSync(claudeDir, { withFileTypes: true });
+    for (const dir of dirs) {
+      if (!dir.isDirectory()) {
+        continue;
+      }
+      const sessionFile = path.join(claudeDir, dir.name, `${sessionId}.jsonl`);
+      if (fs.existsSync(sessionFile)) {
+        return sessionFile;
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  return undefined;
+}
+
+function ccSessionFileExists(repoPath: string, sessionId: string): boolean {
+  return findCcSessionFile(repoPath, sessionId) != null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up an existing CC session for the given agent + repo (+ optional label).
+ * Returns the session ID if found and the session file still exists, otherwise undefined.
+ */
+export function resolveSession(
+  agentId: string,
+  repoPath: string,
+  label?: string,
+): string | undefined {
+  const key = registryKey(repoPath, label);
+  const registry = loadRegistry(agentId);
+  const entry = registry.sessions[key];
+  if (!entry) {
+    return undefined;
+  }
+
+  // Verify the session file still exists (CC cleanup may have removed it).
+  if (!ccSessionFileExists(repoPath, entry.sessionId)) {
+    delete registry.sessions[key];
+    saveRegistry(agentId, registry);
+    return undefined;
+  }
+
+  return entry.sessionId;
+}
+
+/**
+ * Record a session in the registry.
+ */
+export function saveSession(
+  agentId: string,
+  repoPath: string,
+  sessionId: string,
+  meta?: {
+    userId?: string;
+    channel?: string;
+    task?: string;
+    costUsd?: number;
+    label?: string;
+  },
+): void {
+  const key = registryKey(repoPath, meta?.label);
+  const registry = loadRegistry(agentId);
+  const now = new Date().toISOString();
+  const existing = registry.sessions[key];
+
+  if (existing && existing.sessionId === sessionId) {
+    // Update existing entry.
+    existing.lastResumedAt = now;
+    if (meta?.costUsd) {
+      existing.totalCostUsd += meta.costUsd;
+    }
+    if (meta?.task) {
+      existing.taskHistory.push({
+        at: now,
+        task: meta.task,
+        costUsd: meta.costUsd ?? 0,
+      });
+    }
+  } else {
+    // New entry.
+    registry.sessions[key] = {
+      sessionId,
+      createdAt: now,
+      lastResumedAt: now,
+      totalCostUsd: meta?.costUsd ?? 0,
+      totalTurns: 0,
+      triggeredBy: {
+        userId: meta?.userId,
+        channel: meta?.channel,
+      },
+      taskHistory: meta?.task ? [{ at: now, task: meta.task, costUsd: meta.costUsd ?? 0 }] : [],
+      label: meta?.label,
+    };
+  }
+
+  saveRegistry(agentId, registry);
+}
+
+/**
+ * Update turn count and cost after a run completes.
+ */
+export function updateSessionStats(
+  agentId: string,
+  repoPath: string,
+  stats: { turns?: number; costUsd?: number },
+  label?: string,
+): void {
+  const key = registryKey(repoPath, label);
+  const registry = loadRegistry(agentId);
+  const entry = registry.sessions[key];
+  if (!entry) {
+    return;
+  }
+
+  if (stats.turns) {
+    entry.totalTurns += stats.turns;
+  }
+  if (stats.costUsd) {
+    entry.totalCostUsd += stats.costUsd;
+  }
+
+  saveRegistry(agentId, registry);
+}
+
+/**
+ * Delete a session entry (manual reset).
+ */
+export function deleteSession(agentId: string, repoPath: string, label?: string): boolean {
+  const key = registryKey(repoPath, label);
+  const registry = loadRegistry(agentId);
+  if (!registry.sessions[key]) {
+    return false;
+  }
+  delete registry.sessions[key];
+  saveRegistry(agentId, registry);
+  return true;
+}
+
+/**
+ * List all sessions for an agent.
+ */
+export function listSessions(agentId: string): Record<string, ClaudeCodeSessionEntry> {
+  const registry = loadRegistry(agentId);
+  return registry.sessions;
+}
+
+/**
+ * List all sessions across all agents.
+ * Returns a flat array with agentId attached.
+ */
+export function listAllSessions(): Array<
+  ClaudeCodeSessionEntry & { agentId: string; repoPath: string }
+> {
+  const results: Array<ClaudeCodeSessionEntry & { agentId: string; repoPath: string }> = [];
+  const agentsDir = path.join(os.homedir(), ".openclaw", "agents");
+  try {
+    if (!fs.existsSync(agentsDir)) {
+      return results;
+    }
+    const dirs = fs.readdirSync(agentsDir, { withFileTypes: true });
+    for (const dir of dirs) {
+      if (!dir.isDirectory()) {
+        continue;
+      }
+      const agentId = dir.name;
+      const sessions = listSessions(agentId);
+      for (const [key, entry] of Object.entries(sessions)) {
+        // Extract the repoPath from the key (strip ::label suffix if present)
+        const repoPath = key.includes("::") ? key.slice(0, key.indexOf("::")) : key;
+        results.push({ ...entry, agentId, repoPath });
+      }
+    }
+  } catch {
+    // Ignore filesystem errors
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Session history peek — read recent messages from a CC session transcript
+// ---------------------------------------------------------------------------
+
+interface SessionMessage {
+  role: "user" | "assistant";
+  text: string;
+}
+
+/**
+ * Read the last N messages from a Claude Code session's JSONL transcript.
+ * Returns a compact text summary suitable for injecting as context.
+ *
+ * Only extracts text content (skips tool_use/tool_result blocks) to keep
+ * the context lean. Returns empty string if session can't be found/read.
+ */
+export function peekSessionHistory(
+  repoPath: string,
+  sessionId: string,
+  opts?: { maxMessages?: number; maxChars?: number },
+): string {
+  const maxMessages = opts?.maxMessages ?? 6;
+  const maxChars = opts?.maxChars ?? 4000;
+
+  const filePath = findCcSessionFile(repoPath, sessionId);
+  if (!filePath) {
+    return "";
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+
+  // Parse JSONL lines, extract text-only messages
+  const messages: SessionMessage[] = [];
+  const lines = raw.split("\n").filter((l) => l.trim());
+
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+      const msg = entry.message ?? entry;
+      const role = msg.role as string;
+      if (role !== "user" && role !== "assistant") {
+        continue;
+      }
+
+      // Extract text content only
+      let text = "";
+      if (typeof msg.content === "string") {
+        text = msg.content;
+      } else if (Array.isArray(msg.content)) {
+        const textParts = msg.content
+          .filter((b: { type: string }) => b.type === "text")
+          .map((b: { text: string }) => b.text ?? "");
+        text = textParts.join("\n");
+      }
+      if (!text.trim()) {
+        continue;
+      }
+
+      messages.push({ role: role, text: text.trim() });
+    } catch {
+      continue;
+    }
+  }
+
+  if (messages.length === 0) {
+    return "";
+  }
+
+  // Take the last N messages
+  const recent = messages.slice(-maxMessages);
+
+  // Build a compact summary
+  const parts: string[] = [];
+  let totalChars = 0;
+
+  for (const msg of recent) {
+    const prefix = msg.role === "assistant" ? "CC" : "User";
+    let content = msg.text;
+
+    // Truncate individual messages if needed
+    const remaining = maxChars - totalChars;
+    if (remaining <= 0) {
+      break;
+    }
+    if (content.length > remaining) {
+      content = content.slice(0, remaining) + "…";
+    }
+
+    parts.push(`[${prefix}]: ${content}`);
+    totalChars += content.length;
+  }
+
+  return parts.join("\n\n");
+}

--- a/src/agents/claude-code/types.ts
+++ b/src/agents/claude-code/types.ts
@@ -37,10 +37,6 @@ export type ClaudeCodeSubagentConfig = {
   mcpBridge?: {
     /** Enable the MCP bridge (default: true). */
     enabled?: boolean;
-    /** Let CC read OpenClaw memory files. */
-    exposeMemory?: boolean;
-    /** Let CC read triggering conversation context. */
-    exposeConversation?: boolean;
   };
   /** Progress relay settings. */
   progressRelay?: {
@@ -51,6 +47,25 @@ export type ClaudeCodeSubagentConfig = {
     /** Show which tools are being called. */
     includeToolUse?: boolean;
   };
+  /** Session selection settings for intelligent resume vs fresh decisions. */
+  sessionSelection?: Partial<SessionSelectionConfig>;
+};
+
+// ---------------------------------------------------------------------------
+// Session selection config
+// ---------------------------------------------------------------------------
+
+export type SessionSelectionConfig = {
+  /** Model for task relevance scoring. Default: "claude-haiku". */
+  relevanceModel: string;
+  /** Max response tokens for relevance call. Default: 500. */
+  relevanceMaxTokens: number;
+  /** Timeout for relevance call in ms. Default: 3000. */
+  relevanceTimeoutMs: number;
+  /** Score threshold for resume vs fresh. Default: 0.6. */
+  resumeThreshold: number;
+  /** Enable LLM-based relevance. False = keyword fallback only. Default: true. */
+  enabled: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -151,4 +166,44 @@ export type ClaudeCodeTaskHistoryEntry = {
 
 export type ClaudeCodeSessionRegistry = {
   sessions: Record<string, ClaudeCodeSessionEntry>;
+};
+
+// ---------------------------------------------------------------------------
+// Session discovery
+// ---------------------------------------------------------------------------
+
+export type JsonlHeader = {
+  gitBranch?: string;
+  firstUserMessage?: string;
+  slug?: string;
+  version?: string;
+  lineCount: number;
+  originMarker?: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  compactionCount: number;
+};
+
+export type DiscoveredSession = {
+  sessionId: string;
+  source: "openclaw" | "native-only";
+  agentId?: string;
+  repoPath: string;
+  branch: string;
+  /** First user message text (session "title"), max 200 chars. */
+  firstMessage: string;
+  lastModified: Date;
+  messageCount: number;
+  fileSizeBytes: number;
+  totalCostUsd?: number;
+  totalTurns?: number;
+  lastTask?: string;
+  label?: string;
+  slug?: string;
+  isRunning: boolean;
+  originMarker?: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  compactionCount: number;
+  budgetUsedPct?: number;
 };

--- a/src/agents/claude-code/types.ts
+++ b/src/agents/claude-code/types.ts
@@ -1,0 +1,154 @@
+/**
+ * Configuration and result types for Claude Code spawn mode.
+ */
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export type ClaudeCodePermissionMode =
+  | "acceptEdits"
+  | "bypassPermissions"
+  | "default"
+  | "delegate"
+  | "dontAsk"
+  | "plan";
+
+export type ClaudeCodeSubagentConfig = {
+  /** Enable Claude Code spawn mode (default: false). */
+  enabled?: boolean;
+  /** Absolute path to the `claude` binary (null = resolve from PATH). */
+  binaryPath?: string | null;
+  /** Default repo for spawns when none specified. */
+  defaultRepo?: string | null;
+  /** Repo alias → absolute path mapping. */
+  repos?: Record<string, string>;
+  /** USD cap per spawn (--max-budget-usd). */
+  maxBudgetUsd?: number;
+  /** Timeout per spawn in seconds. */
+  timeoutSeconds?: number;
+  /** Permission mode for the spawned CLI. */
+  permissionMode?: ClaudeCodePermissionMode;
+  /** Convenience alias: when true, overrides permissionMode to "bypassPermissions". */
+  dangerouslySkipPermissions?: boolean;
+  /** Model override (null = use claude's own resolution). */
+  model?: string | null;
+  /** MCP bridge server settings. */
+  mcpBridge?: {
+    /** Enable the MCP bridge (default: true). */
+    enabled?: boolean;
+    /** Let CC read OpenClaw memory files. */
+    exposeMemory?: boolean;
+    /** Let CC read triggering conversation context. */
+    exposeConversation?: boolean;
+  };
+  /** Progress relay settings. */
+  progressRelay?: {
+    /** Enable progress relay to chat (default: true). */
+    enabled?: boolean;
+    /** How often to send progress to chat (seconds). */
+    intervalSeconds?: number;
+    /** Show which tools are being called. */
+    includeToolUse?: boolean;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Spawn options
+// ---------------------------------------------------------------------------
+
+export type ClaudeCodeSpawnOptions = {
+  task: string;
+  /** Absolute path to repo root. */
+  repo: string;
+  model?: string;
+  timeoutSeconds?: number;
+  maxBudgetUsd?: number;
+  permissionMode?: ClaudeCodePermissionMode;
+  /** Session ID to resume. */
+  resume?: string;
+  /** Use --continue to resume the most recent session for this project. */
+  continueSession?: boolean;
+  /** Explicit session ID (UUID). */
+  sessionId?: string;
+  /** MCP bridge configuration. */
+  mcpBridge?: ClaudeCodeSubagentConfig["mcpBridge"];
+  /** Progress relay configuration. */
+  progressRelay?: ClaudeCodeSubagentConfig["progressRelay"];
+  /** Progress callback invoked during the run. */
+  onProgress?: (event: ClaudeCodeProgressEvent) => void;
+  /** Permission response callback — called when CC requests permission and we need user input. */
+  onPermissionRequest?: (request: {
+    toolName: string;
+    description: string;
+    requestId: string;
+  }) => void;
+  /** Agent ID (for session registry). */
+  agentId?: string;
+  /** Named session label — allows parallel sessions on the same repo. */
+  label?: string;
+  /** Binary path override. */
+  binaryPath?: string;
+  /** Keep the CC CLI process alive after the first result for follow-up messages. */
+  persistent?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Progress events
+// ---------------------------------------------------------------------------
+
+export type ClaudeCodeProgressEvent =
+  | { kind: "status"; permissionMode?: string; sessionId?: string }
+  | { kind: "tool_use"; toolName: string; input?: Record<string, unknown> }
+  | { kind: "text"; text: string }
+  | { kind: "hook_failed"; hookName: string; exitCode: number; output: string }
+  | { kind: "task_notification"; taskId: string; status: string; summary?: string }
+  | { kind: "auth_error"; error: string }
+  | { kind: "progress_summary"; summary: string }
+  | { kind: "permission_request"; toolName: string; description: string; requestId: string }
+  | { kind: "result"; result: ClaudeCodeResult };
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+export type ClaudeCodeResult = {
+  success: boolean;
+  sessionId: string;
+  /** Final assistant text. */
+  result: string;
+  totalCostUsd: number;
+  durationMs: number;
+  durationApiMs: number;
+  numTurns: number;
+  usage: { input_tokens: number; output_tokens: number };
+  /** Actions the agent wanted but was denied. */
+  permissionDenials: string[];
+  errors: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Session registry
+// ---------------------------------------------------------------------------
+
+export type ClaudeCodeSessionEntry = {
+  sessionId: string;
+  createdAt: string;
+  lastResumedAt: string;
+  totalCostUsd: number;
+  totalTurns: number;
+  triggeredBy?: { userId?: string; channel?: string };
+  taskHistory: ClaudeCodeTaskHistoryEntry[];
+  /** Named session label (e.g. "dashboard-refactor"). Absent for the default session. */
+  label?: string;
+};
+
+export type ClaudeCodeTaskHistoryEntry = {
+  at: string;
+  task: string;
+  costUsd: number;
+};
+
+export type ClaudeCodeSessionRegistry = {
+  sessions: Record<string, ClaudeCodeSessionEntry>;
+};

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -379,7 +379,7 @@ function resolveAnnounceOrigin(
   return mergeDeliveryContext(normalizedRequester, entryForMerge);
 }
 
-async function resolveSubagentCompletionOrigin(params: {
+export async function resolveSubagentCompletionOrigin(params: {
   childSessionKey: string;
   requesterSessionKey: string;
   requesterOrigin?: DeliveryContext;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -984,6 +984,28 @@ function findRunIdsByChildSessionKey(childSessionKey: string): string[] {
   return findRunIdsByChildSessionKeyFromRuns(subagentRuns, childSessionKey);
 }
 
+/**
+ * Look up the subagent run record for a given child session key.
+ * Returns the most recent active (or latest) run matching that key.
+ */
+export function findSubagentRunByChildSessionKey(
+  childSessionKey: string,
+): SubagentRunRecord | null {
+  const runIds = findRunIdsByChildSessionKey(childSessionKey);
+  let best: SubagentRunRecord | null = null;
+  for (const runId of runIds) {
+    const entry = subagentRuns.get(runId);
+    if (!entry) {
+      continue;
+    }
+    // Prefer active (no endedAt) over ended; among same status, prefer newest.
+    if (!best || (!entry.endedAt && best.endedAt) || entry.createdAt > best.createdAt) {
+      best = entry;
+    }
+  }
+  return best;
+}
+
 export function resolveRequesterForChildSession(childSessionKey: string): {
   requesterSessionKey: string;
   requesterOrigin?: DeliveryContext;

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -32,4 +32,6 @@ export type SubagentRunRecord = {
   endedReason?: SubagentLifecycleEndedReason;
   /** Set after the subagent_ended hook has been emitted successfully once. */
   endedHookEmittedAt?: number;
+  /** For Claude Code spawn mode: the resolved repo path. Enables follow-up routing via CC stdin. */
+  ccRepoPath?: string;
 };

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -98,7 +98,7 @@ function summarizeError(err: unknown): string {
   return "error";
 }
 
-async function ensureThreadBindingForSubagentSpawn(params: {
+export async function ensureThreadBindingForSubagentSpawn(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   childSessionKey: string;
   agentId: string;

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,5 +1,13 @@
+import crypto from "node:crypto";
+import path from "node:path";
 import { Type } from "@sinclair/typebox";
+import { loadConfig } from "../../config/config.js";
+import { callGateway } from "../../gateway/call.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import { spawnClaudeCode } from "../claude-code/runner.js";
+import type { ClaudeCodePermissionMode } from "../claude-code/types.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import { SUBAGENT_SPAWN_MODES, spawnSubagentDirect } from "../subagent-spawn.js";
 import type { AnyAgentTool } from "./common.js";
@@ -17,6 +25,10 @@ const SessionsSpawnToolSchema = Type.Object({
   thread: Type.Optional(Type.Boolean()),
   mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
+  // Claude Code spawn mode params
+  repo: Type.Optional(Type.String()),
+  permissionMode: Type.Optional(Type.String()),
+  freshSession: Type.Optional(Type.Boolean()),
 });
 
 export function createSessionsSpawnTool(opts?: {
@@ -61,6 +73,200 @@ export function createSessionsSpawnTool(opts?: {
           : undefined;
       const thread = params.thread === true;
 
+      const cfg = loadConfig();
+
+      // ---------------------------------------------------------------
+      // Claude Code spawn mode — bypasses the standard subagent flow.
+      // ---------------------------------------------------------------
+      const spawnMode = readStringParam(params, "mode");
+      if (spawnMode === "claude-code") {
+        const ccConfig = cfg.agents?.defaults?.subagents?.claudeCode;
+        if (!ccConfig?.enabled) {
+          return jsonResult({
+            status: "error",
+            error:
+              "Claude Code spawn mode is not enabled. Set agents.defaults.subagents.claudeCode.enabled = true in openclaw.json",
+          });
+        }
+
+        const repoParam = readStringParam(params, "repo");
+        let repoPath: string | undefined;
+        if (repoParam) {
+          repoPath = ccConfig.repos?.[repoParam] ?? repoParam;
+        } else {
+          repoPath = ccConfig.defaultRepo ?? undefined;
+        }
+        if (!repoPath) {
+          return jsonResult({
+            status: "error",
+            error:
+              "No repo specified and no defaultRepo configured. Provide a repo alias or absolute path.",
+          });
+        }
+        repoPath = path.resolve(repoPath);
+
+        const permissionModeParam = readStringParam(params, "permissionMode");
+        const permissionMode: ClaudeCodePermissionMode =
+          (permissionModeParam as ClaudeCodePermissionMode) ??
+          ccConfig.permissionMode ??
+          "bypassPermissions";
+
+        const ccModel = modelOverride ?? ccConfig.model ?? undefined;
+        const ccTimeout =
+          (runTimeoutSeconds ?? 0) > 0 ? runTimeoutSeconds! : (ccConfig.timeoutSeconds ?? 600);
+        const ccBudget = ccConfig.maxBudgetUsd;
+
+        const requesterAgentId = normalizeAgentId(
+          opts?.requesterAgentIdOverride ??
+            parseAgentSessionKey(opts?.agentSessionKey ?? "")?.agentId,
+        );
+
+        const spawnId = crypto.randomUUID();
+        const repoLabel = repoParam || path.basename(repoPath);
+        const taskLabel = label || task;
+
+        void (async () => {
+          try {
+            const result = await spawnClaudeCode({
+              task,
+              repo: repoPath,
+              model: ccModel ?? undefined,
+              timeoutSeconds: ccTimeout,
+              maxBudgetUsd: ccBudget,
+              permissionMode,
+              agentId: requesterAgentId,
+              binaryPath: ccConfig.binaryPath ?? undefined,
+              mcpBridge: ccConfig.mcpBridge,
+              progressRelay: ccConfig.progressRelay,
+              onProgress: (event) => {
+                if (event.kind === "progress_summary") {
+                  const reqSessionKey = opts?.agentSessionKey ?? "main";
+                  const progressOrigin = normalizeDeliveryContext({
+                    channel: opts?.agentChannel,
+                    accountId: opts?.agentAccountId,
+                    to: opts?.agentTo,
+                    threadId: opts?.agentThreadId,
+                  });
+                  void callGateway({
+                    method: "agent",
+                    params: {
+                      sessionKey: reqSessionKey,
+                      message: `${event.summary}\n\nRelay this progress update to the user verbatim. Keep it brief.`,
+                      deliver: true,
+                      channel: progressOrigin?.channel,
+                      accountId: progressOrigin?.accountId,
+                      to: progressOrigin?.to,
+                      threadId:
+                        progressOrigin?.threadId != null
+                          ? String(progressOrigin.threadId)
+                          : undefined,
+                      idempotencyKey: crypto.randomUUID(),
+                    },
+                    expectFinal: true,
+                    timeoutMs: 30_000,
+                  }).catch(() => {});
+                }
+              },
+            });
+
+            const requesterOriginForAnnounce = normalizeDeliveryContext({
+              channel: opts?.agentChannel,
+              accountId: opts?.agentAccountId,
+              to: opts?.agentTo,
+              threadId: opts?.agentThreadId,
+            });
+
+            const statusText = result.success ? "completed successfully" : "finished with errors";
+            const costText = result.totalCostUsd > 0 ? ` ($${result.totalCostUsd.toFixed(2)})` : "";
+            const turnsText = result.numTurns > 0 ? `, ${result.numTurns} turns` : "";
+            const durationSec = Math.round(result.durationMs / 1000);
+            const errorText =
+              result.errors.length > 0 ? `\nErrors: ${result.errors.join(", ")}` : "";
+            const denialText =
+              result.permissionDenials.length > 0
+                ? `\nPermission denials: ${result.permissionDenials.join(", ")}`
+                : "";
+
+            const announceMessage = [
+              `A Claude Code task on [${repoLabel}] "${taskLabel}" just ${statusText}.`,
+              "",
+              "Result:",
+              result.result || "(no output)",
+              "",
+              `Stats: ${durationSec}s${costText}${turnsText}`,
+              `Session: ${result.sessionId} (resumable)`,
+              errorText,
+              denialText,
+              "",
+              "Summarize this naturally for the user. Keep it brief.",
+            ].join("\n");
+
+            const reqSessionKey = opts?.agentSessionKey ?? "main";
+            await callGateway({
+              method: "agent",
+              params: {
+                sessionKey: reqSessionKey,
+                message: announceMessage,
+                deliver: true,
+                channel: requesterOriginForAnnounce?.channel,
+                accountId: requesterOriginForAnnounce?.accountId,
+                to: requesterOriginForAnnounce?.to,
+                threadId:
+                  requesterOriginForAnnounce?.threadId != null
+                    ? String(requesterOriginForAnnounce.threadId)
+                    : undefined,
+                idempotencyKey: crypto.randomUUID(),
+              },
+              expectFinal: true,
+              timeoutMs: 60_000,
+            });
+          } catch (err) {
+            const errorMsg =
+              err instanceof Error ? err.message : typeof err === "string" ? err : "unknown error";
+            try {
+              const reqSessionKey = opts?.agentSessionKey ?? "main";
+              const requesterOriginForAnnounce = normalizeDeliveryContext({
+                channel: opts?.agentChannel,
+                accountId: opts?.agentAccountId,
+                to: opts?.agentTo,
+                threadId: opts?.agentThreadId,
+              });
+              await callGateway({
+                method: "agent",
+                params: {
+                  sessionKey: reqSessionKey,
+                  message: `Claude Code task on [${repoLabel}] failed: ${errorMsg}\n\nInform the user about this failure.`,
+                  deliver: true,
+                  channel: requesterOriginForAnnounce?.channel,
+                  accountId: requesterOriginForAnnounce?.accountId,
+                  to: requesterOriginForAnnounce?.to,
+                  threadId:
+                    requesterOriginForAnnounce?.threadId != null
+                      ? String(requesterOriginForAnnounce.threadId)
+                      : undefined,
+                  idempotencyKey: crypto.randomUUID(),
+                },
+                expectFinal: true,
+                timeoutMs: 60_000,
+              });
+            } catch {
+              // Best-effort
+            }
+          }
+        })();
+
+        return jsonResult({
+          status: "accepted",
+          mode: "claude-code",
+          repo: repoPath,
+          spawnId,
+          model: ccModel,
+          permissionMode,
+          timeoutSeconds: ccTimeout,
+        });
+      }
+
+      // Standard subagent spawn path
       const result = await spawnSubagentDirect(
         {
           task,

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -208,6 +208,9 @@ export function shouldMigrateStateFromPath(path: string[]): boolean {
   if (primary === "agent") {
     return false;
   }
+  if (primary === "cc") {
+    return false;
+  }
   return true;
 }
 

--- a/src/cli/cc-cli.ts
+++ b/src/cli/cc-cli.ts
@@ -1,0 +1,405 @@
+/**
+ * `openclaw cc` — Claude Code session management CLI.
+ *
+ * Commands:
+ *   list              List active/recent Claude Code sessions
+ *   info <sessionId>  Show session summary
+ *   attach <sessionId> Resume interactively in terminal (delegates to claude --resume)
+ *   kill <sessionId>  Kill a running session
+ *   costs             Cost summary across all CC sessions
+ */
+
+import { execSync } from "node:child_process";
+import path from "node:path";
+import type { Command } from "commander";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveClaudeBinary } from "../agents/claude-code/binary.js";
+import {
+  getAllLiveSessions,
+  killClaudeCode,
+  isClaudeCodeRunning,
+} from "../agents/claude-code/live-state.js";
+import { listAllSessions, listSessions } from "../agents/claude-code/sessions.js";
+import type { ClaudeCodeSessionEntry } from "../agents/claude-code/types.js";
+import { loadConfig } from "../config/config.js";
+import { defaultRuntime } from "../runtime.js";
+
+type CcListOptions = {
+  json?: boolean;
+  agent?: string;
+  all?: boolean;
+};
+
+type CcInfoOptions = {
+  json?: boolean;
+};
+
+type CcCostsOptions = {
+  json?: boolean;
+  since?: string;
+  agent?: string;
+};
+
+function resolveAgent(agent?: string): string {
+  if (agent?.trim()) {
+    return agent.trim();
+  }
+  const cfg = loadConfig();
+  return resolveDefaultAgentId(cfg);
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function formatCost(usd: number): string {
+  if (usd === 0) {
+    return "$0.00";
+  }
+  if (usd < 0.01) {
+    return `$${usd.toFixed(4)}`;
+  }
+  return `$${usd.toFixed(2)}`;
+}
+
+function formatSessionList(
+  sessions: Array<ClaudeCodeSessionEntry & { agentId: string; repoPath: string }>,
+  livePaths: Set<string>,
+): string {
+  if (sessions.length === 0) {
+    return "No Claude Code sessions found.";
+  }
+
+  const lines: string[] = ["Claude Code Sessions:", ""];
+
+  for (const s of sessions) {
+    const running = livePaths.has(s.repoPath);
+    const status = running ? " [RUNNING]" : "";
+    const repo = path.basename(s.repoPath);
+    const lastTask =
+      s.taskHistory.length > 0
+        ? s.taskHistory[s.taskHistory.length - 1].task.slice(0, 80)
+        : "(no tasks)";
+
+    lines.push(
+      `  ${s.sessionId.slice(0, 12)}...  ${repo}${status}  ${formatCost(s.totalCostUsd)}  ${s.totalTurns} turns`,
+    );
+    lines.push(`    Last: ${lastTask}`);
+    lines.push(`    Agent: ${s.agentId}  Updated: ${formatDate(s.lastResumedAt)}`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function formatSessionInfo(
+  sessionId: string,
+  entry: ClaudeCodeSessionEntry & { repoPath: string },
+  running: boolean,
+): string {
+  const lines: string[] = [
+    `Session: ${entry.sessionId}`,
+    `  Status:  ${running ? "RUNNING" : "idle"}`,
+    `  Repo:    ${entry.repoPath}`,
+    `  Created: ${formatDate(entry.createdAt)}`,
+    `  Updated: ${formatDate(entry.lastResumedAt)}`,
+    `  Cost:    ${formatCost(entry.totalCostUsd)}`,
+    `  Turns:   ${entry.totalTurns}`,
+    "",
+    "Task History:",
+  ];
+
+  if (entry.taskHistory.length === 0) {
+    lines.push("  (no tasks recorded)");
+  } else {
+    for (const t of entry.taskHistory) {
+      lines.push(`  ${formatDate(t.at)}  ${formatCost(t.costUsd)}  ${t.task.slice(0, 100)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function registerCcCli(program: Command) {
+  const cc = program.command("cc").description("Claude Code session management");
+
+  // -----------------------------------------------------------------------
+  // cc list
+  // -----------------------------------------------------------------------
+
+  cc.command("list")
+    .description("List active/recent Claude Code sessions")
+    .option("--json", "Output as JSON", false)
+    .option("--agent <id>", "Filter by agent ID")
+    .option("--all", "Show all agents", false)
+    .action((opts: CcListOptions) => {
+      try {
+        let sessions: Array<ClaudeCodeSessionEntry & { agentId: string; repoPath: string }>;
+        if (opts.all) {
+          sessions = listAllSessions();
+        } else {
+          const agentId = resolveAgent(opts.agent);
+          const agentSessions = listSessions(agentId);
+          sessions = Object.entries(agentSessions).map(([repoPath, entry]) => ({
+            ...entry,
+            agentId,
+            repoPath,
+          }));
+        }
+
+        // Sort by lastResumedAt descending
+        sessions.sort(
+          (a, b) => new Date(b.lastResumedAt).getTime() - new Date(a.lastResumedAt).getTime(),
+        );
+
+        // Get live sessions
+        const live = getAllLiveSessions();
+        const livePaths = new Set(live.keys());
+
+        if (opts.json) {
+          const output = sessions.map((s) => ({
+            ...s,
+            running: livePaths.has(s.repoPath),
+          }));
+          defaultRuntime.log(JSON.stringify(output, null, 2));
+        } else {
+          defaultRuntime.log(formatSessionList(sessions, livePaths));
+        }
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // cc info <sessionId>
+  // -----------------------------------------------------------------------
+
+  cc.command("info")
+    .description("Show session summary")
+    .argument("<sessionId>", "Session ID (partial match supported)")
+    .option("--json", "Output as JSON", false)
+    .action((sessionId: string, opts: CcInfoOptions) => {
+      try {
+        const allSessions = listAllSessions();
+        const match = allSessions.find(
+          (s) => s.sessionId === sessionId || s.sessionId.startsWith(sessionId),
+        );
+
+        if (!match) {
+          defaultRuntime.error(`No session found matching: ${sessionId}`);
+          defaultRuntime.exit(1);
+          return;
+        }
+
+        const running = isClaudeCodeRunning(match.repoPath);
+
+        if (opts.json) {
+          defaultRuntime.log(JSON.stringify({ ...match, running }, null, 2));
+        } else {
+          defaultRuntime.log(formatSessionInfo(sessionId, match, running));
+        }
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // cc attach <sessionId>
+  // -----------------------------------------------------------------------
+
+  cc.command("attach")
+    .description("Resume session interactively in terminal (delegates to claude --resume)")
+    .argument("<sessionId>", "Session ID")
+    .action((sessionId: string) => {
+      try {
+        const allSessions = listAllSessions();
+        const match = allSessions.find(
+          (s) => s.sessionId === sessionId || s.sessionId.startsWith(sessionId),
+        );
+
+        if (!match) {
+          defaultRuntime.error(`No session found matching: ${sessionId}`);
+          defaultRuntime.exit(1);
+          return;
+        }
+
+        if (isClaudeCodeRunning(match.repoPath)) {
+          defaultRuntime.error(
+            `Session is currently running via OpenClaw. Kill it first with: openclaw cc kill ${sessionId}`,
+          );
+          defaultRuntime.exit(1);
+          return;
+        }
+
+        const binary = resolveClaudeBinary();
+        defaultRuntime.log(`Attaching to session ${match.sessionId} in ${match.repoPath}...`);
+        defaultRuntime.log(
+          `Running: ${binary} --resume ${match.sessionId} --cwd ${match.repoPath}\n`,
+        );
+
+        // Exec claude --resume — this replaces the current process
+        execSync(`${binary} --resume ${match.sessionId}`, {
+          cwd: match.repoPath,
+          stdio: "inherit",
+        });
+      } catch (err) {
+        if (err != null && typeof err === "object" && "status" in err) {
+          // Normal exit from claude
+          return;
+        }
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // cc kill <sessionId>
+  // -----------------------------------------------------------------------
+
+  cc.command("kill")
+    .description("Kill a running Claude Code session")
+    .argument("<sessionId>", "Session ID")
+    .action((sessionId: string) => {
+      try {
+        const allSessions = listAllSessions();
+        const match = allSessions.find(
+          (s) => s.sessionId === sessionId || s.sessionId.startsWith(sessionId),
+        );
+
+        if (!match) {
+          defaultRuntime.error(`No session found matching: ${sessionId}`);
+          defaultRuntime.exit(1);
+          return;
+        }
+
+        if (!isClaudeCodeRunning(match.repoPath)) {
+          defaultRuntime.error(`Session ${match.sessionId} is not currently running.`);
+          defaultRuntime.exit(1);
+          return;
+        }
+
+        const killed = killClaudeCode(match.repoPath);
+        if (killed) {
+          defaultRuntime.log(
+            `Killed session ${match.sessionId} on ${path.basename(match.repoPath)}.`,
+          );
+        } else {
+          defaultRuntime.error("Failed to kill session.");
+          defaultRuntime.exit(1);
+        }
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // cc costs
+  // -----------------------------------------------------------------------
+
+  cc.command("costs")
+    .description("Cost summary across all Claude Code sessions")
+    .option("--json", "Output as JSON", false)
+    .option("--since <date>", "Filter by date (ISO format, e.g. 2026-02-01)")
+    .option("--agent <id>", "Filter by agent ID")
+    .action((opts: CcCostsOptions) => {
+      try {
+        let sessions = listAllSessions();
+
+        // Filter by agent
+        if (opts.agent) {
+          const agentId = opts.agent.trim();
+          sessions = sessions.filter((s) => s.agentId === agentId);
+        }
+
+        // Filter by date
+        let sinceDate: Date | null = null;
+        if (opts.since) {
+          sinceDate = new Date(opts.since);
+          if (Number.isNaN(sinceDate.getTime())) {
+            defaultRuntime.error(`Invalid date: ${opts.since}`);
+            defaultRuntime.exit(1);
+            return;
+          }
+          sessions = sessions.filter(
+            (s) => new Date(s.lastResumedAt).getTime() >= sinceDate!.getTime(),
+          );
+        }
+
+        // Compute totals
+        let totalCost = 0;
+        let totalTurns = 0;
+        let totalSessions = 0;
+        const byRepo: Record<string, { cost: number; turns: number; sessions: number }> = {};
+        const byAgent: Record<string, { cost: number; turns: number; sessions: number }> = {};
+
+        for (const s of sessions) {
+          totalCost += s.totalCostUsd;
+          totalTurns += s.totalTurns;
+          totalSessions += 1;
+
+          const repoKey = path.basename(s.repoPath);
+          if (!byRepo[repoKey]) {
+            byRepo[repoKey] = { cost: 0, turns: 0, sessions: 0 };
+          }
+          byRepo[repoKey].cost += s.totalCostUsd;
+          byRepo[repoKey].turns += s.totalTurns;
+          byRepo[repoKey].sessions += 1;
+
+          if (!byAgent[s.agentId]) {
+            byAgent[s.agentId] = { cost: 0, turns: 0, sessions: 0 };
+          }
+          byAgent[s.agentId].cost += s.totalCostUsd;
+          byAgent[s.agentId].turns += s.totalTurns;
+          byAgent[s.agentId].sessions += 1;
+        }
+
+        if (opts.json) {
+          defaultRuntime.log(
+            JSON.stringify({ totalCost, totalTurns, totalSessions, byRepo, byAgent }, null, 2),
+          );
+          return;
+        }
+
+        const sinceText = sinceDate ? ` since ${opts.since}` : "";
+        const lines: string[] = [
+          `Claude Code Cost Summary${sinceText}`,
+          "",
+          `  Total:    ${formatCost(totalCost)}  (${totalTurns} turns, ${totalSessions} sessions)`,
+          "",
+        ];
+
+        if (Object.keys(byRepo).length > 1) {
+          lines.push("  By Repo:");
+          for (const [repo, stats] of Object.entries(byRepo)) {
+            lines.push(
+              `    ${repo}: ${formatCost(stats.cost)}  (${stats.turns} turns, ${stats.sessions} sessions)`,
+            );
+          }
+          lines.push("");
+        }
+
+        if (Object.keys(byAgent).length > 1) {
+          lines.push("  By Agent:");
+          for (const [agent, stats] of Object.entries(byAgent)) {
+            lines.push(
+              `    ${agent}: ${formatCost(stats.cost)}  (${stats.turns} turns, ${stats.sessions} sessions)`,
+            );
+          }
+          lines.push("");
+        }
+
+        defaultRuntime.log(lines.join("\n"));
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+}

--- a/src/cli/cc-cli.ts
+++ b/src/cli/cc-cli.ts
@@ -19,8 +19,8 @@ import {
   killClaudeCode,
   isClaudeCodeRunning,
 } from "../agents/claude-code/live-state.js";
-import { listAllSessions, listSessions } from "../agents/claude-code/sessions.js";
-import type { ClaudeCodeSessionEntry } from "../agents/claude-code/types.js";
+import { listAllSessions, listSessions, discoverSessions } from "../agents/claude-code/sessions.js";
+import type { ClaudeCodeSessionEntry, DiscoveredSession } from "../agents/claude-code/types.js";
 import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 
@@ -28,6 +28,7 @@ type CcListOptions = {
   json?: boolean;
   agent?: string;
   all?: boolean;
+  repo?: string;
 };
 
 type CcInfoOptions = {
@@ -97,6 +98,51 @@ function formatSessionList(
   return lines.join("\n");
 }
 
+function formatAge(date: Date): string {
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) {
+    return "just now";
+  }
+  if (diffMin < 60) {
+    return `${diffMin}m ago`;
+  }
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) {
+    return `${diffHours}h ago`;
+  }
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+function formatDiscoveredSessions(sessions: DiscoveredSession[]): string {
+  if (sessions.length === 0) {
+    return "No Claude Code sessions found.";
+  }
+
+  const lines: string[] = ["Claude Code Sessions (all sources):", ""];
+
+  for (const s of sessions) {
+    const status = s.isRunning ? " [RUNNING]" : "";
+    const source = s.source === "openclaw" ? "openclaw" : "native";
+    const cost = s.totalCostUsd != null ? `  ${formatCost(s.totalCostUsd)}` : "";
+    const turns = s.totalTurns != null ? `  ${s.totalTurns}t` : "";
+    const agent = s.agentId ? `  agent:${s.agentId}` : "";
+    const label = s.label ? `  [${s.label}]` : "";
+    const age = formatAge(s.lastModified);
+    const msgs = `${s.messageCount} msgs`;
+    const firstMsg = s.firstMessage.slice(0, 70).replace(/\n/g, " ");
+
+    lines.push(
+      `  ${s.sessionId.slice(0, 12)}...  ${s.branch}${status}${label}  (${source})  ${age}  ${msgs}${cost}${turns}${agent}`,
+    );
+    lines.push(`    ${firstMsg}`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
 function formatSessionInfo(
   sessionId: string,
   entry: ClaudeCodeSessionEntry & { repoPath: string },
@@ -137,8 +183,27 @@ export function registerCcCli(program: Command) {
     .option("--json", "Output as JSON", false)
     .option("--agent <id>", "Filter by agent ID")
     .option("--all", "Show all agents", false)
-    .action((opts: CcListOptions) => {
+    .option("--repo <path>", "Discover all sessions for a repo (cross-source)")
+    .action(async (opts: CcListOptions) => {
       try {
+        // --repo mode: use discoverSessions() for cross-source discovery
+        if (opts.repo) {
+          const discovered = await discoverSessions(path.resolve(opts.repo));
+          if (opts.json) {
+            defaultRuntime.log(
+              JSON.stringify(
+                discovered.map((s) => ({ ...s, lastModified: s.lastModified.toISOString() })),
+                null,
+                2,
+              ),
+            );
+          } else {
+            defaultRuntime.log(formatDiscoveredSessions(discovered));
+          }
+          return;
+        }
+
+        // Legacy mode: registry-only listing
         let sessions: Array<ClaudeCodeSessionEntry & { agentId: string; repoPath: string }>;
         if (opts.all) {
           sessions = listAllSessions();

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -287,6 +287,15 @@ const entries: SubCliEntry[] = [
       mod.registerCompletionCli(program);
     },
   },
+  {
+    name: "cc",
+    description: "Claude Code session management",
+    hasSubcommands: false,
+    register: async (program) => {
+      const mod = await import("../cc-cli.js");
+      mod.registerCcCli(program);
+    },
+  },
 ];
 
 export function getSubCliEntries(): SubCliEntry[] {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -1,3 +1,4 @@
+import type { ClaudeCodeSubagentConfig } from "../agents/claude-code/types.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared.js";
 import type {
@@ -251,6 +252,8 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
+    /** Claude Code spawn mode configuration. */
+    claudeCode?: ClaudeCodeSubagentConfig;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,3 +1,4 @@
+import type { ClaudeCodeSubagentConfig } from "../agents/claude-code/types.js";
 import type { ChatType } from "../channels/chat-type.js";
 import type { AgentDefaultsConfig } from "./types.agent-defaults.js";
 import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared.js";
@@ -26,6 +27,8 @@ export type AgentConfig = {
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
+    /** Per-agent Claude Code spawn mode overrides. */
+    claudeCode?: ClaudeCodeSubagentConfig;
   };
   /** Optional per-agent sandbox overrides. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -148,6 +148,45 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        claudeCode: z
+          .object({
+            enabled: z.boolean().optional(),
+            binaryPath: z.string().nullable().optional(),
+            defaultRepo: z.string().nullable().optional(),
+            repos: z.record(z.string(), z.string()).optional(),
+            maxBudgetUsd: z.number().positive().optional(),
+            timeoutSeconds: z.number().int().positive().optional(),
+            permissionMode: z
+              .union([
+                z.literal("acceptEdits"),
+                z.literal("bypassPermissions"),
+                z.literal("default"),
+                z.literal("delegate"),
+                z.literal("dontAsk"),
+                z.literal("plan"),
+              ])
+              .optional(),
+            dangerouslySkipPermissions: z.boolean().optional(),
+            model: z.string().nullable().optional(),
+            mcpBridge: z
+              .object({
+                enabled: z.boolean().optional(),
+                exposeMemory: z.boolean().optional(),
+                exposeConversation: z.boolean().optional(),
+              })
+              .strict()
+              .optional(),
+            progressRelay: z
+              .object({
+                enabled: z.boolean().optional(),
+                intervalSeconds: z.number().int().positive().optional(),
+                includeToolUse: z.boolean().optional(),
+              })
+              .strict()
+              .optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -668,6 +668,45 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        claudeCode: z
+          .object({
+            enabled: z.boolean().optional(),
+            binaryPath: z.string().nullable().optional(),
+            defaultRepo: z.string().nullable().optional(),
+            repos: z.record(z.string(), z.string()).optional(),
+            maxBudgetUsd: z.number().positive().optional(),
+            timeoutSeconds: z.number().int().positive().optional(),
+            permissionMode: z
+              .union([
+                z.literal("acceptEdits"),
+                z.literal("bypassPermissions"),
+                z.literal("default"),
+                z.literal("delegate"),
+                z.literal("dontAsk"),
+                z.literal("plan"),
+              ])
+              .optional(),
+            dangerouslySkipPermissions: z.boolean().optional(),
+            model: z.string().nullable().optional(),
+            mcpBridge: z
+              .object({
+                enabled: z.boolean().optional(),
+                exposeMemory: z.boolean().optional(),
+                exposeConversation: z.boolean().optional(),
+              })
+              .strict()
+              .optional(),
+            progressRelay: z
+              .object({
+                enabled: z.boolean().optional(),
+                intervalSeconds: z.number().int().positive().optional(),
+                includeToolUse: z.boolean().optional(),
+              })
+              .strict()
+              .optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -778,6 +778,18 @@ export async function startGatewayServer(
       skillsChangeUnsub();
       authRateLimiter?.dispose();
       channelHealthMonitor?.stop();
+
+      // Kill orphaned Claude Code child processes
+      try {
+        const { killAllClaudeCode } = await import("../agents/claude-code/live-state.js");
+        const killed = killAllClaudeCode();
+        if (killed > 0) {
+          log.info(`killed ${killed} Claude Code child process(es) during shutdown`);
+        }
+      } catch {
+        // claude-code module may not be loaded; ignore
+      }
+
       await close(opts);
     },
   };


### PR DESCRIPTION
## Motivation

OpenClaw agents can spawn sub-agents for background tasks, but these run as API-driven sessions with no persistent workspace. For coding tasks, this means every spawn starts from scratch — no file context, no git state, no tool access beyond what the API provides.

Claude Code (CC) is purpose-built for coding: it understands repos, runs in a project directory, and maintains session state. By spawning CC as the backend instead of an API session, agents get a real coding environment. Critically, **CC sessions are resumable** — an agent can spawn a task, and the session can later be resumed in the CC CLI or VS Code extension for human review, debugging, or continuation. This bridges the gap between autonomous agent work and human-in-the-loop development.

`sessions_spawn(mode: "claude-code")` operates CC as CC — not a simulation, not an API wrapper. It runs the actual CLI binary, communicates via its native NDJSON protocol, and persists sessions in CC's own format. The result is that agent-initiated coding work lives in the same session history a developer would see in their editor.

## What it does

- **Spawns Claude Code CLI** as a child process with the task as input
- **Streams NDJSON protocol** — parses all CC message types (assistant, result, system, tool_use/tool_result)
- **Session persistence** — sessions are stored per-agent per-repo, resumable from CC CLI or VS Code
- **MCP bridge** — exposes select gateway tools (web_search, web_fetch, message, memory) to CC via stdio MCP server
- **Progress relay** — streams periodic summaries back to the requester's chat
- **Result announcement** — announces completion/failure with stats (duration, cost, turns)
- **Graceful lifecycle** — tracks active CC processes, kills orphans on gateway shutdown
- **CLI**: `openclaw cc` for listing, inspecting, attaching to, and killing CC sessions

## Configuration

```jsonc
// openclaw.json
{
  "agents": {
    "defaults": {
      "subagents": {
        "claudeCode": {
          "enabled": true,
          "defaultRepo": "/path/to/project",
          "repos": { "myapp": "/path/to/myapp" },
          "permissionMode": "bypassPermissions",
          "model": "opus",
          "timeoutSeconds": 600,
          "maxBudgetUsd": 5
        }
      }
    }
  }
}
```

## Testing

31 unit tests covering protocol parsing, session management, binary resolution, MCP bridge, runner lifecycle, and live-state tracking.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Claude Code spawn mode, enabling OpenClaw agents to delegate coding tasks to Claude Code CLI as background sub-agents. The implementation includes a complete protocol parser for NDJSON streaming, session management with persistence, an MCP bridge to expose OpenClaw tools to Claude Code, and graceful lifecycle management.

**Key Changes:**
- New `src/agents/claude-code/` module with protocol parser, runner, session registry, MCP bridge, and live-state tracking
- Integration into `sessions_spawn` tool with `mode: "claude-code"` parameter
- Configuration schema for Claude Code settings in agent defaults
- CLI command `openclaw cc` for session management (list, info, attach, kill, costs)
- Gateway shutdown hooks to clean up orphaned child processes
- 31 unit tests covering protocol parsing, session management, and runner lifecycle

**Architecture Highlights:**
- Bidirectional NDJSON communication via stdin/stdout with Claude Code CLI
- Per-repo concurrency control (1 active + 1 queued spawn)
- Progress relay with periodic summaries sent to chat
- MCP bridge exposes 4 tools: conversation context, memory search, announce, session info
- Idle debounce timeout (30s) works around Claude Code CLI bugs where result messages are missing
- Persistent session mode for follow-up messages with 30-minute idle timeout
- Session registry persists to `~/.openclaw/agents/{agentId}/claude-code-sessions.json`

**Testing:**
- Comprehensive unit test coverage (31 tests)
- Protocol parsing validated for all message types
- Session registry CRUD operations tested
- Binary resolution with fallback handling tested

<h3>Confidence Score: 4/5</h3>

- Safe to merge with thorough testing and clean architecture
- Strong implementation with comprehensive test coverage (31 tests), proper error handling, graceful shutdown mechanisms, and well-structured protocol parsing. Environment variables are properly cleaned to prevent nested session issues. The MCP bridge correctly escapes JSON inputs to prevent injection. Minor concern about the idle debounce workaround for upstream CLI bugs, but this is documented and includes active child process detection as a safeguard.
- No files require special attention

<sub>Last reviewed commit: f991bfa</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->
