### PR TITLE
fix: sanitize native command names for Telegram API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: debounce the first draft-stream preview update (30-char threshold) and finalize short responses by editing the stop-time preview message, improving first push notifications and avoiding duplicate final sends. (#18148) Thanks @Marvae.
 - Telegram: disable block streaming when `channels.telegram.streamMode` is `off`, preventing newline/content-block replies from splitting into multiple messages. (#17679) Thanks @saivarunk.
 - Telegram: keep `streamMode: "partial"` draft previews in a single message across assistant-message/reasoning boundaries, preventing duplicate preview bubbles during partial-mode tool-call turns. (#18956) Thanks @obviyus.
+- Telegram: normalize native command names for Telegram menu registration (`-` -> `_`) to avoid `BOT_COMMAND_INVALID` command-menu wipeouts, and log failed command syncs instead of silently swallowing them. (#19257) Thanks @akramcodez.
 - Telegram: route non-abort slash commands on the normal chat/topic sequential lane while keeping true abort requests (`/stop`, `stop`) on the control lane, preventing command/reply race conditions from control-lane bypass. (#17899) Thanks @obviyus.
 - Telegram: ignore `<media:...>` placeholder lines when extracting `MEDIA:` tool-result paths, preventing false local-file reads and dropped replies. (#18510) Thanks @yinghaosang.
 - Telegram: skip retries when inbound media `getFile` fails with Telegram's 20MB limit and continue processing message text, avoiding dropped messages for oversized attachments. (#18531) Thanks @brandonwise.

--- a/src/config/config.telegram-custom-commands.test.ts
+++ b/src/config/config.telegram-custom-commands.test.ts
@@ -21,7 +21,7 @@ describe("telegram custom commands schema", () => {
     ]);
   });
 
-  it("rejects custom commands with invalid names", () => {
+  it("normalizes hyphens in custom command names", () => {
     const res = OpenClawSchema.safeParse({
       channels: {
         telegram: {
@@ -30,17 +30,13 @@ describe("telegram custom commands schema", () => {
       },
     });
 
-    expect(res.success).toBe(false);
-    if (res.success) {
+    expect(res.success).toBe(true);
+    if (!res.success) {
       return;
     }
 
-    expect(
-      res.error.issues.some(
-        (issue) =>
-          issue.path.join(".") === "channels.telegram.customCommands.0.command" &&
-          issue.message.includes("invalid"),
-      ),
-    ).toBe(true);
+    expect(res.data.channels?.telegram?.customCommands).toEqual([
+      { command: "bad_name", description: "Override status" },
+    ]);
   });
 });

--- a/src/config/telegram-custom-commands.ts
+++ b/src/config/telegram-custom-commands.ts
@@ -17,7 +17,7 @@ export function normalizeTelegramCommandName(value: string): string {
     return "";
   }
   const withoutSlash = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
-  return withoutSlash.trim().toLowerCase();
+  return withoutSlash.trim().toLowerCase().replace(/-/g, "_");
 }
 
 export function normalizeTelegramCommandDescription(value: string): string {

--- a/src/telegram/bot-native-command-menu.ts
+++ b/src/telegram/bot-native-command-menu.ts
@@ -1,9 +1,9 @@
 import type { Bot } from "grammy";
-import type { RuntimeEnv } from "../runtime.js";
 import {
   normalizeTelegramCommandName,
   TELEGRAM_COMMAND_NAME_PATTERN,
 } from "../config/telegram-custom-commands.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 
 export const TELEGRAM_MAX_COMMANDS = 100;

--- a/src/telegram/bot-native-command-menu.ts
+++ b/src/telegram/bot-native-command-menu.ts
@@ -1,9 +1,9 @@
 import type { Bot } from "grammy";
+import type { RuntimeEnv } from "../runtime.js";
 import {
   normalizeTelegramCommandName,
   TELEGRAM_COMMAND_NAME_PATTERN,
 } from "../config/telegram-custom-commands.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 
 export const TELEGRAM_MAX_COMMANDS = 100;
@@ -100,5 +100,7 @@ export function syncTelegramMenuCommands(params: {
     });
   };
 
-  void sync().catch(() => {});
+  void sync().catch((err) => {
+    runtime.error?.(`Telegram command sync failed: ${String(err)}`);
+  });
 }

--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -149,6 +149,37 @@ describe("registerTelegramNativeCommands", () => {
     );
   });
 
+  it("normalizes hyphenated native command names for Telegram registration", async () => {
+    const setMyCommands = vi.fn().mockResolvedValue(undefined);
+    const command = vi.fn();
+
+    registerTelegramNativeCommands({
+      ...buildParams({}),
+      bot: {
+        api: {
+          setMyCommands,
+          sendMessage: vi.fn().mockResolvedValue(undefined),
+        },
+        command,
+      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+    });
+
+    await vi.waitFor(() => {
+      expect(setMyCommands).toHaveBeenCalled();
+    });
+
+    const registeredCommands = setMyCommands.mock.calls[0]?.[0] as Array<{
+      command: string;
+      description: string;
+    }>;
+    expect(registeredCommands.some((entry) => entry.command === "export_session")).toBe(true);
+    expect(registeredCommands.some((entry) => entry.command === "export-session")).toBe(false);
+
+    const registeredHandlers = command.mock.calls.map(([name]) => name);
+    expect(registeredHandlers).toContain("export_session");
+    expect(registeredHandlers).not.toContain("export-session");
+  });
+
   it("passes agent-scoped media roots for plugin command replies with media", async () => {
     const commandHandlers = new Map<string, (ctx: unknown) => Promise<void>>();
     const sendMessage = vi.fn().mockResolvedValue(undefined);

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -1,16 +1,6 @@
 import type { Bot, Context } from "grammy";
-import type { CommandArgs } from "../auto-reply/commands-registry.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type { ChannelGroupPolicy } from "../config/group-policy.js";
-import type {
-  ReplyToMode,
-  TelegramAccountConfig,
-  TelegramGroupConfig,
-  TelegramTopicConfig,
-} from "../config/types.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { TelegramContext } from "./bot/types.js";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
+import type { CommandArgs } from "../auto-reply/commands-registry.js";
 import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
@@ -24,12 +14,20 @@ import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/pr
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ChannelGroupPolicy } from "../config/group-policy.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import {
   normalizeTelegramCommandName,
   resolveTelegramCustomCommands,
   TELEGRAM_COMMAND_NAME_PATTERN,
 } from "../config/telegram-custom-commands.js";
+import type {
+  ReplyToMode,
+  TelegramAccountConfig,
+  TelegramGroupConfig,
+  TelegramTopicConfig,
+} from "../config/types.js";
 import { danger, logVerbose } from "../globals.js";
 import { getChildLogger } from "../logging.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
@@ -40,6 +38,7 @@ import {
 } from "../plugins/commands.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { firstDefined, isSenderAllowed, normalizeAllowFromWithStore } from "./bot-access.js";
 import {
@@ -59,6 +58,7 @@ import {
   resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
+import type { TelegramContext } from "./bot/types.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -1,6 +1,16 @@
 import type { Bot, Context } from "grammy";
-import { resolveChunkMode } from "../auto-reply/chunk.js";
 import type { CommandArgs } from "../auto-reply/commands-registry.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ChannelGroupPolicy } from "../config/group-policy.js";
+import type {
+  ReplyToMode,
+  TelegramAccountConfig,
+  TelegramGroupConfig,
+  TelegramTopicConfig,
+} from "../config/types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { TelegramContext } from "./bot/types.js";
+import { resolveChunkMode } from "../auto-reply/chunk.js";
 import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
@@ -14,16 +24,12 @@ import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/pr
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type { ChannelGroupPolicy } from "../config/group-policy.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
-import { resolveTelegramCustomCommands } from "../config/telegram-custom-commands.js";
-import type {
-  ReplyToMode,
-  TelegramAccountConfig,
-  TelegramGroupConfig,
-  TelegramTopicConfig,
-} from "../config/types.js";
+import {
+  normalizeTelegramCommandName,
+  resolveTelegramCustomCommands,
+  TELEGRAM_COMMAND_NAME_PATTERN,
+} from "../config/telegram-custom-commands.js";
 import { danger, logVerbose } from "../globals.js";
 import { getChildLogger } from "../logging.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
@@ -34,7 +40,6 @@ import {
 } from "../plugins/commands.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { firstDefined, isSenderAllowed, normalizeAllowFromWithStore } from "./bot-access.js";
 import {
@@ -54,7 +59,6 @@ import {
   resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
-import type { TelegramContext } from "./bot/types.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,
@@ -310,7 +314,7 @@ export const registerTelegramNativeCommands = ({
       })
     : [];
   const reservedCommands = new Set(
-    listNativeCommandSpecs().map((command) => command.name.toLowerCase()),
+    listNativeCommandSpecs().map((command) => normalizeTelegramCommandName(command.name)),
   );
   for (const command of skillCommands) {
     reservedCommands.add(command.name.toLowerCase());
@@ -326,7 +330,7 @@ export const registerTelegramNativeCommands = ({
   const pluginCommandSpecs = getPluginCommandSpecs();
   const existingCommands = new Set(
     [
-      ...nativeCommands.map((command) => command.name),
+      ...nativeCommands.map((command) => normalizeTelegramCommandName(command.name)),
       ...customCommands.map((command) => command.command),
     ].map((command) => command.toLowerCase()),
   );
@@ -338,10 +342,23 @@ export const registerTelegramNativeCommands = ({
     runtime.error?.(danger(issue));
   }
   const allCommandsFull: Array<{ command: string; description: string }> = [
-    ...nativeCommands.map((command) => ({
-      command: command.name,
-      description: command.description,
-    })),
+    ...nativeCommands
+      .map((command) => {
+        const normalized = normalizeTelegramCommandName(command.name);
+        if (!TELEGRAM_COMMAND_NAME_PATTERN.test(normalized)) {
+          runtime.error?.(
+            danger(
+              `Native command "${command.name}" is invalid for Telegram (resolved to "${normalized}"). Skipping.`,
+            ),
+          );
+          return null;
+        }
+        return {
+          command: normalized,
+          description: command.description,
+        };
+      })
+      .filter((cmd): cmd is { command: string; description: string } => cmd !== null),
     ...(nativeEnabled ? pluginCatalog.commands : []),
     ...customCommands,
   ];
@@ -419,7 +436,8 @@ export const registerTelegramNativeCommands = ({
       logVerbose("telegram: bot.command unavailable; skipping native handlers");
     } else {
       for (const command of nativeCommands) {
-        bot.command(command.name, async (ctx: TelegramNativeCommandContext) => {
+        const normalizedCommandName = normalizeTelegramCommandName(command.name);
+        bot.command(normalizedCommandName, async (ctx: TelegramNativeCommandContext) => {
           const msg = ctx.message;
           if (!msg) {
             return;

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -5,6 +5,7 @@ import {
   listNativeCommandSpecs,
   listNativeCommandSpecsForConfig,
 } from "../auto-reply/commands-registry.js";
+import { normalizeTelegramCommandName } from "../config/telegram-custom-commands.js";
 import {
   answerCallbackQuerySpy,
   commandSpy,
@@ -72,7 +73,7 @@ describe("createTelegramBot", () => {
     }>;
     const skillCommands = resolveSkillCommands(config);
     const native = listNativeCommandSpecsForConfig(config, { skillCommands }).map((command) => ({
-      command: command.name,
+      command: normalizeTelegramCommandName(command.name),
       description: command.description,
     }));
     expect(registered.slice(0, native.length)).toEqual(native);
@@ -113,7 +114,7 @@ describe("createTelegramBot", () => {
     }>;
     const skillCommands = resolveSkillCommands(config);
     const native = listNativeCommandSpecsForConfig(config, { skillCommands }).map((command) => ({
-      command: command.name,
+      command: normalizeTelegramCommandName(command.name),
       description: command.description,
     }));
     const nativeStatus = native.find((command) => command.command === "status");


### PR DESCRIPTION
## Summary

- **Problem:** `export-session` native command uses hyphen, violating Telegram's [a-z0-9_] pattern → BOT_COMMAND_INVALID error
- **Why it matters:** Error wipes ALL commands from bot menu; `setMyCommands` failures were silently swallowed
- **What changed:** Normalize native commands (hyphens→underscores), validate before registration, log sync failures
- **Scope boundary:** Only Telegram command registration; command handlers unchanged

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (Telegram)

## Linked Issue/PR

- Closes #19145

## User-visible / Behavior Changes

- `/export-session` command now appears as `/export_session` in Telegram bot menu
- Invalid native commands are logged and skipped instead of corrupting entire menu
- Command sync failures now logged instead of silent

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment
- Integration: Telegram
- Config: `commands.native: "auto"`, `nativeSkills: false`

### Steps
1. Start gateway with Telegram enabled
2. Restart gateway
3. Observe BOT_COMMAND_INVALID in logs, empty command menu

### Expected
- All commands visible in menu
- `/export_session` (underscore) appears

### Actual (before fix)
- All commands wiped after restart
- Error: `BOT_COMMAND_INVALID` in logs

## Evidence

- [x] Test passing: `pnpm test src/telegram/bot-native-command-menu.test.ts`
- [x] Verified normalizeTelegramCommandName('export-session') === 'export_session'

## Human Verification

**Verified:**
- Normalization function correctly replaces hyphens: ✓
- Unit tests pass: ✓
- Invalid commands skipped with error log: ✓

**Edge cases checked:**
- Multiple hyphens in command name
- Mix of valid/invalid native commands

**Not verified:**
- Live Telegram bot deployment (requires user env)

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

Existing `/export-session` text alias still works; only native registration changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Telegram `BOT_COMMAND_INVALID` error caused by `export-session` containing a hyphen, which violates Telegram's `[a-z0-9_]{1,32}` command name pattern. The fix normalizes hyphens to underscores in `normalizeTelegramCommandName`, validates native commands before registration (skipping invalid ones with error logging), and replaces a silently-swallowed sync error with proper logging.

- `normalizeTelegramCommandName` now replaces hyphens with underscores, so `export-session` becomes `export_session` for Telegram registration
- Native commands are validated against `TELEGRAM_COMMAND_NAME_PATTERN` before being added to the menu; invalid ones are logged and skipped rather than breaking the entire `setMyCommands` call
- `syncTelegramMenuCommands` now logs sync failures via `runtime.error` instead of silently swallowing them
- The `findCommandByNativeName` lookup at line 491 correctly uses the original `command.name` (not the normalized name), so command definition matching continues to work
- Test updated to reflect that hyphenated names are now normalized rather than rejected
- Import reordering in `bot-native-commands.ts` is cosmetic (type imports grouped at top)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a real Telegram API validation error with minimal, well-scoped changes.
- The core normalization fix is correct and well-targeted. The `findCommandByNativeName` lookup correctly uses the original name. The error logging improvements are straightforward. Score of 4 (not 5) because the handler registration loop iterates all nativeCommands without the same validity filter applied to the menu entries — though this is a minor theoretical concern given current command definitions.
- `src/telegram/bot-native-commands.ts` — the handler registration loop (line 438) does not apply the same validity filter as the menu registration (lines 344-361), meaning a hypothetically invalid command could still get a handler registered even if excluded from the menu.

<sub>Last reviewed commit: eab84db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->