### PR TITLE
fix: prevent sanitizeUserFacingText billing false positives (AI-assisted)

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
@@ -72,9 +72,14 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
 
-  it("rewrites billing error-shaped text", () => {
+  it("does not rewrite billing error-shaped text without errorContext", () => {
     const text = "billing: please upgrade your plan";
-    expect(sanitizeUserFacingText(text)).toContain("billing error");
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("rewrites billing error-shaped text in errorContext", () => {
+    const text = "billing: please upgrade your plan";
+    expect(sanitizeUserFacingText(text, { errorContext: true })).toContain("billing error");
   });
 
   it("sanitizes raw API error payloads", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -240,18 +240,6 @@ function shouldRewriteContextOverflowText(raw: string): boolean {
   );
 }
 
-function shouldRewriteBillingText(raw: string): boolean {
-  if (!isBillingErrorMessage(raw)) {
-    return false;
-  }
-  return (
-    isRawApiErrorPayload(raw) ||
-    isLikelyHttpErrorText(raw) ||
-    ERROR_PREFIX_RE.test(raw) ||
-    BILLING_ERROR_HEAD_RE.test(raw)
-  );
-}
-
 type ErrorPayload = Record<string, unknown>;
 
 function isErrorPayloadObject(payload: unknown): payload is ErrorPayload {
@@ -559,13 +547,6 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
       }
       return formatRawAssistantErrorForUi(trimmed);
     }
-  }
-
-  // Preserve legacy behavior for explicit billing-head text outside known
-  // error contexts (e.g., "billing: please upgrade your plan"), while
-  // keeping conversational billing mentions untouched.
-  if (shouldRewriteBillingText(trimmed)) {
-    return BILLING_ERROR_USER_MESSAGE;
   }
 
   // Strip leading blank lines (including whitespace-only lines) without clobbering indentation on


### PR DESCRIPTION
## Summary
- remove billing-error rewrite path from `sanitizeUserFacingText` when `errorContext` is false
- keep billing rewrite behavior inside explicit error context only
- update tests to ensure non-error billing text is preserved and error-context billing payloads are still rewritten

Closes #19258

## Testing
- Degree of testing: fully tested (targeted)
- Ran: `corepack pnpm vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts`
- Result: 2 files passed, 84 tests passed

## AI Assistance
- This PR was AI-assisted via Codex.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed the `shouldRewriteBillingText` function and its call site in `sanitizeUserFacingText` to prevent false positives when the assistant legitimately discusses billing-related topics. The billing error rewrite behavior is now confined to the `errorContext: true` code path, where `isBillingErrorMessage` is checked explicitly. Tests were updated to verify that billing-shaped text like "billing: please upgrade your plan" is preserved when `errorContext` is false and only rewritten when `errorContext` is true.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-tested with 84 passing tests including new tests that explicitly verify the fix. The logic is straightforward: removing a legacy code path that caused false positives while preserving the same behavior within the proper `errorContext: true` path. The PR addresses issue #19258 and follows the repository's testing guidelines.
- No files require special attention

<sub>Last reviewed commit: 0d29ce9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->