### PR TITLE
fix(agents): only seed HEARTBEAT.md on brand-new workspaces

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -311,7 +311,12 @@ export async function ensureAgentWorkspace(params?: {
   await writeFileIfMissing(toolsPath, toolsTemplate);
   await writeFileIfMissing(identityPath, identityTemplate);
   await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  // Only seed HEARTBEAT.md on brand-new workspaces so the empty template acts
+  // as a heartbeat blocker until the user customises it.  Existing workspaces
+  // that deliberately removed the file should not have it recreated (#16065).
+  if (isBrandNewWorkspace) {
+    await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  }
 
   let state = await readWorkspaceOnboardingState(statePath);
   let stateDirty = false;


### PR DESCRIPTION
## Problem

`ensureAgentWorkspace()` creates HEARTBEAT.md for every workspace missing the file — including existing workspaces where the user intentionally removed it. The empty template was designed as a heartbeat blocker for fresh installs; without it, the heartbeat runs without guidance and the agent is left to figure out what to do on its own.

This was introduced in #12027 which removed HEARTBEAT.md creation entirely. The intended behavior (from #11807) is to only create it on brand-new workspaces.

## Fix

Gate `writeFileIfMissing(heartbeatPath, ...)` behind the existing `isBrandNewWorkspace` check. Only genuinely new workspaces receive the template. Existing workspaces that deliberately removed the file no longer have it recreated on every session start.

## Tests

Two new e2e tests in `workspace.e2e.test.ts`:
- `creates HEARTBEAT.md for brand-new workspaces` — verifies the template is still seeded for fresh installs
- `does not create HEARTBEAT.md for existing workspaces that lack it` — verifies the file is not recreated when a user removed it

All 10 workspace tests pass.

Fixes #16065

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes a regression where `HEARTBEAT.md` was being recreated for every workspace that lacked the file — including existing workspaces where the user had intentionally removed it. The fix is minimal and well-targeted: `writeFileIfMissing(heartbeatPath, heartbeatTemplate)` is now guarded by the existing `isBrandNewWorkspace` check, consistent with how `ensureGitRepo` is already gated.

**Key changes:**
- `src/agents/workspace.ts`: `HEARTBEAT.md` creation is now inside `if (isBrandNewWorkspace)` (line 317). The underlying `isBrandNewWorkspace` computation already includes `heartbeatPath` in its six-file check (line 289), so a workspace where all other files exist but `HEARTBEAT.md` was deleted will correctly evaluate to `false` — the fix is logically sound.
- `src/agents/workspace.e2e.test.ts`: Two new tests added — one confirming `HEARTBEAT.md` is seeded on fresh installs, one confirming it isn't recreated on existing workspaces. The second test's setup only pre-writes two of the six core files, which means it doesn't precisely model the described scenario (a fully-initialized workspace that had `HEARTBEAT.md` removed), though it still exercises the correct code path.
- One minor style note: `heartbeatTemplate` is unconditionally loaded (line 308) even when `isBrandNewWorkspace` is `false`, though this is low-impact given the in-process template cache.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; the change is a narrow, well-scoped guard around an existing code path with no risk of data loss or behavioral regression.
- The fix is a one-line conditional guard that only restricts behavior (prevents HEARTBEAT.md recreation on existing workspaces) — it cannot break existing workspaces. The `isBrandNewWorkspace` check already included `heartbeatPath`, ensuring the logic handles the user-deleted-HEARTBEAT.md case correctly. Two new e2e tests cover both the positive and negative path. The test for the "existing workspace" scenario is slightly under-specified but still validates the correct outcome.
- No files require special attention; the test setup in `workspace.e2e.test.ts` for the "existing workspace" scenario could be more precise but does not affect correctness.

<sub>Last reviewed commit: acc511a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->