### PR TITLE
Gateway: respect custom bind host for local health/RPC target resolution

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -135,6 +135,19 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
   });
 
+  it("uses custom bind host when bind is custom", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue(undefined);
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("ws://172.18.0.4:18800");
+  });
+
   it("uses url override in remote mode even when remote url is missing", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },
@@ -211,6 +224,21 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.url).toBe("ws://10.0.0.5:18800");
     expect(details.urlSource).toBe("local lan 10.0.0.5");
     expect(details.bindDetail).toBe("Bind: lan");
+  });
+
+  it("uses custom bind host and reports custom source when bind is custom", () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue(undefined);
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://172.18.0.4:18800");
+    expect(details.urlSource).toBe("local custom 172.18.0.4");
+    expect(details.bindDetail).toBe("Bind: custom");
   });
 
   it("prefers remote url when configured", () => {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -5,6 +5,7 @@ const loadConfig = vi.fn();
 const resolveGatewayPort = vi.fn();
 const pickPrimaryTailnetIPv4 = vi.fn();
 const pickPrimaryLanIPv4 = vi.fn();
+const isCustomBindHostAvailableLocally = vi.fn();
 
 let lastClientOptions: {
   url?: string;
@@ -33,6 +34,7 @@ vi.mock("../infra/tailnet.js", () => ({
 
 vi.mock("./net.js", () => ({
   pickPrimaryLanIPv4,
+  isCustomBindHostAvailableLocally,
 }));
 
 vi.mock("./client.js", () => ({
@@ -77,6 +79,8 @@ describe("callGateway url resolution", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -148,6 +152,20 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.url).toBe("ws://172.18.0.4:18800");
   });
 
+  it("falls back to loopback when custom bind host is unavailable locally", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue(undefined);
+    isCustomBindHostAvailableLocally.mockReturnValue(false);
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
+  });
+
   it("uses url override in remote mode even when remote url is missing", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },
@@ -172,6 +190,8 @@ describe("buildGatewayConnectionDetails", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
   });
 
   it("uses explicit url overrides and omits bind details", () => {
@@ -241,6 +261,22 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.bindDetail).toBe("Bind: custom");
   });
 
+  it("falls back to loopback source when custom bind host is unavailable locally", () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue(undefined);
+    isCustomBindHostAvailableLocally.mockReturnValue(false);
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://127.0.0.1:18800");
+    expect(details.urlSource).toBe("local loopback");
+    expect(details.bindDetail).toBe("Bind: custom");
+  });
+
   it("prefers remote url when configured", () => {
     loadConfig.mockReturnValue({
       gateway: {
@@ -267,6 +303,8 @@ describe("callGateway error details", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -368,6 +406,8 @@ describe("callGateway url override auth requirements", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -405,6 +445,8 @@ describe("callGateway password resolution", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
+    isCustomBindHostAvailableLocally.mockReset();
+    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -5,7 +5,6 @@ const loadConfig = vi.fn();
 const resolveGatewayPort = vi.fn();
 const pickPrimaryTailnetIPv4 = vi.fn();
 const pickPrimaryLanIPv4 = vi.fn();
-const isCustomBindHostAvailableLocally = vi.fn();
 
 let lastClientOptions: {
   url?: string;
@@ -34,7 +33,6 @@ vi.mock("../infra/tailnet.js", () => ({
 
 vi.mock("./net.js", () => ({
   pickPrimaryLanIPv4,
-  isCustomBindHostAvailableLocally,
 }));
 
 vi.mock("./client.js", () => ({
@@ -79,8 +77,6 @@ describe("callGateway url resolution", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
-    isCustomBindHostAvailableLocally.mockReset();
-    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -152,20 +148,6 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.url).toBe("ws://172.18.0.4:18800");
   });
 
-  it("falls back to loopback when custom bind host is unavailable locally", async () => {
-    loadConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
-    });
-    resolveGatewayPort.mockReturnValue(18800);
-    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
-    pickPrimaryLanIPv4.mockReturnValue(undefined);
-    isCustomBindHostAvailableLocally.mockReturnValue(false);
-
-    await callGateway({ method: "health" });
-
-    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
-  });
-
   it("uses url override in remote mode even when remote url is missing", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },
@@ -190,8 +172,6 @@ describe("buildGatewayConnectionDetails", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
-    isCustomBindHostAvailableLocally.mockReset();
-    isCustomBindHostAvailableLocally.mockReturnValue(true);
   });
 
   it("uses explicit url overrides and omits bind details", () => {
@@ -261,22 +241,6 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.bindDetail).toBe("Bind: custom");
   });
 
-  it("falls back to loopback source when custom bind host is unavailable locally", () => {
-    loadConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "custom", customBindHost: "172.18.0.4" },
-    });
-    resolveGatewayPort.mockReturnValue(18800);
-    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
-    pickPrimaryLanIPv4.mockReturnValue(undefined);
-    isCustomBindHostAvailableLocally.mockReturnValue(false);
-
-    const details = buildGatewayConnectionDetails();
-
-    expect(details.url).toBe("ws://127.0.0.1:18800");
-    expect(details.urlSource).toBe("local loopback");
-    expect(details.bindDetail).toBe("Bind: custom");
-  });
-
   it("prefers remote url when configured", () => {
     loadConfig.mockReturnValue({
       gateway: {
@@ -303,8 +267,6 @@ describe("callGateway error details", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
-    isCustomBindHostAvailableLocally.mockReset();
-    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -406,8 +368,6 @@ describe("callGateway url override auth requirements", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
-    isCustomBindHostAvailableLocally.mockReset();
-    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -445,8 +405,6 @@ describe("callGateway password resolution", () => {
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
     pickPrimaryLanIPv4.mockReset();
-    isCustomBindHostAvailableLocally.mockReset();
-    isCustomBindHostAvailableLocally.mockReturnValue(true);
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { isIPv4 } from "node:net";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   loadConfig,
@@ -17,7 +16,7 @@ import {
   type GatewayClientName,
 } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
-import { pickPrimaryLanIPv4 } from "./net.js";
+import { isCustomBindHostAvailableLocally, pickPrimaryLanIPv4 } from "./net.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
 
 export type CallGatewayOptions = {
@@ -104,7 +103,7 @@ export function buildGatewayConnectionDetails(
   const bindMode = config.gateway?.bind ?? "loopback";
   const customBindHostRaw = config.gateway?.customBindHost?.trim();
   const customBindHost =
-    typeof customBindHostRaw === "string" && isIPv4(customBindHostRaw)
+    typeof customBindHostRaw === "string" && isCustomBindHostAvailableLocally(customBindHostRaw)
       ? customBindHostRaw
       : undefined;
   const preferTailnet = bindMode === "tailnet" && !!tailnetIPv4;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { isIPv4 } from "node:net";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   loadConfig,
@@ -16,7 +17,7 @@ import {
   type GatewayClientName,
 } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
-import { isCustomBindHostAvailableLocally, pickPrimaryLanIPv4 } from "./net.js";
+import { pickPrimaryLanIPv4 } from "./net.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
 
 export type CallGatewayOptions = {
@@ -103,7 +104,7 @@ export function buildGatewayConnectionDetails(
   const bindMode = config.gateway?.bind ?? "loopback";
   const customBindHostRaw = config.gateway?.customBindHost?.trim();
   const customBindHost =
-    typeof customBindHostRaw === "string" && isCustomBindHostAvailableLocally(customBindHostRaw)
+    typeof customBindHostRaw === "string" && isIPv4(customBindHostRaw)
       ? customBindHostRaw
       : undefined;
   const preferTailnet = bindMode === "tailnet" && !!tailnetIPv4;

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -25,6 +25,28 @@ export function pickPrimaryLanIPv4(): string | undefined {
   return undefined;
 }
 
+/**
+ * Returns true when a custom bind host points to an IPv4 address currently
+ * present on a local network interface (or loopback).
+ */
+export function isCustomBindHostAvailableLocally(host: string | undefined): boolean {
+  const candidate = host?.trim();
+  if (!candidate || !isValidIPv4(candidate)) {
+    return false;
+  }
+  if (isLoopbackAddress(candidate)) {
+    return true;
+  }
+  const nets = os.networkInterfaces();
+  for (const list of Object.values(nets)) {
+    const entry = list?.find((n) => n.family === "IPv4" && n.address === candidate);
+    if (entry) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function normalizeHostHeader(hostHeader?: string): string {
   return (hostHeader ?? "").trim().toLowerCase();
 }

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -25,28 +25,6 @@ export function pickPrimaryLanIPv4(): string | undefined {
   return undefined;
 }
 
-/**
- * Returns true when a custom bind host points to an IPv4 address currently
- * present on a local network interface (or loopback).
- */
-export function isCustomBindHostAvailableLocally(host: string | undefined): boolean {
-  const candidate = host?.trim();
-  if (!candidate || !isValidIPv4(candidate)) {
-    return false;
-  }
-  if (isLoopbackAddress(candidate)) {
-    return true;
-  }
-  const nets = os.networkInterfaces();
-  for (const list of Object.values(nets)) {
-    const entry = list?.find((n) => n.family === "IPv4" && n.address === candidate);
-    if (entry) {
-      return true;
-    }
-  }
-  return false;
-}
-
 export function normalizeHostHeader(hostHeader?: string): string {
   return (hostHeader ?? "").trim().toLowerCase();
 }


### PR DESCRIPTION
## Summary
Fix local gateway target resolution for `bind=custom` so CLI health/RPC checks connect to `gateway.customBindHost` instead of hardcoded loopback.

## Problem
After configuring:

- `gateway.bind = "custom"`
- `gateway.customBindHost = "<ip>"`

the configure/health flow could still fail because local RPC checks were targeting:

- `ws://127.0.0.1:<port>`

This produced disconnects (often `1006`) when the gateway was actually bound to a custom host (for example `172.18.0.4`).

## Root Cause
`buildGatewayConnectionDetails()` in `src/gateway/call.ts` only handled local URL resolution for:

- `loopback` (default fallback)
- `lan`
- `tailnet`

`custom` bind mode was not included, so it fell through to loopback.

## Changes
- Added `custom` bind handling in local URL resolution:
  - use `gateway.customBindHost` when it is a valid IPv4
- Updated connection metadata source label:
  - now reports `local custom <ip>` for this mode
- Added regression tests in `src/gateway/call.test.ts` for:
  - `callGateway()` URL selection with `bind=custom`
  - `buildGatewayConnectionDetails()` source/URL reporting with `bind=custom`

## Result
When `gateway.bind=custom`, local health/RPC probes now target the configured custom IP, aligning probe behavior with runtime gateway bind settings.

## Validation
- `pnpm vitest run src/gateway/call.test.ts` passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real bug: when `gateway.bind = "custom"` is configured, the CLI health/RPC probes were still targeting `127.0.0.1` instead of the configured `customBindHost`. The fix correctly adds `custom` bind mode handling in `buildGatewayConnectionDetails()` and updates the `urlSource` label accordingly.

Key observations:
- The logic is correct and the fallback to loopback when `customBindHost` is absent or not a valid IPv4 works as expected
- `isIPv4` from `node:net` is imported for validation, while `isValidIPv4` from `./net.js` already exists and is used for the same `customBindHost` purpose elsewhere in the codebase (e.g. `onboard-helpers.ts:469`)
- The new tests cover the happy path but are missing a test for the fallback-to-loopback behavior when `bind=custom` but `customBindHost` is absent or invalid — an analogous fallback test exists for `bind=lan` at line 127

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the fix is narrowly scoped, logically correct, and tests pass
- The core bug fix is sound and the new code mirrors the existing patterns for `tailnet` and `lan` bind modes. The two style-level issues (using `isIPv4` from `node:net` instead of the codebase-consistent `isValidIPv4`, and missing a fallback test) are not blocking. No regressions to existing behavior are introduced.
- No files require special attention beyond the style suggestions noted

<sub>Last reviewed commit: 08db64e</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->