### PR TITLE
feat(discord): clean up sessions when channel is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: keep DM-topic replies and draft previews in the originating private-chat topic by preserving positive `message_thread_id` values for DM threads. (#18586) Thanks @sebslight.
 - Telegram: preserve private-chat topic `message_thread_id` on outbound sends (message/sticker/poll), keep thread-not-found retry fallback, and avoid masking `chat not found` routing errors. (#18993) Thanks @obviyus.
 - Discord: prevent duplicate media delivery when the model uses the `message send` tool with media, by skipping media extraction from messaging tool results since the tool already sent the message directly. (#18270)
+- Discord: clean up orphaned sessions when channels are deleted so session stores do not accumulate stale entries. Thanks @chubes4 and @thewilloftheshadow.
 - Discord: route `audioAsVoice` auto-replies through the voice message API so opt-in audio renders as voice messages. (#18041) Thanks @zerone0x.
 - Discord: skip auto-thread creation in forum/media/voice/stage channels and keep group session last-route metadata fresh to avoid invalid thread API errors and lost follow-up sends. (#18098) Thanks @Clawborn.
 - Discord/Commands: normalize `commands.allowFrom` entries with `user:`/`discord:`/`pk:` prefixes and `<@id>` mentions so command authorization matches Discord allowlist behavior. (#18042)

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -16,8 +16,12 @@ export {
   resolveGroupDmAllow,
   shouldEmitDiscordReactionNotification,
 } from "./monitor/allow-list.js";
-export type { DiscordMessageEvent, DiscordMessageHandler } from "./monitor/listeners.js";
-export { registerDiscordListener } from "./monitor/listeners.js";
+export type {
+  DiscordMessageEvent,
+  DiscordMessageHandler,
+  DiscordChannelDeleteListenerParams,
+} from "./monitor/listeners.js";
+export { DiscordChannelDeleteListener, registerDiscordListener } from "./monitor/listeners.js";
 
 export { createDiscordMessageHandler } from "./monitor/message-handler.js";
 export { buildDiscordMediaPayload } from "./monitor/message-utils.js";

--- a/src/discord/monitor/listeners.channel-delete.test.ts
+++ b/src/discord/monitor/listeners.channel-delete.test.ts
@@ -1,0 +1,224 @@
+import path from "node:path";
+import type { Client } from "@buape/carbon";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { DiscordChannelDeleteListener } from "./listeners.js";
+
+const listAgentIdsMock = vi.hoisted(() => vi.fn());
+const resolveStorePathMock = vi.hoisted(() => vi.fn());
+const updateSessionStoreMock = vi.hoisted(() => vi.fn());
+const resolveMaintenanceConfigMock = vi.hoisted(() => vi.fn());
+const archiveSessionTranscriptsMock = vi.hoisted(() => vi.fn());
+const cleanupArchivedSessionTranscriptsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  listAgentIds: (...args: unknown[]) => listAgentIdsMock(...args),
+}));
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    resolveStorePath: (...args: unknown[]) => resolveStorePathMock(...args),
+    updateSessionStore: (...args: unknown[]) => updateSessionStoreMock(...args),
+    resolveMaintenanceConfig: (...args: unknown[]) => resolveMaintenanceConfigMock(...args),
+  };
+});
+
+vi.mock("../../gateway/session-utils.fs.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../gateway/session-utils.fs.js")>();
+  return {
+    ...actual,
+    archiveSessionTranscripts: (...args: unknown[]) => archiveSessionTranscriptsMock(...args),
+    cleanupArchivedSessionTranscripts: (...args: unknown[]) =>
+      cleanupArchivedSessionTranscriptsMock(...args),
+  };
+});
+
+type Logger = ReturnType<typeof import("../../logging/subsystem.js").createSubsystemLogger>;
+
+type SessionEntryStub = {
+  sessionId?: string;
+  sessionFile?: string;
+};
+
+type SessionStoreStub = Record<string, SessionEntryStub>;
+
+const storeByPath = new Map<string, SessionStoreStub>();
+
+function createLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Logger;
+}
+
+function seedStore(storePath: string, store: SessionStoreStub) {
+  storeByPath.set(storePath, structuredClone(store));
+}
+
+function getStore(storePath: string): SessionStoreStub {
+  return storeByPath.get(storePath) ?? {};
+}
+
+describe("DiscordChannelDeleteListener", () => {
+  beforeEach(() => {
+    storeByPath.clear();
+    listAgentIdsMock.mockReset();
+    resolveStorePathMock.mockReset();
+    updateSessionStoreMock.mockReset();
+    resolveMaintenanceConfigMock.mockReset();
+    archiveSessionTranscriptsMock.mockReset();
+    cleanupArchivedSessionTranscriptsMock.mockReset();
+
+    resolveMaintenanceConfigMock.mockReturnValue({
+      mode: "warn",
+      pruneAfterMs: 123_000,
+      maxEntries: 500,
+      rotateBytes: 1024,
+    });
+
+    updateSessionStoreMock.mockImplementation(async (storePath: string, mutator: unknown) => {
+      const store = getStore(storePath);
+      const result = await (mutator as (store: SessionStoreStub) => unknown)(store);
+      storeByPath.set(storePath, store);
+      return result;
+    });
+
+    archiveSessionTranscriptsMock.mockImplementation(
+      (params: { sessionId: string; storePath: string }) => [
+        path.join(path.dirname(params.storePath), `${params.sessionId}.deleted.1`),
+      ],
+    );
+  });
+
+  it("removes channel sessions across agents and archives transcripts", async () => {
+    listAgentIdsMock.mockReturnValue(["main", "ops"]);
+
+    const mainStorePath = "/tmp/main/sessions.json";
+    const opsStorePath = "/tmp/ops/sessions.json";
+
+    resolveStorePathMock.mockImplementation(
+      (_store: string | undefined, opts?: { agentId?: string }) =>
+        opts?.agentId === "ops" ? opsStorePath : mainStorePath,
+    );
+
+    seedStore(mainStorePath, {
+      "agent:main:discord:channel:123": { sessionId: "s1", sessionFile: "s1.jsonl" },
+      "agent:main:discord:channel:999": { sessionId: "s2" },
+    });
+
+    seedStore(opsStorePath, {
+      "agent:ops:discord:channel:123": { sessionId: "s3" },
+      "agent:ops:discord:channel:456": { sessionId: "s4" },
+    });
+
+    const logger = createLogger();
+
+    const listener = new DiscordChannelDeleteListener({
+      cfg: {} as OpenClawConfig,
+      logger,
+    });
+
+    await listener.handle(
+      { id: "123" } as unknown as Parameters<typeof listener.handle>[0],
+      {
+        listeners: [],
+      } as Client,
+    );
+
+    expect(getStore(mainStorePath)).toEqual({
+      "agent:main:discord:channel:999": { sessionId: "s2" },
+    });
+    expect(getStore(opsStorePath)).toEqual({
+      "agent:ops:discord:channel:456": { sessionId: "s4" },
+    });
+
+    expect(updateSessionStoreMock).toHaveBeenCalledTimes(2);
+    expect(archiveSessionTranscriptsMock).toHaveBeenCalledTimes(2);
+    expect(archiveSessionTranscriptsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "s1",
+        storePath: mainStorePath,
+        agentId: "main",
+        reason: "deleted",
+      }),
+    );
+    expect(archiveSessionTranscriptsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "s3",
+        storePath: opsStorePath,
+        agentId: "ops",
+        reason: "deleted",
+      }),
+    );
+
+    expect(cleanupArchivedSessionTranscriptsMock).toHaveBeenCalledTimes(2);
+    expect(cleanupArchivedSessionTranscriptsMock).toHaveBeenCalledWith({
+      directories: [path.dirname(mainStorePath)],
+      olderThanMs: 123_000,
+      reason: "deleted",
+    });
+    expect(cleanupArchivedSessionTranscriptsMock).toHaveBeenCalledWith({
+      directories: [path.dirname(opsStorePath)],
+      olderThanMs: 123_000,
+      reason: "deleted",
+    });
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      "discord channel-delete: cleaned up 2 session(s) for deleted channel 123",
+    );
+  });
+
+  it("uses nested channel id when top-level id is missing", async () => {
+    listAgentIdsMock.mockReturnValue(["main"]);
+
+    const storePath = "/tmp/main/sessions.json";
+    resolveStorePathMock.mockReturnValue(storePath);
+
+    seedStore(storePath, {
+      "agent:main:discord:channel:456": { sessionId: "s5" },
+    });
+
+    const logger = createLogger();
+
+    const listener = new DiscordChannelDeleteListener({
+      cfg: {} as OpenClawConfig,
+      logger,
+    });
+
+    await listener.handle(
+      { channel: { id: 456 } } as unknown as Parameters<typeof listener.handle>[0],
+      { listeners: [] } as Client,
+    );
+
+    expect(getStore(storePath)).toEqual({});
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns and skips cleanup when channel id is missing", async () => {
+    listAgentIdsMock.mockReturnValue(["main"]);
+
+    const logger = createLogger();
+
+    const listener = new DiscordChannelDeleteListener({
+      cfg: {} as OpenClawConfig,
+      logger,
+    });
+
+    await listener.handle(
+      {} as unknown as Parameters<typeof listener.handle>[0],
+      {
+        listeners: [],
+      } as Client,
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "discord channel-delete: could not resolve channel ID from event data",
+    );
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+    expect(archiveSessionTranscriptsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -467,9 +467,7 @@ export class DiscordChannelDeleteListener extends ChannelDeleteListener {
         logger: this.params.logger,
       });
     } catch (err) {
-      this.params.logger.error(
-        danger(`discord channel-delete handler failed: ${String(err)}`),
-      );
+      this.params.logger.error(danger(`discord channel-delete handler failed: ${String(err)}`));
     } finally {
       logSlowDiscordListener({
         logger: this.params.logger,
@@ -495,9 +493,7 @@ async function handleDiscordChannelDelete(params: {
       : (params.data as Record<string, unknown>).channel &&
           typeof (params.data as Record<string, unknown>).channel === "object" &&
           "id" in ((params.data as Record<string, unknown>).channel as Record<string, unknown>)
-        ? String(
-            ((params.data as Record<string, unknown>).channel as Record<string, string>).id,
-          )
+        ? String(((params.data as Record<string, unknown>).channel as Record<string, string>).id)
         : undefined;
 
   if (!channelId) {
@@ -508,9 +504,8 @@ async function handleDiscordChannelDelete(params: {
   // Lazily import session store utilities to avoid circular dependencies
   // and keep the listener module lightweight.
   const { listAgentIds } = await import("../../agents/agent-scope.js");
-  const { loadSessionStore, resolveStorePath, updateSessionStore } = await import(
-    "../../config/sessions.js"
-  );
+  const { loadSessionStore, resolveStorePath, updateSessionStore } =
+    await import("../../config/sessions.js");
   const { archiveSessionTranscripts } = await import("../../gateway/session-utils.fs.js");
 
   const agentIds = listAgentIds(params.cfg);

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -55,6 +55,7 @@ import { createExecApprovalButton, DiscordExecApprovalHandler } from "./exec-app
 import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
 import {
+  DiscordChannelDeleteListener,
   DiscordMessageListener,
   DiscordPresenceListener,
   DiscordReactionListener,
@@ -606,6 +607,14 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     );
     runtime.log?.("discord: GuildPresences intent enabled — presence listener registered");
   }
+
+  // Clean up orphaned sessions when a Discord channel is deleted (#19333).
+  // The Guilds intent (required for CHANNEL_DELETE) is enabled by default
+  // since guild message events already depend on it.
+  registerDiscordListener(
+    client.listeners,
+    new DiscordChannelDeleteListener({ cfg, logger }),
+  );
 
   runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);
 

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -611,10 +611,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   // Clean up orphaned sessions when a Discord channel is deleted (#19333).
   // The Guilds intent (required for CHANNEL_DELETE) is enabled by default
   // since guild message events already depend on it.
-  registerDiscordListener(
-    client.listeners,
-    new DiscordChannelDeleteListener({ cfg, logger }),
-  );
+  registerDiscordListener(client.listeners, new DiscordChannelDeleteListener({ cfg, logger }));
 
   runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);
 


### PR DESCRIPTION
## Summary

Automatically clean up orphaned sessions when a Discord channel is deleted, preventing session store bloat.

Closes #19333

## Problem

When a Discord channel is deleted, the associated OpenClaw session persists indefinitely in the session store. Over time — especially during development with frequent test channel creation/deletion — this causes significant session bloat. We found **38 orphaned sessions** across a 3-bot fleet from deleted channels.

## Solution

Add a `DiscordChannelDeleteListener` that listens for Discord's `CHANNEL_DELETE` gateway event and removes the associated session(s) from the store.

### Changes

- **`src/discord/monitor/listeners.ts`**: New `DiscordChannelDeleteListener` class extending Carbon's `ChannelDeleteListener`. On channel delete, scans all agent session stores for keys matching `discord:channel:<channelId>`, removes entries, and archives transcripts.
- **`src/discord/monitor/provider.ts`**: Register the new listener alongside existing message/reaction/presence listeners.
- **`src/discord/monitor.ts`**: Export the new listener class and params type.

### Design Decisions

- **Multi-agent aware**: Iterates over all agent IDs via `listAgentIds()` since a channel could be bound to any agent in multi-agent setups.
- **Lazy imports**: Session store utilities are imported dynamically to avoid circular dependency issues and keep the listener module lightweight.
- **No new intents required**: `CHANNEL_DELETE` requires the `Guilds` intent, which is already enabled by default in `gateway-plugin.ts`.
- **Best-effort transcript archival**: Uses the existing `archiveSessionTranscripts` function with `reason: "deleted"`, matching the behavior of `sessions.delete`.
- **Follows existing patterns**: Mirrors the structure of `DiscordReactionListener` and `DiscordPresenceListener` (constructor params, try/catch, slow listener logging).

## Testing

This was discovered and validated on a production fleet where 38 sessions were orphaned from deleted Discord channels. The listener follows the same session store mutation pattern used by the cron session reaper (`src/cron/session-reaper.ts`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `DiscordChannelDeleteListener` that listens for Discord's `CHANNEL_DELETE` gateway event and removes associated sessions from the store, addressing session bloat from orphaned sessions when channels are deleted. The overall design is sound and follows established patterns (`DiscordPresenceListener`, cron session-reaper), and the multi-agent awareness via `listAgentIds()` is appropriate.

Key issues found:

- **Channel ID extraction fragility** (`listeners.ts:492–501`): The two-path fallback extracts the channel ID, but the `"id" in params.data` check has no guard for an empty string — `String(...)` on an empty or undefined value would produce `""` or `"undefined"`, silently matching no sessions or worse. The first branch is almost certainly always taken for valid events (raw Discord `GatewayChannelDeleteDispatchData` always has `id` at the top level), so the fallback path is dead code in practice, but the missing empty-string guard is still a correctness concern.
- **TOCTOU race between initial store read and write lock** (`listeners.ts:519–570`): `matchingKeys` and `sessionsToArchive` are built from a potentially-cached `loadSessionStore` call, but `updateSessionStore` re-reads the store from disk inside the write lock. Sessions written to the store in the narrow window between these two reads will be correctly deleted (because `matchingKeys` is captured and re-used inside the mutator), but those sessions' transcripts won't be archived. The fix is to populate `sessionsToArchive` inside the `updateSessionStore` callback, before deleting.
- **Archived transcripts are never cleaned up** (`listeners.ts:558–568`): `archiveSessionTranscripts` returns the list of archived paths, but the return value is discarded. Unlike every other call site in the codebase (`store.ts`), `cleanupArchivedSessionTranscripts` is never called, so archived `.deleted.<timestamp>` transcript files will accumulate indefinitely.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge but has correctness issues around session transcript handling and a minor channel ID extraction fragility.
- The core session cleanup logic is correct and follows established patterns. However, the TOCTOU issue means sessions created in a narrow window could have their transcripts silently deleted without archival, and the missing cleanup of archived transcript files introduces a slow storage leak. These don't cause data corruption but represent incomplete implementation of the intended behavior.
- src/discord/monitor/listeners.ts — specifically the handleDiscordChannelDelete function: session archival before vs. inside the store lock, and the discarded archiveSessionTranscripts return value.

<sub>Last reviewed commit: 81c6bd9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->