### PR TITLE
fix: suppress undici TLS setSession crash instead of exiting

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -2,11 +2,13 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { normalizeEnv } from "../infra/env.js";
-import { formatUncaughtError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
-import { installUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
+import {
+  installUncaughtExceptionHandler,
+  installUnhandledRejectionHandler,
+} from "../infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "../logging.js";
 import { getCommandPath, getPrimaryCommand, hasHelpOrVersion } from "./argv.js";
 import { tryRouteCli } from "./route.js";
@@ -85,11 +87,7 @@ export async function runCli(argv: string[] = process.argv) {
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
   installUnhandledRejectionHandler();
-
-  process.on("uncaughtException", (error) => {
-    console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-    process.exit(1);
-  });
+  installUncaughtExceptionHandler();
 
   const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
   // Register the primary command (builtin or subcli) so help and command parsing

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ import {
   PortInUseError,
 } from "./infra/ports.js";
 import { assertSupportedRuntime } from "./infra/runtime-guard.js";
-import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
+import {
+  installUncaughtExceptionHandler,
+  installUnhandledRejectionHandler,
+} from "./infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "./logging.js";
 import { runCommandWithTimeout, runExec } from "./process/exec.js";
 import { assertWebChannel, normalizeE164, toWhatsappJid } from "./utils.js";
@@ -80,11 +83,7 @@ if (isMain) {
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
   installUnhandledRejectionHandler();
-
-  process.on("uncaughtException", (error) => {
-    console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-    process.exit(1);
-  });
+  installUncaughtExceptionHandler();
 
   void program.parseAsync(process.argv).catch((err) => {
     console.error("[openclaw] CLI failed:", formatUncaughtError(err));

--- a/src/infra/uncaught-exception.handler.test.ts
+++ b/src/infra/uncaught-exception.handler.test.ts
@@ -1,0 +1,83 @@
+import process from "node:process";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
+import { installUncaughtExceptionHandler } from "./unhandled-rejections.js";
+
+describe("installUncaughtExceptionHandler", () => {
+  let exitCalls: Array<string | number | null> = [];
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let originalExit: typeof process.exit;
+
+  beforeAll(() => {
+    originalExit = process.exit.bind(process);
+    installUncaughtExceptionHandler();
+  });
+
+  beforeEach(() => {
+    exitCalls = [];
+
+    vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
+      if (code !== undefined && code !== null) {
+        exitCalls.push(code);
+      }
+      return undefined as never;
+    });
+
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    process.exit = originalExit;
+  });
+
+  it("suppresses the undici TLS setSession crash without exiting", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at Object.connect (node:_tls_wrap:1826:13)",
+      "    at Client.connect (undici/lib/core/connect.js:70:20)",
+      "    at connect (undici/lib/dispatcher/client.js:452:21)",
+      "    at _resume (undici/lib/dispatcher/client.js:627:7)",
+    ].join("\n");
+
+    process.emit("uncaughtException", err, "uncaughtException");
+
+    expect(exitCalls).toEqual([]);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "[openclaw] Suppressed undici TLS session bug (non-fatal):",
+      expect.stringContaining("setSession"),
+    );
+  });
+
+  it("still exits on unknown uncaught exceptions", () => {
+    const err = new Error("Something completely unexpected");
+
+    process.emit("uncaughtException", err, "uncaughtException");
+
+    expect(exitCalls).toEqual([1]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[openclaw] Uncaught exception:",
+      expect.stringContaining("Something completely unexpected"),
+    );
+  });
+
+  it("still exits on TypeErrors that are NOT the TLS bug", () => {
+    const err = new TypeError("Cannot read properties of undefined (reading 'foo')");
+
+    process.emit("uncaughtException", err, "uncaughtException");
+
+    expect(exitCalls).toEqual([1]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[openclaw] Uncaught exception:",
+      expect.stringContaining("foo"),
+    );
+  });
+});

--- a/src/infra/uncaught-exception.test.ts
+++ b/src/infra/uncaught-exception.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { isUndiciTlsSessionBug } from "./unhandled-rejections.js";
+
+describe("isUndiciTlsSessionBug", () => {
+  it("detects the exact undici TLS setSession crash", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at Object.connect (node:_tls_wrap:1826:13)",
+      "    at Client.connect (openclaw/node_modules/undici/lib/core/connect.js:70:20)",
+      "    at connect (openclaw/node_modules/undici/lib/dispatcher/client.js:452:21)",
+      "    at _resume (openclaw/node_modules/undici/lib/dispatcher/client.js:627:7)",
+      "    at resume (openclaw/node_modules/undici/lib/dispatcher/client.js:561:3)",
+      "    at Client.<computed> (openclaw/node_modules/undici/lib/dispatcher/client.js:285:31)",
+      "    at TLSSocket.onHttpSocketClose (openclaw/node_modules/undici/lib/dispatcher/client-h1.js:942:18)",
+    ].join("\n");
+
+    expect(isUndiciTlsSessionBug(err)).toBe(true);
+  });
+
+  it("detects the crash with varying undici paths (npm global, pnpm, etc.)", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at Object.connect (node:_tls_wrap:1826:13)",
+      "    at Client.connect (/opt/homebrew/lib/node_modules/openclaw/node_modules/undici/lib/core/connect.js:70:20)",
+    ].join("\n");
+
+    expect(isUndiciTlsSessionBug(err)).toBe(true);
+  });
+
+  it("rejects non-TypeError errors", () => {
+    const err = new Error("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "Error: Cannot read properties of null (reading 'setSession')",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at undici/lib/core/connect.js:70:20",
+    ].join("\n");
+
+    expect(isUndiciTlsSessionBug(err)).toBe(false);
+  });
+
+  it("rejects TypeErrors with different messages", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'write')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'write')",
+      "    at TLSSocket.write (node:_tls_wrap:500:16)",
+      "    at undici/lib/core/connect.js:70:20",
+    ].join("\n");
+
+    expect(isUndiciTlsSessionBug(err)).toBe(false);
+  });
+
+  it("rejects setSession errors NOT from undici", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at myApp/src/tls-client.js:42:10",
+    ].join("\n");
+
+    expect(isUndiciTlsSessionBug(err)).toBe(false);
+  });
+
+  it("rejects null/undefined/non-error inputs", () => {
+    expect(isUndiciTlsSessionBug(null)).toBe(false);
+    expect(isUndiciTlsSessionBug(undefined)).toBe(false);
+    expect(isUndiciTlsSessionBug("a string")).toBe(false);
+    expect(isUndiciTlsSessionBug(42)).toBe(false);
+  });
+
+  it("rejects errors with no stack trace", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = undefined;
+
+    expect(isUndiciTlsSessionBug(err)).toBe(false);
+  });
+});

