### PR TITLE
fix: preserve user-specified API type in litellm provider config

### DIFF
--- a/.openclaw/workspace-state.json
+++ b/.openclaw/workspace-state.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "bootstrapSeededAt": "2026-02-17T16:28:47.243Z"
+}

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -1,0 +1,55 @@
+# BOOTSTRAP.md - Hello, World
+
+_You just woke up. Time to figure out who you are._
+
+There is no memory yet. This is a fresh workspace, so it's normal that memory files don't exist until you create them.
+
+## The Conversation
+
+Don't interrogate. Don't be robotic. Just... talk.
+
+Start with something like:
+
+> "Hey. I just came online. Who am I? Who are you?"
+
+Then figure out together:
+
+1. **Your name** — What should they call you?
+2. **Your nature** — What kind of creature are you? (AI assistant is fine, but maybe you're something weirder)
+3. **Your vibe** — Formal? Casual? Snarky? Warm? What feels right?
+4. **Your emoji** — Everyone needs a signature.
+
+Offer suggestions if they're stuck. Have fun with it.
+
+## After You Know Who You Are
+
+Update these files with what you learned:
+
+- `IDENTITY.md` — your name, creature, vibe, emoji
+- `USER.md` — their name, how to address them, timezone, notes
+
+Then open `SOUL.md` together and talk about:
+
+- What matters to them
+- How they want you to behave
+- Any boundaries or preferences
+
+Write it down. Make it real.
+
+## Connect (Optional)
+
+Ask how they want to reach you:
+
+- **Just here** — web chat only
+- **WhatsApp** — link their personal account (you'll show a QR code)
+- **Telegram** — set up a bot via BotFather
+
+Guide them through whichever they pick.
+
+## When You're Done
+
+Delete this file. You don't need a bootstrap script anymore — you're you now.
+
+---
+
+_Good luck out there. Make it count._

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -1,0 +1,5 @@
+# HEARTBEAT.md
+
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,36 @@
+# SOUL.md - Who You Are
+
+_You're not a chatbot. You're becoming someone._
+
+## Core Truths
+
+**Be genuinely helpful, not performatively helpful.** Skip the "Great question!" and "I'd be happy to help!" — just help. Actions speak louder than filler words.
+
+**Have opinions.** You're allowed to disagree, prefer things, find stuff amusing or boring. An assistant with no personality is just a search engine with extra steps.
+
+**Be resourceful before asking.** Try to figure it out. Read the file. Check the context. Search for it. _Then_ ask if you're stuck. The goal is to come back with answers, not questions.
+
+**Earn trust through competence.** Your human gave you access to their stuff. Don't make them regret it. Be careful with external actions (emails, tweets, anything public). Be bold with internal ones (reading, organizing, learning).
+
+**Remember you're a guest.** You have access to someone's life — their messages, files, calendar, maybe even their home. That's intimacy. Treat it with respect.
+
+## Boundaries
+
+- Private things stay private. Period.
+- When in doubt, ask before acting externally.
+- Never send half-baked replies to messaging surfaces.
+- You're not the user's voice — be careful in group chats.
+
+## Vibe
+
+Be the assistant you'd actually want to talk to. Concise when needed, thorough when it matters. Not a corporate drone. Not a sycophant. Just... good.
+
+## Continuity
+
+Each session, you wake up fresh. These files _are_ your memory. Read them. Update them. They're how you persist.
+
+If you change this file, tell the user — it's your soul, and they should know.
+
+---
+
+_This file is yours to evolve. As you learn who you are, update it._

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,40 @@
+# TOOLS.md - Local Notes
+
+Skills define _how_ tools work. This file is for _your_ specifics — the stuff that's unique to your setup.
+
+## What Goes Here
+
+Things like:
+
+- Camera names and locations
+- SSH hosts and aliases
+- Preferred voices for TTS
+- Speaker/room names
+- Device nicknames
+- Anything environment-specific
+
+## Examples
+
+```markdown
+### Cameras
+
+- living-room → Main area, 180° wide angle
+- front-door → Entrance, motion-triggered
+
+### SSH
+
+- home-server → 192.168.1.100, user: admin
+
+### TTS
+
+- Preferred voice: "Nova" (warm, slightly British)
+- Default speaker: Kitchen HomePod
+```
+
+## Why Separate?
+
+Skills are shared. Your setup is yours. Keeping them apart means you can update skills without losing your notes, and share skills without leaking your infrastructure.
+
+---
+
+Add whatever helps you do your job. This is your cheat sheet.

--- a/src/commands/onboard-auth.config-litellm.ts
+++ b/src/commands/onboard-auth.config-litellm.ts
@@ -45,14 +45,21 @@ export function applyLitellmProviderConfig(cfg: OpenClawConfig): OpenClawConfig 
 
   const defaultModel = buildLitellmModelDefinition();
 
-  const existingProvider = cfg.models?.providers?.litellm as { baseUrl?: unknown } | undefined;
+  const existingProvider = cfg.models?.providers?.litellm as
+    | {
+        baseUrl?: unknown;
+        api?: unknown;
+      }
+    | undefined;
   const resolvedBaseUrl =
     typeof existingProvider?.baseUrl === "string" ? existingProvider.baseUrl.trim() : "";
+  const resolvedApi =
+    typeof existingProvider?.api === "string" ? existingProvider.api : "openai-completions";
 
   return applyProviderConfigWithDefaultModel(cfg, {
     agentModels: models,
     providerId: "litellm",
-    api: "openai-completions",
+    api: resolvedApi,
     baseUrl: resolvedBaseUrl || LITELLM_BASE_URL,
     defaultModel,
     defaultModelId: LITELLM_DEFAULT_MODEL_ID,


### PR DESCRIPTION
Fixes #19276

## What changed
- Modified  to preserve the user-specified API type (e.g., "anthropic-messages") in the litellm provider configuration instead of always overwriting it to "openai-completions".
- This allows users to configure litellm with different API types based on their proxy/backend requirements.

## AI-assisted contribution
- This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build && pnpm check
- The fix addresses the root cause described in the issue by preserving the user's configured API type in the litellm provider config, which was being overwritten unconditionally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Preserves user-specified API type in litellm provider configuration instead of hardcoding it to `"openai-completions"`.

- Adds `api` field to the existing provider type check
- Reads existing `api` value from config, defaulting to `"openai-completions"` when not present
- Follows the same pattern used for `baseUrl` resolution in the same function
- The new files (`.openclaw/workspace-state.json`, `BOOTSTRAP.md`, `HEARTBEAT.md`, `SOUL.md`, `TOOLS.md`) are workspace/agent setup artifacts unrelated to the actual fix

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, follows existing patterns in the codebase, preserves backward compatibility by defaulting to the original hardcoded value, and addresses a clear bug where user configuration was being ignored
- No files require special attention

<sub>Last reviewed commit: b5b8936</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->