### PR TITLE
Fix: preserve modelOverride in agent handler (#5369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/agents: preserve fresh session overrides and metadata when stale cached agent-session entries race with store updates, so subagent model/provider overrides and routing policy survive concurrent writes. (#19328) Thanks @CodeReclaimers.
 - Restore Control UI gateway token pairing [AI]. (#85459) Thanks @pgondhi987.
 - CLI/update: repair managed npm plugin `openclaw` peer links during post-core convergence and reject stale or wrong-target peer links before restart. (#83794) Thanks @fuller-stack-dev.
 - CLI/agents: default new omitted-account bindings to all accounts when the channel has multiple configured accounts, and clarify account-scope docs. (#49769) Thanks @Gcaufy.

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1068,6 +1068,67 @@ describe("gateway agent handler", () => {
     expect(capturedEntry?.modelOverride).toBe("qwen3-coder:30b");
     expect(capturedEntry?.providerOverride).toBe("ollama");
   });
+  // Broader regression guard for the #5369 stale-writeback class: any field
+  // that the patch blindly carries from the cached entry will clobber a fresh
+  // concurrent write. The fix dropped all such fields from the patch; this
+  // test ensures none get silently re-added. If a future change puts e.g.
+  // `sendPolicy: entry?.sendPolicy` back into the patch, this test fails.
+  it("preserves all fresh session fields when cached entry is stale (#5369 broader)", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "subagent-session-id",
+        updatedAt: Date.now() - 1000,
+        // All fields below absent — stale pre-patch view
+      },
+      canonicalKey: "agent:main:subagent:test-broader",
+    });
+    const freshFields = {
+      sendPolicy: "allow",
+      skillsSnapshot: { tools: ["bash"] },
+      thinkingLevel: "high",
+      fastMode: true,
+      verboseLevel: "detailed",
+      traceLevel: "info",
+      reasoningLevel: "on",
+      systemSent: true,
+      spawnedWorkspaceDir: "/work/fresh",
+      spawnDepth: 2,
+      cliSessionIds: { "claude-cli": "fresh-cli-id" },
+      cliSessionBindings: { "claude-cli": { sessionId: "fresh-binding" } },
+      claudeCliSessionId: "fresh-cli-id",
+    };
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const freshStore: Record<string, Record<string, unknown>> = {
+        "agent:main:subagent:test-broader": {
+          sessionId: "subagent-session-id",
+          updatedAt: Date.now(),
+          ...freshFields,
+        },
+      };
+      const result = await updater(freshStore);
+      capturedEntry = freshStore["agent:main:subagent:test-broader"];
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:subagent:test-broader",
+        idempotencyKey: "test-5369-broader",
+      },
+      { reqId: "broader-1" },
+    );
+    for (const [field, expected] of Object.entries(freshFields)) {
+      expect(capturedEntry?.[field]).toEqual(expected);
+    }
+  });
   it("reactivates completed subagent sessions and broadcasts send updates", async () => {
     const childSessionKey = "agent:main:subagent:followup";
     const completedRun = {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1021,6 +1021,53 @@ describe("gateway agent handler", () => {
     expect(capturedEntry.cliSessionIds).toEqual(existingCliSessionIds);
     expect(capturedEntry.claudeCliSessionId).toBe(existingClaudeCliSessionId);
   });
+  // #5369: sessions.patch can write modelOverride to the session store between
+  // when the agent handler reads its cached entry and when updateSessionStore
+  // runs. The handler's loadSessionEntry may return the stale pre-patch entry
+  // (no modelOverride), while the store-load inside updateSessionStore has the
+  // fresh value. If the patch built from the stale entry carries modelOverride:
+  // undefined, the merge {...fresh, ...patch} clobbers the fresh value.
+  it("preserves fresh modelOverride when cached entry is stale (#5369)", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "subagent-session-id",
+        updatedAt: Date.now() - 1000,
+        // modelOverride absent — stale pre-patch view
+      },
+      canonicalKey: "agent:main:subagent:test-uuid",
+    });
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const freshStore: Record<string, Record<string, unknown>> = {
+        "agent:main:subagent:test-uuid": {
+          sessionId: "subagent-session-id",
+          updatedAt: Date.now(),
+          modelOverride: "qwen3-coder:30b",
+          providerOverride: "ollama",
+        },
+      };
+      const result = await updater(freshStore);
+      capturedEntry = freshStore["agent:main:subagent:test-uuid"];
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:subagent:test-uuid",
+        idempotencyKey: "test-5369-race",
+      },
+      { reqId: "race-1" },
+    );
+    expect(capturedEntry?.modelOverride).toBe("qwen3-coder:30b");
+    expect(capturedEntry?.providerOverride).toBe("ollama");
+  });
   it("reactivates completed subagent sessions and broadcasts send updates", async () => {
     const childSessionKey = "agent:main:subagent:followup";
     const completedRun = {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1166,6 +1166,7 @@ describe("gateway agent handler", () => {
     });
     mocks.resolveSessionLifecycleTimestamps.mockReturnValue({
       sessionStartedAt: recoveredStartedAt,
+      lastInteractionAt: undefined,
     });
     let capturedEntry: Record<string, unknown> | undefined;
     mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
@@ -1213,6 +1214,7 @@ describe("gateway agent handler", () => {
     });
     mocks.resolveSessionLifecycleTimestamps.mockReturnValue({
       sessionStartedAt: recoveredStartedAt,
+      lastInteractionAt: undefined,
     });
     let capturedEntry: Record<string, unknown> | undefined;
     mocks.updateSessionStore.mockImplementation(async (_path, updater) => {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -40,7 +40,7 @@ const mocks = vi.hoisted(() => ({
   loadConfigReturn: {} as Record<string, unknown>,
   loadVoiceWakeRoutingConfig: vi.fn(),
   resolveVoiceWakeRouteByTrigger: vi.fn(),
-  resolveSendPolicy: vi.fn(() => "allow"),
+  resolveSendPolicy: vi.fn((_args?: { entry?: { sendPolicy?: string } }) => "allow"),
   resolveSessionLifecycleTimestamps: vi.fn(
     ({ entry }: { entry?: { sessionStartedAt?: number; lastInteractionAt?: number } }) => ({
       sessionStartedAt: entry?.sessionStartedAt,
@@ -1110,6 +1110,19 @@ describe("gateway agent handler", () => {
       systemSent: true,
       spawnedWorkspaceDir: "/work/fresh",
       spawnDepth: 2,
+      label: "fresh-label",
+      spawnedBy: "agent:main:main",
+      channel: "telegram",
+      deliveryContext: {
+        channel: "telegram",
+        to: "12345",
+        accountId: "acct-1",
+        threadId: 42,
+      },
+      lastChannel: "telegram",
+      lastTo: "12345",
+      lastAccountId: "acct-1",
+      lastThreadId: 42,
       cliSessionIds: { "claude-cli": "fresh-cli-id" },
       cliSessionBindings: { "claude-cli": { sessionId: "fresh-binding" } },
       claudeCliSessionId: "fresh-cli-id",
@@ -1143,6 +1156,122 @@ describe("gateway agent handler", () => {
     for (const [field, expected] of Object.entries(freshFields)) {
       expect(capturedEntry?.[field]).toEqual(expected);
     }
+  });
+  it("checks delivery sendPolicy against the fresh store entry (#5369)", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "subagent-session-id",
+        updatedAt: Date.now() - 1000,
+        // sendPolicy absent — stale pre-patch view
+      },
+      canonicalKey: "agent:main:subagent:test-policy",
+    });
+    const freshUpdatedAt = Date.now();
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const freshStore: Record<string, Record<string, unknown>> = {
+        "agent:main:subagent:test-policy": {
+          sessionId: "subagent-session-id",
+          updatedAt: freshUpdatedAt,
+          sendPolicy: "deny",
+          channel: "telegram",
+        },
+      };
+      const result = await updater(freshStore);
+      capturedEntry = freshStore["agent:main:subagent:test-policy"];
+      return result;
+    });
+    mocks.resolveSendPolicy.mockImplementation((args?: { entry?: { sendPolicy?: string } }) =>
+      args?.entry?.sendPolicy === "deny" ? "deny" : "allow",
+    );
+    mocks.agentCommand.mockClear();
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    const respond = vi.fn();
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:subagent:test-policy",
+        channel: "telegram",
+        to: "99999",
+        deliver: true,
+        idempotencyKey: "test-5369-policy",
+      },
+      { reqId: "policy-1", respond },
+    );
+    expectRespondError(respond, { message: "send blocked by session policy" });
+    const sendPolicyArgs = expectRecordFields(mockCallArg(mocks.resolveSendPolicy), {
+      sessionKey: "agent:main:subagent:test-policy",
+    });
+    expectRecordFields(sendPolicyArgs.entry, { sendPolicy: "deny" });
+    expectRecordFields(capturedEntry, {
+      sessionId: "subagent-session-id",
+      updatedAt: freshUpdatedAt,
+      sendPolicy: "deny",
+      channel: "telegram",
+      deliveryContext: undefined,
+      lastTo: undefined,
+    });
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+  });
+  it("does not restore a stale session id over a fresh store rotation (#5369)", async () => {
+    mocks.resolveSessionLifecycleTimestamps.mockImplementation(
+      ({ entry }: { entry?: { sessionId?: string; sessionStartedAt?: number } }) => ({
+        sessionStartedAt: entry?.sessionId === "old-session-id" ? 123 : entry?.sessionStartedAt,
+        lastInteractionAt: undefined,
+      }),
+    );
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "old-session-id",
+        updatedAt: Date.now() - 1000,
+      },
+      canonicalKey: "agent:main:subagent:test-rotation",
+    });
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const freshStore: Record<string, Record<string, unknown>> = {
+        "agent:main:subagent:test-rotation": {
+          sessionId: "fresh-session-id",
+          updatedAt: Date.now(),
+          status: "running",
+          startedAt: 111,
+          sessionFile: "/tmp/fresh-session.jsonl",
+        },
+      };
+      const result = await updater(freshStore);
+      capturedEntry = freshStore["agent:main:subagent:test-rotation"];
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:subagent:test-rotation",
+        idempotencyKey: "test-5369-rotation",
+      },
+      { reqId: "rotation-1" },
+    );
+
+    expectRecordFields(capturedEntry, {
+      sessionId: "fresh-session-id",
+      status: "running",
+      startedAt: 111,
+      sessionStartedAt: undefined,
+      sessionFile: "/tmp/fresh-session.jsonl",
+    });
   });
   // Upgrade-path self-heal: a legacy session entry may lack sessionStartedAt
   // because the field was added after the entry was first persisted. The
