### PR TITLE
fix: pass session context to plugin tool hooks in toToolDefinitions

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -547,6 +547,10 @@ export async function compactEmbeddedPiSessionDirect(
       const { builtInTools, customTools } = splitSdkTools({
         tools,
         sandboxEnabled: !!sandbox?.enabled,
+        hookContext: {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+        },
       });
 
       const { session } = await createAgentSession({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -546,6 +546,10 @@ export async function runEmbeddedAttempt(
       const { builtInTools, customTools } = splitSdkTools({
         tools,
         sandboxEnabled: !!sandbox?.enabled,
+        hookContext: {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+        },
       });
 
       // Add client tools (OpenResponses hosted tools) to customTools

--- a/src/agents/pi-embedded-runner/tool-split.ts
+++ b/src/agents/pi-embedded-runner/tool-split.ts
@@ -1,17 +1,22 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { toToolDefinitions } from "../pi-tool-definition-adapter.js";
+import type { HookContext } from "../pi-tools.before-tool-call.js";
 
 // We always pass tools via `customTools` so our policy filtering, sandbox integration,
 // and extended toolset remain consistent across providers.
 type AnyAgentTool = AgentTool;
 
-export function splitSdkTools(options: { tools: AnyAgentTool[]; sandboxEnabled: boolean }): {
+export function splitSdkTools(options: {
+  tools: AnyAgentTool[];
+  sandboxEnabled: boolean;
+  hookContext?: HookContext;
+}): {
   builtInTools: AnyAgentTool[];
   customTools: ReturnType<typeof toToolDefinitions>;
 } {
   const { tools } = options;
   return {
     builtInTools: [],
-    customTools: toToolDefinitions(tools),
+    customTools: toToolDefinitions(tools, options.hookContext),
   };
 }

--- a/src/agents/pi-tool-definition-adapter.hook-context.test.ts
+++ b/src/agents/pi-tool-definition-adapter.hook-context.test.ts
@@ -1,0 +1,162 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
+
+/**
+ * Regression tests for https://github.com/openclaw/openclaw/issues/19381
+ *
+ * Plugin-registered tools that go through toToolDefinitions as unwrapped tools
+ * (without wrapToolWithBeforeToolCallHook) must still receive the correct
+ * sessionKey and agentId in their before_tool_call and after_tool_call hooks.
+ */
+
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn((_: string) => false),
+    runBeforeToolCall: vi.fn(async (_event: unknown, _ctx: unknown) => undefined as unknown),
+    runAfterToolCall: vi.fn(async () => {}),
+  },
+  isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
+  consumeAdjustedParamsForToolCall: vi.fn((_: string) => undefined as unknown),
+  runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
+    blocked: false as const,
+    params,
+  })),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
+vi.mock("./pi-tools.before-tool-call.js", () => ({
+  consumeAdjustedParamsForToolCall: hookMocks.consumeAdjustedParamsForToolCall,
+  isToolWrappedWithBeforeToolCallHook: hookMocks.isToolWrappedWithBeforeToolCallHook,
+  runBeforeToolCallHook: hookMocks.runBeforeToolCallHook,
+}));
+
+function createPluginTool() {
+  return {
+    name: "my_plugin_tool",
+    label: "My Plugin Tool",
+    description: "plugin tool for testing",
+    parameters: Type.Object({}),
+    execute: vi.fn(async () => ({ content: [], details: { ok: true } })),
+  } satisfies AgentTool;
+}
+
+type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
+const extensionContext = {} as Parameters<ToolExecute>[4];
+
+describe("toToolDefinitions passes hookContext (#19381)", () => {
+  beforeEach(() => {
+    hookMocks.runner.hasHooks.mockReset();
+    hookMocks.runner.runBeforeToolCall.mockReset();
+    hookMocks.runner.runAfterToolCall.mockReset();
+    hookMocks.runner.runAfterToolCall.mockResolvedValue(undefined);
+    hookMocks.isToolWrappedWithBeforeToolCallHook.mockReset();
+    hookMocks.isToolWrappedWithBeforeToolCallHook.mockReturnValue(false);
+    hookMocks.consumeAdjustedParamsForToolCall.mockReset();
+    hookMocks.consumeAdjustedParamsForToolCall.mockReturnValue(undefined);
+    hookMocks.runBeforeToolCallHook.mockReset();
+    hookMocks.runBeforeToolCallHook.mockImplementation(async ({ params }) => ({
+      blocked: false as const,
+      params,
+    }));
+  });
+
+  it("passes agentId and sessionKey to before_tool_call for unwrapped tools", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+
+    const defs = toToolDefinitions([createPluginTool()], {
+      agentId: "main",
+      sessionKey: "agent:main:tlon:dm:~user",
+    });
+
+    await defs[0].execute("call-ctx-1", { action: "test" }, undefined, undefined, extensionContext);
+
+    expect(hookMocks.runBeforeToolCallHook).toHaveBeenCalledWith({
+      toolName: "my_plugin_tool",
+      params: { action: "test" },
+      toolCallId: "call-ctx-1",
+      ctx: {
+        agentId: "main",
+        sessionKey: "agent:main:tlon:dm:~user",
+      },
+    });
+  });
+
+  it("passes agentId and sessionKey to after_tool_call on success", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "after_tool_call");
+
+    const defs = toToolDefinitions([createPluginTool()], {
+      agentId: "agent-1",
+      sessionKey: "agent:agent-1:slack:channel:C123",
+    });
+
+    const result = await defs[0].execute("call-ctx-2", {}, undefined, undefined, extensionContext);
+
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledWith(
+      {
+        toolName: "my_plugin_tool",
+        params: {},
+        result,
+      },
+      {
+        toolName: "my_plugin_tool",
+        agentId: "agent-1",
+        sessionKey: "agent:agent-1:slack:channel:C123",
+      },
+    );
+  });
+
+  it("passes agentId and sessionKey to after_tool_call on error", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "after_tool_call");
+
+    const errorTool = {
+      name: "failing_tool",
+      label: "Failing",
+      description: "throws",
+      parameters: Type.Object({}),
+      execute: vi.fn(async () => {
+        throw new Error("tool failure");
+      }),
+    } satisfies AgentTool;
+
+    const defs = toToolDefinitions([errorTool], {
+      agentId: "main",
+      sessionKey: "main-session",
+    });
+
+    await defs[0].execute("call-ctx-3", { cmd: "test" }, undefined, undefined, extensionContext);
+
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledWith(
+      {
+        toolName: "failing_tool",
+        params: { cmd: "test" },
+        error: "tool failure",
+      },
+      {
+        toolName: "failing_tool",
+        agentId: "main",
+        sessionKey: "main-session",
+      },
+    );
+  });
+
+  it("works without hookContext (backwards compatible)", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+
+    // No hookContext passed — should still work, just with undefined ctx
+    const defs = toToolDefinitions([createPluginTool()]);
+
+    await defs[0].execute("call-no-ctx", {}, undefined, undefined, extensionContext);
+
+    expect(hookMocks.runBeforeToolCallHook).toHaveBeenCalledWith({
+      toolName: "my_plugin_tool",
+      params: {},
+      toolCallId: "call-no-ctx",
+      ctx: undefined,
+    });
+  });
+});

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -86,7 +86,10 @@ function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
   };
 }
 
