### PR TITLE
fix(signal): canonicalize message targets in tool and inbound flows

### DIFF
--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -62,6 +62,39 @@ describe("buildThreadingToolContext", () => {
     expect(result.currentChannelId).toBe("chat:99");
   });
 
+  it("normalizes signal direct targets for tool context", () => {
+    const sessionCtx = {
+      Provider: "signal",
+      ChatType: "direct",
+      From: "signal:+15550001",
+      To: "signal:+15550002",
+    } as TemplateContext;
+
+    const result = buildThreadingToolContext({
+      sessionCtx,
+      config: cfg,
+      hasRepliedRef: undefined,
+    });
+
+    expect(result.currentChannelId).toBe("+15550001");
+  });
+
+  it("preserves signal group ids for tool context", () => {
+    const sessionCtx = {
+      Provider: "signal",
+      ChatType: "group",
+      To: "signal:group:VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=",
+    } as TemplateContext;
+
+    const result = buildThreadingToolContext({
+      sessionCtx,
+      config: cfg,
+      hasRepliedRef: undefined,
+    });
+
+    expect(result.currentChannelId).toBe("group:VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=");
+  });
+
   it("uses the sender handle for iMessage direct chats", () => {
     const sessionCtx = {
       Provider: "imessage",

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -28,6 +28,7 @@ import {
   resolveWhatsAppGroupRequireMention,
   resolveWhatsAppGroupToolPolicy,
 } from "./plugins/group-mentions.js";
+import { normalizeSignalMessagingTarget } from "./plugins/normalize/signal.js";
 import type {
   ChannelCapabilities,
   ChannelCommandAdapter,
@@ -97,16 +98,32 @@ const formatDiscordAllowFrom = (allowFrom: Array<string | number>) =>
     )
     .filter(Boolean);
 
-function buildDirectOrGroupThreadToolContext(params: {
+function resolveDirectOrGroupChannelId(context: ChannelThreadingContext): string | undefined {
+  const isDirect = context.ChatType?.toLowerCase() === "direct";
+  return (isDirect ? (context.From ?? context.To) : context.To)?.trim() || undefined;
+}
+
+function buildSignalThreadToolContext(params: {
   context: ChannelThreadingContext;
   hasRepliedRef: ChannelThreadingToolContext["hasRepliedRef"];
 }): ChannelThreadingToolContext {
-  const isDirect = params.context.ChatType?.toLowerCase() === "direct";
-  const channelId =
-    (isDirect ? (params.context.From ?? params.context.To) : params.context.To)?.trim() ||
-    undefined;
+  const currentChannelIdRaw = resolveDirectOrGroupChannelId(params.context);
+  const currentChannelId = currentChannelIdRaw
+    ? (normalizeSignalMessagingTarget(currentChannelIdRaw) ?? currentChannelIdRaw.trim())
+    : undefined;
   return {
-    currentChannelId: channelId,
+    currentChannelId,
+    currentThreadTs: params.context.ReplyToId,
+    hasRepliedRef: params.hasRepliedRef,
+  };
+}
+
+function buildIMessageThreadToolContext(params: {
+  context: ChannelThreadingContext;
+  hasRepliedRef: ChannelThreadingToolContext["hasRepliedRef"];
+}): ChannelThreadingToolContext {
+  return {
+    currentChannelId: resolveDirectOrGroupChannelId(params.context),
     currentThreadTs: params.context.ReplyToId,
     hasRepliedRef: params.hasRepliedRef,
   };
@@ -437,7 +454,7 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     },
     threading: {
       buildToolContext: ({ context, hasRepliedRef }) =>
-        buildDirectOrGroupThreadToolContext({ context, hasRepliedRef }),
+        buildSignalThreadToolContext({ context, hasRepliedRef }),
     },
   },
   imessage: {
@@ -462,7 +479,7 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     },
     threading: {
       buildToolContext: ({ context, hasRepliedRef }) =>
-        buildDirectOrGroupThreadToolContext({ context, hasRepliedRef }),
+        buildIMessageThreadToolContext({ context, hasRepliedRef }),
     },
   },
 };

--- a/src/channels/plugins/plugins-channel.test.ts
+++ b/src/channels/plugins/plugins-channel.test.ts
@@ -42,6 +42,11 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("signal:uuid:123e4567-e89b-12d3-a456-426614174000")).toBe(true);
   });
 
