### PR TITLE
feat: add Soniox speech-to-text provider

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -297,6 +297,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     voyage: "VOYAGE_API_KEY",
     groq: "GROQ_API_KEY",
     deepgram: "DEEPGRAM_API_KEY",
+    soniox: "SONIOX_API_KEY",
     cerebras: "CEREBRAS_API_KEY",
     xai: "XAI_API_KEY",
     openrouter: "OPENROUTER_API_KEY",

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -31,9 +31,10 @@ export const DEFAULT_AUDIO_MODELS: Record<string, string> = {
   groq: "whisper-large-v3-turbo",
   openai: "gpt-4o-mini-transcribe",
   deepgram: "nova-3",
+  soniox: "stt-async-preview",
 };
 
-export const AUTO_AUDIO_KEY_PROVIDERS = ["openai", "groq", "deepgram", "google"] as const;
+export const AUTO_AUDIO_KEY_PROVIDERS = ["openai", "groq", "deepgram", "google", "soniox"] as const;
 export const AUTO_IMAGE_KEY_PROVIDERS = [
   "openai",
   "anthropic",

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -31,7 +31,7 @@ export const DEFAULT_AUDIO_MODELS: Record<string, string> = {
   groq: "whisper-large-v3-turbo",
   openai: "gpt-4o-mini-transcribe",
   deepgram: "nova-3",
-  soniox: "stt-async-preview",
+  soniox: "stt-async-v4",
 };
 
 export const AUTO_AUDIO_KEY_PROVIDERS = ["openai", "groq", "deepgram", "google", "soniox"] as const;

--- a/src/media-understanding/providers/index.ts
+++ b/src/media-understanding/providers/index.ts
@@ -6,6 +6,7 @@ import { googleProvider } from "./google/index.js";
 import { groqProvider } from "./groq/index.js";
 import { minimaxProvider } from "./minimax/index.js";
 import { openaiProvider } from "./openai/index.js";
+import { sonioxProvider } from "./soniox/index.js";
 import { zaiProvider } from "./zai/index.js";
 
 const PROVIDERS: MediaUnderstandingProvider[] = [
@@ -16,6 +17,7 @@ const PROVIDERS: MediaUnderstandingProvider[] = [
   minimaxProvider,
   zaiProvider,
   deepgramProvider,
+  sonioxProvider,
 ];
 
 export function normalizeMediaProviderId(id: string): string {

--- a/src/media-understanding/providers/soniox/audio.test.ts
+++ b/src/media-understanding/providers/soniox/audio.test.ts
@@ -57,7 +57,7 @@ function buildSonioxFetchMock(opts?: {
     }
 
     // Get transcript text
-    if (url.includes("/transcript") && method === "GET") {
+    if (url.endsWith("/transcript") && method === "GET") {
       if (opts?.failAt === "transcript") {
         return new Response(opts.errorBody ?? "transcript error", {
           status: opts.errorStatus ?? 500,

--- a/src/media-understanding/providers/soniox/audio.test.ts
+++ b/src/media-understanding/providers/soniox/audio.test.ts
@@ -108,7 +108,7 @@ describe("transcribeSonioxAudio", () => {
     });
 
     expect(result.text).toBe("Slovenija je lepa dežela");
-    expect(result.model).toBe("stt-async-preview");
+    expect(result.model).toBe("stt-async-v4");
     expect(calls).toHaveLength(4);
     expect(calls[0].method).toBe("POST"); // upload
     expect(calls[0].url).toContain("/files");
@@ -240,7 +240,7 @@ describe("transcribeSonioxAudio", () => {
 
     const parsed = JSON.parse(capturedBody!);
     expect(parsed.language_hints).toEqual(["sl"]);
-    expect(parsed.model).toBe("stt-async-preview");
+    expect(parsed.model).toBe("stt-async-v4");
   });
 
   it("throws on upload failure", async () => {

--- a/src/media-understanding/providers/soniox/audio.test.ts
+++ b/src/media-understanding/providers/soniox/audio.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import { withFetchPreconnect } from "../../../test-utils/fetch-mock.js";
+import { installPinnedHostnameTestHooks, resolveRequestUrl } from "../audio.test-helpers.js";
+import { transcribeSonioxAudio } from "./audio.js";
+
+installPinnedHostnameTestHooks();
+
+/**
+ * Build a mock fetch that responds to the four Soniox API calls in sequence:
+ * 1. POST /files → { file_id }
+ * 2. POST /transcriptions → { id, status: "queued" }
+ * 3. GET /transcriptions/:id → { status: "completed" }
+ * 4. GET /transcriptions/:id/transcript → { text }
+ */
+function buildSonioxFetchMock(opts?: {
+  transcript?: string;
+  pollAttempts?: number;
+  failAt?: "upload" | "create" | "poll" | "transcript";
+  errorStatus?: number;
+  errorBody?: string;
+}) {
+  const transcript = opts?.transcript ?? "Testni transkript";
+  const pollAttempts = opts?.pollAttempts ?? 0; // 0 = complete on first poll
+  let pollCount = 0;
+  const calls: { url: string; method: string; headers: Headers }[] = [];
+
+  const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = resolveRequestUrl(input);
+    const method = init?.method ?? "GET";
+    const headers = new Headers(init?.headers);
+    calls.push({ url, method, headers });
+
+    // Upload file
+    if (url.endsWith("/files") && method === "POST") {
+      if (opts?.failAt === "upload") {
+        return new Response(opts.errorBody ?? "upload error", {
+          status: opts.errorStatus ?? 500,
+        });
+      }
+      return new Response(JSON.stringify({ file_id: "test-file-id" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Create transcription
+    if (url.endsWith("/transcriptions") && method === "POST") {
+      if (opts?.failAt === "create") {
+        return new Response(opts.errorBody ?? "create error", {
+          status: opts.errorStatus ?? 500,
+        });
+      }
+      return new Response(JSON.stringify({ id: "test-transcription-id", status: "queued" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Get transcript text
+    if (url.includes("/transcript") && method === "GET") {
+      if (opts?.failAt === "transcript") {
+        return new Response(opts.errorBody ?? "transcript error", {
+          status: opts.errorStatus ?? 500,
+        });
+      }
+      return new Response(JSON.stringify({ text: transcript }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Poll transcription status
+    if (url.includes("/transcriptions/") && method === "GET") {
+      if (opts?.failAt === "poll") {
+        return new Response(JSON.stringify({ status: "error", error_message: "poll failure" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      pollCount++;
+      const status = pollCount > pollAttempts ? "completed" : "processing";
+      return new Response(JSON.stringify({ id: "test-transcription-id", status }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  });
+
+  return { fetchFn, calls };
+}
+
+describe("transcribeSonioxAudio", () => {
+  it("happy path: upload → create → poll → transcript", async () => {
+    const { fetchFn, calls } = buildSonioxFetchMock({
+      transcript: "Slovenija je lepa dežela",
+    });
+
+    const result = await transcribeSonioxAudio({
+      buffer: Buffer.from("fake-audio"),
+      fileName: "voice.ogg",
+      mime: "audio/ogg",
+      apiKey: "test-key",
+      language: "sl",
+      timeoutMs: 30_000,
+      fetchFn,
+    });
+
+    expect(result.text).toBe("Slovenija je lepa dežela");
+    expect(result.model).toBe("stt-async-preview");
+    expect(calls).toHaveLength(4);
+    expect(calls[0].method).toBe("POST"); // upload
+    expect(calls[0].url).toContain("/files");
+    expect(calls[1].method).toBe("POST"); // create
+    expect(calls[1].url).toContain("/transcriptions");
+    expect(calls[2].method).toBe("GET"); // poll
+    expect(calls[3].method).toBe("GET"); // transcript
+  });
+
+  it("polls multiple times before completion", async () => {
+    const { fetchFn, calls } = buildSonioxFetchMock({
+      transcript: "test",
+      pollAttempts: 3,
+    });
+
+    const result = await transcribeSonioxAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "test.ogg",
+      apiKey: "test-key",
+      timeoutMs: 30_000,
+      fetchFn,
+    });
+
+    expect(result.text).toBe("test");
+    // 1 upload + 1 create + 4 polls (3 processing + 1 completed) + 1 transcript = 7
+    expect(calls).toHaveLength(7);
+  });
+
+  it("multipart body contains correct boundary and filename", async () => {
+    let capturedBody: Uint8Array | null = null;
+    let capturedContentType: string | null = null;
+
+    const { fetchFn } = buildSonioxFetchMock({ transcript: "ok" });
+    // Wrap to capture the upload body
+    const wrappedFetch = withFetchPreconnect(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = resolveRequestUrl(input);
+        if (url.endsWith("/files") && init?.method === "POST") {
+          capturedBody = init.body as Uint8Array;
+          capturedContentType = new Headers(init.headers).get("content-type");
+        }
+        return fetchFn(input, init);
+      },
+    );
+
+    await transcribeSonioxAudio({
+      buffer: Buffer.from("audio-data"),
+      fileName: "moj posnetek.ogg",
+      mime: "audio/ogg",
+      apiKey: "test-key",
+      timeoutMs: 30_000,
+      fetchFn: wrappedFetch,
+    });
+
+    expect(capturedContentType).toContain("multipart/form-data; boundary=");
+    const bodyStr = new TextDecoder().decode(capturedBody!);
+    expect(bodyStr).toContain('name="file"');
+    expect(bodyStr).toContain('filename="moj posnetek.ogg"');
+    expect(bodyStr).toContain("audio-data");
+  });
+
+  it("escapes special characters in filename", async () => {
+    let capturedBody: Uint8Array | null = null;
+
+    const { fetchFn } = buildSonioxFetchMock({ transcript: "ok" });
+    const wrappedFetch = withFetchPreconnect(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = resolveRequestUrl(input);
+        if (url.endsWith("/files") && init?.method === "POST") {
+          capturedBody = init.body as Uint8Array;
+        }
+        return fetchFn(input, init);
+      },
+    );
+
+    await transcribeSonioxAudio({
+      buffer: Buffer.from("audio"),
+      fileName: 'file"with\nnewline.ogg',
+      mime: "audio/ogg",
+      apiKey: "test-key",
+      timeoutMs: 30_000,
+      fetchFn: wrappedFetch,
+    });
+
+    const bodyStr = new TextDecoder().decode(capturedBody!);
+    expect(bodyStr).not.toContain('file"with');
+    expect(bodyStr).toContain('file\\"with');
+    expect(bodyStr).toContain("_newline.ogg");
+  });
+
+  it("sends authorization header with Bearer prefix", async () => {
+    const { fetchFn, calls } = buildSonioxFetchMock({ transcript: "ok" });
+
+    await transcribeSonioxAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "test.ogg",
+      apiKey: "my-secret-key",
+      timeoutMs: 30_000,
+      fetchFn,
+    });
+
+    for (const call of calls) {
+      expect(call.headers.get("authorization")).toBe("Bearer my-secret-key");
+    }
+  });
+
+  it("sends language hints in transcription request", async () => {
+    let capturedBody: string | null = null;
+
+    const { fetchFn } = buildSonioxFetchMock({ transcript: "ok" });
+    const wrappedFetch = withFetchPreconnect(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = resolveRequestUrl(input);
+        if (url.endsWith("/transcriptions") && init?.method === "POST") {
+          capturedBody = new TextDecoder().decode(init.body as Uint8Array);
+        }
+        return fetchFn(input, init);
+      },
+    );
+
+    await transcribeSonioxAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "test.ogg",
+      apiKey: "test-key",
+      language: "sl",
+      timeoutMs: 30_000,
+      fetchFn: wrappedFetch,
+    });
+
+    const parsed = JSON.parse(capturedBody!);
+    expect(parsed.language_hints).toEqual(["sl"]);
+    expect(parsed.model).toBe("stt-async-preview");
+  });
+
+  it("throws on upload failure", async () => {
+    const { fetchFn } = buildSonioxFetchMock({
+      failAt: "upload",
+      errorStatus: 400,
+      errorBody: "bad request",
+    });
+
+    await expect(
+      transcribeSonioxAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "test.ogg",
+        apiKey: "test-key",
+        timeoutMs: 30_000,
+        fetchFn,
+      }),
+    ).rejects.toThrow("Soniox file upload failed");
+  });
+
+  it("throws on transcription error status", async () => {
+    const { fetchFn } = buildSonioxFetchMock({ failAt: "poll" });
+
+    await expect(
+      transcribeSonioxAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "test.ogg",
+        apiKey: "test-key",
+        timeoutMs: 30_000,
+        fetchFn,
+      }),
+    ).rejects.toThrow("Soniox transcription failed: poll failure");
+  });
+
+  it("uses custom model when provided", async () => {
+    const { fetchFn } = buildSonioxFetchMock({ transcript: "ok" });
+    let capturedBody: string | null = null;
+
+    const wrappedFetch = withFetchPreconnect(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = resolveRequestUrl(input);
+        if (url.endsWith("/transcriptions") && init?.method === "POST") {
+          capturedBody = new TextDecoder().decode(init.body as Uint8Array);
+        }
+        return fetchFn(input, init);
+      },
+    );
+
+    const result = await transcribeSonioxAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "test.ogg",
+      apiKey: "test-key",
+      model: "stt-async-v3",
+      timeoutMs: 30_000,
+      fetchFn: wrappedFetch,
+    });
+
+    expect(result.model).toBe("stt-async-v3");
+    const parsed = JSON.parse(capturedBody!);
+    expect(parsed.model).toBe("stt-async-v3");
+  });
+});

--- a/src/media-understanding/providers/soniox/audio.test.ts
+++ b/src/media-understanding/providers/soniox/audio.test.ts
@@ -121,7 +121,7 @@ describe("transcribeSonioxAudio", () => {
   it("polls multiple times before completion", async () => {
     const { fetchFn, calls } = buildSonioxFetchMock({
       transcript: "test",
-      pollAttempts: 3,
+      pollAttempts: 1,
     });
 
     const result = await transcribeSonioxAudio({
@@ -133,8 +133,8 @@ describe("transcribeSonioxAudio", () => {
     });
 
     expect(result.text).toBe("test");
-    // 1 upload + 1 create + 4 polls (3 processing + 1 completed) + 1 transcript = 7
-    expect(calls).toHaveLength(7);
+    // 1 upload + 1 create + 2 polls (1 processing + 1 completed) + 1 transcript = 5
+    expect(calls).toHaveLength(5);
   });
 
   it("multipart body contains correct boundary and filename", async () => {

--- a/src/media-understanding/providers/soniox/audio.ts
+++ b/src/media-understanding/providers/soniox/audio.ts
@@ -85,7 +85,7 @@ async function uploadFile(params: {
 
   const { response: res, release } = await fetchWithTimeoutGuarded(
     `${params.baseUrl}/files`,
-    { method: "POST", headers, body },
+    { method: "POST", headers, body: Buffer.from(body) },
     params.timeoutMs,
     params.fetchFn,
   );

--- a/src/media-understanding/providers/soniox/audio.ts
+++ b/src/media-understanding/providers/soniox/audio.ts
@@ -1,0 +1,307 @@
+import type { AudioTranscriptionRequest, AudioTranscriptionResult } from "../../types.js";
+import { fetchWithTimeoutGuarded, normalizeBaseUrl, readErrorResponse } from "../shared.js";
+
+export const DEFAULT_SONIOX_AUDIO_BASE_URL = "https://api.soniox.com/v1";
+export const DEFAULT_SONIOX_AUDIO_MODEL = "stt-async-preview";
+const POLL_INTERVAL_MS = 2_000;
+
+function resolveModel(model?: string): string {
+  const trimmed = model?.trim();
+  return trimmed || DEFAULT_SONIOX_AUDIO_MODEL;
+}
+
+type SonioxFileResponse = {
+  file_id?: string;
+  id?: string;
+};
+
+type SonioxTranscriptionResponse = {
+  id?: string;
+  transcription_id?: string;
+  status?: string;
+  error_type?: string;
+  error_message?: string;
+};
+
+type SonioxTranscriptWord = {
+  text?: string;
+};
+
+type SonioxTranscriptResponse = {
+  text?: string;
+  transcript?: string;
+  words?: SonioxTranscriptWord[];
+};
+
+/**
+ * Build a multipart/form-data body for file upload.
+ */
+function buildMultipartBody(
+  fileName: string,
+  buffer: Uint8Array,
+  mime: string,
+): { body: Uint8Array; boundary: string } {
+  const boundary = `----SonioxBoundary${Date.now()}${Math.random().toString(36).slice(2)}`;
+  const encoder = new TextEncoder();
+
+  const header = encoder.encode(
+    `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="${fileName}"\r\n` +
+      `Content-Type: ${mime}\r\n` +
+      `\r\n`,
+  );
+  const footer = encoder.encode(`\r\n--${boundary}--\r\n`);
+
+  const body = new Uint8Array(header.length + buffer.length + footer.length);
+  body.set(header, 0);
+  body.set(buffer, header.length);
+  body.set(footer, header.length + buffer.length);
+
+  return { body, boundary };
+}
+
+/**
+ * Upload an audio file to Soniox and return the file_id.
+ */
+async function uploadFile(params: {
+  buffer: Buffer;
+  fileName: string;
+  mime: string;
+  apiKey: string;
+  baseUrl: string;
+  timeoutMs: number;
+  fetchFn: typeof fetch;
+}): Promise<string> {
+  const { body, boundary } = buildMultipartBody(
+    params.fileName,
+    new Uint8Array(params.buffer),
+    params.mime,
+  );
+
+  const headers = new Headers();
+  headers.set("authorization", `Bearer ${params.apiKey}`);
+  headers.set("content-type", `multipart/form-data; boundary=${boundary}`);
+
+  const { response: res, release } = await fetchWithTimeoutGuarded(
+    `${params.baseUrl}/files`,
+    { method: "POST", headers, body },
+    params.timeoutMs,
+    params.fetchFn,
+  );
+
+  try {
+    if (!res.ok) {
+      const detail = await readErrorResponse(res);
+      const suffix = detail ? `: ${detail}` : "";
+      throw new Error(`Soniox file upload failed (HTTP ${res.status})${suffix}`);
+    }
+
+    const payload = (await res.json()) as SonioxFileResponse;
+    const fileId = payload.file_id ?? payload.id;
+    if (!fileId) {
+      throw new Error("Soniox file upload response missing file_id");
+    }
+    return fileId;
+  } finally {
+    await release();
+  }
+}
+
+/**
+ * Create a transcription job and return the transcription ID.
+ */
+async function createTranscription(params: {
+  fileId: string;
+  model: string;
+  language?: string;
+  apiKey: string;
+  baseUrl: string;
+  timeoutMs: number;
+  fetchFn: typeof fetch;
+}): Promise<string> {
+  const payload: Record<string, unknown> = {
+    model: params.model,
+    file_id: params.fileId,
+    enable_speaker_diarization: false,
+  };
+  if (params.language?.trim()) {
+    payload.language_hints = [params.language.trim()];
+  }
+
+  const headers = new Headers();
+  headers.set("authorization", `Bearer ${params.apiKey}`);
+  headers.set("content-type", "application/json");
+
+  const { response: res, release } = await fetchWithTimeoutGuarded(
+    `${params.baseUrl}/transcriptions`,
+    { method: "POST", headers, body: JSON.stringify(payload) },
+    params.timeoutMs,
+    params.fetchFn,
+  );
+
+  try {
+    if (!res.ok) {
+      const detail = await readErrorResponse(res);
+      const suffix = detail ? `: ${detail}` : "";
+      throw new Error(`Soniox transcription creation failed (HTTP ${res.status})${suffix}`);
+    }
+
+    const result = (await res.json()) as SonioxTranscriptionResponse;
+    const transcriptionId = result.transcription_id ?? result.id;
+    if (!transcriptionId) {
+      throw new Error("Soniox transcription response missing transcription_id");
+    }
+    return transcriptionId;
+  } finally {
+    await release();
+  }
+}
+
+/**
+ * Poll a transcription job until it completes or fails.
+ */
+async function pollTranscription(params: {
+  transcriptionId: string;
+  apiKey: string;
+  baseUrl: string;
+  timeoutMs: number;
+  fetchFn: typeof fetch;
+}): Promise<void> {
+  const deadline = Date.now() + params.timeoutMs;
+
+  while (Date.now() < deadline) {
+    const headers = new Headers();
+    headers.set("authorization", `Bearer ${params.apiKey}`);
+
+    const { response: res, release } = await fetchWithTimeoutGuarded(
+      `${params.baseUrl}/transcriptions/${params.transcriptionId}`,
+      { method: "GET", headers },
+      Math.min(30_000, deadline - Date.now()),
+      params.fetchFn,
+    );
+
+    let result: SonioxTranscriptionResponse;
+    try {
+      if (!res.ok) {
+        const detail = await readErrorResponse(res);
+        const suffix = detail ? `: ${detail}` : "";
+        throw new Error(`Soniox poll failed (HTTP ${res.status})${suffix}`);
+      }
+      result = (await res.json()) as SonioxTranscriptionResponse;
+    } finally {
+      await release();
+    }
+
+    if (result.status === "completed") {
+      return;
+    }
+    if (result.status === "error" || result.status === "failed") {
+      const errMsg = result.error_message ?? result.error_type ?? "unknown error";
+      throw new Error(`Soniox transcription failed: ${errMsg}`);
+    }
+
+    // Wait before next poll
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  throw new Error("Soniox transcription timed out while polling");
+}
+
+/**
+ * Retrieve the transcript text for a completed transcription.
+ */
+async function getTranscript(params: {
+  transcriptionId: string;
+  apiKey: string;
+  baseUrl: string;
+  timeoutMs: number;
+  fetchFn: typeof fetch;
+}): Promise<string> {
+  const headers = new Headers();
+  headers.set("authorization", `Bearer ${params.apiKey}`);
+
+  const { response: res, release } = await fetchWithTimeoutGuarded(
+    `${params.baseUrl}/transcriptions/${params.transcriptionId}/transcript`,
+    { method: "GET", headers },
+    params.timeoutMs,
+    params.fetchFn,
+  );
+
+  try {
+    if (!res.ok) {
+      const detail = await readErrorResponse(res);
+      const suffix = detail ? `: ${detail}` : "";
+      throw new Error(`Soniox transcript retrieval failed (HTTP ${res.status})${suffix}`);
+    }
+
+    const payload = (await res.json()) as SonioxTranscriptResponse;
+
+    // Extract text - may be in different fields depending on API version
+    let text = payload.text ?? payload.transcript;
+    if (!text && Array.isArray(payload.words)) {
+      text = payload.words.map((w) => w.text ?? "").join(" ");
+    }
+    if (!text?.trim()) {
+      throw new Error("Soniox transcript response missing text");
+    }
+    return text.trim();
+  } finally {
+    await release();
+  }
+}
+
+/**
+ * Transcribe audio using Soniox async API.
+ *
+ * Workflow: upload file → create transcription → poll → get transcript
+ */
+export async function transcribeSonioxAudio(
+  params: AudioTranscriptionRequest,
+): Promise<AudioTranscriptionResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const baseUrl = normalizeBaseUrl(params.baseUrl, DEFAULT_SONIOX_AUDIO_BASE_URL);
+  const model = resolveModel(params.model);
+  const mime = params.mime ?? "application/octet-stream";
+
+  // Step 1: Upload file
+  const fileId = await uploadFile({
+    buffer: params.buffer,
+    fileName: params.fileName,
+    mime,
+    apiKey: params.apiKey,
+    baseUrl,
+    timeoutMs: params.timeoutMs,
+    fetchFn,
+  });
+
+  // Step 2: Create transcription job
+  const transcriptionId = await createTranscription({
+    fileId,
+    model,
+    language: params.language,
+    apiKey: params.apiKey,
+    baseUrl,
+    timeoutMs: params.timeoutMs,
+    fetchFn,
+  });
+
+  // Step 3: Poll until complete
+  await pollTranscription({
+    transcriptionId,
+    apiKey: params.apiKey,
+    baseUrl,
+    timeoutMs: params.timeoutMs,
+    fetchFn,
+  });
+
+  // Step 4: Get transcript
+  const text = await getTranscript({
+    transcriptionId,
+    apiKey: params.apiKey,
+    baseUrl,
+    timeoutMs: params.timeoutMs,
+    fetchFn,
+  });
+
+  return { text, model };
+}

--- a/src/media-understanding/providers/soniox/audio.ts
+++ b/src/media-understanding/providers/soniox/audio.ts
@@ -2,7 +2,7 @@ import type { AudioTranscriptionRequest, AudioTranscriptionResult } from "../../
 import { fetchWithTimeoutGuarded, normalizeBaseUrl, readErrorResponse } from "../shared.js";
 
 export const DEFAULT_SONIOX_AUDIO_BASE_URL = "https://api.soniox.com/v1";
-export const DEFAULT_SONIOX_AUDIO_MODEL = "stt-async-preview";
+export const DEFAULT_SONIOX_AUDIO_MODEL = "stt-async-v4";
 const POLL_INTERVAL_MS = 2_000;
 
 function resolveModel(model?: string): string {
@@ -135,7 +135,7 @@ async function createTranscription(params: {
 
   const { response: res, release } = await fetchWithTimeoutGuarded(
     `${params.baseUrl}/transcriptions`,
-    { method: "POST", headers, body: JSON.stringify(payload) },
+    { method: "POST", headers, body: Buffer.from(JSON.stringify(payload)) },
     params.timeoutMs,
     params.fetchFn,
   );

--- a/src/media-understanding/providers/soniox/index.ts
+++ b/src/media-understanding/providers/soniox/index.ts
@@ -1,0 +1,8 @@
+import type { MediaUnderstandingProvider } from "../../types.js";
+import { transcribeSonioxAudio } from "./audio.js";
+
+export const sonioxProvider: MediaUnderstandingProvider = {
+  id: "soniox",
+  capabilities: ["audio"],
+  transcribeAudio: transcribeSonioxAudio,
+};


### PR DESCRIPTION
Add Soniox as a new audio transcription provider for the media-understanding system. Soniox uses an async workflow: upload file → create transcription → poll → get transcript.

Features:
- Multipart file upload
- Async transcription with polling
- Language hints support (60+ languages)
- Excellent for Slovenian and other non-English languages
- ~$0.10/hour pricing
- Requires SONIOX_API_KEY env var.

All polling is handled internally — same transcribeAudio() interface as other providers.

Resolves: openclaw/openclaw#7325

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: added 
- Why it matters: new provider with powerfull models
- What changed: new audio transcription provider

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #7325 

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
New audio transcription provider API calls.

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any): telegram
- Relevant config (redacted):

### Steps

1. send audio message via telegram
2. response is transcription

### Expected

- audio transcription

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: sent audio via telegram. audio transcription is working perfectly

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: just revert code
- Files/config to restore: none
- Known bad symptoms reviewers should watch for: no

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Soniox as a new async audio transcription provider, following the established `MediaUnderstandingProvider` interface. The integration wiring (env key lookup, default model, provider registry, `AUTO_AUDIO_KEY_PROVIDERS`) is done correctly and consistently with existing providers.

The main concern is in the core implementation file `soniox/audio.ts`:

- **Timeout budget not shared across sequential steps** — `params.timeoutMs` is passed unchanged to each of the four async helpers (`uploadFile`, `createTranscription`, `pollTranscription`, `getTranscript`). Because each step starts its own independent timer from `Date.now()`, the total wall-clock duration can reach up to `4 × timeoutMs` rather than being bounded by it. With the default 60-second audio timeout this allows up to 4 minutes of blocking.
- **Unescaped `fileName` in manual multipart body** — the filename is interpolated directly into the `Content-Disposition` header string without escaping double-quotes or CRLF sequences. A malformed or adversarial filename (derived from a user-supplied attachment) can corrupt the multipart structure or inject additional header lines. The OpenAI provider avoids this entirely by using the browser `FormData` API.
- **No tests** — unlike `deepgram` and `openai`, no `audio.test.ts` (unit) or `audio.live.test.ts` (live/integration) is provided, leaving the multi-step async workflow, timeout handling, and response parsing untested.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge without fixing the timeout budget leak and the unescaped filename in the multipart body.
- Two logic bugs in the core implementation: (1) the timeout is not tracked as a shared budget across the four sequential async steps, allowing total elapsed time up to 4× the intended limit; (2) the filename is embedded raw into a manually-constructed Content-Disposition header without escaping, which can corrupt the multipart request for filenames containing double-quotes or CRLF. Additionally, no tests are present for any part of the new provider.
- src/media-understanding/providers/soniox/audio.ts requires the most attention — both logic issues are contained here, and it is the only file without tests.

<sub>Last reviewed commit: a262241</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->