### PR TITLE
security: strengthen CSRF protection with SameSite cookies

### DIFF
--- a/src/browser/csrf.ts
+++ b/src/browser/csrf.ts
@@ -61,7 +61,10 @@ export function shouldRejectBrowserMutation(params: {
  */
 export function enforceSameSiteCookies(res: Response): void {
   const originalSetHeader = res.setHeader.bind(res);
-  res.setHeader = function patchedSetHeader(name: string, value: unknown) {
+  res.setHeader = function patchedSetHeader(
+    name: string,
+    value: string | number | readonly string[],
+  ) {
     if (name.toLowerCase() === "set-cookie") {
       const cookies = Array.isArray(value) ? value : [String(value)];
       const patched = cookies.map((cookie: string) => {

--- a/src/browser/csrf.ts
+++ b/src/browser/csrf.ts
@@ -54,12 +54,37 @@ export function shouldRejectBrowserMutation(params: {
   return false;
 }
 
+/**
+ * Apply SameSite=Strict attribute to Set-Cookie headers on the response.
+ * This prevents the browser from sending cookies on cross-site requests,
+ * providing an additional CSRF defense layer.
+ */
+export function enforceSameSiteCookies(res: Response): void {
+  const originalSetHeader = res.setHeader.bind(res);
+  res.setHeader = function patchedSetHeader(name: string, value: unknown) {
+    if (name.toLowerCase() === "set-cookie") {
+      const cookies = Array.isArray(value) ? value : [String(value)];
+      const patched = cookies.map((cookie: string) => {
+        if (!/samesite=/i.test(cookie)) {
+          return `${cookie}; SameSite=Strict`;
+        }
+        return cookie;
+      });
+      return originalSetHeader(name, patched);
+    }
+    return originalSetHeader(name, value);
+  } as typeof res.setHeader;
+}
+
 export function browserMutationGuardMiddleware(): (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => void {
   return (req: Request, res: Response, next: NextFunction) => {
+    // Enforce SameSite=Strict on all cookies set by the response.
+    enforceSameSiteCookies(res);
+
     // OPTIONS is used for CORS preflight. Even if cross-origin, the preflight isn't mutating.
     const method = (req.method || "").trim().toUpperCase();
     if (method === "OPTIONS") {
@@ -78,7 +103,10 @@ export function browserMutationGuardMiddleware(): (
         secFetchSite,
       })
     ) {
-      res.status(403).send("Forbidden");
+      res.status(403).json({
+        error: "Forbidden",
+        message: "Cross-site mutation rejected by CSRF guard",
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Enforce `SameSite=Strict` attribute on all `Set-Cookie` headers via response patching
- Return structured JSON error response on CSRF rejection instead of plain text
- Maintain existing Origin/Referer/Sec-Fetch-Site validation

## Security Impact
Adds defense-in-depth against CSRF by ensuring cookies are never sent on cross-site requests, even if the Origin/Referer checks are somehow bypassed.

## Test plan
- [x] Existing CSRF tests still pass (shouldRejectBrowserMutation)
- [ ] Verify SameSite=Strict is appended to Set-Cookie headers
- [ ] Verify JSON error response on CSRF rejection

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `SameSite=Strict` to all cookies and converts CSRF rejection response from plain text to JSON. The `enforceSameSiteCookies` function monkey-patches the response's `setHeader` method to automatically append `SameSite=Strict` to any `Set-Cookie` headers that don't already have a `SameSite` attribute. This provides defense-in-depth against CSRF attacks by ensuring cookies are never sent on cross-site requests, complementing the existing Origin/Referer/Sec-Fetch-Site validation.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The changes implement defense-in-depth security improvements without breaking existing functionality. The `SameSite=Strict` enforcement is backward-compatible (only adds the attribute if missing), and the JSON error response is a minor API improvement. The monkey-patching approach is localized to each request's response object and is a standard pattern for Express middleware. Existing tests for `shouldRejectBrowserMutation` still pass, validating that core CSRF logic remains intact.
- No files require special attention

<sub>Last reviewed commit: 8e471a5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->