### PR TITLE
fix(session-memory): preserve rotated transcript selection on /new

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -338,6 +338,51 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Recovered directly from reset file");
   });
 
+  it("prefers pointed reset transcript over newer empty active session file", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-session-memory-");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const sessionId = "reset-pointer-with-new-active";
+    const resetSessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: `${sessionId}.jsonl.reset.2026-02-16T22-26-33.000Z`,
+      content: createMockSessionContent([
+        { role: "user", content: "Old transcript content should win" },
+        { role: "assistant", content: "Do not switch to empty new file" },
+      ]),
+    });
+
+    // Simulate /new creating a fresh active transcript in the same directory.
+    await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "new-session.jsonl",
+      content: "",
+    });
+
+    const cfg = {
+      agents: { defaults: { workspace: tempDir } },
+    } satisfies OpenClawConfig;
+
+    const event = createHookEvent("command", "new", "agent:main:main", {
+      cfg,
+      previousSessionEntry: {
+        sessionId,
+        sessionFile: resetSessionFile,
+      },
+    });
+
+    await handler(event);
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+    expect(files.length).toBe(1);
+    const memoryContent = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+
+    expect(memoryContent).toContain("user: Old transcript content should win");
+    expect(memoryContent).toContain("assistant: Do not switch to empty new file");
+  });
+
   it("recovers transcript when previousSessionEntry.sessionFile is missing", async () => {
     const tempDir = await makeTempWorkspace("openclaw-session-memory-");
     const sessionsDir = path.join(tempDir, "sessions");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -128,6 +128,15 @@ async function findPreviousSessionFile(params: {
       return path.join(params.sessionsDir, baseFromReset);
     }
 
+    // If caller already points at a rotated transcript, prefer that exact file.
+    // This avoids accidentally selecting a newer empty .jsonl created by /new.
+    const currentBaseName = params.currentSessionFile
+      ? path.basename(params.currentSessionFile)
+      : undefined;
+    if (currentBaseName?.includes(".reset.") && fileSet.has(currentBaseName)) {
+      return path.join(params.sessionsDir, currentBaseName);
+    }
+
     const trimmedSessionId = params.sessionId?.trim();
     if (trimmedSessionId) {
       const canonicalFile = `${trimmedSessionId}.jsonl`;


### PR DESCRIPTION
## Summary

Closes #18459

When `session-memory` receives a `previousSessionEntry.sessionFile` that already points to a rotated `.jsonl.reset.*` transcript, it could still switch to a newer empty `.jsonl` file created by `/new`. That causes the hook to miss real conversation content and fall back to a timestamp-only slug path.

This change keeps the selected reset transcript stable in that edge case.

### Changes

- **`src/hooks/bundled/session-memory/handler.ts`** - updated `findPreviousSessionFile` to prefer the exact pointed `.reset.*` transcript when it exists, before scanning fallback non-reset files.
- **`src/hooks/bundled/session-memory/handler.test.ts`** - added regression coverage for the race where a fresh empty active `.jsonl` exists alongside the pointed reset transcript.

## Test plan

- [x] `npx oxfmt src/hooks/bundled/session-memory/handler.ts src/hooks/bundled/session-memory/handler.test.ts`
- [x] `npx oxlint src/hooks/bundled/session-memory/handler.ts src/hooks/bundled/session-memory/handler.test.ts`
- [x] `pnpm vitest run src/hooks/bundled/session-memory/handler.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a race condition where `session-memory` could incorrectly prefer a newly created empty `.jsonl` file over an already-rotated `.jsonl.reset.*` transcript when handling `/new` commands.

**Key changes:**
- Added early-return path in `findPreviousSessionFile` (handler.ts:131-138) that preserves the exact pointed reset transcript when `currentSessionFile` already contains `.reset.`
- Added regression test covering the scenario where a reset transcript pointer coexists with a newer empty active session file
- This ensures the hook captures real conversation content instead of falling back to timestamp-only slugs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is narrowly scoped, well-tested with comprehensive regression coverage, and the logic change is straightforward - it simply adds an early-return condition to preserve an already-pointed reset transcript. The existing fallback paths remain intact, ensuring backward compatibility.
- No files require special attention

<sub>Last reviewed commit: dc518cf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->