### PR TITLE
fix(heartbeat): skip isError payloads when resolving heartbeat reply

### DIFF
--- a/src/auto-reply/heartbeat-reply-payload.test.ts
+++ b/src/auto-reply/heartbeat-reply-payload.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { ReplyPayload } from "./types.js";
+import { resolveHeartbeatReplyPayload } from "./heartbeat-reply-payload.js";
+
+describe("resolveHeartbeatReplyPayload", () => {
+  it("returns undefined for undefined input", () => {
+    expect(resolveHeartbeatReplyPayload(undefined)).toBeUndefined();
+  });
+
+  it("returns a single payload as-is", () => {
+    const p: ReplyPayload = { text: "HEARTBEAT_OK" } as ReplyPayload;
+    expect(resolveHeartbeatReplyPayload(p)).toBe(p);
+  });
+
+  it("picks last non-empty payload from array", () => {
+    const a: ReplyPayload = { text: "first" } as ReplyPayload;
+    const b: ReplyPayload = { text: "second" } as ReplyPayload;
+    expect(resolveHeartbeatReplyPayload([a, b])).toBe(b);
+  });
+
+  it("skips error payloads when a non-error payload exists", () => {
+    const agent: ReplyPayload = { text: "HEARTBEAT_OK" } as ReplyPayload;
+    const err: ReplyPayload = {
+      text: "⚠️ 🛠️ Exec: command failed",
+      isError: true,
+    } as ReplyPayload;
+    // Error appended after agent text — agent text should win.
+    expect(resolveHeartbeatReplyPayload([agent, err])).toBe(agent);
+  });
+
+  it("returns error payload when no non-error payload exists", () => {
+    const err: ReplyPayload = {
+      text: "⚠️ 🛠️ Exec: command failed",
+      isError: true,
+    } as ReplyPayload;
+    expect(resolveHeartbeatReplyPayload([err])).toBe(err);
+  });
+
+  it("skips empty payloads", () => {
+    const empty: ReplyPayload = {} as ReplyPayload;
+    const real: ReplyPayload = { text: "ok" } as ReplyPayload;
+    expect(resolveHeartbeatReplyPayload([empty, real])).toBe(real);
+  });
+
+  it("returns undefined for array of empty payloads", () => {
+    const empty: ReplyPayload = {} as ReplyPayload;
+    expect(resolveHeartbeatReplyPayload([empty])).toBeUndefined();
+  });
+
+  it("prefers non-error payload even when error comes first", () => {
+    const err: ReplyPayload = {
+      text: "error",
+      isError: true,
+    } as ReplyPayload;
+    const agent: ReplyPayload = { text: "HEARTBEAT_OK" } as ReplyPayload;
+    expect(resolveHeartbeatReplyPayload([err, agent])).toBe(agent);
+  });
+});

--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -9,12 +9,28 @@ export function resolveHeartbeatReplyPayload(
   if (!Array.isArray(replyResult)) {
     return replyResult;
   }
+
+  const hasContent = (p: ReplyPayload): boolean =>
+    !!(p.text || p.mediaUrl || (p.mediaUrls && p.mediaUrls.length > 0));
+
+  // First pass: prefer non-error payloads (agent's actual reply).
+  for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
+    const payload = replyResult[idx];
+    if (!payload || payload.isError) {
+      continue;
+    }
+    if (hasContent(payload)) {
+      return payload;
+    }
+  }
+
+  // Fallback: return the last error payload if no non-error payload exists.
   for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
     const payload = replyResult[idx];
     if (!payload) {
       continue;
     }
-    if (payload.text || payload.mediaUrl || (payload.mediaUrls && payload.mediaUrls.length > 0)) {
+    if (hasContent(payload)) {
       return payload;
     }
   }


### PR DESCRIPTION
## Summary

Fixes #19302.

`resolveHeartbeatReplyPayload` iterates the reply payload array backwards and picks the last non-empty payload. When `buildFinalReplyPayloads` appends a tool error summary (`isError: true`) after the agent's `HEARTBEAT_OK` text, the error payload wins and gets delivered to the channel — causing spurious error alerts during heartbeats.

## Fix

Two-pass strategy in `resolveHeartbeatReplyPayload`:
1. **First pass** (backwards): skip `isError: true` payloads, prefer the agent's actual reply
2. **Fallback pass** (backwards): if no non-error payload exists, return the last error payload

This preserves existing behavior when there are no error payloads, and correctly suppresses tool error leaks when the agent has already responded with `HEARTBEAT_OK`.

## Tests

Added `heartbeat-reply-payload.test.ts` with 8 test cases covering:
- Single/array payloads
- Error-after-agent-text (the bug scenario)
- Error-only arrays (fallback behavior)
- Empty payloads
- Mixed ordering

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes spurious error alerts during heartbeats by implementing a two-pass payload selection strategy in `resolveHeartbeatReplyPayload`. When tool errors are appended after an agent's `HEARTBEAT_OK` response, the first pass now skips `isError: true` payloads to prefer the agent's actual reply. The fallback pass ensures error payloads are still returned when no non-error content exists.

- Refactored payload content detection into a reusable `hasContent` helper
- Added comprehensive test coverage with 8 test cases covering single/array payloads, error-after-text scenarios, error-only fallback, empty payloads, and mixed ordering
- Preserves backward compatibility for all existing scenarios while fixing the bug where tool error summaries leaked to channels

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-designed with a clear two-pass strategy that preserves all existing behavior while fixing the specific bug. Comprehensive test coverage validates all edge cases including the bug scenario, fallback behavior, and mixed ordering. The implementation is clean, follows the codebase patterns, and doesn't introduce any breaking changes or side effects.
- No files require special attention

<sub>Last reviewed commit: 9308590</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->