### PR TITLE
security: add per-connection WebSocket rate limiting

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -2,7 +2,6 @@ import type { IncomingMessage } from "node:http";
 import os from "node:os";
 import type { WebSocket } from "ws";
 import { loadConfig } from "../../../config/config.js";
-import { createWsConnectionRateLimiter } from "../../ws-rate-limit.js";
 import {
   deriveDeviceIdFromPublicKey,
   normalizeDevicePublicKeyBase64Url,
@@ -58,6 +57,7 @@ import { handleGatewayRequest } from "../../server-methods.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
 import { formatError } from "../../server-utils.js";
 import { formatForLog, logWs } from "../../ws-log.js";
+import { createWsConnectionRateLimiter } from "../../ws-rate-limit.js";
 import { truncateCloseReason } from "../close-reason.js";
 import {
   buildGatewaySnapshot,

--- a/src/gateway/ws-rate-limit.test.ts
+++ b/src/gateway/ws-rate-limit.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createWsConnectionRateLimiter } from "./ws-rate-limit.js";
+
+describe("ws-rate-limit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("allows messages within the limit", () => {
+    const limiter = createWsConnectionRateLimiter({ maxMessages: 5, windowMs: 1000 });
+    for (let i = 0; i < 5; i++) {
+      const result = limiter.hit();
+      expect(result.allowed).toBe(true);
+      expect(result.shouldClose).toBe(false);
+    }
+  });
+
+  it("blocks messages exceeding the limit", () => {
+    const limiter = createWsConnectionRateLimiter({ maxMessages: 3, windowMs: 1000 });
+    limiter.hit();
+    limiter.hit();
+    limiter.hit();
+    const result = limiter.hit();
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.warnings).toBe(1);
+  });
+
+  it("closes connection after maxWarnings exceeded", () => {
+    const limiter = createWsConnectionRateLimiter({
+      maxMessages: 2,
+      windowMs: 1000,
+      maxWarnings: 3,
+    });
+    // Fill the window
+    limiter.hit();
+    limiter.hit();
+    // 3 over-limit hits = 3 warnings
+    limiter.hit(); // warning 1
+    limiter.hit(); // warning 2
+    const result = limiter.hit(); // warning 3
+    expect(result.shouldClose).toBe(true);
+    expect(result.warnings).toBe(3);
+  });
+
+  it("resets state and allows traffic again", () => {
+    const limiter = createWsConnectionRateLimiter({ maxMessages: 2, windowMs: 1000 });
+    limiter.hit();
+    limiter.hit();
+    const blocked = limiter.hit();
+    expect(blocked.allowed).toBe(false);
+
+    limiter.reset();
+    const afterReset = limiter.hit();
+    expect(afterReset.allowed).toBe(true);
+    expect(limiter.warningCount()).toBe(0);
+  });
+
+  it("sliding window expires old messages", () => {
+    const limiter = createWsConnectionRateLimiter({ maxMessages: 3, windowMs: 1000 });
+    limiter.hit();
+    limiter.hit();
+    limiter.hit();
+    // Window is full
+    const blocked = limiter.hit();
+    expect(blocked.allowed).toBe(false);
+
+    // Advance past the window
+    vi.advanceTimersByTime(1100);
+    const afterWindow = limiter.hit();
+    expect(afterWindow.allowed).toBe(true);
+    expect(afterWindow.remaining).toBe(2);
+  });
+
+  it("returns correct remaining count", () => {
+    const limiter = createWsConnectionRateLimiter({ maxMessages: 5, windowMs: 1000 });
+    expect(limiter.hit().remaining).toBe(4);
+    expect(limiter.hit().remaining).toBe(3);
+    expect(limiter.hit().remaining).toBe(2);
+  });
+
+  it("uses default configuration", () => {
+    const limiter = createWsConnectionRateLimiter();
+    // Should allow 100 messages in 10s window by default
+    for (let i = 0; i < 100; i++) {
+      expect(limiter.hit().allowed).toBe(true);
+    }
+    expect(limiter.hit().allowed).toBe(false);
+  });
+});

