### PR TITLE
fix(net): use undici package fetch to match v7 dispatcher (#19147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: disable block streaming when `channels.telegram.streamMode` is `off`, preventing newline/content-block replies from splitting into multiple messages. (#17679) Thanks @saivarunk.
 - Telegram: keep `streamMode: "partial"` draft previews in a single message across assistant-message/reasoning boundaries, preventing duplicate preview bubbles during partial-mode tool-call turns. (#18956) Thanks @obviyus.
 - Telegram: route non-abort slash commands on the normal chat/topic sequential lane while keeping true abort requests (`/stop`, `stop`) on the control lane, preventing command/reply race conditions from control-lane bypass. (#17899) Thanks @obviyus.
+- Net/SSRF: use undici package `fetch` instead of `globalThis.fetch` in the SSRF guard, fixing silent connection failures when the undici v7 pinned dispatcher is passed to Node 22's built-in undici v6 fetch. (#19147)
 - Telegram: ignore `<media:...>` placeholder lines when extracting `MEDIA:` tool-result paths, preventing false local-file reads and dropped replies. (#18510) Thanks @yinghaosang.
 - Telegram: skip retries when inbound media `getFile` fails with Telegram's 20MB limit and continue processing message text, avoiding dropped messages for oversized attachments. (#18531) Thanks @brandonwise.
 - Telegram: clear stored polling offsets when bot tokens change or accounts are deleted, preventing stale offsets after token rotations. (#18233)

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -1,4 +1,5 @@
 import type { Dispatcher } from "undici";
+import { fetch as undiciFetch } from "undici";
 import { logWarn } from "../../logger.js";
 import { bindAbortRelay } from "../../utils/fetch-timeout.js";
 import {
@@ -72,7 +73,7 @@ function buildAbortSignal(params: { timeoutMs?: number; signal?: AbortSignal }):
 }
 
 export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<GuardedFetchResult> {
-  const fetcher: FetchLike | undefined = params.fetchImpl ?? globalThis.fetch;
+  const fetcher: FetchLike | undefined = params.fetchImpl ?? undiciFetch;
   if (!fetcher) {
     throw new Error("fetch is not available");
   }

--- a/src/infra/net/fetch-guard.undici-mismatch.test.ts
+++ b/src/infra/net/fetch-guard.undici-mismatch.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test for #19147: undici v7 Agent passed to globalThis.fetch
+ * (undici v6) causes silent connection failures for Telegram media downloads.
+ *
+ * The fix: use `fetch` from the `undici` package (v7) as the default fetcher
+ * in fetch-guard.ts, ensuring the dispatcher and fetch are from the same version.
+ */
+import { describe, expect, it } from "vitest";
+import { Agent } from "undici";
+
+describe("Issue #19147: undici version mismatch (#19147)", () => {
+  it("confirms package undici is v7+ (different from Node 22 built-in v6)", async () => {
+    const agent = new Agent({ connect: { timeout: 5000 } });
+    expect(agent).toBeInstanceOf(Agent);
+
+    const packageVersion = require("undici/package.json").version;
+    const majorVersion = parseInt(packageVersion.split(".")[0], 10);
+
+    // Package undici is v7+, Node 22 bundles v6
+    expect(majorVersion).toBeGreaterThanOrEqual(7);
+    await agent.close();
+  });
+
+  it("fetch-guard uses undici package fetch, not globalThis.fetch", async () => {
+    const fs = await import("fs");
+    const src = fs.readFileSync("src/infra/net/fetch-guard.ts", "utf-8");
+
+    // After fix: uses undiciFetch from the undici package
+    expect(src).toContain('import { fetch as undiciFetch } from "undici"');
+    expect(src).toContain("params.fetchImpl ?? undiciFetch");
+
+    // Must NOT default to globalThis.fetch (which is Node built-in undici v6)
+    expect(src).not.toContain("params.fetchImpl ?? globalThis.fetch");
+
+    console.log("✅ PASS: fetch-guard.ts uses undici package fetch (v7) with v7 dispatcher");
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: Telegram media downloads silently fail with ETIMEDOUT on Node 22
- **Root cause**: `fetchWithSsrFGuard` in `src/infra/net/fetch-guard.ts` passes an undici v7 `Agent` (from the npm package) as `dispatcher` to `globalThis.fetch` (which uses Node 22's built-in undici v6). The version mismatch causes the dispatcher to be silently ignored or fail.
- **Fix**: Default to `fetch` from the `undici` package instead of `globalThis.fetch`, ensuring the dispatcher and fetch are from the same undici version.

Fixes #19147

## Problem

The SSRF guard in `fetch-guard.ts` creates a pinned DNS `Agent` via `createPinnedDispatcher()` from the `undici` npm package (v7.22.0). This dispatcher is then passed to `globalThis.fetch`, which on Node 22 is backed by the built-in undici v6. Since v7 and v6 use different internal symbols and class hierarchies, the v6 fetch either silently ignores the v7 dispatcher or fails to connect.

This affects all SSRF-guarded fetches, most visibly Telegram media downloads which time out with ETIMEDOUT.

**Before fix:**
```
fetchWithSsrFGuard → globalThis.fetch (undici v6) + undici v7 Agent → ETIMEDOUT
```

## Changes

- `src/infra/net/fetch-guard.ts` — Import `fetch` from the `undici` package and use it as the default fetcher instead of `globalThis.fetch`. The `fetchImpl` override still works for callers that provide their own fetch.
- `src/infra/net/fetch-guard.undici-mismatch.test.ts` — Regression test confirming the version mismatch exists and that the fix uses the correct fetch.
- `CHANGELOG.md` — Added entry under Fixes.

**After fix:**
```
fetchWithSsrFGuard → undici v7 fetch + undici v7 Agent → success
```

## Test plan

- [x] New test: `fetch-guard.undici-mismatch.test.ts` — confirms package undici is v7+ and fetch-guard uses `undiciFetch` not `globalThis.fetch`
- [x] All 16 existing tests in `src/infra/net/` pass (SSRF hardening, pinning, IP classification)
- [x] Lint passes (0 warnings, 0 errors)

## Effect on User Experience

**Before:** Telegram media messages (images, documents, voice) silently fail to download with connection timeouts. Users see missing media or error messages.
**After:** Media downloads work correctly because the SSRF guard's pinned dispatcher is paired with a compatible fetch implementation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Telegram media download timeouts by ensuring the SSRF guard uses `fetch` from the `undici` npm package (v7) instead of `globalThis.fetch` (Node 22's built-in undici v6). The version mismatch caused the v7 `Agent` dispatcher to be silently ignored by the v6 fetch implementation, resulting in ETIMEDOUT errors.

- Changed default fetcher in `fetchWithSsrFGuard` from `globalThis.fetch` to imported `undiciFetch` from the undici package
- Added regression test confirming undici v7+ is used and verifying the fix
- Maintains backward compatibility through the `fetchImpl` override parameter

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a critical bug with a minimal, well-tested change
- The fix correctly addresses a real version mismatch bug between undici v7 (npm package) and v6 (Node 22 built-in). The change is minimal (2 lines), maintains backward compatibility via `fetchImpl` parameter, includes regression test coverage, and all existing tests pass. The root cause analysis is thorough and the solution is correct.
- No files require special attention

<sub>Last reviewed commit: 6c1a114</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->