### PR TITLE
fix(agents): continue model fallback on failover text payloads

### DIFF
--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -97,7 +97,7 @@ describe("runWithModelFallback – probe logic", () => {
     // Should skip primary and use fallback
     expect(result.result).toBe("ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5");
+    expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5", expect.any(Object));
     expect(result.attempts[0]?.reason).toBe("rate_limit");
   });
 
@@ -119,7 +119,7 @@ describe("runWithModelFallback – probe logic", () => {
     // Should probe primary and succeed
     expect(result.result).toBe("probed-ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", expect.any(Object));
   });
 
   it("probes primary model when cooldown already expired", async () => {
@@ -139,7 +139,7 @@ describe("runWithModelFallback – probe logic", () => {
 
     expect(result.result).toBe("recovered");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", expect.any(Object));
   });
 
   it("does NOT probe non-primary candidates during cooldown", async () => {
@@ -178,7 +178,7 @@ describe("runWithModelFallback – probe logic", () => {
     } catch {
       // Primary was probed (i === 0 + within margin), non-primary were skipped
       expect(run).toHaveBeenCalledTimes(1); // only primary was actually called
-      expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+      expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", expect.any(Object));
     }
   });
 
@@ -203,7 +203,7 @@ describe("runWithModelFallback – probe logic", () => {
     // Should be throttled → skip primary, use fallback
     expect(result.result).toBe("ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5");
+    expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5", expect.any(Object));
     expect(result.attempts[0]?.reason).toBe("rate_limit");
   });
 
@@ -226,7 +226,7 @@ describe("runWithModelFallback – probe logic", () => {
 
     expect(result.result).toBe("probed-ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", expect.any(Object));
   });
 
   it("handles non-finite soonest safely (treats as probe-worthy)", async () => {
@@ -245,7 +245,7 @@ describe("runWithModelFallback – probe logic", () => {
     });
 
     expect(result.result).toBe("ok-infinity");
-    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", expect.any(Object));
   });
 
   it("handles NaN soonest safely (treats as probe-worthy)", async () => {
@@ -263,7 +263,7 @@ describe("runWithModelFallback – probe logic", () => {
     });
 
     expect(result.result).toBe("ok-nan");
-    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", expect.any(Object));
   });
 
   it("handles null soonest safely (treats as probe-worthy)", async () => {
@@ -281,7 +281,7 @@ describe("runWithModelFallback – probe logic", () => {
     });
 
     expect(result.result).toBe("ok-null");
-    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", expect.any(Object));
   });
 
   it("single candidate skips with rate_limit and exhausts candidates", async () => {
@@ -337,7 +337,7 @@ describe("runWithModelFallback – probe logic", () => {
       run,
     });
 
-    expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini");
-    expect(run).toHaveBeenNthCalledWith(2, "openai", "gpt-4.1-mini");
+    expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini", expect.any(Object));
+    expect(run).toHaveBeenNthCalledWith(2, "openai", "gpt-4.1-mini", expect.any(Object));
   });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -48,6 +48,7 @@ describe("isBillingErrorMessage", () => {
       "insufficient credits",
       "Payment Required",
       "HTTP 402 Payment Required",
+      "402 This request requires more credits, or fewer max_tokens. You requested up to 4096 tokens, but can only afford 2973.",
       "plans & billing",
     ];
     for (const sample of samples) {
@@ -280,6 +281,7 @@ describe("isFailoverErrorMessage", () => {
       "invalid api key",
       "429 rate limit exceeded",
       "Your credit balance is too low",
+      "402 This request requires more credits, or fewer max_tokens. You requested up to 4096 tokens, but can only afford 2973.",
       "request timed out",
       "invalid request format",
     ];
@@ -336,6 +338,11 @@ describe("classifyFailoverReason", () => {
     ).toBe("rate_limit");
     expect(classifyFailoverReason("invalid request format")).toBe("format");
     expect(classifyFailoverReason("credit balance too low")).toBe("billing");
+    expect(
+      classifyFailoverReason(
+        "402 This request requires more credits, or fewer max_tokens. You requested up to 4096 tokens, but can only afford 2973.",
+      ),
+    ).toBe("billing");
     expect(classifyFailoverReason("deadline exceeded")).toBe("timeout");
     expect(classifyFailoverReason("request ended without sending any chunks")).toBe("timeout");
     expect(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -607,6 +607,8 @@ const ERROR_PATTERNS = {
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,
     "payment required",
     "insufficient credits",
+    "requires more credits",
+    "can only afford",
     "credit balance",
     "plans & billing",
     "insufficient balance",

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -203,6 +203,7 @@ export async function runEmbeddedPiAgent(
       let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
       const fallbackConfigured =
+        params.modelFallbackActive ??
         (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
       await ensureOpenClawModelsJson(params.config, agentDir);
 

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -68,6 +68,11 @@ export type RunEmbeddedPiAgentParams = {
   disableTools?: boolean;
   provider?: string;
   model?: string;
+  /**
+   * True when this run is part of an active model fallback chain.
+   * Allows failover-shaped errors to bubble for upstream candidate retries.
+   */
+  modelFallbackActive?: boolean;
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
   thinkLevel?: ThinkLevel;


### PR DESCRIPTION
## Summary
- detect failover-shaped error payloads returned as successful run results in `runWithModelFallback`
- convert those payload-only failures into fallback retries so the chain advances instead of stopping on OpenRouter-style `402` text
- keep guardrails to avoid false positives for normal instructional text mentioning rate limits

## Testing
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/model-fallback.e2e.test.ts`
- `pnpm oxlint --type-aware src/agents/model-fallback.ts src/agents/model-fallback.e2e.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends model fallback system to detect and retry when providers return failover-shaped error payloads as "successful" run results. The PR adds:

- **Payload-level failover detection** (`resolveFailoverPayloadMessage`) in `model-fallback.ts:89-134` that inspects successful run results for error text payloads and converts them to fallback retries
- **New billing error patterns** (`requires more credits`, `can only afford`) to catch OpenRouter-style 402 messages
- **Context parameter** (`ModelFallbackRunContext`) passed to all run callbacks, enabling callers to know when fallback chains are active
- **`probePrimaryDuringCooldown` configuration** set to `"always"` across auto-reply, followup, memory, and CLI flows so primary models are always attempted first (then fallback if rate-limited)
- **Cron agent model merge fix** preserving default `fallbacks` when agent configs only override `primary`
- **User-facing fallback notices** shown when billing/rate-limit causes model switching

The detection logic guards against false positives by requiring error-like signals (payload marked `isError`, stopReason `"error"`, or regex match for HTTP codes/error keywords) before treating instructional text about rate limits as actual failures.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-tested with comprehensive e2e tests covering both positive cases (detecting real failover payloads) and negative cases (not treating instructional text as errors). The detection logic includes multiple safeguards against false positives, all integration points are updated consistently, and the cron model merge fix has dedicated unit tests. The changes follow established patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: 29d6606</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->