### PR TITLE
feat(persist-postgres): PostgreSQL persistence plugin

### DIFF
--- a/extensions/persist-postgres/openclaw.plugin.json
+++ b/extensions/persist-postgres/openclaw.plugin.json
@@ -1,0 +1,21 @@
+{
+  "id": "persist-postgres",
+  "uiHints": {
+    "databaseUrl": {
+      "label": "PostgreSQL URL",
+      "sensitive": true,
+      "placeholder": "postgresql://user:pass@host:5432/dbname",
+      "help": "PostgreSQL connection string (or use ${DATABASE_URL})"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "databaseUrl": {
+        "type": "string"
+      }
+    },
+    "required": []
+  }
+}

--- a/extensions/persist-postgres/package.json
+++ b/extensions/persist-postgres/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/persist-postgres",
+  "version": "2026.2.1",
+  "private": true,
+  "description": "PostgreSQL-backed session and message persistence for OpenClaw",
+  "type": "module",
+  "dependencies": {
+    "postgres": "^3.4.5"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  }
+}

--- a/extensions/persist-postgres/src/db.ts
+++ b/extensions/persist-postgres/src/db.ts
@@ -1,0 +1,127 @@
+import postgres from "postgres";
+
+export type PgSessionRow = {
+  id: string;
+  session_key: string;
+  channel: string;
+  started_at: Date;
+  last_message_at: Date;
+  message_count: number;
+};
+
+export type MessageRole = "user" | "assistant" | "system" | "tool";
+
+export type PgMessageRow = {
+  id: string;
+  conversation_id: string;
+  role: MessageRole;
+  content: string;
+  created_at: Date;
+  metadata: Record<string, unknown>;
+};
+
+export function createPgClient(databaseUrl: string) {
+  return postgres(databaseUrl, { max: 10 });
+}
+
+/**
+ * Ensure the lp_conversations and lp_messages tables exist.
+ * Safe to call repeatedly (uses IF NOT EXISTS).
+ * Requires PostgreSQL 13+ (gen_random_uuid() is built-in since PG 13).
+ */
+export async function ensureSchema(sql: postgres.Sql) {
+  await sql`
+    CREATE TABLE IF NOT EXISTS lp_conversations (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      channel VARCHAR(50) NOT NULL,
+      session_key VARCHAR(512) NOT NULL UNIQUE,
+      started_at TIMESTAMPTZ DEFAULT now(),
+      last_message_at TIMESTAMPTZ DEFAULT now(),
+      message_count INTEGER DEFAULT 0
+    )
+  `;
+
+  // session_key UNIQUE constraint already creates an implicit index — no explicit index needed
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_lp_conv_last_msg ON lp_conversations (last_message_at DESC)
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS lp_messages (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      conversation_id UUID NOT NULL REFERENCES lp_conversations(id) ON DELETE CASCADE,
+      role VARCHAR(20) NOT NULL,
+      content TEXT NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT now(),
+      metadata JSONB DEFAULT '{}'
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_lp_msg_conv ON lp_messages (conversation_id, created_at)
+  `;
+}
+
+/**
+ * Upsert a conversation (session) into PostgreSQL.
+ * Maps OpenClaw session keys to lp_conversations rows.
+ */
+export async function upsertConversation(
+  sql: postgres.Sql,
+  opts: {
+    sessionKey: string;
+    channel: string;
+    startedAt?: Date;
+    lastMessageAt?: Date;
+  },
+) {
+  const now = new Date();
+  const rows = await sql`
+    INSERT INTO lp_conversations (session_key, channel, started_at, last_message_at)
+    VALUES (
+      ${opts.sessionKey},
+      ${opts.channel},
+      ${opts.startedAt ?? now},
+      ${opts.lastMessageAt ?? now}
+    )
+    ON CONFLICT (session_key) DO UPDATE SET
+      channel = EXCLUDED.channel,
+      last_message_at = EXCLUDED.last_message_at
+    RETURNING *
+  `;
+  return rows[0] as PgSessionRow;
+}
+
+/**
+ * Insert a message and increment message_count atomically using a CTE.
+ * Single-statement atomicity avoids the need for an explicit transaction.
+ */
+export async function insertMessage(
+  sql: postgres.Sql,
+  opts: {
+    conversationId: string;
+    role: MessageRole;
+    content: string;
+    metadata?: Record<string, unknown>;
+  },
+) {
+  const rows = await sql`
+    WITH ins AS (
+      INSERT INTO lp_messages (conversation_id, role, content, metadata)
+      VALUES (
+        ${opts.conversationId},
+        ${opts.role},
+        ${opts.content},
+        ${sql.json((opts.metadata ?? {}) as postgres.JSONValue)}
+      )
+      RETURNING *
+    ), _upd AS (
+      UPDATE lp_conversations
+      SET message_count = message_count + 1
+      WHERE id = (SELECT conversation_id FROM ins)
+    )
+    SELECT * FROM ins
+  `;
+  return rows[0] as PgMessageRow;
+}

--- a/extensions/persist-postgres/src/index.ts
+++ b/extensions/persist-postgres/src/index.ts
@@ -1,0 +1,154 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { extractTextFromChatContent, stripEnvelope } from "openclaw/plugin-sdk";
+import { createPgClient, ensureSchema, upsertConversation, insertMessage } from "./db.js";
+
+/**
+ * Derive the messaging channel from a session key.
+ * Session keys follow the pattern "agent:{agentId}:{channel}:{userId}".
+ * Falls back to "unknown" if the key format is unexpected.
+ */
+function deriveChannel(sessionKey: string): string {
+  const parts = sessionKey.split(":");
+  // Standard format: agent:main:telegram:user123 → "telegram"
+  if (parts.length >= 3 && parts[0] === "agent") {
+    return parts[2];
+  }
+  return "unknown";
+}
+
+const persistPostgresPlugin = {
+  id: "persist-postgres",
+  name: "Persist (PostgreSQL)",
+  description: "Persists sessions and messages to PostgreSQL instead of local files",
+  register(api: OpenClawPluginApi) {
+    const databaseUrl =
+      (api.pluginConfig?.databaseUrl as string | undefined) ?? process.env.DATABASE_URL ?? "";
+    if (!databaseUrl) {
+      api.logger.warn(
+        "persist-postgres: no databaseUrl in plugin config or DATABASE_URL env, plugin disabled",
+      );
+      return;
+    }
+
+    api.logger.info(`persist-postgres: connecting to PostgreSQL`);
+    const sql = createPgClient(databaseUrl);
+    let schemaReady = false;
+    let initError: unknown = null;
+
+    async function ensureReady() {
+      if (schemaReady) {
+        return;
+      }
+      if (initError) {
+        throw initError;
+      }
+      try {
+        await sql`SELECT 1`;
+        await ensureSchema(sql);
+        schemaReady = true;
+        api.logger.info("persist-postgres: schema ready");
+      } catch (err) {
+        initError = err;
+        api.logger.error(`persist-postgres: init failed (will not retry): ${err}`);
+        throw err;
+      }
+    }
+
+    // Persist the user prompt when an agent run starts
+    api.on(
+      "before_agent_start",
+      async (event, ctx) => {
+        try {
+          if (!event.prompt) {
+            return {};
+          }
+          await ensureReady();
+          const sessionKey = ctx?.sessionKey ?? "unknown";
+          const channel = ctx?.messageProvider ?? deriveChannel(sessionKey);
+          const conv = await upsertConversation(sql, {
+            sessionKey,
+            channel,
+            lastMessageAt: new Date(),
+          });
+          // Strip channel envelope headers and format as structured JSON
+          const rawPrompt = event.prompt;
+          const strippedPrompt = stripEnvelope(rawPrompt);
+          const hasEnvelope = strippedPrompt !== rawPrompt;
+          const userText = strippedPrompt.trim();
+          const content = hasEnvelope
+            ? JSON.stringify({
+                text: userText,
+                envelope: rawPrompt.slice(0, rawPrompt.length - userText.length).trim(),
+              })
+            : userText;
+          await insertMessage(sql, {
+            conversationId: conv.id,
+            role: "user",
+            content,
+            metadata: hasEnvelope ? { hasEnvelope: true } : undefined,
+          });
+          api.logger.info(`persist-postgres: persisted user message for session ${sessionKey}`);
+        } catch (err) {
+          api.logger.error(`persist-postgres: before_agent_start error: ${err}`);
+        }
+        return {};
+      },
+      { priority: 50 },
+    );
+
+    // Persist the agent's response after the run ends
+    api.on(
+      "agent_end",
+      async (event, ctx) => {
+        try {
+          type Msg = { role?: string; content?: unknown };
+          const messages = (event.messages ?? []) as Msg[];
+          const lastAssistant = messages.toReversed().find((m) => m.role === "assistant");
+          if (!lastAssistant) {
+            return;
+          }
+          await ensureReady();
+          const sessionKey = ctx?.sessionKey ?? "unknown";
+          const channel = ctx?.messageProvider ?? deriveChannel(sessionKey);
+          const conv = await upsertConversation(sql, {
+            sessionKey,
+            channel,
+            lastMessageAt: new Date(),
+          });
+          // Use shared utility for extracting human-readable text from content blocks
+          const content = extractTextFromChatContent(lastAssistant.content);
+          if (!content) {
+            return;
+          }
+          await insertMessage(sql, {
+            conversationId: conv.id,
+            role: "assistant",
+            content,
+          });
+          api.logger.info(
+            `persist-postgres: persisted assistant message for session ${sessionKey}`,
+          );
+        } catch (err) {
+          api.logger.error(`persist-postgres: agent_end error: ${err}`);
+        }
+      },
+      { priority: 50 },
+    );
+
+    // Close connection pool on gateway shutdown
+    api.on(
+      "gateway_stop",
+      async (_event, _ctx) => {
+        try {
+          await sql.end({ timeout: 5 });
+          api.logger.info("persist-postgres: database connections closed");
+        } catch (err) {
+          api.logger.error(`persist-postgres: error closing connections: ${err}`);
+        }
+      },
+      { priority: 90 },
+    );
+  },
+};
+
+export default persistPostgresPlugin;

--- a/extensions/persist-postgres/src/integration.e2e.test.ts
+++ b/extensions/persist-postgres/src/integration.e2e.test.ts
@@ -1,0 +1,207 @@
+import postgres from "postgres";
+/**
+ * Integration tests for persist-postgres plugin.
+ *
+ * Requires a running PostgreSQL instance. Uses DATABASE_URL env var
+ * or falls back to a local default.
+ *
+ * Run with: DATABASE_URL=postgresql://postgres:postgres@localhost:5432/openclaw_e2e_test bun test extensions/persist-postgres/src/integration.e2e.test.ts
+ */
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { ensureSchema, upsertConversation, insertMessage } from "./db.js";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/openclaw_e2e_test";
+
+const sql = postgres(DATABASE_URL, { max: 5 });
+
+const testPrefix = `test_lp_${Date.now()}`;
+
+const hour = 3_600_000;
+const baseTime = new Date("2024-06-15T12:00:00Z").getTime();
+
+let convOldId: string;
+let convMidId: string;
+let convNewId: string;
+
+beforeAll(async () => {
+  await ensureSchema(sql);
+
+  // Seed three conversations with distinct timestamps
+  const [convOld] = await sql`
+    INSERT INTO lp_conversations (channel, session_key, started_at, last_message_at, message_count)
+    VALUES (
+      'whatsapp', ${`${testPrefix}:old-session`},
+      ${new Date(baseTime - 24 * hour).toISOString()}::timestamptz,
+      ${new Date(baseTime - 12 * hour).toISOString()}::timestamptz,
+      3
+    )
+    RETURNING id
+  `;
+  convOldId = convOld.id;
+
+  const [convMid] = await sql`
+    INSERT INTO lp_conversations (channel, session_key, started_at, last_message_at, message_count)
+    VALUES (
+      'telegram', ${`${testPrefix}:mid-session`},
+      ${new Date(baseTime - 6 * hour).toISOString()}::timestamptz,
+      ${new Date(baseTime - 3 * hour).toISOString()}::timestamptz,
+      5
+    )
+    RETURNING id
+  `;
+  convMidId = convMid.id;
+
+  const [convNew] = await sql`
+    INSERT INTO lp_conversations (channel, session_key, started_at, last_message_at, message_count)
+    VALUES (
+      'web', ${`${testPrefix}:new-session`},
+      ${new Date(baseTime - 1 * hour).toISOString()}::timestamptz,
+      ${new Date(baseTime).toISOString()}::timestamptz,
+      1
+    )
+    RETURNING id
+  `;
+  convNewId = convNew.id;
+
+  // Seed messages for each conversation
+  await insertMessage(sql, {
+    conversationId: convOldId,
+    role: "user",
+    content: "Hello from old session",
+    metadata: { source: "integration-test" },
+  });
+  await insertMessage(sql, {
+    conversationId: convOldId,
+    role: "assistant",
+    content: "Response in old session",
+  });
+
+  await insertMessage(sql, {
+    conversationId: convMidId,
+    role: "user",
+    content: "Hello from mid session",
+  });
+
+  await insertMessage(sql, {
+    conversationId: convNewId,
+    role: "user",
+    content: "Hello from new session",
+  });
+});
+
+afterAll(async () => {
+  // Clean up test data
+  await sql`DELETE FROM lp_messages WHERE conversation_id IN (
+    SELECT id FROM lp_conversations WHERE session_key LIKE ${testPrefix + "%"}
+  )`;
+  await sql`DELETE FROM lp_conversations WHERE session_key LIKE ${testPrefix + "%"}`;
+  await sql.end();
+});
+
+// ── PostgreSQL CRUD Tests ────────────────────────────────────────────
+
+describe("PostgreSQL conversation CRUD", () => {
+  test("seeded conversations are queryable", async () => {
+    const rows = await sql`
+      SELECT * FROM lp_conversations
+      WHERE session_key LIKE ${testPrefix + "%"}
+      ORDER BY started_at ASC
+    `;
+    expect(rows.length).toBe(3);
+    expect(rows[0].channel).toBe("whatsapp");
+    expect(rows[1].channel).toBe("telegram");
+    expect(rows[2].channel).toBe("web");
+  });
+
+  test("messages are linked to conversations", async () => {
+    const rows = await sql`
+      SELECT m.role, m.content, c.session_key
+      FROM lp_messages m
+      JOIN lp_conversations c ON c.id = m.conversation_id
+      WHERE c.session_key LIKE ${testPrefix + "%"}
+      ORDER BY m.created_at ASC
+    `;
+    expect(rows.length).toBe(4);
+    expect(rows[0].role).toBe("user");
+    expect(rows[0].content).toBe("Hello from old session");
+  });
+
+  test("upsertConversation updates last_message_at on conflict", async () => {
+    const before = await sql`
+      SELECT last_message_at FROM lp_conversations WHERE id = ${convOldId}
+    `;
+    const beforeTs = new Date(before[0].last_message_at).getTime();
+
+    const newTime = new Date(baseTime + 1 * hour);
+    await upsertConversation(sql, {
+      sessionKey: `${testPrefix}:old-session`,
+      channel: "whatsapp",
+      lastMessageAt: newTime,
+    });
+
+    const after = await sql`
+      SELECT last_message_at, message_count FROM lp_conversations WHERE id = ${convOldId}
+    `;
+    const afterTs = new Date(after[0].last_message_at).getTime();
+    expect(afterTs).toBeGreaterThan(beforeTs);
+    // message_count stays at 5 (seeded 3 + 2 insertMessage calls in beforeAll);
+    // upsert no longer increments count
+    expect(after[0].message_count).toBe(5);
+
+    // Restore original timestamp for subsequent tests
+    await sql`
+      UPDATE lp_conversations
+      SET last_message_at = ${new Date(baseTime - 12 * hour).toISOString()}::timestamptz
+      WHERE id = ${convOldId}
+    `;
+  });
+
+  test("insertMessage increments message_count atomically", async () => {
+    const before = await sql`
+      SELECT message_count FROM lp_conversations WHERE id = ${convNewId}
+    `;
+    const beforeCount = before[0].message_count;
+
+    await insertMessage(sql, {
+      conversationId: convNewId,
+      role: "assistant",
+      content: "Atomic count test",
+    });
+
+    const after = await sql`
+      SELECT message_count FROM lp_conversations WHERE id = ${convNewId}
+    `;
+    expect(after[0].message_count).toBe(beforeCount + 1);
+  });
+
+  test("NOT NULL constraint prevents orphaned messages", async () => {
+    // conversation_id is NOT NULL — inserting with NULL should fail
+    await expect(
+      sql`INSERT INTO lp_messages (conversation_id, role, content) VALUES (NULL, 'user', 'orphan')`,
+    ).rejects.toThrow();
+  });
+
+  test("CASCADE delete removes messages when conversation is deleted", async () => {
+    // Create a temporary conversation
+    const [tmpConv] = await sql`
+      INSERT INTO lp_conversations (channel, session_key)
+      VALUES ('test', ${`${testPrefix}:cascade-test`})
+      RETURNING id
+    `;
+    await insertMessage(sql, {
+      conversationId: tmpConv.id,
+      role: "user",
+      content: "will be cascade deleted",
+    });
+
+    // Delete the conversation
+    await sql`DELETE FROM lp_conversations WHERE id = ${tmpConv.id}`;
+
+    // Messages should be gone
+    const msgs = await sql`
+      SELECT * FROM lp_messages WHERE conversation_id = ${tmpConv.id}
+    `;
+    expect(msgs.length).toBe(0);
+  });
+});

--- a/extensions/persist-postgres/src/plugin.test.ts
+++ b/extensions/persist-postgres/src/plugin.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for persist-postgres plugin lifecycle.
+ *
+ * These tests verify plugin registration, configuration validation,
+ * and error handling without requiring a running PostgreSQL instance.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { extractTextFromChatContent, stripEnvelope } from "../../../src/plugin-sdk/index.js";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+
+function createMockApi(
+  overrides: Partial<{
+    pluginConfig: Record<string, unknown>;
+    env: Record<string, string | undefined>;
+  }> = {},
+): OpenClawPluginApi & { _hooks: Array<{ name: string; handler: Function; opts: unknown }> } {
+  const hooks: Array<{ name: string; handler: Function; opts: unknown }> = [];
+  return {
+    _hooks: hooks,
+    id: "persist-postgres",
+    name: "Persist (PostgreSQL)",
+    source: "test",
+    config: {} as OpenClawPluginApi["config"],
+    pluginConfig: overrides.pluginConfig ?? {},
+    runtime: {} as OpenClawPluginApi["runtime"],
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    on: vi.fn((name: string, handler: Function, opts?: unknown) => {
+      hooks.push({ name, handler, opts });
+    }),
+    registerTool: vi.fn(),
+    registerHook: vi.fn(),
+    registerHttpHandler: vi.fn(),
+    registerHttpRoute: vi.fn(),
+    registerChannel: vi.fn(),
+    registerGatewayMethod: vi.fn(),
+    registerCli: vi.fn(),
+    registerService: vi.fn(),
+    registerProvider: vi.fn(),
+    registerCommand: vi.fn(),
+    resolvePath: vi.fn((p: string) => p),
+  } as unknown as OpenClawPluginApi & {
+    _hooks: Array<{ name: string; handler: Function; opts: unknown }>;
+  };
+}
+
+describe("persist-postgres plugin registration", () => {
+  const originalEnv = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  // Restore after each test
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.DATABASE_URL = originalEnv;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+  });
+
+  test("plugin has correct metadata", async () => {
+    const { default: plugin } = await import("./index.js");
+    expect(plugin.id).toBe("persist-postgres");
+    expect(plugin.name).toBe("Persist (PostgreSQL)");
+    // No kind — persistence plugins don't participate in slot management
+    expect((plugin as Record<string, unknown>).kind).toBeUndefined();
+  });
+
+  test("warns and skips hook registration when databaseUrl is missing", async () => {
+    const { default: plugin } = await import("./index.js");
+    const api = createMockApi({ pluginConfig: {} });
+
+    plugin.register(api);
+
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("no databaseUrl in plugin config or DATABASE_URL env"),
+    );
+    expect(api.on).not.toHaveBeenCalled();
+  });
+
+  test("registers hooks when databaseUrl is provided via pluginConfig", async () => {
+    const { default: plugin } = await import("./index.js");
+    const api = createMockApi({
+      pluginConfig: { databaseUrl: "postgresql://localhost:5432/test" },
+    });
+
+    plugin.register(api);
+
+    expect(api.logger.warn).not.toHaveBeenCalled();
+    expect(api.on).toHaveBeenCalledTimes(3);
+    const hookNames = api._hooks.map((h) => h.name);
+    expect(hookNames).toContain("before_agent_start");
+    expect(hookNames).toContain("agent_end");
+    expect(hookNames).toContain("gateway_stop");
+  });
+
+  test("registers hooks when DATABASE_URL env var is set", async () => {
+    process.env.DATABASE_URL = "postgresql://localhost:5432/test";
+    const { default: plugin } = await import("./index.js");
+    const api = createMockApi({ pluginConfig: {} });
+
+    plugin.register(api);
+
+    expect(api.on).toHaveBeenCalledTimes(3);
+  });
+
+  test("before_agent_start hook logs error on database failure", async () => {
+    const { default: plugin } = await import("./index.js");
+    const api = createMockApi({
+      // Use an unreachable host to force connection failure
+      pluginConfig: { databaseUrl: "postgresql://invalid:invalid@127.0.0.1:1/nope" },
+    });
+
+    plugin.register(api);
+
+    const beforeAgentHook = api._hooks.find((h) => h.name === "before_agent_start");
+    expect(beforeAgentHook).toBeDefined();
+
+    // Invoke the hook — connection will fail, error should be caught and logged
+    const result = await beforeAgentHook!.handler(
+      { prompt: "test message" },
+      { sessionKey: "agent:main:test" },
+    );
+
+    expect(result).toEqual({});
+    expect(api.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("before_agent_start error"),
+    );
+  });
+
+  test("init error is cached — second call does not retry", async () => {
+    const { default: plugin } = await import("./index.js");
+    const api = createMockApi({
+      pluginConfig: { databaseUrl: "postgresql://invalid:invalid@127.0.0.1:1/nope" },
+    });
+
+    plugin.register(api);
+
+    const beforeAgentHook = api._hooks.find((h) => h.name === "before_agent_start");
+    const agentEndHook = api._hooks.find((h) => h.name === "agent_end");
+
+    // First call triggers init failure
+    await beforeAgentHook!.handler({ prompt: "msg1" }, { sessionKey: "test" });
+    expect(api.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("init failed (will not retry)"),
+    );
+
+    // Clear mock to verify second call behavior
+    (api.logger.error as ReturnType<typeof vi.fn>).mockClear();
+
+    // Second call should fail fast with cached error (no "init failed" again)
+    await agentEndHook!.handler(
+      { messages: [{ role: "assistant", content: "hi" }], success: true },
+      { sessionKey: "test" },
+    );
+    expect(api.logger.error).toHaveBeenCalledWith(expect.stringContaining("agent_end error"));
+    // Should NOT log "init failed" again — error was cached
+    expect(api.logger.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("init failed (will not retry)"),
+    );
+  });
+
+  test("before_agent_start returns empty object when prompt is missing", async () => {
+    const { default: plugin } = await import("./index.js");
+    const api = createMockApi({
+      pluginConfig: { databaseUrl: "postgresql://localhost:5432/test" },
+    });
+
+    plugin.register(api);
+
+    const hook = api._hooks.find((h) => h.name === "before_agent_start");
+    const result = await hook!.handler({ prompt: "" }, { sessionKey: "test" });
+
+    expect(result).toEqual({});
+    // Should not attempt database connection for empty prompt
+    expect(api.logger.error).not.toHaveBeenCalled();
+  });
+
+  test("agent_end hook does nothing when no assistant message exists", async () => {
+    const { default: plugin } = await import("./index.js");
+    const api = createMockApi({
+      pluginConfig: { databaseUrl: "postgresql://invalid:invalid@127.0.0.1:1/nope" },
+    });
+
+    plugin.register(api);
+
+    const hook = api._hooks.find((h) => h.name === "agent_end");
+    await hook!.handler(
+      { messages: [{ role: "user", content: "hi" }], success: true },
+      { sessionKey: "test" },
+    );
+
+    // No assistant message → no DB operation → no error
+    expect(api.logger.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("content formatting utilities", () => {
+  test("extracts text from string content", () => {
+    expect(extractTextFromChatContent("Hello world")).toBe("Hello world");
+  });
+
+  test("extracts text from content blocks array", () => {
+    const content = [
+      { type: "text", text: "Hello " },
+      { type: "text", text: "world" },
+    ];
+    expect(extractTextFromChatContent(content)).toBe("Hello world");
+  });
+
+  test("filters non-text content blocks", () => {
+    const content = [
+      { type: "text", text: "visible" },
+      { type: "tool_use", id: "123", name: "test", input: {} },
+      { type: "text", text: "also visible" },
+    ];
+    expect(extractTextFromChatContent(content)).toBe("visible also visible");
+  });
+
+  test("returns null for empty content blocks", () => {
+    expect(extractTextFromChatContent([])).toBeNull();
+    expect(
+      extractTextFromChatContent([{ type: "tool_use", id: "1", name: "x", input: {} }]),
+    ).toBeNull();
+  });
+
+  test("returns null for non-string, non-array content", () => {
+    expect(extractTextFromChatContent(undefined)).toBeNull();
+    expect(extractTextFromChatContent(null)).toBeNull();
+    expect(extractTextFromChatContent(42)).toBeNull();
+  });
+
+  test("stripEnvelope removes channel envelope headers", () => {
+    expect(stripEnvelope("[WhatsApp 2024-01-15 12:00Z] Hello")).toBe("Hello");
+    expect(stripEnvelope("[Telegram 2024-01-15 12:00Z] Hi")).toBe("Hi");
+  });
+
+  test("stripEnvelope preserves plain messages", () => {
+    expect(stripEnvelope("Hello world")).toBe("Hello world");
+    expect(stripEnvelope("[not-a-channel] test")).toBe("[not-a-channel] test");
+  });
+
+  test("user prompt with envelope is formatted as structured JSON", () => {
+    const rawPrompt = "[WhatsApp 2024-01-15 12:00Z] Hello doctor";
+    const userText = stripEnvelope(rawPrompt).trim();
+    const hasEnvelope = userText !== rawPrompt;
+    expect(hasEnvelope).toBe(true);
+    const content = hasEnvelope
+      ? JSON.stringify({
+          text: userText,
+          envelope: rawPrompt.slice(0, rawPrompt.length - userText.length).trim(),
+        })
+      : userText;
+    const parsed = JSON.parse(content);
+    expect(parsed.text).toBe("Hello doctor");
+    expect(parsed.envelope).toBe("[WhatsApp 2024-01-15 12:00Z]");
+  });
+
+  test("user prompt without envelope is stored as plain text", () => {
+    const rawPrompt = "Hello doctor";
+    const userText = stripEnvelope(rawPrompt).trim();
+    const hasEnvelope = userText !== rawPrompt;
+    expect(hasEnvelope).toBe(false);
+    expect(userText).toBe("Hello doctor");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,6 +469,16 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/persist-postgres:
+    dependencies:
+      postgres:
+        specifier: ^3.4.5
+        version: 3.4.8
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/signal:
     devDependencies:
       openclaw:
@@ -6839,7 +6849,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6855,7 +6865,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7058,7 +7068,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7957,7 +7967,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8003,7 +8013,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8891,14 +8901,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9477,8 +9479,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -457,3 +457,7 @@ export type { ProcessedLineMessage } from "../line/markdown-to-line.js";
 
 // Media utilities
 export { loadWebMedia, type WebMediaResult } from "../web/media.js";
+
+// Content utilities
+export { extractTextFromChatContent } from "../shared/chat-content.js";
+export { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";


### PR DESCRIPTION
## Summary

Minimal PostgreSQL persistence plugin that records user prompts and assistant responses to PostgreSQL. Extension-only — no core schema changes.

**Supersedes #16163** — this PR extracts only the `persist-postgres` extension from the original combined PR, dropping the core `SessionEntry.createdAt` / date-range filtering changes to keep scope atomic and low-risk. Session-level date filtering is deferred to a follow-up if/when core `createdAt` tracking lands.

**Discussion**: #17785

### What

New `persist-postgres` extension that hooks into the gateway lifecycle:

- **`before_agent_start`**: persists the user prompt (strips channel envelope headers via `stripEnvelope`, stores structured JSON when envelope is present)
- **`agent_end`**: persists the last assistant response (extracts human-readable text via shared `extractTextFromChatContent`)
- **`gateway_stop`**: cleanly closes the connection pool

Implementation details:
- Auto-creates `lp_conversations` and `lp_messages` tables (PostgreSQL 13+, `gen_random_uuid()`)
- Upserts conversations by `session_key` with `ON CONFLICT` handling (updates both `channel` and `last_message_at`)
- Atomic insert+count increment via CTE (single statement, no drift on crash)
- `NOT NULL` FK constraint on `conversation_id` prevents orphaned messages
- Channel derived from `ctx.messageProvider` with session-key parsing as fallback
- Reads `databaseUrl` from plugin config with `DATABASE_URL` env fallback
- Init error is cached — no retry storm on persistent DB failures

### Why

Enables durable, queryable conversation storage in PostgreSQL — useful for analytics, compliance, and multi-gateway deployments where the default file-based persistence is insufficient.

### Scope

Extension-only, zero core changes:
- No modifications to `SessionEntry`, gateway protocol schemas, or session-utils
- Date-range query helpers (`queryConversations`, `pgRowToSessionEntry`) deferred to a follow-up PR
- Keeps the PR reviewable and low-risk

### Files

| File | Purpose |
|------|---------|
| `openclaw.plugin.json` | Plugin config schema with `databaseUrl` UI hint |
| `package.json` | Plugin manifest (`private: true`), `postgres` dependency |
| `src/db.ts` | Schema DDL, upsert (with channel update), atomic insert |
| `src/index.ts` | Plugin registration, lifecycle hooks, content extraction |
| `src/plugin.test.ts` | 8 unit + 10 content-utility tests (no DB required) |
| `src/integration.e2e.test.ts` | 5 CRUD e2e tests (requires live PostgreSQL) |
| `src/plugin-sdk/index.ts` | Export `extractTextFromChatContent` and `stripEnvelope` for extensions |

### Commits

1. **`feat(plugin-sdk): export extractTextFromChatContent and stripEnvelope utilities`** — re-exports shared utilities so extensions can use them via `openclaw/plugin-sdk`
2. **`feat(persist-postgres): PostgreSQL persistence plugin`** — complete extension with all files

## Review feedback addressed

All 4 items from the initial Greptile review have been incorporated:

| Issue | Resolution |
|-------|-----------|
| Assistant content stored as raw JSON instead of text | Uses shared `extractTextFromChatContent` from plugin-sdk |
| Redundant channel derivation from session key | Prefers `ctx.messageProvider` with `deriveChannel` as fallback |
| `ON CONFLICT` doesn't update `channel` | Added `channel = EXCLUDED.channel` to upsert |
| Missing `"private": true` | Added to `package.json` |

## Testing

- [x] 8 unit tests — plugin registration, config validation, error handling
- [x] 10 content utility tests — `extractTextFromChatContent` (string, array, mixed, edge cases) + `stripEnvelope`
- [x] 5 gated e2e tests — CRUD, upsert conflict, atomic count, NOT NULL, CASCADE delete
- [x] Lint passes

## AI Disclosure

🤖 AI-assisted: Implementation done with Claude Code. All code reviewed and understood.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds minimal PostgreSQL persistence plugin that records user prompts and assistant responses to PostgreSQL. This is an extension-only change with zero core modifications.

- Uses shared `extractTextFromChatContent` and `stripEnvelope` utilities (newly exported from plugin-sdk)
- Auto-creates schema (`lp_conversations`, `lp_messages`) with PostgreSQL 13+ support
- Atomic insert+count with CTE prevents drift on crash
- Prefers `ctx.messageProvider` over session-key parsing for channel derivation
- All previous review feedback addressed (`channel` upsert update, `private: true`, content extraction)

Issues found:
- Envelope detection logic compares trimmed stripped text with raw prompt, causing false positives when prompts have leading/trailing whitespace but no envelope (low impact in practice)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor logical bug fix recommended
- Extension-only change with no core modifications, thorough tests (18 tests total), and all previous review feedback addressed. One envelope detection edge case found (whitespace handling) but has minimal real-world impact. Schema design is solid (NOT NULL constraints, CASCADE deletes, atomic operations). Code follows project conventions.
- extensions/persist-postgres/src/index.ts:74-76 has the envelope detection logic issue

<sub>Last reviewed commit: 4f6f4da</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->