### PR TITLE
fix(voice-call): add .ngrok-free.dev to ngrok free tier domain check

### DIFF
--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -510,7 +510,7 @@ export function verifyTwilioWebhook(
 
   // Check if this is ngrok free tier - the URL might have different format
   const isNgrokFreeTier =
-    verificationUrl.includes(".ngrok-free.app") || verificationUrl.includes(".ngrok.io");
+    verificationUrl.includes(".ngrok-free.app") || verificationUrl.includes(".ngrok-free.dev") || verificationUrl.includes(".ngrok.io");
 
   return {
     ok: false,


### PR DESCRIPTION
## Problem

ngrok free tier now issues tunnels on `.ngrok-free.dev` in addition to `.ngrok-free.app`. The current ngrok free tier detection in `webhook-security.ts` only checks for `.ngrok-free.app` and `.ngrok.io`, so users with the newer `.ngrok-free.dev` domain hit webhook signature validation failures even when `allowNgrokFreeTierLoopbackBypass` is enabled.

## Fix

Add `.ngrok-free.dev` to the `isNgrokFreeTier` check. One-line change.

## Testing

Tested with ngrok free tier on `.ngrok-free.dev` domain with Twilio voice calls -- webhook validation passes correctly after this fix.

Tested on OpenClaw 2026.2.9 through 2026.2.15.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `.ngrok-free.dev` to the ngrok free tier domain detection in `webhook-security.ts:513`. This fixes webhook signature validation failures for users with the newer ngrok free tier domain when `allowNgrokFreeTierLoopbackBypass` is enabled.

- The change is a simple addition to the boolean check that identifies ngrok free tier URLs
- Maintains consistency with existing `.ngrok-free.app` and `.ngrok.io` domain checks
- The fix is minimal, targeted, and well-tested according to the PR description

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a single-line addition to a string matching condition that adds a new ngrok domain variant. The logic is straightforward, follows the existing pattern, and has been tested by the author. There are no security implications, breaking changes, or edge cases introduced by this change.
- No files require special attention

<sub>Last reviewed commit: a59df83</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->