### PR TITLE
fix(commands): use session model for native arg menus

### DIFF
--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -314,6 +314,41 @@ describe("commands registry args", () => {
     expect(seenChoice?.model).toBeTruthy();
   });
 
+  it("resolves function-based choices with explicit provider/model context", () => {
+    let seen: { provider?: string; model?: string } | null = null;
+
+    const command: ChatCommandDefinition = {
+      key: "think",
+      description: "think",
+      textAliases: [],
+      scope: "both",
+      argsMenu: "auto",
+      argsParsing: "positional",
+      args: [
+        {
+          name: "level",
+          description: "level",
+          type: "string",
+          choices: ({ provider, model }) => {
+            seen = { provider, model };
+            return ["low", "high"];
+          },
+        },
+      ],
+    };
+
+    const menu = resolveCommandArgMenu({
+      command,
+      args: undefined,
+      cfg: {} as never,
+      provider: "github-copilot",
+      model: "gpt-5.2-codex",
+    });
+    expect(menu?.choices.length).toBeGreaterThan(0);
+    expect(seen?.provider).toBe("github-copilot");
+    expect(seen?.model).toBe("gpt-5.2-codex");
+  });
+
   it("does not show menus when args were provided as raw text only", () => {
     const command = createUsageModeCommand("none", "on or off");
 

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -345,8 +345,9 @@ describe("commands registry args", () => {
       model: "gpt-5.2-codex",
     });
     expect(menu?.choices.length).toBeGreaterThan(0);
-    expect(seen?.provider).toBe("github-copilot");
-    expect(seen?.model).toBe("gpt-5.2-codex");
+    const seenChoice = seen as { provider?: string; model?: string } | null;
+    expect(seenChoice?.provider).toBe("github-copilot");
+    expect(seenChoice?.model).toBe("gpt-5.2-codex");
   });
 
   it("does not show menus when args were provided as raw text only", () => {

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -336,6 +336,8 @@ export function resolveCommandArgMenu(params: {
   command: ChatCommandDefinition;
   args?: CommandArgs;
   cfg?: OpenClawConfig;
+  provider?: string;
+  model?: string;
 }): { arg: CommandArgDefinition; choices: ResolvedCommandArgChoice[]; title?: string } | null {
   const { command, args, cfg } = params;
   if (!command.args || !command.argsMenu) {
@@ -347,7 +349,16 @@ export function resolveCommandArgMenu(params: {
   const argSpec = command.argsMenu;
   const argName =
     argSpec === "auto"
-      ? command.args.find((arg) => resolveCommandArgChoices({ command, arg, cfg }).length > 0)?.name
+      ? command.args.find(
+          (arg) =>
+            resolveCommandArgChoices({
+              command,
+              arg,
+              cfg,
+              provider: params.provider,
+              model: params.model,
+            }).length > 0,
+        )?.name
       : argSpec.arg;
   if (!argName) {
     return null;
@@ -362,7 +373,13 @@ export function resolveCommandArgMenu(params: {
   if (!arg) {
     return null;
   }
-  const choices = resolveCommandArgChoices({ command, arg, cfg });
+  const choices = resolveCommandArgChoices({
+    command,
+    arg,
+    cfg,
+    provider: params.provider,
+    model: params.model,
+  });
   if (choices.length === 0) {
     return null;
   }

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1535,21 +1535,6 @@ async function dispatchDiscordCommandInteraction(params: {
     return;
   }
 
-  const isGuild = Boolean(interaction.guild);
-  const channelId = rawChannelId || "unknown";
-  const interactionId = interaction.rawData.id;
-  const route = resolveAgentRoute({
-    cfg,
-    channel: "discord",
-    accountId,
-    guildId: interaction.guild?.id ?? undefined,
-    memberRoleIds,
-    peer: {
-      kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
-      id: isDirectMessage ? user.id : channelId,
-    },
-    parentPeer: threadParentId ? { kind: "channel", id: threadParentId } : undefined,
-  });
   const threadBinding = isThreadChannel ? threadBindings.getByThreadId(rawChannelId) : undefined;
   const boundSessionKey = threadBinding?.targetSessionKey?.trim();
   const boundAgentId = boundSessionKey ? resolveAgentIdFromSessionKey(boundSessionKey) : undefined;
@@ -1560,12 +1545,6 @@ async function dispatchDiscordCommandInteraction(params: {
         agentId: boundAgentId ?? route.agentId,
       }
     : route;
-  const conversationLabel = isDirectMessage ? (user.globalName ?? user.username) : channelId;
-  const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
-    channelConfig,
-    guildInfo,
-    sender: { id: sender.id, name: sender.name, tag: sender.tag },
-  });
   const ctxPayload = finalizeInboundContext({
     Body: prompt,
     BodyForAgent: prompt,

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -14,7 +14,9 @@ import {
   type StringSelectMenuInteraction,
 } from "@buape/carbon";
 import { ApplicationCommandOptionType, ButtonStyle } from "discord-api-types/v10";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
+import { resolveConfiguredModelRef } from "../../agents/model-selection.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import type {
   ChatCommandDefinition,
@@ -88,6 +90,32 @@ import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
 const log = createSubsystemLogger("discord/native-command");
+
+function resolveMenuModelContext(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+}): { provider: string; model: string } {
+  const resolved = resolveConfiguredModelRef({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  let provider = resolved.provider ?? DEFAULT_PROVIDER;
+  let model = resolved.model ?? DEFAULT_MODEL;
+  try {
+    const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
+    const store = loadSessionStore(storePath);
+    const entry = store[params.sessionKey];
+    if (entry) {
+      provider = entry.providerOverride?.trim() || entry.modelProvider?.trim() || provider;
+      model = entry.modelOverride?.trim() || entry.model?.trim() || model;
+    }
+  } catch {
+    // Ignore session store read errors and fall back to defaults.
+  }
+  return { provider, model };
+}
 
 function buildDiscordCommandOptions(params: {
   command: ChatCommandDefinition;
@@ -1426,10 +1454,38 @@ async function dispatchDiscordCommandInteraction(params: {
     return;
   }
 
+  const isGuild = Boolean(interaction.guild);
+  const channelId = rawChannelId || "unknown";
+  const interactionId = interaction.rawData.id;
+  const route = resolveAgentRoute({
+    cfg,
+    channel: "discord",
+    accountId,
+    guildId: interaction.guild?.id ?? undefined,
+    memberRoleIds,
+    peer: {
+      kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
+      id: isDirectMessage ? user.id : channelId,
+    },
+    parentPeer: threadParentId ? { kind: "channel", id: threadParentId } : undefined,
+  });
+  const conversationLabel = isDirectMessage ? (user.globalName ?? user.username) : channelId;
+  const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
+    channelConfig,
+    guildInfo,
+    sender: { id: sender.id, name: sender.name, tag: sender.tag },
+  });
+  const menuModelContext = resolveMenuModelContext({
+    cfg,
+    agentId: route.agentId,
+    sessionKey: route.sessionKey,
+  });
   const menu = resolveCommandArgMenu({
     command,
     args: commandArgs,
     cfg,
+    provider: menuModelContext.provider,
+    model: menuModelContext.model,
   });
   if (menu) {
     const menuPayload = buildDiscordCommandArgMenu({

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -117,6 +117,8 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
     resolveCommandArgMenu: (params: {
       command?: { key?: string };
       args?: { values?: unknown };
+      provider?: string;
+      model?: string;
     }) => {
       if (params.command?.key === "report") {
         return resolvePeriodMenu(params, [

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -1,4 +1,6 @@
 import type { Bot, Context } from "grammy";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
 import type { CommandArgs } from "../auto-reply/commands-registry.js";
 import {
@@ -17,7 +19,7 @@ import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ChannelGroupPolicy } from "../config/group-policy.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
-import { recordSessionMetaFromInbound, resolveStorePath } from "../config/sessions.js";
+import { loadSessionStore, recordSessionMetaFromInbound, resolveStorePath } from "../config/sessions.js";
 import {
   normalizeTelegramCommandName,
   resolveTelegramCustomCommands,
@@ -68,6 +70,32 @@ import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
 import { buildInlineKeyboard } from "./send.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
+
+function resolveMenuModelContext(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+}): { provider: string; model: string } {
+  const resolved = resolveConfiguredModelRef({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  let provider = resolved.provider ?? DEFAULT_PROVIDER;
+  let model = resolved.model ?? DEFAULT_MODEL;
+  try {
+    const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
+    const store = loadSessionStore(storePath);
+    const entry = store[params.sessionKey];
+    if (entry) {
+      provider = entry.providerOverride?.trim() || entry.modelProvider?.trim() || provider;
+      model = entry.modelOverride?.trim() || entry.model?.trim() || model;
+    }
+  } catch {
+    // Ignore session store read errors and fall back to defaults.
+  }
+  return { provider, model };
+}
 
 type TelegramNativeCommandContext = Context & { match?: string };
 
@@ -504,11 +532,29 @@ export const registerTelegramNativeCommands = ({
             : rawText
               ? `/${command.name} ${rawText}`
               : `/${command.name}`;
+          const baseSessionKey = route.sessionKey;
+          // DMs: use raw messageThreadId for thread sessions (not resolvedThreadId which is for forums)
+          const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
+          const threadKeys =
+            dmThreadId != null
+              ? resolveThreadSessionKeys({
+                  baseSessionKey,
+                  threadId: String(dmThreadId),
+                })
+              : null;
+          const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
+          const menuModelContext = resolveMenuModelContext({
+            cfg,
+            agentId: route.agentId,
+            sessionKey,
+          });
           const menu = commandDefinition
             ? resolveCommandArgMenu({
                 command: commandDefinition,
                 args: commandArgs,
                 cfg,
+                provider: menuModelContext.provider,
+                model: menuModelContext.model,
               })
             : null;
           if (menu && commandDefinition) {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -19,7 +19,11 @@ import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ChannelGroupPolicy } from "../config/group-policy.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
-import { loadSessionStore, recordSessionMetaFromInbound, resolveStorePath } from "../config/sessions.js";
+import {
+  loadSessionStore,
+  recordSessionMetaFromInbound,
+  resolveStorePath,
+} from "../config/sessions.js";
 import {
   normalizeTelegramCommandName,
   resolveTelegramCustomCommands,
@@ -588,17 +592,6 @@ export const registerTelegramNativeCommands = ({
             });
             return;
           }
-          const baseSessionKey = route.sessionKey;
-          // DMs: use raw messageThreadId for thread sessions (not resolvedThreadId which is for forums)
-          const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
-          const threadKeys =
-            dmThreadId != null
-              ? resolveThreadSessionKeys({
-                  baseSessionKey,
-                  threadId: String(dmThreadId),
-                })
-              : null;
-          const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
           const { skillFilter, groupSystemPrompt } = resolveTelegramGroupPromptSettings({
             groupConfig,
             topicConfig,


### PR DESCRIPTION
## Summary
Native /think menus were using the config default provider/model when building arg menus, so xhigh was omitted even when the active session model supported it. This uses the current session’s model context for Telegram/Discord/Slack native command menus.

## Changes
- Pass provider/model into resolveCommandArgMenu and its choice resolution
- Resolve provider/model from the session store for native command menus
- Add a commands-registry test for explicit provider/model context
- Update Slack menu mock signature

## Testing
pnpm vitest run src/auto-reply/commands-registry.test.ts src/slack/monitor/slash.test.ts