### PR TITLE
fix(feishu): scope dedup keys by account id

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -501,7 +501,7 @@ export async function handleFeishuMessage(params: {
 
   // Dedup check: skip if this message was already processed
   const messageId = event.message.message_id;
-  if (!tryRecordMessage(messageId)) {
+  if (!tryRecordMessage(messageId, account.accountId)) {
     log(`feishu: skipping duplicate message ${messageId}`);
     return;
   }


### PR DESCRIPTION
## Summary
Fix Feishu dedup collisions across multiple bot accounts in the same process.

Previously, inbound Feishu dedup used only `message_id` as the key.
When two Feishu bots are both @mentioned in one group message, Feishu can deliver the same `message_id` to both accounts.
The first account recorded the ID, and the second account was incorrectly dropped as a duplicate.

## What changed
- `extensions/feishu/src/dedup.ts`
  - Extend `tryRecordMessage` to accept an optional `scope`.
  - Build dedup key as `${scope}:${messageId}`.
- `extensions/feishu/src/bot.ts`
  - Call `tryRecordMessage(messageId, account.accountId)`.

## Why this is safe
- Existing single-account behavior remains unchanged (`scope` defaults to `"default"`).
- Dedup still prevents reconnect/redelivery duplicates within each account.
- Prevents cross-account false positives.

## Repro (before)
1. Add two Feishu bots to the same group.
2. Send one message that mentions both bots.
3. Often only one bot responds; the other is dropped as duplicate.

## Repro (after)
Both bots can process and respond to the same mentioned message independently.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a deduplication collision bug in the Feishu extension where multiple bot accounts in the same process would incorrectly drop messages as duplicates.

**Key Changes:**
- Modified `tryRecordMessage()` in `dedup.ts` to accept an optional `scope` parameter (defaults to `"default"`)
- Dedup keys now use the format `${scope}:${messageId}` instead of just `messageId`
- Updated the call site in `bot.ts:504` to pass `account.accountId` as the scope

**How It Works:**
When Feishu delivers the same group message to multiple bot accounts (e.g., when both are `@mentioned`), they receive identical `message_id` values. Previously, the first account would record the ID and the second would be incorrectly rejected. Now each account maintains its own dedup namespace, preventing false positives while still catching genuine duplicates within each account.

**Backward Compatibility:**
Single-account setups continue to work unchanged since the `scope` parameter defaults to `"default"`, which is also what `normalizeAccountId()` returns for undefined/null/empty values.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-scoped, and correctly implement account-scoped deduplication. The fix directly addresses the stated problem without introducing side effects. Backward compatibility is preserved through the default parameter value.
- No files require special attention

<sub>Last reviewed commit: 5668aaa</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->