### PR TITLE
fix(cron): persist delivery status in job state

### DIFF
--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -20,6 +20,7 @@ export type CronEvent = {
   summary?: string;
   sessionId?: string;
   sessionKey?: string;
+  delivered?: boolean;
   nextRunAtMs?: number;
 } & CronRunTelemetry;
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -66,6 +66,7 @@ function applyJobResult(
   result: {
     status: CronRunStatus;
     error?: string;
+    delivered?: boolean;
     startedAt: number;
     endedAt: number;
   },
@@ -75,6 +76,7 @@ function applyJobResult(
   job.state.lastStatus = result.status;
   job.state.lastDurationMs = Math.max(0, result.endedAt - result.startedAt);
   job.state.lastError = result.error;
+  job.state.lastDelivered = result.delivered;
   job.updatedAtMs = result.endedAt;
 
   // Track consecutive errors for backoff / auto-disable.
@@ -288,6 +290,7 @@ export async function onTimer(state: CronServiceState) {
           const shouldDelete = applyJobResult(state, job, {
             status: result.status,
             error: result.error,
+            delivered: result.delivered,
             startedAt: result.startedAt,
             endedAt: result.endedAt,
           });
@@ -545,6 +548,7 @@ async function executeJobCore(
     summary: res.summary,
     sessionId: res.sessionId,
     sessionKey: res.sessionKey,
+    delivered: res.delivered,
     model: res.model,
     provider: res.provider,
     usage: res.usage,
@@ -583,6 +587,7 @@ export async function executeJob(
   const shouldDelete = applyJobResult(state, job, {
     status: coreResult.status,
     error: coreResult.error,
+    delivered: coreResult.delivered,
     startedAt,
     endedAt,
   });
@@ -612,6 +617,7 @@ function emitJobFinished(
     summary: result.summary,
     sessionId: result.sessionId,
     sessionKey: result.sessionKey,
+    delivered: result.delivered,
     runAtMs,
     durationMs: job.state.lastDurationMs,
     nextRunAtMs: job.state.nextRunAtMs,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -43,6 +43,13 @@ export type CronRunOutcome = {
   summary?: string;
   sessionId?: string;
   sessionKey?: string;
+  /**
+   * Whether the run's output was actually delivered to the target channel.
+   * `true`  — at least one outbound send reached the target.
+   * `false` — delivery was attempted but failed (best-effort swallowed the error).
+   * `undefined` — delivery was not requested or not applicable.
+   */
+  delivered?: boolean;
 };
 
 export type CronPayload =
@@ -83,6 +90,13 @@ export type CronJobState = {
   lastStatus?: "ok" | "error" | "skipped";
   lastError?: string;
   lastDurationMs?: number;
+  /**
+   * Whether the last run's output was actually delivered to the target channel.
+   * `true`  — at least one outbound send reached the target.
+   * `false` — delivery was attempted but failed (best-effort swallowed the error).
+   * `undefined` — delivery was not requested or not applicable (e.g. systemEvent payload).
+   */
+  lastDelivered?: boolean;
   /** Number of consecutive execution errors (reset on success). Used for backoff. */
   consecutiveErrors?: number;
   /** Number of consecutive schedule computation errors. Auto-disables job after threshold. */


### PR DESCRIPTION
## Summary

Adds a `lastDelivered` field to `CronJobState` so users can distinguish agent execution success from delivery success.

## Problem

Cron jobs report `lastStatus: "ok"` even when delivery silently fails under `bestEffort` mode. There's no programmatic way to detect delivery failures from job state — users must inspect gateway logs.

## Root Cause

The `delivered` boolean is already computed in `isolated-agent/run.ts` (line 556–613) but was discarded before reaching job state persistence. `executeJobCore()` strips it from the return, and `applyJobResult()` never writes it.

## Fix

Thread the `delivered` boolean through the full execution pipeline:

- **`CronRunOutcome`** — add `delivered?: boolean`
- **`CronJobState`** — add `lastDelivered?: boolean`
- **`CronEvent`** — add `delivered?: boolean` (finish events)
- **`executeJobCore()`** — include `delivered` in return value
- **`applyJobResult()`** — accept and persist `delivered` to `job.state.lastDelivered`
- **`emitJobFinished()`** — include `delivered` in event

## Semantics

| Value | Meaning |
|-------|---------|
| `true` | At least one outbound send reached the target |
| `false` | Delivery was attempted but failed (best-effort swallowed the error) |
| `undefined` | Delivery not requested or not applicable (e.g., systemEvent payload) |

## Backward Compatibility

Fully additive — `lastStatus` continues to reflect agent execution status. `lastDelivered` provides the missing delivery signal. No breaking changes.

Fixes #19154

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `lastDelivered` field to cron job state to track whether output was successfully delivered to the target channel, addressing a gap where delivery failures were silently swallowed in best-effort mode. The change threads the existing `delivered` boolean (already computed in `isolated-agent/run.ts`) through the execution pipeline (`CronRunOutcome` → `executeJobCore` → `applyJobResult` → `CronJobState.lastDelivered`) and includes it in finish events. The implementation is fully additive and backward compatible—`lastStatus` continues to reflect agent execution, while `lastDelivered` provides the missing delivery signal.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is purely additive, introducing optional fields that don't affect existing behavior. The implementation correctly threads the `delivered` boolean through all necessary layers with proper TypeScript typing. No breaking changes or edge cases identified—the `delivered` field has well-defined semantics (true/false/undefined) and is correctly persisted from the isolated agent runner to job state.
- No files require special attention

<sub>Last reviewed commit: acccaa2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->