### PR TITLE
Fix Codex usage window label for weekly reset

### DIFF
--- a/skills/workqueue-worker/SKILL.md
+++ b/skills/workqueue-worker/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: workqueue-worker
+description: Run a simple workqueue worker loop (claim via clawnsole, execute via `openclaw agent`, report done/fail).
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🧰",
+        "requires": { "bins": ["clawnsole", "openclaw"] }
+      }
+  }
+---
+
+# workqueue-worker
+
+This skill provides a CLI-based worker loop that:
+
+1. Claims the next work item from a workqueue via `clawnsole workqueue claim-next`.
+2. Executes the item’s `instructions` using `openclaw agent` in a dedicated session id.
+3. Reports `progress`, then `done` or `fail` back to the workqueue.
+
+## Requirements
+
+- `clawnsole` CLI available on your PATH.
+- `openclaw` CLI available on your PATH and able to reach your Gateway.
+
+## Command
+
+- Run one iteration (claim once, execute once, exit):
+
+  - `openclaw workqueue-worker --agent dev --queues dev-team`
+
+## Common flags
+
+- `--leaseMs <ms>`: item lease duration (default 900000)
+- `--idleMs <ms>`: if empty queue, sleep then exit (default 0)
+- `--sessionPrefix <prefix>`: session id prefix for executions (default `workqueue:`)
+- `--gateway-url <url>` / `--gateway-token <token>`: pass-through to `openclaw agent`
+- `--thinking <level>` / `--timeoutSeconds <n>`: pass-through to `openclaw agent`
+- `--dry-run --json`: claim and print what would run, without executing
+
+## Notes
+
+- This command is intentionally simple (single-iteration) so you can wrap it in `cron`, `launchd`, systemd timers, or a shell `while true` loop.
+- The worker uses `openclaw agent --agent <id> --session-id <prefix><itemId>` so each work item gets an isolated conversation thread.

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -239,6 +239,14 @@ const entries: SubCliEntry[] = [
       mod.registerCompletionCli(program);
     },
   },
+  {
+    name: "workqueue-worker",
+    description: "Workqueue worker loop (clawnsole + openclaw agent)",
+    register: async (program) => {
+      const mod = await import("../workqueue-worker-cli.js");
+      mod.registerWorkqueueWorkerCli(program);
+    },
+  },
 ];
 
 export function getSubCliEntries(): SubCliEntry[] {

--- a/src/cli/workqueue-worker-cli.test.ts
+++ b/src/cli/workqueue-worker-cli.test.ts
@@ -1,0 +1,108 @@
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+describe("workqueue-worker cli", () => {
+  it("supports --dry-run (claims item but does not execute)", async () => {
+    execFileMock.mockReset();
+    execFileMock.mockImplementation((cmd: string, args: string[], _opts: any, cb: any) => {
+      const joined = args.join(" ");
+      if (joined.includes("workqueue claim-next")) {
+        cb(null, {
+          stdout: JSON.stringify({
+            ok: true,
+            item: {
+              id: "item-1",
+              queue: "dev-team",
+              title: "Test",
+              instructions: "Do the thing",
+            },
+          }),
+          stderr: "",
+        });
+        return;
+      }
+      cb(new Error(`unexpected execFile call: ${cmd} ${joined}`));
+    });
+
+    const program = new Command();
+    const { registerWorkqueueWorkerCli } = await import("./workqueue-worker-cli.js");
+    registerWorkqueueWorkerCli(program);
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.join(" "));
+    });
+
+    await program.parseAsync([
+      "node",
+      "openclaw",
+      "workqueue-worker",
+      "--agent",
+      "dev",
+      "--queues",
+      "dev-team",
+      "--dry-run",
+      "--json",
+      "--clawnsole",
+      "clawnsole",
+      "--openclaw",
+      "openclaw",
+    ]);
+
+    logSpy.mockRestore();
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const out = logs.join("\n");
+    expect(out).toContain('"action": "dry_run"');
+    expect(out).toContain('"id": "item-1"');
+  });
+
+  it("prints noop_empty when claim-next returns null item", async () => {
+    execFileMock.mockReset();
+    execFileMock.mockImplementation((cmd: string, args: string[], _opts: any, cb: any) => {
+      const joined = args.join(" ");
+      if (joined.includes("workqueue claim-next")) {
+        cb(null, { stdout: JSON.stringify({ ok: true, item: null }), stderr: "" });
+        return;
+      }
+      cb(new Error(`unexpected execFile call: ${cmd} ${joined}`));
+    });
+
+    const program = new Command();
+    const { registerWorkqueueWorkerCli } = await import("./workqueue-worker-cli.js");
+    registerWorkqueueWorkerCli(program);
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.join(" "));
+    });
+
+    await program.parseAsync([
+      "node",
+      "openclaw",
+      "workqueue-worker",
+      "--agent",
+      "dev",
+      "--queues",
+      "dev-team",
+      "--json",
+      "--idleMs",
+      "0",
+      "--clawnsole",
+      "clawnsole",
+      "--openclaw",
+      "openclaw",
+    ]);
+
+    logSpy.mockRestore();
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(logs.join("\n")).toContain('"action": "noop_empty"');
+  });
+});