@@ -3695,7 +3824,7 @@ describe("gateway agent handler", () => {
       let capturedEntry: Record<string, unknown> | undefined;
       mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
         const store: Record<string, unknown> = {
-          [sessionKey]: { sessionId: "existing-session-id" },
+          [sessionKey]: { sessionId: "existing-session-id", ...entry },
         };
         await updater(store);
         capturedEntry = store[sessionKey] as Record<string, unknown>;

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -41,6 +41,12 @@ const mocks = vi.hoisted(() => ({
   loadVoiceWakeRoutingConfig: vi.fn(),
   resolveVoiceWakeRouteByTrigger: vi.fn(),
   resolveSendPolicy: vi.fn(() => "allow"),
+  resolveSessionLifecycleTimestamps: vi.fn(
+    ({ entry }: { entry?: { sessionStartedAt?: number; lastInteractionAt?: number } }) => ({
+      sessionStartedAt: entry?.sessionStartedAt,
+      lastInteractionAt: entry?.lastInteractionAt,
+    }),
+  ),
 }));
 
 vi.mock("../session-utils.js", async () => {
@@ -59,6 +65,7 @@ vi.mock("../../config/sessions.js", async () => {
   return {
     ...actual,
     updateSessionStore: mocks.updateSessionStore,
+    resolveSessionLifecycleTimestamps: mocks.resolveSessionLifecycleTimestamps,
     resolveAgentIdFromSessionKey: (sessionKey: string) => {
       const m = /^agent:([^:]+):/.exec(sessionKey.trim());
       return m?.[1] ?? "main";
@@ -497,6 +504,14 @@ describe("gateway agent handler", () => {
     mocks.resolveBareResetBootstrapFileAccess.mockReset().mockReturnValue(true);
     mocks.listAgentIds.mockReset().mockReturnValue(["main"]);
     mocks.resolveSendPolicy.mockReset().mockReturnValue("allow");
+    mocks.resolveSessionLifecycleTimestamps
+      .mockReset()
+      .mockImplementation(
+        ({ entry }: { entry?: { sessionStartedAt?: number; lastInteractionAt?: number } }) => ({
+          sessionStartedAt: entry?.sessionStartedAt,
+          lastInteractionAt: entry?.lastInteractionAt,
+        }),
+      );
     dateOnlyFakeClockActive = false;
     vi.useRealTimers();
     resetExecApprovalFollowupRuntimeHandoffsForTests();
@@ -1128,6 +1143,105 @@ describe("gateway agent handler", () => {
     for (const [field, expected] of Object.entries(freshFields)) {
       expect(capturedEntry?.[field]).toEqual(expected);
     }
+  });
+  // Upgrade-path self-heal: a legacy session entry may lack sessionStartedAt
+  // because the field was added after the entry was first persisted. The
+  // handler recovers it from the transcript JSONL header and writes it back,
+  // but only when the fresh store still lacks the field — so a concurrent
+  // writer that sets it cannot be clobbered (the #5369 stale-writeback class).
+  it("self-heals missing sessionStartedAt from JSONL when fresh store also lacks it", async () => {
+    // Use a value distinct from `now` but recent enough that
+    // evaluateSessionFreshness — which also calls the mocked
+    // resolveSessionLifecycleTimestamps — keeps this session fresh.
+    const recoveredStartedAt = Date.now() - 5_000;
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "legacy-session-id",
+        updatedAt: Date.now() - 1000,
+        // sessionStartedAt absent — legacy schema
+      },
+      canonicalKey: "agent:main:subagent:legacy",
+    });
+    mocks.resolveSessionLifecycleTimestamps.mockReturnValue({
+      sessionStartedAt: recoveredStartedAt,
+    });
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const freshStore: Record<string, Record<string, unknown>> = {
+        "agent:main:subagent:legacy": {
+          sessionId: "legacy-session-id",
+          updatedAt: Date.now(),
+          // sessionStartedAt absent on disk too — self-heal should fire
+        },
+      };
+      const result = await updater(freshStore);
+      capturedEntry = freshStore["agent:main:subagent:legacy"];
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:subagent:legacy",
+        idempotencyKey: "test-selfheal-write",
+      },
+      { reqId: "selfheal-1" },
+    );
+    expect(capturedEntry?.sessionStartedAt).toBe(recoveredStartedAt);
+  });
+  it("does not clobber fresh sessionStartedAt with the recovered candidate", async () => {
+    // See note in the prior test: keep both values recent so freshness
+    // evaluation (which also reads the lifecycle mock) doesn't trip the
+    // idle-reset path and turn this into an isNewSession path.
+    const recoveredStartedAt = Date.now() - 5_000;
+    const freshStartedAt = Date.now() - 2_500;
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "legacy-session-id",
+        updatedAt: Date.now() - 1000,
+        // sessionStartedAt absent in cached entry — would trigger recovery
+      },
+      canonicalKey: "agent:main:subagent:concurrent",
+    });
+    mocks.resolveSessionLifecycleTimestamps.mockReturnValue({
+      sessionStartedAt: recoveredStartedAt,
+    });
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const freshStore: Record<string, Record<string, unknown>> = {
+        "agent:main:subagent:concurrent": {
+          sessionId: "legacy-session-id",
+          updatedAt: Date.now(),
+          // Concurrent writer set sessionStartedAt between cache load and lock
+          sessionStartedAt: freshStartedAt,
+        },
+      };
+      const result = await updater(freshStore);
+      capturedEntry = freshStore["agent:main:subagent:concurrent"];
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:subagent:concurrent",
+        idempotencyKey: "test-selfheal-noclobber",
+      },
+      { reqId: "selfheal-2" },
+    );
+    expect(capturedEntry?.sessionStartedAt).toBe(freshStartedAt);
   });
   it("reactivates completed subagent sessions and broadcasts send updates", async () => {
     const childSessionKey = "agent:main:subagent:followup";

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -882,6 +882,67 @@ describe("gateway agent handler", () => {
     expect(capturedEntry?.modelOverride).toBe("qwen3-coder:30b");
     expect(capturedEntry?.providerOverride).toBe("ollama");
   });
+  // Broader regression guard for the #5369 stale-writeback class: any field
+  // that the patch blindly carries from the cached entry will clobber a fresh
+  // concurrent write. The fix dropped all such fields from the patch; this
+  // test ensures none get silently re-added. If a future change puts e.g.
+  // `sendPolicy: entry?.sendPolicy` back into the patch, this test fails.
+  it("preserves all fresh session fields when cached entry is stale (#5369 broader)", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "subagent-session-id",
+        updatedAt: Date.now() - 1000,
+        // All fields below absent — stale pre-patch view
+      },
+      canonicalKey: "agent:main:subagent:test-broader",
+    });
+    const freshFields = {
+      sendPolicy: "allow",
+      skillsSnapshot: { tools: ["bash"] },
+      thinkingLevel: "high",
+      fastMode: true,
+      verboseLevel: "detailed",
+      traceLevel: "info",
+      reasoningLevel: "on",
+      systemSent: true,
+      spawnedWorkspaceDir: "/work/fresh",
+      spawnDepth: 2,
+      cliSessionIds: { "claude-cli": "fresh-cli-id" },
+      cliSessionBindings: { "claude-cli": { sessionId: "fresh-binding" } },
+      claudeCliSessionId: "fresh-cli-id",
+    };
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const freshStore: Record<string, Record<string, unknown>> = {
+        "agent:main:subagent:test-broader": {
+          sessionId: "subagent-session-id",
+          updatedAt: Date.now(),
+          ...freshFields,
+        },
+      };
+      const result = await updater(freshStore);
+      capturedEntry = freshStore["agent:main:subagent:test-broader"];
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:subagent:test-broader",
+        idempotencyKey: "test-5369-broader",
+      },
+      { reqId: "broader-1" },
+    );
+    for (const [field, expected] of Object.entries(freshFields)) {
+      expect(capturedEntry?.[field]).toEqual(expected);
+    }
+  });
   it("reactivates completed subagent sessions and broadcasts send updates", async () => {
     const childSessionKey = "agent:main:subagent:followup";
     const completedRun = {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -835,6 +835,53 @@ describe("gateway agent handler", () => {
     expect(capturedEntry.cliSessionIds).toEqual(existingCliSessionIds);
     expect(capturedEntry.claudeCliSessionId).toBe(existingClaudeCliSessionId);
   });
+  // #5369: sessions.patch can write modelOverride to the session store between
+  // when the agent handler reads its cached entry and when updateSessionStore
+  // runs. The handler's loadSessionEntry may return the stale pre-patch entry
+  // (no modelOverride), while the store-load inside updateSessionStore has the
+  // fresh value. If the patch built from the stale entry carries modelOverride:
+  // undefined, the merge {...fresh, ...patch} clobbers the fresh value.
+  it("preserves fresh modelOverride when cached entry is stale (#5369)", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "subagent-session-id",
+        updatedAt: Date.now() - 1000,
+        // modelOverride absent — stale pre-patch view
+      },
+      canonicalKey: "agent:main:subagent:test-uuid",
+    });
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const freshStore: Record<string, Record<string, unknown>> = {
+        "agent:main:subagent:test-uuid": {
+          sessionId: "subagent-session-id",
+          updatedAt: Date.now(),
+          modelOverride: "qwen3-coder:30b",
+          providerOverride: "ollama",
+        },
+      };
+      const result = await updater(freshStore);
+      capturedEntry = freshStore["agent:main:subagent:test-uuid"];
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:subagent:test-uuid",
+        idempotencyKey: "test-5369-race",
+      },
+      { reqId: "race-1" },
+    );
+    expect(capturedEntry?.modelOverride).toBe("qwen3-coder:30b");
+    expect(capturedEntry?.providerOverride).toBe("ollama");
+  });
   it("reactivates completed subagent sessions and broadcasts send updates", async () => {
     const childSessionKey = "agent:main:subagent:followup";
     const completedRun = {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1415,6 +1415,19 @@ export const agentHandlers: GatewayRequestHandlers = {
         resolvedSessionKey = canonicalSessionKey;
         const agentId = resolveAgentIdFromSessionKey(canonicalSessionKey);
         const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId });
+        // Legacy stores may lack sessionStartedAt entirely. Pre-compute a
+        // JSONL-transcript-derived candidate outside the store lock; the
+        // updater below only writes it when the freshly-loaded store still
+        // lacks the field, so a concurrent writer that sets it cannot be
+        // clobbered (the #5369 stale-writeback class).
+        const recoveredSessionStartedAt: number | undefined =
+          !isNewSession && entry !== undefined && entry.sessionStartedAt === undefined
+            ? resolveSessionLifecycleTimestamps({
+                entry,
+                storePath,
+                agentId,
+              }).sessionStartedAt
+            : undefined;
         if (storePath) {
           const requestedStoreKey = requestedSessionKey;
           const persisted = await updateSessionStore(storePath, (store) => {
@@ -1423,7 +1436,12 @@ export const agentHandlers: GatewayRequestHandlers = {
               key: requestedStoreKey,
               store,
             });
-            const merged = mergeSessionEntry(store[primaryKey], nextEntryPatch);
+            const effectivePatch =
+              recoveredSessionStartedAt !== undefined &&
+              store[primaryKey]?.sessionStartedAt === undefined
+                ? { ...nextEntryPatch, sessionStartedAt: recoveredSessionStartedAt }
+                : nextEntryPatch;
+            const merged = mergeSessionEntry(store[primaryKey], effectivePatch);
             store[primaryKey] = merged;
             return merged;
           });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1254,68 +1254,14 @@ export const agentHandlers: GatewayRequestHandlers = {
           request.bootstrapContextRunKind !== "cron" &&
           request.bootstrapContextRunKind !== "heartbeat" &&
           !request.internalEvents?.length;
-        const labelValue = normalizeOptionalString(request.label) || entry?.label;
-        const pluginOwnerId =
-          entry === undefined
-            ? normalizeOptionalString(client?.internal?.pluginRuntimeOwnerId)
-            : normalizeOptionalString(entry.pluginOwnerId);
         const sessionAgent = resolveAgentIdFromSessionKey(canonicalKey);
-        spawnedByValue = canonicalizeSpawnedByForAgent(cfg, sessionAgent, entry?.spawnedBy);
-        const storedGroup = normalizeTrustedGroupMetadata(entry);
-        let inheritedGroup: TrustedGroupMetadata | undefined;
-        if (
-          spawnedByValue &&
-          (!storedGroup.groupId || !storedGroup.groupChannel || !storedGroup.groupSpace)
-        ) {
-          try {
-            const parentEntry = loadSessionEntry(spawnedByValue)?.entry;
-            inheritedGroup = normalizeTrustedGroupMetadata({
-              groupId: parentEntry?.groupId,
-              groupChannel: parentEntry?.groupChannel,
-              groupSpace: parentEntry?.space,
-            });
-          } catch {
-            inheritedGroup = undefined;
-          }
-        }
-        const trustedGroup = resolveTrustedGroupMetadata({
-          sessionKey: canonicalKey,
-          spawnedBy: spawnedByValue,
-          stored: storedGroup,
-          inherited: inheritedGroup,
-        });
-        const validatedGroup = trustedGroup.groupId
-          ? resolveTrustedGroupId({
-              groupId: trustedGroup.groupId,
-              sessionKey: canonicalKey,
-              spawnedBy: spawnedByValue,
-            })
-          : undefined;
-        if (validatedGroup?.dropped) {
-          resolvedGroupId = undefined;
-          resolvedGroupChannel = undefined;
-          resolvedGroupSpace = undefined;
-        } else {
-          const trustRequestSelectors =
-            Boolean(trustedGroup.groupId) &&
-            requestGroupMatchesTrusted({
-              requestGroupId: normalizedSpawned.groupId,
-              trustedGroupId: trustedGroup.groupId,
-            });
-          resolvedGroupId = trustedGroup.groupId;
-          resolvedGroupChannel =
-            trustedGroup.groupChannel ??
-            (trustRequestSelectors ? normalizedSpawned.groupChannel : undefined);
-          resolvedGroupSpace =
-            trustedGroup.groupSpace ??
-            (trustRequestSelectors ? normalizedSpawned.groupSpace : undefined);
-        }
-        const deliveryFields = normalizeSessionDeliveryFields(entry);
-        // When the session has no delivery context yet (e.g. a freshly-spawned subagent
-        // with deliver: false), seed it from the request's channel/to/threadId params.
-        // Without this, subagent sessions end up with a channel-only deliveryContext
-        // and no `to`/`threadId`, which causes announce delivery to either target the
-        // wrong channel (when the parent's lastTo drifts) or fail entirely.
+        type AgentSessionPatchBuild = {
+          patch: Partial<SessionEntry>;
+          spawnedBy: string | undefined;
+          groupId: string | undefined;
+          groupChannel: string | undefined;
+          groupSpace: string | undefined;
+        };
         const requestDeliveryHint = normalizeDeliveryContext({
           channel: request.channel?.trim(),
           to: request.to?.trim(),
@@ -1324,93 +1270,139 @@ export const agentHandlers: GatewayRequestHandlers = {
           // string and numeric threadIds (e.g., Matrix uses integers).
           threadId: request.threadId,
         });
-        const effectiveDelivery = mergeDeliveryContext(
-          deliveryFields.deliveryContext,
-          requestDeliveryHint,
-        );
-        const effectiveDeliveryFields = normalizeSessionDeliveryFields({
-          route: deliveryFields.route,
-          deliveryContext: effectiveDelivery,
-        });
-        // Patch carries only fields derived from the current request. Fields
-        // read from the stale cached `entry` must NOT appear here — the patch
-        // is later merged via `{...freshStore, ...patch}` in updateSessionStore,
-        // so any stale value in the patch would clobber a fresh store value
-        // written concurrently (e.g. by sessions.patch setting modelOverride
-        // on a subagent between spawn and run — see #5369).
-        const nextEntryPatch: Partial<SessionEntry> = {
-          sessionId,
-          updatedAt: now,
-          // sessionStartedAt is only written for genuinely new sessions; the
-          // reuse path lets mergeSessionEntry preserve the freshStore value
-          // (and re-derive from updatedAt if absent). Reading entry?.sessionStartedAt
-          // here would re-introduce the #5369 stale-writeback class.
-          ...(isNewSession ? { sessionStartedAt: now } : {}),
-          // Same principle for lastInteractionAt: only write the request-derived
-          // value (now) when this run actually counts as user interaction; let
-          // mergeSessionEntry preserve freshStore otherwise.
-          ...(touchInteraction ? { lastInteractionAt: now } : {}),
-          route: effectiveDeliveryFields.route,
-          deliveryContext: effectiveDeliveryFields.deliveryContext,
-          lastChannel: effectiveDeliveryFields.lastChannel ?? entry?.lastChannel,
-          lastTo: effectiveDeliveryFields.lastTo ?? entry?.lastTo,
-          lastAccountId: effectiveDeliveryFields.lastAccountId ?? entry?.lastAccountId,
-          lastThreadId: effectiveDeliveryFields.lastThreadId ?? entry?.lastThreadId,
-          label: labelValue,
-          spawnedBy: spawnedByValue,
-          channel: entry?.channel ?? request.channel?.trim(),
-          // groupId/groupChannel/space carry the *validated* request-derived
-          // values; trust resolution against session key + spawnedBy happens
-          // upstream in resolveTrustedGroup (#73720). Falling back to entry?.X
-          // here would bypass that validation and let a forged groupId persist
-          // across reconnects.
-          groupId: resolvedGroupId,
-          groupChannel: resolvedGroupChannel,
-          space: resolvedGroupSpace,
-          // Only seed pluginOwnerId when the session is brand new (no cached
-          // entry) and the value comes from the connecting client. For existing
-          // entries pluginOwnerId is read from the stale cache, so writing it
-          // back into the patch would be the same #5369 stale-writeback bug.
-          ...(entry === undefined && pluginOwnerId ? { pluginOwnerId } : {}),
-          // On session rotation (failed-with-missing-transcript or sessionId
-          // change), explicitly clear the failed run's lifecycle state and
-          // transcript path. In the same-session case omit these fields so
-          // mergeSessionEntry preserves the freshStore values — falling back
-          // to `entry?.X` would re-introduce the #5369 stale-writeback class.
-          ...(rotatedSessionId
-            ? {
-                status: undefined,
-                startedAt: undefined,
-                endedAt: undefined,
-                runtimeMs: undefined,
-                abortedLastRun: undefined,
-                sessionFile: undefined,
-              }
-            : {}),
-          // cliSessionIds / cliSessionBindings / claudeCliSessionId are
-          // intentionally NOT carried via `entry?.X` writebacks here:
-          // mergeSessionEntry preserves them from the fresh store, and reading
-          // them from the stale cache would be the #5369 stale-writeback class.
-        };
-        sessionEntry = mergeSessionEntry(entry, nextEntryPatch);
-        if (request.deliver === true) {
-          const sendPolicy = resolveSendPolicy({
+        const buildSessionPatch = (
+          freshEntry: SessionEntry | undefined,
+        ): AgentSessionPatchBuild => {
+          const freshSpawnedBy = canonicalizeSpawnedByForAgent(
             cfg,
-            entry: sessionEntry,
-            sessionKey: canonicalKey,
-            channel: sessionEntry?.channel,
-            chatType: sessionEntry?.chatType,
-          });
-          if (sendPolicy === "deny") {
-            respond(
-              false,
-              undefined,
-              errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"),
-            );
-            return;
+            sessionAgent,
+            freshEntry?.spawnedBy,
+          );
+          const storedGroup = normalizeTrustedGroupMetadata(freshEntry);
+          let inheritedGroup: TrustedGroupMetadata | undefined;
+          if (
+            freshSpawnedBy &&
+            (!storedGroup.groupId || !storedGroup.groupChannel || !storedGroup.groupSpace)
+          ) {
+            try {
+              const parentEntry = loadSessionEntry(freshSpawnedBy)?.entry;
+              inheritedGroup = normalizeTrustedGroupMetadata({
+                groupId: parentEntry?.groupId,
+                groupChannel: parentEntry?.groupChannel,
+                groupSpace: parentEntry?.space,
+              });
+            } catch {
+              inheritedGroup = undefined;
+            }
           }
-        }
-        resolvedSessionId = sessionId;
+          const trustedGroup = resolveTrustedGroupMetadata({
+            sessionKey: canonicalKey,
+            spawnedBy: freshSpawnedBy,
+            stored: storedGroup,
+            inherited: inheritedGroup,
+          });
+          const validatedGroup = trustedGroup.groupId
+            ? resolveTrustedGroupId({
+                groupId: trustedGroup.groupId,
+                sessionKey: canonicalKey,
+                spawnedBy: freshSpawnedBy,
+              })
+            : undefined;
+          const nextGroup =
+            validatedGroup?.dropped === true
+              ? {
+                  groupId: undefined,
+                  groupChannel: undefined,
+                  groupSpace: undefined,
+                }
+              : (() => {
+                  const trustRequestSelectors =
+                    Boolean(trustedGroup.groupId) &&
+                    requestGroupMatchesTrusted({
+                      requestGroupId: normalizedSpawned.groupId,
+                      trustedGroupId: trustedGroup.groupId,
+                    });
+                  return {
+                    groupId: trustedGroup.groupId,
+                    groupChannel:
+                      trustedGroup.groupChannel ??
+                      (trustRequestSelectors ? normalizedSpawned.groupChannel : undefined),
+                    groupSpace:
+                      trustedGroup.groupSpace ??
+                      (trustRequestSelectors ? normalizedSpawned.groupSpace : undefined),
+                  };
+                })();
+
+          const deliveryFields = normalizeSessionDeliveryFields(freshEntry);
+          // When the session has no delivery context yet (e.g. a freshly-spawned
+          // subagent with deliver: false), seed it from request channel/to/threadId.
+          const effectiveDelivery = mergeDeliveryContext(
+            deliveryFields.deliveryContext,
+            requestDeliveryHint,
+          );
+          const effectiveDeliveryFields = normalizeSessionDeliveryFields({
+            route: deliveryFields.route,
+            deliveryContext: effectiveDelivery,
+          });
+          const labelValue = normalizeOptionalString(request.label) || freshEntry?.label;
+          const channelValue = freshEntry?.channel ?? request.channel?.trim();
+          const pluginOwnerId =
+            freshEntry === undefined
+              ? normalizeOptionalString(client?.internal?.pluginRuntimeOwnerId)
+              : undefined;
+          const freshSessionRotatedSinceLoad = Boolean(
+            entry?.sessionId && freshEntry?.sessionId && freshEntry.sessionId !== entry.sessionId,
+          );
+          const patchSessionId = freshSessionRotatedSinceLoad ? freshEntry?.sessionId : sessionId;
+          const shouldClearRotatedState = rotatedSessionId && !freshSessionRotatedSinceLoad;
+          const patch: Partial<SessionEntry> = {
+            sessionId: patchSessionId,
+            updatedAt: now,
+            ...(isNewSession && !freshSessionRotatedSinceLoad ? { sessionStartedAt: now } : {}),
+            ...(touchInteraction ? { lastInteractionAt: now } : {}),
+            ...(effectiveDeliveryFields.route ? { route: effectiveDeliveryFields.route } : {}),
+            ...(effectiveDeliveryFields.deliveryContext
+              ? { deliveryContext: effectiveDeliveryFields.deliveryContext }
+              : {}),
+            ...(effectiveDeliveryFields.lastChannel
+              ? { lastChannel: effectiveDeliveryFields.lastChannel }
+              : {}),
+            ...(effectiveDeliveryFields.lastTo ? { lastTo: effectiveDeliveryFields.lastTo } : {}),
+            ...(effectiveDeliveryFields.lastAccountId
+              ? { lastAccountId: effectiveDeliveryFields.lastAccountId }
+              : {}),
+            ...(effectiveDeliveryFields.lastThreadId != null
+              ? { lastThreadId: effectiveDeliveryFields.lastThreadId }
+              : {}),
+            ...(labelValue ? { label: labelValue } : {}),
+            ...(freshSpawnedBy ? { spawnedBy: freshSpawnedBy } : {}),
+            ...(channelValue ? { channel: channelValue } : {}),
+            groupId: nextGroup.groupId,
+            groupChannel: nextGroup.groupChannel,
+            space: nextGroup.groupSpace,
+            ...(pluginOwnerId ? { pluginOwnerId } : {}),
+            ...(shouldClearRotatedState
+              ? {
+                  status: undefined,
+                  startedAt: undefined,
+                  endedAt: undefined,
+                  runtimeMs: undefined,
+                  abortedLastRun: undefined,
+                  sessionFile: undefined,
+                }
+              : {}),
+          };
+          return {
+            patch,
+            spawnedBy: freshSpawnedBy,
+            groupId: nextGroup.groupId,
+            groupChannel: nextGroup.groupChannel,
+            groupSpace: nextGroup.groupSpace,
+          };
+        };
+        let patchBuild = buildSessionPatch(entry);
+        sessionEntry = mergeSessionEntry(entry, patchBuild.patch);
+        resolvedSessionId = sessionEntry?.sessionId ?? sessionId;
         const canonicalSessionKey = canonicalKey;
         resolvedSessionKey = canonicalSessionKey;
         const agentId = resolveAgentIdFromSessionKey(canonicalSessionKey);
@@ -1430,22 +1422,72 @@ export const agentHandlers: GatewayRequestHandlers = {
             : undefined;
         if (storePath) {
           const requestedStoreKey = requestedSessionKey;
+          let deniedBySendPolicy = false;
           const persisted = await updateSessionStore(storePath, (store) => {
             const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
               cfg,
               key: requestedStoreKey,
               store,
             });
+            const freshEntry = store[primaryKey];
+            patchBuild = buildSessionPatch(freshEntry);
             const effectivePatch =
               recoveredSessionStartedAt !== undefined &&
-              store[primaryKey]?.sessionStartedAt === undefined
-                ? { ...nextEntryPatch, sessionStartedAt: recoveredSessionStartedAt }
-                : nextEntryPatch;
-            const merged = mergeSessionEntry(store[primaryKey], effectivePatch);
+              freshEntry?.sessionStartedAt === undefined &&
+              freshEntry?.sessionId === entry?.sessionId
+                ? { ...patchBuild.patch, sessionStartedAt: recoveredSessionStartedAt }
+                : patchBuild.patch;
+            const merged = mergeSessionEntry(freshEntry, effectivePatch);
+            const sendPolicy =
+              request.deliver === true
+                ? resolveSendPolicy({
+                    cfg,
+                    entry: merged,
+                    sessionKey: canonicalKey,
+                    channel: merged?.channel,
+                    chatType: merged?.chatType,
+                  })
+                : "allow";
+            if (sendPolicy === "deny") {
+              deniedBySendPolicy = true;
+              return merged;
+            }
             store[primaryKey] = merged;
             return merged;
           });
-          sessionEntry = persisted;
+          if (persisted) {
+            sessionEntry = persisted;
+            resolvedSessionId = sessionEntry.sessionId;
+          }
+          if (deniedBySendPolicy) {
+            respond(
+              false,
+              undefined,
+              errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"),
+            );
+            return;
+          }
+        }
+        spawnedByValue = patchBuild.spawnedBy;
+        resolvedGroupId = patchBuild.groupId;
+        resolvedGroupChannel = patchBuild.groupChannel;
+        resolvedGroupSpace = patchBuild.groupSpace;
+        if (request.deliver === true) {
+          const sendPolicy = resolveSendPolicy({
+            cfg,
+            entry: sessionEntry,
+            sessionKey: canonicalKey,
+            channel: sessionEntry?.channel,
+            chatType: sessionEntry?.chatType,
+          });
+          if (sendPolicy === "deny") {
+            respond(
+              false,
+              undefined,
+              errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"),
+            );
+            return;
+          }
         }
         if (canonicalSessionKey === mainSessionKey || canonicalSessionKey === "global") {
           context.addChatRun(idem, {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1332,43 +1332,51 @@ export const agentHandlers: GatewayRequestHandlers = {
           route: deliveryFields.route,
           deliveryContext: effectiveDelivery,
         });
-        const nextEntryPatch: SessionEntry = {
+        // Patch carries only fields derived from the current request. Fields
+        // read from the stale cached `entry` must NOT appear here — the patch
+        // is later merged via `{...freshStore, ...patch}` in updateSessionStore,
+        // so any stale value in the patch would clobber a fresh store value
+        // written concurrently (e.g. by sessions.patch setting modelOverride
+        // on a subagent between spawn and run — see #5369).
+        const nextEntryPatch: Partial<SessionEntry> = {
           sessionId,
           updatedAt: now,
-          sessionStartedAt: isNewSession
-            ? now
-            : (entry?.sessionStartedAt ??
-              resolveSessionLifecycleTimestamps({
-                entry,
-                storePath,
-                agentId: resolveAgentIdFromSessionKey(canonicalKey),
-              }).sessionStartedAt),
-          lastInteractionAt: touchInteraction ? now : entry?.lastInteractionAt,
-          thinkingLevel: entry?.thinkingLevel,
-          fastMode: entry?.fastMode,
-          verboseLevel: entry?.verboseLevel,
-          traceLevel: entry?.traceLevel,
-          reasoningLevel: entry?.reasoningLevel,
-          systemSent: entry?.systemSent,
-          sendPolicy: entry?.sendPolicy,
-          skillsSnapshot: entry?.skillsSnapshot,
+          // sessionStartedAt is only written for genuinely new sessions; the
+          // reuse path lets mergeSessionEntry preserve the freshStore value
+          // (and re-derive from updatedAt if absent). Reading entry?.sessionStartedAt
+          // here would re-introduce the #5369 stale-writeback class.
+          ...(isNewSession ? { sessionStartedAt: now } : {}),
+          // Same principle for lastInteractionAt: only write the request-derived
+          // value (now) when this run actually counts as user interaction; let
+          // mergeSessionEntry preserve freshStore otherwise.
+          ...(touchInteraction ? { lastInteractionAt: now } : {}),
           route: effectiveDeliveryFields.route,
           deliveryContext: effectiveDeliveryFields.deliveryContext,
           lastChannel: effectiveDeliveryFields.lastChannel ?? entry?.lastChannel,
           lastTo: effectiveDeliveryFields.lastTo ?? entry?.lastTo,
           lastAccountId: effectiveDeliveryFields.lastAccountId ?? entry?.lastAccountId,
           lastThreadId: effectiveDeliveryFields.lastThreadId ?? entry?.lastThreadId,
-          modelOverride: entry?.modelOverride,
-          providerOverride: entry?.providerOverride,
           label: labelValue,
           spawnedBy: spawnedByValue,
-          spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
-          spawnDepth: entry?.spawnDepth,
           channel: entry?.channel ?? request.channel?.trim(),
+          // groupId/groupChannel/space carry the *validated* request-derived
+          // values; trust resolution against session key + spawnedBy happens
+          // upstream in resolveTrustedGroup (#73720). Falling back to entry?.X
+          // here would bypass that validation and let a forged groupId persist
+          // across reconnects.
           groupId: resolvedGroupId,
           groupChannel: resolvedGroupChannel,
           space: resolvedGroupSpace,
-          ...(pluginOwnerId ? { pluginOwnerId } : {}),
+          // Only seed pluginOwnerId when the session is brand new (no cached
+          // entry) and the value comes from the connecting client. For existing
+          // entries pluginOwnerId is read from the stale cache, so writing it
+          // back into the patch would be the same #5369 stale-writeback bug.
+          ...(entry === undefined && pluginOwnerId ? { pluginOwnerId } : {}),
+          // On session rotation (failed-with-missing-transcript or sessionId
+          // change), explicitly clear the failed run's lifecycle state and
+          // transcript path. In the same-session case omit these fields so
+          // mergeSessionEntry preserves the freshStore values — falling back
+          // to `entry?.X` would re-introduce the #5369 stale-writeback class.
           ...(rotatedSessionId
             ? {
                 status: undefined,
@@ -1378,10 +1386,11 @@ export const agentHandlers: GatewayRequestHandlers = {
                 abortedLastRun: undefined,
                 sessionFile: undefined,
               }
-            : { sessionFile: entry?.sessionFile }),
-          cliSessionIds: entry?.cliSessionIds,
-          cliSessionBindings: entry?.cliSessionBindings,
-          claudeCliSessionId: entry?.claudeCliSessionId,
+            : {}),
+          // cliSessionIds / cliSessionBindings / claudeCliSessionId are
+          // intentionally NOT carried via `entry?.X` writebacks here:
+          // mergeSessionEntry preserves them from the fresh store, and reading
+          // them from the stale cache would be the #5369 stale-writeback class.
         };
         sessionEntry = mergeSessionEntry(entry, nextEntryPatch);
         if (request.deliver === true) {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1048,47 +1048,56 @@ export const agentHandlers: GatewayRequestHandlers = {
       const effectiveDeliveryFields = normalizeSessionDeliveryFields({
         deliveryContext: effectiveDelivery,
       });
-      const nextEntryPatch: SessionEntry = {
+      // Patch carries only fields derived from the current request. Fields
+      // read from the stale cached `entry` must NOT appear here — the patch
+      // is later merged via `{...freshStore, ...patch}` in updateSessionStore,
+      // so any stale value in the patch would clobber a fresh store value
+      // written concurrently (e.g. by sessions.patch setting modelOverride
+      // on a subagent between spawn and run — see #5369).
+      const nextEntryPatch: Partial<SessionEntry> = {
         sessionId,
         updatedAt: now,
-        sessionStartedAt: isNewSession
-          ? now
-          : (entry?.sessionStartedAt ??
-            resolveSessionLifecycleTimestamps({
-              entry,
-              storePath,
-              agentId: resolveAgentIdFromSessionKey(canonicalKey),
-            }).sessionStartedAt),
-        lastInteractionAt: touchInteraction ? now : entry?.lastInteractionAt,
-        thinkingLevel: entry?.thinkingLevel,
-        fastMode: entry?.fastMode,
-        verboseLevel: entry?.verboseLevel,
-        traceLevel: entry?.traceLevel,
-        reasoningLevel: entry?.reasoningLevel,
-        systemSent: entry?.systemSent,
-        sendPolicy: entry?.sendPolicy,
-        skillsSnapshot: entry?.skillsSnapshot,
+        // sessionStartedAt is only written for genuinely new sessions; the
+        // reuse path lets mergeSessionEntry preserve the freshStore value
+        // (and re-derive from updatedAt if absent). Reading entry?.sessionStartedAt
+        // here would re-introduce the #5369 stale-writeback class.
+        ...(isNewSession ? { sessionStartedAt: now } : {}),
+        // Same principle for lastInteractionAt: only write the request-derived
+        // value (now) when this run actually counts as user interaction; let
+        // mergeSessionEntry preserve freshStore otherwise.
+        ...(touchInteraction ? { lastInteractionAt: now } : {}),
         deliveryContext: effectiveDeliveryFields.deliveryContext,
         lastChannel: effectiveDeliveryFields.lastChannel ?? entry?.lastChannel,
         lastTo: effectiveDeliveryFields.lastTo ?? entry?.lastTo,
         lastAccountId: effectiveDeliveryFields.lastAccountId ?? entry?.lastAccountId,
         lastThreadId: effectiveDeliveryFields.lastThreadId ?? entry?.lastThreadId,
-        modelOverride: entry?.modelOverride,
-        providerOverride: entry?.providerOverride,
         label: labelValue,
         spawnedBy: spawnedByValue,
-        spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
-        spawnDepth: entry?.spawnDepth,
         channel: entry?.channel ?? request.channel?.trim(),
+        // groupId/groupChannel/space carry the *validated* request-derived
+        // values; trust resolution against session key + spawnedBy happens
+        // upstream in resolveTrustedGroup (#73720). Falling back to entry?.X
+        // here would bypass that validation and let a forged groupId persist
+        // across reconnects.
         groupId: resolvedGroupId,
         groupChannel: resolvedGroupChannel,
         space: resolvedGroupSpace,
-        ...(pluginOwnerId ? { pluginOwnerId } : {}),
-        sessionFile:
-          entry?.sessionId && entry.sessionId !== sessionId ? undefined : entry?.sessionFile,
-        cliSessionIds: entry?.cliSessionIds,
-        cliSessionBindings: entry?.cliSessionBindings,
-        claudeCliSessionId: entry?.claudeCliSessionId,
+        // Only seed pluginOwnerId when the session is brand new (no cached
+        // entry) and the value comes from the connecting client. For existing
+        // entries pluginOwnerId is read from the stale cache, so writing it
+        // back into the patch would be the same #5369 stale-writeback bug.
+        ...(entry === undefined && pluginOwnerId ? { pluginOwnerId } : {}),
+        // On session rotation, explicitly clear the stale transcript path
+        // (#79076). In the same-session case let mergeSessionEntry preserve
+        // freshStore.sessionFile — falling back to entry?.sessionFile here
+        // would re-introduce the #5369 stale-writeback class.
+        ...(entry?.sessionId && entry.sessionId !== sessionId
+          ? { sessionFile: undefined }
+          : {}),
+        // cliSessionIds / cliSessionBindings / claudeCliSessionId are
+        // intentionally NOT carried via `entry?.X` writebacks here:
+        // mergeSessionEntry preserves them from the fresh store, and reading
+        // them from the stale cache would be the #5369 stale-writeback class.
       };
       sessionEntry = mergeSessionEntry(entry, nextEntryPatch);
       if (request.deliver === true) {


### PR DESCRIPTION
## Summary

Fixes the intermittent race condition where sub-agent model overrides were silently ignored (~3% failure rate).

- When `sessions.patch` writes a fresh `modelOverride` between when the agent handler captures its local `entry` reference and when it builds `nextEntryPatch`, the captured stale value would clobber the fresh store value through `mergeSessionEntry({...freshStore, ...patch})`.
- The fix removes the stale `entry?.X` writebacks from `nextEntryPatch` (incl. `modelOverride`, `providerOverride`, `cliSessionIds`, `cliSessionBindings`, `claudeCliSessionId`, gated `pluginOwnerId`). `mergeSessionEntry` already preserves anything not in the patch, so fresh store values survive the write.
- Rotation-clearing for `sessionFile` (added by #79076) is preserved through a conditional spread that only writes `sessionFile: undefined` on session rotation.

## Root Cause

The agent handler was:
1. Reading the session entry early via `loadSessionEntry()` and holding it in a local variable.
2. Building `nextEntryPatch` with `modelOverride: entry?.modelOverride` and several siblings — values read from that captured local entry, not the fresh store.
3. Calling `updateSessionStore()` whose mutator does `mergeSessionEntry(store[primaryKey], nextEntryPatch)` — which spreads `{...freshStore, ...patch}`, so any stale value in the patch clobbers the fresh store value written concurrently (e.g., by `sessions.patch` setting `modelOverride` on a sub-agent between spawn and run).

## Changes

- `src/gateway/server-methods/agent.ts`: drop stale `entry?.X` writebacks from `nextEntryPatch`. Switch the patch type to `Partial<SessionEntry>`. Gate `pluginOwnerId` behind `entry === undefined`. Convert the `sessionFile` rotation-clearing from #79076 into a conditional spread that fires only when `entry.sessionId !== sessionId`.
- `src/gateway/server-methods/agent.test.ts`: add the original #5369 regression and a broader regression guard for the whole stale-writeback class (sendPolicy, skillsSnapshot, thinkingLevel, fastMode, verboseLevel, traceLevel, reasoningLevel, systemSent, spawnedWorkspaceDir, spawnDepth, cliSessionIds, cliSessionBindings, claudeCliSessionId).

## Real behavior proof

**Behavior or issue addressed:** When `sessions.patch` writes a fresh `modelOverride` between when the agent handler captures its local `entry` reference and when it builds `nextEntryPatch`, the captured stale value clobbers the fresh store value through `mergeSessionEntry({...freshStore, ...patch})`. Per #5369, this manifested as ~3% of sub-agent runs silently ignoring an explicit model override and falling back to the parent's model.

**Real environment tested:**
- Host: Linux 6.14.0-34-generic on x86_64, Node v22.22.0, openclaw production session-store modules from this branch (`src/config/sessions/store.ts`, `src/config/sessions/types.ts`).
- Multipass guest VM `ai-assistant`: Ubuntu 24.04 LTS, IP 10.119.193.216, Node v22.22.2, same modules from this branch via a host mount at `/home/ubuntu/openclaw-pr5369`.

Both run the production `loadSessionStore` / `updateSessionStore` / `mergeSessionEntry` code paths against a real on-disk JSON store in a per-run tmp directory. No mocking. No shims.

**Exact steps or command run after this patch:**

```
node --import tsx scripts/repro-5369.mts 1000
```

The driver lives in this branch (local-only, intentionally not committed). For each of 1000 iterations it:

1. Initializes a session entry on disk via `updateSessionStore` (no override yet).
2. Captures the entry via `loadSessionStore({ skipCache: true })` — the same shape the agent handler holds in its local `entry` variable.
3. Fires a concurrent `updateSessionStore` to set `modelOverride: haiku-4.5-iter-N` (mimicking what `sessions.patch` does during sub-agent setup).
4. Builds `nextEntryPatch` two ways and applies each through the same `mergeSessionEntry(store[primaryKey], nextEntryPatch)` call shape that `src/gateway/server-methods/agent.ts` uses:
   - PRE-FIX shape: `modelOverride: capturedEntry.modelOverride` (writes back the captured stale `undefined`).
   - POST-FIX shape: `modelOverride` dropped from the patch — `mergeSessionEntry` preserves the fresh store value.
5. Reads the persisted entry back from disk and reports whether the override survived.

**Evidence after fix:**

Host (Linux 6.14, Node v22.22.0):

```
[repro #5369] node v22.22.0 on linux x64
[repro #5369] storePath=/tmp/openclaw-pr5369-0fZPH1/sessions.json
[repro #5369] iterations=1000

[repro #5369] running PRE-FIX patch shape (entry?.modelOverride writeback)...
[repro #5369] PRE-FIX :  1000/1000 sub-agents lost their override  (338 ms)
[repro #5369]           sample: expected=haiku-4.5-iter-0 actual=undefined

[repro #5369] running POST-FIX patch shape (modelOverride dropped from patch)...
[repro #5369] POST-FIX:  0/1000 sub-agents lost their override  (254 ms)
[repro #5369]           sample: expected=haiku-4.5-iter-0 actual=haiku-4.5-iter-0

[repro #5369] verdict: fix VERIFIED
```

Multipass guest VM `ai-assistant` (Ubuntu 24.04 LTS, Node v22.22.2):

```
[repro #5369] node v22.22.2 on linux x64
[repro #5369] storePath=/tmp/openclaw-pr5369-4EJXTF/sessions.json
[repro #5369] iterations=1000

[repro #5369] running PRE-FIX patch shape (entry?.modelOverride writeback)...
[repro #5369] PRE-FIX :  1000/1000 sub-agents lost their override  (2602 ms)
[repro #5369]           sample: expected=haiku-4.5-iter-0 actual=undefined

[repro #5369] running POST-FIX patch shape (modelOverride dropped from patch)...
[repro #5369] POST-FIX:  0/1000 sub-agents lost their override  (1337 ms)
[repro #5369]           sample: expected=haiku-4.5-iter-0 actual=haiku-4.5-iter-0

[repro #5369] verdict: fix VERIFIED
```

**Observed result after fix:** in both environments every one of 1000 iterations preserved the sub-agent `modelOverride` written by the concurrent store update. The same 1000 iterations under the pre-fix patch shape lost the override every single time — confirming the writeback was the clobbering vector and that dropping it from `nextEntryPatch` is what makes the override durable. The persisted on-disk values (`actual=haiku-4.5-iter-0`) match what `sessions.patch` wrote, end-to-end, through the production merge code.

The 100% pre-fix loss rate (vs the ~3% reported in #5369) reflects that the driver deterministically forces the stale-then-fresh ordering on every iteration. Production traffic only hits that ordering when `sessions.patch` lands in the narrow window between the agent handler's `loadSessionEntry` and its own `updateSessionStore` call — about 3% of the time per the linked issue. Whenever that ordering does occur in production, the driver shows the pre-fix shape always loses the override and the post-fix shape never does.

**What was not tested:** end-to-end Anthropic API calls burning credit on each of the 1000 iterations. The sub-agent dispatch loop is upstream of the `modelOverride` persistence the fix addresses; a real model loop would only confirm what the persisted `modelOverride` value is, which the driver already reads back from disk on every iteration. Driving 1000 real Anthropic calls would not provide additional information about the persistence behavior the fix changes.

Fixes #5369

Supersedes #8398 (rebased onto latest main to resolve conflicts).
