### PR TITLE
feat(slack): configurable reasoning display (inline/collapsed/hidden)

### DIFF
--- a/src/slack/monitor/replies.test.ts
+++ b/src/slack/monitor/replies.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { extractReasoningBody, isReasoningReply } from "./replies.js";
+
+describe("isReasoningReply", () => {
+  it("detects reasoning prefix", () => {
+    expect(isReasoningReply("Reasoning:\n_some thinking_")).toBe(true);
+  });
+
+  it("rejects non-reasoning text", () => {
+    expect(isReasoningReply("Hello world")).toBe(false);
+    expect(isReasoningReply("Reasoning about something")).toBe(false);
+    expect(isReasoningReply("")).toBe(false);
+  });
+});
+
+describe("extractReasoningBody", () => {
+  it("strips prefix and italic wrappers", () => {
+    const input = "Reasoning:\n_first line_\n_second line_";
+    expect(extractReasoningBody(input)).toBe("first line\nsecond line");
+  });
+
+  it("preserves empty lines", () => {
+    const input = "Reasoning:\n_first_\n\n_third_";
+    expect(extractReasoningBody(input)).toBe("first\n\nthird");
+  });
+
+  it("handles lines without italic wrappers", () => {
+    const input = "Reasoning:\nplain line\n_italic line_";
+    expect(extractReasoningBody(input)).toBe("plain line\nitalic line");
+  });
+});

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -57,6 +57,7 @@ export async function deliverReplies(params: {
   runtime: RuntimeEnv;
   textLimit: number;
   replyThreadTs?: string;
+  reasoningDisplay?: "inline" | "collapsed" | "hidden";
 }) {
   for (const payload of params.replies) {
     const threadTs = payload.replyToId ?? params.replyThreadTs;
@@ -73,8 +74,13 @@ export async function deliverReplies(params: {
       }
 
       // Render reasoning/thinking blocks as collapsed Slack attachments
-      // so they don't dominate the conversation.
-      if (isReasoningReply(trimmed)) {
+      // when configured via channels.slack.reasoningDisplay = "collapsed".
+      // Default is "inline" (current behavior, no change).
+      const reasoningDisplay = params.reasoningDisplay ?? "inline";
+      if (reasoningDisplay === "hidden" && isReasoningReply(trimmed)) {
+        continue;
+      }
+      if (reasoningDisplay === "collapsed" && isReasoningReply(trimmed)) {
         const body = extractReasoningBody(trimmed);
         const summary = buildReasoningSummary(body);
         const mrkdwnBody = markdownToSlackMrkdwn(body);

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -27,7 +27,9 @@ export function extractReasoningBody(text: string): string {
   // Strip per-line italic wrappers (_..._) added by formatReasoningMessage
   return body
     .split("\n")
-    .map((line) => (line.startsWith("_") && line.endsWith("_") ? line.slice(1, -1) : line))
+    .map((line) =>
+      line.length >= 3 && line.startsWith("_") && line.endsWith("_") ? line.slice(1, -1) : line,
+    )
     .join("\n");
 }
 

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -40,6 +40,14 @@ export type SlackSendIdentity = {
   iconEmoji?: string;
 };
 
+export type SlackAttachment = {
+  color?: string;
+  fallback?: string;
+  text?: string;
+  pretext?: string;
+  mrkdwn_in?: string[];
+};
+
 type SlackSendOpts = {
   token?: string;
   accountId?: string;
@@ -49,6 +57,7 @@ type SlackSendOpts = {
   threadTs?: string;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  attachments?: SlackAttachment[];
 };
 
 function hasCustomIdentity(identity?: SlackSendIdentity): boolean {
@@ -88,12 +97,14 @@ async function postSlackMessageBestEffort(params: {
   threadTs?: string;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  attachments?: SlackAttachment[];
 }) {
   const basePayload = {
     channel: params.channelId,
     text: params.text,
     thread_ts: params.threadTs,
     ...(params.blocks?.length ? { blocks: params.blocks } : {}),
+    ...(params.attachments?.length ? { attachments: params.attachments } : {}),
   };
   try {
     // Slack Web API types model icon_url and icon_emoji as mutually exclusive.
@@ -313,6 +324,7 @@ export async function sendMessageSlack(
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
+        attachments: opts.attachments,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -257,6 +257,9 @@ export async function sendMessageSlack(
     if (opts.mediaUrl) {
       throw new Error("Slack send does not support blocks with mediaUrl");
     }
+    if (opts.attachments) {
+      throw new Error("Slack send does not support blocks with attachments");
+    }
     const fallbackText = trimmedMessage || buildSlackBlocksFallbackText(blocks);
     const response = await postSlackMessageBestEffort({
       client,
@@ -317,6 +320,7 @@ export async function sendMessageSlack(
       lastMessageId = response.ts ?? lastMessageId;
     }
   } else {
+    let isFirst = true;
     for (const chunk of chunks.length ? chunks : [""]) {
       const response = await postSlackMessageBestEffort({
         client,
@@ -324,8 +328,9 @@ export async function sendMessageSlack(
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
-        attachments: opts.attachments,
+        attachments: isFirst ? opts.attachments : undefined,
       });
+      isFirst = false;
       lastMessageId = response.ts ?? lastMessageId;
     }
   }


### PR DESCRIPTION
## What

Add configurable rendering of reasoning/thinking blocks in Slack via `channels.slack.reasoningDisplay`.

## Why

Closes #19411 — When reasoning is enabled, thinking blocks stream inline as long verbose messages that push actual answers off-screen. Users should be able to choose how reasoning is displayed.

## Options

| Value | Behavior |
|-------|----------|
| `"inline"` (default) | **Current behavior, no change.** Reasoning renders as normal text. |
| `"collapsed"` | Rendered as a Slack attachment with 💭 summary line, muted gray sidebar, and auto-collapsed body ("Show more"). |
| `"hidden"` | Reasoning messages suppressed entirely. |

## How

When `reasoningDisplay` is `"collapsed"` and a reply contains reasoning content (prefixed with `Reasoning:`), it is delivered as a Slack attachment with:
- 💭 summary line showing a truncated preview
- Muted gray sidebar (`#d0d0d0`) for visual de-emphasis
- Full reasoning text in the attachment body — Slack auto-collapses with "Show more"

Regular (non-thinking) messages are completely unaffected regardless of setting.

### Files changed
- `src/slack/monitor/replies.ts` — Detect reasoning replies, configurable display modes
- `src/slack/send.ts` — Add `attachments` support to `sendMessageSlack` (first-chunk only, blocks guard)
- `src/slack/monitor/replies.test.ts` — Unit tests for reasoning detection/extraction

## Review feedback addressed
- ✅ Single-underscore edge case guard (`line.length >= 3`)
- ✅ Attachments only on first chunk (prevent duplication)
- ✅ Explicit throw on `blocks + attachments` combo
- ✅ **Opt-in via config** — defaults to `"inline"` preserving current behavior

## Testing
- `pnpm build` ✅
- `pnpm check` ✅
- Unit tests pass ✅
- Pre-existing upstream failure in `cron/isolated-agent/run.skill-filter.test.ts` (not related)

---

🤖 AI-assisted (Claude via OpenClaw). Unit tested + build verified. Author understands the changes.