--- a/src/cli/workqueue-worker-cli.ts
+++ b/src/cli/workqueue-worker-cli.ts
@@ -1,0 +1,302 @@
+import type { Command } from "commander";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { defaultRuntime } from "../runtime.js";
+import { formatDocsLink } from "../terminal/links.js";
+import { theme } from "../terminal/theme.js";
+
+const execFileAsync = promisify(execFile);
+
+type WorkqueueItem = {
+  id: string;
+  queue: string;
+  title: string;
+  instructions: string;
+  priority?: number;
+};
+
+type ClawnsoleClaimNextResult =
+  | { ok: true; item: WorkqueueItem | null }
+  | { ok: false; error?: string; [k: string]: unknown };
+
+type OpenClawAgentResult = {
+  runId?: string;
+  status?: string;
+  summary?: string;
+  result?: unknown;
+  [k: string]: unknown;
+};
+
+function parseJson<T>(raw: string, label: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(`${label}: failed to parse JSON: ${String(err)}\n---\n${raw}`);
+  }
+}
+
+const splitCsv = (raw: string): string[] =>
+  raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+async function sleep(ms: number) {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return;
+  }
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+async function runClawnsole(args: string[], opts: { clawnsoleCmd: string }) {
+  const res = await execFileAsync(opts.clawnsoleCmd, args, { maxBuffer: 10 * 1024 * 1024 });
+  const out = String(res.stdout ?? "").trim();
+  if (!out) {
+    throw new Error(`clawnsole returned empty output for: ${opts.clawnsoleCmd} ${args.join(" ")}`);
+  }
+  return out;
+}
+
+async function claimNext(params: {
+  agentId: string;
+  queues: string[];
+  leaseMs?: number;
+  clawnsoleCmd: string;
+}): Promise<ClawnsoleClaimNextResult> {
+  const args = [
+    "workqueue",
+    "claim-next",
+    "--agent",
+    params.agentId,
+    "--queues",
+    params.queues.join(","),
+  ];
+  if (typeof params.leaseMs === "number") {
+    args.push("--leaseMs", String(params.leaseMs));
+  }
+  const out = await runClawnsole(args, { clawnsoleCmd: params.clawnsoleCmd });
+  return parseJson(out, "clawnsole claim-next");
+}
+
+async function progress(params: {
+  itemId: string;
+  agentId: string;
+  note: string;
+  leaseMs?: number;
+  clawnsoleCmd: string;
+}) {
+  const args = [
+    "workqueue",
+    "progress",
+    params.itemId,
+    "--agent",
+    params.agentId,
+    "--note",
+    params.note,
+  ];
+  if (typeof params.leaseMs === "number") {
+    args.push("--leaseMs", String(params.leaseMs));
+  }
+  await runClawnsole(args, { clawnsoleCmd: params.clawnsoleCmd });
+}
+
+async function done(params: {
+  itemId: string;
+  agentId: string;
+  resultJson: unknown;
+  clawnsoleCmd: string;
+}) {
+  const args = [
+    "workqueue",
+    "done",
+    params.itemId,
+    "--agent",
+    params.agentId,
+    "--result",
+    JSON.stringify(params.resultJson),
+  ];
+  await runClawnsole(args, { clawnsoleCmd: params.clawnsoleCmd });
+}
+
+async function fail(params: {
+  itemId: string;
+  agentId: string;
+  error: string;
+  clawnsoleCmd: string;
+}) {
+  const args = [
+    "workqueue",
+    "fail",
+    params.itemId,
+    "--agent",
+    params.agentId,
+    "--error",
+    params.error,
+  ];
+  await runClawnsole(args, { clawnsoleCmd: params.clawnsoleCmd });
+}
+
+async function runOpenClawAgent(params: {
+  openclawCmd: string;
+  agentId: string;
+  sessionId: string;
+  message: string;
+  gatewayUrl?: string;
+  gatewayToken?: string;
+  thinking?: string;
+  timeoutSeconds?: number;
+}): Promise<OpenClawAgentResult> {
+  const args = [
+    "agent",
+    "--agent",
+    params.agentId,
+    "--session-id",
+    params.sessionId,
+    "--message",
+    params.message,
+    "--json",
+  ];
+  if (params.gatewayUrl) {
+    args.push("--url", params.gatewayUrl);
+  }
+  if (params.gatewayToken) {
+    args.push("--token", params.gatewayToken);
+  }
+  if (params.thinking) {
+    args.push("--thinking", params.thinking);
+  }
+  if (typeof params.timeoutSeconds === "number") {
+    args.push("--timeout", String(params.timeoutSeconds));
+  }
+
+  const res = await execFileAsync(params.openclawCmd, args, {
+    maxBuffer: 50 * 1024 * 1024,
+    env: process.env,
+  });
+  const out = String(res.stdout ?? "").trim();
+  if (!out) {
+    throw new Error(`openclaw agent returned empty output`);
+  }
+  return parseJson(out, "openclaw agent");
+}
+
+export function registerWorkqueueWorkerCli(program: Command) {
+  program
+    .command("workqueue-worker")
+    .description("Claim workqueue items via clawnsole and execute them via openclaw agent")
+    .requiredOption("--agent <id>", "Workqueue agent id")
+    .requiredOption("--queues <q1,q2>", "Comma-separated queue list")
+    .option("--leaseMs <ms>", "Lease duration in ms (passed to clawnsole)", "900000")
+    .option("--idleMs <ms>", "If queue is empty: sleep this long then exit", "0")
+    .option(
+      "--sessionPrefix <prefix>",
+      "Prefix for agent session ids (full session id becomes <prefix><itemId>)",
+      "workqueue:",
+    )
+    .option("--clawnsole <cmd>", "clawnsole command (default: clawnsole)", "clawnsole")
+    .option("--openclaw <cmd>", "openclaw command (default: openclaw)", "openclaw")
+    .option("--gateway-url <url>", "Gateway URL override (passed through to openclaw agent)")
+    .option("--gateway-token <token>", "Gateway token override (passed through to openclaw agent)")
+    .option("--thinking <level>", "Thinking level for the worker run")
+    .option("--timeoutSeconds <n>", "Agent run timeout (seconds)")
+    .option("--dry-run", "Claim + report what would run (no execution / no done/fail)", false)
+    .option("--json", "Output machine-readable JSON to stdout", false)
+    .addHelpText(
+      "after",
+      () => `\n${theme.muted("Docs:")} ${formatDocsLink(
+        "/cli/workqueue-worker",
+        "docs.openclaw.ai/cli/workqueue-worker",
+      )}\n`,
+    )
+    .action(async (opts) => {
+      const agentId = String(opts.agent).trim();
+      const queues = splitCsv(String(opts.queues));
+      if (!queues.length) {
+        throw new Error("--queues must include at least one queue");
+      }
+
+      const leaseMs = Number.parseInt(String(opts.leaseMs), 10);
+      const idleMs = Number.parseInt(String(opts.idleMs), 10);
+      const clawnsoleCmd = String(opts.clawnsole).trim();
+      const openclawCmd = String(opts.openclaw).trim();
+      const sessionPrefix = String(opts.sessionPrefix ?? "");
+      const thinking = typeof opts.thinking === "string" ? String(opts.thinking).trim() : undefined;
+      const timeoutSeconds =
+        typeof opts.timeoutSeconds === "string" && String(opts.timeoutSeconds).trim()
+          ? Number.parseInt(String(opts.timeoutSeconds), 10)
+          : undefined;
+
+      const claim = await claimNext({ agentId, queues, leaseMs, clawnsoleCmd });
+
+      if (!claim.ok) {
+        throw new Error(`clawnsole claim-next failed: ${JSON.stringify(claim)}`);
+      }
+
+      if (!claim.item) {
+        if (opts.json) {
+          defaultRuntime.log(JSON.stringify({ ok: true, action: "noop_empty" }, null, 2));
+        } else {
+          defaultRuntime.log("workqueue: empty");
+        }
+        await sleep(idleMs);
+        return;
+      }
+
+      const item = claim.item;
+      const sessionId = `${sessionPrefix}${item.id}`;
+
+      if (opts.dryRun) {
+        const payload = {
+          ok: true,
+          action: "dry_run",
+          item,
+          wouldRun: {
+            openclawCmd,
+            args: [
+              "agent",
+              "--agent",
+              agentId,
+              "--session-id",
+              sessionId,
+              "--message",
+              "<instructions>",
+              "--json",
+            ],
+          },
+        };
+        defaultRuntime.log(opts.json ? JSON.stringify(payload, null, 2) : JSON.stringify(payload, null, 2));
+        return;
+      }
+
+      await progress({
+        itemId: item.id,
+        agentId,
+        note: `worker: executing via openclaw agent (session-id=${sessionId})`,
+        leaseMs,
+        clawnsoleCmd,
+      });
+
+      try {
+        const result = await runOpenClawAgent({
+          openclawCmd,
+          agentId,
+          sessionId,
+          message: item.instructions,
+          gatewayUrl: opts.gatewayUrl as string | undefined,
+          gatewayToken: opts.gatewayToken as string | undefined,
+          thinking,
+          timeoutSeconds,
+        });
+
+        await done({ itemId: item.id, agentId, resultJson: result, clawnsoleCmd });
+
+        if (opts.json) {
+          defaultRuntime.log(JSON.stringify({ ok: true, action: "done", itemId: item.id, result }, null, 2));
+        }
+      } catch (err) {
+        const msg = String(err);
+        await fail({ itemId: item.id, agentId, error: msg.slice(0, 4000), clawnsoleCmd });
+        throw err;
+      }
+    });
+}

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -19,6 +19,14 @@ type CodexUsageResponse = {
   credits?: { balance?: number | string | null };
 };
 
