### PR TITLE
fix(feishu): honor wildcard group config for reply policy

### DIFF
--- a/extensions/feishu/src/policy.test.ts
+++ b/extensions/feishu/src/policy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { resolveFeishuGroupConfig } from "./policy.js";
+import type { FeishuConfig } from "./types.js";
+
+describe("resolveFeishuGroupConfig", () => {
+  it("falls back to wildcard group config when direct match is missing", () => {
+    const cfg = {
+      groups: {
+        "*": { requireMention: false },
+        "oc-explicit": { requireMention: true },
+      },
+    } as FeishuConfig;
+
+    const resolved = resolveFeishuGroupConfig({
+      cfg,
+      groupId: "oc-missing",
+    });
+
+    expect(resolved).toEqual({ requireMention: false });
+  });
+
+  it("prefers exact group config over wildcard", () => {
+    const cfg = {
+      groups: {
+        "*": { requireMention: false },
+        "oc-explicit": { requireMention: true },
+      },
+    } as FeishuConfig;
+
+    const resolved = resolveFeishuGroupConfig({
+      cfg,
+      groupId: "oc-explicit",
+    });
+
+    expect(resolved).toEqual({ requireMention: true });
+  });
+
+  it("keeps case-insensitive matching for explicit group ids", () => {
+    const cfg = {
+      groups: {
+        "*": { requireMention: false },
+        OC_UPPER: { requireMention: true },
+      },
+    } as FeishuConfig;
+
+    const resolved = resolveFeishuGroupConfig({
+      cfg,
+      groupId: "oc_upper",
+    });
+
+    expect(resolved).toEqual({ requireMention: true });
+  });
+});

--- a/extensions/feishu/src/policy.ts
+++ b/extensions/feishu/src/policy.ts
@@ -21,6 +21,7 @@ export function resolveFeishuGroupConfig(params: {
   groupId?: string | null;
 }): FeishuGroupConfig | undefined {
   const groups = params.cfg?.groups ?? {};
+  const wildcard = groups["*"];
   const groupId = params.groupId?.trim();
   if (!groupId) {
     return undefined;
@@ -33,7 +34,12 @@ export function resolveFeishuGroupConfig(params: {
 
   const lowered = groupId.toLowerCase();
   const matchKey = Object.keys(groups).find((key) => key.toLowerCase() === lowered);
-  return matchKey ? groups[matchKey] : undefined;
+  if (matchKey) {
+    return groups[matchKey];
+  }
+
+  // Fallback to wildcard/default group policy.
+  return wildcard;
 }
 
 export function resolveFeishuGroupToolPolicy(


### PR DESCRIPTION
## Summary
Fix Feishu group wildcard policy handling so `channels.feishu.groups["*"]` is applied when a specific group ID entry is missing.

Without this fallback, wildcard group settings (for example `requireMention: false`) are ignored for unmatched groups, causing group behavior to unexpectedly fall back to global defaults.

## Changes
- `extensions/feishu/src/policy.ts`
  - In `resolveFeishuGroupConfig`, return the wildcard group config (`groups["*"]`) when no exact/case-insensitive match exists.
- `extensions/feishu/src/policy.test.ts` (new)
  - Added tests for:
    - wildcard fallback when direct group config is absent
    - exact match taking precedence over wildcard
    - case-insensitive explicit group ID matching still working

## Repro
1. Configure:
   - `channels.feishu.groups["*"].requireMention = false`
   - no explicit entry for a target group
2. Send a group message without mentioning the bot.

### Before
The wildcard was not applied; message could still be treated as mention-gated.

### After
The wildcard config is applied; behavior follows `groups["*"]` as expected.

## Validation
- Ran:
  - `pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/policy.test.ts`
- Result:
  - `1 passed`, `3 passed`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds wildcard fallback logic to `resolveFeishuGroupConfig` so that `channels.feishu.groups["*"]` configuration is properly applied when no explicit group ID match exists. This fixes unintended fallback to global defaults for unconfigured groups.

- **Logic change**: Returns wildcard config (`groups["*"]`) after exhausting exact and case-insensitive matching
- **Test coverage**: Added comprehensive tests validating wildcard fallback, precedence rules, and case-insensitive matching
- **Consistency**: Aligns with similar wildcard patterns in other channel extensions (e.g., IRC)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is simple, well-tested, and follows established patterns in the codebase. The logic correctly implements wildcard fallback with proper precedence (exact > case-insensitive > wildcard). Tests cover all critical paths including edge cases.
- No files require special attention

<sub>Last reviewed commit: 2e8ec64</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->