### PR TITLE
telegram: convert hyphens to underscores in command names

### DIFF
--- a/src/config/config.telegram-custom-commands.test.ts
+++ b/src/config/config.telegram-custom-commands.test.ts
@@ -21,7 +21,7 @@ describe("telegram custom commands schema", () => {
     ]);
   });
 
-  it("rejects custom commands with invalid names", () => {
+  it("normalizes hyphens to underscores in command names", () => {
     const res = OpenClawSchema.safeParse({
       channels: {
         telegram: {
@@ -30,17 +30,13 @@ describe("telegram custom commands schema", () => {
       },
     });
 
-    expect(res.success).toBe(false);
-    if (res.success) {
+    // Hyphens are now converted to underscores for Telegram compatibility
+    expect(res.success).toBe(true);
+    if (!res.success) {
       return;
     }
-
-    expect(
-      res.error.issues.some(
-        (issue) =>
-          issue.path.join(".") === "channels.telegram.customCommands.0.command" &&
-          issue.message.includes("invalid"),
-      ),
-    ).toBe(true);
+    expect(res.data.channels?.telegram?.customCommands).toEqual([
+      { command: "bad_name", description: "Override status" },
+    ]);
   });
 });

--- a/src/config/telegram-custom-commands.ts
+++ b/src/config/telegram-custom-commands.ts
@@ -17,7 +17,9 @@ export function normalizeTelegramCommandName(value: string): string {
     return "";
   }
   const withoutSlash = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
-  return withoutSlash.trim().toLowerCase();
+  // Convert hyphens to underscores for Telegram compatibility
+  // Telegram command names only allow a-z, 0-9, underscore
+  return withoutSlash.trim().toLowerCase().replace(/-/g, "_");
 }
 
 export function normalizeTelegramCommandDescription(value: string): string {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -1,6 +1,16 @@
 import type { Bot, Context } from "grammy";
-import { resolveChunkMode } from "../auto-reply/chunk.js";
 import type { CommandArgs } from "../auto-reply/commands-registry.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ChannelGroupPolicy } from "../config/group-policy.js";
+import type {
+  ReplyToMode,
+  TelegramAccountConfig,
+  TelegramGroupConfig,
+  TelegramTopicConfig,
+} from "../config/types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { TelegramContext } from "./bot/types.js";
+import { resolveChunkMode } from "../auto-reply/chunk.js";
 import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
@@ -14,16 +24,11 @@ import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/pr
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type { ChannelGroupPolicy } from "../config/group-policy.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
-import { resolveTelegramCustomCommands } from "../config/telegram-custom-commands.js";
-import type {
-  ReplyToMode,
-  TelegramAccountConfig,
-  TelegramGroupConfig,
-  TelegramTopicConfig,
-} from "../config/types.js";
+import {
+  normalizeTelegramCommandName,
+  resolveTelegramCustomCommands,
+} from "../config/telegram-custom-commands.js";
 import { danger, logVerbose } from "../globals.js";
 import { getChildLogger } from "../logging.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
@@ -34,7 +39,6 @@ import {
 } from "../plugins/commands.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { firstDefined, isSenderAllowed, normalizeAllowFromWithStore } from "./bot-access.js";
 import {
@@ -54,7 +58,6 @@ import {
   resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
-import type { TelegramContext } from "./bot/types.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,
@@ -339,7 +342,7 @@ export const registerTelegramNativeCommands = ({
   }
   const allCommandsFull: Array<{ command: string; description: string }> = [
     ...nativeCommands.map((command) => ({
-      command: command.name,
+      command: normalizeTelegramCommandName(command.name),
       description: command.description,
     })),
     ...(nativeEnabled ? pluginCatalog.commands : []),

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -5,6 +5,7 @@ import {
   listNativeCommandSpecs,
   listNativeCommandSpecsForConfig,
 } from "../auto-reply/commands-registry.js";
+import { normalizeTelegramCommandName } from "../config/telegram-custom-commands.js";
 import {
   answerCallbackQuerySpy,
   commandSpy,
@@ -72,7 +73,7 @@ describe("createTelegramBot", () => {
     }>;
     const skillCommands = resolveSkillCommands(config);
     const native = listNativeCommandSpecsForConfig(config, { skillCommands }).map((command) => ({
-      command: command.name,
+      command: normalizeTelegramCommandName(command.name),
       description: command.description,
     }));
     expect(registered.slice(0, native.length)).toEqual(native);
@@ -113,7 +114,7 @@ describe("createTelegramBot", () => {
     }>;
     const skillCommands = resolveSkillCommands(config);
     const native = listNativeCommandSpecsForConfig(config, { skillCommands }).map((command) => ({
-      command: command.name,
+      command: normalizeTelegramCommandName(command.name),
       description: command.description,
     }));
     const nativeStatus = native.find((command) => command.command === "status");


### PR DESCRIPTION
## Summary

- Telegram Bot API requires command names to use underscores, not hyphens
- Convert hyphenated command names to underscores before registering with Telegram
- Fixes command matching for bots with hyphenated command names (e.g., `!show-context` becomes `/show_context`)

## Test plan

- [ ] Test with a bot that has hyphenated commands (e.g., `!show-context`)
- [ ] Verify command is registered as `/show_context` on Telegram
- [ ] Verify `!show-context` still triggers the command in messages

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Converts hyphens to underscores in Telegram command names during normalization, since the Telegram Bot API only allows `a-z`, `0-9`, and underscores in command names. The change is minimal and well-targeted: a single `.replace(/-/g, "_")` added to `normalizeTelegramCommandName` in `telegram-custom-commands.ts`, with the test updated to verify the new behavior instead of rejecting hyphenated names.

- `normalizeTelegramCommandName` now converts hyphens to underscores (e.g., `show-context` → `show_context`)
- The existing test that expected hyphenated names to be rejected is updated to verify successful normalization
- The change propagates correctly to all three call sites: Zod schema transform, `resolveTelegramCustomCommands`, and `buildPluginTelegramMenuCommands`
- No issues found with existing test coverage — the `bot-native-command-menu.test.ts` test case `bad-name!` still fails correctly (due to `!`, not the hyphen)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — minimal, well-tested change with no risk of regression.
- The change is a single-line addition to an existing normalization function, with the test correctly updated to verify the new behavior. All three call sites of `normalizeTelegramCommandName` benefit from the fix consistently. Existing tests in `bot-native-command-menu.test.ts` remain unaffected because their test cases use characters beyond just hyphens (e.g., `!`) that still fail validation. No logic, security, or behavioral concerns.
- No files require special attention.

<sub>Last reviewed commit: b66ddc7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->