### PR TITLE
fix(compaction): preserve exact identifiers in summarization

### DIFF
--- a/src/agents/compaction-instructions.test.ts
+++ b/src/agents/compaction-instructions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  DEFAULT_COMPACTION_INSTRUCTIONS,
+  resolveCompactionInstructions,
+} from "./compaction-instructions.js";
+
+describe("resolveCompactionInstructions", () => {
+  it("returns default when config is undefined", () => {
+    expect(resolveCompactionInstructions(undefined)).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+  });
+
+  it("returns default when config.agents is undefined", () => {
+    const config = {} as OpenClawConfig;
+    expect(resolveCompactionInstructions(config)).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+  });
+
+  it("returns default when config.agents.defaults is undefined", () => {
+    const config = { agents: {} } as OpenClawConfig;
+    expect(resolveCompactionInstructions(config)).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+  });
+
+  it("returns default when config.agents.defaults.compaction is undefined", () => {
+    const config = { agents: { defaults: {} } } as OpenClawConfig;
+    expect(resolveCompactionInstructions(config)).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+  });
+
+  it("returns default when customInstructions is undefined", () => {
+    const config = { agents: { defaults: { compaction: {} } } } as OpenClawConfig;
+    expect(resolveCompactionInstructions(config)).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+  });
+
+  it("returns default when customInstructions is empty string", () => {
+    const config = {
+      agents: { defaults: { compaction: { customInstructions: "" } } },
+    } as OpenClawConfig;
+    expect(resolveCompactionInstructions(config)).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+  });
+
+  it("returns default when customInstructions is whitespace only", () => {
+    const config = {
+      agents: { defaults: { compaction: { customInstructions: "   \n\t  " } } },
+    } as OpenClawConfig;
+    expect(resolveCompactionInstructions(config)).toBe(DEFAULT_COMPACTION_INSTRUCTIONS);
+  });
+
+  it("returns config value when customInstructions is set", () => {
+    const custom = "Keep all UUIDs and IPs intact.";
+    const config = {
+      agents: { defaults: { compaction: { customInstructions: custom } } },
+    } as OpenClawConfig;
+    expect(resolveCompactionInstructions(config)).toBe(custom);
+  });
+});

--- a/src/agents/compaction-instructions.ts
+++ b/src/agents/compaction-instructions.ts
@@ -1,0 +1,25 @@
+import type { OpenClawConfig } from "../config/config.js";
+
+export const DEFAULT_COMPACTION_INSTRUCTIONS = `Preserve ALL exact identifiers verbatim, including:
+- UUIDs and GUIDs
+- IP addresses, hostnames, and ports
+- Git commit SHAs and branch names
+- Docker container IDs and image hashes
+- API endpoint paths and URL-embedded IDs
+- Database row IDs and table names
+- Session tokens and auth headers
+- Kubernetes pod/service/namespace names
+- Version numbers and build IDs
+- Serial numbers and MAC addresses
+- Connection strings and DSNs
+- File paths and function names
+- Error messages and stack traces
+Never truncate, abbreviate, or omit these values.`;
+
+export function resolveCompactionInstructions(config: OpenClawConfig | undefined): string {
+  const custom = config?.agents?.defaults?.compaction?.customInstructions;
+  if (typeof custom === "string" && custom.trim().length > 0) {
+    return custom;
+  }
+  return DEFAULT_COMPACTION_INSTRUCTIONS;
+}

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -10,6 +10,7 @@ import {
   markAuthProfileGood,
   markAuthProfileUsed,
 } from "../auth-profiles.js";
