### PR TITLE
fix(gateway): mirror delivered agent replies into routed target sessions

### DIFF
--- a/src/commands/agent/delivery.mirror.test.ts
+++ b/src/commands/agent/delivery.mirror.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { CliDeps } from "../../cli/outbound-send-deps.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { RuntimeEnv } from "../../runtime.js";
+
+const {
+  deliverOutboundPayloadsMock,
+  resolveOutboundSessionRouteMock,
+  resolveAgentDeliveryPlanMock,
+  resolveAgentOutboundTargetMock,
+} = vi.hoisted(() => ({
+  deliverOutboundPayloadsMock: vi.fn(),
+  resolveOutboundSessionRouteMock: vi.fn(),
+  resolveAgentDeliveryPlanMock: vi.fn(),
+  resolveAgentOutboundTargetMock: vi.fn(),
+}));
+
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: deliverOutboundPayloadsMock,
+}));
+
+vi.mock("../../infra/outbound/outbound-session.js", () => ({
+  resolveOutboundSessionRoute: resolveOutboundSessionRouteMock,
+}));
+
+vi.mock("../../infra/outbound/agent-delivery.js", () => ({
+  resolveAgentDeliveryPlan: resolveAgentDeliveryPlanMock,
+  resolveAgentOutboundTarget: resolveAgentOutboundTargetMock,
+}));
+
+import { deliverAgentCommandResult } from "./delivery.js";
+
+describe("deliverAgentCommandResult mirroring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveAgentDeliveryPlanMock.mockReturnValue({
+      resolvedChannel: "telegram",
+      resolvedTo: "123456",
+      resolvedThreadId: undefined,
+      resolvedReplyToId: undefined,
+      resolvedAccountId: undefined,
+    });
+    resolveAgentOutboundTargetMock.mockReturnValue({
+      resolvedTarget: { ok: true },
+      resolvedTo: "123456",
+    });
+    deliverOutboundPayloadsMock.mockResolvedValue([{ messageId: "m1" }]);
+  });
+
+  it("mirrors to resolved outbound session when target session differs", async () => {
+    resolveOutboundSessionRouteMock.mockResolvedValue({
+      sessionKey: "agent:main:telegram:chat:123456",
+    });
+
+    await deliverAgentCommandResult({
+      cfg: {} as unknown as OpenClawConfig,
+      deps: {} as unknown as CliDeps,
+      runtime: { log: vi.fn() } as unknown as RuntimeEnv,
+      opts: {
+        message: "hello",
+        deliver: true,
+        channel: "telegram",
+        to: "123456",
+        sessionKey: "agent:main:hook:gmail:abc",
+      },
+      sessionEntry: undefined,
+      result: { meta: {} } as unknown as { meta: unknown },
+      payloads: [{ text: "hello" }] as unknown as Array<{ text: string }>,
+    });
+
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(deliverOutboundPayloadsMock.mock.calls[0][0]).toMatchObject({
+      mirror: {
+        sessionKey: "agent:main:telegram:chat:123456",
+        text: "hello",
+      },
+    });
+  });
+
+  it("does not mirror when outbound session matches source session", async () => {
+    resolveOutboundSessionRouteMock.mockResolvedValue({
+      sessionKey: "agent:main:telegram:chat:123456",
+    });
+
+    await deliverAgentCommandResult({
+      cfg: {} as unknown as OpenClawConfig,
+      deps: {} as unknown as CliDeps,
+      runtime: { log: vi.fn() } as unknown as RuntimeEnv,
+      opts: {
+        message: "hello",
+        deliver: true,
+        channel: "telegram",
+        to: "123456",
+        sessionKey: "agent:main:telegram:chat:123456",
+      },
+      sessionEntry: undefined,
+      result: { meta: {} } as unknown as { meta: unknown },
+      payloads: [{ text: "hello" }] as unknown as Array<{ text: string }>,
+    });
+
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(deliverOutboundPayloadsMock.mock.calls[0][0].mirror).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
When a run delivers outbound text to a routed channel target (e.g. hook/cron with deliver=true), the message can be posted successfully but `sessions_history` for that target session may stay stale because no mirror append occurs.

This change adds target-session mirroring for delivered agent replies in `deliverAgentCommandResult`.

## Root cause
`deliverOutboundPayloads()` only appends transcript entries when `mirror` metadata is provided.
In the affected path, delivery was executed without `mirror`.

## What changed
- In `src/commands/agent/delivery.ts`:
  - resolve outbound session route for `(channel, to, accountId, threadId)`
  - pass `mirror` to `deliverOutboundPayloads` when the resolved target session differs from the source session
  - avoid duplicate appends when source and target session keys are the same

## Tests
Added `src/commands/agent/delivery.mirror.test.ts`:
1. mirrors when routed target session differs
2. does not mirror when source and target sessions match

## Notes
This is intentionally minimal and scoped to the delivery path to preserve existing behavior while restoring observability for routed deliveries.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an observability gap where agent replies delivered to routed channel targets (e.g., hook/cron routing to a Telegram chat) were successfully posted but the target session transcripts remained stale because no mirror append occurred.

**Key changes:**
- In `delivery.ts`: resolves the outbound session route for the delivery target and passes mirror metadata to `deliverOutboundPayloads` when the target session differs from the source session
- Adds case-insensitive session key comparison to avoid duplicate appends when source and target sessions are identical
- Test coverage validates both mirroring when sessions differ and skipping when they match

The fix is minimal and scoped to the delivery path in `deliverAgentCommandResult`, preserving existing behavior while restoring observability for routed deliveries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows established patterns from the outbound session mirroring refactor documented in `docs/refactor/outbound-session-mirroring.md`. The change is minimal and scoped to fix a specific observability gap without affecting existing behavior. Error handling is appropriate (`.catch(() => null)` allows graceful degradation), and the case-insensitive session key comparison prevents duplicate appends. Test coverage validates both the positive case (mirroring when sessions differ) and negative case (no mirroring when sessions match).
- No files require special attention

<sub>Last reviewed commit: c9a627b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->