### PR TITLE
feat: add 'stop all' command and fix subagent cascade on word-trigger abort

### DIFF
--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -26,6 +26,7 @@ import {
   handleActivationCommand,
   handleRestartCommand,
   handleSendPolicyCommand,
+  handleStopAllCommand,
   handleStopCommand,
   handleUsageCommand,
 } from "./commands-session.js";
@@ -58,6 +59,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleDebugCommand,
       handleModelsCommand,
       handleStopCommand,
+      handleStopAllCommand,
       handleCompactCommand,
       handleAbortTrigger,
     ];


### PR DESCRIPTION
## Problem

When a channel has multiple active agents running (e.g. a main session that spawned background work), saying **'stop'** only kills the current agent run. The next active session starts speaking and the user has to say stop again — repeat for every session. This is especially painful in voice mode.

Two root causes:

1. **Bug:** `handleAbortTrigger` (word-trigger: 'stop', 'abort', 'esc'…) does **not** call `stopSubagentsForRequester`, so registered subagents keep running after a word-trigger abort. The `/stop` slash command already calls it correctly — this brings word triggers in line.

2. **Gap:** Even with the fix above, sessions that were activated *indirectly* (e.g. a Discord channel session spun up when a subagent posted a message) are not in the subagent registry and are not stopped by any existing mechanism.

## Solution

### Fix 1 — `handleAbortTrigger` now stops registered subagents

Mirrors what `/stop` already does: calls `stopSubagentsForRequester` with cascade, then reports the count in the reply text.

### Fix 2 — new `stop all` command (`handleStopAllCommand`)

Trigger phrases (case-insensitive): **stop all**, **abort all**, **stop everything**, **cancel all**, **cancel everything**, **/stop-all**

Behaviour:
- Calls `stopSubagentsForRequester` (cascade-stops everything in the subagent registry)
- Then calls new `stopAllAgentSessions` which iterates the live session store and aborts every session that shares the same agent prefix (e.g. `agent:main`) and was active in the last 30 minutes — excluding the caller's own session

Scoping is intentionally conservative: same agent, recent activity only. Does not kill sessions from other agents or sessions idle >30 min.

## Files changed

- `src/auto-reply/reply/abort.ts` — adds `STOP_ALL_TRIGGERS`, `isStopAllTrigger`, `stopAllAgentSessions`
- `src/auto-reply/reply/commands-session.ts` — fixes `handleAbortTrigger` + adds `handleStopAllCommand`
- `src/auto-reply/reply/commands-core.ts` — registers `handleStopAllCommand` in the handler chain

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds cascade subagent stopping to word-trigger abort and introduces a new "stop all" command. The PR fixes a bug where saying "stop" in voice mode would only kill the current agent, leaving background sessions running. Now `handleAbortTrigger` mirrors `/stop` behavior by calling `stopSubagentsForRequester`. The new "stop all" command (`/stop-all` or phrases like "stop all", "abort all") goes further by terminating all recently-active sessions for the current agent (not just registered subagents), with conservative scoping: same agent prefix only, active within 30 minutes, excludes caller's own session.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly addresses both stated problems with clean, focused changes. The bug fix brings `handleAbortTrigger` in line with `/stop` behavior, and the new "stop all" command has conservative scoping rules (same agent, 30-minute window, excludes self) that prevent unintended impact. The code follows existing patterns for session cleanup and authorization checks.
- No files require special attention

<sub>Last reviewed commit: aec5eea</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->