### PR TITLE
fix: pass authProfileId from cron session to runEmbeddedPiAgent

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,3 +1,7 @@
+import type { MessagingToolSend } from "../../agents/pi-embedded-messaging.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { AgentDefaultsConfig } from "../../config/types.js";
+import type { CronJob, CronRunOutcome, CronRunTelemetry } from "../types.js";
 import {
   resolveAgentConfig,
   resolveAgentDir,
@@ -20,7 +24,6 @@ import {
   resolveHooksGmailModel,
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
-import type { MessagingToolSend } from "../../agents/pi-embedded-messaging.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { runSubagentAnnounceFlow } from "../../agents/subagent-announce.js";
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
@@ -34,13 +37,11 @@ import {
 } from "../../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import {
   resolveAgentMainSessionKey,
   resolveSessionTranscriptPath,
   updateSessionStore,
 } from "../../config/sessions.js";
-import type { AgentDefaultsConfig } from "../../config/types.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
@@ -52,8 +53,8 @@ import {
   getHookType,
   isExternalHookSession,
 } from "../../security/external-content.js";
+import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
-import type { CronJob, CronRunOutcome, CronRunTelemetry } from "../types.js";
 import { resolveDeliveryTarget } from "./delivery-target.js";
 import {
   isHeartbeatOnlyResponse,
@@ -234,6 +235,16 @@ export async function runCronIsolatedAgentTurn(params: {
     agentId,
     nowMs: now,
   });
+  // Apply payload.model override to the session entry so session_status and
+  // auth profile resolution see the requested model, matching sub-agent behavior.
+  if (provider !== resolvedDefault.provider || model !== resolvedDefault.model) {
+    applyModelOverrideToSessionEntry({
+      entry: cronSession.sessionEntry,
+      selection: { provider, model },
+      profileOverride: cronSession.sessionEntry.authProfileOverride,
+      profileOverrideSource: cronSession.sessionEntry.authProfileOverrideSource,
+    });
+  }
   const runSessionId = cronSession.sessionEntry.sessionId;
   const runSessionKey = baseSessionKey.startsWith("cron:")
     ? `${agentSessionKey}:run:${runSessionId}`
@@ -436,6 +447,8 @@ export async function runCronIsolatedAgentTurn(params: {
             cliSessionId,
           });
         }
+        const cronAuthProfileId =
+          providerOverride === provider ? cronSession.sessionEntry.authProfileOverride : undefined;
         return runEmbeddedPiAgent({
           sessionId: cronSession.sessionEntry.sessionId,
           sessionKey: agentSessionKey,
@@ -450,6 +463,10 @@ export async function runCronIsolatedAgentTurn(params: {
           lane: params.lane ?? "cron",
           provider: providerOverride,
           model: modelOverride,
+          authProfileId: cronAuthProfileId,
+          authProfileIdSource: cronAuthProfileId
+            ? cronSession.sessionEntry.authProfileOverrideSource
+            : undefined,
           thinkLevel,
           verboseLevel: resolvedVerboseLevel,
           timeoutMs,

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -76,6 +76,28 @@ describe("resolveCronSession", () => {
     expect(result.isNewSession).toBe(true);
   });
 
+  it("preserves authProfileOverride from existing session entry", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main:cron:test-job": {
+        sessionId: "old-session-id",
+        updatedAt: 1000,
+        authProfileOverride: "claude-max",
+        authProfileOverrideSource: "user",
+      },
+    });
+    vi.mocked(evaluateSessionFreshness).mockReturnValue({ fresh: true });
+
+    const result = resolveCronSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:main:cron:test-job",
+      agentId: "main",
+      nowMs: Date.now(),
+    });
+
+    expect(result.sessionEntry.authProfileOverride).toBe("claude-max");
+    expect(result.sessionEntry.authProfileOverrideSource).toBe("user");
+  });
+
   // New tests for session reuse behavior (#18027)
   describe("session reuse for webhooks/cron", () => {
     it("reuses existing sessionId when session is fresh", () => {

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -131,6 +131,8 @@ describe("resolveCronSession", () => {
           modelOverride: "gpt-4.1-mini",
           providerOverride: "openai",
           sendPolicy: "allow",
+          authProfileOverride: "cli-profile",
+          authProfileOverrideSource: "user",
         },
       });
       vi.mocked(evaluateSessionFreshness).mockReturnValue({ fresh: false });
@@ -148,6 +150,8 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.modelOverride).toBe("gpt-4.1-mini");
       expect(result.sessionEntry.providerOverride).toBe("openai");
       expect(result.sessionEntry.sendPolicy).toBe("allow");
+      expect(result.sessionEntry.authProfileOverride).toBe("cli-profile");
+      expect(result.sessionEntry.authProfileOverrideSource).toBe("user");
     });
 
     it("creates new sessionId when forceNew is true", () => {


### PR DESCRIPTION
## Summary
- Cron isolated-agent jobs were not passing `authProfileId` to `runEmbeddedPiAgent`, causing the runner to fall back to default auth profile ordering (OAuth > Token > API Key)
- CLI auth (API key type) was deprioritized, so billing-eligible profiles were tried first, producing repeated "payment verification failed" messages on every cron run
- This applies the same fix as #16303 — passes `authProfileId`/`authProfileIdSource` from the session entry and applies `applyModelOverrideToSessionEntry` when the resolved model differs from the default

## Changes (2 files)
- **`src/cron/isolated-agent/run.ts`** — import `applyModelOverrideToSessionEntry`, apply it after `resolveCronSession` when model override is active, and pass `authProfileId`/`authProfileIdSource` to `runEmbeddedPiAgent`
- **`src/cron/isolated-agent/session.test.ts`** — add test verifying `authProfileOverride` fields are preserved across session resets

Fixes #14401
Ref: #16303, #14376

## Test plan
- [x] All 145 cron tests pass (`npx vitest run src/cron/`)
- [x] New test verifies `authProfileOverride`/`authProfileOverrideSource` preservation
- [ ] Manual: configure a cron job with Claude CLI auth, verify it uses CLI profile instead of billing-eligible profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where cron isolated-agent jobs were not passing `authProfileId` to `runEmbeddedPiAgent`, causing the runner to fall back to the default auth profile ordering (OAuth > Token > API Key) and repeatedly attempt billing-eligible profiles before CLI API key profiles, resulting in "payment verification failed" spam on every cron run.

**Key changes:**
- In `run.ts`: imports `applyModelOverrideToSessionEntry` and calls it after `resolveCronSession` when a model override is active, mirroring existing sub-agent behavior. Also computes `cronAuthProfileId` (only when `providerOverride === provider` to guard against cross-provider profile leakage during fallback) and passes `authProfileId`/`authProfileIdSource` to `runEmbeddedPiAgent`.
- In `session.test.ts`: adds a regression test verifying `authProfileOverride`/`authProfileOverrideSource` are preserved across session loads.

The implementation correctly mirrors the pattern in `src/commands/agent.ts` (the reference PR #16303) where `authProfileId` is set to `undefined` when the active provider differs from the primary, preventing an auth profile for one provider from being mistakenly applied to a fallback provider. The logic flows cleanly and doesn't introduce any correctness issues.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; the fix is a targeted, well-scoped bug fix that mirrors an existing pattern in the codebase.
- The logic correctly mirrors the reference pattern from `commands/agent.ts`, the provider-guard check prevents cross-provider auth profile leakage during model fallback, `applyModelOverrideToSessionEntry` is called with the session entry's own override fields (so it either preserves them or correctly clears them when unset), and the code doesn't introduce any new execution paths. The one style note is about incomplete test coverage for the stale-session case, but the underlying implementation is correct (the `...entry` spread in `resolveCronSession` already preserves the fields unconditionally).
- No files require special attention

<sub>Last reviewed commit: e627be4</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->