### PR TITLE
feat(bluebubbles): send TTS as native iMessage voice memos

### DIFF
--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -1,4 +1,7 @@
 import crypto from "node:crypto";
+import { execSync } from "node:child_process";
+import { writeFileSync, readFileSync, unlinkSync, mkdtempSync, rmdirSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { resolveBlueBubblesServerAccount } from "./account-resolve.js";
@@ -91,6 +94,33 @@ export type SendBlueBubblesAttachmentResult = {
   messageId: string;
 };
 
+
+/**
+ * Convert MP3 buffer to Opus CAF format for iMessage voice memos.
+ * iMessage requires Opus@24000Hz mono in CAF container.
+ * BlueBubbles' built-in conversion produces PCM Int16@44100Hz which iMessage rejects.
+ */
+function convertMp3ToOpusCaf(mp3Buffer: Uint8Array): Uint8Array {
+  if (process.platform !== "darwin") {
+    throw new Error("afconvert requires macOS");
+  }
+  const tempDir = mkdtempSync(path.join(tmpdir(), "bb-voice-"));
+  const mp3Path = path.join(tempDir, "input.mp3");
+  const cafPath = path.join(tempDir, "output.caf");
+  try {
+    writeFileSync(mp3Path, mp3Buffer);
+    execSync(`/usr/bin/afconvert -f caff -d opus@24000 -c 1 "${mp3Path}" "${cafPath}"`, {
+      stdio: "pipe",
+      timeout: 30000,
+    });
+    return new Uint8Array(readFileSync(cafPath));
+  } finally {
+    try { unlinkSync(mp3Path); } catch {}
+    try { unlinkSync(cafPath); } catch {}
+    try { rmdirSync(tempDir); } catch {}
+  }
+}
+
 /**
  * Send an attachment via BlueBubbles API.
  * Supports sending media files (images, videos, audio, documents) to a chat.
@@ -124,8 +154,18 @@ export async function sendBlueBubblesAttachment(params: {
       throw new Error("BlueBubbles voice messages require audio media (mp3 or caf).");
     }
     if (voiceInfo.isMp3) {
-      filename = ensureExtension(filename, ".mp3", fallbackName);
-      contentType = contentType ?? "audio/mpeg";
+      // Convert MP3 to Opus CAF — iMessage requires Opus@24000Hz for voice memos.
+      // BlueBubbles' built-in MP3->CAF produces PCM which iMessage rejects (0-second audio).
+      try {
+        buffer = convertMp3ToOpusCaf(buffer);
+        filename = ensureExtension(filename, ".caf", fallbackName);
+        contentType = "audio/x-caf";
+      } catch (err) {
+        console.error("BB_VOICE_CONVERT_FAIL", String(err));
+        // Fall back to MP3 (BB will convert, but voice memo will be broken)
+        filename = ensureExtension(filename, ".mp3", fallbackName);
+        contentType = contentType ?? "audio/mpeg";
+      }
     } else if (voiceInfo.isCaf) {
       filename = ensureExtension(filename, ".caf", fallbackName);
       contentType = contentType ?? "audio/x-caf";

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -1,5 +1,5 @@
-import crypto from "node:crypto";
 import { execSync } from "node:child_process";
+import crypto from "node:crypto";
 import { writeFileSync, readFileSync, unlinkSync, mkdtempSync, rmdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -94,7 +94,6 @@ export type SendBlueBubblesAttachmentResult = {
   messageId: string;
 };
 
-
 /**
  * Convert MP3 buffer to Opus CAF format for iMessage voice memos.
  * iMessage requires Opus@24000Hz mono in CAF container.
@@ -115,9 +114,15 @@ function convertMp3ToOpusCaf(mp3Buffer: Uint8Array): Uint8Array {
     });
     return new Uint8Array(readFileSync(cafPath));
   } finally {
-    try { unlinkSync(mp3Path); } catch {}
-    try { unlinkSync(cafPath); } catch {}
-    try { rmdirSync(tempDir); } catch {}
+    try {
+      unlinkSync(mp3Path);
+    } catch {}
+    try {
+      unlinkSync(cafPath);
+    } catch {}
+    try {
+      rmdirSync(tempDir);
+    } catch {}
   }
 }
 

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -938,6 +938,7 @@ export async function processMessage(
                   caption: caption ?? undefined,
                   replyToId: replyToMessageGuid || null,
                   accountId: account.accountId,
+                  asVoice: payload.audioAsVoice === true,
                 });
               } catch (err) {
                 forgetPendingOutboundMessageId(pendingId);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -421,10 +421,16 @@ export async function dispatchReplyFromConfig(params: {
         });
         // Only send if TTS was actually applied (mediaUrl exists)
         if (ttsSyntheticReply.mediaUrl) {
-          // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content
+          // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content.
+          // Exception: when audioAsVoice is true, include text so voice memo channels
+          // deliver text alongside the audio (block-streamed text arrives separately and
+          // won't pair with the voice bubble in the conversation UI).
           const ttsOnlyPayload: ReplyPayload = {
             mediaUrl: ttsSyntheticReply.mediaUrl,
             audioAsVoice: ttsSyntheticReply.audioAsVoice,
+            ...(ttsSyntheticReply.audioAsVoice && accumulatedBlockText.trim()
+              ? { text: accumulatedBlockText.trim() }
+              : {}),
           };
           if (shouldRouteToOriginating && originatingChannel && originatingTo) {
             const result = await routeReply({

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -905,7 +905,8 @@ export async function maybeApplyTtsToPayload(params: {
     };
 
     const channelId = resolveChannelId(params.channel);
-    const shouldVoice = (channelId === "telegram" && result.voiceCompatible === true) || channelId === "bluebubbles";
+    const shouldVoice =
+      (channelId === "telegram" && result.voiceCompatible === true) || channelId === "bluebubbles";
     const finalPayload = {
       ...nextPayload,
       mediaUrl: result.audioPath,

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -905,7 +905,7 @@ export async function maybeApplyTtsToPayload(params: {
     };
 
     const channelId = resolveChannelId(params.channel);
-    const shouldVoice = channelId === "telegram" && result.voiceCompatible === true;
+    const shouldVoice = (channelId === "telegram" && result.voiceCompatible === true) || channelId === "bluebubbles";
     const finalPayload = {
       ...nextPayload,
       mediaUrl: result.audioPath,


### PR DESCRIPTION
## Summary

Enables TTS replies to arrive as native iMessage voice bubbles instead of MP3 file attachments when using the BlueBubbles channel.

## Problem

Three issues prevented voice memos from working correctly:

1. **OpenClaw gap:** `shouldVoice` in `tts.ts` only included Telegram. BlueBubbles TTS never got the `audioAsVoice` flag, and `monitor-processing.ts` never passed `asVoice` to `sendBlueBubblesMedia()` even though the parameter existed.

2. **BlueBubbles server bug:** BB's `convertMp3ToCaf()` converts to PCM Int16@44100Hz, but iMessage voice memos require Opus@24000Hz. iMessage rejects the wrong codec, showing 0-second unplayable audio. Filed upstream: BlueBubblesApp/bluebubbles-server#773

3. **Text dropped from voice memo replies:** When block streaming is active, the TTS-only payload intentionally omits text to avoid duplication. But for voice memo channels, block-streamed text arrives as separate messages that don't visually pair with the voice bubble — recipients only see a voice memo with no text.

## Changes

| File | Change |
|------|--------|
| `src/tts/tts.ts:910` | Add BlueBubbles to `shouldVoice` condition |
| `extensions/bluebubbles/src/monitor-processing.ts:752` | Pass `asVoice: payload.audioAsVoice === true` to `sendBlueBubblesMedia()` |
| `extensions/bluebubbles/src/attachments.ts` | Add `convertMp3ToOpusCaf()` with platform guard — pre-converts MP3 to Opus@24000Hz CAF before BB API call |
| `src/auto-reply/reply/dispatch-from-config.ts` | Include text in TTS-only payload when `audioAsVoice` is true |

## How It Works

- Patches 1+2 route BlueBubbles TTS through the `isAudioMessage=true` code path
- Patch 3 converts MP3→Opus CAF using macOS-native `/usr/bin/afconvert` before handing to BB. Includes `process.platform !== "darwin"` guard for graceful degradation on non-macOS
- BB's send path (`messageInterface.ts:277`) only converts `.mp3` files, so our `.caf` passes through untouched to iMessage
- Patch 4 ensures text is delivered alongside voice memos when block streaming is used — adds `text` to the TTS-only payload when `audioAsVoice` is true (non-voice payloads unchanged)

## Platform Note

The conversion requires macOS `/usr/bin/afconvert` (always present on macOS). BlueBubbles itself is macOS-only (requires Messages.app and the Private API helper), so in practice this code path can only run on macOS. The platform guard is a safety net — it makes the macOS requirement explicit rather than relying on a cryptic "command not found" error, and ensures graceful degradation if the BB extension is ever ported.

## Testing

- [x] MP3 as voice memo via BB API → voice bubble plays with correct duration
- [x] TTS reply via iMessage → arrives as playable voice bubble with text
- [x] Regular MP3 attachments → still work as file attachments (no regression)
- [x] afconvert failure path → falls back to MP3, logs `BB_VOICE_CONVERT_FAIL`
- [x] Voice memo includes paired text message (not voice-only)

## Related

- Upstream BB bug: BlueBubblesApp/bluebubbles-server#773
- Fixes #16848

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enables BlueBubbles to send TTS replies as native iMessage voice bubbles by routing through the voice memo code path and converting MP3 to Opus CAF format. The implementation correctly addresses three issues: adds BlueBubbles to the `shouldVoice` condition in `tts.ts:908`, passes the `asVoice` flag through to `sendBlueBubblesMedia()` in `monitor-processing.ts:941`, converts MP3 to the correct Opus@24000Hz CAF format using macOS `/usr/bin/afconvert`, and includes text in voice memo payloads to prevent text-audio separation in the conversation UI. The conversion logic includes proper platform guards and fallback handling.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the command injection concern in attachments.ts
- The implementation is well-architected with proper error handling, platform guards, and fallback mechanisms. The logic correctly routes BlueBubbles TTS through the voice memo path and solves the text-pairing issue. However, the use of `execSync` with string interpolation (already flagged in previous comments) should be replaced with `execFileSync` before merging to prevent potential command injection vulnerabilities, even though the current paths are system-generated.
- Pay attention to `extensions/bluebubbles/src/attachments.ts` - ensure the command injection fix is applied before merging

<sub>Last reviewed commit: 69f49de</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->