### PR TITLE
iOS: use operator session for ChatSheet RPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Auth: clear stale device-auth tokens after device token mismatch errors so re-paired clients can re-auth. (#18201)
 - Voice call/Gateway: prevent overlapping closed-loop turn races with per-call turn locking, route transcript dedupe via source-aware fingerprints with strict cache eviction bounds, and harden `voicecall latency` stats for large logs without spread-operator stack overflow. (#19140) Thanks @mbelinky.
 - iOS/Onboarding: stop auth Step 3 retry-loop churn by pausing reconnect attempts on unauthorized/missing-token gateway errors and keeping auth/pairing issue state sticky during manual retry. (#19153) Thanks @mbelinky.
+- iOS/Chat: route ChatSheet RPCs through the operator session instead of the node session to avoid node-role authorization failures for `chat.history`, `chat.send`, and `sessions.list`. (#19320) Thanks @mbelinky.
 - Fix types in all tests. Typecheck the whole repository.
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -97,9 +97,8 @@ struct RootCanvas: View {
                     .environment(self.gatewayController)
             case .chat:
                 ChatSheet(
-                    // Mobile chat UI should use the node role RPC surface (chat.* / sessions.*)
-                    // to avoid requiring operator scopes like operator.read.
-                    gateway: self.appModel.gatewaySession,
+                    // Chat RPCs run on the operator session (read/write scopes).
+                    gateway: self.appModel.operatorSession,
                     sessionKey: self.appModel.mainSessionKey,
                     agentName: self.appModel.activeAgentName,
                     userAccent: self.appModel.seamColor)


### PR DESCRIPTION
## Summary
- route `ChatSheet` to `operatorSession` instead of `gatewaySession` (node session)
- align iOS chat RPC calls (`chat.history`, `chat.send`, `sessions.list`) with gateway role authorization
- fix runtime error in chat: `chat.history: [INVALID_REQUEST] unauthorized role: node`

## Testing
- not run (Swift/iOS build not run in this CLI session)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a runtime authorization error in the iOS chat UI by routing `ChatSheet` RPC calls through the operator session instead of the node (gateway) session.

- The gateway's `authorizeGatewayMethod` function (`src/gateway/server-methods.ts:117-118`) rejects all non-`NODE_ROLE_METHODS` calls from the `node` role with `unauthorized role: node`. Chat methods (`chat.history`, `chat.send`, `chat.abort`, `sessions.list`) are categorized as operator read/write methods, not node-role methods, so they require the `operator` role with `operator.read`/`operator.write` scopes.
- Both `gatewaySession` and `operatorSession` are typed as `GatewayNodeSession`, so the change is type-safe. The operator session connects with `role: "operator"` and `scopes: ["operator.read", "operator.write", "operator.talk.secrets"]`, which satisfies the authorization requirements for all chat RPCs.
- The old comment ("use the node role RPC surface to avoid requiring operator scopes") was incorrect — the gateway already enforced operator-only access for these methods. The new comment accurately reflects the authorization model.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a verified authorization bug with a minimal, type-safe one-line change.
- The change is a single property swap (gatewaySession → operatorSession) that fixes a confirmed runtime error. Both properties return the same GatewayNodeSession type, so there's no type mismatch risk. The gateway's server-side authorization logic validates that chat RPCs require operator role, which the operatorSession provides. No new code paths are introduced, and the fix aligns the iOS client with the existing server authorization model.
- No files require special attention.

<sub>Last reviewed commit: 0753b3a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->