### PR TITLE
revert: PR 18288 accidental merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents: revert accidental per-model thinkingDefault override merge. (#19195) Thanks @sebslight.
+- Sessions: revert accidental session transcript permission hardening from PR #18288. (#19224) Thanks @sebslight.
 - Voice call/Gateway: prevent overlapping closed-loop turn races with per-call turn locking, route transcript dedupe via source-aware fingerprints with strict cache eviction bounds, and harden `voicecall latency` stats for large logs without spread-operator stack overflow. (#19140) Thanks @mbelinky.
 - iOS/Onboarding: stop auth Step 3 retry-loop churn by pausing reconnect attempts on unauthorized/missing-token gateway errors and keeping auth/pairing issue state sticky during manual retry. (#19153) Thanks @mbelinky.
 - Fix types in all tests. Typecheck the whole repository.

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -43,7 +43,7 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", { encoding: "utf-8", mode: 0o600 });
+    await fs.writeFile(params.sessionFile, "", "utf-8");
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -89,10 +89,7 @@ function forkSessionFromParent(params: {
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, {
-      encoding: "utf-8",
-      mode: 0o600,
-    });
+    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
     return { sessionId, sessionFile };
   } catch {
     return null;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -471,10 +471,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     const archived = archiveFileOnDisk(filePath, "bak");
     const keptLines = lines.slice(-maxLines);
-    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, {
-      encoding: "utf-8",
-      mode: 0o600,
-    });
+    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, "utf-8");
 
     await updateSessionStore(storePath, (store) => {
       const entryKey = compactTarget.primaryKey;


### PR DESCRIPTION
## Summary
- Revert PR #18288 (session transcript permission follow-up) after an accidental merge.

## Testing
- pnpm build
- pnpm check
- pnpm test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts commit `ae0b110e` ("fix(security): set 0o600 on remaining session file write paths"), which was a follow-up to PR #18066 that added restrictive file permissions (`mode: 0o600`) to three session transcript write paths that were originally missed. The revert is described as undoing an accidental merge of PR #18288.

- Reverts `mode: 0o600` → default umask permissions on `writeFile`/`writeFileSync` calls in three files: `session-manager-init.ts`, `session.ts`, and `sessions.ts`
- These three paths now have a permission inconsistency with other session file writes (e.g., `transcript.ts:75`, `chat.ts:302`) that still use `mode: 0o600`
- The `security/fix.ts` module provides defense-in-depth by scanning and fixing `.jsonl` transcript permissions, mitigating the immediate risk
- The security hardening from the original fix should be re-landed once properly reviewed

<h3>Confidence Score: 4/5</h3>

- This PR is a straightforward revert of a small security hardening commit, with low risk due to existing defense-in-depth via the security fix module.
- Score of 4 reflects that this is a clean, minimal revert of 3 files with only permission-related changes. The reverted security hardening is partially mitigated by the existing security/fix.ts remediation module. The only concern is a minor permission inconsistency on new file creation in the session fork path, but this is a style-level observation rather than a critical issue.
- `src/auto-reply/reply/session.ts` — the `forkSessionFromParent` function creates new session files without `mode: 0o600`, unlike other creation paths.

<sub>Last reviewed commit: ff5261c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->