### PR TITLE
docs(telegram): fix 5 discrepancies between docs and config schema

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -715,6 +715,8 @@ Primary reference:
   - `channels.telegram.groups.<id>.topics.<threadId>.*`: per-topic overrides (same fields as group).
   - `channels.telegram.groups.<id>.topics.<threadId>.groupPolicy`: per-topic override for groupPolicy (`open | allowlist | disabled`).
   - `channels.telegram.groups.<id>.topics.<threadId>.requireMention`: per-topic mention gating override.
+  - `channels.telegram.groups.<id>.tools`: per-group tool policy override (`allow`, `alsoAllow`, `deny`).
+  - `channels.telegram.groups.<id>.toolsBySender.<senderId>`: per-sender tool policy override within a group (`allow`, `alsoAllow`, `deny`).
 - `channels.telegram.capabilities.inlineButtons`: `off | dm | group | all | allowlist` (default: allowlist).
 - `channels.telegram.accounts.<account>.capabilities.inlineButtons`: per-account override.
 - `channels.telegram.replyToMode`: `off | first | all` (default: `off`).
@@ -722,6 +724,9 @@ Primary reference:
 - `channels.telegram.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.
 - `channels.telegram.linkPreview`: toggle link previews for outbound messages (default: true).
 - `channels.telegram.streamMode`: `off | partial | block` (live stream preview).
+- `channels.telegram.blockStreaming`: when `true`, suppresses live stream previews for this channel regardless of `streamMode`.
+- `channels.telegram.markdown.tables`: `off | bullets | code` — controls how markdown tables are rendered in outbound messages.
+- `channels.telegram.accounts.<account>.name`: optional display name for the account (used in CLI/UI lists).
 - `channels.telegram.mediaMaxMb`: inbound/outbound media cap (MB).
 - `channels.telegram.retry`: retry policy for outbound Telegram API calls (attempts, minDelayMs, maxDelayMs, jitter).
 - `channels.telegram.network.autoSelectFamily`: override Node autoSelectFamily (true=enable, false=disable). Defaults to disabled on Node 22 to avoid Happy Eyeballs timeouts.
@@ -732,6 +737,7 @@ Primary reference:
 - `channels.telegram.webhookHost`: local webhook bind host (default `127.0.0.1`).
 - `channels.telegram.actions.reactions`: gate Telegram tool reactions.
 - `channels.telegram.actions.sendMessage`: gate Telegram tool message sends.
+- `channels.telegram.actions.editMessage`: gate Telegram tool message edits.
 - `channels.telegram.actions.deleteMessage`: gate Telegram tool message deletes.
 - `channels.telegram.actions.sticker`: gate Telegram sticker actions — send and search (default: false).
 - `channels.telegram.reactionNotifications`: `off | own | all` — control which reactions trigger system events (default: `own` when not set).


### PR DESCRIPTION
Fixes discrepancies identified in #19222.

## Changes

Cross-referenced `docs/channels/telegram.md` against the config schema and source types (`src/config/types.telegram.ts`) and found 5 missing fields in the config reference section:

### Added
- `channels.telegram.actions.editMessage` — was present in the accordion and the high-signal summary but missing from the per-field reference list
- `channels.telegram.groups.<id>.tools` — per-group tool policy override (`allow`, `alsoAllow`, `deny`)
- `channels.telegram.groups.<id>.toolsBySender.<senderId>` — per-sender tool policy override within a group
- `channels.telegram.blockStreaming` — boolean to suppress live stream previews
- `channels.telegram.markdown.tables` — table rendering mode (`off | bullets | code`)
- `channels.telegram.accounts.<account>.name` — optional display name for the account

## Verification
All added fields confirmed present in `src/config/types.telegram.ts` and `src/config/types.base.ts`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added 6 missing Telegram configuration fields to the documentation reference section. All fields are verified to exist in `src/config/types.telegram.ts` and `src/config/types.base.ts`:

- `channels.telegram.actions.editMessage` — tool action gate for message editing (already documented in Actions section but missing from config reference)
- `channels.telegram.groups.<id>.tools` — per-group tool policy override
- `channels.telegram.groups.<id>.toolsBySender.<senderId>` — per-sender tool policy override within groups
- `channels.telegram.blockStreaming` — boolean flag to suppress stream previews
- `channels.telegram.markdown.tables` — table rendering mode configuration
- `channels.telegram.accounts.<account>.name` — optional account display name

The documentation additions match the schema types exactly and maintain consistency with existing documentation patterns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns - it only adds missing documentation entries.
- Documentation-only change that accurately reflects the existing codebase. All added fields are verified to exist in the source schema files with matching types and descriptions. No code changes, no runtime impact, and follows existing documentation patterns.
- No files require special attention

<sub>Last reviewed commit: f84fa29</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->