### PR TITLE
Refactor chat state management: reset chat messages and queue on session change, and ensure chat history loading respects session key

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,16 +1,16 @@
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import type { AppViewState } from "./app-view-state.ts";
+import type { ThemeTransitionContext } from "./theme-transition.ts";
+import type { ThemeMode } from "./theme.ts";
+import type { SessionsListResult } from "./types.ts";
 import { t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
-import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
-import type { ThemeTransitionContext } from "./theme-transition.ts";
-import type { ThemeMode } from "./theme.ts";
-import type { SessionsListResult } from "./types.ts";
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
@@ -35,6 +35,8 @@ function resolveSidebarChatSessionKey(state: AppViewState): string {
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {
   state.sessionKey = sessionKey;
   state.chatMessage = "";
+  state.chatMessages = [];
+  state.chatQueue = [];
   state.chatStream = null;
   (state as unknown as OpenClawApp).chatStreamStartedAt = null;
   state.chatRunId = null;
@@ -70,6 +72,7 @@ export function renderTab(state: AppViewState, tab: Tab) {
           if (state.sessionKey !== mainSessionKey) {
             resetChatStateForSessionSwitch(state, mainSessionKey);
             void state.loadAssistantIdentity();
+            void loadChatHistory(state as unknown as ChatState);
           }
         }
         state.setTab(tab);
@@ -137,6 +140,8 @@ export function renderChatControls(state: AppViewState) {
             const next = (e.target as HTMLSelectElement).value;
             state.sessionKey = next;
             state.chatMessage = "";
+            state.chatMessages = [];
+            state.chatQueue = [];
             state.chatStream = null;
             (state as unknown as OpenClawApp).chatStreamStartedAt = null;
             state.chatRunId = null;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1,10 +1,10 @@
 import { html, nothing } from "lit";
+import type { AppViewState } from "./app-view-state.ts";
 import { parseAgentSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers.ts";
-import type { AppViewState } from "./app-view-state.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
 import { loadAgentSkills } from "./controllers/agent-skills.ts";
@@ -790,6 +790,7 @@ export function renderApp(state: AppViewState) {
                 onSessionKeyChange: (next) => {
                   state.sessionKey = next;
                   state.chatMessage = "";
+                  state.chatMessages = [];
                   state.chatAttachments = [];
                   state.chatStream = null;
                   state.chatStreamStartedAt = null;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,6 +1,6 @@
-import { extractText } from "../chat/message-extract.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ChatAttachment } from "../ui-types.ts";
+import { extractText } from "../chat/message-extract.ts";
 import { generateUUID } from "../uuid.ts";
 
 export type ChatState = {
@@ -31,19 +31,27 @@ export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;
   }
+  const requestedSessionKey = state.sessionKey;
   state.chatLoading = true;
   state.lastError = null;
   try {
     const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
       "chat.history",
       {
-        sessionKey: state.sessionKey,
+        sessionKey: requestedSessionKey,
         limit: 200,
       },
     );
+    // Only apply result if user has not switched to another session (avoids race).
+    if (state.sessionKey !== requestedSessionKey) {
+      return;
+    }
     state.chatMessages = Array.isArray(res.messages) ? res.messages : [];
     state.chatThinkingLevel = res.thinkingLevel ?? null;
   } catch (err) {
+    if (state.sessionKey !== requestedSessionKey) {
+      return;
+    }
     state.lastError = String(err);
   } finally {
     state.chatLoading = false;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -54,7 +54,10 @@ export async function loadChatHistory(state: ChatState) {
     }
     state.lastError = String(err);
   } finally {
-    state.chatLoading = false;
+    // Only clear loading for this session; avoid stale response clearing B's loading when A completes.
+    if (state.sessionKey === requestedSessionKey) {
+      state.chatLoading = false;
+    }
   }
 }
 


### PR DESCRIPTION
Fix Control UI session isolation bug causing chat history to leak between dropdown sessions.

Fixes #19187

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a session isolation bug in the Control UI where chat history would leak between sessions when switching via the dropdown or navigation tabs. The fix has two parts: (1) `loadChatHistory` now snapshots the `sessionKey` before the async request and guards all state writes (including `chatLoading` cleanup in `finally`) against session mismatches, and (2) session-switch paths in `renderChatControls` and `resetChatStateForSessionSwitch` now eagerly clear `chatMessages` and `chatQueue` so stale data is immediately wiped before the new history loads.

- `controllers/chat.ts`: Added session key snapshot and post-await session checks in `loadChatHistory` to prevent stale responses from overwriting the current session's state; the `finally` block now conditionally clears `chatLoading` only when the session key still matches.
- `app-render.helpers.ts`: `resetChatStateForSessionSwitch` now clears `chatMessages` and `chatQueue`; the tab-click handler now calls `loadChatHistory` after resetting state; the session dropdown handler also clears `chatMessages` and `chatQueue`.
- `app-render.ts`: The chat view's `onSessionKeyChange` callback now clears `chatMessages` on session change (it already cleared `chatQueue`).
- Import reordering in all three files follows Oxfmt's type-first import ordering conventions.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it addresses a real session-isolation regression with targeted, well-reasoned changes and no regressions introduced.
- The core `loadChatHistory` guard logic is correct and handles multi-switch races properly. The eager state clearing across all session-switch paths is consistent. No new APIs are introduced and the changes are confined to UI state management. Minor pre-existing inconsistency remains in the overview tab's `onSessionKeyChange` handler (which still doesn't clear `chatMessages`/`chatQueue`), but that handler doesn't directly trigger `loadChatHistory` and was already that way before this PR.
- No files require special attention; the changes are focused and correct.

<sub>Last reviewed commit: c7aed1a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->