### PR TITLE
fix: support target param in message tool send extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 **/node_modules/
 .env
+cloud-init.yaml
 docker-compose.extra.yml
 dist
 pnpm-lock.yaml

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -249,7 +249,12 @@ export function extractMessagingToolSend(
     if (action !== "send" && action !== "thread-reply") {
       return undefined;
     }
-    const toRaw = typeof args.to === "string" ? args.to : undefined;
+    const toRaw =
+      typeof args.to === "string"
+        ? args.to
+        : typeof args.target === "string"
+          ? args.target
+          : undefined;
     if (!toRaw) {
       return undefined;
     }


### PR DESCRIPTION
## Problem

`extractMessagingToolSend()` in `pi-embedded-subscribe.tools.ts` only checks `args.to` when extracting the recipient from a message tool call. However, the message tool also accepts `target` as the recipient parameter.

When agents use `target` instead of `to`, the extraction returns `undefined` — breaking the duplicate-send suppression logic. This causes the agent to send the message via the tool AND echo it again as a block reply, resulting in duplicate messages.

## Fix

Add `args.target` as a fallback in the recipient extraction:

```typescript
const toRaw = typeof args.to === "string" ? args.to
  : typeof args.target === "string" ? args.target
  : undefined;
```

## Changes

- `src/agents/pi-embedded-subscribe.tools.ts` — check `args.target` after `args.to` in `extractMessagingToolSend()`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed duplicate message suppression by checking both `to` and `target` parameters in message tool send extraction. The message tool schema accepts `target` as an alternative to `to` for specifying recipients (line 45 in `message-tool.ts`), and the tool's execute function checks both parameters (lines 605-606). However, `extractMessagingToolSend()` only checked `args.to`, causing it to return `undefined` when agents used `target`, which broke the duplicate-send suppression logic.

The fix adds `args.target` as a fallback after checking `args.to`, ensuring extraction works correctly regardless of which parameter name the agent uses.

Minor unrelated change: Added `cloud-init.yaml` to `.gitignore`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward, well-justified, and aligns with existing code patterns. The message tool already handles both `to` and `target` parameters in its execute function (lines 605-606), and the schema explicitly defines `target` as an optional parameter. The extraction function now matches this behavior. The change is minimal, defensive (checks type before accessing), and follows the existing code structure. The `.gitignore` addition is a standard configuration file exclusion.
- No files require special attention

<sub>Last reviewed commit: 55de282</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->