### PR TITLE
fix: set supportsDeveloperRole false as default for moonshot provider

### DIFF
--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -4,10 +4,24 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
   return model.api === "openai-completions";
 }
 
-export function normalizeModelCompat(model: Model<Api>): Model<Api> {
+function isMoonshotProvider(model: Model<Api>): boolean {
   const baseUrl = model.baseUrl ?? "";
-  const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  return model.provider === "moonshot" || baseUrl.includes("api.moonshot.ai");
+}
+
+function isZaiProvider(model: Model<Api>): boolean {
+  const baseUrl = model.baseUrl ?? "";
+  return model.provider === "zai" || baseUrl.includes("api.z.ai");
+}
+
+export function normalizeModelCompat(model: Model<Api>): Model<Api> {
+  const isZai = isZaiProvider(model);
+  const isMoonshot = isMoonshotProvider(model);
+  if (!isZai && !isMoonshot) {
+    return model;
+  }
+
+  if (!isOpenAiCompletionsModel(model)) {
     return model;
   }
 


### PR DESCRIPTION
Fixes #19260

## What changed
- Set supportsDeveloperRole: false as default for moonshot provider when using openai-completions API to prevent 400 errors

## AI-assisted contribution
- This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build
- The fix addresses the root cause by setting the correct default to avoid developer role issues with Moonshot/Kimi models

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended `normalizeModelCompat` to support Moonshot provider alongside Zai, setting `supportsDeveloperRole: false` by default to prevent 400 errors with openai-completions API

- Refactored provider detection into separate helper functions (`isMoonshotProvider`, `isZaiProvider`)
- Changed early return logic from OR to AND condition to handle both providers

One issue found: the `isMoonshotProvider` baseUrl check only covers `api.moonshot.ai` but not `api.moonshot.cn` (China endpoint documented in the codebase).

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge with one logical issue that should be addressed
- The refactoring is clean and the logic is correct for the `.ai` endpoint, but the code doesn't handle the documented China endpoint (`api.moonshot.cn`), which could leave users on that endpoint still experiencing 400 errors. The test coverage also doesn't validate the new Moonshot functionality.
- Pay attention to `src/agents/model-compat.ts` for the missing `.cn` endpoint check

<sub>Last reviewed commit: 03c1a84</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->