### PR TITLE
Fix Codex usage window label for weekly reset

### DIFF
--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -19,6 +19,14 @@ type CodexUsageResponse = {
   credits?: { balance?: number | string | null };
 };
 
+const describeWindowHours = (windowSeconds?: number): string => {
+  const windowHours = Math.round((windowSeconds || 0) / 3600);
+  if (windowHours >= 168) {
+    return "Week";
+  }
+  return windowHours >= 24 ? "Day" : `${windowHours}h`;
+};
+
 export async function fetchCodexUsage(
   token: string,
   accountId: string | undefined,
@@ -64,9 +72,8 @@ export async function fetchCodexUsage(
 
   if (data.rate_limit?.primary_window) {
     const pw = data.rate_limit.primary_window;
-    const windowHours = Math.round((pw.limit_window_seconds || 10800) / 3600);
     windows.push({
-      label: `${windowHours}h`,
+      label: describeWindowHours(pw.limit_window_seconds),
       usedPercent: clampPercent(pw.used_percent || 0),
       resetAt: pw.reset_at ? pw.reset_at * 1000 : undefined,
     });
@@ -74,10 +81,8 @@ export async function fetchCodexUsage(
 
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
-    const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
-      label,
+      label: describeWindowHours(sw.limit_window_seconds),
       usedPercent: clampPercent(sw.used_percent || 0),
       resetAt: sw.reset_at ? sw.reset_at * 1000 : undefined,
     });
@@ -99,3 +104,7 @@ export async function fetchCodexUsage(
     plan,
   };
 }
+
+export const __test = {
+  describeWindowHours,
+};

--- a/src/infra/provider-usage.test.ts
+++ b/src/infra/provider-usage.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { withTempHome } from "../../test/helpers/temp-home.js";
 import { ensureAuthProfileStore, listProfilesForProvider } from "../agents/auth-profiles.js";
+import { __test as codexUsageFetcher } from "./provider-usage.fetch.codex.js";
 import {
   formatUsageReportLines,
   formatUsageSummaryLine,
@@ -108,6 +109,14 @@ describe("provider usage formatting", () => {
     };
     const lines = formatUsageReportLines(summary, { now });
     expect(lines.join("\n")).toContain("resets 1m");
+  });
+
+  it("labels codex 24h+ windows with true weekly cadence as Week", () => {
+    expect(codexUsageFetcher.describeWindowHours(1 * 3600)).toBe("1h");
+    expect(codexUsageFetcher.describeWindowHours(24 * 3600)).toBe("Day");
+    expect(codexUsageFetcher.describeWindowHours(48 * 3600)).toBe("Day");
+    expect(codexUsageFetcher.describeWindowHours(168 * 3600)).toBe("Week");
+    expect(codexUsageFetcher.describeWindowHours(336 * 3600)).toBe("Week");
   });
 });
 


### PR DESCRIPTION
## Summary
- Fix Codex usage window label derivation to avoid labeling weekly windows as "Day".
- Use 24h+ as Day only for sub-week windows and 7d+ (>=168h) as Week.
- Add test coverage for label behavior.

## Details
This updates `src/infra/provider-usage.fetch.codex.ts`:
- Refactor window labeling into `describeWindowHours(windowSeconds)`.
- Labels both `primary_window` and `secondary_window` with this helper.

Touches:
- `src/infra/provider-usage.fetch.codex.ts`
- `src/infra/provider-usage.test.ts`

Closes #19266

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors Codex usage window labeling to correctly distinguish between daily and weekly rate limit windows. Previously, any window >=24 hours (including 168-hour weekly windows) was labeled "Day". The new `describeWindowHours` helper correctly labels windows <24h with hour counts, 24-167h as "Day", and >=168h as "Week". Test coverage verifies the fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple refactoring with clear logic and comprehensive test coverage. The fix correctly addresses the labeling issue without changing any business logic or external behavior
- No files require special attention

<sub>Last reviewed commit: ac32e1f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->