### PR TITLE
fix(android): auto-capitalize first letter in chat input

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowUpward
@@ -37,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import ai.openclaw.android.chat.ChatSessionEntry
@@ -144,6 +146,7 @@ fun ChatComposer(
         onValueChange = { input = it },
         modifier = Modifier.fillMaxWidth(),
         placeholder = { Text("Message OpenClaw…") },
+        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
         minLines = 2,
         maxLines = 6,
       )


### PR DESCRIPTION
## Summary
- Adds `KeyboardOptions(capitalization = KeyboardCapitalization.Sentences)` to the chat input `TextField`, so the keyboard starts with a capital letter at the beginning of each sentence — matching standard messaging app behavior.

## AI Disclosure
- [x] AI-assisted (ClaudeCode via OpenClaw) — human reviewed and tested
- [x] I understand what this code does

## Testing
- Lightly tested on OnePlus 12 (Android 15)
- Verified keyboard opens with uppercase at start of input

## Screenshots
![Screenshot_2026-02-17-09-30-59-07_9e4f220af4158cf313504e53a3b01c8c](https://github.com/user-attachments/assets/65b5ec5f-3010-4aac-ba85-3da999278280)

🤖 Generated with [Claude Code](https://claude.com/claude-code)