### PR TITLE
test(signal): add E.164 format acceptance for signal target detection

### DIFF
--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -57,5 +57,7 @@ export function looksLikeSignalTargetId(raw: string): boolean {
   if (UUID_PATTERN.test(trimmed) || UUID_COMPACT_PATTERN.test(trimmed)) {
     return true;
   }
-  return /^\+?\d{3,}$/.test(trimmed);
+  // E.164: accept with or without signal: prefix (e.g. signal:+15551234567)
+  const forE164 = trimmed.replace(/^signal:/i, "").trim();
+  return /^\+?\d{3,}$/.test(forE164);
 }

--- a/src/channels/plugins/plugins-channel.test.ts
+++ b/src/channels/plugins/plugins-channel.test.ts
@@ -51,6 +51,12 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("uuid:")).toBe(false);
     expect(looksLikeSignalTargetId("uuid:not-a-uuid")).toBe(false);
   });
+
+  it("accepts signal:+E.164 for target detection (media and message send)", () => {
+    expect(looksLikeSignalTargetId("signal:+10123566789")).toBe(true);
+    expect(looksLikeSignalTargetId("signal:+15551234567")).toBe(true);
+    expect(looksLikeSignalTargetId("+15551234567")).toBe(true);
+  });
 });
 
 describe("telegramOutbound.sendPayload", () => {

--- a/src/channels/plugins/plugins-channel.test.ts
+++ b/src/channels/plugins/plugins-channel.test.ts
@@ -56,6 +56,8 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("signal:+10123566789")).toBe(true);
     expect(looksLikeSignalTargetId("signal:+15551234567")).toBe(true);
     expect(looksLikeSignalTargetId("+15551234567")).toBe(true);
+    expect(looksLikeSignalTargetId("signal:notanumber")).toBe(false);
+    expect(looksLikeSignalTargetId("signal:")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fix Signal media validation rejecting valid conversation targets.

Fixes #18783

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `looksLikeSignalTargetId` rejected `signal:`-prefixed E.164 phone numbers (e.g. `signal:+15551234567`), causing media and message send operations to fail when targets were specified with the full channel-qualified prefix.

- In `signal.ts`, the final phone-number check now strips an optional `signal:` prefix before applying the `/^\+?\d{3,}$/` regex, consistent with how `normalizeSignalMessagingTarget` already handled the prefix.
- The test block in `plugins-channel.test.ts` covers both positive cases (`signal:+E.164`, bare `+E.164`) and negative cases (`signal:notanumber`, `signal:` empty string), giving reasonable coverage for the new branch.
- The fix is minimal, targeted, and consistent with the existing prefix-stripping pattern used throughout `signal.ts` and `extensions/signal/src/channel.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; the change is a small, well-targeted regex fix with adequate test coverage and no regressions to existing behavior.
- The diff is two files, a single-line logic change plus five test assertions. The fix is directly analogous to how `normalizeSignalMessagingTarget` already handles the `signal:` prefix. Manual trace of old vs new behavior confirms only `signal:`-prefixed phone numbers are newly accepted, which is the intended fix. Negative cases are tested. No security concerns, no regressions to UUID/group/username paths.
- No files require special attention.

<sub>Last reviewed commit: 9819b2f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->