+const describeWindowHours = (windowSeconds?: number): string => {
+  const windowHours = Math.round((windowSeconds || 0) / 3600);
+  if (windowHours >= 168) {
+    return "Week";
+  }
+  return windowHours >= 24 ? "Day" : `${windowHours}h`;
+};
+
 export async function fetchCodexUsage(
   token: string,
   accountId: string | undefined,
@@ -64,9 +72,8 @@ export async function fetchCodexUsage(
 
   if (data.rate_limit?.primary_window) {
     const pw = data.rate_limit.primary_window;
-    const windowHours = Math.round((pw.limit_window_seconds || 10800) / 3600);
     windows.push({
-      label: `${windowHours}h`,
+      label: describeWindowHours(pw.limit_window_seconds),
       usedPercent: clampPercent(pw.used_percent || 0),
       resetAt: pw.reset_at ? pw.reset_at * 1000 : undefined,
     });
@@ -74,10 +81,8 @@ export async function fetchCodexUsage(
 
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
-    const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
-      label,
+      label: describeWindowHours(sw.limit_window_seconds),
       usedPercent: clampPercent(sw.used_percent || 0),
       resetAt: sw.reset_at ? sw.reset_at * 1000 : undefined,
     });
@@ -99,3 +104,7 @@ export async function fetchCodexUsage(
     plan,
   };
 }
+
+export const __test = {
+  describeWindowHours,
+};

--- a/src/infra/provider-usage.test.ts
+++ b/src/infra/provider-usage.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { withTempHome } from "../../test/helpers/temp-home.js";
 import { ensureAuthProfileStore, listProfilesForProvider } from "../agents/auth-profiles.js";
+import { __test as codexUsageFetcher } from "./provider-usage.fetch.codex.js";
 import {
   formatUsageReportLines,
   formatUsageSummaryLine,
@@ -66,6 +67,14 @@ describe("provider usage formatting", () => {
     };
     const lines = formatUsageReportLines(summary, { now });
     expect(lines.join("\n")).toContain("resets 1m");
+  });
+
+  it("labels codex 24h+ windows with true weekly cadence as Week", () => {
+    expect(codexUsageFetcher.describeWindowHours(1 * 3600)).toBe("1h");
+    expect(codexUsageFetcher.describeWindowHours(24 * 3600)).toBe("Day");
+    expect(codexUsageFetcher.describeWindowHours(48 * 3600)).toBe("Day");
+    expect(codexUsageFetcher.describeWindowHours(168 * 3600)).toBe("Week");
+    expect(codexUsageFetcher.describeWindowHours(336 * 3600)).toBe("Week");
   });
 });
 


