### PR TITLE
fix(feishu): pass mediaLocalRoots to sendMediaFeishu for agent-scoped workspaces

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -1,8 +1,8 @@
-import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { Readable } from "stream";
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { getFeishuRuntime } from "./runtime.js";

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -1,8 +1,8 @@
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { Readable } from "stream";
-import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { getFeishuRuntime } from "./runtime.js";
@@ -394,8 +394,10 @@ export async function sendMediaFeishu(params: {
   fileName?: string;
   replyToMessageId?: string;
   accountId?: string;
+  mediaLocalRoots?: readonly string[];
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, mediaLocalRoots } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -412,6 +414,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
+      localRoots: mediaLocalRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
@@ -26,6 +26,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           mediaUrl,
           accountId: accountId ?? undefined,
+          mediaLocalRoots,
         });
         return { channel: "feishu", ...result };
       } catch (err) {


### PR DESCRIPTION
## Problem

The Feishu outbound adapter's `sendMedia` handler does not pass `mediaLocalRoots` from the `ChannelOutboundContext` to `sendMediaFeishu`. This causes `loadWebMedia` to use default allowed roots, which explicitly block `workspace-*` directories (a security hardening added in the media path validator).

As a result, non-default agents (e.g., agent `zxx` with workspace at `~/.openclaw/workspace-zxx/`) cannot send files via Feishu — the upload fails with:

```
Local media path is not under an allowed directory: /home/weitian/.openclaw/workspace-zxx/file.xlsx
```

Other built-in channels (Telegram, Discord, Slack, Signal, iMessage) correctly pass `mediaLocalRoots` through their outbound adapters.

## Fix

- **`outbound.ts`**: Destructure `mediaLocalRoots` from the outbound context and pass it to `sendMediaFeishu`.
- **`media.ts`**: Accept `mediaLocalRoots` in `sendMediaFeishu` params and forward it as `localRoots` to `loadWebMedia`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Feishu outbound adapter to correctly pass `mediaLocalRoots` from the `ChannelOutboundContext` through to `sendMediaFeishu` and then to `loadWebMedia`. Without this fix, agent-scoped workspaces (e.g., `workspace-zxx`) could not send files via Feishu because the media path validator's default allowlist explicitly blocks `workspace-*` directories.

- `outbound.ts`: Destructures `mediaLocalRoots` from the context and passes it to `sendMediaFeishu`
- `media.ts`: Accepts `mediaLocalRoots` in `sendMediaFeishu` params and forwards it as `localRoots` to `loadWebMedia`
- The change is minimal, well-scoped, and consistent with how all other built-in channels (Telegram, Discord, Slack, Signal, iMessage) handle `mediaLocalRoots`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-understood bug fix that aligns Feishu with all other channel adapters.
- The change is a 2-file, ~6-line fix that threads an existing parameter (`mediaLocalRoots`) through the Feishu adapter, matching the exact same pattern used by Telegram, Discord, Slack, Signal, and iMessage. The types are correct (`readonly string[]` matches the context and `WebMediaOptions`), no new security surface is introduced, and no existing behavior changes for the default workspace.
- No files require special attention

<sub>Last reviewed commit: 1a8b9a2</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->