### PR TITLE
fix(agents): normalize tool call arguments dropped to {} (#19261)

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -260,6 +260,6 @@ export function applyExtraParamsToAgent(
 
   // Normalize tool call arguments for providers that return objects instead of JSON strings.
   // Applied universally as a safety net — no-op when arguments are already correct.
-  // See: https://github.com/anthropics/claude-code/issues/19261
+  // See: https://github.com/openclaw/openclaw/issues/19261
   agent.streamFn = createToolArgsNormalizerWrapper(agent.streamFn);
 }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -3,6 +3,7 @@ import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import { log } from "./logger.js";
+import { createToolArgsNormalizerWrapper } from "./stream-tool-args-normalizer.js";
 
 const OPENROUTER_APP_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://openclaw.ai",
@@ -256,4 +257,9 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI/OpenAI Codex providers so multi-turn
   // server-side conversation state is preserved.
   agent.streamFn = createOpenAIResponsesStoreWrapper(agent.streamFn);
+
+  // Normalize tool call arguments for providers that return objects instead of JSON strings.
+  // Applied universally as a safety net — no-op when arguments are already correct.
+  // See: https://github.com/anthropics/claude-code/issues/19261
+  agent.streamFn = createToolArgsNormalizerWrapper(agent.streamFn);
 }

--- a/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
@@ -4,12 +4,16 @@ import { describe, expect, it, vi } from "vitest";
 import { applyExtraParamsToAgent } from "./extra-params.js";
 
 // Mock streamSimple for testing
