### PR TITLE
Revert "fix(webchat): strip reply/audio directive tags before rendering #18079"

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -25,48 +25,6 @@ describe("extractTextCached", () => {
   });
 });
 
-describe("extractText strips directive tags from assistant messages", () => {
-  it("strips [[reply_to_current]]", () => {
-    const message = {
-      role: "assistant",
-      content: "Hello there [[reply_to_current]]",
-    };
-    expect(extractText(message)).toBe("Hello there");
-  });
-
-  it("strips [[reply_to:<id>]]", () => {
-    const message = {
-      role: "assistant",
-      content: [{ type: "text", text: "Done [[reply_to: abc123]]" }],
-    };
-    expect(extractText(message)).toBe("Done");
-  });
-
-  it("strips [[audio_as_voice]]", () => {
-    const message = {
-      role: "assistant",
-      content: "Listen up [[audio_as_voice]]",
-    };
-    expect(extractText(message)).toBe("Listen up");
-  });
-
-  it("does not strip tags from user messages", () => {
-    const message = {
-      role: "user",
-      content: "Hello [[reply_to_current]]",
-    };
-    expect(extractText(message)).toBe("Hello [[reply_to_current]]");
-  });
-
-  it("strips tag from .text property", () => {
-    const message = {
-      role: "assistant",
-      text: "Hi [[reply_to_current]]",
-    };
-    expect(extractText(message)).toBe("Hi");
-  });
-});
-
 describe("extractThinkingCached", () => {
   it("matches extractThinking output", () => {
     const message = {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,19 +1,6 @@
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
 import { stripThinkingTags } from "../format.ts";
 
-/**
- * Strip inline directive tags (`[[reply_to_current]]`, `[[reply_to:<id>]]`,
- * `[[audio_as_voice]]`) that should never be rendered to the user.
- * Matches the same patterns as `src/utils/directive-tags.ts`.
- */
-function stripDirectiveTags(text: string): string {
-  return text
-    .replace(/\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+|audio_as_voice)\s*\]\]/gi, "")
-    .replace(/[ \t]+/g, " ")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .trim();
-}
-
 const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
@@ -22,10 +9,7 @@ export function extractText(message: unknown): string | null {
   const role = typeof m.role === "string" ? m.role : "";
   const content = m.content;
   if (typeof content === "string") {
-    let processed = role === "assistant" ? stripThinkingTags(content) : stripEnvelope(content);
-    if (role === "assistant") {
-      processed = stripDirectiveTags(processed);
-    }
+    const processed = role === "assistant" ? stripThinkingTags(content) : stripEnvelope(content);
     return processed;
   }
   if (Array.isArray(content)) {
@@ -40,18 +24,12 @@ export function extractText(message: unknown): string | null {
       .filter((v): v is string => typeof v === "string");
     if (parts.length > 0) {
       const joined = parts.join("\n");
-      let processed = role === "assistant" ? stripThinkingTags(joined) : stripEnvelope(joined);
-      if (role === "assistant") {
-        processed = stripDirectiveTags(processed);
-      }
+      const processed = role === "assistant" ? stripThinkingTags(joined) : stripEnvelope(joined);
       return processed;
     }
   }
   if (typeof m.text === "string") {
-    let processed = role === "assistant" ? stripThinkingTags(m.text) : stripEnvelope(m.text);
-    if (role === "assistant") {
-      processed = stripDirectiveTags(processed);
-    }
+    const processed = role === "assistant" ? stripThinkingTags(m.text) : stripEnvelope(m.text);
     return processed;
   }
   return null;


### PR DESCRIPTION
-

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts commit `e24e465c` (PR #18093), which added client-side stripping of inline directive tags (`[[reply_to_current]]`, `[[reply_to:<id>]]`, `[[audio_as_voice]]`) from assistant messages in the webchat UI's `extractText` function.

- Removes the `stripDirectiveTags()` function and its application across all three `extractText` code paths (string content, content array, `.text` property)
- Removes the corresponding test suite covering directive tag stripping
- **Potential regression**: While live-streamed messages are unaffected (the server-side pipeline in `pi-embedded-subscribe.handlers.messages.ts` strips tags before emitting agent events), messages loaded from session history via `chat.history` read raw transcripts that may still contain directive tags. The `chat.history` sanitization pipeline (`stripEnvelopeFromMessages` + `sanitizeChatHistoryMessages`) does not strip these tags from assistant messages. This means directive tags could render as literal text after a page reload — the original bug from #18079.
- If the intent is to move tag stripping to the server side (e.g., in `chat.history`), that change should ideally land alongside or before this revert to avoid a window where the bug resurfaces.

<h3>Confidence Score: 2/5</h3>

- This revert may re-introduce bug #18079 where directive tags render as literal text in chat history after page reload.
- Score of 2 reflects a likely regression: removing UI-side directive tag stripping without a corresponding server-side fix in the `chat.history` path means raw session transcripts containing `[[reply_to_current]]`, `[[reply_to:<id>]]`, or `[[audio_as_voice]]` will surface as literal text. Live streaming is fine (server strips before broadcasting), but history reload reads raw transcripts.
- Pay close attention to `ui/src/ui/chat/message-extract.ts` — the removed `stripDirectiveTags` was the only defense against raw directive tags in `chat.history` responses. Also consider `src/gateway/server-methods/chat.ts` (the `chat.history` handler) and `src/gateway/chat-sanitize.ts` which lack assistant-message directive tag stripping.

<sub>Last reviewed commit: 0eab07e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->