### PR TITLE
revert: per-model thinkingDefault override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: revert accidental per-model thinkingDefault override merge. (#19195) Thanks @sebslight.
 - Voice call/Gateway: prevent overlapping closed-loop turn races with per-call turn locking, route transcript dedupe via source-aware fingerprints with strict cache eviction bounds, and harden `voicecall latency` stats for large logs without spread-operator stack overflow. (#19140) Thanks @mbelinky.
 - iOS/Onboarding: stop auth Step 3 retry-loop churn by pausing reconnect attempts on unauthorized/missing-token gateway errors and keeping auth/pairing issue state sticky during manual retry. (#19153) Thanks @mbelinky.
 - Fix types in all tests. Typecheck the whole repository.

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -452,29 +452,10 @@ export function resolveThinkingDefault(params: {
   model: string;
   catalog?: ModelCatalogEntry[];
 }): ThinkLevel {
-  // 1. Per-model thinkingDefault (highest priority)
-  // Normalize config keys via parseModelRef (consistent with buildModelAliasIndex,
-  // buildAllowedModelSet, etc.) so aliases like "anthropic/opus-4.6" resolve correctly.
-  const configModels = params.cfg.agents?.defaults?.models ?? {};
-  for (const [rawKey, entry] of Object.entries(configModels)) {
-    const parsed = parseModelRef(rawKey, params.provider);
-    if (
-      parsed &&
-      parsed.provider === params.provider &&
-      parsed.model === params.model &&
-      entry?.thinkingDefault
-    ) {
-      return entry.thinkingDefault as ThinkLevel;
-    }
-  }
-
-  // 2. Global thinkingDefault
   const configured = params.cfg.agents?.defaults?.thinkingDefault;
   if (configured) {
     return configured;
   }
-
-  // 3. Auto-detect from model catalog (reasoning-capable → "low")
   const candidate = params.catalog?.find(
     (entry) => entry.provider === params.provider && entry.id === params.model,
   );

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -18,8 +18,6 @@ export type AgentModelEntryConfig = {
   params?: Record<string, unknown>;
   /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
   streaming?: boolean;
-  /** Per-model default thinking level (overrides global thinkingDefault). */
-  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 };
 
 export type AgentModelListConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -38,17 +38,6 @@ export const AgentDefaultsSchema = z
             params: z.record(z.string(), z.unknown()).optional(),
             /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
             streaming: z.boolean().optional(),
-            /** Per-model default thinking level (overrides global thinkingDefault). */
-            thinkingDefault: z
-              .union([
-                z.literal("off"),
-                z.literal("minimal"),
-                z.literal("low"),
-                z.literal("medium"),
-                z.literal("high"),
-                z.literal("xhigh"),
-              ])
-              .optional(),
           })
           .strict(),
       )


### PR DESCRIPTION
## Summary
- Revert PR #18152 (per-model thinkingDefault override).

## Reason
Accidental merge; feature not ready and should be reworked.

## Testing
- Not run (revert only).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Cleanly reverts PR #18152 which added per-model `thinkingDefault` configuration to `AgentModelEntryConfig`. The revert is complete and correctly removes:

- Per-model thinking resolution logic from `resolveThinkingDefault()` in `src/agents/model-selection.ts:452-470`
- `thinkingDefault` field from `AgentModelEntryConfig` type definition
- Corresponding Zod schema validation for the `thinkingDefault` field

The function returns to its previous behavior with two-level priority: global config → catalog auto-detect, instead of the three-level priority that included per-model overrides.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The revert is clean and complete, exactly reversing the changes from commit 671f91312. All three modified files (model-selection.ts, types.agent-defaults.ts, zod-schema.agent-defaults.ts) have been properly reverted. No tests or other files reference the removed feature, and the code returns to a previously working state.
- No files require special attention

<sub>Last reviewed commit: b846dc0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->