### PR TITLE
Fix WhatsApp internal error leakage + cron.run timeout defaults

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -17,6 +17,28 @@ describe("cron tool", () => {
     callGatewayMock.mockResolvedValue({ ok: true });
   });
 
+  it("uses a higher default gateway timeout for cron.run/runs", async () => {
+    const tool = createCronTool();
+
+    await tool.execute("call-run", { action: "run", jobId: "job-1" });
+    const runCall = callGatewayMock.mock.calls.at(-1)?.[0] as { timeoutMs?: number };
+    expect(runCall.timeoutMs).toBe(180_000);
+
+    callGatewayMock.mockReset();
+    callGatewayMock.mockResolvedValue({ ok: true });
+
+    await tool.execute("call-runs", { action: "runs", jobId: "job-1" });
+    const runsCall = callGatewayMock.mock.calls.at(-1)?.[0] as { timeoutMs?: number };
+    expect(runsCall.timeoutMs).toBe(180_000);
+
+    callGatewayMock.mockReset();
+    callGatewayMock.mockResolvedValue({ ok: true });
+
+    await tool.execute("call-list", { action: "list" });
+    const listCall = callGatewayMock.mock.calls.at(-1)?.[0] as { timeoutMs?: number };
+    expect(listCall.timeoutMs).toBe(60_000);
+  });
+
   it.each([
     [
       "update",

--- a/src/web/auto-reply/deliver-reply.test.ts
+++ b/src/web/auto-reply/deliver-reply.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebInboundMsg } from "./types.js";
+import { deliverWebReply } from "./deliver-reply.js";
+
+vi.mock("../media.js", () => ({
+  loadWebMedia: vi.fn(),
+}));
+
+const { loadWebMedia } = await import("../media.js");
+
+const makeMsg = (overrides: Partial<WebInboundMsg> = {}): WebInboundMsg =>
+  ({
+    id: "m1",
+    from: "+10000000000",
+    conversationId: "c1",
+    to: "+20000000000",
+    accountId: "default",
+    body: "",
+    chatType: "direct",
+    chatId: "c1",
+    sendComposing: async () => {},
+    reply: vi.fn(async () => undefined),
+    sendMedia: vi.fn(async () => undefined),
+    ...overrides,
+  }) as unknown as WebInboundMsg;
+
+const replyLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+describe("deliverWebReply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("strips internal tool-error banners from WhatsApp outbound text", async () => {
+    const msg = makeMsg();
+
+    await deliverWebReply({
+      replyResult: {
+        text: "⚠️ 🛠️ Exec: set -euo pipefail failed: Command exited with code 1\nReal message line 1\n\nReal message line 2",
+      },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 5000,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+    expect(msg.reply).toHaveBeenCalledWith("Real message line 1\n\nReal message line 2");
+  });
+
+  it("skips invalid mediaUrl candidates (placeholders) and sends caption only", async () => {
+    const msg = makeMsg();
+
+    await deliverWebReply({
+      replyResult: { text: "caption", mediaUrl: "image" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 5000,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(loadWebMedia).not.toHaveBeenCalled();
+    expect(msg.sendMedia).not.toHaveBeenCalled();
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+    expect(msg.reply).toHaveBeenCalledWith("caption");
+  });
+});

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -29,13 +29,44 @@ export async function deliverWebReply(params: {
   const replyStarted = Date.now();
   const tableMode = params.tableMode ?? "code";
   const chunkMode = params.chunkMode ?? "length";
-  const convertedText = convertMarkdownTables(replyResult.text || "", tableMode);
+
+  // WhatsApp safety: never forward internal tool banners/log lines into chats.
+  // These are usually from agent/tool failures and look like:
+  // "⚠️ 🛠️ Exec: ...", "Command exited with code ...", etc.
+  const rawText = replyResult.text || "";
+  const sanitizedText = rawText
+    .split(/\r?\n/)
+    .filter((line) => {
+      const t = line.trim();
+      if (!t) {
+        return true;
+      }
+      if (/^⚠️\s*🛠️\s*(Exec|Read|Edit|Cron|Tool)\b/i.test(t)) {
+        return false;
+      }
+      if (/^(Exec|Read|Edit|Cron|Tool):\s*/i.test(t)) {
+        return false;
+      }
+      if (/^Command exited with code\s+\d+/i.test(t)) {
+        return false;
+      }
+      return true;
+    })
+    .join("\n")
+    .trim();
+
+  const convertedText = convertMarkdownTables(sanitizedText, tableMode);
   const textChunks = chunkMarkdownTextWithMode(convertedText, textLimit, chunkMode);
   const mediaList = replyResult.mediaUrls?.length
     ? replyResult.mediaUrls
     : replyResult.mediaUrl
       ? [replyResult.mediaUrl]
       : [];
+
+  if (mediaList.length === 0 && textChunks.length === 0) {
+    // Entire reply was internal noise.
+    return;
+  }
 
   const sendWithRetry = async (fn: () => Promise<unknown>, label: string, maxAttempts = 3) => {
     let lastErr: unknown;
@@ -95,8 +126,28 @@ export async function deliverWebReply(params: {
   // Media (with optional caption on first item)
   for (const [index, mediaUrl] of mediaList.entries()) {
     const caption = index === 0 ? remainingText.shift() || undefined : undefined;
+
+    // Guard: sometimes model output includes placeholder strings like "image"/"document" or pasted instructions.
+    // Only treat values as media sources if they look like an http(s) URL, file:// URL, or a local path.
+    const rawMediaUrl = String(mediaUrl ?? "");
+    const normalized = rawMediaUrl.replace(/^\s*MEDIA\s*:\s*/i, "").trim();
+    const isRemote = /^https?:\/\//i.test(normalized);
+    const isFileUrl = /^file:\/\//i.test(normalized);
+    const isLocalPath =
+      normalized.startsWith("/") || normalized.startsWith("./") || normalized.startsWith("../");
+
+    if (!isRemote && !isFileUrl && !isLocalPath) {
+      whatsappOutboundLog.warn(
+        `Skipping invalid mediaUrl candidate for ${msg.from}: ${elide(rawMediaUrl, 120)}`,
+      );
+      if (index === 0 && caption) {
+        await sendWithRetry(() => msg.reply(caption), "text");
+      }
+      continue;
+    }
+
     try {
-      const media = await loadWebMedia(mediaUrl, maxMediaBytes);
+      const media = await loadWebMedia(normalized, maxMediaBytes);
       if (shouldLogVerbose()) {
         logVerbose(
           `Web auto-reply media size: ${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB`,
@@ -158,7 +209,7 @@ export async function deliverWebReply(params: {
           to: msg.from,
           from: msg.to,
           text: caption ?? null,
-          mediaUrl,
+          mediaUrl: normalized,
           mediaSizeBytes: media.buffer.length,
           mediaKind: media.kind,
           durationMs: Date.now() - replyStarted,
@@ -169,10 +220,9 @@ export async function deliverWebReply(params: {
       whatsappOutboundLog.error(`Failed sending web media to ${msg.from}: ${formatError(err)}`);
       replyLogger.warn({ err, mediaUrl }, "failed to send web media reply");
       if (index === 0) {
-        const warning =
-          err instanceof Error ? `⚠️ Media failed: ${err.message}` : "⚠️ Media failed.";
-        const fallbackTextParts = [remainingText.shift() ?? caption ?? "", warning].filter(Boolean);
-        const fallbackText = fallbackTextParts.join("\n");
+        // Never leak internal/technical errors into user chats.
+        // If media fails, just send the intended text (caption/body) without warnings.
+        const fallbackText = (remainingText.shift() ?? caption ?? "").trim();
         if (fallbackText) {
           whatsappOutboundLog.warn(`Media skipped; sent text-only to ${msg.from}`);
           await msg.reply(fallbackText);


### PR DESCRIPTION
## Summary
Fix two reliability/UX issues that caused noisy internal errors to leak into WhatsApp chats and misleading cron timeout alerts.

## What changed
### WhatsApp web auto-reply (`deliverWebReply`)
- Strip internal tool/log banner lines from outbound WhatsApp text (e.g. `⚠️ 🛠️ Exec: ...`, `Command exited with code ...`).
- Skip clearly invalid `mediaUrl` placeholders (e.g. `image`, `document`, pasted instructions). If invalid, fall back to sending caption/text only.
- When media sending fails, **do not** append "⚠️ Media failed" warnings to the chat. Fall back to intended text only.

### Cron tool
- Increase default gateway timeout for `cron.run` and `cron.runs` to **180s** (other actions remain 60s). This prevents spurious `gateway timeout after 60000ms` messages for legitimate long cron runs.

## Tests
- Added unit tests for WhatsApp reply sanitization + placeholder mediaUrl handling.
- Added unit test for the cron tool timeout defaults.

## Motivation
Users reported:
- WhatsApp group chats receiving internal tool failures as messages.
- Cron appearing to fail due to the 60s gateway timeout while the underlying job eventually completed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents internal tool errors and timeout warnings from leaking into WhatsApp chats. Strips tool failure banners (like `⚠️ 🛠️ Exec: ...` and `Command exited with code ...`) before sending replies, validates media URLs to reject placeholder strings, and increases cron gateway timeout defaults from 60s to 180s for `cron.run` and `cron.runs` actions to prevent spurious timeout alerts.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Focused, well-tested fixes for real user-reported issues. Changes are defensive (adding sanitization and validation) rather than risky refactors. Test coverage validates the sanitization logic and timeout defaults. No breaking changes to existing behavior.
- No files require special attention

<sub>Last reviewed commit: 869cdb4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->