### PR TITLE
security: block prototype pollution in template path resolver

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -437,6 +437,9 @@ function resolveTemplateExpr(expr: string, ctx: HookMappingContext) {
   return getByPath(ctx.payload, expr);
 }
 
+/** Property names that must never be traversed to prevent prototype pollution. */
+const BLOCKED_PATH_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
+
 function getByPath(input: Record<string, unknown>, pathExpr: string): unknown {
   if (!pathExpr) {
     return undefined;
@@ -463,6 +466,9 @@ function getByPath(input: Record<string, unknown>, pathExpr: string): unknown {
       }
       current = current[part] as unknown;
       continue;
+    }
+    if (BLOCKED_PATH_SEGMENTS.has(part)) {
+      return undefined;
     }
     if (typeof current !== "object") {
       return undefined;


### PR DESCRIPTION
## Summary
- Block `__proto__`, `constructor`, and `prototype` segments in template expression path resolution (`getByPath`)
- Prevent prototype pollution attacks via hook transform templates
- Add `BLOCKED_PATH_SEGMENTS` set for efficient lookup

## Security Impact
Prevents prototype pollution which could lead to arbitrary property injection on `Object.prototype`, potentially enabling RCE or data exfiltration through crafted webhook payloads.

## Test plan
- [x] Unit tests for `__proto__` path blocking
- [x] Unit tests for `constructor` path blocking
- [x] Unit tests for nested `prototype` path blocking
- [x] Verify legitimate deep paths still resolve correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds critical prototype pollution protection to template path resolution by blocking `__proto__`, `constructor`, and `prototype` segments in `getByPath`. The security check correctly happens after array indexing but before object property access, preventing attacks via crafted webhook payloads while preserving legitimate deep path access like `messages[0].subject`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix is correctly implemented with proper placement of the check after array indexing, comprehensive test coverage for all blocked segments and nested cases, and verification that legitimate paths still work
- No files require special attention

<sub>Last reviewed commit: c218084</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->