### PR TITLE
fix: normalize room ID case in Matrix config lookup

### DIFF
--- a/extensions/matrix/src/matrix/monitor/rooms.ts
+++ b/extensions/matrix/src/matrix/monitor/rooms.ts
@@ -18,10 +18,13 @@ export function resolveMatrixRoomConfig(params: {
   const rooms = params.rooms ?? {};
   const keys = Object.keys(rooms);
   const allowlistConfigured = keys.length > 0;
+  // Normalize room ID to lowercase to match the case used when stored in config
+  const normalizedRoomId = params.roomId.toLowerCase();
+  const normalizedAliases = params.aliases.map((alias) => alias.toLowerCase());
   const candidates = buildChannelKeyCandidates(
-    params.roomId,
-    `room:${params.roomId}`,
-    ...params.aliases,
+    normalizedRoomId,
+    `room:${normalizedRoomId}`,
+    ...normalizedAliases,
   );
   const {
     entry: matched,


### PR DESCRIPTION
Fixes #19278

## What changed
- Normalize room ID and aliases to lowercase in resolveMatrixRoomConfig() before building lookup candidates
- This ensures case-insensitive matching between the room ID from Matrix events and the config entries

## AI-assisted contribution
- This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build && pnpm check && pnpm test
- The fix addresses the root cause described in the issue by normalizing the room ID to lowercase before lookup, ensuring config entries stored in any case can be found regardless of the case used in Matrix events

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalized Matrix room IDs and aliases to lowercase before config lookup to enable case-insensitive matching between Matrix events and configuration entries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-commented, and addresses a specific bug. The normalization to lowercase is consistent with Matrix server behavior and other parts of the codebase that normalize Matrix IDs.
- No files require special attention

<sub>Last reviewed commit: a1357d8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->