### PR TITLE
fix(discord): dedupe native skill commands across agents by skill name

### DIFF
--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -106,7 +106,7 @@ describe("resolveSkillCommandInvocation", () => {
 });
 
 describe("listSkillCommandsForAgents", () => {
-  it("merges command names across agents and de-duplicates", async () => {
+  it("drops duplicate skills across agents while keeping unique skills", async () => {
     const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-"));
     const mainWorkspace = path.join(baseDir, "main");
     const researchWorkspace = path.join(baseDir, "research");
@@ -125,7 +125,7 @@ describe("listSkillCommandsForAgents", () => {
     });
     const names = commands.map((entry) => entry.name);
     expect(names).toContain("demo_skill");
-    expect(names).toContain("demo_skill_2");
+    expect(names).not.toContain("demo_skill_2");
     expect(names).toContain("extra_skill");
   });
 });

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -47,6 +47,7 @@ export function listSkillCommandsForAgents(params: {
 }): SkillCommandSpec[] {
   const used = listReservedChatSlashCommandNames();
   const entries: SkillCommandSpec[] = [];
+  const seenSkillNames = new Set<string>();
   const agentIds = params.agentIds ?? listAgentIds(params.cfg);
   // Track visited workspace dirs to avoid registering duplicate commands
   // when multiple agents share the same workspace directory (#5717).
@@ -68,6 +69,13 @@ export function listSkillCommandsForAgents(params: {
       reservedNames: used,
     });
     for (const command of commands) {
+      const skillKey = command.skillName.trim().toLowerCase();
+      if (skillKey && seenSkillNames.has(skillKey)) {
+        continue;
+      }
+      if (skillKey) {
+        seenSkillNames.add(skillKey);
+      }
       used.add(command.name.toLowerCase());
       entries.push(command);
     }


### PR DESCRIPTION
## Summary
- follow-up to #17365
- de-duplicate skill native command specs across agents/workspaces by canonical `skillName` before Discord registration
- keep unique skills intact; only drop true duplicates that currently surface as suffixed variants (for example `_2`)

## Why
`skillName` duplicates can still enter the final native command set when multiple agents/workspaces expose the same skill. That can lead to suffixed command variants being registered on Discord depending on ordering/reconciliation.

## Changes
- `src/auto-reply/skill-commands.ts`
  - added `seenSkillNames` tracking in `listSkillCommandsForAgents`
  - skip duplicate entries when the same normalized `skillName` is encountered again
- `src/auto-reply/skill-commands.test.ts`
  - updated expectations to assert duplicate skill command variants are not emitted

## Validation
- `pnpm exec vitest run --config vitest.unit.config.ts src/auto-reply/skill-commands.test.ts src/discord/monitor/provider.skill-dedupe.test.ts`
- both test files pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves skill command deduplication from the Discord provider layer to the core `listSkillCommandsForAgents` function. By tracking seen skill names (normalized to lowercase) during command collection, it prevents duplicate skill commands with `_2` suffixes from being created in the first place, rather than filtering them out later at the Discord registration stage.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- The implementation is clean and correct, moves deduplication to an earlier and more logical place in the pipeline, includes proper test coverage with updated assertions, and follows the existing code patterns
- No files require special attention

<sub>Last reviewed commit: 9c66eaf</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->