### PR TITLE
feat(copilot): add gpt-5.3-codex to GitHub Copilot provider with xhigh reasoning

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
@@ -57,7 +57,7 @@ describe("directive behavior", () => {
     await withTempHome(async (home) => {
       const texts = await runThinkingDirective(home, "openai/gpt-4.1-mini");
       expect(texts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
+        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.3-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
       );
     });
   });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -56,6 +56,10 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("github-copilot", "gpt-5.2-codex")).toContain("xhigh");
   });
 
+  it("includes xhigh for github-copilot gpt-5.3-codex", () => {
+    expect(listThinkingLevels("github-copilot", "gpt-5.3-codex")).toContain("xhigh");
+  });
+
   it("excludes xhigh for non-codex models", () => {
     expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain("xhigh");
   });

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -27,6 +27,7 @@ export const XHIGH_MODEL_REFS = [
   "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
+  "github-copilot/gpt-5.3-codex",
   "github-copilot/gpt-5.2-codex",
   "github-copilot/gpt-5.2",
 ] as const;

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -11,6 +11,7 @@ const DEFAULT_MODEL_IDS = [
   "gpt-4.1",
   "gpt-4.1-mini",
   "gpt-4.1-nano",
+  "gpt-5.3-codex",
   "o1",
   "o1-mini",
   "o3-mini",


### PR DESCRIPTION
## Summary
Add gpt-5.3-codex to the GitHub Copilot provider default model list and to XHIGH_MODEL_REFS, enabling /think xhigh.

## Changes
- src/providers/github-copilot-models.ts: add gpt-5.3-codex to DEFAULT_MODEL_IDS
- src/auto-reply/thinking.ts: add github-copilot/gpt-5.3-codex to XHIGH_MODEL_REFS
- src/auto-reply/thinking.test.ts: test xhigh for github-copilot/gpt-5.3-codex
- e2e test: update expected error string to include new ref

## Testing
pnpm vitest run src/auto-reply/thinking.test.ts

Closes #19301

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `gpt-5.3-codex` support to the GitHub Copilot provider by including it in the default model list (`DEFAULT_MODEL_IDS`) and enabling xhigh thinking via `XHIGH_MODEL_REFS`. This mirrors the existing `openai-codex/gpt-5.3-codex` support but through the `github-copilot` provider path.

- `src/providers/github-copilot-models.ts`: adds `gpt-5.3-codex` to the default Copilot model list
- `src/auto-reply/thinking.ts`: adds `github-copilot/gpt-5.3-codex` to `XHIGH_MODEL_REFS` for xhigh thinking support
- Unit and e2e tests updated to cover the new model ref and updated error message string

No issues found. The changes follow established patterns and are consistent with how `gpt-5.2-codex` was previously added for the `github-copilot` provider.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a model entry and corresponding xhigh thinking support with proper test coverage.
- All changes follow existing patterns precisely. The model is added to the default list (which is intentionally broad per code comments), the xhigh ref is correctly placed in the array, the error message string is updated to match, and both unit and e2e tests are provided. No logic changes, no new code paths, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: f3cf758</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->