-vi.mock("@mariozechner/pi-ai", () => ({
-  streamSimple: vi.fn(() => ({
-    push: vi.fn(),
-    result: vi.fn(),
-  })),
-}));
+vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@mariozechner/pi-ai")>();
+  return {
+    ...mod,
+    streamSimple: vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(),
+    })),
+  };
+});
 
 type ToolStreamCase = {
   applyProvider: string;

--- a/src/agents/pi-embedded-runner/stream-tool-args-normalizer.test.ts
+++ b/src/agents/pi-embedded-runner/stream-tool-args-normalizer.test.ts
@@ -1,0 +1,410 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, AssistantMessageEvent, ToolCall } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createToolArgsNormalizerWrapper,
+  isEmptyObject,
+  normalizeEvent,
+} from "./stream-tool-args-normalizer.js";
+
+// Mock logger to avoid side-effects
+vi.mock("./logger.js", () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makePartial(content: AssistantMessage["content"] = []): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    api: "openai-completions",
+    provider: "test",
+    model: "test-model",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+function makeToolCall(args: Record<string, unknown> = {}): ToolCall {
+  return {
+    type: "toolCall",
+    id: "call_123",
+    name: "test_tool",
+    arguments: args,
+  };
+}
+
+// ── isEmptyObject ────────────────────────────────────────────────────────────
+
+describe("isEmptyObject", () => {
+  it("returns true for {}", () => {
+    expect(isEmptyObject({})).toBe(true);
+  });
+
+  it("returns false for { a: 1 }", () => {
+    expect(isEmptyObject({ a: 1 })).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isEmptyObject(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isEmptyObject(undefined)).toBe(false);
+  });
+
+  it("returns false for []", () => {
+    expect(isEmptyObject([])).toBe(false);
+  });
+
+  it("returns false for a string", () => {
+    expect(isEmptyObject("string")).toBe(false);
+  });
+
+  it("returns false for a number", () => {
+    expect(isEmptyObject(42)).toBe(false);
+  });
+});
+
+// ── normalizeEvent ───────────────────────────────────────────────────────────
+
+describe("normalizeEvent", () => {
+  it("passes through toolcall_delta with string delta unchanged", () => {
+    const map = new Map<number, Record<string, unknown>>();
+    const event: AssistantMessageEvent = {
+      type: "toolcall_delta",
+      contentIndex: 0,
+      delta: '{"foo":"bar"}',
+      partial: makePartial(),
+    };
+    const result = normalizeEvent(event, map);
+    expect(result).toBe(event);
+    expect(map.size).toBe(0);
+  });
+
+  it("captures object delta from toolcall_delta", () => {
+    const map = new Map<number, Record<string, unknown>>();
+    const objectDelta = { command: "ls -la" };
+    const event = {
+      type: "toolcall_delta" as const,
+      contentIndex: 0,
+      delta: objectDelta as unknown as string,
+      partial: makePartial(),
+    } as AssistantMessageEvent;
+
+    const result = normalizeEvent(event, map);
+    expect(result).toBe(event);
+    expect(map.get(0)).toEqual({ command: "ls -la" });
+  });
+
+  it("returns toolcall_end unchanged when arguments are non-empty", () => {
+    const map = new Map<number, Record<string, unknown>>();
+    const tc = makeToolCall({ command: "ls" });
+    const event: AssistantMessageEvent = {
+      type: "toolcall_end",
+      contentIndex: 0,
+      toolCall: tc,
+      partial: makePartial([tc]),
+    };
+    const result = normalizeEvent(event, map);
+    expect(result).toBe(event);
+  });
+
+  it("repairs toolcall_end when arguments are {} and captured object exists", () => {
+    const map = new Map<number, Record<string, unknown>>();
+    map.set(0, { command: "ls -la" });
+
+    const tc = makeToolCall({});
+    const event: AssistantMessageEvent = {
+      type: "toolcall_end",
+      contentIndex: 0,
+      toolCall: tc,
+      partial: makePartial([tc]),
+    };
+
+    const result = normalizeEvent(event, map);
+    expect(result).not.toBe(event);
+    expect(result.type).toBe("toolcall_end");
+    if (result.type === "toolcall_end") {
+      expect(result.toolCall.arguments).toEqual({ command: "ls -la" });
+      const contentItem = result.partial.content[0];
+      expect(contentItem.type).toBe("toolCall");
+      if (contentItem.type === "toolCall") {
+        expect(contentItem.arguments).toEqual({ command: "ls -la" });
+      }
+    }
+  });
+
+  it("returns toolcall_end unchanged when arguments are {} but no captured object", () => {
+    const map = new Map<number, Record<string, unknown>>();
+    const tc = makeToolCall({});
+    const event: AssistantMessageEvent = {
+      type: "toolcall_end",
+      contentIndex: 0,
+      toolCall: tc,
+      partial: makePartial([tc]),
+    };
+    const result = normalizeEvent(event, map);
+    expect(result).toBe(event);
+  });
+
+  it("tracks multiple content indices independently", () => {
+    const map = new Map<number, Record<string, unknown>>();
+    const obj0 = { command: "ls" };
+    const obj1 = { file: "test.txt" };
+
+    // Capture two different deltas at different indices
+    normalizeEvent(
+      {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: obj0 as unknown as string,
+        partial: makePartial(),
+      } as AssistantMessageEvent,
+      map,
+    );
+    normalizeEvent(
+      {
+        type: "toolcall_delta",
+        contentIndex: 1,
+        delta: obj1 as unknown as string,
+        partial: makePartial(),
+      } as AssistantMessageEvent,
+      map,
+    );
+
+    expect(map.get(0)).toEqual({ command: "ls" });
+    expect(map.get(1)).toEqual({ file: "test.txt" });
+  });
+
+  it("passes through text_delta and other non-toolcall events unchanged", () => {
+    const map = new Map<number, Record<string, unknown>>();
+    const textEvent: AssistantMessageEvent = {
+      type: "text_delta",
+      contentIndex: 0,
+      delta: "hello",
+      partial: makePartial(),
+    };
+    expect(normalizeEvent(textEvent, map)).toBe(textEvent);
+
+    const startEvent: AssistantMessageEvent = {
+      type: "start",
+      partial: makePartial(),
+    };
+    expect(normalizeEvent(startEvent, map)).toBe(startEvent);
+  });
+
+  it("repairs done event when tool calls have empty arguments", () => {
+    const map = new Map<number, Record<string, unknown>>();
+    map.set(1, { command: "ls -la" });
+
+    const tc0: ToolCall = { type: "toolCall", id: "c0", name: "tool_a", arguments: { x: 1 } };
+    const tc1: ToolCall = { type: "toolCall", id: "c1", name: "tool_b", arguments: {} };
+
+    const msg = makePartial([tc0, tc1]);
+    const event: AssistantMessageEvent = {
+      type: "done",
+      reason: "toolUse",
+      message: msg,
+    };
+
+    const result = normalizeEvent(event, map);
+    expect(result).not.toBe(event);
+    if (result.type === "done") {
+      expect(result.message.content[0]).toEqual(tc0); // unchanged
+      const repaired = result.message.content[1];
+      expect(repaired.type).toBe("toolCall");
+      if (repaired.type === "toolCall") {
+        expect(repaired.arguments).toEqual({ command: "ls -la" });
+      }
+    }
+  });
+
+  it("returns done event unchanged when no captured args", () => {
+    const map = new Map<number, Record<string, unknown>>();
+    const msg = makePartial([makeToolCall({ a: 1 })]);
+    const event: AssistantMessageEvent = {
+      type: "done",
+      reason: "stop",
+      message: msg,
+    };
+    expect(normalizeEvent(event, map)).toBe(event);
+  });
+});
+
+// ── createToolArgsNormalizerWrapper integration ──────────────────────────────
+
+describe("createToolArgsNormalizerWrapper", () => {
+  it("repairs tool args from object delta through full stream", async () => {
+    const objectArgs = { command: "ls -la", timeout: 5000 };
+    const tc = makeToolCall({});
+
+    // Build a mock stream that simulates a provider returning object deltas
+    const sourceStream = createAssistantMessageEventStream();
+
+    const baseStreamFn = vi.fn().mockReturnValue(sourceStream);
+    const wrapped = createToolArgsNormalizerWrapper(baseStreamFn);
+
+    const resultStream = wrapped(
+      {
+        id: "test",
+        api: "openai-completions",
+        provider: "test",
+      } as unknown as Parameters<StreamFn>[0],
+      { messages: [] },
+      {},
+    );
+
+    // Collect events from the wrapped stream
+    const events: AssistantMessageEvent[] = [];
+    const collectPromise = (async () => {
+      for await (const event of resultStream as AsyncIterable<AssistantMessageEvent>) {
+        events.push(event);
+      }
+    })();
+
+    // Push events to the source stream
+    sourceStream.push({
+      type: "toolcall_start",
+      contentIndex: 0,
+      partial: makePartial(),
+    });
+    sourceStream.push({
+      type: "toolcall_delta",
+      contentIndex: 0,
+      delta: objectArgs as unknown as string,
+      partial: makePartial(),
+    } as AssistantMessageEvent);
+    sourceStream.push({
+      type: "toolcall_end",
+      contentIndex: 0,
+      toolCall: tc,
+      partial: makePartial([tc]),
+    });
+    const doneMsg = makePartial([tc]);
+    doneMsg.stopReason = "toolUse";
+    sourceStream.push({
+      type: "done",
+      reason: "toolUse",
+      message: doneMsg,
+    });
+
+    await collectPromise;
+
+    // Verify the toolcall_end was repaired
+    const toolcallEnd = events.find((e) => e.type === "toolcall_end");
+    expect(toolcallEnd).toBeDefined();
+    if (toolcallEnd?.type === "toolcall_end") {
+      expect(toolcallEnd.toolCall.arguments).toEqual(objectArgs);
+    }
+
+    // Verify the done event was also repaired
+    const doneEvent = events.find((e) => e.type === "done");
+    expect(doneEvent).toBeDefined();
+    if (doneEvent?.type === "done") {
+      const content = doneEvent.message.content[0];
+      if (content.type === "toolCall") {
+        expect(content.arguments).toEqual(objectArgs);
+      }
+    }
+  });
+
+  it("passes through normal string-delta streams without modification", async () => {
+    const tc = makeToolCall({ command: "ls" });
+    const sourceStream = createAssistantMessageEventStream();
+
+    const baseStreamFn = vi.fn().mockReturnValue(sourceStream);
+    const wrapped = createToolArgsNormalizerWrapper(baseStreamFn);
+
+    const resultStream = wrapped(
+      {
+        id: "test",
+        api: "openai-completions",
+        provider: "test",
+      } as unknown as Parameters<StreamFn>[0],
+      { messages: [] },
+      {},
+    );
+
+    const events: AssistantMessageEvent[] = [];
+    const collectPromise = (async () => {
+      for await (const event of resultStream as AsyncIterable<AssistantMessageEvent>) {
+        events.push(event);
+      }
+    })();
+
+    sourceStream.push({
+      type: "toolcall_delta",
+      contentIndex: 0,
+      delta: '{"command":"ls"}',
+      partial: makePartial(),
+    });
+    sourceStream.push({
+      type: "toolcall_end",
+      contentIndex: 0,
+      toolCall: tc,
+      partial: makePartial([tc]),
+    });
+    sourceStream.push({
+      type: "done",
+      reason: "toolUse",
+      message: makePartial([tc]),
+    });
+
+    await collectPromise;
+
+    // toolcall_end should be unchanged (arguments are already populated)
+    const toolcallEnd = events.find((e) => e.type === "toolcall_end");
+    if (toolcallEnd?.type === "toolcall_end") {
+      expect(toolcallEnd.toolCall.arguments).toEqual({ command: "ls" });
+    }
+  });
+
+  it("handles Promise-returning base stream functions", async () => {
+    const sourceStream = createAssistantMessageEventStream();
+    const baseStreamFn = vi.fn().mockResolvedValue(sourceStream);
+    const wrapped = createToolArgsNormalizerWrapper(baseStreamFn);
+
+    const resultPromise = wrapped(
+      {
+        id: "test",
+        api: "openai-completions",
+        provider: "test",
+      } as unknown as Parameters<StreamFn>[0],
+      { messages: [] },
+      {},
+    );
+
+    // The result should be a promise since the base returned a promise
+    expect(resultPromise).toBeInstanceOf(Promise);
+
+    const resultStream = await (resultPromise as Promise<unknown>);
+
+    const events: AssistantMessageEvent[] = [];
+    const collectPromise = (async () => {
+      for await (const event of resultStream as AsyncIterable<AssistantMessageEvent>) {
+        events.push(event);
+      }
+    })();
+
+    sourceStream.push({
+      type: "done",
+      reason: "stop",
+      message: makePartial(),
+    });
+
+    await collectPromise;
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("done");
+  });
+});

--- a/src/agents/pi-embedded-runner/stream-tool-args-normalizer.ts
+++ b/src/agents/pi-embedded-runner/stream-tool-args-normalizer.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { AssistantMessageEvent, ToolCall } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
@@ -63,8 +64,7 @@ export function normalizeEvent(
         );
       }
       return {
-        type: "toolcall_end",
-        contentIndex: event.contentIndex,
+        ...event,
         toolCall: repairedToolCall,
         partial: repairedPartial,
       };
