### PR TITLE
feat(android): add disconnect button via StatusPill tap

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/RootScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/RootScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
@@ -37,6 +38,8 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ScreenShare
@@ -72,6 +75,7 @@ import ai.openclaw.android.MainViewModel
 @Composable
 fun RootScreen(viewModel: MainViewModel) {
   var sheet by remember { mutableStateOf<Sheet?>(null) }
+  var showDisconnectDialog by remember { mutableStateOf(false) }
   val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
   val safeOverlayInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
   val context = LocalContext.current
@@ -209,7 +213,13 @@ fun RootScreen(viewModel: MainViewModel) {
       gateway = gatewayState,
       voiceEnabled = voiceEnabled,
       activity = activity,
-      onClick = { sheet = Sheet.Settings },
+      onClick = {
+        if (gatewayState == GatewayState.Connected) {
+          showDisconnectDialog = true
+        } else {
+          sheet = Sheet.Settings
+        }
+      },
       modifier = Modifier.windowInsetsPadding(safeOverlayInsets).padding(start = 12.dp, top = 12.dp),
     )
   }
@@ -273,6 +283,30 @@ fun RootScreen(viewModel: MainViewModel) {
         isSpeaking = talkIsSpeaking,
       )
     }
+  }
+
+  if (showDisconnectDialog) {
+    AlertDialog(
+      onDismissRequest = { showDisconnectDialog = false },
+      title = { Text("Gateway") },
+      text = { Text("Disconnect from the gateway?") },
+      confirmButton = {
+        TextButton(onClick = {
+          showDisconnectDialog = false
+          viewModel.disconnect()
+        }) {
+          Text("Disconnect")
+        }
+      },
+      dismissButton = {
+        TextButton(onClick = {
+          showDisconnectDialog = false
+          sheet = Sheet.Settings
+        }) {
+          Text("Settings")
+        }
+      },
+    )
   }
 
   val currentSheet = sheet


### PR DESCRIPTION
## Summary
- When connected to a gateway, tapping the green "Connected" status pill now shows a confirmation dialog with options to **Disconnect** or open **Settings**.
- Previously, tapping the pill always opened Settings regardless of connection state.
- This is needed if your gateway is offline (for the crazy people who don't run 24/7), the app will constantly try to connect, and the only way around it was to force stop the app. Clicking Disconnect in settings would just try to auto reconnect (possibly only if manual connection was used. I had tailscale issues with auto discovery, so I cannot test that workflow)

## AI Disclosure
- [x] AI-assisted (ClaudeCode Via OpenClaw) — human reviewed and tested
- [x] I understand what this code does

## Testing
- Lightly tested on OnePlus 12 (Android 15)
- Verified the disconnect dialog appears when tapping the "Connected" pill
- Confirmed tapping "Disconnect" actually disconnects from the gateway
- Confirmed tapping "Settings" opens the settings sheet

## Screenshots
![Screenshot_2026-02-17-07-55-58-73_9e4f220af4158cf313504e53a3b01c8c](https://github.com/user-attachments/assets/00225346-99e2-435a-9af5-bf48ead9b2c2)
![Screenshot_2026-02-17-09-35-13-51_9e4f220af4158cf313504e53a3b01c8c](https://github.com/user-attachments/assets/6392db58-ff2c-47bc-903e-951243120eb6)
![Screenshot_2026-02-17-09-34-50-13_9e4f220af4158cf313504e53a3b01c8c](https://github.com/user-attachments/assets/65983c5b-f861-4928-aa44-e928012ab997)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added conditional disconnect dialog when tapping the status pill in connected state. When tapped while connected to a gateway, users now see a confirmation dialog with "Disconnect" and "Settings" options instead of immediately opening Settings. The dialog integrates with the existing `viewModel.disconnect()` method and maintains the original behavior (opening Settings) for all other connection states.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal and well-scoped: adds a simple state variable, conditional logic based on existing `GatewayState` enum, and a standard Material3 `AlertDialog`. The disconnect flow calls an existing `viewModel.disconnect()` method, and the fallback behavior (opening Settings) is preserved for non-connected states. No complex logic, edge cases are handled cleanly, and the implementation follows Jetpack Compose best practices.
- No files require special attention

<sub>Last reviewed commit: 349fac8</sub>
