### PR TITLE
Fix cron store backup churn

### DIFF
--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -2,7 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loadCronStore, resolveCronStorePath } from "./store.js";
+import { loadCronStore, resolveCronStorePath, saveCronStore } from "./store.js";
+import type { CronStoreFile } from "./types.js";
 
 async function makeStorePath() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-store-"));
@@ -12,6 +13,27 @@ async function makeStorePath() {
     cleanup: async () => {
       await fs.rm(dir, { recursive: true, force: true });
     },
+  };
+}
+
+function makeStore(jobId: string, enabled: boolean): CronStoreFile {
+  const now = Date.now();
+  return {
+    version: 1,
+    jobs: [
+      {
+        id: jobId,
+        name: `Job ${jobId}`,
+        enabled,
+        createdAtMs: now,
+        updatedAtMs: now,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: `tick-${jobId}` },
+        state: {},
+      },
+    ],
   };
 }
 
@@ -41,6 +63,32 @@ describe("cron store", () => {
     const store = await makeStorePath();
     await fs.writeFile(store.storePath, "{ not json", "utf-8");
     await expect(loadCronStore(store.storePath)).rejects.toThrow(/Failed to parse cron store/i);
+    await store.cleanup();
+  });
+
+  it("does not create a backup file when saving unchanged content", async () => {
+    const store = await makeStorePath();
+    const payload = makeStore("job-1", true);
+
+    await saveCronStore(store.storePath, payload);
+    await saveCronStore(store.storePath, payload);
+
+    await expect(fs.stat(`${store.storePath}.bak`)).rejects.toThrow();
+    await store.cleanup();
+  });
+
+  it("backs up previous content before replacing the store", async () => {
+    const store = await makeStorePath();
+    const first = makeStore("job-1", true);
+    const second = makeStore("job-2", false);
+
+    await saveCronStore(store.storePath, first);
+    await saveCronStore(store.storePath, second);
+
+    const currentRaw = await fs.readFile(store.storePath, "utf-8");
+    const backupRaw = await fs.readFile(`${store.storePath}.bak`, "utf-8");
+    expect(JSON.parse(currentRaw)).toEqual(second);
+    expect(JSON.parse(backupRaw)).toEqual(first);
     await store.cleanup();
   });
 });

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -50,13 +50,26 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
 export async function saveCronStore(storePath: string, store: CronStoreFile) {
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
   const { randomBytes } = await import("node:crypto");
-  const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   const json = JSON.stringify(store, null, 2);
-  await fs.promises.writeFile(tmp, json, "utf-8");
-  await fs.promises.rename(tmp, storePath);
+  let previous: string | null = null;
   try {
-    await fs.promises.copyFile(storePath, `${storePath}.bak`);
-  } catch {
-    // best-effort
+    previous = await fs.promises.readFile(storePath, "utf-8");
+  } catch (err) {
+    if ((err as { code?: unknown }).code !== "ENOENT") {
+      throw err;
+    }
   }
+  if (previous === json) {
+    return;
+  }
+  const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  await fs.promises.writeFile(tmp, json, "utf-8");
+  if (previous !== null) {
+    try {
+      await fs.promises.copyFile(storePath, `${storePath}.bak`);
+    } catch {
+      // best-effort
+    }
+  }
+  await fs.promises.rename(tmp, storePath);
 }


### PR DESCRIPTION
## Summary
`saveCronStore` in `src/cron/store.ts` was always writing `jobs.json.bak` on every save, even when the serialized cron payload was unchanged. This created unnecessary disk churn and made the backup file less useful because it was being overwritten with the latest state each write.

## Root Cause
The previous save flow always:
1. wrote a temp file,
2. renamed it over `jobs.json`,
3. copied the new `jobs.json` to `jobs.json.bak`.

That means `.bak` represented the newest snapshot, not the previous one, and it was rewritten on every persist tick.

## Fix
- Added a pre-write read of the current store content.
- Added a no-op short-circuit when serialized JSON is unchanged.
- When content changes, create `jobs.json.bak` from the previous on-disk `jobs.json` before replacing it.

This preserves meaningful backup semantics and avoids unnecessary backup rewrites.

## Tests
Added/updated tests in `src/cron/store.test.ts`:
- verifies no backup file is created when saving identical content twice,
- verifies backup contains the previous store content after a changed save.

## Validation
- `pnpm lint`
- `pnpm build`
- `pnpm test`

## AI Assistance
- [x] AI-assisted
- [x] Fully tested

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed unnecessary disk churn in cron store backup mechanism. The previous implementation always created a backup file on every save, even when the content was unchanged. Now the function reads the current file first, short-circuits if the serialized JSON is identical, and only creates `jobs.json.bak` from the previous `jobs.json` when the content actually changes. This preserves proper backup semantics (backup = previous state, not current state) and eliminates wasteful disk writes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper error handling, atomic file operations via temp files, and comprehensive test coverage. The logic correctly handles all edge cases including missing files, unchanged content, and first-time saves. The changes eliminate unnecessary disk I/O while preserving backup semantics.
- No files require special attention

<sub>Last reviewed commit: 3dbb196</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->