### PR TITLE
fix(macos): handle .gateway case in DeepLinks.swift

### DIFF
--- a/apps/macos/Sources/OpenClaw/DeepLinks.swift
+++ b/apps/macos/Sources/OpenClaw/DeepLinks.swift
@@ -67,6 +67,8 @@ final class DeepLinkHandler {
         switch route {
         case let .agent(link):
             await self.handleAgent(link: link, originalURL: url)
+        case .gateway:
+            break
         }
     }
 


### PR DESCRIPTION
Match iOS behavior: ignore gateway deep links with a simple `break` instead of logging.

No functional change — gateway deep links are not yet implemented on either platform.