+  it("accepts signal-prefixed E.164 targets for detection", () => {
+    expect(looksLikeSignalTargetId("signal:+15551234567")).toBe(true);
+    expect(looksLikeSignalTargetId("signal:15551234567")).toBe(true);
+  });
+
   it("accepts compact UUIDs for target detection", () => {
     expect(looksLikeSignalTargetId("123e4567e89b12d3a456426614174000")).toBe(true);
     expect(looksLikeSignalTargetId("uuid:123e4567e89b12d3a456426614174000")).toBe(true);

--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import type { MsgContext } from "../../auto-reply/templating.js";
 import { buildDispatchInboundCaptureMock } from "../../../test/helpers/dispatch-inbound-capture.js";
 import { expectInboundContextContract } from "../../../test/helpers/inbound-contract.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
 
 let capturedCtx: MsgContext | undefined;
 

--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
 import { buildDispatchInboundCaptureMock } from "../../../test/helpers/dispatch-inbound-capture.js";
 import { expectInboundContextContract } from "../../../test/helpers/inbound-contract.js";
-import type { MsgContext } from "../../auto-reply/templating.js";
 
 let capturedCtx: MsgContext | undefined;
 
@@ -79,8 +79,13 @@ describe("signal createSignalEventHandler inbound contract", () => {
     });
 
     expect(capturedCtx).toBeTruthy();
-    expect(capturedCtx?.ChatType).toBe("direct");
-    expect(capturedCtx?.To).toBe("+15550002222");
-    expect(capturedCtx?.OriginatingTo).toBe("+15550002222");
+    const context = capturedCtx as unknown as {
+      ChatType?: string;
+      To?: string;
+      OriginatingTo?: string;
+    };
+    expect(context.ChatType).toBe("direct");
+    expect(context.To).toBe("+15550002222");
+    expect(context.OriginatingTo).toBe("+15550002222");
   });
 });

--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -51,4 +51,36 @@ describe("signal createSignalEventHandler inbound contract", () => {
     expect(String(contextWithBody.Body ?? "")).toMatch(/Alice.*:/);
     expect(String(contextWithBody.Body ?? "")).not.toContain("[from:");
   });
+
+  it("normalizes direct chat To/OriginatingTo targets to canonical Signal ids", async () => {
+    capturedCtx = undefined;
+
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler({
+      event: "receive",
+      data: JSON.stringify({
+        envelope: {
+          sourceNumber: "+15550002222",
+          sourceName: "Bob",
+          timestamp: 1700000000001,
+          dataMessage: {
+            message: "hello",
+            attachments: [],
+          },
+        },
+      }),
+    });
+
+    expect(capturedCtx).toBeTruthy();
+    expect(capturedCtx?.ChatType).toBe("direct");
+    expect(capturedCtx?.To).toBe("+15550002222");
+    expect(capturedCtx?.OriginatingTo).toBe("+15550002222");
+  });
 });

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -21,6 +21,7 @@ import { createReplyDispatcherWithTyping } from "../../auto-reply/reply/reply-di
 import { resolveControlCommandGate } from "../../channels/command-gating.js";
 import { logInboundDrop, logTypingFailure } from "../../channels/logging.js";
 import { resolveMentionGatingWithBypass } from "../../channels/mention-gating.js";
+import { normalizeSignalMessagingTarget } from "../../channels/plugins/normalize/signal.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
 import { createTypingCallbacks } from "../../channels/typing.js";
@@ -126,7 +127,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           }),
       });
     }