-export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
+export function toToolDefinitions(
+  tools: AnyAgentTool[],
+  hookContext?: HookContext,
+): ToolDefinition[] {
   return tools.map((tool) => {
     const name = tool.name || "tool";
     const normalizedName = normalizeToolName(name);
@@ -105,6 +108,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
               toolName: name,
               params,
               toolCallId,
+              ctx: hookContext,
             });
             if (hookOutcome.blocked) {
               throw new Error(hookOutcome.reason);
@@ -126,7 +130,11 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
                   params: isPlainObject(afterParams) ? afterParams : {},
                   result,
                 },
-                { toolName: name },
+                {
+                  toolName: name,
+                  agentId: hookContext?.agentId,
+                  sessionKey: hookContext?.sessionKey,
+                },
               );
             } catch (hookErr) {
               logDebug(
@@ -172,7 +180,11 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
                   params: isPlainObject(params) ? params : {},
                   error: described.message,
                 },
-                { toolName: normalizedName },
+                {
+                  toolName: normalizedName,
+                  agentId: hookContext?.agentId,
+                  sessionKey: hookContext?.sessionKey,
+                },
               );
             } catch (hookErr) {
               logDebug(


### PR DESCRIPTION
## Summary

Fixes #19381

Plugin-registered tools that go through `toToolDefinitions` without being pre-wrapped by `wrapToolWithBeforeToolCallHook` receive `undefined` for both `agentId` and `sessionKey` in their `before_tool_call` and `after_tool_call` hooks, making per-session access control impossible.

### Root cause

`toToolDefinitions` has a fallback path (line 103-108) for unwrapped tools that calls `runBeforeToolCallHook` without passing `ctx`. Additionally, `after_tool_call` hooks (both success and error paths) only pass `{ toolName }` as context, never `agentId`/`sessionKey`.

### Changes

- **`src/agents/pi-tool-definition-adapter.ts`**: Accept optional `hookContext` parameter in `toToolDefinitions`. Pass it to `runBeforeToolCallHook` for unwrapped tools and include `agentId`/`sessionKey` in all `after_tool_call` hook contexts.
- **`src/agents/pi-embedded-runner/tool-split.ts`**: Forward `hookContext` through `splitSdkTools` to `toToolDefinitions`.
- **`src/agents/pi-embedded-runner/run/attempt.ts`**: Pass `sessionAgentId`/`sessionKey` as hook context to `splitSdkTools`.
- **`src/agents/pi-embedded-runner/compact.ts`**: Pass `sessionAgentId`/`sessionKey` as hook context to `splitSdkTools`.
- **`src/agents/pi-tool-definition-adapter.hook-context.test.ts`**: 4 regression tests covering:
  - `before_tool_call` receives `agentId`/`sessionKey` for unwrapped tools
  - `after_tool_call` receives context on success
  - `after_tool_call` receives context on error
  - Backwards compatibility when no `hookContext` is provided

### Test plan

- [x] All 4 new regression tests pass
- [x] All 395 existing agent tests pass (65 test files)
- [x] `pnpm format:check` — clean
- [x] `pnpm tsgo` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes the root cause described in issue #19381: plugin tools processed through `toToolDefinitions` without being pre-wrapped by `wrapToolWithBeforeToolCallHook` were receiving `undefined` for `agentId` and `sessionKey` in their `before_tool_call` and `after_tool_call` hooks, making per-session access control impossible. The fix threads an optional `hookContext` parameter through `splitSdkTools` → `toToolDefinitions` and wires it into all three hook invocation sites. Both call sites (`attempt.ts` and `compact.ts`) are updated consistently.

Key observations:
- The core fix is correct and the approach is clean and backward-compatible (optional parameter with `undefined` fallback).
- There is a pre-existing inconsistency now made more consequential: the `after_tool_call` success path passes the raw, un-normalized tool `name` as `toolName` in both event payload and context (lines 129, 134), while the error path passes `normalizedName` (lines 179, 184). Since plugins can now rely on `toolName` in the hook context for access control routing, receiving different values for the same tool depending on success vs. failure is a correctness hazard.
- The regression tests use all-lowercase tool names (`"my_plugin_tool"`, `"failing_tool"`), which are unchanged by `normalizeToolName`, so the `name` vs. `normalizedName` discrepancy is not caught.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logic issue that should be addressed before plugins rely on consistent toolName values in after_tool_call contexts.
- The fix correctly addresses the reported bug and is backward-compatible. However, a pre-existing inconsistency — raw name on the success path vs normalizedName on the error path in after_tool_call — becomes a real correctness hazard now that hookContext is plumbed through and plugins can perform access control using toolName. The regression tests don't cover this edge case. This warrants attention before the feature is relied upon in production plugins.
- src/agents/pi-tool-definition-adapter.ts (lines 129 and 134: success-path after_tool_call uses raw name instead of normalizedName)

<sub>Last reviewed commit: 4ec8a93</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->