### PR TITLE
fix(extensions): add peerDependencies to resolve workspace:* for npm consumers

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -19,6 +19,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -11,6 +11,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/google-antigravity-auth/package.json
+++ b/extensions/google-antigravity-auth/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -13,6 +13,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -12,6 +12,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/minimax-portal-auth/package.json
+++ b/extensions/minimax-portal-auth/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -12,6 +12,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -10,6 +10,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -10,6 +10,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -13,6 +13,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -11,6 +11,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -9,6 +9,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -9,6 +9,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"


### PR DESCRIPTION
## Problem

All 29 extensions declare `openclaw` as a `devDependency` with `workspace:*`. This reference only resolves inside the pnpm workspace. When extensions are installed standalone via npm (e.g. as published packages), the dependency fails to resolve because `workspace:*` has no meaning outside a pnpm/yarn workspace.

## Fix

Add `peerDependencies: { "openclaw": ">=2026.2.14" }` to every extension that uses `workspace:*` in `devDependencies`. The existing `devDependencies` entry is preserved for local development — `peerDependencies` serves as the resolution hint for external consumers.

## Scope

29 extensions, 87 insertions, zero deletions. Mechanical change — each `package.json` gets the same 3-line block inserted after `devDependencies`.

## Previous attempts

This fix has been attempted three times, all closed without merge:

- **#8387** — fixed only `nextcloud-talk`; closed as duplicate of #15034
- **#15034** — covered all extensions; closed, superseded by #15889
- **#15889** — covered most extensions (missed `irc`); auto-closed by stale bot

This PR is a fresh, clean branch from `main` with a single commit covering all 29 extensions.

## Testing

- `pnpm install` resolves cleanly
- `pnpm run build` passes
- No runtime behavior changes — only package metadata

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `"peerDependencies": { "openclaw": ">=2026.2.14" }` to all 29 extensions that previously only declared `openclaw` as `"workspace:*"` in `devDependencies`. The change ensures that npm consumers of published extension packages receive a proper resolution hint for the `openclaw` host package rather than encountering the unresolvable `workspace:*` specifier.

Key observations from the review:

- The change is consistent and mechanical across all 29 extensions — each gets the same 3-line block inserted after `devDependencies`.
- Two extensions (`googlechat` and `memory-core`) already had `peerDependencies` set to `>=2026.1.26` before this PR; those were not modified, creating a minor inconsistency in minimum version across the extension ecosystem.
- Several extensions in this PR carry `"private": true` (e.g. `copilot-proxy`, `google-antigravity-auth`, `imessage`, `signal`, `slack`, `telegram`, `whatsapp`, and others). `peerDependencies` has no practical effect on private packages since they cannot be published to npm, though its presence is harmless.
- The chosen minimum version `>=2026.2.14` is higher than what the two pre-existing extensions use (`>=2026.1.26`), but `2026.2.14` is a valid released version per the CHANGELOG. No rationale is given for why this specific version floor was chosen over aligning with the existing `>=2026.1.26` baseline.
- All extensions that declare `openclaw: workspace:*` in `devDependencies` are now covered.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — pure package metadata change with no runtime behavior impact; the only concern is a minor version inconsistency with two pre-existing extensions.
- The change is additive-only (zero deletions), touches only `package.json` metadata, and is correctly applied across all 29 targeted extensions. Existing `devDependencies` entries are preserved. The small inconsistency — two older extensions (`googlechat`, `memory-core`) use `>=2026.1.26` while this PR uses `>=2026.2.14` — is cosmetic and does not break anything. Several `"private": true` packages receive a no-op `peerDependencies` entry, which is harmless. No logic, types, or build output is changed.
- No files require special attention; the change is uniform across all 29 `package.json` files.

<sub>Last reviewed commit: 862df34</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->