-    const signalTo = entry.isGroup ? `group:${entry.groupId}` : `signal:${entry.senderRecipient}`;
+    const signalToRaw = entry.isGroup
+      ? `group:${entry.groupId}`
+      : `signal:${entry.senderRecipient}`;
+    const signalTo = normalizeSignalMessagingTarget(signalToRaw) ?? signalToRaw;
     const inboundHistory =
       entry.isGroup && historyKey && deps.historyLimit > 0
         ? (deps.groupHistories.get(historyKey) ?? []).map((historyEntry) => ({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Signal target handling was inconsistent across codepaths (`signal:+E.164` accepted in one path but rejected/forwarded as invalid in another), causing `Unknown target "signal:+..." for Signal` failures.
- Why it matters: Signal sends could fail and error messages could be routed back to the same recipient, creating confusing UX and noisy retries.
- What changed: Signal-specific canonicalization now runs in both dock threading context and Signal inbound event handling; `looksLikeSignalTargetId` now correctly accepts `signal:+E.164`/`signal:digits` formats.
- What did NOT change (scope boundary): No non-Signal channel behavior changes; no config schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18783
- Related #18489
- Related #19358

## User-visible / Behavior Changes

- Signal sends now consistently accept canonical phone-style targets when prefixed (`signal:+1555...`).
- Signal direct-thread tool context now uses canonical target IDs (e.g. `+E.164`), reducing mismatches between inbound and outbound paths.
- Signal group IDs remain preserved (no new lowercasing behavior introduced).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node/Bun local dev runtime
- Model/provider: MiniMax M2.5 on Fireworks
- Integration/channel (if any): Signal
- Relevant config (redacted): `channels.signal.*` with direct messaging target using `signal:+E.164`

### Steps

1. Use Signal channel and attempt send/media path with target `signal:+1555...`.
2. Trigger inbound handling and threading context generation for Signal direct messages.
3. Run targeted tests for Signal normalization and threading context.

### Expected

- `signal:+E.164` is recognized as a valid Signal target.
- No `Unknown target "signal:+..."` rejection from OpenClaw target validation.
- Signal direct context uses canonical `+E.164` consistently.

### Actual

- On this branch, Signal target detection accepts prefixed E.164 and canonicalization is consistent across the touched paths.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Example observed error before fix:
`Unknown target "signal:+15556667777" for Signal. Hint: <E.164|uuid:ID|group:ID|signal:group:ID|signal:+E.164>`

Targeted tests passing on this branch:
`bunx vitest run src/signal/monitor/event-handler.inbound-contract.test.ts src/channels/plugins/plugins-channel.test.ts src/auto-reply/reply/
reply-plumbing.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

Pre-Change Observed Behavior:
- When my agent was attempting to send Signal messages, they were emitting the error in **Evidence**.

Post-Change Observed Behavior:
- Deploying this source resulted in Signal message sending passing a basic conversation smoke test.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `cba3cd8d4`.
- Files/config to restore: `src/channels/dock.ts`, `src/channels/plugins/normalize/signal.ts`, `src/signal/monitor/event-handler.ts` (+
related tests).
- Known bad symptoms reviewers should watch for: regressions in Signal direct-thread routing or false negatives in Signal target validation.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: subtle behavior change in Signal target detection for unusual non-E.164 strings.
- Mitigation: detection remains constrained by explicit regex/prefix checks and is covered by targeted tests.
- Risk: threading-context canonicalization divergence from legacy raw-value expectations.
- Mitigation: Signal-only scope, fallback to trimmed raw target when normalization returns undefined, and explicit tests for direct/group behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an inconsistency in Signal target handling where `signal:+E.164` format was accepted in some codepaths but rejected in others, causing `Unknown target "signal:+..."` errors during outbound sends.

**Key changes:**

- **`src/channels/plugins/normalize/signal.ts`**: `looksLikeSignalTargetId` now strips the `signal:` prefix before the E.164/digit check, correctly accepting `signal:+15551234567` and `signal:15551234567`. An optional `normalized` parameter is added (backward-compatible, existing callers pass only `raw`). The function is also used in the plugin SDK so the added optional parameter maintains API compatibility.

- **`src/signal/monitor/event-handler.ts`**: Applies `normalizeSignalMessagingTarget` to `signalTo` in the inbound message handler. Direct DM targets (`signal:+E.164` → `+E.164`) are now canonicalized before being stored in `To` and `OriginatingTo`. Group targets (`group:ID`) pass through unchanged. Note: `From` is intentionally not normalized in this PR (it remains `signal:+E.164`), but downstream consumers use `OriginatingTo`/`To` first, and `normalizeE164` on `From` works correctly regardless because it strips non-digit characters.

- **`src/channels/dock.ts`**: Extracts `resolveDirectOrGroupChannelId` as a shared helper. Signal channel now uses a dedicated `buildSignalThreadToolContext` that normalizes `currentChannelId`, while iMessage uses a renamed `buildIMessageThreadToolContext` with unchanged behavior.

- **Tests**: New unit tests cover `signal:+E.164` detection, Signal direct/group threading context normalization, and the inbound `To`/`OriginatingTo` canonicalization contract.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a targeted bug fix with no behavioral regressions for non-Signal channels and explicit test coverage for the fixed paths.
- All changed logic is Signal-specific and well-scoped. The `looksLikeSignalTargetId` change is backward-compatible (optional second parameter, existing callers unaffected). The `normalizeSignalMessagingTarget` call in the event handler is idempotent for groups and correctly canonicalizes direct targets. All downstream consumers of `To`/`OriginatingTo` (`sendMessageSignal`, `sendTypingSignal`, `outbound-policy.ts` normalization) tolerate both `signal:+E.164` and `+E.164` formats. New tests directly cover the fixed contract. The iMessage dock rename is a pure refactor with no logic change.
- No files require special attention.

<sub>Last reviewed commit: 9d0b819</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->