### PR TITLE
Docker: install extension workspace deps for memory-lancedb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,12 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
 
 COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY --chown=node:node ui/package.json ./ui/package.json
+COPY --chown=node:node extensions ./extensions
 COPY --chown=node:node patches ./patches
 COPY --chown=node:node scripts ./scripts
 
 USER node
-RUN pnpm install --frozen-lockfile
+RUN pnpm -r install --frozen-lockfile
 
 # Optionally install Chromium and Xvfb for browser automation.
 # Build with: docker build --build-arg OPENCLAW_INSTALL_BROWSER=1 ...

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -9,7 +9,7 @@ const dockerfilePath = join(repoRoot, "Dockerfile");
 describe("Dockerfile", () => {
   it("installs optional browser dependencies after pnpm install", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
-    const installIndex = dockerfile.indexOf("RUN pnpm install --frozen-lockfile");
+    const installIndex = dockerfile.search(/RUN pnpm(?: -r)? install --frozen-lockfile/);
     const browserArgIndex = dockerfile.indexOf("ARG OPENCLAW_INSTALL_BROWSER");
 
     expect(installIndex).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary
- fix Docker install flow so bundled extension dependencies are installed
- copy `extensions/` before install and run workspace-aware install

## Changes
- `Dockerfile`
  - `COPY extensions ./extensions` before dependency install
  - `RUN pnpm -r install --frozen-lockfile`

## Why this is minimal
- avoids broad Docker/build refactors
- targets only the packaging gap that caused `memory-lancedb` runtime dependency misses

## Validation
- built Docker image locally
- confirmed plugin-context resolution for `openai` and `@lancedb/lancedb`
- loaded `extensions/memory-lancedb/index.ts` in container
- triggered `memory_store` with invalid key and got upstream `401 Incorrect API key provided`, confirming request path is functional

Fixes #19466

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Docker builds by ensuring extension dependencies are installed correctly. The change copies the `extensions/` directory before running `pnpm install` and uses the `-r` (recursive) flag to install all workspace package dependencies, including those from bundled extensions like `memory-lancedb`. This is a cleaner approach than the previously-reverted fix that attempted to install extension dependencies after the build as a separate step.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal and well-targeted: copying extensions before install and using pnpm's recursive flag is the correct approach for workspace package management. This fixes a real issue (missing runtime dependencies) in a clean, maintainable way. The author validated the fix locally and confirmed functional behavior. The approach is superior to the previously-reverted band-aid fix that installed dependencies after the build.
- No files require special attention

<sub>Last reviewed commit: b657092</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->