@@ -94,8 +94,7 @@ export function normalizeEvent(
     });
     if (repaired) {
       return {
-        type: "done",
-        reason: event.reason,
+        ...event,
         message: { ...message, content: repairedContent },
       };
     }
@@ -123,8 +122,10 @@ export function createToolArgsNormalizerWrapper(baseStreamFn: StreamFn | undefin
     // This shouldn't happen in practice since applyExtraParamsToAgent always
     // has a streamFn by this point, but handle gracefully.
     return (...args) => {
-      const { streamSimple } =
-        require("@mariozechner/pi-ai") as typeof import("@mariozechner/pi-ai");
+      const esmRequire = createRequire(import.meta.url);
+      const { streamSimple } = esmRequire(
+        "@mariozechner/pi-ai",
+      ) as typeof import("@mariozechner/pi-ai");
       return streamSimple(...args);
     };
   }

--- a/src/agents/pi-embedded-runner/stream-tool-args-normalizer.ts
+++ b/src/agents/pi-embedded-runner/stream-tool-args-normalizer.ts
@@ -1,0 +1,181 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { AssistantMessageEvent, ToolCall } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { log } from "./logger.js";
+
+/**
+ * Returns true only for a plain object with zero own keys (`{}`).
+ */
+export function isEmptyObject(v: unknown): boolean {
+  return (
+    v !== null &&
+    v !== undefined &&
+    typeof v === "object" &&
+    !Array.isArray(v) &&
+    Object.keys(v as Record<string, unknown>).length === 0
+  );
+}
+
+/**
+ * Pure function that normalizes a single AssistantMessageEvent.
+ *
+ * On `toolcall_delta`: if the `delta` field is a non-string object, captures
+ * it in `capturedArgs` keyed by `contentIndex`. The event is returned as-is.
+ *
+ * On `toolcall_end`: if `toolCall.arguments` is `{}` and we have a captured
+ * object for that `contentIndex`, replaces the arguments with the captured value.
+ *
+ * On `done`: repairs any tool calls in `message.content` that have empty
+ * arguments but have a captured value.
+ */
+export function normalizeEvent(
+  event: AssistantMessageEvent,
+  capturedArgs: Map<number, Record<string, unknown>>,
+): AssistantMessageEvent {
+  if (event.type === "toolcall_delta") {
+    const delta = (event as { delta: unknown }).delta;
+    if (
+      typeof delta !== "string" &&
+      delta !== null &&
+      delta !== undefined &&
+      typeof delta === "object"
+    ) {
+      capturedArgs.set(event.contentIndex, delta as Record<string, unknown>);
+    }
+    return event;
+  }
+
+  if (event.type === "toolcall_end") {
+    const captured = capturedArgs.get(event.contentIndex);
+    if (captured && isEmptyObject(event.toolCall.arguments)) {
+      log.debug(
+        `[tool-args-normalizer] repairing empty arguments for tool "${event.toolCall.name}" ` +
+          `(contentIndex=${event.contentIndex})`,
+      );
+      const repairedToolCall: ToolCall = {
+        ...event.toolCall,
+        arguments: captured,
+      };
+      const repairedPartial = { ...event.partial };
+      if (Array.isArray(repairedPartial.content)) {
+        repairedPartial.content = repairedPartial.content.map((c, i) =>
+          i === event.contentIndex && c.type === "toolCall" ? { ...c, arguments: captured } : c,
+        );
+      }
+      return {
+        type: "toolcall_end",
+        contentIndex: event.contentIndex,
+        toolCall: repairedToolCall,
+        partial: repairedPartial,
+      };
+    }
+    return event;
+  }
+
+  if (event.type === "done") {
+    if (capturedArgs.size === 0) {
+      return event;
+    }
+    const message = event.message;
+    let repaired = false;
+    const repairedContent = message.content.map((c, i) => {
+      if (c.type === "toolCall" && isEmptyObject(c.arguments)) {
+        const captured = capturedArgs.get(i);
+        if (captured) {
+          repaired = true;
+          log.debug(
+            `[tool-args-normalizer] repairing empty arguments in done event for tool "${c.name}" ` +
+              `(contentIndex=${i})`,
+          );
+          return { ...c, arguments: captured };
+        }
+      }
+      return c;
+    });
+    if (repaired) {
+      return {
+        type: "done",
+        reason: event.reason,
+        message: { ...message, content: repairedContent },
+      };
+    }
+    return event;
+  }
+
+  return event;
+}
+
+/**
+ * Creates a StreamFn wrapper that fixes tool call arguments being dropped to `{}`
+ * when providers return `function.arguments` as an object instead of a JSON string.
+ *
+ * The pi-ai streaming parser accumulates arguments via string concatenation:
+ *   `partialArgs += toolCall.function.arguments`
+ * When a non-standard provider returns an object, this produces `"[object Object]"`
+ * which `parseStreamingJson()` can't parse, yielding `{}`.
+ *
+ * The original object leaks through the `toolcall_delta` event's `delta` field.
+ * This wrapper captures it and repairs the empty `{}` at `toolcall_end` and `done`.
+ */
+export function createToolArgsNormalizerWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  if (!baseStreamFn) {
+    // Nothing to wrap — return a passthrough that would need a real streamFn.
+    // This shouldn't happen in practice since applyExtraParamsToAgent always
+    // has a streamFn by this point, but handle gracefully.
+    return (...args) => {
+      const { streamSimple } =
+        require("@mariozechner/pi-ai") as typeof import("@mariozechner/pi-ai");
+      return streamSimple(...args);
+    };
+  }
+
+  return (...args) => {
+    const maybeStream = baseStreamFn(...args);
+
+    // baseStreamFn can return sync or Promise<AssistantMessageEventStream>
+    const wrap = (originalStream: Awaited<ReturnType<StreamFn>>) => {
+      const proxy = createAssistantMessageEventStream();
+      const capturedArgs = new Map<number, Record<string, unknown>>();
+
+      void (async () => {
+        try {
+          for await (const event of originalStream) {
+            const normalized = normalizeEvent(event, capturedArgs);
+            proxy.push(normalized);
+          }
+        } catch (err) {
+          // If the original stream errors, push an error event to the proxy
+          proxy.push({
+            type: "error",
+            reason: "error",
+            error: {
+              role: "assistant",
+              content: [],
+              stopReason: "error",
+              errorMessage: err instanceof Error ? err.message : String(err),
+              api: "",
+              provider: "",
+              model: "",
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              timestamp: Date.now(),
+            },
+          });
+        }
+      })();
+
+      return proxy;
+    };
+
+    if (maybeStream instanceof Promise) {
+      return maybeStream.then(wrap) as unknown as ReturnType<StreamFn>;
+    }
+    return wrap(maybeStream);
+  };
+}

