### PR TITLE
Fix Telegram DM last-route metadata leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: unify message-like inbound handling so `message` and `channel_post` share the same dedupe/access/media pipeline and remain behaviorally consistent. (#20591) Thanks @obviyus.
 - Telegram/Agents: gate exec/bash tool-failure warnings behind verbose mode so default Telegram replies stay clean while verbose sessions still surface diagnostics. (#20560) Thanks @obviyus.
 - Telegram/Cron/Heartbeat: honor explicit Telegram topic targets in cron and heartbeat delivery (`<chatId>:topic:<threadId>`) so scheduled sends land in the configured topic instead of the last active thread. (#19367) Thanks @Lukavyi.
+- Telegram/DM routing: prevent DM inbound origin metadata from leaking into main-session `lastRoute` updates and normalize DM `lastRoute.to` to provider-prefixed `telegram:<chatId>`. (#19491) thanks @guirguispierre.
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
 - Agents/Billing: include the active model that produced a billing error in user-facing billing messages (for example, `OpenAI (gpt-5.3)`) across payload, failover, and lifecycle error paths, so users can identify exactly which key needs credits. (#20510) Thanks @echoVic.
 - Gateway/TUI: honor `agents.defaults.blockStreamingDefault` for `chat.send` by removing the hardcoded block-streaming disable override, so replies can use configured block-mode delivery. (#19693) Thanks @neipor.

--- a/src/channels/session.test.ts
+++ b/src/channels/session.test.ts
@@ -1,0 +1,78 @@
+import type { MsgContext } from "../auto-reply/templating.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const recordSessionMetaFromInboundMock = vi.fn(() => Promise.resolve(undefined));
+const updateLastRouteMock = vi.fn(() => Promise.resolve(undefined));
+
+vi.mock("../config/sessions.js", () => ({
+  recordSessionMetaFromInbound: (...args: unknown[]) => recordSessionMetaFromInboundMock(...args),
+  updateLastRoute: (...args: unknown[]) => updateLastRouteMock(...args),
+}));
+
+describe("recordInboundSession", () => {
+  const ctx: MsgContext = {
+    Provider: "telegram",
+    From: "telegram:1234",
+    SessionKey: "agent:main:telegram:1234:thread:42",
+    OriginatingTo: "telegram:1234",
+  };
+
+  beforeEach(() => {
+    recordSessionMetaFromInboundMock.mockClear();
+    updateLastRouteMock.mockClear();
+  });
+
+  it("does not pass ctx when updating a different session key", async () => {
+    const { recordInboundSession } = await import("./session.js");
+
+    await recordInboundSession({
+      storePath: "/tmp/openclaw-session-store.json",
+      sessionKey: "agent:main:telegram:1234:thread:42",
+      ctx,
+      updateLastRoute: {
+        sessionKey: "agent:main:main",
+        channel: "telegram",
+        to: "telegram:1234",
+      },
+      onRecordError: vi.fn(),
+    });
+
+    expect(updateLastRouteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        ctx: undefined,
+        deliveryContext: expect.objectContaining({
+          channel: "telegram",
+          to: "telegram:1234",
+        }),
+      }),
+    );
+  });
+
+  it("passes ctx when updating the same session key", async () => {
+    const { recordInboundSession } = await import("./session.js");
+
+    await recordInboundSession({
+      storePath: "/tmp/openclaw-session-store.json",
+      sessionKey: "agent:main:telegram:1234:thread:42",
+      ctx,
+      updateLastRoute: {
+        sessionKey: "agent:main:telegram:1234:thread:42",
+        channel: "telegram",
+        to: "telegram:1234",
+      },
+      onRecordError: vi.fn(),
+    });
+
+    expect(updateLastRouteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:telegram:1234:thread:42",
+        ctx,
+        deliveryContext: expect.objectContaining({
+          channel: "telegram",
+          to: "telegram:1234",
+        }),
+      }),
+    );
+  });
+});

--- a/src/channels/session.test.ts
+++ b/src/channels/session.test.ts
@@ -1,12 +1,12 @@
-import type { MsgContext } from "../auto-reply/templating.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
 
-const recordSessionMetaFromInboundMock = vi.fn(() => Promise.resolve(undefined));
-const updateLastRouteMock = vi.fn(() => Promise.resolve(undefined));
+const recordSessionMetaFromInboundMock = vi.fn((_args?: unknown) => Promise.resolve(undefined));
+const updateLastRouteMock = vi.fn((_args?: unknown) => Promise.resolve(undefined));
 
 vi.mock("../config/sessions.js", () => ({
-  recordSessionMetaFromInbound: (...args: unknown[]) => recordSessionMetaFromInboundMock(...args),
-  updateLastRoute: (...args: unknown[]) => updateLastRouteMock(...args),
+  recordSessionMetaFromInbound: (args: unknown) => recordSessionMetaFromInboundMock(args),
+  updateLastRoute: (args: unknown) => updateLastRouteMock(args),
 }));
 
 describe("recordInboundSession", () => {

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -45,7 +45,8 @@ export async function recordInboundSession(params: {
       accountId: update.accountId,
       threadId: update.threadId,
     },
-    ctx,
+    // Avoid leaking inbound origin metadata into a different target session.
+    ctx: update.sessionKey === sessionKey ? ctx : undefined,
     groupResolution,
   });
 }

--- a/src/telegram/bot-message-context.dm-topic-threadid.test.ts
+++ b/src/telegram/bot-message-context.dm-topic-threadid.test.ts
@@ -41,8 +41,9 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
     expect(recordInboundSessionMock).toHaveBeenCalled();
 
     // Check that updateLastRoute includes threadId
-    const updateLastRoute = getUpdateLastRoute() as { threadId?: string } | undefined;
+    const updateLastRoute = getUpdateLastRoute() as { threadId?: string; to?: string } | undefined;
     expect(updateLastRoute).toBeDefined();
+    expect(updateLastRoute?.to).toBe("telegram:1234");
     expect(updateLastRoute?.threadId).toBe("42");
   });
 