--- a/src/macos/relay.ts
+++ b/src/macos/relay.ts
@@ -57,18 +57,14 @@ async function main() {
 
   const { assertSupportedRuntime } = await import("../infra/runtime-guard.js");
   assertSupportedRuntime();
-  const { formatUncaughtError } = await import("../infra/errors.js");
-  const { installUnhandledRejectionHandler } = await import("../infra/unhandled-rejections.js");
+  const { installUncaughtExceptionHandler, installUnhandledRejectionHandler } =
+    await import("../infra/unhandled-rejections.js");
 
   const { buildProgram } = await import("../cli/program.js");
   const program = buildProgram();
 
   installUnhandledRejectionHandler();
-
-  process.on("uncaughtException", (error) => {
-    console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-    process.exit(1);
-  });
+  installUncaughtExceptionHandler();
 
   await program.parseAsync(process.argv);
 }


### PR DESCRIPTION
## Summary

Suppresses the known undici TLS `setSession` null pointer crash (`TypeError: Cannot read properties of null (reading 'setSession')`) instead of killing the gateway process. The error is logged as a warning and the process continues normally.

## Problem

The gateway crashes when undici attempts TLS session resumption on a socket whose internal `_handle` has already been destroyed. This is a race condition in undici's HTTP/1.1 connection pool: when a TLS socket closes, undici immediately tries to reconnect via `_resume()`, calling `tls.connect()` with a cached session — but `this._handle` is already null.

