### PR TITLE
fix: respect job timeoutSeconds for stuck runningAtMs detection

### DIFF
--- a/src/cron/service.stuck-running-timeout.test.ts
+++ b/src/cron/service.stuck-running-timeout.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { recomputeNextRunsForMaintenance } from "./service/jobs.js";
+import type { CronServiceState } from "./service/state.js";
+import type { CronJob } from "./types.js";
+
+/**
+ * Regression tests for https://github.com/openclaw/openclaw/issues/18120
+ *
+ * When a cron job's session times out or the process crashes mid-execution,
+ * `runningAtMs` can persist indefinitely.  The scheduler's stuck-run detection
+ * previously used a blanket 2-hour threshold regardless of the job's configured
+ * timeout.  A job with a 5-minute timeout would remain blocked for up to
+ * 2 hours instead of being unblocked after ~15 minutes.
+ *
+ * The fix makes stuck detection respect the job's `payload.timeoutSeconds`
+ * (plus a 5-minute buffer) so jobs are unblocked promptly.
+ */
+
+// Base time: 2026-01-15 12:00:00 UTC
+const BASE_TIME_MS = Date.parse("2026-01-15T12:00:00.000Z");
+
+function createMockState(jobs: CronJob[], nowMs: number): CronServiceState {
+  return {
+    store: { version: 1, jobs },
+    running: false,
+    timer: null,
+    storeLoadedAtMs: nowMs,
+    storeFileMtimeMs: null,
+    op: Promise.resolve(),
+    warnedDisabled: false,
+    deps: {
+      storePath: "/mock/stuck-test",
+      cronEnabled: true,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: () => {},
+      requestHeartbeatNow: () => {},
+      runIsolatedAgentJob: async () => ({ status: "ok" }),
+      log: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      } as never,
+    },
+  };
+}
+
+function makeAgentTurnJob(overrides: {
+  id: string;
+  timeoutSeconds?: number;
+  runningAtMs: number;
+}): CronJob {
+  return {
+    id: overrides.id,
+    name: `Agent job ${overrides.id}`,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 3_600_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: {
+      kind: "agentTurn",
+      message: "do work",
+      timeoutSeconds: overrides.timeoutSeconds,
+    },
+    createdAtMs: BASE_TIME_MS - 86_400_000,
+    updatedAtMs: BASE_TIME_MS - 86_400_000,
+    state: {
+      nextRunAtMs: BASE_TIME_MS + 3_600_000,
+      runningAtMs: overrides.runningAtMs,
+    },
+  };
+}
+
+function makeSystemEventJob(overrides: { id: string; runningAtMs: number }): CronJob {
+  return {
+    id: overrides.id,
+    name: `System job ${overrides.id}`,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 3_600_000 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "check something" },
+    createdAtMs: BASE_TIME_MS - 86_400_000,
+    updatedAtMs: BASE_TIME_MS - 86_400_000,
+    state: {
+      nextRunAtMs: BASE_TIME_MS + 3_600_000,
+      runningAtMs: overrides.runningAtMs,
+    },
+  };
+}
+
+describe("stuck runningAtMs respects job timeout (#18120)", () => {
+  it("clears runningAtMs after job timeout + buffer for agentTurn jobs", () => {
+    // 5-minute timeout + 5-minute buffer = 10 min threshold
+    // Running for 16 minutes → exceeds threshold → should clear
+    const job = makeAgentTurnJob({
+      id: "short-timeout-job",
+      timeoutSeconds: 300,
+      runningAtMs: BASE_TIME_MS - 16 * 60_000,
+    });
+
+    const state = createMockState([job], BASE_TIME_MS);
+    recomputeNextRunsForMaintenance(state);
+
+    expect(job.state.runningAtMs).toBeUndefined();
+  });
+
+  it("does NOT clear runningAtMs while still within timeout + buffer", () => {
+    // 5-minute timeout + 5-minute buffer = 10 min threshold
+    // Running for 8 minutes → within threshold → should NOT clear
+    const runningAt = BASE_TIME_MS - 8 * 60_000;
+    const job = makeAgentTurnJob({
+      id: "still-running-job",
+      timeoutSeconds: 300,
+      runningAtMs: runningAt,
+    });
+
+    const state = createMockState([job], BASE_TIME_MS);
+    recomputeNextRunsForMaintenance(state);
+
+    expect(job.state.runningAtMs).toBe(runningAt);
+  });
+
+  it("uses default job timeout for systemEvent jobs (no timeoutSeconds)", () => {
+    // systemEvent jobs have no timeoutSeconds → falls back to
+    // DEFAULT_JOB_TIMEOUT_MS (10 min) + 5 min buffer = 15 min threshold.
+    // Running for 16 minutes → exceeds threshold → should clear
+    const job = makeSystemEventJob({
+      id: "system-event-stuck",
+      runningAtMs: BASE_TIME_MS - 16 * 60_000,
+    });
+
+    const state = createMockState([job], BASE_TIME_MS);
+    recomputeNextRunsForMaintenance(state);
+
+    expect(job.state.runningAtMs).toBeUndefined();
+  });
+
+  it("does NOT clear systemEvent job within default timeout + buffer", () => {
+    // DEFAULT_JOB_TIMEOUT_MS (10 min) + 5 min buffer = 15 min threshold.
+    // Running for 12 minutes → within threshold → should NOT clear
+    const runningAt = BASE_TIME_MS - 12 * 60_000;
+    const job = makeSystemEventJob({
+      id: "system-event-recent",
+      runningAtMs: runningAt,
+    });
+
+    const state = createMockState([job], BASE_TIME_MS);
+    recomputeNextRunsForMaintenance(state);
+
+    expect(job.state.runningAtMs).toBe(runningAt);
+  });
+
+  it("respects long custom timeout on agentTurn jobs", () => {
+    // 30-minute timeout + 5-minute buffer = 35 min threshold
+    // Running for 25 minutes → within threshold → should NOT clear
+    const runningAt = BASE_TIME_MS - 25 * 60_000;
+    const job = makeAgentTurnJob({
+      id: "long-timeout-job",
+      timeoutSeconds: 1800,
+      runningAtMs: runningAt,
+    });
+
+    const state = createMockState([job], BASE_TIME_MS);
+    recomputeNextRunsForMaintenance(state);
+
+    expect(job.state.runningAtMs).toBe(runningAt);
+  });
+
+  it("clears long-timeout job once past timeout + buffer", () => {
+    // 30-minute timeout + 5-minute buffer = 35 min threshold
+    // Running for 36 minutes → exceeds threshold → should clear
+    const job = makeAgentTurnJob({
+      id: "long-timeout-expired",
+      timeoutSeconds: 1800,
+      runningAtMs: BASE_TIME_MS - 36 * 60_000,
+    });
+
+    const state = createMockState([job], BASE_TIME_MS);
+    recomputeNextRunsForMaintenance(state);
+
+    expect(job.state.runningAtMs).toBeUndefined();
+  });
+
+  it("falls back to default timeout for agentTurn jobs without timeoutSeconds", () => {
+    // agentTurn WITHOUT timeoutSeconds → falls back to
+    // DEFAULT_JOB_TIMEOUT_MS (10 min) + 5 min buffer = 15 min threshold.
+    // Running for 16 minutes → exceeds threshold → should clear
+    const job = makeAgentTurnJob({
+      id: "no-timeout-agent",
+      // timeoutSeconds intentionally omitted
+      runningAtMs: BASE_TIME_MS - 16 * 60_000,
+    });
+
+    const state = createMockState([job], BASE_TIME_MS);
+    recomputeNextRunsForMaintenance(state);
+
+    expect(job.state.runningAtMs).toBeUndefined();
+  });
+
+  it("does NOT clear agentTurn without timeoutSeconds within default threshold", () => {
+    // agentTurn WITHOUT timeoutSeconds → 15 min threshold.
+    // Running for 12 minutes → within threshold → should NOT clear
+    const runningAt = BASE_TIME_MS - 12 * 60_000;
+    const job = makeAgentTurnJob({
+      id: "no-timeout-recent",
+      runningAtMs: runningAt,
+    });
+
+    const state = createMockState([job], BASE_TIME_MS);
+    recomputeNextRunsForMaintenance(state);
+
+    expect(job.state.runningAtMs).toBe(runningAt);
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -20,7 +20,24 @@ import {
 } from "./normalize.js";
 import type { CronServiceState } from "./state.js";
 
-const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
+/** Extra buffer added on top of the job timeout before declaring it stuck. */
+const STUCK_RUN_BUFFER_MS = 5 * 60 * 1000;
+
+/** Default per-job timeout — duplicated from timer.ts to avoid a circular import. */
+const DEFAULT_JOB_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Compute the stuck-run threshold for a job.  Uses the job's configured
+ * `timeoutSeconds` (with a buffer) when available, falling back to
+ * {@link DEFAULT_JOB_TIMEOUT_MS} for jobs without an explicit timeout.
+ */
+function resolveStuckRunMs(job: CronJob): number {
+  const payloadTimeout =
+    job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+      ? job.payload.timeoutSeconds * 1_000
+      : DEFAULT_JOB_TIMEOUT_MS;
+  return payloadTimeout + STUCK_RUN_BUFFER_MS;
+}
 
 function resolveEveryAnchorMs(params: {
   schedule: { everyMs: number; anchorMs?: number };
@@ -168,13 +185,16 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
   }
 
   const runningAt = job.state.runningAtMs;
-  if (typeof runningAt === "number" && nowMs - runningAt > STUCK_RUN_MS) {
-    state.deps.log.warn(
-      { jobId: job.id, runningAtMs: runningAt },
-      "cron: clearing stuck running marker",
-    );
-    job.state.runningAtMs = undefined;
-    changed = true;
+  if (typeof runningAt === "number") {
+    const stuckMs = resolveStuckRunMs(job);
+    if (nowMs - runningAt > stuckMs) {
+      state.deps.log.warn(
+        { jobId: job.id, runningAtMs: runningAt, stuckThresholdMs: stuckMs },
+        "cron: clearing stuck running marker",
+      );
+      job.state.runningAtMs = undefined;
+      changed = true;
+    }
   }
 
   return { changed, skip: false };


### PR DESCRIPTION
## Summary

Fixes #18120

The scheduler's stuck-run detection previously used a blanket 2-hour threshold (`STUCK_RUN_MS`) regardless of the job's configured timeout. A job with a 5-minute timeout would remain blocked for up to 2 hours instead of being unblocked after ~15 minutes.

### Changes

- **`src/cron/service/jobs.ts`**: Replace the hardcoded `STUCK_RUN_MS` constant with a per-job `resolveStuckRunMs()` function that computes the threshold from `payload.timeoutSeconds` (+ 5 min buffer) when available, falling back to `DEFAULT_JOB_TIMEOUT_MS` (10 min) + buffer for jobs without an explicit timeout.
- **`src/cron/service.stuck-running-timeout.test.ts`**: 8 regression tests covering all branches of the new logic:
  - agentTurn jobs with short timeout (5 min) — clear vs. retain
  - agentTurn jobs with long timeout (30 min) — clear vs. retain
  - agentTurn jobs without `timeoutSeconds` — fallback behavior
  - systemEvent jobs (no timeout field) — fallback behavior

### How it works

```
resolveStuckRunMs(job):
  if agentTurn && timeoutSeconds is set:
    return timeoutSeconds * 1000 + STUCK_RUN_BUFFER_MS (5 min)
  else:
    return DEFAULT_JOB_TIMEOUT_MS (10 min) + STUCK_RUN_BUFFER_MS (5 min)
```

This ensures that a job with `timeoutSeconds: 300` (5 min) gets its `runningAtMs` cleared after 10 minutes instead of waiting 2 hours.

### Test plan

- [x] All 8 new regression tests pass
- [x] All 152 existing cron tests pass (no regressions)
- [x] `pnpm format:check` — clean
- [x] `pnpm tsgo` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a long-standing scheduler bug where stuck-run detection used a blanket 2-hour threshold regardless of a job's configured `timeoutSeconds`. A job with a 5-minute timeout would remain blocked for up to 2 hours instead of ~10 minutes.

The fix introduces `resolveStuckRunMs()` in `src/cron/service/jobs.ts`, which computes a per-job threshold from `payload.timeoutSeconds` (+ 5-minute buffer) for `agentTurn` jobs, and falls back to `DEFAULT_JOB_TIMEOUT_MS` (10 min) + buffer for jobs without an explicit timeout. This logic mirrors the execution timeout already applied in `timer.ts` and is consistent with how the scheduler itself enforces deadlines.

Key observations:
- The behavioral change is correct and well-targeted: the threshold is now proportional to the job's actual timeout.
- The new `stuckThresholdMs` field in the log payload improves observability.
- 8 regression tests cover all branches cleanly and confirm both the clear and retain cases for each job type.
- **One maintenance concern**: `DEFAULT_JOB_TIMEOUT_MS` is now defined independently in both `jobs.ts` and `timer.ts`. Both values are identical today (`10 * 60 * 1000`), but the duplication could silently diverge if the execution timeout in `timer.ts` is changed in the future. Exporting the constant from a single location would eliminate this risk.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the fix is correct and well-tested, with one minor maintainability concern about a duplicated constant.
- The logic change is small, well-understood, and directly mirrors existing timeout handling already present in `timer.ts`. All 8 new regression tests pass, and the test coverage is thorough across all code paths. The only concern is the duplication of `DEFAULT_JOB_TIMEOUT_MS` between `jobs.ts` and `timer.ts`, which is a style/maintainability issue rather than a functional bug today.
- No files require special attention, though reviewers should note the duplicated `DEFAULT_JOB_TIMEOUT_MS` constant in `src/cron/service/jobs.ts` vs `src/cron/service/timer.ts`.

<sub>Last reviewed commit: 05608da</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->