--- a/src/agents/pi-tool-definition-adapter.e2e.test.ts
+++ b/src/agents/pi-tool-definition-adapter.e2e.test.ts
@@ -59,4 +59,84 @@ describe("pi tool definition adapter", () => {
       error: "nope",
     });
   });
+
+  describe("splitToolExecuteArgs — arg format handling", () => {
+    function createCaptureTool() {
+      let captured:
+        | {
+            toolCallId: string;
+            params: unknown;
+            hasSignal: boolean;
+            hasOnUpdate: boolean;
+          }
+        | undefined;
+      const tool: AgentTool = {
+        name: "capture",
+        label: "Capture",
+        description: "captures args",
+        parameters: Type.Object({ foo: Type.String() }),
+        execute: async (toolCallId, params, signal, onUpdate) => {
+          captured = {
+            toolCallId,
+            params,
+            hasSignal: signal !== undefined,
+            hasOnUpdate: onUpdate !== undefined,
+          };
+          return { content: [{ type: "text" as const, text: "ok" }], details: {} };
+        },
+      };
+      return { tool, getCaptured: () => captured };
+    }
+
+    it("handles current format: [id, params, signal, onUpdate, extensionCtx]", async () => {
+      const { tool, getCaptured } = createCaptureTool();
+      const defs = toToolDefinitions([tool]);
+      const signal = new AbortController().signal;
+      const onUpdate = () => {};
+      await defs[0].execute("call-1", { foo: "bar" }, signal, onUpdate, extensionContext);
+      expect(getCaptured()).toMatchObject({
+        toolCallId: "call-1",
+        params: { foo: "bar" },
+        hasSignal: true,
+        hasOnUpdate: true,
+      });
+    });
+
+    it("handles current format with undefined signal/onUpdate", async () => {
+      const { tool, getCaptured } = createCaptureTool();
+      const defs = toToolDefinitions([tool]);
+      await defs[0].execute("call-2", { foo: "baz" }, undefined, undefined, extensionContext);
+      expect(getCaptured()).toMatchObject({
+        toolCallId: "call-2",
+        params: { foo: "baz" },
+        hasSignal: false,
+        hasOnUpdate: false,
+      });
+    });
+
+    it("handles empty params {}", async () => {
+      const { tool, getCaptured } = createCaptureTool();
+      const defs = toToolDefinitions([tool]);
+      await defs[0].execute("call-3", {}, undefined, undefined, extensionContext);
+      expect(getCaptured()).toMatchObject({
+        toolCallId: "call-3",
+        params: {},
+      });
+    });
+
+    it("handles legacy format: [id, params, onUpdate, ctx, signal]", async () => {
+      const { tool, getCaptured } = createCaptureTool();
+      const defs = toToolDefinitions([tool]);
+      const signal = new AbortController().signal;
+      const onUpdate = () => {};
+      // Legacy format: 3rd arg is function (onUpdate), 5th is AbortSignal
+      await (defs[0].execute as Function)("call-4", { foo: "legacy" }, onUpdate, {}, signal);
+      expect(getCaptured()).toMatchObject({
+        toolCallId: "call-4",
+        params: { foo: "legacy" },
+        hasSignal: true,
+        hasOnUpdate: true,
+      });
+    });
+  });
 });

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -100,7 +100,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
         let executeParams = params;
         // Warn if params are empty but tool has required properties — likely a streaming parse bug.