This crash:
- Kills the gateway process (restart takes 2-5s depending on orchestrator)
- Drops all in-flight requests silently
- Disconnects IM channels (Telegram, Discord, etc.)
- Can trigger crash loops under heavy HTTPS traffic

Tracked in nodejs/undici#3869. Affects Node 22+ with undici 7.x.

## Why it's safe to suppress

- The socket was already closing — no in-flight data is lost
- undici creates a fresh connection on the next request automatically
- No application state is corrupted
- The error is purely in the connection lifecycle, not in request/response handling

## Changes

### `src/infra/unhandled-rejections.ts`
- **`isUndiciTlsSessionBug(err)`** — Narrowly detects this specific crash by checking:
  1. Error is a `TypeError`
  2. Message contains `reading 'setSession'`
  3. Stack trace contains both `TLSSocket.setSession` AND `undici`
  
  All three conditions required to avoid false positives.

- **`installUncaughtExceptionHandler()`** — Centralized handler that suppresses the TLS bug with `console.warn` while preserving `process.exit(1)` for all other uncaught exceptions.

### Entry points (`src/index.ts`, `src/cli/run-main.ts`, `src/macos/relay.ts`)
- Replaced inline `process.on("uncaughtException", ...)` handlers with the centralized `installUncaughtExceptionHandler()`
- No behavioral change for non-TLS errors

### Tests
- **`uncaught-exception.test.ts`** — 7 unit tests for `isUndiciTlsSessionBug()` covering exact match, path variations, wrong error types, wrong messages, non-undici stacks, null inputs, and missing stacks
- **`uncaught-exception.handler.test.ts`** — 3 integration tests verifying the handler suppresses the TLS bug without exiting, still exits on unknown exceptions, and still exits on unrelated TypeErrors

All 10 new tests + 10 existing tests pass.

## AI Disclosure

- [x] AI-assisted (built with OpenClaw/Claude)
- [x] Fully tested (unit + integration, all passing)

Fixes #16206
Fixes #19168
Ref #16335

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real, well-documented Node 22 + undici 7.x race condition (`TypeError: Cannot read properties of null (reading 'setSession')`) that was killing the gateway process. The approach — narrowly detecting the specific bug by requiring all three of: `TypeError`, the exact `reading 'setSession'` message substring, and both `TLSSocket.setSession` and `undici` in the stack — is conservative and unlikely to suppress unrelated errors. The refactoring to a centralized `installUncaughtExceptionHandler()` is clean and consistent with the existing `installUnhandledRejectionHandler()` pattern.

Key observations:

- **Duplicate registration risk**: `installUncaughtExceptionHandler` uses `process.on(...)` with no idempotency guard. If called more than once (which can occur in tests or if entry points change), duplicate listeners accumulate, causing double-logging and multiple `process.exit(1)` calls on a single non-TLS exception. The existing `installUnhandledRejectionHandler` has the same design, but this PR compounds the risk by adding a second unguarded installer.

- **Test teardown gap**: `uncaught-exception.handler.test.ts` installs the handler in `beforeAll` with no corresponding `afterAll` cleanup to `removeListener`. Combined with the existing `unhandled-rejections.fatal-detection.test.ts` doing the same for the rejection handler, both listeners remain live for the entire Vitest worker. If another test file later emits `uncaughtException`, the (now restored real) `process.exit` inside the handler would actually kill the test worker.

- **Detection coverage is appropriate**: The three-condition check is tight enough to avoid false positives while covering the known crash signature. Tests cover the main paths (exact match, path variations, wrong type, wrong message, non-undici stacks, null inputs, missing stack).

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the core fix is correct and narrowly scoped, with one non-critical architectural concern around idempotency of the handler installer.
- The bug being fixed is real and well-understood, the detection heuristic is appropriately conservative, and the entry-point changes are straightforward refactors. The main concern — lack of an idempotency guard on `installUncaughtExceptionHandler` — is a pre-existing pattern in the codebase (same issue exists on `installUnhandledRejectionHandler`) and does not cause a regression in the normal single-call path. The test teardown issue is minor and consistent with existing test files.
- src/infra/unhandled-rejections.ts (idempotency guard), src/infra/uncaught-exception.handler.test.ts (handler not removed in afterAll)

<sub>Last reviewed commit: af1b9f5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->