### PR TITLE
fix: use parseAgentSessionKey instead of fragile split pattern

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -17,6 +17,7 @@ import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
@@ -598,7 +599,7 @@ export async function compactEmbeddedPiSessionDirect(
         // the compaction LLM call — no need to block or wait for after_compaction.
         const hookRunner = getGlobalHookRunner();
         const hookCtx = {
-          agentId: params.sessionKey?.split(":")[0] ?? "main",
+          agentId: parseAgentSessionKey(params.sessionKey)?.agentId ?? "main",
           sessionKey: params.sessionKey,
           sessionId: params.sessionId,
           workspaceDir: params.workspaceDir,

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -8,6 +8,7 @@ import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
 import { handleAllowlistCommand } from "./commands-allowlist.js";
 import { handleApproveCommand } from "./commands-approve.js";
@@ -137,7 +138,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
           await hookRunner.runBeforeReset(
             { sessionFile, messages, reason: commandAction },
             {
-              agentId: params.sessionKey?.split(":")[0] ?? "main",
+              agentId: parseAgentSessionKey(params.sessionKey)?.agentId ?? "main",
               sessionKey: params.sessionKey,
               sessionId: prevEntry?.sessionId,
               workspaceDir: params.workspaceDir,


### PR DESCRIPTION
## Summary

- Replace `params.sessionKey?.split(":")[0]` with `parseAgentSessionKey(params.sessionKey)?.agentId` in two hook contexts
- The split pattern silently returns the wrong agentId for agent session keys (e.g. `"agent:mybot:abc"` yields `"agent"` instead of `"mybot"`)
- The `parseAgentSessionKey()` utility in `src/sessions/session-key-utils.ts` already handles this correctly

## Files changed (2 files, ~4 lines each)

- `src/agents/pi-embedded-runner/compact.ts` — `before_compaction` hook context
- `src/auto-reply/reply/commands-core.ts` — `before_reset` hook context

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (lint + format) passes
- [x] `pnpm test` — no new failures (pre-existing failures unrelated to this change)
- [ ] Verify hooks fire with correct agentId for subagent sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Correct bug fix that replaces a broken `sessionKey?.split(":")[0]` pattern with the existing `parseAgentSessionKey()` utility in two hook contexts (`before_compaction` and `before_reset`).

- The old `.split(":")[0]` pattern always extracted the literal `"agent"` prefix from session keys like `"agent:mybot:abc"`, rather than the actual agent ID (`"mybot"`). This meant hooks always received `"agent"` as the `agentId`, which is wrong.
- `parseAgentSessionKey()` from `src/sessions/session-key-utils.ts` correctly returns the second colon-delimited segment as `agentId`, and returns `null` for non-agent or malformed keys (falling back to `"main"` via `?? "main"`).
- No remaining instances of the fragile split pattern exist in the codebase. All other call sites already use `parseAgentSessionKey` or `resolveSessionAgentId`.
- The change is minimal, well-scoped, and introduces no new behavior beyond the bug fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a straightforward, correct bug fix with no risk of regression.
- The change is minimal (2 lines changed + 2 import additions), uses an existing well-tested utility function, and fixes a clear bug where the agentId was always incorrectly set to the literal string "agent". No behavioral change for the main agent case (both old and new code produce "main" as fallback). No other instances of the broken pattern remain.
- No files require special attention.

<sub>Last reviewed commit: 221230b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->