### PR TITLE
fix(cron): normalize jobId → id for file-backed jobs

### DIFF
--- a/src/cron/service.file-backed-jobid.test.ts
+++ b/src/cron/service.file-backed-jobid.test.ts
@@ -1,0 +1,244 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createCronStoreHarness,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+/**
+ * Regression test for https://github.com/openclaw/openclaw/issues/19300
+ *
+ * File-backed cron jobs that use "jobId" instead of "id" (a common convention
+ * in hand-written jobs.json files) were not found by `cron run`, `cron update`,
+ * or `cron remove` because `findJobOrThrow` searches by `j.id`.  The store
+ * migration now normalizes `jobId` → `id` during load.
+ */
+
+const logger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-jobid-" });
+installCronTestHooks({ logger });
+
+function createCronService(storePath: string) {
+  return new CronService({
+    storePath,
+    cronEnabled: true,
+    log: logger,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeatNow: vi.fn(),
+    runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+  });
+}
+
+async function seedStoreFile(storePath: string, store: object) {
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+}
+
+describe("file-backed jobs with jobId field (#19300)", () => {
+  it("normalizes jobId → id so cron.run succeeds", async () => {
+    const { storePath } = await makeStorePath();
+    await seedStoreFile(storePath, {
+      version: 1,
+      jobs: [
+        {
+          jobId: "daily-standup",
+          name: "Daily Standup",
+          enabled: true,
+          schedule: { kind: "cron", expr: "0 7 * * 1-5", tz: "America/Los_Angeles" },
+          sessionTarget: "main",
+          wakeMode: "now",
+          payload: { kind: "systemEvent", text: "Run the daily standup." },
+        },
+      ],
+    });
+
+    const cron = createCronService(storePath);
+    await cron.start();
+
+    try {
+      const result = await cron.run("daily-standup", "force");
+      expect(result).toMatchObject({ ok: true, ran: true });
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("normalizes jobId → id so cron.list returns proper id", async () => {
+    const { storePath } = await makeStorePath();
+    await seedStoreFile(storePath, {
+      version: 1,
+      jobs: [
+        {
+          jobId: "my-custom-id",
+          name: "Test Job",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "ping" },
+        },
+      ],
+    });
+
+    const cron = createCronService(storePath);
+    await cron.start();
+
+    try {
+      const jobs = await cron.list();
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].id).toBe("my-custom-id");
+      expect((jobs[0] as Record<string, unknown>).jobId).toBeUndefined();
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("getJob finds file-backed jobs by normalized id", async () => {
+    const { storePath } = await makeStorePath();
+    await seedStoreFile(storePath, {
+      version: 1,
+      jobs: [
+        {
+          jobId: "email-triage",
+          name: "Email Triage",
+          enabled: true,
+          schedule: { kind: "cron", expr: "0 8-18 * * 1-5" },
+          sessionTarget: "main",
+          wakeMode: "now",
+          payload: { kind: "systemEvent", text: "Triage email." },
+        },
+      ],
+    });
+
+    const cron = createCronService(storePath);
+    await cron.start();
+
+    try {
+      const job = cron.getJob("email-triage");
+      expect(job).toBeDefined();
+      expect(job?.id).toBe("email-triage");
+      expect(job?.name).toBe("Email Triage");
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("generates a UUID when neither id nor jobId is present", async () => {
+    const { storePath } = await makeStorePath();
+    await seedStoreFile(storePath, {
+      version: 1,
+      jobs: [
+        {
+          name: "No ID Job",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "test" },
+        },
+      ],
+    });
+
+    const cron = createCronService(storePath);
+    await cron.start();
+
+    try {
+      const jobs = await cron.list();
+      expect(jobs).toHaveLength(1);
+      // Should have a generated UUID (36 chars with hyphens)
+      expect(jobs[0].id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("preserves existing id field when present", async () => {
+    const { storePath } = await makeStorePath();
+    await seedStoreFile(storePath, {
+      version: 1,
+      jobs: [
+        {
+          id: "existing-id",
+          name: "Existing ID Job",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "test" },
+        },
+      ],
+    });
+
+    const cron = createCronService(storePath);
+    await cron.start();
+
+    try {
+      const jobs = await cron.list();
+      expect(jobs[0].id).toBe("existing-id");
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("id field takes precedence when both id and jobId are present", async () => {
+    const { storePath } = await makeStorePath();
+    await seedStoreFile(storePath, {
+      version: 1,
+      jobs: [
+        {
+          id: "canonical-id",
+          jobId: "legacy-id",
+          name: "Both Fields",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "test" },
+        },
+      ],
+    });
+
+    const cron = createCronService(storePath);
+    await cron.start();
+
+    try {
+      const jobs = await cron.list();
+      expect(jobs[0].id).toBe("canonical-id");
+      expect((jobs[0] as Record<string, unknown>).jobId).toBeUndefined();
+      const result = await cron.run("canonical-id", "force");
+      expect(result).toMatchObject({ ok: true, ran: true });
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("persists normalized id back to the store file", async () => {
+    const { storePath } = await makeStorePath();
+    await seedStoreFile(storePath, {
+      version: 1,
+      jobs: [
+        {
+          jobId: "persisted-id",
+          name: "Persist Test",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "test" },
+        },
+      ],
+    });
+
+    const cron = createCronService(storePath);
+    await cron.start();
+    cron.stop();
+
+    // Re-read the persisted file to verify jobId was replaced with id
+    const raw = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(raw.jobs[0].id).toBe("persisted-id");
+    expect(raw.jobs[0].jobId).toBeUndefined();
+  });
+});

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import {
   buildDeliveryFromLegacyPayload,
@@ -244,6 +245,23 @@ export async function ensureLoaded(
     const state = raw.state;
     if (!state || typeof state !== "object" || Array.isArray(state)) {
       raw.state = {};
+      mutated = true;
+    }
+
+    // Normalize jobId → id: file-backed jobs commonly use "jobId" but the
+    // internal model expects "id".  Also generate a stable id when neither
+    // field is present so that run/update/remove lookups always succeed.
+    if (typeof raw.id !== "string" || !raw.id.trim()) {
+      const jobId = raw.jobId;
+      if (typeof jobId === "string" && jobId.trim()) {
+        raw.id = jobId.trim();
+        delete raw.jobId;
+      } else {
+        raw.id = crypto.randomUUID();
+      }
+      mutated = true;
+    } else if ("jobId" in raw) {
+      delete raw.jobId;
       mutated = true;
     }
 


### PR DESCRIPTION
Fixes #19300

## Summary

File-backed cron jobs that use `jobId` instead of `id` in `jobs.json` (a common convention in hand-written configs) were invisible to `cron run`, `cron update`, `cron remove`, and `cron enable/disable` because `findJobOrThrow()` searches by `j.id`.

The scheduler was unaffected because it iterates the array without looking up by id, and `cron list` returned jobs normally since it returns the full array — making this particularly confusing to diagnose.

## Root cause

`ensureLoaded()` in `src/cron/service/store.ts` normalizes ~10 fields during the store migration loop (name, description, sessionKey, enabled, payload, schedule, delivery, etc.) but never normalized `jobId` → `id`. When a job had `jobId` but no `id`, `j.id` was `undefined` at runtime, causing `findJobOrThrow()` to fail with `"unknown cron job id"`.

## Fix

Added `jobId` → `id` normalization in `ensureLoaded()` alongside the existing field migrations:

- If a job has `jobId` but no `id`, the value is copied to `id` and `jobId` is removed
- If neither field is present, a UUID is generated
- When both `id` and `jobId` are present, `id` takes precedence
- The normalized id is persisted back to the store file

## Testing

7 regression tests covering:
- `cron.run` succeeds with normalized `jobId`
- `cron.list` returns proper `id` field
- `getJob` finds file-backed jobs by normalized id
- UUID generation when neither `id` nor `jobId` is present
- Existing `id` field is preserved
- `id` takes precedence over `jobId` when both present
- Normalized id is persisted to disk

All 151 existing cron tests continue to pass with zero regressions.

AI-assisted: This fix was developed with Claude Code. Testing was done against the full cron test suite.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real bug (#19300) where file-backed cron jobs using `jobId` instead of `id` were invisible to `cron run`, `cron update`, and `cron remove`. The normalization added to `ensureLoaded()` in `store.ts` correctly handles the main case, and the 7 regression tests provide solid coverage.

One incomplete case in the fix:
- When a job has **both** a valid `id` and a legacy `jobId`, the guard `if (typeof raw.id !== "string" || !raw.id.trim())` short-circuits the whole block, so `jobId` is never deleted. It gets passed through the `as CronJob[]` cast and written back to disk. The primary bug (lookup failure) is resolved since `findJobOrThrow` uses `j.id`, but the stray `jobId` field lingers in the persisted store — inconsistent with the fix's stated goal of stripping it. The corresponding test also lacks an assertion verifying that `jobId` was removed in this scenario.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for the primary fix; the stray `jobId` in the both-fields case is a minor correctness gap that does not reintroduce the original bug.
- The fix correctly resolves the reported bug and is well-tested for the common cases. Score is 3 rather than 4-5 because there is an incomplete cleanup path when both `id` and `jobId` are present — `jobId` is not deleted from the persisted store in that scenario, and the test for it does not assert this. The primary lookup issue is fully resolved.
- Pay close attention to `src/cron/service/store.ts` lines 254–263 — the `else if ("jobId" in raw)` cleanup branch is missing.

<sub>Last reviewed commit: 50dd40a</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->