### PR TITLE
docs(slack): document assistant:write for thread typing status

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -290,6 +290,7 @@ Available action groups in current Slack tooling:
 - Message edits/deletes/thread broadcasts are mapped into system events.
 - Reaction add/remove events are mapped into system events.
 - Member join/leave, channel created/renamed, and pin add/remove events are mapped into system events.
+- Assistant thread status updates (for "is typing..." indicators in threads) use `assistant.threads.setStatus` and require bot scope `assistant:write`.
 - `channel_id_changed` can migrate channel config keys when `configWrites` is enabled.
 - Channel topic/purpose metadata is treated as untrusted context and can be injected into routing context.
 - Block actions and modal interactions emit structured `Slack interaction: ...` system events with rich payload fields:
@@ -351,6 +352,7 @@ Notes:
         "mpim:history",
         "users:read",
         "app_mentions:read",
+        "assistant:write",
         "reactions:read",
         "reactions:write",
         "pins:read",


### PR DESCRIPTION
## Summary
- document that Slack thread typing/status updates use `assistant.threads.setStatus`
- add `assistant:write` to the Slack bot scope checklist example in docs

## Why
- clarifies the required scope when users see `missing_scope` for thread typing status updates

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two small documentation improvements to `docs/channels/slack.md` to clarify the `assistant:write` bot scope requirement:

- Adds a bullet in the "Events and operational behavior" section explaining that assistant thread status updates (typing indicators) use `assistant.threads.setStatus` and require the `assistant:write` scope.
- Adds `"assistant:write"` to the bot scopes list in the Slack app manifest example.

Both changes are accurate and verified against the implementation in `src/slack/monitor/context.ts` where `assistant.threads.setStatus` is called for thread typing status updates. The documentation is a helpful addition for users encountering `missing_scope` errors when using thread typing indicators.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure documentation change with no code modifications.
- The changes are documentation-only, adding a scope note and updating the manifest example. The `assistant.threads.setStatus` API call and the `assistant:write` scope requirement are both verified in the source code at `src/slack/monitor/context.ts`. No logic, configuration, or behavior changes are introduced.
- No files require special attention.

<sub>Last reviewed commit: 3c83a62</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->