### PR TITLE
fix(gateway): avoid stale running status from Windows Scheduled Task

### DIFF
--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -44,6 +44,14 @@ describe("scheduled task runtime derivation", () => {
     ).toEqual({ status: "running" });
   });
 
+  it("treats Running without last result as running", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Running",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
   it("downgrades stale Running status when last result is not a running code", () => {
     expect(
       deriveScheduledTaskRuntimeStatus({

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { parseSchtasksQuery, readScheduledTaskCommand, resolveTaskScriptPath } from "./schtasks.js";
+import {
+  deriveScheduledTaskRuntimeStatus,
+  parseSchtasksQuery,
+  readScheduledTaskCommand,
+  resolveTaskScriptPath,
+} from "./schtasks.js";
 
 describe("schtasks runtime parsing", () => {
   it.each(["Ready", "Running"])("parses %s status", (status) => {
@@ -16,6 +21,38 @@ describe("schtasks runtime parsing", () => {
       status,
       lastRunTime: "1/8/2026 1:23:45 AM",
       lastRunResult: "0x0",
+    });
+  });
+});
+
+describe("scheduled task runtime derivation", () => {
+  it("treats Running + 0x41301 as running", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Running",
+        lastRunResult: "0x41301",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
+  it("treats Running + decimal 267009 as running", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Running",
+        lastRunResult: "267009",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
+  it("downgrades stale Running status when last result is not a running code", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Running",
+        lastRunResult: "0x0",
+      }),
+    ).toEqual({
+      status: "stopped",
+      detail: "Task reports Running but Last Run Result=0x0; treating as stale runtime state.",
     });
   });
 });


### PR DESCRIPTION
Fix stale 'running' reports from schtasks by validating Last Run Result (0x41301/267009) before treating runtime as active. Includes unit tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real-world bug where Windows Scheduled Tasks can report a stale `Running` status in `schtasks /Query` output even after the process has already exited. The fix validates the `Last Run Result` field against the well-known "task currently running" code (`0x41301` / `267009`) before trusting the `Running` status, and downgrades to `stopped` with a descriptive detail message when the codes don't match.

Key changes:
- Adds `normalizeTaskResultCode` to canonicalize both hex (`0x41301`) and decimal (`267009`) representations of result codes for reliable comparison
- Adds `deriveScheduledTaskRuntimeStatus` (exported and unit-tested) to encapsulate the stale-state logic, replacing the previous one-liner in `readScheduledTaskRuntime`
- `readScheduledTaskRuntime` now spreads `derived.detail` into its return value when the stale condition is detected, giving callers visibility into why status was overridden
- Three new unit tests cover the hex, decimal, and stale-detection paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it tightens a runtime status check without altering any installation, scheduling, or process-management logic.
- The change is narrowly scoped: it adds a new exported pure function and reroutes a single-line status derivation through it. The normalization logic correctly handles both hex and decimal input, and the fallback when `lastRunResult` is absent (trusting "Running") is sound. The only gap is a missing test for the `Running` + no-`lastRunResult` case, which is a minor coverage concern rather than a correctness risk.
- No files require special attention; `src/daemon/schtasks.test.ts` could benefit from one additional edge-case test.

<sub>Last reviewed commit: 77f901a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->