--- a/src/gateway/ws-rate-limit.ts
+++ b/src/gateway/ws-rate-limit.ts
@@ -1,0 +1,107 @@
+/**
+ * Per-connection sliding-window rate limiter for WebSocket messages.
+ *
+ * Prevents a single WebSocket connection from flooding the gateway with
+ * excessive messages. Each connection gets its own tracker created via
+ * {@link createWsConnectionRateLimiter}.
+ *
+ * Limits are configurable. When the limit is exceeded a JSON warning is
+ * sent to the client. After {@link WsRateLimitConfig.maxWarnings}
+ * consecutive bursts the connection is closed with code 1008 (Policy
+ * Violation).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WsRateLimitConfig {
+  /** Maximum messages allowed inside the sliding window.  @default 100 */
+  maxMessages?: number;
+  /** Sliding window duration in milliseconds.             @default 10_000 (10 s) */
+  windowMs?: number;
+  /** Number of warnings before the connection is forcibly closed.  @default 3 */
+  maxWarnings?: number;
+}
+
+export interface WsRateLimitResult {
+  /** Whether the message is allowed to proceed. */
+  allowed: boolean;
+  /** Number of remaining messages before the limit is reached. */
+  remaining: number;
+  /** Current warning count (resets when traffic falls below the limit). */
+  warnings: number;
+  /** True when the connection should be terminated. */
+  shouldClose: boolean;
+}
+
+export interface WsConnectionRateLimiter {
+  /** Record an incoming message and return the rate-limit decision. */
+  hit(): WsRateLimitResult;
+  /** Reset the limiter (e.g. on reconnect). */
+  reset(): void;
+  /** Return the current warning count. */
+  warningCount(): number;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_MESSAGES = 100;
+const DEFAULT_WINDOW_MS = 10_000; // 10 seconds
+const DEFAULT_MAX_WARNINGS = 3;
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export function createWsConnectionRateLimiter(
+  config?: WsRateLimitConfig,
+): WsConnectionRateLimiter {
+  const maxMessages = config?.maxMessages ?? DEFAULT_MAX_MESSAGES;
+  const windowMs = config?.windowMs ?? DEFAULT_WINDOW_MS;
+  const maxWarnings = config?.maxWarnings ?? DEFAULT_MAX_WARNINGS;
+
+  let timestamps: number[] = [];
+  let warnings = 0;
+
+  function slideWindow(now: number): void {
+    const cutoff = now - windowMs;
+    timestamps = timestamps.filter((ts) => ts > cutoff);
+  }
+
+  function hit(): WsRateLimitResult {
+    const now = Date.now();
+    slideWindow(now);
+    timestamps.push(now);
+
+    const count = timestamps.length;
+    const remaining = Math.max(0, maxMessages - count);
+
+    if (count <= maxMessages) {
+      // Traffic is within limits – reset warning counter so that occasional
+      // bursts don't accumulate across long-lived connections.
+      if (warnings > 0 && count <= maxMessages * 0.5) {
+        warnings = 0;
+      }
+      return { allowed: true, remaining, warnings, shouldClose: false };
+    }
+
+    // Over the limit.
+    warnings += 1;
+    const shouldClose = warnings >= maxWarnings;
+    return { allowed: false, remaining: 0, warnings, shouldClose };
+  }
+
+  function reset(): void {
+    timestamps = [];
+    warnings = 0;
+  }
+
+  function warningCount(): number {
+    return warnings;
+  }
+
+  return { hit, reset, warningCount };
+}

--- a/src/gateway/ws-rate-limit.ts
+++ b/src/gateway/ws-rate-limit.ts
@@ -56,9 +56,7 @@ const DEFAULT_MAX_WARNINGS = 3;
 // Implementation
 // ---------------------------------------------------------------------------
 
-export function createWsConnectionRateLimiter(
-  config?: WsRateLimitConfig,
-): WsConnectionRateLimiter {
+export function createWsConnectionRateLimiter(config?: WsRateLimitConfig): WsConnectionRateLimiter {
   const maxMessages = config?.maxMessages ?? DEFAULT_MAX_MESSAGES;
   const windowMs = config?.windowMs ?? DEFAULT_WINDOW_MS;
   const maxWarnings = config?.maxWarnings ?? DEFAULT_MAX_WARNINGS;


### PR DESCRIPTION
## Summary
- Add sliding window rate limiter for WebSocket connections (`ws-rate-limit.ts`)
- Default limit: 100 messages per 10 seconds per connection
- Warn client with JSON event before disconnecting on sustained abuse (3 warnings)
- Integrate rate limiter into the WebSocket message handler
- Configurable limits via `WsRateLimitConfig`

## Security Impact
Prevents WebSocket flood attacks that could DoS the gateway server. Each connection is independently tracked.

## Test plan
- [x] Unit tests for rate limiter logic (allow, block, sliding window, reset)
- [x] Test warning count before disconnect
- [x] Test default configuration (100 msg / 10s)
- [x] Verify sliding window expiry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added per-connection WebSocket rate limiting to prevent flood attacks. Each connection is independently tracked with a sliding window limiter (default: 100 messages per 10 seconds). The implementation includes:

- New rate limiter module with configurable limits and automatic warning decay when traffic drops below 50%
- Integration into WebSocket message handler that warns clients before disconnecting after 3 sustained violations
- Comprehensive test coverage for core rate limiting logic

The security improvement is sound and follows the existing patterns in the codebase (similar to `auth-rate-limit.ts`). The implementation correctly handles edge cases and uses an efficient sliding window algorithm.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase, includes comprehensive test coverage, and addresses a real security concern. The sliding window algorithm is correctly implemented with proper bounds checking, and the integration into the message handler is clean and non-invasive. No breaking changes or risky modifications to existing code.
- No files require special attention

<sub>Last reviewed commit: bf4113a</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->