### PR TITLE
fix(docker): prevent HTTPS downgrade in curl commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-bookworm
 
 # Install Bun (required for build scripts)
-RUN curl -fsSL https://bun.sh/install | bash
+RUN curl --proto "=https" -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
 RUN corepack enable

--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -26,20 +26,19 @@ RUN apt-get update \
 RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
 
 RUN if [ "${INSTALL_BUN}" = "1" ]; then \
-  curl -fsSL https://bun.sh/install | bash; \
+  curl --proto "=https" -fsSL https://bun.sh/install | bash; \
   ln -sf "${BUN_INSTALL_DIR}/bin/bun" /usr/local/bin/bun; \
-fi
+  fi
 
 RUN if [ "${INSTALL_BREW}" = "1" ]; then \
   if ! id -u linuxbrew >/dev/null 2>&1; then useradd -m -s /bin/bash linuxbrew; fi; \
   mkdir -p "${BREW_INSTALL_DIR}"; \
   chown -R linuxbrew:linuxbrew "$(dirname "${BREW_INSTALL_DIR}")"; \
-  su - linuxbrew -c "NONINTERACTIVE=1 CI=1 /bin/bash -c '$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)'"; \
+  su - linuxbrew -c "NONINTERACTIVE=1 CI=1 /bin/bash -c '$(curl --proto "=https" -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)'"; \
   if [ ! -e "${BREW_INSTALL_DIR}/Library" ]; then ln -s "${BREW_INSTALL_DIR}/Homebrew/Library" "${BREW_INSTALL_DIR}/Library"; fi; \
   if [ ! -x "${BREW_INSTALL_DIR}/bin/brew" ]; then echo \"brew install failed\"; exit 1; fi; \
   ln -sf "${BREW_INSTALL_DIR}/bin/brew" /usr/local/bin/brew; \
-fi
+  fi
 
 # Default is sandbox, but allow BASE_IMAGE overrides to select another final user.
 USER ${FINAL_USER}
-


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
Some curl commands in our Dockerfiles used -L (follow redirects) without restricting the protocol. This could allow a redirect from HTTPS → HTTP, potentially exposing the build process to a Man-in-the-Middle (MitM) downgrade attack (CWE-319).

- Why it matters:
Without protocol restrictions, an attacker could intercept traffic by forcing a redirect to an insecure HTTP endpoint (e.g., SSL stripping).

- What changed:
Added: `--proto "=https"` 3 curl invocations across:
  Dockerfile
  Dockerfile.sandbox-common
This ensures redirects are followed only if they remain HTTPS.

- What did NOT change (scope boundary):
❌ No base image changes
❌ No package version updates
❌ No build logic changes
❌ No runtime behavior changes

## Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [X] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [X] CI/CD / infra

## Linked Issue/PR

- Related #None

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
None.
This is a background security hardening change affecting only the container build process

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes (Restricted to HTTPS only)
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation:
  - Change: curl will now refuse to follow redirects to non-HTTPS URLs.
  - Risk: If a dependency provider legitimately redirects to HTTP (unlikely for Bun/Homebrew), the build will fail.
  - Mitigation: Upstream providers (Bun, Homebrew) strictly enforce HTTPS.

## Repro + Verification

### Environment

OS: Windows / Linux (Docker)
Runtime/container: Docker (Debian Bookworm)

### Steps

1. Checkout the branch security/dockerfile-hardening.
2. Run docker build . (or trigger a CI build).
3. Observe the build logs during the curl steps for Bun and Homebrew installation.

### Expected

- The build should complete successfully without errors, confirming that the --proto "=https" flag allows valid HTTPS connections.

### Actual

- Build completes successfully (pending CI verification).

## Evidence

Attach at least one:

- [X]  Verified syntax correctness of the curl flags.
- [X] Checked compatibility of --proto flag with standard curl versions available in Debian Bookworm (base image).
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Manually verified that curl --proto "=https" syntax is correct and supported in the base image debian:bookworm-slim.
- Edge cases checked: N/A - standard flag usage.
- What you did NOT verify: Did not spin up a malicious HTTP redirect server to fail the build (negative testing).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit or remove the --proto "=https" flag.
- Files/config to restore: Dockerfile, Dockerfile.sandbox-common

## Risks and Mitigations

- Risk: Upstream dependency servers (Bun, Homebrew) changing their redirect logic to use HTTP.
- Mitigation: Extremely unlikely for security-conscious providers. If it happens, we update the URL or revert the flag.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `--proto "=https"` flag to 3 curl invocations across `Dockerfile` and `Dockerfile.sandbox-common` to prevent protocol downgrade attacks (CWE-319). The flag restricts redirects to HTTPS only, mitigating potential Man-in-the-Middle attacks where HTTP redirects could expose the build process to SSL stripping. Changes affect Bun installation (both files) and Homebrew installation (`Dockerfile.sandbox-common`). Also includes minor whitespace cleanup (`fi` indentation alignment).

**Key points:**
- Security improvement with no functional changes to build behavior
- Upstream providers (Bun, Homebrew) use HTTPS exclusively, so no risk of legitimate redirects failing
- Standard curl flag, compatible with Debian Bookworm's curl version

<h3>Confidence Score: 5/5</h3>

- Safe to merge - security hardening change with no impact on functionality
- The change adds a security flag to curl commands without altering any logic or behavior. The `--proto "=https"` flag is a standard curl option that prevents protocol downgrade attacks. Both Bun and Homebrew use HTTPS exclusively, so there's no risk of breaking legitimate redirects. The minor whitespace cleanup improves consistency without functional impact.
- No files require special attention

<sub>Last reviewed commit: 1b71282</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->