### PR TITLE
fix: pass agentId in wake() so enqueueSystemEvent resolves session key

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -629,9 +629,10 @@ export function wake(
   if (!text) {
     return { ok: false } as const;
   }
-  state.deps.enqueueSystemEvent(text);
+  const agentId = state.deps.defaultAgentId ?? DEFAULT_AGENT_ID;
+  state.deps.enqueueSystemEvent(text, { agentId });
   if (opts.mode === "now") {
-    state.deps.requestHeartbeatNow({ reason: "wake" });
+    state.deps.requestHeartbeatNow({ reason: "wake", agentId });
   }
   return { ok: true } as const;
 }


### PR DESCRIPTION
## Summary

`wake()` in `src/cron/service/timer.ts` called `enqueueSystemEvent(text)` without a `sessionKey` or `agentId`. The `server-cron.ts` wrapper resolves the session key from `agentId`, but `wake()` passed neither — causing `requireSessionKey()` to throw and the event to be silently dropped.

This meant `openclaw system event --text "..." --mode now` returned `ok` but never actually queued the event or woke the agent.

## Root cause

Regression from the fix for #510, which added session key resolution to cron job execution paths (line 454) but missed the `wake()` function (line 632) in the same file.

## Fix

Pass `agentId` (resolved from `state.deps.defaultAgentId` or `DEFAULT_AGENT_ID`) to both `enqueueSystemEvent` and `requestHeartbeatNow`, matching the pattern used by cron job execution.

## Testing

Tested locally with an IRC mention watcher that calls `openclaw system event --mode now`:
- **Before fix:** Event returned `ok` but agent never woke. System event was silently dropped
- **After fix:** Agent wakes immediately and processes the system event

Fixes #19438

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression in the `wake()` function in `src/cron/service/timer.ts` where `enqueueSystemEvent` and `requestHeartbeatNow` were called without an `agentId` or `sessionKey`. Since `enqueueSystemEvent` in `src/infra/system-events.ts` calls `requireSessionKey()` and throws if no key is provided, and the `server-cron.ts` wrapper resolves the session key from `agentId`, the missing `agentId` caused a silent failure — events appeared to succeed (returning `ok: true`) but were never actually queued.

**Changes:**
- Adds `const agentId = state.deps.defaultAgentId ?? DEFAULT_AGENT_ID` in `wake()` to resolve the correct agent
- Passes `{ agentId }` to `enqueueSystemEvent` so the `server-cron.ts` wrapper can derive the session key
- Passes `{ reason: "wake", agentId }` to `requestHeartbeatNow` for consistent agent targeting

**Assessment:** The fix is minimal, targeted, and consistent with the existing pattern used in `executeJobCore` (lines 454–504). No issues were found with the implementation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a silent regression with a minimal, well-targeted change that aligns with the established pattern in the same file.
- The fix is exactly two lines and directly mirrors the pattern already used by executeJobCore (lines 454-458 and 498-502). The root cause is clearly identified: enqueueSystemEvent in server-cron.ts requires an agentId to derive the sessionKey, and wake() was the only call site missing it. No new logic is introduced, no edge cases are added, and the fallback to DEFAULT_AGENT_ID ("main") matches the same fallback used throughout the file (e.g., lines 315 and 319). No tests were broken or need to be added for this one-line omission fix.
- No files require special attention.

<sub>Last reviewed commit: 98feb9f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->