### PR TITLE
fix(telegram): skip redundant final edit in partial streaming mode

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -52,11 +52,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     loadSessionStore.mockReturnValue({});
   });
 
-  function createDraftStream(messageId?: number) {
+  function createDraftStream(messageId?: number, lastSentText?: string) {
     return {
       update: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
       messageId: vi.fn().mockReturnValue(messageId),
+      lastSentText: vi.fn().mockReturnValue(lastSentText),
       clear: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
       forceNewMessage: vi.fn(),
@@ -554,6 +555,98 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(draftStream.clear).not.toHaveBeenCalled();
     expect(draftStream.stop).toHaveBeenCalled();
+  });
+
+  it("skips final preview edit when draft already matches final plain text", async () => {
+    const draftStream = createDraftStream(999, "Hello final");
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Hello final" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(draftStream.stop).toHaveBeenCalled();
+  });
+
+  it("still edits preview when markdown formatting pass is needed", async () => {
+    const draftStream = createDraftStream(999, "**bold**");
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "**bold**" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(editMessageTelegram).toHaveBeenCalledWith(123, 999, "**bold**", expect.any(Object));
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("still edits preview when final buttons mutate message markup", async () => {
+    const draftStream = createDraftStream(999, "Hello final");
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        {
+          text: "Hello final",
+          channelData: {
+            telegram: {
+              buttons: [[{ text: "Press", callback_data: "press" }]],
+            },
+          },
+        },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      999,
+      "Hello final",
+      expect.objectContaining({
+        buttons: [[{ text: "Press", callback_data: "press" }]],
+      }),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("still edits preview when linkPreview setting requires final mutation", async () => {
+    const draftStream = createDraftStream(999, "https://example.com");
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "https://example.com" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({
+      context: createContext(),
+      telegramCfg: { linkPreview: false },
+    });
+
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      999,
+      "https://example.com",
+      expect.objectContaining({
+        linkPreview: false,
+      }),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("falls back to normal delivery when preview final is too long to edit", async () => {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -422,7 +422,19 @@ export const dispatchTelegramMessage = async ({
     stopDraftLane: async (lane) => {
       await lane.stream?.stop();
     },
-    editPreview: async ({ messageId, text, previewButtons }) => {
+    editPreview: async ({ laneName, messageId, text, previewButtons, context }) => {
+      // Skip no-op final edits: if the preview already shows the rendered final text
+      // and no markup mutation is needed, avoid the edit call (which can error on
+      // identical content and trigger spurious fallback resend/duplicate output).
+      if (
+        context === "final" &&
+        laneName === "answer" &&
+        !previewButtons &&
+        telegramCfg.linkPreview === undefined &&
+        renderTelegramHtmlText(text, { tableMode }) === answerLane.stream?.lastSentText?.()
+      ) {
+        return;
+      }
       await editMessageTelegram(chatId, messageId, text, {
         api: bot.api,
         cfg,

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -71,11 +71,13 @@ describe("createTelegramDraftStream", () => {
     stream.update("Hello");
     await expectInitialForumSend(api);
     await (api.sendMessage.mock.results[0]?.value as Promise<unknown>);
+    expect(stream.lastSentText()).toBe("Hello");
 
     stream.update("Hello again");
     await stream.flush();
 
     expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello again");
+    expect(stream.lastSentText()).toBe("Hello again");
   });
 
   it("waits for in-flight updates before final flush edit", async () => {
@@ -238,6 +240,33 @@ describe("createTelegramDraftStream", () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("telegram stream preview stopped (text length 127 > 100)"),
     );
+  });
+
+  it("keeps lastSentText at the last successful value when an edit fails", async () => {
+    const api = {
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
+      editMessageText: vi.fn().mockRejectedValue(new Error("edit failed")),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+    };
+    const stream = createTelegramDraftStream({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      api: api as any,
+      chatId: 123,
+      thread: { id: 99, scope: "forum" },
+    });
+
+    stream.update("Hello");
+    await vi.waitFor(() =>
+      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 99 }),
+    );
+    await (api.sendMessage.mock.results[0]?.value as Promise<unknown>);
+    expect(stream.lastSentText()).toBe("Hello");
+
+    stream.update("Hello again");
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello again");
+    expect(stream.lastSentText()).toBe("Hello");
   });
 });
 

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -9,6 +9,7 @@ export type TelegramDraftStream = {
   update: (text: string) => void;
   flush: () => Promise<void>;
   messageId: () => number | undefined;
+  lastSentText: () => string | undefined;
   clear: () => Promise<void>;
   stop: () => Promise<void>;
   /** Reset internal state so the next update creates a new message instead of editing. */
@@ -97,8 +98,6 @@ export function createTelegramDraftStream(params: {
       }
     }
 
-    lastSentText = renderedText;
-    lastSentParseMode = renderedParseMode;
     try {
       if (typeof streamMessageId === "number") {
         if (renderedParseMode) {
@@ -108,6 +107,8 @@ export function createTelegramDraftStream(params: {
         } else {
           await params.api.editMessageText(chatId, streamMessageId, renderedText);
         }
+        lastSentText = renderedText;
+        lastSentParseMode = renderedParseMode;
         return true;
       }
       const sendParams = renderedParseMode
@@ -133,6 +134,8 @@ export function createTelegramDraftStream(params: {
         return true;
       }
       streamMessageId = normalizedMessageId;
+      lastSentText = renderedText;
+      lastSentParseMode = renderedParseMode;
       return true;
     } catch (err) {
       streamState.stopped = true;
@@ -178,6 +181,7 @@ export function createTelegramDraftStream(params: {
     update,
     flush: loop.flush,
     messageId: () => streamMessageId,
+    lastSentText: () => lastSentText,
     clear,
     stop,
     forceNewMessage,


### PR DESCRIPTION
## Summary

- Problem: In draft streaming, Telegram finalization would attempt editMessageText with unchanged content.
- Why it matters: Telegram rejects same-content edits (`message is not modified`), which trigger failover cleanup/send and create duplicate visible messages plus error logs.
- What changed: Added `lastAppliedText()` tracking in `draft-stream.ts` and used it in `bot-message-dispatch.ts` to short-circuit unchanged final edits when no mutation is needed.
- Kept final edit behavior for real mutations (formatting pass, inline buttons, `linkPreview=false`) and expanded tests.

Rebased cleanly onto main — turns out merging main into a feature branch makes the bot think you're trying to smuggle 200 unrelated commits into your PR. Lesson learned. 2 clean commits now, as intended.

Replaces #17766 (auto-closed by bot after a merge commit polluted the history).

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations

## Related Fix

Commit [ac2ede5](https://github.com/openclaw/openclaw/commit/ac2ede5bb) by @steipete already treats `message is not modified` API errors as success. This PR adds a complementary optimization that prevents the unnecessary API call from being attempted in the first place.

Both fixes work together:
- `ac2ede5bb`: Reactive safety net at the API error handling layer
- This PR: Proactive optimization at the logic layer to avoid the no-op API call entirely

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a proactive optimization to skip the redundant `editMessageText` Telegram API call when the preview stream already shows the exact final text, complementing the existing reactive error-handling safety net.

The approach is sound — adding `lastSentText()` to `TelegramDraftStream` and checking it in `bot-message-dispatch.ts` before attempting the final edit. The skip conditions correctly account for formatting passes (`renderTelegramHtmlText` comparison), inline button mutations, and `linkPreview=false` mutations.

**Key issue found:**

- `lastSentText` is assigned **optimistically before the API call** (line 78 of `draft-stream.ts`). When `editMessageText` or `sendMessage` throws, `lastSentText` already reflects the attempted text, not the last successfully delivered text. This contradicts the test assertion added in `draft-stream.test.ts` (`"keeps lastSentText at the last successful value when an edit fails"`) — that test will fail against the current implementation.
- More critically, this creates a correctness gap in the dispatch optimization: if a mid-stream edit fails (e.g. network error), `lastSentText` equals the failed-attempt text. If the final text also equals that value, the final edit is skipped, leaving the Telegram message showing the last *successfully delivered* (older) content rather than the final text.
- The fix is straightforward: save the previous `lastSentText` value before the assignment, and restore it in the catch block (and in the `sendMessage` early-return path).

**Everything else looks good:**
- The `needsFormattingPass` check using `renderTelegramHtmlText` is correct and matches how `editMessageTelegram` renders text internally.
- The `hasFinalEditMutation` check for buttons and `linkPreview` correctly identifies cases requiring the final edit.
- Test coverage in `bot-message-dispatch.test.ts` is comprehensive (plain text match, formatting pass, buttons, linkPreview).
- The `lastSentText: () => string | undefined` type is slightly wider than the actual `""` initialization (always returns `string`), but this is harmless.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is: the new draft-stream test will fail, and the optimization has a correctness gap when a streaming edit fails mid-stream.
- The `lastSentText` variable is set before the API call (optimistic update), but the test and the dispatch optimization require it to reflect the last *confirmed* delivery. A failing streaming edit leaves `lastSentText` pointing to the undelivered text, allowing the final edit to be incorrectly skipped. The new `draft-stream.test.ts` test ("keeps lastSentText at the last successful value when an edit fails") will fail against the current implementation. Fixing it requires restoring `lastSentText` to its prior value in the catch block.
- src/telegram/draft-stream.ts — the `sendOrEditStreamMessage` function needs to restore `lastSentText` on API failure.

<sub>Last reviewed commit: 1999e63</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->