### PR TITLE
feat(models): add Claude Sonnet 4.6 support

### DIFF
--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -23,6 +23,7 @@ const CLAUDE_MODEL_ALIASES: Record<string, string> = {
   "sonnet-4.5": "sonnet",
   "sonnet-4.1": "sonnet",
   "sonnet-4.0": "sonnet",
+  "claude-sonnet-4-6": "sonnet",
   "claude-sonnet-4-5": "sonnet",
   "claude-sonnet-4-1": "sonnet",
   "claude-sonnet-4-0": "sonnet",

--- a/src/agents/cloudflare-ai-gateway.ts
+++ b/src/agents/cloudflare-ai-gateway.ts
@@ -1,7 +1,7 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
 
 export const CLOUDFLARE_AI_GATEWAY_PROVIDER_ID = "cloudflare-ai-gateway";
-export const CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_ID = "claude-sonnet-4-5";
+export const CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_ID = "claude-sonnet-4-6";
 export const CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF = `${CLOUDFLARE_AI_GATEWAY_PROVIDER_ID}/${CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_ID}`;
 
 export const CLOUDFLARE_AI_GATEWAY_DEFAULT_CONTEXT_WINDOW = 200_000;

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -6,6 +6,7 @@ export type ModelRef = {
 const ANTHROPIC_PREFIXES = [
   "claude-opus-4-6",
   "claude-opus-4-5",
+  "claude-sonnet-4-6",
   "claude-sonnet-4-5",
   "claude-haiku-4-5",
 ];

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -19,6 +19,7 @@ export type ModelAliasIndex = {
 const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
   "opus-4.6": "claude-opus-4-6",
   "opus-4.5": "claude-opus-4-5",
+  "sonnet-4.6": "claude-sonnet-4-6",
   "sonnet-4.5": "claude-sonnet-4-5",
 };
 const OPENAI_CODEX_OAUTH_MODEL_PREFIXES = ["gpt-5.3-codex"] as const;

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -31,6 +31,7 @@ function sanitizeTokenValue(value: string | undefined): string | undefined {
 const ANTHROPIC_OAUTH_MODEL_KEYS = [
   "anthropic/claude-opus-4-6",
   "anthropic/claude-opus-4-5",
+  "anthropic/claude-sonnet-4-6",
   "anthropic/claude-sonnet-4-5",
   "anthropic/claude-haiku-4-5",
 ];

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -14,7 +14,7 @@ type AnthropicAuthDefaultsMode = "api_key" | "oauth";
 const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   // Anthropic (pi-ai catalog uses "latest" ids without date suffix)
   opus: "anthropic/claude-opus-4-6",
-  sonnet: "anthropic/claude-sonnet-4-5",
+  sonnet: "anthropic/claude-sonnet-4-6",
 
   // OpenAI
   gpt: "openai/gpt-5.2",


### PR DESCRIPTION
Adds support for Claude Sonnet 4.6, released today (Feb 17, 2026).

## Changes
- Update default `sonnet` alias to `claude-sonnet-4-6`
- Add `sonnet-4.6` to Anthropic model aliases in model-selection
- Add `claude-sonnet-4-6` to CLI backends mapping
- Add to live model filter prefixes
- Add to OAuth model keys list
- Update Cloudflare AI Gateway default model to sonnet-4-6

Sonnet 4.6 offers Opus-level reasoning at Sonnet pricing ($3/$15 per million tokens), 1M context window (beta), and improved coding/agent/computer-use capabilities.

Ref: https://www.anthropic.com/news/claude-sonnet-4-6

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for Claude Sonnet 4.6 across the codebase, updating the default `sonnet` alias, model aliases, CLI backends mapping, live model filter, OAuth model keys, and Cloudflare AI Gateway default model. The changes are straightforward and follow the established pattern used when previous Sonnet versions were added.

Two issues were found:

- **Stale display name in `cloudflare-ai-gateway.ts`**: The `buildCloudflareAiGatewayModelDefinition` function's hardcoded default name was not updated from `"Claude Sonnet 4.5"` to `"Claude Sonnet 4.6"`. Since the default model ID was correctly changed to `claude-sonnet-4-6`, calling this function without an explicit name (as done in `models-config.providers.ts`) will display the wrong model name in UI.
- **Missing short-form alias in `cli-backends.ts`**: The pattern for every other Sonnet version includes both a short dotted alias (e.g., `"sonnet-4.5"`) and a full dashed alias (e.g., `"claude-sonnet-4-5"`). Sonnet 4.6 only received the full form `"claude-sonnet-4-6"`, omitting `"sonnet-4.6"`, which is inconsistent and may cause resolution failures when users specify the short form.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe but has two logic issues that should be fixed before merging.
- The core changes (defaults.ts, model-selection.ts, live-model-filter.ts, configure.gateway-auth.ts) are correct and follow established patterns. However, the stale display name in cloudflare-ai-gateway.ts will show "Claude Sonnet 4.5" in UI when the default Cloudflare model is used, and the missing short-form alias in cli-backends.ts breaks the consistent alias pattern and may cause resolution failures for users specifying "sonnet-4.6".
- src/agents/cloudflare-ai-gateway.ts (stale name), src/agents/cli-backends.ts (missing short alias)

<sub>Last reviewed commit: d8ce113</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->