### PR TITLE
Agents: improve z.ai GLM-5 integration and failover

### DIFF
--- a/src/agents/failover-error.e2e.test.ts
+++ b/src/agents/failover-error.e2e.test.ts
@@ -32,7 +32,12 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ message: "Unhandled stop reason: abort" })).toBe(
       "timeout",
     );
+    expect(resolveFailoverReasonFromError({ message: "Unhandled stop_reason: abort" })).toBe(
+      "timeout",
+    );
     expect(resolveFailoverReasonFromError({ message: "stop reason: abort" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ message: 'stop_reason = "abort"' })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ message: "finish_reason=abort" })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ message: "reason: abort" })).toBe("timeout");
   });
 

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -1,7 +1,7 @@
 import { classifyFailoverReason, type FailoverReason } from "./pi-embedded-helpers.js";
 
 const TIMEOUT_HINT_RE =
-  /timeout|timed out|deadline exceeded|context deadline exceeded|stop reason:\s*abort|reason:\s*abort|unhandled stop reason:\s*abort/i;
+  /timeout|timed out|deadline exceeded|context deadline exceeded|(?:unhandled\s+)?(?:stop|finish)[_\s]?reason\s*[:=]\s*["']?abort|reason\s*[:=]\s*["']?abort/i;
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
 
 export class FailoverError extends Error {

--- a/src/agents/model-compat.e2e.test.ts
+++ b/src/agents/model-compat.e2e.test.ts
@@ -66,7 +66,9 @@ describe("normalizeModelCompat", () => {
       compat: { supportsDeveloperRole: false },
     };
     const normalized = normalizeModelCompat(model);
-    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
     expect(normalized.input).toEqual(expect.arrayContaining(["image"]));
   });
 });

--- a/src/agents/model-compat.e2e.test.ts
+++ b/src/agents/model-compat.e2e.test.ts
@@ -45,4 +45,28 @@ describe("normalizeModelCompat", () => {
       (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
     ).toBe(false);
   });
+
+  it("marks glm-5 as image-capable for runtime feature gating", () => {
+    const model = {
+      ...baseModel(),
+      id: "glm-5",
+      name: "GLM-5",
+      input: ["text"] as Array<"text" | "image">,
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.input).toEqual(expect.arrayContaining(["text", "image"]));
+  });
+
+  it("keeps explicit compat false and still enables glm-5 image input", () => {
+    const model = {
+      ...baseModel(),
+      id: "glm-5",
+      name: "GLM-5",
+      input: ["text"] as Array<"text" | "image">,
+      compat: { supportsDeveloperRole: false },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+    expect(normalized.input).toEqual(expect.arrayContaining(["image"]));
+  });
 });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -4,6 +4,14 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
   return model.api === "openai-completions";
 }
 
+function isZaiGlm5Model(model: Model<Api>): boolean {
+  const normalizedId = model.id?.trim().toLowerCase();
+  if (!normalizedId) {
+    return false;
+  }
+  return normalizedId === "glm-5" || normalizedId.startsWith("glm-5-");
+}
+
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
   const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
@@ -13,12 +21,17 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
 
   const openaiModel = model;
   const compat = openaiModel.compat ?? undefined;
-  if (compat?.supportsDeveloperRole === false) {
-    return model;
+  if (compat?.supportsDeveloperRole !== false) {
+    openaiModel.compat = compat
+      ? { ...compat, supportsDeveloperRole: false }
+      : { supportsDeveloperRole: false };
   }
 
-  openaiModel.compat = compat
-    ? { ...compat, supportsDeveloperRole: false }
-    : { supportsDeveloperRole: false };
+  // Some pi-ai catalogs still mark GLM-5 as text-only. OpenClaw can use image
+  // inputs on GLM-5 endpoints, so advertise vision to unlock attachment flows.
+  if (isZaiGlm5Model(openaiModel) && !openaiModel.input.includes("image")) {
+    openaiModel.input = [...openaiModel.input, "image"];
+  }
+
   return openaiModel;
 }

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -12,7 +12,15 @@ const ANTHROPIC_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
 const ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS = ["claude-opus-4-5", "claude-opus-4.5"] as const;
 
 const ZAI_GLM5_MODEL_ID = "glm-5";
