### PR TITLE
feat(ui): add ★ Main badge to session selector and sessions list

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSessionKey, resolveSessionDisplayName } from "./app-render.helpers.ts";
+import { isMainSession, parseSessionKey, resolveSessionDisplayName } from "./app-render.helpers.ts";
 import type { SessionsListResult } from "./types.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
@@ -89,6 +89,36 @@ describe("parseSessionKey", () => {
       prefix: "",
       fallbackName: "something-unknown",
     });
+  });
+});
+
+/* ================================================================
+ *  isMainSession – identifies main session keys
+ * ================================================================ */
+
+describe("isMainSession", () => {
+  it("returns true for 'main'", () => {
+    expect(isMainSession("main")).toBe(true);
+  });
+
+  it("returns true for 'agent:main:main'", () => {
+    expect(isMainSession("agent:main:main")).toBe(true);
+  });
+
+  it("returns false for subagent sessions", () => {
+    expect(isMainSession("agent:main:subagent:abc-123")).toBe(false);
+  });
+
+  it("returns false for cron sessions", () => {
+    expect(isMainSession("agent:main:cron:daily")).toBe(false);
+  });
+
+  it("returns false for channel sessions", () => {
+    expect(isMainSession("agent:main:telegram:direct:user123")).toBe(false);
+  });
+
+  it("returns false for unknown keys", () => {
+    expect(isMainSession("something-else")).toBe(false);
   });
 });
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -161,7 +161,7 @@ export function renderChatControls(state: AppViewState) {
             (entry) => entry.key,
             (entry) =>
               html`<option value=${entry.key} title=${entry.key}>
-                ${entry.displayName ?? entry.key}
+                ${entry.isMain ? `★ ${entry.displayName ?? entry.key}` : (entry.displayName ?? entry.key)}
               </option>`,
           )}
         </select>
@@ -347,7 +347,7 @@ function resolveSessionOptions(
   mainSessionKey?: string | null,
 ) {
   const seen = new Set<string>();
-  const options: Array<{ key: string; displayName?: string }> = [];
+  const options: Array<{ key: string; displayName?: string; isMain?: boolean }> = [];
 
   const resolvedMain = mainSessionKey && sessions?.sessions?.find((s) => s.key === mainSessionKey);
   const resolvedCurrent = sessions?.sessions?.find((s) => s.key === sessionKey);
@@ -358,6 +358,7 @@ function resolveSessionOptions(
     options.push({
       key: mainSessionKey,
       displayName: resolveSessionDisplayName(mainSessionKey, resolvedMain || undefined),
+      isMain: true,
     });
   }
 
@@ -367,6 +368,7 @@ function resolveSessionOptions(
     options.push({
       key: sessionKey,
       displayName: resolveSessionDisplayName(sessionKey, resolvedCurrent),
+      isMain: isMainSession(sessionKey),
     });
   }
 
@@ -378,12 +380,18 @@ function resolveSessionOptions(
         options.push({
           key: s.key,
           displayName: resolveSessionDisplayName(s.key, s),
+          isMain: isMainSession(s.key),
         });
       }
     }
   }
 
   return options;
+}
+
+/** Check if a session key represents the main session. */
+export function isMainSession(key: string): boolean {
+  return key === "main" || key === "agent:main:main";
 }
 
 const THEME_ORDER: ThemeMode[] = ["system", "light", "dark"];

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { isMainSession } from "../app-render.helpers.ts";
 import { formatRelativeTimestamp } from "../format.ts";
 import { pathForTab } from "../navigation.ts";
 import { formatSessionTokens } from "../presenter.ts";
@@ -244,6 +245,7 @@ function renderRow(
   return html`
     <div class="table-row">
       <div class="mono session-key-cell">
+        ${isMainSession(row.key) ? html`<span class="session-main-badge" title="Main session">★</span> ` : nothing}
         ${canLink ? html`<a href=${chatUrl} class="session-link">${row.key}</a>` : row.key}
         ${showDisplayName ? html`<span class="muted session-key-display-name">${displayName}</span>` : nothing}
       </div>


### PR DESCRIPTION
## Problem

In the webchat UI, there's no visual indicator to distinguish the **main session** from sub-agent sessions, cron jobs, or channel sessions in the session dropdown (upper-right selector). Users have to run `/status` to confirm which session they're in.

## Solution

Adds a **★** (star) badge to identify the main session in two places:

1. **Chat session dropdown** — the main session option is prefixed with `★` so it's instantly recognizable
2. **Sessions admin panel** — a `★` badge appears before the session key in the list

Also exports an `isMainSession()` utility function for consistent detection across UI components, with full test coverage (6 new tests).

## Changes

- `ui/src/ui/app-render.helpers.ts` — added `isMain` flag to session options + `isMainSession()` export + ★ prefix in dropdown rendering
- `ui/src/ui/views/sessions.ts` — added ★ badge in the sessions list key column
- `ui/src/ui/app-render.helpers.node.test.ts` — 6 new tests for `isMainSession()`

## Screenshots

**Before:** All sessions look identical in the dropdown
**After:** Main session shows `★ Main Session` — immediately identifiable

---

_Feature suggested by a user who couldn't tell which session was the main one from the dropdown._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a ★ (star) badge to identify the main session in the chat session dropdown and the sessions admin panel, along with an exported `isMainSession()` utility and 6 new tests. The feature addresses a genuine UX gap where users couldn't distinguish the main session from other session types.

Key observations from the review:

- **Dropdown badge**: The dropdown implementation is correct — the `mainSessionKey` path in `resolveSessionOptions()` unconditionally sets `isMain: true` (line 361) regardless of the actual key value, so the star will always appear on the right entry in the dropdown.
- **Sessions admin panel badge**: The `sessions.ts` view calls `isMainSession(row.key)` directly (line 248) with no knowledge of the resolved `mainSessionKey`. Since `isMainSession()` only checks for the two hardcoded values `"main"` and `"agent:main:main"`, the ★ badge will be absent in the admin panel for users with a custom `session.mainKey`, a non-default agent ID, or `session.scope: "global"` (key `"global"`).
- **Missing CSS class**: The `session-main-badge` class used in `sessions.ts` is not defined in `ui/src/styles/components.css`, where all other session-specific styles (`.session-key-cell`, `.session-link`, `.session-key-display-name`) live. The badge renders as unstyled plain text.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor issues; the dropdown works correctly but the sessions admin badge and styling are incomplete for non-default configurations.
- The core feature works correctly for the standard case (default agent/key). Two issues prevent a higher score: (1) `isMainSession()` doesn't cover non-default main session key formats used in the sessions admin panel, causing the badge to silently not appear in some valid configurations; (2) the `session-main-badge` CSS class is missing from the stylesheet, leaving the star unstyled. Neither issue causes a runtime error or regression, but both represent incomplete implementation of the stated feature goal.
- ui/src/ui/views/sessions.ts and ui/src/ui/app-render.helpers.ts (isMainSession logic), plus the missing CSS entry in ui/src/styles/components.css

<sub>Last reviewed commit: b546439</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->