### PR TITLE
Signal: preserve group ID casing in session keys

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -67,6 +67,18 @@ describe("sessions", () => {
     ).toBe("agent:main:discord:group:12345");
   });
 
+  it("preserves Signal group id case when explicit SessionKey is provided", () => {
+    expect(
+      resolveSessionKey(
+        "per-sender",
+        {
+          SessionKey: "agent:main:signal:group:ABcDeFgHiJkLmN==",
+        },
+        "main",
+      ),
+    ).toBe("agent:main:signal:group:ABcDeFgHiJkLmN==");
+  });
+
   it("builds discord display name with guild+channel slugs", () => {
     expect(
       buildGroupDisplayName({

--- a/src/config/sessions/session-key.ts
+++ b/src/config/sessions/session-key.ts
@@ -2,6 +2,7 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_AGENT_ID,
+  normalizeSessionKeyForStorage,
   normalizeMainKey,
 } from "../../routing/session-key.js";
 import { normalizeE164 } from "../../utils.js";
@@ -28,7 +29,7 @@ export function deriveSessionKey(scope: SessionScope, ctx: MsgContext) {
 export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?: string) {
   const explicit = ctx.SessionKey?.trim();
   if (explicit) {
-    return explicit.toLowerCase();
+    return normalizeSessionKeyForStorage(explicit);
   }
   const raw = deriveSessionKey(scope, ctx);
   if (scope === "global") {

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -222,6 +222,26 @@ describe("gateway send mirroring", () => {
     );
   });
 
+  it("preserves signal group session key casing for mirroring", async () => {
+    mocks.deliverOutboundPayloads.mockResolvedValue([{ messageId: "m-signal", channel: "signal" }]);
+
+    await runSend({
+      to: "group:ABcDeFgHiJkLmN==",
+      message: "hi",
+      channel: "signal",
+      idempotencyKey: "idem-signal-case",
+      sessionKey: "agent:main:signal:group:ABcDeFgHiJkLmN==",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mirror: expect.objectContaining({
+          sessionKey: "agent:main:signal:group:ABcDeFgHiJkLmN==",
+        }),
+      }),
+    );
+  });
+
   it("derives a target session key when none is provided", async () => {
     mockDeliverySuccess("m3");
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -11,6 +11,7 @@ import {
 import { normalizeReplyPayloadsForDelivery } from "../../infra/outbound/payloads.js";
 import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { normalizePollInput } from "../../polls.js";
+import { normalizeSessionKeyForStorage } from "../../routing/session-key.js";
 import {
   ErrorCodes,
   errorShape,
@@ -176,7 +177,7 @@ export const sendHandlers: GatewayRequestHandlers = {
         );
         const providedSessionKey =
           typeof request.sessionKey === "string" && request.sessionKey.trim()
-            ? request.sessionKey.trim().toLowerCase()
+            ? normalizeSessionKeyForStorage(request.sessionKey)
             : undefined;
         const derivedAgentId = resolveSessionAgentId({ config: cfg });
         // If callers omit sessionKey, derive a target session key from the outbound route.

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -107,6 +107,20 @@ describe("gateway session utils", () => {
     );
   });
 
+  test("resolveSessionStoreKey preserves signal group id casing", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+
+    expect(
+      resolveSessionStoreKey({
+        cfg,
+        sessionKey: "agent:ops:signal:group:ABcDeFgHiJkLmN==",
+      }),
+    ).toBe("agent:ops:signal:group:ABcDeFgHiJkLmN==");
+  });
+
   test("resolveSessionStoreKey honors global scope", () => {
     const cfg = {
       session: { scope: "global", mainKey: "work" },

--- a/src/infra/outbound/outbound-policy.ts
+++ b/src/infra/outbound/outbound-policy.ts
@@ -66,7 +66,19 @@ function resolveContextGuardTarget(
 }
 
 function normalizeTarget(channel: ChannelId, raw: string): string | undefined {
-  return normalizeTargetForProvider(channel, raw) ?? raw.trim().toLowerCase();
+  const normalized = normalizeTargetForProvider(channel, raw);
+  if (normalized) {
+    return normalized;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  // Signal group IDs are base64 and case-sensitive.
+  if (channel === "signal") {
+    return trimmed;
+  }
+  return trimmed.toLowerCase();
 }
 
 function isCrossContextTarget(params: {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -768,6 +768,19 @@ describe("resolveOutboundSessionRoute", () => {
     expect(route?.from).toBe("group:ABC123");
   });
 
+  it("preserves Signal group id case in session keys", async () => {
+    const route = await resolveOutboundSessionRoute({
+      cfg: baseConfig,
+      channel: "signal",
+      agentId: "main",
+      target: "signal:group:ABcDeFgHiJkLmN==",
+    });
+
+    expect(route?.sessionKey).toBe("agent:main:signal:group:ABcDeFgHiJkLmN==");
+    expect(route?.from).toBe("group:ABcDeFgHiJkLmN==");
+    expect(route?.to).toBe("group:ABcDeFgHiJkLmN==");
+  });
+
   it("treats Zalo Personal DM targets as direct sessions", async () => {
     const cfg = { session: { dmScope: "per-channel-peer" } } as OpenClawConfig;
     const route = await resolveOutboundSessionRoute({

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { getSubagentDepth, isCronSessionKey } from "../sessions/session-key-utils.js";
-import { classifySessionKeyShape } from "./session-key.js";
+import {
+  buildAgentPeerSessionKey,
+  classifySessionKeyShape,
+  normalizeSessionKeyForStorage,
+  toAgentStoreSessionKey,
+} from "./session-key.js";
 
 describe("classifySessionKeyShape", () => {
   it("classifies empty keys as missing", () => {
@@ -64,5 +69,30 @@ describe("isCronSessionKey", () => {
     expect(isCronSessionKey("agent:main:subagent:worker")).toBe(false);
     expect(isCronSessionKey("cron:job-1")).toBe(false);
     expect(isCronSessionKey(undefined)).toBe(false);
+  });
+});
+
+describe("signal group session keys", () => {
+  it("preserves signal group id casing for non-direct route keys", () => {
+    expect(
+      buildAgentPeerSessionKey({
+        agentId: "main",
+        channel: "signal",
+        peerKind: "group",
+        peerId: "ABcDeFgHiJkLmN==",
+      }),
+    ).toBe("agent:main:signal:group:ABcDeFgHiJkLmN==");
+  });
+
+  it("keeps signal group id casing when normalizing store keys", () => {
+    expect(
+      toAgentStoreSessionKey({
+        agentId: "main",
+        requestKey: "signal:group:ABcDeFgHiJkLmN==",
+      }),
+    ).toBe("agent:main:signal:group:ABcDeFgHiJkLmN==");
+    expect(normalizeSessionKeyForStorage("agent:Main:signal:group:ABcDeFgHiJkLmN==")).toBe(
+      "agent:main:signal:group:ABcDeFgHiJkLmN==",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- preserve case for `signal:group:<groupId>` session keys instead of lowercasing the base64 group ID
- route explicit `SessionKey` and gateway `sessionKey` inputs through a signal-aware normalizer
- keep non-Signal providers on the existing lowercase normalization path

## Testing
- pnpm test src/routing/session-key.test.ts src/config/sessions.test.ts src/infra/outbound/outbound.test.ts src/gateway/server-methods/send.test.ts src/gateway/session-utils.test.ts
- pnpm lint -- src/routing/session-key.ts src/routing/session-key.test.ts src/config/sessions/session-key.ts src/config/sessions.test.ts src/gateway/server-methods/send.ts src/gateway/server-methods/send.test.ts src/gateway/session-utils.ts src/gateway/session-utils.test.ts src/infra/outbound/outbound-policy.ts src/infra/outbound/outbound.test.ts

Fixes #19139

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Signal group IDs (which are base64-encoded and case-sensitive) were being lowercased during session key normalization, causing session key mismatches.

- Introduces `normalizeSessionKeyForStorage()` in `src/routing/session-key.ts` that selectively preserves case for Signal group IDs (the `signal:group:<base64Id>` segment) while lowercasing all other components (agent IDs, channel names, other provider IDs)
- Adds `normalizePeerIdForSessionKey()` to handle case preservation at the peer ID level in `buildAgentPeerSessionKey` and `buildGroupHistoryKey`
- Updates `normalizeTarget()` in outbound policy to preserve Signal target casing for cross-context comparison
- Replaces all direct `.toLowerCase()` calls on session keys with `normalizeSessionKeyForStorage()` across 5 call sites: explicit `SessionKey` resolution, gateway send handler, session store key resolution, session key canonicalization, and spawned-by canonicalization
- Comprehensive test coverage added across all affected modules
- One potential follow-up: `src/auto-reply/reply/dispatch-from-config.ts:70` still uses `sessionKey.toLowerCase()` for store lookups, which could miss Signal group sessions stored with preserved casing (mitigated by fallback to original key)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk; the normalization logic is well-structured and comprehensively tested.
- Score of 4 reflects that the core changes are correct, well-tested, and narrowly scoped. One minor concern is that a pre-existing session store lookup in dispatch-from-config.ts still uses .toLowerCase() which could theoretically miss Signal group sessions, though this is mitigated by its fallback to the original key. All changed paths are covered by tests.
- No files in the PR require special attention. Outside the PR, `src/auto-reply/reply/dispatch-from-config.ts` has a pre-existing `sessionKey.toLowerCase()` store lookup that may warrant a follow-up.

<sub>Last reviewed commit: ade6f06</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->