### PR TITLE
fix: accept BRAVE_SEARCH_API_KEY for Brave web search

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1,9 +1,9 @@
 import { Type } from "@sinclair/typebox";
-import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { AnyAgentTool } from "./common.js";
+import { formatCliCommand } from "../../cli/command-format.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
-import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import {
   CacheEntry,
@@ -185,7 +185,8 @@ function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
       ? normalizeSecretInput(search.apiKey)
       : "";
   const fromEnv = normalizeSecretInput(process.env.BRAVE_API_KEY);
-  return fromConfig || fromEnv || undefined;
+  const fromOpenWebUIEnv = normalizeSecretInput(process.env.BRAVE_SEARCH_API_KEY);
+  return fromConfig || fromEnv || fromOpenWebUIEnv || undefined;
 }
 
 function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
@@ -207,7 +208,7 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
   }
   return {
     error: "missing_brave_api_key",
-    message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
+    message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY or BRAVE_SEARCH_API_KEY in the Gateway environment.`,
     docs: "https://docs.openclaw.ai/tools/web",
   };
 }

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1,20 +1,20 @@
-import { isToolAllowedByPolicies } from "../agents/pi-tools.policy.js";
-import {
-  resolveSandboxConfigForAgent,
-  resolveSandboxToolPolicyForAgent,
-} from "../agents/sandbox.js";
 /**
  * Synchronous security audit collector functions.
  *
  * These functions analyze config-based security properties without I/O.
  */
 import type { SandboxToolPolicy } from "../agents/sandbox/types.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { AgentToolsConfig } from "../config/types.tools.js";
+import { isToolAllowedByPolicies } from "../agents/pi-tools.policy.js";
+import {
+  resolveSandboxConfigForAgent,
+  resolveSandboxToolPolicyForAgent,
+} from "../agents/sandbox.js";
 import { getBlockedBindReason } from "../agents/sandbox/validate-sandbox-security.js";
 import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import { resolveBrowserConfig } from "../browser/config.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type { AgentToolsConfig } from "../config/types.tools.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { resolveNodeCommandAllowlist } from "../gateway/node-command-policy.js";
 import { inferParamBFromIdOrName } from "../shared/model-param-b.js";
@@ -261,6 +261,7 @@ function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
     search?.apiKey ||
     search?.perplexity?.apiKey ||
     env.BRAVE_API_KEY ||
+    env.BRAVE_SEARCH_API_KEY ||
     env.PERPLEXITY_API_KEY ||
     env.OPENROUTER_API_KEY,
   );


### PR DESCRIPTION
## Summary
- accept `BRAVE_SEARCH_API_KEY` as an env-var alias when resolving Brave web search API credentials
- preserve existing precedence: explicit config `apiKey`, then `BRAVE_API_KEY`, then `BRAVE_SEARCH_API_KEY`
- update missing-key guidance text to mention both supported Brave env vars

## Testing
- pre-commit formatting/lint hook passed during commit on this branch
- verified branch diff is isolated to `src/agents/tools/web-search.ts`

## Notes
- this PR supersedes #19182 with a clean branch based on current `main`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `BRAVE_SEARCH_API_KEY` as a fallback environment variable for Brave web search API credentials in `resolveSearchApiKey()`, preserving the existing precedence: explicit config `apiKey` > `BRAVE_API_KEY` > `BRAVE_SEARCH_API_KEY`. The error message is updated to mention both supported env vars. The change is minimal and well-scoped.

- The core logic in `resolveSearchApiKey()` correctly chains the new env var as a third fallback
- Import reordering groups type imports together (cosmetic, no functional impact)
- **Missing update**: `hasWebSearchKey()` in `src/security/audit-extra.sync.ts` also needs to check for `BRAVE_SEARCH_API_KEY`, otherwise the audit will incorrectly report the key as missing when only the new alias is set
- Several other files reference only `BRAVE_API_KEY` in user-facing guidance text (onboarding, configure wizard, config schema help, type comments) — not bugs, but worth a follow-up to mention both env vars for consistency

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the core change is correct, but a related audit function in another file should be updated to stay consistent.
- The change is small, well-scoped, and the fallback logic is correct. Deducting one point because `hasWebSearchKey()` in `audit-extra.sync.ts` was not updated, which could cause the security audit to misreport key availability when only `BRAVE_SEARCH_API_KEY` is set.
- `src/security/audit-extra.sync.ts` — the `hasWebSearchKey` function needs to also check for `BRAVE_SEARCH_API_KEY` to match the new runtime behavior.

<sub>Last reviewed commit: dc5161c</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->