-const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
+const ZAI_GLM5_TEMPLATE_MODEL_IDS = [
+  "glm-5",
+  "glm-4.7",
+  "glm-4.7-flash",
+  "glm-4.7-flashx",
+] as const;
+const ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4";
+const ZAI_DEFAULT_CONTEXT_TOKENS = 204800;
+const ZAI_DEFAULT_MAX_TOKENS = 131072;
 
 const ANTIGRAVITY_OPUS_46_MODEL_ID = "claude-opus-4-6";
 const ANTIGRAVITY_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
@@ -173,11 +181,12 @@ function resolveZaiGlm5ForwardCompatModel(
     name: trimmed,
     api: "openai-completions",
     provider: "zai",
+    baseUrl: ZAI_DEFAULT_BASE_URL,
     reasoning: true,
-    input: ["text"],
+    input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    contextWindow: ZAI_DEFAULT_CONTEXT_TOKENS,
+    maxTokens: ZAI_DEFAULT_MAX_TOKENS,
   } as Model<Api>);
 }
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -289,7 +289,16 @@ describe("isFailoverErrorMessage", () => {
   });
 
   it("matches abort stop-reason timeout variants", () => {
-    const samples = ["Unhandled stop reason: abort", "stop reason: abort", "reason: abort"];
+    const samples = [
+      "Unhandled stop reason: abort",
+      "Unhandled stop_reason: abort",
+      "stop reason: abort",
+      'stop_reason = "abort"',
+      "finish reason: abort",
+      "finish_reason=abort",
+      "reason: abort",
+      "reason='abort'",
+    ];
     for (const sample of samples) {
       expect(isTimeoutErrorMessage(sample)).toBe(true);
       expect(classifyFailoverReason(sample)).toBe("timeout");

--- a/src/agents/pi-embedded-helpers.thinking.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.thinking.e2e.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeThinkLevelForProvider } from "./pi-embedded-helpers.js";
+
+describe("normalizeThinkLevelForProvider", () => {
+  it("keeps off for z.ai providers", () => {
+    expect(normalizeThinkLevelForProvider({ provider: "zai", thinkLevel: "off" })).toBe("off");
+  });
+
+  it("collapses non-off levels to low for z.ai providers", () => {
+    expect(normalizeThinkLevelForProvider({ provider: "zai", thinkLevel: "minimal" })).toBe("low");
+    expect(normalizeThinkLevelForProvider({ provider: "z.ai", thinkLevel: "high" })).toBe("low");
+    expect(normalizeThinkLevelForProvider({ provider: "z-ai", thinkLevel: "xhigh" })).toBe("low");
+  });
+
+  it("does not change non-zai providers", () => {
+    expect(normalizeThinkLevelForProvider({ provider: "anthropic", thinkLevel: "high" })).toBe(
+      "high",
+    );
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -51,7 +51,10 @@ export {
   normalizeTextForComparison,
 } from "./pi-embedded-helpers/messaging-dedupe.js";
 
-export { normalizeThinkLevelForProvider, pickFallbackThinkingLevel } from "./pi-embedded-helpers/thinking.js";
+export {
+  normalizeThinkLevelForProvider,
+  pickFallbackThinkingLevel,
+} from "./pi-embedded-helpers/thinking.js";
 
 export {
   mergeConsecutiveUserTurns,

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -51,7 +51,7 @@ export {
   normalizeTextForComparison,
 } from "./pi-embedded-helpers/messaging-dedupe.js";
 
-export { pickFallbackThinkingLevel } from "./pi-embedded-helpers/thinking.js";
+export { normalizeThinkLevelForProvider, pickFallbackThinkingLevel } from "./pi-embedded-helpers/thinking.js";
 
 export {
   mergeConsecutiveUserTurns,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -600,8 +600,13 @@ const ERROR_PATTERNS = {
     "context deadline exceeded",
     /without sending (?:any )?chunks?/i,
     /\bstop reason:\s*abort\b/i,
+    /\bstop_reason\s*[:=]\s*["']?abort\b/i,
     /\breason:\s*abort\b/i,
+    /\breason\s*[:=]\s*["']?abort\b/i,
     /\bunhandled stop reason:\s*abort\b/i,
+    /\bunhandled stop_reason:\s*abort\b/i,
+    /\bfinish reason:\s*abort\b/i,
+    /\bfinish_reason\s*[:=]\s*["']?abort\b/i,
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,

--- a/src/agents/pi-embedded-helpers/thinking.ts
+++ b/src/agents/pi-embedded-helpers/thinking.ts
@@ -1,5 +1,33 @@
 import { normalizeThinkLevel, type ThinkLevel } from "../../auto-reply/thinking.js";
 
+function normalizeProviderId(provider?: string | null): string {
+  if (!provider) {
+    return "";
+  }
+  const normalized = provider.trim().toLowerCase();
+  if (normalized === "z-ai" || normalized === "z.ai") {
+    return "zai";
+  }
+  return normalized;
+}
+
+/**
+ * Normalize model thinking levels for providers with binary switches.
+ *
+ * Z.AI accepts on/off-style thinking controls. Mapping all non-off values to
+ * `low` keeps behavior deterministic and avoids one failed call before fallback.
+ */
+export function normalizeThinkLevelForProvider(params: {
+  provider?: string | null;
+  thinkLevel: ThinkLevel;
+}): ThinkLevel {
+  const provider = normalizeProviderId(params.provider);
+  if (provider === "zai" && params.thinkLevel !== "off") {
+    return "low";
+  }
+  return params.thinkLevel;
+}
+
 function extractSupportedValues(raw: string): string[] {
   const match =
     raw.match(/supported values are:\s*([^\n.]+)/i) ?? raw.match(/supported values:\s*([^\n.]+)/i);

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -351,6 +351,8 @@ export async function compactEmbeddedPiSessionDirect(
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      provider,
+      modelId,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -302,6 +302,22 @@ describe("resolveModel", () => {
     });
   });
 
+  it("builds a default zai forward-compat fallback for glm-5 when no template exists", () => {
+    const result = resolveModel("zai", "glm-5", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "zai",
+      id: "glm-5",
+      api: "openai-completions",
+      baseUrl: "https://api.z.ai/api/paas/v4",
+      reasoning: true,
+      contextWindow: 204800,
+      maxTokens: 131072,
+    });
+    expect(result.model?.input).toEqual(expect.arrayContaining(["text", "image"]));
+  });
+
   it("keeps unknown-model errors when no antigravity thinking template exists", () => {
     expectUnknownModelError("google-antigravity", "claude-opus-4-6-thinking");
   });

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.e2e.test.ts
@@ -42,6 +42,7 @@ vi.mock("../pi-embedded-helpers.js", async () => {
     formatAssistantErrorText: vi.fn(() => ""),
     parseImageSizeError: vi.fn(() => null),
     pickFallbackThinkingLevel: vi.fn(() => null),
+    normalizeThinkLevelForProvider: vi.fn(({ thinkLevel }: { thinkLevel: string }) => thinkLevel),
     isTimeoutErrorMessage: vi.fn(() => false),
     parseImageDimensionError: vi.fn(() => null),
   };

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
@@ -42,7 +42,13 @@ vi.mock("../pi-embedded-helpers.js", () => ({
   formatAssistantErrorText: vi.fn(() => ""),
   isAuthAssistantError: vi.fn(() => false),
   isBillingAssistantError: vi.fn(() => false),
-  isCompactionFailureError: vi.fn(() => false),
+  isCompactionFailureError: vi.fn((msg?: string) => {
+    if (!msg) {
+      return false;
+    }
+    const lower = msg.toLowerCase();
+    return lower.includes("request_too_large") && lower.includes("summarization failed");
+  }),
   isLikelyContextOverflowError: vi.fn((msg?: string) => {
     const lower = (msg ?? "").toLowerCase();
     return lower.includes("request_too_large") || lower.includes("context window exceeded");
@@ -54,6 +60,7 @@ vi.mock("../pi-embedded-helpers.js", () => ({
   isRateLimitAssistantError: vi.fn(() => false),
   isTimeoutErrorMessage: vi.fn(() => false),
   pickFallbackThinkingLevel: vi.fn(() => null),
+  normalizeThinkLevelForProvider: vi.fn(({ thinkLevel }: { thinkLevel: string }) => thinkLevel),
 }));
 
 vi.mock("./run/attempt.js", () => ({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -102,7 +102,7 @@ import {
   selectCompactionTimeoutSnapshot,
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
-import { detectAndLoadPromptImages } from "./images.js";
+import { detectAndLoadPromptImages, modelSupportsImages } from "./images.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 export function injectHistoryImagesIntoMessages(
@@ -264,6 +264,8 @@ export async function runEmbeddedAttempt(
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      provider: params.provider,
+      modelId: params.modelId,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
@@ -284,7 +286,7 @@ export async function runEmbeddedAttempt(
     const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
 
     // Check if the model supports native image input
-    const modelHasVision = params.model.input?.includes("image") ?? false;
+    const modelHasVision = modelSupportsImages(params.model);
     const toolsRaw = params.disableTools
       ? []
       : createOpenClawCodingTools({
@@ -553,6 +555,8 @@ export async function runEmbeddedAttempt(
       const clientToolLoopDetection = resolveToolLoopDetectionConfig({
         cfg: params.config,
         agentId: sessionAgentId,
+        provider: params.provider,
+        modelId: params.modelId,
       });
       const clientToolDefs = params.clientTools
         ? toClientToolDefinitions(

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -676,10 +676,13 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getMessagingToolSentMediaUrls: () => messagingToolSentMediaUrls.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
     getSuccessfulCronAdds: () => state.successfulCronAdds,
-    // Returns true if any messaging tool successfully sent a message.
+    // Returns true if any messaging tool successfully sent outbound content.
     // Used to suppress agent's confirmation text (e.g., "Respondi no Telegram!")
     // which is generated AFTER the tool sends the actual answer.
-    didSendViaMessagingTool: () => messagingToolSentTexts.length > 0,
+    didSendViaMessagingTool: () =>
+      messagingToolSentTexts.length > 0 ||
+      messagingToolSentTargets.length > 0 ||
+      messagingToolSentMediaUrls.length > 0,
     getLastToolError: () => (state.lastToolError ? { ...state.lastToolError } : undefined),
     getUsageTotals,
     getCompactionCount: () => compactionCount,

--- a/src/agents/pi-tool-definition-adapter.after-tool-call.e2e.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.e2e.test.ts
@@ -150,14 +150,25 @@ describe("pi tool definition adapter after_tool_call", () => {
       name: "bash",
       label: "Bash",
       description: "throws",
-      parameters: {},
+      parameters: Type.Object({}),
       execute: vi.fn(async () => {
         throw new Error("boom");
       }),
-    } satisfies AgentTool<unknown, unknown>;
+    } satisfies AgentTool;
 
     const defs = toToolDefinitions([tool]);
-    const result = await defs[0].execute("call-err-adjusted", { cmd: "ls" }, undefined, undefined);
+    const def = defs[0];
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+    const execute = (...args: Parameters<(typeof defs)[0]["execute"]>) => def.execute(...args);
+    const result = await execute(
+      "call-err-adjusted",
+      { cmd: "ls" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
 
     expect(result.details).toMatchObject({
       status: "error",

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -147,9 +147,9 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
           if (name === "AbortError") {
             throw err;
           }
-          if (beforeHookWrapped) {
-            consumeAdjustedParamsForToolCall(toolCallId);
-          }
+          const afterParams = beforeHookWrapped
+            ? (consumeAdjustedParamsForToolCall(toolCallId) ?? executeParams)
+            : executeParams;
           const described = describeToolExecutionError(err);
           if (described.stack && described.stack !== described.message) {
             logDebug(`tools: ${normalizedName} failed stack:\n${described.stack}`);
@@ -169,7 +169,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
               await hookRunner.runAfterToolCall(
                 {
                   toolName: normalizedName,
-                  params: isPlainObject(params) ? params : {},
+                  params: isPlainObject(afterParams) ? afterParams : {},
                   error: described.message,
                 },
                 { toolName: normalizedName },

--- a/src/agents/pi-tools.loop-detection-config.e2e.test.ts
+++ b/src/agents/pi-tools.loop-detection-config.e2e.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveToolLoopDetectionConfig } from "./pi-tools.js";
+
+describe("resolveToolLoopDetectionConfig", () => {
+  it("returns undefined by default for non-zai providers", () => {
+    const resolved = resolveToolLoopDetectionConfig({
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+    });
+    expect(resolved).toBeUndefined();
+  });
+
+  it("enables tighter defaults for zai glm models", () => {
+    const resolved = resolveToolLoopDetectionConfig({
+      provider: "z.ai",
+      modelId: "glm-5",
+    });
+    expect(resolved).toMatchObject({
+      enabled: true,
+      historySize: 24,
+      warningThreshold: 6,
+      criticalThreshold: 10,
+      globalCircuitBreakerThreshold: 14,
+      detectors: {
+        genericRepeat: true,
+        knownPollNoProgress: true,
+        pingPong: true,
+      },
+    });
+  });
+
+  it("merges configured values while filling missing zai glm defaults", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        loopDetection: {
+          warningThreshold: 9,
+          detectors: { pingPong: false },
+        },
+      },
+    };
+    const resolved = resolveToolLoopDetectionConfig({
+      cfg,
+      provider: "zai",
+      modelId: "glm-5",
+    });
+    expect(resolved).toMatchObject({
+      enabled: true,
+      historySize: 24,
+      warningThreshold: 9,
+      criticalThreshold: 10,
+      globalCircuitBreakerThreshold: 14,
+      detectors: {
+        genericRepeat: true,
+        knownPollNoProgress: true,
+        pingPong: false,
+      },
+    });
+  });
+
+  it("respects explicit enabled=false for zai glm configs", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        loopDetection: {
+          enabled: false,
+        },
+      },
+    };
+    const resolved = resolveToolLoopDetectionConfig({
+      cfg,
+      provider: "z-ai",
+      modelId: "glm-5",
+    });
+    expect(resolved?.enabled).toBe(false);
+  });
+});

--- a/src/agents/skills.resolveskillspromptforrun.e2e.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.e2e.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { SkillEntry } from "./skills.js";
 import { resolveSkillsPromptForRun } from "./skills.js";
 import type { SkillEntry } from "./skills/types.js";
 
@@ -28,5 +29,29 @@ describe("resolveSkillsPromptForRun", () => {
     });
     expect(prompt).toContain("<available_skills>");
     expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
+  });
+
+  it("rebuilds snapshot prompts for zai glm models", () => {
+    const resolvedSkills = [
+      {
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/app/skills/demo-skill/SKILL.md",
+        baseDir: "/app/skills/demo-skill",
+        source: "openclaw-bundled",
+      },
+    ];
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt: "SNAPSHOT",
+        skills: [],
+        resolvedSkills,
+      },
+      workspaceDir: "/tmp/openclaw",
+      provider: "zai",
+      modelId: "glm-5",
+    });
+    expect(prompt).toContain("<available_skills>");
+    expect(prompt).not.toBe("SNAPSHOT");
   });
 });

--- a/src/agents/skills.resolveskillspromptforrun.e2e.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.e2e.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SkillEntry } from "./skills.js";
 import { resolveSkillsPromptForRun } from "./skills.js";
-import type { SkillEntry } from "./skills/types.js";
 
 describe("resolveSkillsPromptForRun", () => {
   it("prefers snapshot prompt when available", () => {
@@ -39,6 +38,7 @@ describe("resolveSkillsPromptForRun", () => {
         filePath: "/app/skills/demo-skill/SKILL.md",
         baseDir: "/app/skills/demo-skill",
         source: "openclaw-bundled",
+        disableModelInvocation: false,
       },
     ];
     const prompt = resolveSkillsPromptForRun({

--- a/src/agents/zai.live.test.ts
+++ b/src/agents/zai.live.test.ts
@@ -1,4 +1,5 @@
-import { completeSimple, getModel } from "@mariozechner/pi-ai";
+import { complete, completeSimple, getModel } from "@mariozechner/pi-ai";
+import { Type } from "@sinclair/typebox";
 import { describe, expect, it } from "vitest";
 import { isTruthyEnvValue } from "../infra/env.js";
 
@@ -7,8 +8,13 @@ const LIVE = isTruthyEnvValue(process.env.ZAI_LIVE_TEST) || isTruthyEnvValue(pro
 
 const describeLive = LIVE && ZAI_KEY ? describe : describe.skip;
 
-async function expectModelReturnsAssistantText(modelId: "glm-4.7" | "glm-4.7-flashx") {
-  const model = getModel("zai", modelId as "glm-4.7");
+type ZaiLiveModelId = "glm-5" | "glm-4.7" | "glm-4.7-flashx";
+
+async function expectModelReturnsAssistantText(modelId: ZaiLiveModelId) {
+  const model = getModel("zai", modelId as "glm-5");
+  if (!model) {
+    throw new Error(`Model not available in catalog: zai/${modelId}`);
+  }
   const res = await completeSimple(
     model,
     {
@@ -29,12 +35,73 @@ async function expectModelReturnsAssistantText(modelId: "glm-4.7" | "glm-4.7-fla
   expect(text.length).toBeGreaterThan(0);
 }
 
-describeLive("zai live", () => {
-  it("returns assistant text", async () => {
-    await expectModelReturnsAssistantText("glm-4.7");
-  }, 20000);
+async function expectModelReturnsToolCall(modelId: "glm-5") {
+  const model = getModel("zai", modelId as "glm-5");
+  if (!model) {
+    throw new Error(`Model not available in catalog: zai/${modelId}`);
+  }
+  const res = await complete(
+    model,
+    {
+      messages: [
+        {
+          role: "user",
+          content: "Call the ping tool with {} and do not add extra text.",
+          timestamp: Date.now(),
+        },
+      ],
+      tools: [
+        {
+          name: "ping",
+          description: "Return pong",
+          parameters: Type.Object({}),
+        },
+      ],
+    },
+    { apiKey: ZAI_KEY, maxTokens: 64, temperature: 0, toolChoice: "required" },
+  );
+  const hasToolCall = res.content.some((block) => block.type === "toolCall");
+  expect(hasToolCall).toBe(true);
+}
 
-  it("glm-4.7-flashx returns assistant text", async () => {
-    await expectModelReturnsAssistantText("glm-4.7-flashx");
-  }, 20000);
+function hasZaiModel(modelId: ZaiLiveModelId): boolean {
+  try {
+    return Boolean(getModel("zai", modelId as "glm-5"));
+  } catch {
+    return false;
+  }
+}
+
+describeLive("zai live", () => {
+  it.skipIf(!hasZaiModel("glm-5"))(
+    "glm-5 returns assistant text",
+    async () => {
+      await expectModelReturnsAssistantText("glm-5");
+    },
+    20000,
+  );
+
+  it.skipIf(!hasZaiModel("glm-4.7"))(
+    "glm-4.7 returns assistant text",
+    async () => {
+      await expectModelReturnsAssistantText("glm-4.7");
+    },
+    20000,
+  );
+
+  it.skipIf(!hasZaiModel("glm-5"))(
+    "glm-5 returns tool call",
+    async () => {
+      await expectModelReturnsToolCall("glm-5");
+    },
+    30000,
+  );
+
+  it.skipIf(!hasZaiModel("glm-4.7-flashx"))(
+    "glm-4.7-flashx returns assistant text",
+    async () => {
+      await expectModelReturnsAssistantText("glm-4.7-flashx");
+    },
+    20000,
+  );
 });

--- a/src/commands/zai-endpoint-detect.e2e.test.ts
+++ b/src/commands/zai-endpoint-detect.e2e.test.ts
@@ -2,8 +2,21 @@ import { describe, expect, it } from "vitest";
 import { detectZaiEndpoint } from "./zai-endpoint-detect.js";
 
 function makeFetch(map: Record<string, { status: number; body?: unknown }>) {
-  return (async (url: string) => {
-    const entry = map[url];
+  return (async (url: string, init?: RequestInit) => {
+    let model = "";
+    try {
+      const rawBody = init?.body;
+      if (typeof rawBody === "string") {
+        const parsed = JSON.parse(rawBody) as { model?: unknown };
+        if (typeof parsed.model === "string") {
+          model = parsed.model;
+        }
+      }
+    } catch {
+      // ignore malformed body in tests
+    }
+    const modelKey = model ? `${url}::${model}` : "";
+    const entry = (modelKey && map[modelKey]) || map[url];
     if (!entry) {
       throw new Error(`unexpected url: ${url}`);
     }
@@ -40,11 +53,25 @@ describe("detectZaiEndpoint", () => {
     expect(detected?.modelId).toBe("glm-5");
   });
 
-  it("falls back to coding endpoint with glm-4.7", async () => {
+  it("uses glm-5 on coding endpoint when available", async () => {
     const fetchFn = makeFetch({
       "https://api.z.ai/api/paas/v4/chat/completions": { status: 404 },
       "https://open.bigmodel.cn/api/paas/v4/chat/completions": { status: 404 },
-      "https://api.z.ai/api/coding/paas/v4/chat/completions": { status: 200 },
+      "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5": { status: 200 },
+    });
+
+    const detected = await detectZaiEndpoint({ apiKey: "sk-test", fetchFn });
+    expect(detected?.endpoint).toBe("coding-global");
+    expect(detected?.modelId).toBe("glm-5");
+  });
+
+  it("falls back to coding endpoint with glm-4.7 when coding glm-5 fails", async () => {
+    const fetchFn = makeFetch({
+      "https://api.z.ai/api/paas/v4/chat/completions": { status: 404 },
+      "https://open.bigmodel.cn/api/paas/v4/chat/completions": { status: 404 },
+      "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5": { status: 404 },
+      "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5": { status: 404 },
+      "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-4.7": { status: 200 },
     });
 
     const detected = await detectZaiEndpoint({ apiKey: "sk-test", fetchFn });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: z.AI GLM integration had multiple rough edges vs Opus-grade behavior (endpoint probing fallback, thinking-level mismatch handling, tool loop resilience, model capability metadata, and compaction/auth retry ergonomics).
- Why it matters: these issues increased failure rates (or avoidable retries), especially in long tool-heavy sessions where users expect stable behavior with lower-cost GLM models.
- What changed: improved GLM endpoint/model handling, provider-aware thinking/tool-loop/auth cooldown behavior, GLM-focused skills prompt compaction, and additional safety/observability tests (including live z.AI probes).
- What did NOT change (scope boundary): no dependency patches, no broad architecture refactor, no unrelated channel behavior changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `zai-endpoint-detect` now probes `glm-5` on coding endpoints before downgrading to `glm-4.7`.
- GLM-5 model compatibility now consistently forces `supportsDeveloperRole=false` and marks GLM-5 as image-capable where catalog metadata lags.
- Provider-aware thinking normalization now maps non-`off` thinking levels to `low` for z.AI to avoid unsupported-level retries.
- GLM runs get tighter default skills prompt limits and model-aware prompt rebuild from stored snapshots.
- GLM tool sessions get safer default loop-detection thresholds unless explicitly overridden.
- z.AI rate-limit/timeout auth-profile cooldown backoff is tuned to recover faster while preserving default behavior for non-rate failures.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node 25.x, pnpm, Vitest
- Model/provider: z.AI (`glm-5`, `glm-4.7`)
- Integration/channel (if any): embedded agent runtime + gateway model probes
- Relevant config (redacted): local `~/.openclaw/openclaw.json` with z.AI credentials

### Steps

1. Run targeted unit/e2e suites for changed GLM/auth/skills/tool-loop paths.
2. Run live z.AI test suite (`src/agents/zai.live.test.ts`).
3. Validate endpoint detect fallback behavior and overflow compaction regression coverage.

### Expected

- GLM-5 path succeeds without avoidable downgrade/retry loops.
- Tool loops are guarded with sane defaults for GLM.
- Skills prompt remains compact and stable for GLM runs.
- Auth rotation recovers from z.AI rate limits more smoothly.

### Actual

- All targeted unit/e2e suites passed.
- Live z.AI probes passed (`glm-5` text, `glm-5` tool call, `glm-4.7` text).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence snippets from local runs:

- `pnpm vitest run --config vitest.e2e.config.ts ...` → 11 files / 86 tests passed
- `pnpm vitest run --config vitest.unit.config.ts ...` → 4 files / 43 tests passed
- `ZAI_LIVE_TEST=1 pnpm vitest run --config vitest.live.config.ts src/agents/zai.live.test.ts` → 3 passed / 1 skipped

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - endpoint detection prefers `glm-5` where supported
  - z.AI thinking normalization avoids unsupported-level retry churn
  - GLM snapshot skills prompt rebuild + compact limits
  - GLM loop-detection defaults and config merge behavior
  - z.AI rate-limit cooldown tuning
  - live `glm-5` tool-call path
- Edge cases checked:
  - explicit compat false still preserves GLM-5 image capability
  - compaction path resilience when compact helper returns empty result
  - mock coverage updated for new helper exports
- What you did **not** verify:
  - full repository test matrix / full CI runtime
  - production traffic behavior across all providers/channels

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit
  - temporarily pin to non-GLM provider/model in agent defaults
  - override loop-detection/auth cooldown values in config if needed
- Files/config to restore:
  - `src/agents/pi-tools.ts`
  - `src/agents/auth-profiles/usage.ts`
  - `src/agents/skills/workspace.ts`
  - `src/agents/model-compat.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected aggressive loop blocks for custom tool flows
  - provider mismatch if non-z.AI models are accidentally treated as GLM
  - compaction retry behavior regressions in overflow paths

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: GLM loop thresholds may be too strict for some long polling workflows.
  - Mitigation: thresholds are still config-overridable; merge logic preserves explicit user config.
- Risk: provider/model heuristics (`zai` + `glm-*`) might not match future naming.
  - Mitigation: scoped helper checks + tests; fallback behavior remains existing defaults when no match.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved z.AI GLM integration with better endpoint detection, provider-aware defaults, and auth retry tuning.

**Major changes:**
- Endpoint detection now probes `glm-5` on coding endpoints before falling back to `glm-4.7`
- Provider-aware thinking normalization maps non-`off` thinking levels to `low` for z.AI to avoid unsupported-level retries
- GLM models get tighter loop detection defaults (`warningThreshold: 6`, `criticalThreshold: 10`) with config merge logic that preserves explicit user overrides
- Skills prompt compaction for GLM models (80 skills/16k chars vs 150 skills/30k chars default), with snapshot rebuild logic for GLM runs
- z.AI rate-limit/timeout cooldown uses faster backoff (20s, 60s, 3m, 9m vs default geometric progression)
- Tool stream enabled by default for GLM-5 models (opt-out via `tool_stream: false` param)
- GLM-5 forward-compat fallback includes vision capability (`input: ["text", "image"]`) and correct context limits
- Defensive null check for compaction result before accessing properties
- Tool start metadata isolation by `runId::toolCallId` composite key to prevent cross-run collisions
- Media URL deduplication when committing messaging tool sends

**Testing:**
Comprehensive test coverage includes endpoint detection fallback paths, loop detection config merging, skills prompt rebuilding for GLM, thinking normalization, auth cooldown tuning, tool metadata isolation, and live z.AI probes.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor edge case considerations
- Comprehensive changes with thorough test coverage across all modified paths. The PR addresses real integration issues with z.AI GLM models and includes defensive programming patterns. Minor deduction due to the broad scope touching multiple critical paths (auth, loop detection, skills, endpoint detection) and potential for provider heuristics to need future adjustments.
- No files require special attention - changes are well-tested and follow established patterns

<sub>Last reviewed commit: 12ab0d7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->