@@ -57,8 +58,9 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
     expect(recordInboundSessionMock).toHaveBeenCalled();
 
     // Check that updateLastRoute does NOT include threadId
-    const updateLastRoute = getUpdateLastRoute() as { threadId?: string } | undefined;
+    const updateLastRoute = getUpdateLastRoute() as { threadId?: string; to?: string } | undefined;
     expect(updateLastRoute).toBeDefined();
+    expect(updateLastRoute?.to).toBe("telegram:1234");
     expect(updateLastRoute?.threadId).toBeUndefined();
   });
 

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -765,7 +765,7 @@ export const buildTelegramMessageContext = async ({
       ? {
           sessionKey: route.mainSessionKey,
           channel: "telegram",
-          to: String(chatId),
+          to: `telegram:${chatId}`,
           accountId: route.accountId,
           // Preserve DM topic threadId for replies (fixes #8891)
           threadId: dmThreadId != null ? String(dmThreadId) : undefined,


### PR DESCRIPTION
## Summary
This PR fixes a Telegram DM routing regression where inbound DM metadata could overwrite the main session's origin metadata when `updateLastRoute` targeted a different session key.

## Problem
For Telegram DMs, `buildTelegramMessageContext` records inbound metadata on the DM thread/session but updates `lastRoute` on `route.mainSessionKey`.

`recordInboundSession` always forwarded the inbound `ctx` into `updateLastRoute`, even when `updateLastRoute.sessionKey !== sessionKey`. That let `updateLastRoute` derive origin/group fields from the DM payload and apply them to the main session, which should only receive delivery-route updates.

Additionally, Telegram DM `lastRoute.to` was written as a raw chat id (`"1234"`) instead of normalized provider-prefixed form (`"telegram:1234"`).

## Changes
- `src/channels/session.ts`
  - In `recordInboundSession`, only pass `ctx` to `updateLastRoute` when the target session matches the inbound session key.
  - This preserves route updates while preventing cross-session origin metadata pollution.
- `src/telegram/bot-message-context.ts`
  - Normalize Telegram DM `updateLastRoute.to` to `telegram:<chatId>`.
- `src/channels/session.test.ts` (new)
  - Added tests covering both behaviors:
    - no `ctx` forwarding when updating a different session key
    - `ctx` forwarding when updating the same session key
- `src/telegram/bot-message-context.dm-topic-threadid.test.ts`
  - Added assertions that DM `updateLastRoute.to` is provider-prefixed (`telegram:1234`) while preserving existing threadId behavior checks.

## Validation
- `pnpm lint`
- `pnpm build`
- `pnpm test`

All pass locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related bugs in Telegram DM routing: (1) inbound DM metadata was leaking into the main session when `updateLastRoute` targeted a different session key, and (2) `updateLastRoute.to` was written as a raw chat ID string instead of the normalized `telegram:<chatId>` provider-prefixed form.

- **`src/channels/session.ts`**: The core fix — `ctx` is now conditionally passed to `updateLastRoute` only when `update.sessionKey === sessionKey`, preventing inbound origin metadata (`origin`, `chatType`, `channel`, etc.) from being written to the main session via `deriveSessionMetaPatch`.
- **`src/telegram/bot-message-context.ts`**: Normalizes the `to` field in `updateLastRoute` from `String(chatId)` to `` `telegram:${chatId}` ``, matching the provider-prefixed convention used throughout the rest of the codebase.
- **`src/channels/session.test.ts`** (new): Adds unit tests for the `recordInboundSession` function covering both the cross-session case (ctx suppressed) and same-session case (ctx forwarded).
- **`src/telegram/bot-message-context.dm-topic-threadid.test.ts`**: Extends existing DM topic thread ID tests to also assert that `updateLastRoute.to` is `"telegram:1234"`, catching the normalization bug.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the changes are targeted, well-reasoned, and backed by new tests.
- The logic change in `session.ts` is a one-line conditional guard with clear semantics: `ctx` is only forwarded when the session being updated is the same as the inbound session. The existing `updateLastRoute` implementation already gates `deriveSessionMetaPatch` behind `ctx != null`, so passing `undefined` is well-handled. The `groupResolution` passthrough when `ctx` is suppressed is harmless (it's only consumed inside `deriveSessionMetaPatch`). The `telegram:${chatId}` normalization aligns with the established provider-prefix convention. New tests directly exercise both branches of the conditional and the normalization. No breaking changes are introduced.
- No files require special attention.

<sub>Last reviewed commit: 2597442</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->