### PR TITLE
fix(tests): repair tsgo typing for fetch mocks

### DIFF
--- a/src/agents/tools/web-fetch.ssrf.e2e.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.e2e.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../../infra/net/ssrf.js";
-import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import { type FetchMock, withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 
 const lookupMock = vi.fn();
 const resolvePinnedHostname = ssrf.resolvePinnedHostname;
@@ -28,10 +28,6 @@ function textResponse(body: string): Response {
     text: async () => body,
   } as unknown as Response;
 }
-
-type FetchMock = ReturnType<
-  typeof vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>
->;
 
 function setMockFetch(
   impl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,

--- a/src/agents/tools/web-fetch.ssrf.e2e.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.e2e.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../../infra/net/ssrf.js";
-import { type FetchMock, withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 
 const lookupMock = vi.fn();
 const resolvePinnedHostname = ssrf.resolvePinnedHostname;
@@ -29,10 +29,16 @@ function textResponse(body: string): Response {
   } as unknown as Response;
 }
 
+type FetchMock = ReturnType<
+  typeof vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>
+>;
+
 function setMockFetch(
-  impl: FetchMock = async (_input: RequestInfo | URL, _init?: RequestInit) => textResponse(""),
-) {
-  const fetchSpy = vi.fn<FetchMock>(impl);
+  impl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+): FetchMock {
+  const fetchSpy = impl
+    ? vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(impl)
+    : vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
   global.fetch = withFetchPreconnect(fetchSpy);
   return fetchSpy;
 }

--- a/src/memory/embeddings-voyage.test.ts
+++ b/src/memory/embeddings-voyage.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as authModule from "../agents/model-auth.js";
-import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
+import { type FetchMock, withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import { createVoyageEmbeddingProvider, normalizeVoyageModel } from "./embeddings-voyage.js";
 
 vi.mock("../agents/model-auth.js", () => ({
@@ -12,10 +12,6 @@ vi.mock("../agents/model-auth.js", () => ({
     throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth?.mode}).`);
   },
 }));
-
-type FetchMock = ReturnType<
-  typeof vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>
->;
 
 const embeddingResponse = (embeddings: number[][]): Response =>
   new Response(

--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../../infra/net/ssrf.js";
 import type { SavedMedia } from "../../media/store.js";
 import * as mediaStore from "../../media/store.js";
-import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import { type FetchMock, withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import {
   fetchWithSlackAuth,
   resolveSlackAttachmentContent,
@@ -12,9 +12,6 @@ import {
 
 // Store original fetch
 const originalFetch = globalThis.fetch;
-type FetchMock = ReturnType<
-  typeof vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>
->;
 let mockFetch: FetchMock;
 const createSavedMedia = (filePath: string, contentType: string): SavedMedia => ({
   id: "saved-media-id",

--- a/src/test-utils/fetch-mock.ts
+++ b/src/test-utils/fetch-mock.ts
@@ -1,4 +1,6 @@
-type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export type FetchMock = ReturnType<typeof import("vitest").vi.fn<FetchLike>>;
 
 export const withFetchPreconnect = <T extends FetchLike>(fn: T): T & { preconnect: () => void } =>
   Object.assign(fn, {

--- a/src/test-utils/fetch-mock.ts
+++ b/src/test-utils/fetch-mock.ts
@@ -1,22 +1,6 @@
-export type FetchMock = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
-type FetchPreconnectOptions = {
-  dns?: boolean;
-  tcp?: boolean;
-  http?: boolean;
-  https?: boolean;
-};
-
-type FetchWithPreconnect = {
-  preconnect: (url: string | URL, options?: FetchPreconnectOptions) => void;
-};
-
-export function withFetchPreconnect<T extends typeof fetch>(fn: T): T & FetchWithPreconnect;
-export function withFetchPreconnect<T extends object>(
-  fn: T,
-): T & FetchWithPreconnect & typeof fetch;
-export function withFetchPreconnect(fn: object) {
-  return Object.assign(fn, {
-    preconnect: (_url: string | URL, _options?: FetchPreconnectOptions) => {},
+export const withFetchPreconnect = <T extends FetchLike>(fn: T): T & { preconnect: () => void } =>
+  Object.assign(fn, {
+    preconnect: () => {},
   });
-}


### PR DESCRIPTION
## Summary
Fix TypeScript Native Preview (tsgo) typecheck failures in tests caused by untyped `vi.fn()` fetch mocks and overly-generic helper typings.

## Changes
- Tighten `withFetchPreconnect()` typing to a concrete fetch-compatible signature (avoids `unknown[]` inference issues).
- Add explicit fetch mock typings in affected tests.
- Use real `Response` objects in voyage embedding tests and fix typed access to mock call args.
- Add a small URL extraction helper in Slack media tests to satisfy type-aware lint without behavior change.

## Testing
- `pnpm check`

## Notes
This is a test-only / typing-only change intended to restore CI signal for `pnpm check`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed TypeScript typing issues in test files by adding explicit type annotations to `vi.fn()` fetch mocks. Changes tightened the `withFetchPreconnect()` helper signature from overly-generic `unknown[]` to concrete `FetchLike` signature, preventing type inference issues. Tests now use real `Response` objects in voyage embedding tests instead of plain objects, and added a small `requestUrl()` helper in Slack media tests to handle different `RequestInfo` variants type-safely. All changes are test-only and restore type-checking without altering runtime behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- All changes are test-only TypeScript type annotations that don't affect runtime behavior. The typing improvements make mocks more type-safe by explicitly specifying fetch signatures, replacing plain objects with proper Response instances, and adding type-safe helper functions. No production code is modified.
- No files require special attention

<sub>Last reviewed commit: a7ff04d</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->