### PR TITLE
iOS onboarding: stop auth step-3 retry loop churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Voice call/Gateway: prevent overlapping closed-loop turn races with per-call turn locking, route transcript dedupe via source-aware fingerprints with strict cache eviction bounds, and harden `voicecall latency` stats for large logs without spread-operator stack overflow. (#19140) Thanks @mbelinky.
+- iOS/Onboarding: stop auth Step 3 retry-loop churn by pausing reconnect attempts on unauthorized/missing-token gateway errors and keeping auth/pairing issue state sticky during manual retry. (#19153) Thanks @mbelinky.
 - Fix types in all tests. Typecheck the whole repository.
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -1626,6 +1626,10 @@ private extension NodeAppModel {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     continue
                 }
+                if !self.gatewayAutoReconnectEnabled {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    continue
+                }
                 if await self.isOperatorConnected() {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     continue
@@ -1705,6 +1709,10 @@ private extension NodeAppModel {
 
             while !Task.isCancelled {
                 if self.gatewayPairingPaused {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    continue
+                }
+                if !self.gatewayAutoReconnectEnabled {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     continue
                 }
@@ -1795,10 +1803,18 @@ private extension NodeAppModel {
                     }
                     GatewayDiagnostics.log("gateway connect error: \(error.localizedDescription)")
 
+                    // If auth is missing/rejected, pause reconnect churn until the user intervenes.
+                    // Reconnect loops only spam the same failing handshake and make onboarding noisy.
+                    let lower = error.localizedDescription.lowercased()
+                    if lower.contains("unauthorized") || lower.contains("gateway token missing") {
+                        await MainActor.run {
+                            self.gatewayAutoReconnectEnabled = false
+                        }
+                    }
+
                     // If pairing is required, stop reconnect churn. The user must approve the request
                     // on the gateway before another connect attempt will succeed, and retry loops can
                     // generate multiple pending requests.
-                    let lower = error.localizedDescription.lowercased()
                     if lower.contains("not_paired") || lower.contains("pairing required") {
                         let requestId: String? = {
                             // GatewayResponseError for connect decorates the message with `(requestId: ...)`.

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -818,7 +818,7 @@ struct OnboardingWizardView: View {
 
     private func retryLastAttempt() async {
         self.connectingGatewayID = "retry"
-        self.issue = .none
+        // Keep current auth/pairing issue sticky while retrying to avoid Step 3 UI flip-flop.
         self.connectMessage = "Retrying…"
         self.statusLine = "Retrying last connection…"
         defer { self.connectingGatewayID = nil }


### PR DESCRIPTION
## Summary
Stabilize iOS onboarding authentication flow to stop the Step 3 retry flip-flop between auth states.

## What changed
- `apps/ios/Sources/Onboarding/OnboardingWizardView.swift`
  - Keep current `issue` sticky during `retryLastAttempt()` instead of resetting to `.none`.
  - Prevents UI oscillation between pairing/auth states while retry is in progress.

- `apps/ios/Sources/Model/NodeAppModel.swift`
  - Both reconnect loops (`operator` and `node`) now honor `gatewayAutoReconnectEnabled`.
  - On `unauthorized` / `gateway token missing`, auto-reconnect is paused to avoid retry churn until user intervention.

## Why
Previously onboarding set `gatewayAutoReconnectEnabled = false`, but reconnect loops ignored that flag. Combined with clearing `issue` on retry, this could produce Step 3 churn and unstable auth UX.

## Validation
- Build: `xcodebuild build -project OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17'` ✅
- Targeted test attempt: `xcodebuild test ... -only-testing:OpenClawTests/GatewayConnectionIssueTests` ❌
  - Fails due to unrelated pre-existing compile error in tests: `GatewayTLSStore` not found in `apps/ios/Tests/GatewayConnectionSecurityTests.swift`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Step 3 retry loop churn during iOS onboarding by making two coordinated changes:

- **Reconnect loops now respect `gatewayAutoReconnectEnabled`**: Both the operator and node gateway reconnect loops in `NodeAppModel.swift` add a guard check for the flag. Previously, onboarding set this flag to `false`, but the loops ignored it, causing continued retry churn. Additionally, the node loop's error handler now disables auto-reconnect on `unauthorized` / `gateway token missing` errors, matching the existing pairing-pause pattern.
- **Sticky issue state during retry**: `OnboardingWizardView.retryLastAttempt()` no longer resets `self.issue` to `.none`, preventing the auth step UI from flip-flopping between states while a retry is in flight. Fresh user-initiated actions (manual connect, QR scan) still correctly clear the issue.

The changes are well-scoped and consistent with existing patterns (`gatewayPairingPaused` guard, `GatewayConnectionIssue.detect` logic).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the changes are defensive guards that prevent unnecessary retry loops and UI oscillation.
- Score of 4 reflects that the changes are well-scoped, follow existing patterns in the codebase (mirroring the gatewayPairingPaused guard), and address a clear UX bug. The string-matching approach for error detection is consistent with GatewayConnectionIssue.detect. Minor concern: the operator loop's catch block doesn't independently detect auth errors to set gatewayAutoReconnectEnabled = false, but this is mitigated because the node loop handles it and both loops check the shared flag. Build verification passed per the PR description.
- No files require special attention. Both changes are straightforward and consistent with existing patterns.

<sub>Last reviewed commit: 9bcc356</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->