-        // See: https://github.com/anthropics/claude-code/issues/19261
+        // See: https://github.com/openclaw/openclaw/issues/19261
         if (
           executeParams != null &&
           typeof executeParams === "object" &&
@@ -111,7 +111,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
         ) {
           logWarn(
             `[tools] ${normalizedName}: received empty params {} but tool has required properties. ` +
-              `This may indicate a provider streaming bug. See: https://github.com/anthropics/claude-code/issues/19261`,
+              `This may indicate a provider streaming bug. See: https://github.com/openclaw/openclaw/issues/19261`,
           );
         }
         try {

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -4,7 +4,7 @@ import type {
   AgentToolUpdateCallback,
 } from "@mariozechner/pi-agent-core";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
-import { logDebug, logError } from "../logger.js";
+import { logDebug, logError, logWarn } from "../logger.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { isPlainObject } from "../utils.js";
 import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
@@ -99,6 +99,21 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
         let executeParams = params;
+        // Warn if params are empty but tool has required properties — likely a streaming parse bug.
+        // See: https://github.com/anthropics/claude-code/issues/19261
+        if (
+          executeParams != null &&
+          typeof executeParams === "object" &&
+          !Array.isArray(executeParams) &&
+          Object.keys(executeParams as Record<string, unknown>).length === 0 &&
+          tool.parameters?.required &&
+          (tool.parameters.required as unknown[]).length > 0
+        ) {
+          logWarn(
+            `[tools] ${normalizedName}: received empty params {} but tool has required properties. ` +
+              `This may indicate a provider streaming bug. See: https://github.com/anthropics/claude-code/issues/19261`,
+          );
+        }
         try {
           if (!beforeHookWrapped) {
             const hookOutcome = await runBeforeToolCallHook({


### PR DESCRIPTION
## Summary
- Fix ALL tool calls with required parameters failing because `arguments` becomes `{}` on non-standard providers
- Add a `StreamFn` wrapper that captures object-typed deltas and repairs empty arguments at stream end
- Add diagnostic warning when empty params are passed to tools with required properties

## Root Cause

pi-ai's `openai-completions.js` accumulates streaming tool arguments via string concatenation (`partialArgs += toolCall.function.arguments`). When a non-standard provider returns `function.arguments` as an **object** instead of a JSON string, this produces `"[object Object]"` which `parseStreamingJson()` can't parse, returning `{}`. AJV validation then throws "must have required property" for every tool with required params.

**Key insight**: The original object value leaks through the `toolcall_delta` event's `delta` field — the normalizer captures it and repairs the corrupted arguments.

## Changes

| File | Change |
|------|--------|
| `stream-tool-args-normalizer.ts` | New `StreamFn` wrapper — monitors `toolcall_delta` for object deltas, repairs `{}` at `toolcall_end`/`done` |
| `extra-params.ts` | Wire normalizer as last wrapper in `applyExtraParamsToAgent` (universal safety net) |
| `pi-tool-definition-adapter.ts` | `logWarn` when params are `{}` but tool has required properties |
| `stream-tool-args-normalizer.test.ts` | 19 unit tests for `isEmptyObject`, `normalizeEvent`, full integration |
| `pi-tool-definition-adapter.e2e.test.ts` | 4 tests for `splitToolExecuteArgs` (current + legacy formats) |
| `extra-params.zai-tool-stream.test.ts` | Update mock to preserve `createAssistantMessageEventStream` export |

## Test plan
- [x] `pnpm vitest run src/agents/pi-embedded-runner/stream-tool-args-normalizer.test.ts` — 19 pass
- [x] `pnpm vitest run --config vitest.e2e.config.ts src/agents/pi-tool-definition-adapter.e2e.test.ts` — 6 pass
- [x] `pnpm build` — clean
- [x] `pnpm check` (format + typecheck + lint) — 0 errors
- [x] `pnpm test` — 7246 tests pass, 0 failures
- [x] Manual verification: kimi-cli and codex-cli tool calls work correctly

Fixes #19261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a streaming bug where non-standard OpenAI-compatible providers return `function.arguments` as an object instead of a JSON string, causing `pi-ai`'s string-concatenation accumulator to produce `"[object Object]"`, which then parses as `{}` and fails AJV validation.

The fix adds a `StreamFn` wrapper (`createToolArgsNormalizerWrapper`) that intercepts `toolcall_delta` events, captures object-typed deltas by `contentIndex`, and repairs `{}` arguments at `toolcall_end` and `done` events. A diagnostic warning is added to `toToolDefinitions` as a last-resort safety net. The mock update in `extra-params.zai-tool-stream.test.ts` is necessary because the new normalizer imports `createAssistantMessageEventStream` from the mocked module.

Key issues found:

- **Wrong repository in issue URL**: Three places reference the `anthropics/claude-code` GitHub repository, but this is the `openclaw/openclaw` repo — all other issue references in the codebase use the correct repo. The user-visible warning message also embeds this incorrect URL.
- **Bare `require()` in ESM fallback path** (`stream-tool-args-normalizer.ts:127`): Every other `require()` call in the project first creates a local require via `createRequire(import.meta.url)`. The fallback path would throw `ReferenceError: require is not defined` at runtime in this pure ESM module. Although the comment says this path "shouldn't happen in practice," it's still broken code.
- **Event reconstruction drops unknown fields**: Both the `toolcall_end` and `done` event repairs reconstruct events with only the currently-known fields rather than spreading `{ ...event, ...repairs }`, which would silently drop any additional fields added in a future version of `@mariozechner/pi-ai`.

<h3>Confidence Score: 3/5</h3>

- The core fix is sound and the tests pass, but a broken fallback path (bare `require()` in ESM) and wrong issue URLs need correction before merging.
- The primary fix logic is correct and well-tested with 19 unit tests. However, the fallback path in `createToolArgsNormalizerWrapper` uses a bare `require()` call that would fail at runtime in this ESM module (inconsistent with the rest of the codebase which uses `createRequire(import.meta.url)`). The issue URLs in both source comments and a user-visible warning message point to the wrong repository (`anthropics/claude-code` instead of `openclaw/openclaw`). The event reconstruction style issues are minor and forward-compatibility concerns only.
- Pay close attention to `src/agents/pi-embedded-runner/stream-tool-args-normalizer.ts` (the bare `require()` fallback) and the issue URL references in `src/agents/pi-embedded-runner/extra-params.ts` and `src/agents/pi-tool-definition-adapter.ts`.

<sub>Last reviewed commit: d18f50c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->