### PR TITLE
fix(cli): validate --session-id is not a session key format

### DIFF
--- a/src/commands/agent.e2e.test.ts
+++ b/src/commands/agent.e2e.test.ts
@@ -84,6 +84,12 @@ beforeEach(() => {
 });
 
 describe("agentCommand", () => {
+  it("rejects session key format passed to --session-id", async () => {
+    await expect(
+      agentCommand({ message: "hi", sessionId: "agent:mybot:main" }, runtime),
+    ).rejects.toThrow(/--session-key/);
+  });
+
   it("creates a session entry when deriving from --to", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.session-id-validation.test.ts
+++ b/src/commands/agent.session-id-validation.test.ts
@@ -27,9 +27,7 @@ describe("session-id validation", () => {
   });
 
   it("rejects session key format with leading whitespace", () => {
-    expect(() => validateSessionId("  agent:foo:bar")).toThrow(
-      "Please use --session-key instead",
-    );
+    expect(() => validateSessionId("  agent:foo:bar")).toThrow("Please use --session-key instead");
   });
 
   it("accepts UUID format", () => {

--- a/src/commands/agent.session-id-validation.test.ts
+++ b/src/commands/agent.session-id-validation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Validates that --session-id does not accept session key format.
+ * The actual validation is in agentCommand, but we test the logic here
+ * to avoid complex mocking of the full agent command.
+ */
+function validateSessionId(sessionId: string | undefined): void {
+  if (sessionId?.trim().toLowerCase().startsWith("agent:")) {
+    throw new Error(
+      "It looks like you passed a session key to --session-id. Please use --session-key instead.",
+    );
+  }
+}
+
+describe("session-id validation", () => {
+  it("rejects session key format passed to --session-id", () => {
+    expect(() => validateSessionId("agent:jarvis:main")).toThrow(
+      "Please use --session-key instead",
+    );
+  });
+
+  it("rejects session key format with different casing", () => {
+    expect(() => validateSessionId("Agent:Main:telegram")).toThrow(
+      "Please use --session-key instead",
+    );
+  });
+
+  it("rejects session key format with leading whitespace", () => {
+    expect(() => validateSessionId("  agent:foo:bar")).toThrow(
+      "Please use --session-key instead",
+    );
+  });
+
+  it("accepts UUID format", () => {
+    expect(() => validateSessionId("550e8400-e29b-41d4-a716-446655440000")).not.toThrow();
+  });
+
+  it("accepts undefined", () => {
+    expect(() => validateSessionId(undefined)).not.toThrow();
+  });
+});

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -190,6 +190,12 @@ export async function agentCommand(
   if (!body) {
     throw new Error("Message (--message) is required");
   }
+  // Validate --session-id is not a session key format
+  if (opts.sessionId?.trim().toLowerCase().startsWith("agent:")) {
+    throw new Error(
+      "It looks like you passed a session key to --session-id. Please use --session-key instead.",
+    );
+  }
   if (!opts.to && !opts.sessionId && !opts.sessionKey && !opts.agentId) {
     throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
   }


### PR DESCRIPTION
When users pass a session key format (`agent:...`) to `--session-id`, show a helpful error message directing them to use `--session-key` instead.

## Problem
Users sometimes confuse `--session-id` (for UUIDs) with `--session-key` (for `agent:...` format keys), leading to unexpected behavior where the agent workspace is not resolved correctly.

## Solution
Add validation that detects when a session key format is passed to `--session-id` and throws a clear error:
```
It looks like you passed a session key to --session-id. Please use --session-key instead.
```

This teaches users the correct parameter usage rather than silently accepting both formats.

Closes #13635

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds input validation to the `agentCommand` function in `src/commands/agent.ts` that detects when a session key format (`agent:...`) is mistakenly passed to `--session-id` and throws a descriptive error directing users to use `--session-key` instead.

- The validation check at line 194 uses `.trim().toLowerCase().startsWith("agent:")`, which is consistent with session key detection patterns used elsewhere in the codebase (`src/routing/session-key.ts`, `src/infra/state-migrations.ts`, `src/gateway/session-utils.ts`).
- Placement is correct: after the message-required check but before the session resolution logic that would silently accept the malformed input.
- No tests were added for this validation. While the logic is simple, a unit test covering the error case would strengthen confidence.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a straightforward input validation guard with no side effects on existing behavior.
- The change is minimal (6 lines), isolated to an early validation check, and follows established codebase patterns for detecting session key formats. It only affects the error path for a specific misuse pattern and cannot regress normal operation. Deducting one point for the absence of a test covering the new error condition.
- No files require special attention.

<sub>Last reviewed commit: 78345e8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->