### PR TITLE
fix(telegram): serialize per-chat sends and await block reply flush before tools

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -134,9 +134,11 @@ export async function handleToolExecutionStart(
   evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
 ) {
   // Flush pending block replies to preserve message boundaries before tool execution.
+  // Await the flush to ensure block replies are delivered before tool-initiated sends
+  // (e.g., message tool sending a file), preventing out-of-order delivery on Telegram.
   ctx.flushBlockReplyBuffer();
   if (ctx.params.onBlockReplyFlush) {
-    void ctx.params.onBlockReplyFlush();
+    await ctx.params.onBlockReplyFlush();
   }
 
   const rawToolName = String(evt.toolName);


### PR DESCRIPTION
## Problem

When an agent sends text (block reply) followed by a tool-initiated send (e.g., message tool sending a PDF), messages can arrive out of order on Telegram.

## Root Cause

1. **No per-chat send ordering**: sendMessageTelegram calls from block replies and the message tool fire concurrently
2. **Block reply buffer not flushed before tools**: The coalescer holds buffered text when a tool starts

## Fix

### Per-chat send serializer (src/telegram/send.ts)
- chatSendChains Map keyed by accountId:chatId
- serializeChatSend chains concurrent sends via promise chaining
- Wraps sendMessageTelegram for FIFO ordering per chat

### Await block reply flush (src/agents/pi-embedded-subscribe.handlers.tools.ts)
- flushBlockReplyBuffer() + await onBlockReplyFlush() before tool execution
- Ensures pending text is delivered before tool-initiated sends

## Changes
- src/telegram/send.ts — per-chat send serializer (37 lines)
- src/agents/pi-embedded-subscribe.handlers.tools.ts — flush + await (3 lines)