+import { resolveCompactionInstructions } from "../compaction-instructions.js";
 import {
   CONTEXT_WINDOW_HARD_MIN_TOKENS,
   CONTEXT_WINDOW_WARN_BELOW_TOKENS,
@@ -661,6 +662,7 @@ export async function runEmbeddedPiAgent(
                 bashElevated: params.bashElevated,
                 extraSystemPrompt: params.extraSystemPrompt,
                 ownerNumbers: params.ownerNumbers,
+                customInstructions: resolveCompactionInstructions(params.config),
                 trigger: "overflow",
                 diagId: overflowDiagId,
                 attempt: overflowCompactionAttempts,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -1,3 +1,4 @@
+import { resolveCompactionInstructions } from "../../agents/compaction-instructions.js";
 import {
   abortEmbeddedPiRun,
   compactEmbeddedPiSession,
@@ -68,13 +69,14 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     abortEmbeddedPiRun(sessionId);
     await waitForEmbeddedPiRunEnd(sessionId, 15_000);
   }
-  const customInstructions = extractCompactInstructions({
+  const userInstructions = extractCompactInstructions({
     rawBody: params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body,
     ctx: params.ctx,
     cfg: params.cfg,
     agentId: params.agentId,
     isGroup: params.isGroup,
   });
+  const customInstructions = userInstructions ?? resolveCompactionInstructions(params.cfg);
   const result = await compactEmbeddedPiSession({
     sessionId,
     sessionKey: params.sessionKey,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -295,6 +295,8 @@ export type AgentCompactionConfig = {
   maxHistoryShare?: number;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
+  /** Custom instructions for compaction summarization (overrides default identifier preservation list). */
+  customInstructions?: string;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -102,6 +102,7 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        customInstructions: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Fixes #19207

## What
Expands compaction summarization to preserve all exact identifiers, not just file paths, function names, and error messages.

## Why
Users reported that UUIDs, IPs, commit SHAs, container hashes, and other precise identifiers were being truncated during compaction. The model would then hallucinate replacements, causing API failures and misconfigurations.

## How
- Added `customInstructions` option to `AgentCompactionConfig`
- Created `DEFAULT_COMPACTION_INSTRUCTIONS` with a comprehensive identifier preservation list
- Applied default instructions to both automatic (overflow) and manual (`/compact`) compaction
- Users can override via config if needed

## Testing
- [x] Added unit tests for instruction resolution
- [x] `pnpm check` passes (pre-existing TS2742 errors unrelated to this PR)
- [x] `pnpm build` passes

## AI-Assisted 🤖
This PR was built with AI assistance (Claude via OpenClaw).
- [x] Code reviewed and understood
- [x] Lightly tested
- [x] Session available on request

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds default compaction instructions to preserve exact identifiers (UUIDs, IPs, commit SHAs, container hashes, etc.) during session compaction summarization. The change is well-structured, adding a new `compaction-instructions.ts` module with a `resolveCompactionInstructions` helper that falls back to sensible defaults when no user override is provided.

- Added `DEFAULT_COMPACTION_INSTRUCTIONS` with a comprehensive identifier preservation list
- Integrated default instructions into both overflow (automatic) and manual (`/compact`) compaction paths
- User-provided `/compact:` inline instructions correctly take precedence over defaults
- Users can override via `agents.defaults.compaction.customInstructions` config (but see issue below)
- **Issue**: The Zod validation schema in `src/config/zod-schema.agent-defaults.ts` was not updated to include `customInstructions`. The compaction schema uses `.strict()`, so user configs that set this field will fail validation with an unrecognized key error. The default instructions work fine since they don't require config, but the user-override path is broken.

<h3>Confidence Score: 3/5</h3>

- The default behavior works correctly, but the config override path is broken due to a missing Zod schema update.
- The core feature (applying default identifier-preservation instructions to compaction) works as intended and is well-tested. However, the advertised user-override via config will cause validation errors because the Zod schema was not updated to match the new TypeScript type field. This is a functional gap that prevents users from customizing the instructions as documented in the type.
- Pay attention to `src/config/types.agent-defaults.ts` — the `customInstructions` field needs a corresponding entry in `src/config/zod-schema.agent-defaults.ts`.

<sub>Last reviewed commit: dc3a654</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->