### PR TITLE
Fix/custom bind host validation 

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it } from "vitest";
 import { validateConfigObject } from "./config.js";
 
 describe("config schema regressions", () => {
+  it('accepts gateway.customBindHost when gateway.bind is "custom"', () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "custom",
+        customBindHost: "172.18.0.4",
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts nested telegram groupPolicy overrides", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -395,6 +395,7 @@ export const OpenClawSchema = z
             z.literal("tailnet"),
           ])
           .optional(),
+        customBindHost: z.string().optional(),
         controlUi: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -135,6 +135,19 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
   });
 
+  it("uses custom bind host when bind is custom", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue(undefined);
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("ws://172.18.0.4:18800");
+  });
+
   it("uses url override in remote mode even when remote url is missing", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },
@@ -211,6 +224,21 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.url).toBe("ws://10.0.0.5:18800");
     expect(details.urlSource).toBe("local lan 10.0.0.5");
     expect(details.bindDetail).toBe("Bind: lan");
+  });
+
+  it("uses custom bind host and reports custom source when bind is custom", () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue(undefined);
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://172.18.0.4:18800");
+    expect(details.urlSource).toBe("local custom 172.18.0.4");
+    expect(details.bindDetail).toBe("Bind: custom");
   });
 
   it("prefers remote url when configured", () => {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -5,6 +5,7 @@ const loadConfig = vi.fn();
 const resolveGatewayPort = vi.fn();
 const pickPrimaryTailnetIPv4 = vi.fn();
 const pickPrimaryLanIPv4 = vi.fn();
+const isCustomBindHostAvailableLocally = vi.fn();
 
 let lastClientOptions: {
   url?: string;
@@ -33,6 +34,7 @@ vi.mock("../infra/tailnet.js", () => ({
 
 vi.mock("./net.js", () => ({
   pickPrimaryLanIPv4,
+  isCustomBindHostAvailableLocally,
 }));
 
 vi.mock("./client.js", () => ({
@@ -77,6 +79,8 @@ describe("callGateway url resolution", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -148,6 +152,20 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.url).toBe("ws://172.18.0.4:18800");
   });
 
+  it("falls back to loopback when custom bind host is unavailable locally", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue(undefined);
+    isCustomBindHostAvailableLocally.mockReturnValue(false);
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
+  });
+
   it("uses url override in remote mode even when remote url is missing", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },
@@ -172,6 +190,8 @@ describe("buildGatewayConnectionDetails", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
   });
 
   it("uses explicit url overrides and omits bind details", () => {
@@ -241,6 +261,22 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.bindDetail).toBe("Bind: custom");
   });
 
+  it("falls back to loopback source when custom bind host is unavailable locally", () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue(undefined);
+    isCustomBindHostAvailableLocally.mockReturnValue(false);
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://127.0.0.1:18800");
+    expect(details.urlSource).toBe("local loopback");
+    expect(details.bindDetail).toBe("Bind: custom");
+  });
+
   it("prefers remote url when configured", () => {
     loadConfig.mockReturnValue({
       gateway: {
@@ -267,6 +303,8 @@ describe("callGateway error details", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -368,6 +406,8 @@ describe("callGateway url override auth requirements", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -405,6 +445,8 @@ describe("callGateway password resolution", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { isIPv4 } from "node:net";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   loadConfig,
@@ -17,7 +16,7 @@ import {
   type GatewayClientName,
 } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
-import { pickPrimaryLanIPv4 } from "./net.js";
+import { isCustomBindHostAvailableLocally, pickPrimaryLanIPv4 } from "./net.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
 
 export type CallGatewayOptions = {
@@ -104,7 +103,7 @@ export function buildGatewayConnectionDetails(
   const bindMode = config.gateway?.bind ?? "loopback";
   const customBindHostRaw = config.gateway?.customBindHost?.trim();
   const customBindHost =
-    typeof customBindHostRaw === "string" && isIPv4(customBindHostRaw)
+    typeof customBindHostRaw === "string" && isCustomBindHostAvailableLocally(customBindHostRaw)
       ? customBindHostRaw
       : undefined;
   const preferTailnet = bindMode === "tailnet" && !!tailnetIPv4;

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -25,6 +25,28 @@ export function pickPrimaryLanIPv4(): string | undefined {
   return undefined;
 }
 
+/**
+ * Returns true when a custom bind host points to an IPv4 address currently
+ * present on a local network interface (or loopback).
+ */
+export function isCustomBindHostAvailableLocally(host: string | undefined): boolean {
+  const candidate = host?.trim();
+  if (!candidate || !isValidIPv4(candidate)) {
+    return false;
+  }
+  if (isLoopbackAddress(candidate)) {
+    return true;
+  }
+  const nets = os.networkInterfaces();
+  for (const list of Object.values(nets)) {
+    const entry = list?.find((n) => n.family === "IPv4" && n.address === candidate);
+    if (entry) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function normalizeHostHeader(hostHeader?: string): string {
   return (hostHeader ?? "").trim().toLowerCase();
 }


### PR DESCRIPTION
Fixes a config validation mismatch that breaks `configure` when selecting a custom Gateway bind IP.

## Problem
When running `openclaw configure` and choosing Gateway bind mode `custom`, the wizard writes:
- `gateway.bind = "custom"`
- `gateway.customBindHost = "<ip>"`

Config validation then fails with:
`Config validation failed: gateway: Unrecognized key: "customBindHost"`

## Root cause
`GatewayConfig` types and runtime code already support `gateway.customBindHost`, but `OpenClawSchema.gateway` in `src/config/zod-schema.ts` did not include this key.

## Fix
- Added `gateway.customBindHost` as an optional string in `src/config/zod-schema.ts`.
- Added regression coverage in `src/config/config.schema-regressions.test.ts` to validate:
  - `{ gateway: { bind: "custom", customBindHost: "172.18.0.4" } }`

## Result
`configure` no longer fails after selecting a custom gateway IP, and schema/type/runtime behavior is now aligned.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a config validation mismatch introduced by the `.strict()` Zod schema on the `gateway` object: `customBindHost` was already part of the `GatewayConfig` TypeScript type and used throughout the runtime, but was absent from `OpenClawSchema.gateway` in `zod-schema.ts`, causing `openclaw configure` to fail after selecting a custom bind IP.

Key changes:
- **`src/config/zod-schema.ts`**: Adds the missing `customBindHost: z.string().optional()` field to the gateway Zod schema — the core fix.
- **`src/gateway/call.ts`**: Adds client-side URL resolution for `bind: "custom"`, using `node:net`'s `isIPv4` to validate the host before constructing the WebSocket URL, with a silent fallback to loopback on invalid input.
- **`src/config/config.schema-regressions.test.ts`**: Adds a regression test to prevent the schema omission from recurring.
- **`src/gateway/call.ts` tests**: Adds coverage for the new custom-bind URL resolution path.

The fix is minimal, well-targeted, and aligns schema, type, and runtime behavior. The `call.ts` changes add functionality (client-side custom bind host resolution for RPC calls) that was previously broken alongside the schema fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a targeted schema alignment fix with no behavioral regressions.
- The change is minimal and fixes a clear, documented omission. The `GatewayConfig` type, runtime code, configure wizard, and all downstream consumers already expected `customBindHost` to exist; the schema was simply missing the field. The added `call.ts` logic correctly validates IPv4 input and falls back gracefully. Tests are appropriate and focused. No security implications, no breaking changes.
- No files require special attention.

<sub>Last reviewed commit: f972c02</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->