### PR TITLE
fix(tts): pass audioAsVoice flag through tool result pipeline

### DIFF
--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -92,7 +92,11 @@ export type RunEmbeddedPiAgentParams = {
   blockReplyChunking?: BlockReplyChunking;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onReasoningEnd?: () => void | Promise<void>;
-  onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  onToolResult?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  }) => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
   lane?: string;
   enqueue?: typeof enqueueCommand;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -10,6 +10,7 @@ import type {
 } from "./pi-embedded-subscribe.handlers.types.js";
 import {
   extractToolErrorMessage,
+  extractToolResultAudioAsVoice,
   extractToolResultMediaPaths,
   extractToolResultText,
   extractMessagingToolSend,
@@ -383,8 +384,12 @@ export async function handleToolExecutionEnd(
   if (ctx.params.onToolResult && !isToolError && !ctx.shouldEmitToolOutput()) {
     const mediaPaths = extractToolResultMediaPaths(result);
     if (mediaPaths.length > 0) {
+      const audioAsVoice = extractToolResultAudioAsVoice(result);
       try {
-        void ctx.params.onToolResult({ mediaUrls: mediaPaths });
+        void ctx.params.onToolResult({
+          mediaUrls: mediaPaths,
+          audioAsVoice: audioAsVoice || undefined,
+        });
       } catch {
         // ignore delivery failures
       }

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -201,6 +201,35 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
   return [];
 }
 
+/**
+ * Extract audioAsVoice flag from tool result text content.
+ * Looks for [[audio_as_voice]] tag in text content blocks.
+ */
+export function extractToolResultAudioAsVoice(result: unknown): boolean {
+  if (!result || typeof result !== "object") {
+    return false;
+  }
+  const record = result as Record<string, unknown>;
+  const content = Array.isArray(record.content) ? record.content : null;
+  if (!content) {
+    return false;
+  }
+
+  for (const item of content) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const entry = item as Record<string, unknown>;
+    if (entry.type === "text" && typeof entry.text === "string") {
+      if (entry.text.includes("[[audio_as_voice]]")) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 export function isToolResultError(result: unknown): boolean {
   if (!result || typeof result !== "object") {
     return false;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -323,7 +323,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     const agg = formatToolAggregate(toolName, meta ? [meta] : undefined, {
       markdown: useMarkdown,
     });
-    const { text: cleanedText, mediaUrls } = parseReplyDirectives(agg);
+    const { text: cleanedText, mediaUrls, audioAsVoice } = parseReplyDirectives(agg);
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0)) {
       return;
     }
@@ -331,6 +331,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       void params.onToolResult({
         text: cleanedText,
         mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
+        audioAsVoice: audioAsVoice || undefined,
       });
     } catch {
       // ignore tool result delivery failures
@@ -344,7 +345,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       markdown: useMarkdown,
     });
     const message = `${agg}\n${formatToolOutputBlock(output)}`;
-    const { text: cleanedText, mediaUrls } = parseReplyDirectives(message);
+    const { text: cleanedText, mediaUrls, audioAsVoice } = parseReplyDirectives(message);
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0)) {
       return;
     }
@@ -352,6 +353,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       void params.onToolResult({
         text: cleanedText,
         mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
+        audioAsVoice: audioAsVoice || undefined,
       });
     } catch {
       // ignore tool result delivery failures

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -16,7 +16,11 @@ export type SubscribeEmbeddedPiSessionParams = {
   toolResultFormat?: ToolResultFormat;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
-  onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  onToolResult?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  }) => void | Promise<void>;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */
   onReasoningEnd?: () => void | Promise<void>;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -380,6 +380,7 @@ export async function runAgentTurnWithFallback(params: {
                     await onToolResult({
                       text,
                       mediaUrls: payload.mediaUrls,
+                      audioAsVoice: payload.audioAsVoice,
                     });
                   })()
                     .catch((err) => {


### PR DESCRIPTION
Fixes #14174

## What
The built-in `tts` agent tool now correctly delivers voice messages on Telegram by passing the `audioAsVoice` flag through the tool result pipeline.

## Why  
The TTS tool was returning `[[audio_as_voice]]` tags in text content, but this flag was being dropped when passing through `onToolResult` callbacks. This caused voice messages to be sent as regular audio file attachments instead of voice bubbles.

The parsing in `parseReplyDirectives` / `splitMediaFromOutput` was working correctly to extract the flag, but `emitToolOutput` and the downstream pipeline weren't passing it through.

## How
- Added `audioAsVoice?: boolean` to the `onToolResult` callback payload type in `pi-embedded-subscribe.types.ts`
- Updated `emitToolOutput` and `emitToolSummary` to pass `audioAsVoice` from `parseReplyDirectives`
- Added `extractToolResultAudioAsVoice()` helper to extract the flag for the direct media delivery path (when `shouldEmitToolOutput` is false)
- Passes `audioAsVoice` through `agent-runner-execution.ts` to the final delivery

## Testing
- [x] Added unit tests for `extractToolResultAudioAsVoice()`
- [x] Existing tests pass (`pnpm vitest run`)
- [x] `pnpm build` passes

## AI-Assisted 🤖
This PR was built with AI assistance (Claude via OpenClaw).
- [x] Code reviewed and understood
- [x] Matches existing patterns in the codebase

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the `tts` agent tool was delivering voice messages as regular audio file attachments on Telegram instead of voice bubbles. The `[[audio_as_voice]]` flag was being emitted by the TTS tool but dropped when passing through the `onToolResult` callback pipeline.

Key changes:
- Added `audioAsVoice?: boolean` to `onToolResult` callback payload types in `pi-embedded-subscribe.types.ts` and `pi-embedded-runner/run/params.ts`
- Added `extractToolResultAudioAsVoice()` in `pi-embedded-subscribe.tools.ts` to extract the flag for the direct media delivery path (when `shouldEmitToolOutput` is false)
- Updated `emitToolSummary` and `emitToolOutput` in `pi-embedded-subscribe.ts` to pass `audioAsVoice` from `parseReplyDirectives`
- Propagated `payload.audioAsVoice` through `agent-runner-execution.ts` to the outer `onToolResult` handler
- Added unit tests covering edge cases for `extractToolResultAudioAsVoice()`

The fix correctly threads the flag through both delivery paths (verbose tool output and direct media delivery). The implementation follows the same patterns used elsewhere in the codebase for `audioAsVoice` propagation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a clear bug with a minimal, well-scoped change that follows existing codebase patterns.
- The changes are small and targeted, threading a single boolean flag through the tool result pipeline. The new `extractToolResultAudioAsVoice()` helper mirrors the existing `extractToolResultMediaPaths()` pattern exactly. Both delivery paths (verbose/emitToolOutput and direct media delivery) are handled. Unit tests cover null/undefined, non-object, missing content, and the TTS format. No pre-existing behavior is altered, and the type changes are backward compatible (optional field added).
- No files require special attention

<sub>Last reviewed commit: 8979a3b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->