### PR TITLE
feat(discord): add edit-based preview streaming (streamMode)

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -7,6 +7,8 @@ import type {
   OutboundRetryConfig,
   ReplyToMode,
 } from "./types.base.js";
+
+export type DiscordStreamMode = "partial" | "off";
 import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
 import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
@@ -153,6 +155,13 @@ export type DiscordAccountConfig = {
   chunkMode?: "length" | "newline";
   /** Disable block streaming for this account. */
   blockStreaming?: boolean;
+  /**
+   * Live preview streaming mode (edit-based, like Telegram).
+   * - "partial": send a message and continuously edit it with new content as tokens arrive.
+   * - "off": no preview streaming (default).
+   * When enabled, block streaming is automatically suppressed to avoid double-streaming.
+   */
+  streamMode?: DiscordStreamMode;
   /** Merge streamed block replies before sending. */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
   /**

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -287,6 +287,7 @@ export const DiscordAccountSchema = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    streamMode: z.enum(["partial", "off"]).optional(),
     maxLinesPerMessage: z.number().int().positive().optional(),
     mediaMaxMb: z.number().positive().optional(),
     retry: RetryConfigSchema,

--- a/src/discord/draft-stream.ts
+++ b/src/discord/draft-stream.ts
@@ -1,0 +1,161 @@
+import type { RequestClient } from "@buape/carbon";
+import { Routes } from "discord-api-types/v10";
+import { createDraftStreamLoop } from "../channels/draft-stream-loop.js";
+
+/** Discord messages cap at 2000 characters. */
+const DISCORD_STREAM_MAX_CHARS = 2000;
+const DEFAULT_THROTTLE_MS = 1200;
+
+export type DiscordDraftStream = {
+  update: (text: string) => void;
+  flush: () => Promise<void>;
+  messageId: () => string | undefined;
+  clear: () => Promise<void>;
+  stop: () => Promise<void>;
+  /** Reset internal state so the next update creates a new message instead of editing. */
+  forceNewMessage: () => void;
+};
+
+export function createDiscordDraftStream(params: {
+  rest: RequestClient;
+  channelId: string;
+  maxChars?: number;
+  replyToMessageId?: string;
+  throttleMs?: number;
+  /** Minimum chars before sending first message (debounce for push notifications) */
+  minInitialChars?: number;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}): DiscordDraftStream {
+  const maxChars = Math.min(
+    params.maxChars ?? DISCORD_STREAM_MAX_CHARS,
+    DISCORD_STREAM_MAX_CHARS,
+  );
+  const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
+  const minInitialChars = params.minInitialChars;
+  const channelId = params.channelId;
+  const rest = params.rest;
+
+  let streamMessageId: string | undefined;
+  let lastSentText = "";
+  let stopped = false;
+  let isFinal = false;
+
+  const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
+    // Allow final flush even if stopped (e.g., after clear()).
+    if (stopped && !isFinal) {
+      return false;
+    }
+    const trimmed = text.trimEnd();
+    if (!trimmed) {
+      return false;
+    }
+    if (trimmed.length > maxChars) {
+      // Discord messages cap at 2000 chars.
+      // Stop streaming once we exceed the cap to avoid repeated API failures.
+      stopped = true;
+      params.warn?.(
+        `discord stream preview stopped (text length ${trimmed.length} > ${maxChars})`,
+      );
+      return false;
+    }
+    if (trimmed === lastSentText) {
+      return true;
+    }
+
+    // Debounce first preview send for better push notification quality.
+    if (streamMessageId === undefined && minInitialChars != null && !isFinal) {
+      if (trimmed.length < minInitialChars) {
+        return false;
+      }
+    }
+
+    lastSentText = trimmed;
+    try {
+      if (streamMessageId !== undefined) {
+        // Edit existing message
+        await rest.patch(Routes.channelMessage(channelId, streamMessageId), {
+          body: { content: trimmed },
+        });
+        return true;
+      }
+      // Send new message
+      const messageReference = params.replyToMessageId
+        ? { message_id: params.replyToMessageId, fail_if_not_exists: false }
+        : undefined;
+      const sent = (await rest.post(Routes.channelMessages(channelId), {
+        body: {
+          content: trimmed,
+          ...(messageReference ? { message_reference: messageReference } : {}),
+        },
+      })) as { id?: string } | undefined;
+      const sentMessageId = sent?.id;
+      if (typeof sentMessageId !== "string" || !sentMessageId) {
+        stopped = true;
+        params.warn?.("discord stream preview stopped (missing message id from send)");
+        return false;
+      }
+      streamMessageId = sentMessageId;
+      return true;
+    } catch (err) {
+      stopped = true;
+      params.warn?.(
+        `discord stream preview failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return false;
+    }
+  };
+
+  const loop = createDraftStreamLoop({
+    throttleMs,
+    isStopped: () => stopped,
+    sendOrEditStreamMessage,
+  });
+
+  const update = (text: string) => {
+    if (stopped || isFinal) {
+      return;
+    }
+    loop.update(text);
+  };
+
+  const stop = async (): Promise<void> => {
+    isFinal = true;
+    await loop.flush();
+  };
+
+  const clear = async () => {
+    stopped = true;
+    loop.stop();
+    await loop.waitForInFlight();
+    const messageId = streamMessageId;
+    streamMessageId = undefined;
+    if (typeof messageId !== "string") {
+      return;
+    }
+    try {
+      await rest.delete(Routes.channelMessage(channelId, messageId));
+    } catch (err) {
+      params.warn?.(
+        `discord stream preview cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+
+  const forceNewMessage = () => {
+    streamMessageId = undefined;
+    lastSentText = "";
+    loop.resetPending();
+  };
+
+  params.log?.(`discord stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);
+
+  return {
+    update,
+    flush: loop.flush,
+    messageId: () => streamMessageId,
+    clear,
+    stop,
+    forceNewMessage,
+  };
+}


### PR DESCRIPTION
## Summary

Adds live preview streaming for Discord, using the same `sendMessage` + `editMessage` pattern as Telegram's `streamMode`.

When `channels.discord.streamMode` is set to `"partial"`, the agent's response is sent as a single message that gets continuously edited as tokens arrive — giving users real-time feedback instead of waiting for the full response.

Inspired by @steipete's [tweet about Telegram streaming](https://x.com/steipete/status/2023247982427070784) — we thought Discord deserved the same treatment.

## Changes

- **New `src/discord/draft-stream.ts`** — Discord-specific draft stream using the shared `createDraftStreamLoop` infrastructure (same as Telegram)
- **Modified `message-handler.process.ts`** — Hooks `onPartialReply` into the dispatch pipeline with preview finalization via edit
- **Config type + Zod schema** — Adds `streamMode: "partial" | "off"` to `DiscordAccountConfig`
- Auto-suppresses block streaming when `streamMode` is active to avoid double-streaming

## Config

```json
{
  "channels": {
    "discord": {
      "streamMode": "partial"
    }
  }
}
```

## How it works

1. User sends a message
2. Bot sends a single Discord message with initial text (after 30-char debounce)
3. As tokens stream in → bot edits that same message with accumulated text
4. When generation completes → final edit with the complete response (no delete + resend)
5. Falls back to standard delivery for media, errors, or >2000 char responses

## Technical details

- Reuses `createDraftStreamLoop` from `src/channels/draft-stream-loop.ts` (battle-tested by Telegram)
- Default throttle: 1200ms (respects Discord's ~5 edits/5s rate limit)
- 2000-char Discord message limit enforced (stops streaming at cap, falls back)
- Push notification debounce: waits for 30+ chars before first send
- Anti-flicker: ignores regressive text updates
- Graceful cleanup: preview message deleted on error or when response needs standard delivery

## Testing

- TypeScript: zero compilation errors
- 7 unit tests passing (send/edit flow, debounce, char limit, cleanup, reply-to, anti-flicker, flush)
- **Live tested on Discord** — confirmed working with real agent responses streaming in real-time

## Screenshots

Tested live in a Discord guild — messages stream in progressively just like Telegram's `streamMode: "partial"`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds edit-based live preview streaming for Discord, mirroring the existing Telegram `streamMode: "partial"` feature. When enabled, the bot sends a single message and continuously edits it as tokens stream in, providing real-time feedback instead of waiting for the full response.

The implementation correctly reuses the shared `createDraftStreamLoop` infrastructure and follows the established Telegram pattern closely. The new `draft-stream.ts` is a clean Discord-specific adapter with proper 2000-char limit enforcement, rate-limit-aware throttling (1200ms), and graceful fallback to standard delivery for media, errors, or oversized responses.

- Config schema (`streamMode: "partial" | "off"`) is correctly added to both Zod validation and TypeScript types
- Block streaming is properly suppressed when draft streaming is active to avoid double-streaming
- Finalization path handles multiple edge cases: preview edit, post-stop edit, and clear-and-fallback
- Two pieces of dead code in `message-handler.process.ts`: `hasStreamedMessage` is assigned but never read, and `flushDraft` is declared but never called — both are used in the Telegram equivalent but appear to have been copied without being wired up
- The `DiscordStreamMode` type export is placed between import blocks in `types.discord.ts` (minor style issue)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the core streaming logic is sound and well-tested, with only minor dead code to clean up.
- Score of 4 reflects that the feature implementation is architecturally sound, reuses battle-tested infrastructure, and handles edge cases well. Deducted one point for two pieces of dead code (hasStreamedMessage and flushDraft) that suggest incomplete adaptation from the Telegram template — they're harmless but indicate potential missed functionality or untidy code.
- `src/discord/monitor/message-handler.process.ts` contains dead code (unused `hasStreamedMessage` variable and `flushDraft` function) that should be cleaned up or wired in.

<sub>Last reviewed commit: 6ed76d5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->