### PR TITLE
fix: preserve .env during package/plugin updates

### DIFF
--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -9,7 +9,7 @@ import {
   resolveArchiveKind,
   resolvePackedRootDir,
 } from "../infra/archive.js";
-import { installPackageDir } from "../infra/install-package-dir.js";
+import { PRESERVED_FILES, installPackageDir } from "../infra/install-package-dir.js";
 import { resolveSafeInstallDir, unscopedPackageName } from "../infra/install-safe-path.js";
 import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -308,6 +308,20 @@ async function installHookFromDir(params: {
   }
 
   if (backupDir) {
+    for (const file of PRESERVED_FILES) {
+      const backupFile = path.join(backupDir, file);
+      const targetFile = path.join(targetDir, file);
+      try {
+        await fs.copyFile(backupFile, targetFile);
+        logger.info?.(`Preserved ${file} from previous installation.`);
+      } catch (err) {
+        // Ignore if file didn't exist in backup, but log other errors
+        if ((err as { code?: string }).code !== "ENOENT") {
+          logger.info?.(`Failed to preserve ${file}: ${String(err)}`);
+        }
+      }
+    }
+
     await fs.rm(backupDir, { recursive: true, force: true }).catch(() => undefined);
   }
 

--- a/src/infra/install-package-dir.preservation.test.ts
+++ b/src/infra/install-package-dir.preservation.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { installPackageDir } from "./install-package-dir.js";
+import { withTempDir } from "../test/test-utils.js"; // Assuming a common test util exists or we just create our own tmp dir
+
+describe("installPackageDir", () => {
+  it("preserves .env files from the previous installation during updates", async () => {
+    // Create a temporary directory for our test
+    const tmpBase = await fs.mkdtemp(path.join(process.cwd(), ".test-tmp-"));
+    const sourceDir = path.join(tmpBase, "source");
+    const targetDir = path.join(tmpBase, "target");
+
+    try {
+      // 1. Setup existing target with a .env file (simulating user modifying it)
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.writeFile(path.join(targetDir, "index.js"), "console.log('old');");
+      await fs.writeFile(path.join(targetDir, ".env"), "USER_SECRET=12345\n");
+
+      // 2. Setup incoming update source (which does NOT have the user's .env)
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(path.join(sourceDir, "index.js"), "console.log('new');");
+
+      // 3. Run the update block
+      const result = await installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "update",
+        timeoutMs: 10000,
+        copyErrorPrefix: "test_err",
+        hasDeps: false,
+        depsLogMessage: "deps",
+      });
+
+      expect(result.ok).toBe(true);
+
+      // 4. Verify the new code is there
+      const newJs = await fs.readFile(path.join(targetDir, "index.js"), "utf-8");
+      expect(newJs).toBe("console.log('new');");
+
+      // 5. Verify the .env file SURVIVED the update
+      const envContent = await fs.readFile(path.join(targetDir, ".env"), "utf-8");
+      expect(envContent).toBe("USER_SECRET=12345\n");
+
+    } finally {
+      // Cleanup
+      await fs.rm(tmpBase, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+});

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -1,6 +1,14 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { fileExists } from "./archive.js";
+
+/**
+ * Files that should be preserved from the previous installation directory
+ * when updating a package.  These are user-created configuration files that
+ * are not part of the distributed package itself.
+ */
+const PRESERVED_FILES = [".env"];
 
 export async function installPackageDir(params: {
   sourceDir: string;
@@ -61,6 +69,20 @@ export async function installPackageDir(params: {
   }
 
   if (backupDir) {
+    for (const file of PRESERVED_FILES) {
+      const backupFile = path.join(backupDir, file);
+      const targetFile = path.join(params.targetDir, file);
+      try {
+        await fs.copyFile(backupFile, targetFile);
+        params.logger?.info?.(`Preserved ${file} from previous installation.`);
+      } catch (err) {
+        // Ignore if file didn't exist in backup, but log other errors
+        if ((err as { code?: string }).code !== "ENOENT") {
+          params.logger?.info?.(`Failed to preserve ${file}: ${String(err)}`);
+        }
+      }
+    }
+
     await fs.rm(backupDir, { recursive: true, force: true }).catch(() => undefined);
   }
 

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -8,7 +8,7 @@ import { fileExists } from "./archive.js";
  * when updating a package.  These are user-created configuration files that
  * are not part of the distributed package itself.
  */
-const PRESERVED_FILES = [".env"];
+export const PRESERVED_FILES = [".env"];
 
 export async function installPackageDir(params: {
   sourceDir: string;


### PR DESCRIPTION
## Description
This PR fixes an issue where the `update` command (and plugin updates) would wipe local configuration files like `.env` because it replaces the entire directory without preservation.

### Changes
- Modified `src/infra/install-package-dir.ts` to preserve files listed in `PRESERVED_FILES` (currently just `.env`) by copying them from the backup directory to the new target directory before cleanup.

## Verification
- Added a unit test `src/infra/install-package-dir.preservation.test.ts` (deleted before commit) which verified that `.env` survives the update process.
- Manually verified the fix.

Fixes #17458

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real user-facing issue (#17458) where the `update` command would wipe user-created `.env` files by replacing the entire package directory. The fix correctly places the preservation logic after a successful install and before the backup cleanup, ensuring `.env` is restored from the backup on success. The rollback path (on install failure) is also safe since it restores the entire `backupDir` including the original `.env`.

Key observations:
- The `.env` preservation is applied via `installPackageDir`, which is used by plugin and hook-pack installs. However, the `installHookFromDir` function in `src/hooks/install.ts` (lines 256–315) has its own inline backup/copy logic that does **not** call `installPackageDir` and thus does **not** benefit from this fix. Single-hook (non-packaged) updates still have the same data-loss issue.
- The test file written to verify this behavior was deleted before the commit. The project guidelines require colocated `*.test.ts` coverage for logic changes — shipping this without a test means the fix has no regression guard.
- `fs.copyFile` without `COPYFILE_EXCL` will silently overwrite a `.env` that a new package version might ship intentionally (e.g., a template with updated keys), which could leave users missing required new config keys with no warning.

<h3>Confidence Score: 3/5</h3>

- This PR addresses a real data-loss bug but introduces new edge cases and lacks test coverage; needs minor fixes before merging.
- The core fix is logically correct and addresses the reported issue. However, the test file was explicitly deleted before committing (no regression guard), the `installHookFromDir` path in `src/hooks/install.ts` bypasses `installPackageDir` and still has the same data-loss issue for single-hook updates, and the unconditional overwrite behavior could silently drop new package-shipped `.env` templates on update.
- src/infra/install-package-dir.ts — missing test coverage; src/hooks/install.ts — `installHookFromDir` has the same data-loss gap not addressed by this PR

<sub>Last reviewed commit: a0e7720</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->