### PR TITLE
fix(cron): persist delivered flag in job state to surface delivery failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Pairing: tolerate legacy paired devices missing `roles`/`scopes` metadata in websocket upgrade checks and backfill metadata on reconnect. (#21447, fixes #21236) Thanks @joshavant.
 - Gateway/Pairing/CLI: align read-scope compatibility in pairing/device-token checks and add local `openclaw devices` fallback recovery for loopback `pairing required` deadlocks, with explicit fallback notice to unblock approval bootstrap flows. (#21616) Thanks @shakkernerd.
 - Cron: honor `cron.maxConcurrentRuns` in the timer loop so due jobs can execute up to the configured parallelism instead of always running serially. (#11595) Thanks @Takhoffman.
+- Cron/Isolated delivery: persist `lastDelivered` in cron job state and run logs for isolated-session runs so delivery failures are visible even when execution status is `ok`. (#19154) Thanks @simonemacario.
 - Agents/Compaction: restore embedded compaction safeguard/context-pruning extension loading in production by wiring bundled extension factories into the resource loader instead of runtime file-path resolution. (#22349) Thanks @Glucksberg.
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.
 - Agents/System Prompt: label allowlisted senders as authorized senders to avoid implying ownership. Thanks @thewilloftheshadow.

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -9,6 +9,7 @@ export type CronRunLogEntry = {
   status?: CronRunStatus;
   error?: string;
   summary?: string;
+  delivered?: boolean;
   sessionId?: string;
   sessionKey?: string;
   runAtMs?: number;
@@ -127,6 +128,9 @@ export async function readCronRunLogEntries(
             }
           : undefined,
       };
+      if (typeof obj.delivered === "boolean") {
+        entry.delivered = obj.delivered;
+      }
       if (typeof obj.sessionId === "string" && obj.sessionId.trim().length > 0) {
         entry.sessionId = obj.sessionId;
       }

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createStartedCronServiceWithFinishedBarrier,
+  createCronStoreHarness,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+describe("CronService persists delivered status", () => {
+  it("persists lastDelivered=true when isolated job reports delivered", async () => {
+    const store = await makeStorePath();
+    const finished = {
+      resolvers: new Map<string, () => void>(),
+      waitForOk(jobId: string) {
+        return new Promise<void>((resolve) => {
+          this.resolvers.set(jobId, resolve);
+        });
+      },
+    };
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        delivered: true,
+      })),
+      onEvent: (evt) => {
+        if (evt.action === "finished" && evt.status === "ok") {
+          finished.resolvers.get(evt.jobId)?.();
+          finished.resolvers.delete(evt.jobId);
+        }
+      },
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "delivered-true",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "test" },
+      delivery: { mode: "none" },
+    });
+
+    vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+    await vi.runOnlyPendingTimersAsync();
+    await finished.waitForOk(job.id);
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const updated = jobs.find((j) => j.id === job.id);
+
+    expect(updated?.state.lastStatus).toBe("ok");
+    expect(updated?.state.lastDelivered).toBe(true);
+
+    cron.stop();
+  });
+
+  it("persists lastDelivered=undefined when isolated job does not deliver", async () => {
+    const store = await makeStorePath();
+    const finished = {
+      resolvers: new Map<string, () => void>(),
+      waitForOk(jobId: string) {
+        return new Promise<void>((resolve) => {
+          this.resolvers.set(jobId, resolve);
+        });
+      },
+    };
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+      })),
+      onEvent: (evt) => {
+        if (evt.action === "finished" && evt.status === "ok") {
+          finished.resolvers.get(evt.jobId)?.();
+          finished.resolvers.delete(evt.jobId);
+        }
+      },
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "no-delivery",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "test" },
+      delivery: { mode: "none" },
+    });
+
+    vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+    await vi.runOnlyPendingTimersAsync();
+    await finished.waitForOk(job.id);
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const updated = jobs.find((j) => j.id === job.id);
+
+    expect(updated?.state.lastStatus).toBe("ok");
+    expect(updated?.state.lastDelivered).toBeUndefined();
+
+    cron.stop();
+  });
+
+  it("does not set lastDelivered for main session jobs", async () => {
+    const store = await makeStorePath();
+    const { cron, enqueueSystemEvent, finished } = createStartedCronServiceWithFinishedBarrier({
+      storePath: store.storePath,
+      logger: noopLogger,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "main-session",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    });
+
+    vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+    await vi.runOnlyPendingTimersAsync();
+    await finished.waitForOk(job.id);
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const updated = jobs.find((j) => j.id === job.id);
+
+    expect(updated?.state.lastStatus).toBe("ok");
+    expect(updated?.state.lastDelivered).toBeUndefined();
+    expect(enqueueSystemEvent).toHaveBeenCalled();
+
+    cron.stop();
+  });
+
+  it("emits delivered in the finished event", async () => {
+    const store = await makeStorePath();
+    let capturedEvent: { jobId: string; delivered?: boolean } | undefined;
+    const finished = {
+      resolvers: new Map<string, () => void>(),
+      waitForOk(jobId: string) {
+        return new Promise<void>((resolve) => {
+          this.resolvers.set(jobId, resolve);
+        });
+      },
+    };
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        delivered: true,
+      })),
+      onEvent: (evt) => {
+        if (evt.action === "finished") {
+          capturedEvent = { jobId: evt.jobId, delivered: evt.delivered };
+          if (evt.status === "ok") {
+            finished.resolvers.get(evt.jobId)?.();
+            finished.resolvers.delete(evt.jobId);
+          }
+        }
+      },
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "event-test",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "test" },
+      delivery: { mode: "none" },
+    });
+
+    vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+    await vi.runOnlyPendingTimersAsync();
+    await finished.waitForOk(job.id);
+
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent?.delivered).toBe(true);
+
+    // Flush pending store writes before stopping so the temp file is released
+    // (prevents ENOTEMPTY on Windows when afterAll removes the fixture dir).
+    await cron.list({ includeDisabled: true });
+    cron.stop();
+  });
+});

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -18,6 +18,7 @@ export type CronEvent = {
   status?: CronRunStatus;
   error?: string;
   summary?: string;
+  delivered?: boolean;
   sessionId?: string;
   sessionKey?: string;
   nextRunAtMs?: number;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -93,6 +93,8 @@ export type CronJobState = {
   consecutiveErrors?: number;
   /** Number of consecutive schedule computation errors. Auto-disables job after threshold. */
   scheduleErrorCount?: number;
+  /** Whether the last run's output was delivered to the target channel. */
+  lastDelivered?: boolean;
 };
 
 export type CronJob = {

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -157,6 +157,7 @@ export const CronJobStateSchema = Type.Object(
     lastError: Type.Optional(Type.String()),
     lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
     consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
+    lastDelivered: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -295,6 +295,7 @@ export function buildGatewayCronService(params: {
           status: evt.status,
           error: evt.error,
           summary: evt.summary,
+          delivered: evt.delivered,
           sessionId: evt.sessionId,
           sessionKey: evt.sessionKey,
           runAtMs: evt.runAtMs,


### PR DESCRIPTION
**tl;dr:** 7 files, ~20 lines of production code, 4 new tests — threads the existing `delivered` boolean from isolated cron runs into persistent job state.

## Summary

Closes the gap where `lastStatus: "ok"` masks silent delivery failures in isolated cron sessions. The `delivered` boolean is already computed in `runCronIsolatedAgentTurn()` and used internally, but it was stripped from the return path and never persisted — making it impossible to distinguish "agent ran successfully" from "output was actually delivered."

This is a common pain point: cron jobs report success while output silently fails to reach the target channel (webhook timeout, messaging tool error, channel misconfiguration). Without `lastDelivered`, operators have no signal until they notice missing messages.

## Problem

```
job.state.lastStatus === "ok"   // ← agent ran fine
job.state.lastDelivered === ???  // ← field doesn't exist, delivery may have failed
```

The `delivered` flag is computed in `runCronIsolatedAgentTurn()` across multiple delivery paths (direct delivery, messaging tool, webhook), but `executeJobCore()` strips it from the return value, and `applyJobResult()` never writes it to `job.state`.

## Fix

Thread `delivered` through the full pipeline:

```
executeJobCore() → TimedCronRunOutcome → applyJobResult() → job.state.lastDelivered
                                       → emitJobFinished() → CronEvent.delivered
                                       → appendCronRunLog() → JSONL entry
```

## Changes

| File | Change |
|------|--------|
| `src/cron/types.ts` | Add `lastDelivered?: boolean` to `CronJobState` |
| `src/cron/service/timer.ts` | Thread `delivered` through `executeJobCore`, `applyJobResult`, `emitJobFinished` |
| `src/cron/service/state.ts` | Add `delivered` to `CronEvent` type |
| `src/cron/run-log.ts` | Add `delivered` to `CronRunLogEntry` type and parsing |
| `src/gateway/protocol/schema/cron.ts` | Add `lastDelivered` to `CronJobStateSchema` |
| `src/gateway/server-cron.ts` | Include `delivered` in run log entry construction |
| `src/cron/service.persists-delivered-status.test.ts` | 4 test cases |

## Test plan

- [x] `lastDelivered=true` persisted when isolated job reports `delivered: true`
- [x] `lastDelivered=undefined` when isolated job does not deliver
- [x] Main session jobs (`sessionTarget: "main"`) do not set `lastDelivered`
- [x] Finished event includes `delivered` field for downstream consumers
- [x] All 149 cron tests pass (30 files)
- [x] `pnpm build` — no type errors
- [x] `pnpm check` — 0 warnings, 0 errors

## Scope

- **Additive only** — new optional field, no breaking changes
- **Backward compatible** — existing jobs without `lastDelivered` work unchanged
- **Minimal surface** — ~20 lines of production code across 6 files
- **AI-assisted** — authored with Claude, fully tested

Fixes #19154
Related: #14743, #16927, #17905

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `lastDelivered` boolean to cron job state to track whether output was successfully delivered to target channels. The `delivered` flag was already computed in `runCronIsolatedAgentTurn()` but wasn't being persisted, making it impossible to distinguish between "job ran successfully" and "output was actually delivered."

**Key changes:**
- Threads `delivered` through the execution pipeline: `executeJobCore()` → `applyJobResult()` → `job.state.lastDelivered`
- Adds `delivered` to `CronEvent`, `CronRunLogEntry`, and `CronJobState` types
- Includes `delivered` in JSONL run logs for historical tracking
- Adds `lastDelivered` to gateway protocol schema for API consumers
- Comprehensive test coverage with 4 test cases covering isolated jobs with/without delivery and main session jobs

**Scope:**
- Additive only - new optional field, backward compatible
- Only applies to isolated session jobs that attempt delivery
- Main session jobs leave `lastDelivered` as `undefined`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - clean implementation of a well-scoped additive feature.
- The change is purely additive (optional field), backward compatible, well-tested (4 comprehensive test cases), and follows existing patterns throughout the codebase. The implementation correctly threads the `delivered` flag through the entire pipeline without modifying any existing behavior. Type safety is maintained across all layers (TypeScript types, TypeBox schemas, and JSONL parsing).
- No files require special attention

<sub>Last reviewed commit: 8eabdc6</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->