### PR TITLE
security: add SSRF validation for external URLs

### DIFF
--- a/src/security/ssrf-guard.test.ts
+++ b/src/security/ssrf-guard.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { isPrivateIp, SsrfError, validateUrl } from "./ssrf-guard.js";
+
+describe("ssrf-guard", () => {
+  describe("isPrivateIp", () => {
+    it.each([
+      ["10.0.0.1", true],
+      ["10.255.255.255", true],
+      ["172.16.0.1", true],
+      ["172.31.255.255", true],
+      ["172.15.0.1", false],
+      ["172.32.0.1", false],
+      ["192.168.0.1", true],
+      ["192.168.255.255", true],
+      ["127.0.0.1", true],
+      ["127.0.0.2", true],
+      ["169.254.0.1", true],
+      ["169.254.169.254", true],
+      ["0.0.0.0", true],
+      ["8.8.8.8", false],
+      ["1.1.1.1", false],
+      ["93.184.216.34", false],
+      ["::1", true],
+      ["fc00::1", true],
+      ["fd00::1", true],
+      ["fe80::1", true],
+      ["::", true],
+      ["", true],
+    ])("isPrivateIp(%s) = %s", (ip, expected) => {
+      expect(isPrivateIp(ip)).toBe(expected);
+    });
+  });
+
+  describe("validateUrl", () => {
+    it("rejects non-HTTP protocols", async () => {
+      await expect(validateUrl("file:///etc/passwd")).rejects.toThrow(SsrfError);
+      await expect(validateUrl("ftp://example.com/file")).rejects.toThrow(SsrfError);
+      await expect(validateUrl("gopher://example.com")).rejects.toThrow(SsrfError);
+    });
+
+    it("rejects invalid URLs", async () => {
+      await expect(validateUrl("not-a-url")).rejects.toThrow(SsrfError);
+      await expect(validateUrl("")).rejects.toThrow(SsrfError);
+    });
+
+    it("rejects private IP literals", async () => {
+      await expect(validateUrl("http://10.0.0.1/admin")).rejects.toThrow(SsrfError);
+      await expect(validateUrl("http://192.168.1.1/")).rejects.toThrow(SsrfError);
+      await expect(validateUrl("http://127.0.0.1:8080/")).rejects.toThrow(SsrfError);
+      await expect(validateUrl("http://[::1]/")).rejects.toThrow(SsrfError);
+    });
+
+    it("rejects cloud metadata endpoints", async () => {
+      await expect(validateUrl("http://169.254.169.254/latest/meta-data/")).rejects.toThrow(
+        SsrfError,
+      );
+    });
+
+    it("allows legitimate public URLs", async () => {
+      // These may fail in CI without DNS, but the point is they don't throw SsrfError
+      // for protocol/IP checks
+      await expect(validateUrl("https://example.com")).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/security/ssrf-guard.test.ts
+++ b/src/security/ssrf-guard.test.ts
@@ -1,65 +1,146 @@
-import { describe, expect, it } from "vitest";
-import { isPrivateIp, SsrfError, validateUrl } from "./ssrf-guard.js";
+import { describe, expect, it, vi } from "vitest";
+import type { LookupAddress } from "node:dns";
+import {
+  validateUrl,
+  isPrivateIpAddress,
+  isBlockedHostname,
+  SsrFBlockedError,
+} from "./ssrf-guard.js";
 
-describe("ssrf-guard", () => {
-  describe("isPrivateIp", () => {
-    it.each([
-      ["10.0.0.1", true],
-      ["10.255.255.255", true],
-      ["172.16.0.1", true],
-      ["172.31.255.255", true],
-      ["172.15.0.1", false],
-      ["172.32.0.1", false],
-      ["192.168.0.1", true],
-      ["192.168.255.255", true],
-      ["127.0.0.1", true],
-      ["127.0.0.2", true],
-      ["169.254.0.1", true],
-      ["169.254.169.254", true],
-      ["0.0.0.0", true],
-      ["8.8.8.8", false],
-      ["1.1.1.1", false],
-      ["93.184.216.34", false],
-      ["::1", true],
-      ["fc00::1", true],
-      ["fd00::1", true],
-      ["fe80::1", true],
-      ["::", true],
-      ["", true],
-    ])("isPrivateIp(%s) = %s", (ip, expected) => {
-      expect(isPrivateIp(ip)).toBe(expected);
-    });
+// ---------------------------------------------------------------------------
+// Helper: deterministic mock DNS lookup (no network needed in CI)
+// ---------------------------------------------------------------------------
+
+function fakeLookup(address: string, family = 4) {
+  const fn = vi.fn<(hostname: string, opts: { all: boolean }) => Promise<LookupAddress[]>>();
+  fn.mockResolvedValue([{ address, family }]);
+  // Cast to the expected LookupFn signature used by ssrf.ts
+  return fn as unknown as typeof import("node:dns/promises").lookup;
+}
+
+// ---------------------------------------------------------------------------
+// isPrivateIpAddress (re-exported from src/infra/net/ssrf.ts)
+// ---------------------------------------------------------------------------
+
+describe("isPrivateIpAddress (re-exported)", () => {
+  it.each([
+    // IPv4 private ranges
+    ["10.0.0.1", true],
+    ["10.255.255.255", true],
+    ["172.16.0.1", true],
+    ["172.31.255.255", true],
+    ["192.168.0.1", true],
+    ["192.168.255.255", true],
+    ["127.0.0.1", true],
+    ["127.0.0.2", true],
+    ["169.254.0.1", true],
+    ["169.254.169.254", true],
+    ["0.0.0.0", true],
+    // CGNAT range (RFC 6598) – missed by original implementation
+    ["100.64.0.1", true],
+    ["100.127.255.255", true],
+    // Public IPs
+    ["8.8.8.8", false],
+    ["1.1.1.1", false],
+    ["93.184.216.34", false],
+    ["172.15.0.1", false],
+    ["172.32.0.1", false],
+    ["100.63.255.255", false],
+    ["100.128.0.1", false],
+    // IPv6
+    ["::1", true],
+    ["fc00::1", true],
+    ["fd00::1", true],
+    ["fe80::1", true],
+    ["::", true],
+    // IPv4-mapped IPv6 – was a bypass vector in the original
+    ["::ffff:127.0.0.1", true],
+    ["::ffff:10.0.0.1", true],
+    ["::ffff:192.168.1.1", true],
+    ["::ffff:8.8.8.8", false],
+    // Site-local (deprecated but internal) – fec0::/10
+    ["fec0::1", true],
+  ])("isPrivateIpAddress(%s) = %s", (ip, expected) => {
+    expect(isPrivateIpAddress(ip)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isBlockedHostname (re-exported from src/infra/net/ssrf.ts)
+// ---------------------------------------------------------------------------
+
+describe("isBlockedHostname (re-exported)", () => {
+  it.each([
+    ["localhost", true],
+    ["metadata.google.internal", true],
+    ["evil.localhost", true],
+    ["service.local", true],
+    ["secret.internal", true],
+    ["example.com", false],
+    ["api.github.com", false],
+  ])("isBlockedHostname(%s) = %s", (hostname, expected) => {
+    expect(isBlockedHostname(hostname)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateUrl
+// ---------------------------------------------------------------------------
+
+describe("validateUrl", () => {
+  it("rejects non-HTTP protocols", async () => {
+    await expect(validateUrl("file:///etc/passwd")).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("ftp://example.com/file")).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("gopher://example.com")).rejects.toThrow(SsrFBlockedError);
   });
 
-  describe("validateUrl", () => {
-    it("rejects non-HTTP protocols", async () => {
-      await expect(validateUrl("file:///etc/passwd")).rejects.toThrow(SsrfError);
-      await expect(validateUrl("ftp://example.com/file")).rejects.toThrow(SsrfError);
-      await expect(validateUrl("gopher://example.com")).rejects.toThrow(SsrfError);
-    });
+  it("rejects invalid URLs", async () => {
+    await expect(validateUrl("not-a-url")).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("")).rejects.toThrow(SsrFBlockedError);
+  });
 
-    it("rejects invalid URLs", async () => {
-      await expect(validateUrl("not-a-url")).rejects.toThrow(SsrfError);
-      await expect(validateUrl("")).rejects.toThrow(SsrfError);
-    });
+  it("rejects private IP literals", async () => {
+    await expect(validateUrl("http://10.0.0.1/admin")).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("http://192.168.1.1/")).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("http://127.0.0.1:8080/")).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("http://[::1]/")).rejects.toThrow(SsrFBlockedError);
+  });
 
-    it("rejects private IP literals", async () => {
-      await expect(validateUrl("http://10.0.0.1/admin")).rejects.toThrow(SsrfError);
-      await expect(validateUrl("http://192.168.1.1/")).rejects.toThrow(SsrfError);
-      await expect(validateUrl("http://127.0.0.1:8080/")).rejects.toThrow(SsrfError);
-      await expect(validateUrl("http://[::1]/")).rejects.toThrow(SsrfError);
-    });
+  it("rejects IPv4-mapped IPv6 literals", async () => {
+    await expect(validateUrl("http://[::ffff:127.0.0.1]/")).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("http://[::ffff:10.0.0.1]/")).rejects.toThrow(SsrFBlockedError);
+  });
 
-    it("rejects cloud metadata endpoints", async () => {
-      await expect(validateUrl("http://169.254.169.254/latest/meta-data/")).rejects.toThrow(
-        SsrfError,
-      );
-    });
+  it("rejects CGNAT range (100.64.0.0/10)", async () => {
+    await expect(validateUrl("http://100.64.0.1/")).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("http://100.127.255.255/")).rejects.toThrow(SsrFBlockedError);
+  });
 
-    it("allows legitimate public URLs", async () => {
-      // These may fail in CI without DNS, but the point is they don't throw SsrfError
-      // for protocol/IP checks
-      await expect(validateUrl("https://example.com")).resolves.toBeUndefined();
-    });
+  it("rejects cloud metadata endpoints", async () => {
+    await expect(validateUrl("http://169.254.169.254/latest/meta-data/")).rejects.toThrow(
+      SsrFBlockedError,
+    );
+  });
+
+  it("rejects blocked hostnames (localhost, .local, .internal)", async () => {
+    const mockLookup = fakeLookup("127.0.0.1");
+    await expect(validateUrl("http://localhost/admin", mockLookup)).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("http://metadata.google.internal/", mockLookup)).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("http://service.local/", mockLookup)).rejects.toThrow(SsrFBlockedError);
+  });
+
+  it("rejects hostnames that resolve to private IPs", async () => {
+    const mockLookup = fakeLookup("10.0.0.1");
+    await expect(validateUrl("https://evil.example.com", mockLookup)).rejects.toThrow(SsrFBlockedError);
+  });
+
+  it("allows legitimate public URLs (mocked DNS)", async () => {
+    const mockLookup = fakeLookup("93.184.216.34");
+    await expect(validateUrl("https://example.com", mockLookup)).resolves.toBeUndefined();
+  });
+
+  it("allows public IP literals", async () => {
+    await expect(validateUrl("http://8.8.8.8/dns-query")).resolves.toBeUndefined();
+    await expect(validateUrl("https://1.1.1.1/")).resolves.toBeUndefined();
   });
 });

--- a/src/security/ssrf-guard.test.ts
+++ b/src/security/ssrf-guard.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
 import type { LookupAddress } from "node:dns";
+import { describe, expect, it, vi } from "vitest";
 import {
   validateUrl,
   isPrivateIpAddress,
@@ -124,14 +124,22 @@ describe("validateUrl", () => {
 
   it("rejects blocked hostnames (localhost, .local, .internal)", async () => {
     const mockLookup = fakeLookup("127.0.0.1");
-    await expect(validateUrl("http://localhost/admin", mockLookup)).rejects.toThrow(SsrFBlockedError);
-    await expect(validateUrl("http://metadata.google.internal/", mockLookup)).rejects.toThrow(SsrFBlockedError);
-    await expect(validateUrl("http://service.local/", mockLookup)).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("http://localhost/admin", mockLookup)).rejects.toThrow(
+      SsrFBlockedError,
+    );
+    await expect(validateUrl("http://metadata.google.internal/", mockLookup)).rejects.toThrow(
+      SsrFBlockedError,
+    );
+    await expect(validateUrl("http://service.local/", mockLookup)).rejects.toThrow(
+      SsrFBlockedError,
+    );
   });
 
   it("rejects hostnames that resolve to private IPs", async () => {
     const mockLookup = fakeLookup("10.0.0.1");
-    await expect(validateUrl("https://evil.example.com", mockLookup)).rejects.toThrow(SsrFBlockedError);
+    await expect(validateUrl("https://evil.example.com", mockLookup)).rejects.toThrow(
+      SsrFBlockedError,
+    );
   });
 
   it("allows legitimate public URLs (mocked DNS)", async () => {

--- a/src/security/ssrf-guard.ts
+++ b/src/security/ssrf-guard.ts
@@ -1,0 +1,135 @@
+/**
+ * SSRF (Server-Side Request Forgery) guard.
+ *
+ * Validates URLs before making outbound HTTP requests to prevent access to
+ * internal networks, cloud metadata endpoints, and non-HTTP protocols.
+ *
+ * Key protections:
+ * - Blocks private/internal IP ranges (RFC 1918, loopback, link-local)
+ * - Blocks cloud metadata endpoints (169.254.169.254)
+ * - Blocks non-HTTP(S) protocols (file://, ftp://, etc.)
+ * - Resolves DNS before validation to prevent DNS rebinding
+ */
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+// ---------------------------------------------------------------------------
+// Blocked IP ranges (CIDR-style checks)
+// ---------------------------------------------------------------------------
+
+/** Returns true if the IP address belongs to a private or reserved range. */
+export function isPrivateIp(ip: string): boolean {
+  if (!ip) {
+    return true;
+  }
+
+  // IPv4 checks
+  const parts = ip.split(".");
+  if (parts.length === 4) {
+    const a = Number(parts[0]);
+    const b = Number(parts[1]);
+
+    // 10.0.0.0/8
+    if (a === 10) return true;
+    // 172.16.0.0/12
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    // 192.168.0.0/16
+    if (a === 192 && b === 168) return true;
+    // 127.0.0.0/8 (loopback)
+    if (a === 127) return true;
+    // 169.254.0.0/16 (link-local, includes cloud metadata)
+    if (a === 169 && b === 254) return true;
+    // 0.0.0.0/8
+    if (a === 0) return true;
+  }
+
+  // IPv6 checks
+  const lower = ip.toLowerCase();
+  // ::1 (loopback)
+  if (lower === "::1" || lower === "0:0:0:0:0:0:0:1") return true;
+  // fc00::/7 (unique local)
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  // fe80::/10 (link-local)
+  if (lower.startsWith("fe80")) return true;
+  // :: (unspecified)
+  if (lower === "::") return true;
+
+  return false;
+}
+
+/** Specific IPs that must always be blocked (cloud metadata endpoints). */
+const BLOCKED_IPS = new Set(["169.254.169.254", "fd00:ec2::254"]);
+
+/** Allowed URL protocols. */
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export class SsrfError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SsrfError";
+  }
+}
+
+/**
+ * Validate a URL for outbound requests. Throws {@link SsrfError} if the URL
+ * targets a private/internal resource or uses a disallowed protocol.
+ *
+ * @param rawUrl - The URL string to validate.
+ */
+export async function validateUrl(rawUrl: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new SsrfError(`invalid URL: ${rawUrl}`);
+  }
+
+  // Protocol check
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new SsrfError(`protocol not allowed: ${parsed.protocol}`);
+  }
+
+  const hostname = parsed.hostname;
+  if (!hostname) {
+    throw new SsrfError("URL has no hostname");
+  }
+
+  // Strip IPv6 brackets for net.isIP check
+  const cleanHost = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
+
+  // If the hostname is already an IP literal, validate directly
+  if (isIP(cleanHost)) {
+    if (isPrivateIp(cleanHost)) {
+      throw new SsrfError(`private/internal IP blocked: ${cleanHost}`);
+    }
+    if (BLOCKED_IPS.has(cleanHost)) {
+      throw new SsrfError(`blocked IP address: ${cleanHost}`);
+    }
+    return;
+  }
+
+  // Resolve DNS to prevent DNS rebinding attacks
+  try {
+    const result = await lookup(hostname, { all: true });
+    const addresses = Array.isArray(result) ? result : [result];
+    for (const entry of addresses) {
+      const addr = typeof entry === "string" ? entry : entry.address;
+      if (isPrivateIp(addr)) {
+        throw new SsrfError(`hostname ${hostname} resolves to private IP: ${addr}`);
+      }
+      if (BLOCKED_IPS.has(addr)) {
+        throw new SsrfError(`hostname ${hostname} resolves to blocked IP: ${addr}`);
+      }
+    }
+  } catch (err) {
+    if (err instanceof SsrfError) {
+      throw err;
+    }
+    throw new SsrfError(`DNS resolution failed for ${hostname}: ${(err as Error).message}`);
+  }
+}

--- a/src/security/ssrf-guard.ts
+++ b/src/security/ssrf-guard.ts
@@ -1,135 +1,112 @@
 /**
- * SSRF (Server-Side Request Forgery) guard.
+ * SSRF (Server-Side Request Forgery) guard – convenience layer.
  *
- * Validates URLs before making outbound HTTP requests to prevent access to
- * internal networks, cloud metadata endpoints, and non-HTTP protocols.
+ * Delegates to the battle-tested primitives in src/infra/net/ssrf.ts
+ * for IP validation, hostname blocking, and DNS-pinned resolution.
  *
- * Key protections:
- * - Blocks private/internal IP ranges (RFC 1918, loopback, link-local)
- * - Blocks cloud metadata endpoints (169.254.169.254)
- * - Blocks non-HTTP(S) protocols (file://, ftp://, etc.)
- * - Resolves DNS before validation to prevent DNS rebinding
+ * Exports:
+ * - {@link validateUrl} – one-shot URL check (protocol, hostname, resolved IPs).
+ * - {@link safeFetch}   – end-to-end guarded fetch with DNS pinning so the
+ *   resolved addresses cannot change between validation and the HTTP request
+ *   (prevents DNS rebinding / TOCTOU attacks).
+ * - Re-exports of the underlying {@link isPrivateIpAddress},
+ *   {@link isBlockedHostname}, and {@link SsrFBlockedError} for direct use.
  */
 
-import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
+import {
+  isPrivateIpAddress,
+  isBlockedHostname,
+  SsrFBlockedError,
+  type LookupFn,
+  resolvePinnedHostnameWithPolicy,
+} from "../infra/net/ssrf.js";
+import {
+  fetchWithSsrFGuard,
+  type GuardedFetchOptions,
+  type GuardedFetchResult,
+} from "../infra/net/fetch-guard.js";
 
-// ---------------------------------------------------------------------------
-// Blocked IP ranges (CIDR-style checks)
-// ---------------------------------------------------------------------------
-
-/** Returns true if the IP address belongs to a private or reserved range. */
-export function isPrivateIp(ip: string): boolean {
-  if (!ip) {
-    return true;
-  }
-
-  // IPv4 checks
-  const parts = ip.split(".");
-  if (parts.length === 4) {
-    const a = Number(parts[0]);
-    const b = Number(parts[1]);
-
-    // 10.0.0.0/8
-    if (a === 10) return true;
-    // 172.16.0.0/12
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    // 192.168.0.0/16
-    if (a === 192 && b === 168) return true;
-    // 127.0.0.0/8 (loopback)
-    if (a === 127) return true;
-    // 169.254.0.0/16 (link-local, includes cloud metadata)
-    if (a === 169 && b === 254) return true;
-    // 0.0.0.0/8
-    if (a === 0) return true;
-  }
-
-  // IPv6 checks
-  const lower = ip.toLowerCase();
-  // ::1 (loopback)
-  if (lower === "::1" || lower === "0:0:0:0:0:0:0:1") return true;
-  // fc00::/7 (unique local)
-  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
-  // fe80::/10 (link-local)
-  if (lower.startsWith("fe80")) return true;
-  // :: (unspecified)
-  if (lower === "::") return true;
-
-  return false;
-}
-
-/** Specific IPs that must always be blocked (cloud metadata endpoints). */
-const BLOCKED_IPS = new Set(["169.254.169.254", "fd00:ec2::254"]);
+// Re-export canonical implementations so consumers can use a single import.
+export { isPrivateIpAddress, isBlockedHostname, SsrFBlockedError };
+export type { GuardedFetchResult };
 
 /** Allowed URL protocols. */
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-export class SsrfError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "SsrfError";
-  }
-}
-
 /**
- * Validate a URL for outbound requests. Throws {@link SsrfError} if the URL
- * targets a private/internal resource or uses a disallowed protocol.
+ * Validate a URL for outbound requests without making the request.
  *
- * @param rawUrl - The URL string to validate.
+ * Checks the protocol, hostname (including `localhost`, `.local`, `.internal`),
+ * and resolves DNS to verify all addresses are public. The DNS result is
+ * **not pinned** to a subsequent request, so this function is suitable for
+ * pre-flight validation only. For end-to-end protection (including DNS
+ * rebinding), use {@link safeFetch} instead.
+ *
+ * @throws {SsrFBlockedError} if the URL targets a private resource.
  */
-export async function validateUrl(rawUrl: string): Promise<void> {
+export async function validateUrl(rawUrl: string, lookupFn?: LookupFn): Promise<void> {
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
   } catch {
-    throw new SsrfError(`invalid URL: ${rawUrl}`);
+    throw new SsrFBlockedError(`invalid URL: ${rawUrl}`);
   }
 
   // Protocol check
   if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
-    throw new SsrfError(`protocol not allowed: ${parsed.protocol}`);
+    throw new SsrFBlockedError(`protocol not allowed: ${parsed.protocol}`);
   }
 
   const hostname = parsed.hostname;
   if (!hostname) {
-    throw new SsrfError("URL has no hostname");
+    throw new SsrFBlockedError("URL has no hostname");
   }
 
-  // Strip IPv6 brackets for net.isIP check
+  // Strip IPv6 brackets for checks
   const cleanHost = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
+
+  // Blocked hostname patterns (localhost, .local, .internal, metadata.google.internal)
+  if (isBlockedHostname(cleanHost)) {
+    throw new SsrFBlockedError(`blocked hostname: ${cleanHost}`);
+  }
 
   // If the hostname is already an IP literal, validate directly
   if (isIP(cleanHost)) {
-    if (isPrivateIp(cleanHost)) {
-      throw new SsrfError(`private/internal IP blocked: ${cleanHost}`);
-    }
-    if (BLOCKED_IPS.has(cleanHost)) {
-      throw new SsrfError(`blocked IP address: ${cleanHost}`);
+    if (isPrivateIpAddress(cleanHost)) {
+      throw new SsrFBlockedError(`private/internal IP blocked: ${cleanHost}`);
     }
     return;
   }
 
-  // Resolve DNS to prevent DNS rebinding attacks
-  try {
-    const result = await lookup(hostname, { all: true });
-    const addresses = Array.isArray(result) ? result : [result];
-    for (const entry of addresses) {
-      const addr = typeof entry === "string" ? entry : entry.address;
-      if (isPrivateIp(addr)) {
-        throw new SsrfError(`hostname ${hostname} resolves to private IP: ${addr}`);
-      }
-      if (BLOCKED_IPS.has(addr)) {
-        throw new SsrfError(`hostname ${hostname} resolves to blocked IP: ${addr}`);
-      }
-    }
-  } catch (err) {
-    if (err instanceof SsrfError) {
-      throw err;
-    }
-    throw new SsrfError(`DNS resolution failed for ${hostname}: ${(err as Error).message}`);
-  }
+  // Resolve DNS and validate all addresses.
+  // resolvePinnedHostnameWithPolicy throws SsrFBlockedError for private IPs.
+  await resolvePinnedHostnameWithPolicy(hostname, {
+    ...(lookupFn ? { lookupFn } : {}),
+  });
+}
+
+/**
+ * Fetch a URL with full SSRF protection and DNS pinning.
+ *
+ * This is the recommended entry point for making outbound HTTP requests.
+ * It resolves DNS once, validates all addresses, then pins the HTTP
+ * connection to the validated IPs — preventing DNS rebinding / TOCTOU
+ * attacks.
+ *
+ * The caller **must** call `result.release()` when done with the response.
+ *
+ * @throws {SsrFBlockedError} if the URL targets a private resource.
+ */
+export async function safeFetch(
+  url: string,
+  init?: RequestInit,
+  options?: Partial<Pick<GuardedFetchOptions, "maxRedirects" | "timeoutMs" | "signal" | "lookupFn" | "auditContext">>,
+): Promise<GuardedFetchResult> {
+  return fetchWithSsrFGuard({
+    url,
+    init,
+    pinDns: true,
+    ...options,
+  });
 }

--- a/src/security/ssrf-guard.ts
+++ b/src/security/ssrf-guard.ts
@@ -15,17 +15,17 @@
 
 import { isIP } from "node:net";
 import {
+  fetchWithSsrFGuard,
+  type GuardedFetchOptions,
+  type GuardedFetchResult,
+} from "../infra/net/fetch-guard.js";
+import {
   isPrivateIpAddress,
   isBlockedHostname,
   SsrFBlockedError,
   type LookupFn,
   resolvePinnedHostnameWithPolicy,
 } from "../infra/net/ssrf.js";
-import {
-  fetchWithSsrFGuard,
-  type GuardedFetchOptions,
-  type GuardedFetchResult,
-} from "../infra/net/fetch-guard.js";
 
 // Re-export canonical implementations so consumers can use a single import.
 export { isPrivateIpAddress, isBlockedHostname, SsrFBlockedError };
@@ -101,7 +101,9 @@ export async function validateUrl(rawUrl: string, lookupFn?: LookupFn): Promise<
 export async function safeFetch(
   url: string,
   init?: RequestInit,
-  options?: Partial<Pick<GuardedFetchOptions, "maxRedirects" | "timeoutMs" | "signal" | "lookupFn" | "auditContext">>,
+  options?: Partial<
+    Pick<GuardedFetchOptions, "maxRedirects" | "timeoutMs" | "signal" | "lookupFn" | "auditContext">
+  >,
 ): Promise<GuardedFetchResult> {
   return fetchWithSsrFGuard({
     url,

--- a/src/security/ssrf-guard.ts
+++ b/src/security/ssrf-guard.ts
@@ -81,9 +81,11 @@ export async function validateUrl(rawUrl: string, lookupFn?: LookupFn): Promise<
 
   // Resolve DNS and validate all addresses.
   // resolvePinnedHostnameWithPolicy throws SsrFBlockedError for private IPs.
-  await resolvePinnedHostnameWithPolicy(hostname, {
-    ...(lookupFn ? { lookupFn } : {}),
-  });
+  const resolveOpts: { lookupFn?: LookupFn } = {};
+  if (lookupFn) {
+    resolveOpts.lookupFn = lookupFn;
+  }
+  await resolvePinnedHostnameWithPolicy(hostname, resolveOpts);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add SSRF guard utility (`src/security/ssrf-guard.ts`) for validating outbound URLs
- Block private IP ranges: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 169.254.0.0/16
- Block cloud metadata endpoints (169.254.169.254)
- Block non-HTTP protocols (file://, ftp://, gopher://, etc.)
- Resolve DNS before validation to prevent DNS rebinding attacks
- Export `validateUrl()` async function and `isPrivateIp()` utility

## Security Impact
Prevents Server-Side Request Forgery attacks that could access internal services, cloud instance metadata, or other private resources through crafted webhook/callback URLs.

## Test plan
- [x] Unit tests for all blocked IP ranges (IPv4 + IPv6)
- [x] Test DNS resolution validation
- [x] Verify legitimate external URLs pass
- [x] Test cloud metadata endpoint blocking
- [x] Test non-HTTP protocol rejection

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new SSRF guard utility at `src/security/ssrf-guard.ts`, but the codebase already has a comprehensive, production-hardened SSRF implementation at `src/infra/net/ssrf.ts` and `src/infra/net/fetch-guard.ts`. The new module duplicates this functionality with a weaker implementation, creating two diverging SSRF implementations to maintain.

**Key issues found:**

- **DNS rebinding not actually prevented**: `validateUrl` resolves DNS and checks the result, but then returns. The caller's subsequent HTTP request will perform a new DNS lookup. Without pinning the resolved IPs to the connection (as `fetchWithSsrFGuard` does via `createPinnedDispatcher`), a DNS rebinding attack can still succeed — an attacker returns a public IP during validation and a private IP during the actual connection (with a short TTL). The JSDoc claim that this "prevents DNS rebinding attacks" is incorrect.

- **Missing IP ranges vs. existing implementation**: `isPrivateIp` does not handle IPv4-mapped IPv6 addresses (`::ffff:10.0.0.1`), the CGNAT range `100.64.0.0/10` (RFC 6598), or the deprecated site-local `fec0::/10` range — all of which are covered by the existing `isPrivateIpAddress` in `src/infra/net/ssrf.ts`.

- **`localhost` and `.local`/`.internal` hostnames not blocked**: The existing `isBlockedHostname()` function covers `localhost`, `metadata.google.internal`, and `.local`/`.internal` suffixes. This new module skips all hostname-level checks.

- **`BLOCKED_IPS` set is dead code**: Both entries (`169.254.169.254` and `fd00:ec2::254`) are already caught earlier by `isPrivateIp()`, making all `BLOCKED_IPS.has()` checks unreachable.

- **No call sites**: The new module is not imported or used anywhere in the codebase yet, so none of these protections are active.

<h3>Confidence Score: 1/5</h3>

- This PR is not safe to merge as-is: it introduces a parallel SSRF implementation that is weaker than the existing one, contains a DNS rebinding bypass, and is not integrated anywhere.
- The new `ssrf-guard.ts` module has multiple security gaps compared to the existing `src/infra/net/ssrf.ts`: it lacks IPv4-mapped IPv6 handling (a concrete bypass vector), misses CGNAT and site-local ranges, has no hostname-level blocking for `localhost`/`.local`/`.internal`, and critically does not pin DNS results — meaning the core DNS rebinding protection it claims to provide does not work. The module is also not wired into any request path, so it provides no actual protection. Merging it risks fragmentation of the SSRF defence layer and could lead to the new, weaker implementation being adopted over the robust existing one.
- src/security/ssrf-guard.ts requires significant rework before it is safe to use; the existing src/infra/net/ssrf.ts and src/infra/net/fetch-guard.ts should be referenced as the canonical implementation.

<sub>Last reviewed commit: 56a3b27</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->