### PR TITLE
fix: make slug generator use configured model

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -5,13 +5,15 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
-import type { OpenClawConfig } from "../config/config.js";
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM
@@ -38,6 +40,13 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
+    // Use the user's configured model instead of falling back to defaults
+    const modelRef = resolveConfiguredModelRef({
+      cfg: params.cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    });
+
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,
       sessionKey: "temp:slug-generator",
@@ -47,6 +56,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
+      provider: modelRef.provider,
+      model: modelRef.model,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
     });


### PR DESCRIPTION
Fixes issue where slug generator always tried to use anthropic even when user configured a different model.

## Problem
The `llm-slug-generator.ts` was calling `runEmbeddedPiAgent()` without specifying `provider` and `model` parameters, causing it to fall back to the hardcoded defaults (anthropic/claude-opus-4-6) even when users configured a different model.

This resulted in errors like:
```
Error: No API key found for provider "anthropic"
```

## Solution
Use `resolveConfiguredModelRef()` to get the user's configured model from `agents.defaults.model.primary` and pass it to `runEmbeddedPiAgent()`.

## Changes
- Import `resolveConfiguredModelRef` from `../agents/model-selection.js`
- Import `DEFAULT_MODEL` and `DEFAULT_PROVIDER` from `../agents/defaults.js`
- Call `resolveConfiguredModelRef()` before `runEmbeddedPiAgent()` to get the configured provider/model
- Pass `provider` and `model` to `runEmbeddedPiAgent()`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the slug generator to respect the user's configured model instead of always falling back to the hardcoded Anthropic defaults. The `runEmbeddedPiAgent()` call in `llm-slug-generator.ts` was missing `provider` and `model` parameters, causing it to default to `anthropic/claude-opus-4-6` regardless of configuration — resulting in `No API key found for provider "anthropic"` errors for users on different providers.

- Uses `resolveConfiguredModelRef()` to read from `agents.defaults.model.primary`, matching the pattern used by other `runEmbeddedPiAgent` callers throughout the codebase (cron runner, agent command, model probe)
- Falls back to `DEFAULT_PROVIDER`/`DEFAULT_MODEL` when no user configuration exists, preserving backward compatibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a focused bug fix that aligns with established patterns in the codebase.
- The change is minimal and correct. It adds a `resolveConfiguredModelRef()` call that follows the exact same pattern used by other `runEmbeddedPiAgent` callers in the codebase. The function's signature, imports, and fallback behavior are all verified against the source. No new logic is introduced — it simply wires up existing infrastructure that was missing.
- No files require special attention.

<sub>Last reviewed commit: 6add23b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->