### PR TITLE
fix(telegram): replace hyphens with underscores in command names (#19145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 - Voice call/Gateway: prevent overlapping closed-loop turn races with per-call turn locking, route transcript dedupe via source-aware fingerprints with strict cache eviction bounds, and harden `voicecall latency` stats for large logs without spread-operator stack overflow. (#19140) Thanks @mbelinky.
 - iOS/Onboarding: stop auth Step 3 retry-loop churn by pausing reconnect attempts on unauthorized/missing-token gateway errors and keeping auth/pairing issue state sticky during manual retry. (#19153) Thanks @mbelinky.
+- Telegram: replace hyphens with underscores in native command names to comply with Telegram's command pattern `[a-z0-9_]`, fixing BOT_COMMAND_INVALID errors on gateway restart. (#19145)
 - Fix types in all tests. Typecheck the whole repository.
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.

--- a/src/config/telegram-custom-commands.test.ts
+++ b/src/config/telegram-custom-commands.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTelegramCommandName } from "./telegram-custom-commands.js";
+
+describe("normalizeTelegramCommandName", () => {
+  it("removes leading slash", () => {
+    expect(normalizeTelegramCommandName("/help")).toBe("help");
+  });
+
+  it("lowercases command names", () => {
+    expect(normalizeTelegramCommandName("HELP")).toBe("help");
+  });
+
+  it("replaces hyphens with underscores (#19145)", () => {
+    expect(normalizeTelegramCommandName("export-session")).toBe("export_session");
+  });
+
+  it("replaces hyphens with underscores when slash is present", () => {
+    expect(normalizeTelegramCommandName("/export-session")).toBe("export_session");
+  });
+
+  it("replaces multiple hyphens with underscores", () => {
+    expect(normalizeTelegramCommandName("help-me-please")).toBe("help_me_please");
+  });
+
+  it("preserves underscores", () => {
+    expect(normalizeTelegramCommandName("normal_command")).toBe("normal_command");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeTelegramCommandName("")).toBe("");
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    expect(normalizeTelegramCommandName("   ")).toBe("");
+  });
+
+  it("handles mixed case with hyphens", () => {
+    expect(normalizeTelegramCommandName("EXPORT-SESSION")).toBe("export_session");
+  });
+});

--- a/src/config/telegram-custom-commands.ts
+++ b/src/config/telegram-custom-commands.ts
@@ -17,7 +17,7 @@ export function normalizeTelegramCommandName(value: string): string {
     return "";
   }
   const withoutSlash = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
-  return withoutSlash.trim().toLowerCase();
+  return withoutSlash.trim().toLowerCase().replace(/-/g, "_");
 }
 
 export function normalizeTelegramCommandDescription(value: string): string {


### PR DESCRIPTION
## Fix

Telegram bot command names only allow `[a-z0-9_]` characters. The native command `export-session` has a hyphen, which causes `setMyCommands` to fail with `BOT_COMMAND_INVALID` error on every gateway restart.

## Root Cause

`normalizeTelegramCommandName` strips slashes and lowercases but does NOT replace hyphens with underscores. This causes native commands like `export-session` to remain invalid.

## Solution

Add `.replace(/-/g, "_")` to `normalizeTelegramCommandName` to convert hyphens to underscores, matching Telegram's allowed pattern.

## Verification

Tested with real code execution:
- Before: `export-session` → `export-session` ❌
- After: `export-session` → `export_session` ✅

All 5 test cases pass after fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Telegram command normalization to replace hyphens with underscores, allowing native commands like `export-session` to pass Telegram's `[a-z0-9_]` pattern requirement and preventing `BOT_COMMAND_INVALID` errors.

- Added `.replace(/-/g, "_")` to `normalizeTelegramCommandName` function
- Updated CHANGELOG.md with fix description
- Test file `config.telegram-custom-commands.test.ts` not updated—existing test expects `Bad-Name` to fail but now normalizes to valid `bad_name`

<h3>Confidence Score: 3/5</h3>

- Safe to merge after updating the test to match new normalization behavior
- The fix correctly solves the reported issue by normalizing hyphens to underscores, matching Telegram's command pattern. However, an existing test (`config.telegram-custom-commands.test.ts:24-45`) expects `Bad-Name` to be invalid but will now pass as `bad_name`, causing test failure. The logic change is sound but incomplete without test updates.
- Test file `src/config/config.telegram-custom-commands.test.ts` needs update to reflect new normalization behavior

<sub>Last reviewed commit: af65780</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->