### PR TITLE
fix(auth): clear all usage stats fields in clearAuthProfileCooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ Docs: https://docs.openclaw.ai
 
 - Tests/Telegram: add regression coverage for command-menu sync that asserts all `setMyCommands` entries are Telegram-safe and hyphen-normalized across native/custom/plugin command sources. (#19703) Thanks @obviyus.
 - Agents/Image: collapse resize diagnostics to one line per image and include visible pixel/byte size details in the log message for faster triage.
+- Auth/Cooldowns: clear all usage stats fields (`disabledUntil`, `disabledReason`, `failureCounts`) in `clearAuthProfileCooldown` so manual cooldown resets fully recover billing-disabled profiles without requiring direct file edits. (#19211) Thanks @nabbilkhan.
 - Agents/Subagents: preemptively guard accumulated tool-result context before model calls by truncating oversized outputs and compacting oldest tool-result messages to avoid context-window overflow crashes. Thanks @tyler6204.
 - Agents/Subagents/CLI: fail `sessions_spawn` when subagent model patching is rejected, allow subagent model patch defaults from `subagents.model`, and keep `sessions list`/`status` model reporting aligned to runtime model resolution. (#18660) Thanks @robbyczgw-cla.
 - Agents/Subagents: add explicit subagent guidance to recover from `[compacted: tool output removed to free context]` / `[truncated: output exceeded context limit]` markers by re-reading with smaller chunks instead of full-file `cat`. Thanks @tyler6204.

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -400,6 +400,9 @@ export async function clearAuthProfileCooldown(params: {
         ...freshStore.usageStats[profileId],
         errorCount: 0,
         cooldownUntil: undefined,
+        disabledUntil: undefined,
+        disabledReason: undefined,
+        failureCounts: undefined,
       };
       return true;
     },
@@ -416,6 +419,9 @@ export async function clearAuthProfileCooldown(params: {
     ...store.usageStats[profileId],
     errorCount: 0,
     cooldownUntil: undefined,
+    disabledUntil: undefined,
+    disabledReason: undefined,
+    failureCounts: undefined,
   };
   saveAuthProfileStore(store, agentDir);
 }


### PR DESCRIPTION
## Summary

- **Problem:** `clearAuthProfileCooldown` only resets `errorCount` and `cooldownUntil`, leaving `disabledUntil`, `disabledReason`, and `failureCounts` intact. Ran into this while rotating API keys across providers — cleared the cooldown but the profile stayed disabled, had to manually edit the JSON to recover.
- **Why it matters:** billing-disabled profiles remain stuck even after manual clear, and stale `failureCounts` cause the next transient failure to immediately escalate to a disproportionately long cooldown via `computeNextProfileUsageStats`.
- **What changed:** added `disabledUntil: undefined`, `disabledReason: undefined`, and `failureCounts: undefined` to both the lock-path updater and the fallback path in `clearAuthProfileCooldown`. Added three unit tests covering full reset, timestamp preservation, and no-op on unknown profiles.
- **What did NOT change (scope boundary):** `clearExpiredCooldowns` (automatic time-based expiry) is untouched. `markAuthProfileUsed` already handles all fields correctly and was not modified. Function signature unchanged — fully backward compatible.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #3604 (stale cooldowns — addressed automatic expiry; this PR completes the manual clear path)
- Related #13623, #15851, #11972, #8434 (auth profile stuck / escalation reports)

## User-visible / Behavior Changes

- Users who manually clear a profile cooldown (via gateway UI, plugin API, or CLI) will now get a full reset of error state. Previously, profiles with billing-triggered disables (`disabledUntil` + `disabledReason`) would remain stuck despite the manual clear, requiring direct file editing to recover.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Linux 6.8.0)
- Runtime/container: Node 22 + pnpm
- Model/provider: Any (Anthropic, OpenAI) — affects auth profile usage tracking
- Integration/channel (if any): N/A (core auth-profiles module)
- Relevant config (redacted): default `auth-profiles.json` with billing-disabled entries

### Steps

1. Configure an auth profile and trigger billing errors until `disabledUntil` + `disabledReason` are set.
2. Call `clearAuthProfileCooldown` (e.g., via gateway UI "Reset" button or plugin API).
3. Observe profile state after clear.

### Expected

- All error fields reset: `cooldownUntil`, `disabledUntil`, `disabledReason`, `errorCount`, and `failureCounts` should all be cleared.

### Actual (before fix)

- `cooldownUntil` and `errorCount` were cleared, but `disabledUntil`, `disabledReason`, and `failureCounts` remained, keeping the profile stuck.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Before (current main):**
```typescript
// clearAuthProfileCooldown only resets 2 of 5 fields:
freshStore.usageStats[profileId] = {
  ...freshStore.usageStats[profileId],
  errorCount: 0,
  cooldownUntil: undefined,
  // MISSING: disabledUntil, disabledReason, failureCounts
};
```

**After (this PR):**
```typescript
// Now resets all 5 fields, matching markAuthProfileUsed:
freshStore.usageStats[profileId] = {
  ...freshStore.usageStats[profileId],
  errorCount: 0,
  cooldownUntil: undefined,
  disabledUntil: undefined,
  disabledReason: undefined,
  failureCounts: undefined,
};
```

**Test output:**
```
✓ src/agents/auth-profiles/usage.test.ts (20 tests) 5ms
  ✓ clears all error state fields including disabledUntil and failureCounts
  ✓ preserves lastUsed and lastFailureAt timestamps
  ✓ no-ops for unknown profile id

Test Files  656 passed (656)
     Tests  5364 passed (5364)
```

## Verification

- New unit tests confirm complete field reset (all 5 error-state fields cleared)
- Confirmed `lastUsed` and `lastFailureAt` timestamps are preserved through the clear
- Confirmed no-op behavior when clearing a nonexistent profile ID
- All 656 test files (5364 tests) pass on the clean branch
- Compared `clearAuthProfileCooldown` field list against `markAuthProfileUsed` (lines 142–150) to confirm alignment
- Edge cases: profile with only `disabledUntil` set, profile with only stale `failureCounts`, unknown profile ID

## Compatibility / Migration

- Backward compatible? `Yes` — function signature unchanged, no new parameters, no config changes
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: single-commit revert
- Files/config to restore: `src/agents/auth-profiles/usage.ts`, `src/agents/auth-profiles/usage.test.ts`
- Known bad symptoms reviewers should watch for: profiles losing `lastUsed`/`lastFailureAt` after clear (would indicate spread order issue — verified this does not happen via test)

## Risks and Mitigations

- Risk: `clearAuthProfileCooldown` is exported and consumed by gateway/plugins; changing its reset scope could affect downstream behavior.
  - Mitigation: The change only clears *more* fields — it goes from partial reset to full reset. No consumer relies on `disabledUntil`/`disabledReason`/`failureCounts` surviving a manual clear (that was the bug). The pattern matches `markAuthProfileUsed` which has been in production without issues.
