### PR TITLE
fix(matrix): preserve room ID casing in directory resolution (#19278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Docs: https://docs.openclaw.ai
 - Sandbox: fix workspace-directory orphaning during SHA-1 -> SHA-256 slug migration. (#18523) Thanks @yinghaosang.
 - Ollama/Qwen: handle Qwen 3 reasoning field format in Ollama responses. (#18631) Thanks @mr-sk.
 - OpenAI/Transcripts: always drop orphaned reasoning blocks from transcript repair. (#18632) Thanks @TySabs.
+- Matrix: preserve original casing for room IDs and aliases in directory resolution so per-room config (requireMention, autoReply) is matched correctly. (#19278)
 - Fix types in all tests. Typecheck the whole repository.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.
 - Gateway/WebChat: hard-cap `chat.history` oversized payloads by truncating high-cost fields and replacing over-budget entries with placeholders, so history fetches stay within configured byte limits and avoid chat UI freezes. (#18505)

--- a/extensions/matrix/src/directory-live.test.ts
+++ b/extensions/matrix/src/directory-live.test.ts
@@ -51,4 +51,60 @@ describe("matrix directory live", () => {
 
     expect(resolveMatrixAuth).toHaveBeenCalledWith({ cfg, accountId: "assistant" });
   });
+
+  it("preserves original casing for explicit !-prefixed room ID (#19278)", async () => {
+    const mixedCaseRoomId = "!ArAQdbw5b42R5uBHuWz84xs6GI:matrix.org";
+    const result = await listMatrixDirectoryGroupsLive({
+      cfg,
+      query: mixedCaseRoomId,
+      limit: 5,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(mixedCaseRoomId);
+    expect(result[0].name).toBe(mixedCaseRoomId);
+  });
+
+  it("preserves original casing for #-prefixed alias query (#19278)", async () => {
+    const alias = "#MyRoom:Example.org";
+    const serverRoomId = "!ServerRoomId123:example.org";
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ room_id: serverRoomId }),
+      text: async () => "",
+    } as Response);
+
+    const result = await listMatrixDirectoryGroupsLive({
+      cfg,
+      query: alias,
+      limit: 5,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(serverRoomId);
+    expect(result[0].name).toBe(alias);
+    expect(result[0].handle).toBe(alias);
+  });
+
+  it("lowercases query for fuzzy room name search", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joined_rooms: ["!room1:example.org"] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ name: "Dev Chat" }),
+      } as Response);
+
+    const result = await listMatrixDirectoryGroupsLive({
+      cfg,
+      query: "Dev",
+      limit: 5,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("!room1:example.org");
+    expect(result[0].name).toBe("Dev Chat");
+  });
 });

--- a/extensions/matrix/src/directory-live.ts
+++ b/extensions/matrix/src/directory-live.ts
@@ -127,15 +127,15 @@ export async function listMatrixDirectoryGroupsLive(params: {
   query?: string | null;
   limit?: number | null;
 }): Promise<ChannelDirectoryEntry[]> {
-  const query = normalizeQuery(params.query);
-  if (!query) {
+  const trimmed = params.query?.trim() ?? "";
+  if (!trimmed) {
     return [];
   }
   const auth = await resolveMatrixAuth({ cfg: params.cfg as never, accountId: params.accountId });
   const limit = typeof params.limit === "number" && params.limit > 0 ? params.limit : 20;
 
-  if (query.startsWith("#")) {
-    const roomId = await resolveMatrixRoomAlias(auth.homeserver, auth.accessToken, query);
+  if (trimmed.startsWith("#")) {
+    const roomId = await resolveMatrixRoomAlias(auth.homeserver, auth.accessToken, trimmed);
     if (!roomId) {
       return [];
     }
@@ -143,22 +143,23 @@ export async function listMatrixDirectoryGroupsLive(params: {
       {
         kind: "group",
         id: roomId,
-        name: query,
-        handle: query,
+        name: trimmed,
+        handle: trimmed,
       } satisfies ChannelDirectoryEntry,
     ];
   }
 
-  if (query.startsWith("!")) {
+  if (trimmed.startsWith("!")) {
     return [
       {
         kind: "group",
-        id: query,
-        name: query,
+        id: trimmed,
+        name: trimmed,
       } satisfies ChannelDirectoryEntry,
     ];
   }
 
+  const query = trimmed.toLowerCase();
   const joined = await fetchMatrixJson<MatrixJoinedRoomsResponse>({
     homeserver: auth.homeserver,
     accessToken: auth.accessToken,


### PR DESCRIPTION
## Summary

- **Bug**: Per-room Matrix config (requireMention, autoReply) silently ignored due to room ID case mismatch
- **Root cause**: `normalizeQuery()` in `directory-live.ts` lowercases room IDs/aliases before returning them, but `resolveChannelEntryMatch()` performs exact-case lookup at runtime
- **Fix**: Preserve original casing for `!`-prefixed room IDs and `#`-prefixed aliases; only lowercase for fuzzy name search

Fixes #19278

## Problem

When a user configures a Matrix room by its room ID (e.g. `!ArAQdbw5b42R5uBHuWz84xs6GI:matrix.org`), the directory resolution step in `listMatrixDirectoryGroupsLive()` passes the query through `normalizeQuery()` which calls `.toLowerCase()`. The lowercased ID becomes the key in the internal `roomsConfig` map.

At runtime, Matrix events arrive with the original-case room ID. `resolveMatrixRoomConfig()` builds lookup candidates using this original-case ID and calls `resolveChannelEntryMatch()`, which uses `Object.prototype.hasOwnProperty.call(entries, key)` — an exact-case match. The lookup fails because `!araqdbw5...` ≠ `!ArAQdbw5...`.

**Before fix:**
```
Input:  "!ArAQdbw5b42R5uBHuWz84xs6GI:matrix.org"
Output: "!araqdbw5b42r5ubhuwz84xs6gi:matrix.org"  (lowercased)
Config lookup: MISS → requireMention defaults to true
```

## Changes

- `extensions/matrix/src/directory-live.ts` — Use `trim()` instead of `normalizeQuery()` for the `!` and `#` code paths, preserving original casing. Only apply `toLowerCase()` for the fuzzy room-name search path where case-insensitive comparison is needed.
- `extensions/matrix/src/directory-live.test.ts` — Add regression tests for room ID case preservation, alias case preservation, and fuzzy search lowercasing.
- `CHANGELOG.md` — Add fix entry.

**After fix:**
```
Input:  "!ArAQdbw5b42R5uBHuWz84xs6GI:matrix.org"
Output: "!ArAQdbw5b42R5uBHuWz84xs6GI:matrix.org"  (preserved)
Config lookup: HIT → requireMention: false applied correctly
```

## Test plan

- [x] New test: preserves original casing for `!`-prefixed room ID
- [x] New test: preserves original casing for `#`-prefixed alias
- [x] New test: lowercases query for fuzzy room name search (existing behavior)
- [x] All 37 existing matrix tests pass
- [x] Lint passes

## Effect on User Experience

**Before:** Per-room settings like `requireMention: false` and `autoReply: true` are silently ignored for Matrix rooms configured by room ID. The bot requires a mention even when configured not to.

**After:** Per-room settings are applied correctly regardless of room ID casing.