### PR TITLE
feat: support messages.mediaLocalRoots for custom media directories

### DIFF
--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -122,6 +122,12 @@ export type MessagesConfig = {
   suppressToolErrors?: boolean;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
+  /**
+   * Additional local directories allowed for media file attachments.
+   * Paths are resolved to absolute. Merged with the built-in roots
+   * (tmpdir, state-dir subdirs, agent workspace).
+   */
+  mediaLocalRoots?: string[];
 };
 
 export type NativeCommandsSetting = boolean | "auto";

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -188,6 +188,7 @@ export const MessagesSchema = z
       .optional(),
     suppressToolErrors: z.boolean().optional(),
     tts: TtsConfigSchema,
+    mediaLocalRoots: z.array(z.string()).optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -188,7 +188,7 @@ export const MessagesSchema = z
       .optional(),
     suppressToolErrors: z.boolean().optional(),
     tts: TtsConfigSchema,
-    mediaLocalRoots: z.array(z.string()).optional(),
+    mediaLocalRoots: z.array(z.string().min(1).startsWith("/")).optional(),
   })
   .strict()
   .optional();

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -41,16 +41,24 @@ export function getAgentScopedMediaLocalRoots(
   agentId?: string,
 ): readonly string[] {
   const roots = buildMediaLocalRoots(resolveStateDir());
-  if (!agentId?.trim()) {
-    return roots;
+  if (agentId?.trim()) {
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    if (workspaceDir) {
+      const normalizedWorkspaceDir = path.resolve(workspaceDir);
+      if (!roots.includes(normalizedWorkspaceDir)) {
+        roots.push(normalizedWorkspaceDir);
+      }
+    }
   }
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  if (!workspaceDir) {
-    return roots;
-  }
-  const normalizedWorkspaceDir = path.resolve(workspaceDir);
-  if (!roots.includes(normalizedWorkspaceDir)) {
-    roots.push(normalizedWorkspaceDir);
+  // Merge user-configured extra media roots from messages.mediaLocalRoots
+  const extra = cfg.messages?.mediaLocalRoots;
+  if (extra) {
+    for (const dir of extra) {
+      const resolved = path.resolve(dir);
+      if (!roots.includes(resolved)) {
+        roots.push(resolved);
+      }
+    }
   }
   return roots;
 }

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -54,7 +54,9 @@ export function getAgentScopedMediaLocalRoots(
   const extra = cfg.messages?.mediaLocalRoots;
   if (extra) {
     for (const dir of extra) {
-      const resolved = path.resolve(dir);
+      const trimmed = dir.trim();
+      if (!trimmed || !path.isAbsolute(trimmed)) continue;
+      const resolved = path.resolve(trimmed);
       if (!roots.includes(resolved)) {
         roots.push(resolved);
       }


### PR DESCRIPTION
## Problem

Agents cannot send local files (via the message tool's `filePath`/`media` parameters) from directories outside the built-in allowlist (tmpdir, state-dir subdirs, agent workspace). This forces workarounds like direct API calls with `curl` for common use cases:

- Sending images from ComfyUI/Stable Diffusion output directories
- Attaching files from custom asset folders
- Sharing generated content from any non-workspace directory

## Solution

Add a `messages.mediaLocalRoots` config option — an array of additional local directories to allow for media attachments. These are merged with the existing built-in roots and agent workspace directory.

### Example config

```json
{
  "messages": {
    "mediaLocalRoots": ["/home/user/assets", "/home/user/ComfyUI/output"]
  }
}
```

## Changes

- **`src/config/types.messages.ts`** — Add `mediaLocalRoots?: string[]` to `MessagesConfig`
- **`src/config/zod-schema.session.ts`** — Add `mediaLocalRoots` to the messages zod schema
- **`src/media/local-roots.ts`** — Read and merge user-configured roots in `getAgentScopedMediaLocalRoots()`

Paths are resolved to absolute and deduplicated against built-in roots. No filesystem-root entries are possible (existing validation in `assertLocalMediaAllowed` rejects them).

## Notes

- The `mediaLocalRoots` field already existed in the BlueBubbles channel schema but was never wired up globally. This PR adds it at the `messages` level so it applies across all channels.
- Minimal change: 3 files, ~24 lines added.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `messages.mediaLocalRoots` config to allow agents to send local files from custom directories beyond the built-in allowlist. Paths are validated as non-empty absolute paths at both schema load time and runtime, then merged with existing built-in roots. The implementation addresses prior review feedback by enforcing `min(1)` and `startsWith("/")` in the zod schema and adding defensive `trim()` + `isAbsolute()` checks in the runtime path resolution.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal (3 files, ~24 lines), address a clear use case, and include proper validation at both schema and runtime levels. Previous review concerns about empty strings and relative paths have been addressed with defensive validation. Existing security validation in `assertLocalMediaAllowed` prevents filesystem root entries. The implementation follows established patterns and doesn't introduce new attack vectors.
- No files require special attention

<sub>Last reviewed commit: 082f22b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->