### PR TITLE
fix(agents): strip thinking blocks on cross-provider model switch (#19295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: strip thinking blocks from session history when switching between model providers, preventing 400 errors from stale Anthropic thinking blocks during failover. (#19295)
 - macOS/Update: correct the Sparkle appcast version for 2026.2.15 so updates are offered again. (#18201)
 - Gateway/Auth: clear stale device-auth tokens after device token mismatch errors so re-paired clients can re-auth. (#18201)
 - Voice call/Gateway: prevent overlapping closed-loop turn races with per-call turn locking, route transcript dedupe via source-aware fingerprints with strict cache eviction bounds, and harden `voicecall latency` stats for large logs without spread-operator stack overflow. (#19140) Thanks @mbelinky.

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -40,7 +40,10 @@ export {
 } from "./pi-embedded-helpers/errors.js";
 export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers/google.js";
 
-export { downgradeOpenAIReasoningBlocks } from "./pi-embedded-helpers/openai.js";
+export {
+  downgradeOpenAIReasoningBlocks,
+  stripNonNativeThinkingBlocks,
+} from "./pi-embedded-helpers/openai.js";
 export {
   isEmptyAssistantMessageContent,
   sanitizeSessionMessagesImages,

--- a/src/agents/pi-embedded-helpers/openai.ts
+++ b/src/agents/pi-embedded-helpers/openai.ts
@@ -60,16 +60,17 @@ function hasFollowingNonThinkingBlock(
 }
 
 /**
- * Strip all `type: "thinking"` blocks from assistant messages that do NOT carry
- * an OpenAI reasoning signature (`rs_`-prefixed `thinkingSignature`).
+ * Strip all `type: "thinking"` blocks from assistant messages.
  *
- * When failing over from Anthropic (which produces unsigned thinking blocks) to
- * another provider (or back to Anthropic after a model change), stale thinking
- * blocks in the session history can cause 400 errors because the target API
- * either doesn't understand them or rejects invalid/missing signatures.
+ * When failing over from one provider to another (e.g. Anthropic → OpenAI),
+ * thinking blocks produced by the previous provider remain in session history
+ * and can cause 400 errors because the target API didn't produce them and
+ * cannot validate their signatures (or doesn't understand them at all).
  *
  * This should be called when the model has changed between providers so that
  * provider-specific thinking blocks don't leak across provider boundaries.
+ * All `type: "thinking"` content blocks are removed; assistant messages that
+ * become empty after stripping are dropped entirely.
  *
  * See: https://github.com/openclaw/openclaw/issues/19295
  */

--- a/src/agents/pi-embedded-runner.thinking-fallback.test.ts
+++ b/src/agents/pi-embedded-runner.thinking-fallback.test.ts
@@ -1,0 +1,210 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { stripNonNativeThinkingBlocks } from "./pi-embedded-helpers/openai.js";
+import { sanitizeSessionHistory } from "./pi-embedded-runner/google.js";
+
+describe("stripNonNativeThinkingBlocks", () => {
+  it("strips all thinking blocks from assistant messages", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hi" } as unknown as AgentMessage,
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning..." },
+          { type: "text", text: "hello" },
+        ],
+      } as unknown as AgentMessage,
+    ];
+
+    const result = stripNonNativeThinkingBlocks(messages);
+    const assistant = result.find((m) => (m as { role?: string }).role === "assistant") as {
+      content?: Array<{ type?: string }>;
+    };
+
+    expect(assistant.content?.map((b) => b.type)).toEqual(["text"]);
+  });
+
+  it("drops assistant message entirely when only thinking blocks remain", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hi" } as unknown as AgentMessage,
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "reasoning..." }],
+      } as unknown as AgentMessage,
+    ];
+
+    const result = stripNonNativeThinkingBlocks(messages);
+    const assistant = result.find((m) => (m as { role?: string }).role === "assistant");
+    expect(assistant).toBeUndefined();
+  });
+
+  it("preserves non-assistant messages unchanged", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hi" } as unknown as AgentMessage,
+      { role: "user", content: "hello" } as unknown as AgentMessage,
+    ];
+
+    const result = stripNonNativeThinkingBlocks(messages);
+    expect(result).toEqual(messages);
+  });
+
+  it("preserves assistant messages with no thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "hello" }],
+      } as unknown as AgentMessage,
+    ];
+
+    const result = stripNonNativeThinkingBlocks(messages);
+    expect(result).toStrictEqual(messages);
+  });
+
+  it("preserves assistant messages with string content", () => {
+    const messages: AgentMessage[] = [
+      { role: "assistant", content: "hello" } as unknown as AgentMessage,
+    ];
+
+    const result = stripNonNativeThinkingBlocks(messages);
+    expect(result).toStrictEqual(messages);
+  });
+});
+
+describe("sanitizeSessionHistory — cross-provider thinking block stripping (#19295)", () => {
+  it("strips Anthropic thinking blocks when switching to openai-completions", async () => {
+    const sessionManager = SessionManager.inMemory();
+
+    // Set initial model snapshot to Anthropic
+    await sanitizeSessionHistory({
+      messages: [{ role: "user", content: "Hi" } as unknown as AgentMessage],
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5-20250929",
+      sessionManager,
+      sessionId: "session:test",
+    });
+
+    const history: AgentMessage[] = [
+      { role: "user", content: "What is 2+2?" } as unknown as AgentMessage,
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Let me calculate 2+2 = 4" },
+          { type: "text", text: "2+2 = 4" },
+        ],
+      } as unknown as AgentMessage,
+      { role: "user", content: "Thanks" } as unknown as AgentMessage,
+    ];
+
+    // Switch to OpenAI — thinking blocks should be stripped
+    const sanitized = await sanitizeSessionHistory({
+      messages: history,
+      modelApi: "openai-completions",
+      provider: "openai",
+      modelId: "gpt-5.2",
+      sessionManager,
+      sessionId: "session:test",
+    });
+
+    const assistant = sanitized.find((m) => (m as { role?: string }).role === "assistant") as {
+      content?: Array<{ type?: string }>;
+    };
+
+    expect(assistant.content?.map((b) => b.type)).toEqual(["text"]);
+  });
+
+  it("strips thinking blocks on round-trip Anthropic → OpenAI → Anthropic", async () => {
+    const sessionManager = SessionManager.inMemory();
+
+    const history: AgentMessage[] = [
+      { role: "user", content: "What is 2+2?" } as unknown as AgentMessage,
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Calculating..." },
+          { type: "text", text: "4" },
+        ],
+      } as unknown as AgentMessage,
+      { role: "user", content: "What is 3+3?" } as unknown as AgentMessage,
+    ];
+
+    // Anthropic first
+    await sanitizeSessionHistory({
+      messages: history.slice(0, 1),
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5-20250929",
+      sessionManager,
+      sessionId: "session:roundtrip",
+    });
+
+    // Switch to OpenAI
+    await sanitizeSessionHistory({
+      messages: history,
+      modelApi: "openai-completions",
+      provider: "openai",
+      modelId: "gpt-5.2",
+      sessionManager,
+      sessionId: "session:roundtrip",
+    });
+
+    // Switch back to Anthropic
+    const sanitized = await sanitizeSessionHistory({
+      messages: history,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5-20250929",
+      sessionManager,
+      sessionId: "session:roundtrip",
+    });
+
+    const assistant = sanitized.find((m) => (m as { role?: string }).role === "assistant") as {
+      content?: Array<{ type?: string }>;
+    };
+
+    // Thinking blocks should be stripped because model changed
+    expect(assistant.content?.map((b) => b.type)).toEqual(["text"]);
+  });
+
+  it("preserves thinking blocks when model has NOT changed", async () => {
+    const sessionManager = SessionManager.inMemory();
+
+    // Same model both times
+    await sanitizeSessionHistory({
+      messages: [{ role: "user", content: "Hi" } as unknown as AgentMessage],
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5-20250929",
+      sessionManager,
+      sessionId: "session:no-change",
+    });
+
+    const history: AgentMessage[] = [
+      { role: "user", content: "What is 2+2?" } as unknown as AgentMessage,
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Calculating..." },
+          { type: "text", text: "4" },
+        ],
+      } as unknown as AgentMessage,
+      { role: "user", content: "Thanks" } as unknown as AgentMessage,
+    ];
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: history,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5-20250929",
+      sessionManager,
+      sessionId: "session:no-change",
+    });
+
+    const assistant = sanitized.find((m) => (m as { role?: string }).role === "assistant") as {
+      content?: Array<{ type?: string }>;
+    };
+
+    expect(assistant.content?.map((b) => b.type)).toEqual(["thinking", "text"]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: Anthropic thinking blocks survive session history sanitization when failing over to a different model provider, causing 400 errors.
- **Root cause**: `sanitizeSessionHistory` in `src/agents/pi-embedded-runner/google.ts` had `downgradeOpenAIReasoningBlocks` for OpenAI reasoning blocks but no equivalent stripping for Anthropic `type: "thinking"` blocks on model change.
- **Fix**: Add `stripNonNativeThinkingBlocks` that removes all `type: "thinking"` blocks from assistant messages, wired into the sanitization pipeline when `modelChanged` is true.

Fixes #19295

## Problem

When the primary model (e.g. Anthropic Claude) rate-limits and the system fails over to a fallback provider (e.g. OpenAI), Anthropic-specific `type: "thinking"` blocks remain in the session history. The fallback provider rejects these with 400 errors because it doesn't understand unsigned thinking blocks.

The existing `downgradeOpenAIReasoningBlocks` only handles OpenAI `rs_`-signed reasoning blocks. There was no equivalent for Anthropic thinking blocks.

**Before fix:**
```
Input:  Session history with Anthropic thinking blocks + model switch to OpenAI
Output: 400 error — thinking blocks sent to OpenAI as-is
```

## Changes

- `src/agents/pi-embedded-helpers/openai.ts` — Add `stripNonNativeThinkingBlocks` function that strips all `type: "thinking"` blocks from assistant messages, dropping empty assistant messages entirely.
- `src/agents/pi-embedded-helpers.ts` — Export the new function from the barrel.
- `src/agents/pi-embedded-runner/google.ts` — Wire `stripNonNativeThinkingBlocks` into `sanitizeSessionHistory` when `modelChanged` is true, after the existing OpenAI reasoning block downgrade.

**After fix:**
```
Input:  Session history with Anthropic thinking blocks + model switch to OpenAI
Output: Thinking blocks stripped, only text/tool_use blocks remain — no 400 error
```

## Test plan

- [x] New tests: 5 unit tests for `stripNonNativeThinkingBlocks` (strip, drop empty, preserve non-assistant, preserve no-thinking, preserve string content)
- [x] New tests: 3 integration tests for `sanitizeSessionHistory` (Anthropic→OpenAI strip, round-trip Anthropic→OpenAI→Anthropic strip, same-model preserve)
- [x] All 8 regression tests pass
- [x] Verified with real Anthropic API (haiku with extended thinking) — thinking blocks produced and correctly stripped on model switch
- [x] Lint passes (0 errors)

## Effect on User Experience

**Before:** When the primary Anthropic model rate-limits and the system fails over to OpenAI (or another provider), users see 400 errors and the agent session breaks because stale thinking blocks are rejected by the fallback provider.

**After:** Model failover works seamlessly — thinking blocks from the previous provider are automatically stripped from session history before sending to the new provider.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug (#19295) where Anthropic `type: "thinking"` blocks survived session history sanitization during model provider failover (e.g. Anthropic → OpenAI), causing 400 errors from the fallback provider. The fix adds a `stripNonNativeThinkingBlocks` helper that removes all `type: "thinking"` blocks from assistant messages, wired into `sanitizeSessionHistory` in `google.ts` when `modelChanged` is true — complementing the existing `downgradeOpenAIReasoningBlocks` (which handles a different but related OpenAI Responses API edge case on same-provider reuse).

- The core fix logic in `google.ts` is correct: both return paths are updated to use `sanitizedThinkingCrossProvider`, and the guard condition (`modelChanged`) is appropriate.
- The new function is correctly placed after `downgradeOpenAIReasoningBlocks` in the pipeline; since `downgradeOpenAIReasoningBlocks` only runs for `openai-responses` / `openai-codex-responses` APIs, and `stripNonNativeThinkingBlocks` runs for any cross-provider switch, they handle non-overlapping cases cleanly.
- Test coverage is solid for the stated scenarios. The round-trip test (Anthropic → OpenAI → Anthropic) uses the same static `history` object on every call rather than the progressively built history, but this still exercises the `modelChanged` guard correctly.
- One style issue: the docstring for `stripNonNativeThinkingBlocks` claims it "strips blocks that do NOT carry an OpenAI reasoning signature" (implying `rs_`-signed blocks are preserved), but the implementation strips **all** `type: "thinking"` blocks unconditionally — there is no signature check. The function name also suggests selective behavior ("NonNative") that isn't implemented. The behavior is correct given the call-site guard (`modelChanged`), but the docstring is misleading for future readers.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the fix correctly addresses the 400-error regression during cross-provider failover with minimal blast radius.
- The logic is correct and well-tested. The only issue is a misleading docstring and function name that don't reflect the actual (unconditional) stripping behavior, which could cause confusion for future contributors but doesn't affect runtime correctness. The call-site guard (`modelChanged`) ensures the function is only applied in the appropriate cross-provider context.
- src/agents/pi-embedded-helpers/openai.ts — the docstring for `stripNonNativeThinkingBlocks` should be updated to accurately describe the unconditional stripping behavior.

<sub>Last reviewed commit: 6793915</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->