### PR TITLE
fix(discord): defer guild listing in allowlist resolution to avoid unnecessary API failures

### DIFF
--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -221,9 +221,16 @@ async function promptDiscordAllowFrom(params: {
     const results = await resolveDiscordUserAllowlist({
       token,
       entries: parts,
-    }).catch(() => null);
-    if (!results) {
-      await params.prompter.note("Failed to resolve usernames. Try again.", "Discord allowlist");
+    }).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      return { error: message } as const;
+    });
+    if (!results || "error" in results) {
+      const detail = results && "error" in results ? `: ${results.error}` : "";
+      await params.prompter.note(
+        `Failed to resolve usernames${detail}. Try numeric user ids instead.`,
+        "Discord allowlist",
+      );
       continue;
     }
     const unresolved = results.filter((res) => !res.resolved || !res.id);

--- a/src/discord/resolve-users.test.ts
+++ b/src/discord/resolve-users.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { resolveDiscordUserAllowlist } from "./resolve-users.js";
+
+/**
+ * Stub fetcher that records calls and returns canned responses.
+ * Throws on unexpected paths to catch unintended API calls.
+ */
+function makeFetcher(responses: Record<string, unknown>): typeof fetch & { calls: string[] } {
+  const calls: string[] = [];
+  const fn = (async (url: RequestInfo | URL) => {
+    const urlStr = typeof url === "string" ? url : (url as URL).href;
+    const path = urlStr.replace("https://discord.com/api/v10", "");
+    calls.push(path);
+    const body = responses[path];
+    if (body === undefined) {
+      return { ok: false, status: 404, text: async () => "not found" } as Response;
+    }
+    return {
+      ok: true,
+      json: async () => body,
+    } as Response;
+  }) as typeof fetch & { calls: string[] };
+  fn.calls = calls;
+  return fn;
+}
+
+describe("resolveDiscordUserAllowlist", () => {
+  const VALID_TOKEN = "Bot MTIz.abc.def";
+
+  it("resolves numeric user ids without any API calls", async () => {
+    const fetcher = makeFetcher({});
+
+    const results = await resolveDiscordUserAllowlist({
+      token: VALID_TOKEN,
+      entries: ["994979735488692324", "123456789012345678"],
+      fetcher,
+    });
+
+    expect(results).toEqual([
+      { input: "994979735488692324", resolved: true, id: "994979735488692324" },
+      { input: "123456789012345678", resolved: true, id: "123456789012345678" },
+    ]);
+    // No API calls should have been made
+    expect(fetcher.calls).toHaveLength(0);
+  });
+
+  it("resolves mention-form ids without API calls", async () => {
+    const fetcher = makeFetcher({});
+
+    const results = await resolveDiscordUserAllowlist({
+      token: VALID_TOKEN,
+      entries: ["<@994979735488692324>", "<@!123456789012345678>"],
+      fetcher,
+    });
+
+    expect(results).toEqual([
+      { input: "<@994979735488692324>", resolved: true, id: "994979735488692324" },
+      { input: "<@!123456789012345678>", resolved: true, id: "123456789012345678" },
+    ]);
+    expect(fetcher.calls).toHaveLength(0);
+  });
+
+  it("resolves prefixed ids without API calls", async () => {
+    const fetcher = makeFetcher({});
+
+    const results = await resolveDiscordUserAllowlist({
+      token: VALID_TOKEN,
+      entries: ["user:994979735488692324", "discord:123456789012345678"],
+      fetcher,
+    });
+
+    expect(results).toEqual([
+      { input: "user:994979735488692324", resolved: true, id: "994979735488692324" },
+      { input: "discord:123456789012345678", resolved: true, id: "123456789012345678" },
+    ]);
+    expect(fetcher.calls).toHaveLength(0);
+  });
+
+  it("fetches guilds only when a username needs resolution", async () => {
+    const fetcher = makeFetcher({
+      "/users/@me/guilds": [{ id: "111", name: "Test Guild" }],
+      "/guilds/111/members/search?query=tonic_1&limit=25": [
+        {
+          user: { id: "999", username: "tonic_1", global_name: "Tonic" },
+        },
+      ],
+    });
+
+    const results = await resolveDiscordUserAllowlist({
+      token: VALID_TOKEN,
+      entries: ["994979735488692324", "tonic_1"],
+      fetcher,
+    });
+
+    expect(results[0]).toEqual({
+      input: "994979735488692324",
+      resolved: true,
+      id: "994979735488692324",
+    });
+    expect(results[1]).toMatchObject({
+      input: "tonic_1",
+      resolved: true,
+      id: "999",
+    });
+    // Guild listing + member search = 2 calls (not called for the numeric id)
+    expect(fetcher.calls).toHaveLength(2);
+    expect(fetcher.calls[0]).toBe("/users/@me/guilds");
+  });
+
+  it("returns unresolved for empty token", async () => {
+    const results = await resolveDiscordUserAllowlist({
+      token: "",
+      entries: ["alice"],
+    });
+
+    expect(results).toEqual([{ input: "alice", resolved: false }]);
+  });
+
+  it("returns unresolved for empty input", async () => {
+    const fetcher = makeFetcher({
+      "/users/@me/guilds": [],
+    });
+
+    const results = await resolveDiscordUserAllowlist({
+      token: VALID_TOKEN,
+      entries: [""],
+      fetcher,
+    });
+
+    expect(results).toEqual([{ input: "", resolved: false }]);
+    // No guild call needed for empty input
+    expect(fetcher.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #18955.

During Discord onboarding, `resolveDiscordUserAllowlist()` calls `listGuilds()` **unconditionally** at the top of the function — before processing individual entries. This means that even pure numeric user ids (which need no API resolution at all) will fail if the `listGuilds` call errors out (rate limit, invalid token, network issue, bot not in any guild yet).

The onboarding flow then swallows the error with `.catch(() => null)` and shows the generic "Failed to resolve usernames. Try again." — giving users zero information about what went wrong or how to work around it.

## Root Cause

```ts
// Before: guilds fetched unconditionally, even for numeric ids
const guilds = await listGuilds(token, fetcher);
// ... then loops through entries
```

## Fix

**1. Defer `listGuilds` (resolve-users.ts)**

Guild listing is now lazy — only called when the first username-based entry actually needs guild member search. Numeric user ids (bare `994979735488692324`, mention `<@994979735488692324>`, prefixed `user:994979735488692324`) resolve immediately without any Discord API call.

**2. Surface the error (onboarding/discord.ts)**

When `resolveDiscordUserAllowlist` does throw, the onboarding prompt now shows the actual error message and suggests using numeric user ids as a fallback:

```
Failed to resolve usernames: Discord API /users/@me/guilds failed (401): 401: Unauthorized. Try numeric user ids instead.
```

## Tests

New test suite `src/discord/resolve-users.test.ts` (6 tests):
- Numeric ids resolve without any API calls
- Mention-form ids resolve without any API calls
- Prefixed ids (`user:`, `discord:`) resolve without any API calls
- Guild listing only triggered when a username needs resolution
- Empty token returns unresolved
- Empty input returns unresolved

All existing Discord tests continue to pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Deferred guild listing in `resolveDiscordUserAllowlist()` to avoid unnecessary Discord API calls when all allowlist entries are numeric user IDs. Previously, `listGuilds()` was called unconditionally at the start, causing failures even for pure numeric entries if the API call failed (rate limits, invalid tokens, bot not in any guilds). Now guild listing only happens when the first username-based entry needs resolution.

Improved error handling in the onboarding flow (`promptDiscordAllowFrom`) to surface the actual error message to users instead of the generic "Failed to resolve usernames. Try again." Users now see specific Discord API errors and are advised to use numeric user IDs as a fallback.

Added comprehensive test coverage for the lazy loading behavior with 6 new tests verifying that numeric IDs (bare, mention-form, and prefixed) resolve without API calls and that guild listing is only triggered when needed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused performance and UX improvement with comprehensive test coverage. The lazy loading pattern is correctly implemented using a null check, only fetching guilds when needed. Error handling is improved to provide users actionable feedback. All existing tests pass, and 6 new tests validate the deferred behavior for numeric IDs and ensure guild listing only happens when necessary. The implementation maintains backward compatibility and improves both performance and error messages without introducing breaking changes.
- No files require special attention

<sub>Last reviewed commit: ddc689e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->