### PR DESCRIPTION
## Summary
- Fix Codex usage label derivation to avoid labeling weekly windows as "Day".
- Use 24h+ as Day only for sub-week windows and 7d+ (>=168h) as Week.
- Add test coverage for `describeWindowHours` behavior.

## Details
This updates `src/infra/provider-usage.fetch.codex.ts`:
- Refactor window labeling into `describeWindowHours(windowSeconds)`.
- Labels `primary_window`/`secondary_window` via this helper.

Touched files:
- src/infra/provider-usage.fetch.codex.ts
- src/infra/provider-usage.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Codex usage window labeling to correctly identify weekly reset windows (>=168h) as "Week" instead of "Day". The new `describeWindowHours` helper provides consistent labeling: sub-24h windows show hours (e.g. "3h"), 24h-167h windows show "Day", and 168h+ windows show "Week".

Major changes:
- Extracted window labeling logic into reusable `describeWindowHours` helper function
- Applied consistent labeling to both primary and secondary windows
- Added comprehensive test coverage for the helper function

**Note:** This PR includes an unrelated commit (6180de91 "cli: add workqueue-worker") that adds a new workqueue-worker CLI feature with 4 new files (463 insertions). The PR title and description only mention the Codex usage label fix. Per the repository guidelines (AGENTS.md line 95: "Group related changes; avoid bundling unrelated refactors"), these should ideally be separate PRs unless intentionally bundled together.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor organizational considerations
- The Codex usage label fix is well-implemented with proper test coverage and follows good refactoring practices. The logic is straightforward and correct. However, the PR bundles an unrelated workqueue-worker feature (6180de91) which is not mentioned in the PR title or description. While both commits appear individually sound, mixing unrelated changes reduces clarity. The score is 4 rather than 5 due to this organizational issue, though the code itself is safe.
- No files require special attention - both the Codex fix and workqueue-worker implementation appear well-tested and properly structured

<sub>Last reviewed commit: 1731c26</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->