### PR TITLE
security: migrate sensitive Docker env vars to Docker secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ USER.md
 # local tooling
 .serena/
 
+# Docker secrets (NEVER COMMIT)
+secrets/
+
 # Agent credentials and memory (NEVER COMMIT)
 /memory/
 .agent/*.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,11 @@ RUN chown -R node:node /app
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
 
+# Entrypoint loads Docker secrets from /run/secrets/ into env vars.
+# Falls back to direct environment variables for backward compatibility.
+COPY --chown=node:node docker-entrypoint.sh /app/docker-entrypoint.sh
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,13 @@ services:
       # Direct env vars still work as a fallback (entrypoint skips if already set).
     secrets:
       - openclaw_gateway_token
+      - openclaw_gateway_password
       - claude_ai_session_key
       - claude_web_session_key
       - claude_web_cookie
+      - openai_api_key
+      - anthropic_api_key
+      - gemini_api_key
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
@@ -39,9 +43,13 @@ services:
       BROWSER: echo
     secrets:
       - openclaw_gateway_token
+      - openclaw_gateway_password
       - claude_ai_session_key
       - claude_web_session_key
       - claude_web_cookie
+      - openai_api_key
+      - anthropic_api_key
+      - gemini_api_key
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
@@ -56,9 +64,17 @@ services:
 secrets:
   openclaw_gateway_token:
     file: ${OPENCLAW_SECRETS_DIR:-./secrets}/openclaw_gateway_token
+  openclaw_gateway_password:
+    file: ${OPENCLAW_SECRETS_DIR:-./secrets}/openclaw_gateway_password
   claude_ai_session_key:
     file: ${OPENCLAW_SECRETS_DIR:-./secrets}/claude_ai_session_key
   claude_web_session_key:
     file: ${OPENCLAW_SECRETS_DIR:-./secrets}/claude_web_session_key
   claude_web_cookie:
     file: ${OPENCLAW_SECRETS_DIR:-./secrets}/claude_web_cookie
+  openai_api_key:
+    file: ${OPENCLAW_SECRETS_DIR:-./secrets}/openai_api_key
+  anthropic_api_key:
+    file: ${OPENCLAW_SECRETS_DIR:-./secrets}/anthropic_api_key
+  gemini_api_key:
+    file: ${OPENCLAW_SECRETS_DIR:-./secrets}/gemini_api_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,14 @@ services:
     environment:
       HOME: /home/node
       TERM: xterm-256color
-      OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+      # Non-sensitive env vars can remain here.
+      # Sensitive credentials are loaded from Docker secrets by the entrypoint.
+      # Direct env vars still work as a fallback (entrypoint skips if already set).
+    secrets:
+      - openclaw_gateway_token
+      - claude_ai_session_key
+      - claude_web_session_key
+      - claude_web_cookie
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
@@ -32,15 +36,29 @@ services:
     environment:
       HOME: /home/node
       TERM: xterm-256color
-      OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
       BROWSER: echo
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+    secrets:
+      - openclaw_gateway_token
+      - claude_ai_session_key
+      - claude_web_session_key
+      - claude_web_cookie
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
     stdin_open: true
     tty: true
     init: true
-    entrypoint: ["node", "dist/index.js"]
+    entrypoint: ["/app/docker-entrypoint.sh", "node", "dist/index.js"]
+
+# Docker secrets – point each to a local file containing the credential.
+# Create the files before running: echo "your-token" > ./secrets/openclaw_gateway_token
+# Files should be chmod 600 and NOT committed to version control.
+secrets:
+  openclaw_gateway_token:
+    file: ${OPENCLAW_SECRETS_DIR:-./secrets}/openclaw_gateway_token
+  claude_ai_session_key:
+    file: ${OPENCLAW_SECRETS_DIR:-./secrets}/claude_ai_session_key
+  claude_web_session_key:
+    file: ${OPENCLAW_SECRETS_DIR:-./secrets}/claude_web_session_key
+  claude_web_cookie:
+    file: ${OPENCLAW_SECRETS_DIR:-./secrets}/claude_web_cookie

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # docker-entrypoint.sh
 #
 # Load Docker secrets from /run/secrets/ into environment variables.
@@ -16,12 +16,14 @@ load_secret() {
   local secret_file="$2"
 
   # Skip if the variable is already set
-  if [ -n "$(eval echo "\$$env_name")" ]; then
+  if printenv "$env_name" >/dev/null 2>&1; then
     return
   fi
 
-  if [ -f "$secret_file" ]; then
-    export "$env_name"="$(cat "$secret_file")"
+  if [ -f "$secret_file" ] && [ -r "$secret_file" ]; then
+    if ! export "$env_name"="$(cat "$secret_file")"; then
+      echo "Warning: Failed to load secret from $secret_file" >&2
+    fi
   fi
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# docker-entrypoint.sh
+#
+# Load Docker secrets from /run/secrets/ into environment variables.
+# Falls back to direct environment variables for backward compatibility.
+#
+# Secret file naming convention:
+#   /run/secrets/openclaw_gateway_token -> OPENCLAW_GATEWAY_TOKEN
+#   /run/secrets/claude_ai_session_key -> CLAUDE_AI_SESSION_KEY
+#
+# Only exports a variable if it is not already set in the environment,
+# so direct env vars always take precedence.
+
+load_secret() {
+  local env_name="$1"
+  local secret_file="$2"
+
+  # Skip if the variable is already set
+  if [ -n "$(eval echo "\$$env_name")" ]; then
+    return
+  fi
+
+  if [ -f "$secret_file" ]; then
+    export "$env_name"="$(cat "$secret_file")"
+  fi
+}
+
+# Map Docker secrets to environment variables
+load_secret "OPENCLAW_GATEWAY_TOKEN" "/run/secrets/openclaw_gateway_token"
+load_secret "OPENCLAW_GATEWAY_PASSWORD" "/run/secrets/openclaw_gateway_password"
+load_secret "CLAUDE_AI_SESSION_KEY" "/run/secrets/claude_ai_session_key"
+load_secret "CLAUDE_WEB_SESSION_KEY" "/run/secrets/claude_web_session_key"
+load_secret "CLAUDE_WEB_COOKIE" "/run/secrets/claude_web_cookie"
+load_secret "OPENAI_API_KEY" "/run/secrets/openai_api_key"
+load_secret "ANTHROPIC_API_KEY" "/run/secrets/anthropic_api_key"
+load_secret "GEMINI_API_KEY" "/run/secrets/gemini_api_key"
+
+# Execute the original command
+exec "$@"


### PR DESCRIPTION
## Summary
- Use Docker secrets for sensitive credentials (session keys, tokens, cookies)
- Add `docker-entrypoint.sh` that reads from `/run/secrets/` and exports as env vars
- Update `docker-compose.yml` with secrets section pointing to local files
- Update `Dockerfile` with entrypoint
- Backward compatible: direct env vars still override Docker secrets

## Security Impact
Prevents credential exposure in `docker-compose.yml`, `docker inspect` output, and `/proc/<pid>/environ`.

## Migration
1. Create a `./secrets/` directory (chmod 700)
2. Write each credential to its own file: `echo "your-token" > ./secrets/openclaw_gateway_token`
3. Set file permissions: `chmod 600 ./secrets/*`
4. Optionally set `OPENCLAW_SECRETS_DIR` to customize the secrets directory

## Test plan
- [ ] Test Docker secrets flow with sample secrets files
- [ ] Verify backward compatibility with direct env vars
- [ ] Test container startup with both approaches

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates sensitive Docker environment variables to Docker secrets, improving security by preventing credential exposure in `docker inspect` output and process environments. The implementation adds a shell entrypoint that loads secrets from `/run/secrets/` and falls back to environment variables for backward compatibility.

**Key changes:**
- Added `docker-entrypoint.sh` to load 8 secrets into env vars with fallback logic
- Updated `docker-compose.yml` to use Docker secrets (but only defines 4 of the 8 secrets the entrypoint expects)
- Modified `Dockerfile` to set the entrypoint

**Issues found:**
- **Critical mismatch**: entrypoint loads 8 secrets but compose only defines 4 (`openclaw_gateway_password`, `openai_api_key`, `anthropic_api_key`, `gemini_api_key` are missing)
- **Security gap**: `secrets/` directory not in `.gitignore` - users following migration instructions could accidentally commit credentials
- **Shell compatibility**: script uses `local` keyword (bash-specific) but has `#!/bin/sh` shebang
- **Code injection risk**: `eval` usage in the entrypoint could be replaced with safer `printenv`

<h3>Confidence Score: 2/5</h3>

- This PR has critical issues that will cause runtime failures and potential security gaps
- The mismatch between secrets defined in docker-compose.yml (4 secrets) and secrets loaded in the entrypoint (8 secrets) will cause container startup failures. The missing .gitignore entry creates a risk of accidental credential exposure. The eval usage and shell compatibility issues need fixing before merge.
- All three files need attention: docker-compose.yml needs 4 additional secret definitions, .gitignore needs the secrets/ directory pattern, and docker-entrypoint.sh needs safer variable checking and correct shebang

<sub>Last reviewed commit: 3a446be</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->