### PR TITLE
feat: add timeout and exponential backoff retry for frontend API calls

### DIFF
--- a/ui/src/ui/resilient-fetch.test.ts
+++ b/ui/src/ui/resilient-fetch.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resilientFetch } from "./resilient-fetch.ts";
+
+describe("resilient-fetch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns successful response on first attempt", async () => {
+    const mockResponse = new Response("ok", { status: 200 });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(mockResponse);
+
+    const result = await resilientFetch("https://example.com");
+    expect(result.status).toBe(200);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on 4xx client errors", async () => {
+    const mockResponse = new Response("bad request", { status: 400 });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse);
+
+    const result = await resilientFetch("https://example.com", undefined, {
+      maxAttempts: 3,
+      baseDelayMs: 10,
+    });
+    expect(result.status).toBe(400);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 5xx server errors", async () => {
+    const error500 = new Response("error", { status: 500 });
+    const ok200 = new Response("ok", { status: 200 });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(error500)
+      .mockResolvedValueOnce(ok200);
+
+    const promise = resilientFetch("https://example.com", undefined, {
+      maxAttempts: 3,
+      baseDelayMs: 100,
+    });
+
+    // Advance timer to trigger retry
+    await vi.advanceTimersByTimeAsync(200);
+
+    const result = await promise;
+    expect(result.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on network errors", async () => {
+    const ok200 = new Response("ok", { status: 200 });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(ok200);
+
+    const promise = resilientFetch("https://example.com", undefined, {
+      maxAttempts: 3,
+      baseDelayMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+
+    const result = await promise;
+    expect(result.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after exhausting all retries", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const promise = resilientFetch("https://example.com", undefined, {
+      maxAttempts: 2,
+      baseDelayMs: 50,
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(promise).rejects.toThrow("Failed to fetch");
+  });
+});

--- a/ui/src/ui/resilient-fetch.ts
+++ b/ui/src/ui/resilient-fetch.ts
@@ -1,0 +1,113 @@
+/**
+ * Resilient fetch wrapper with timeout and exponential backoff retry.
+ *
+ * - Configurable timeout via AbortController (default: 30s)
+ * - Exponential backoff retry with jitter (default: 3 attempts)
+ * - Only retries on network errors and 5xx server responses
+ * - 4xx client errors are NOT retried (they indicate a client-side issue)
+ */
+
+export interface RetryConfig {
+  /** Maximum number of attempts (including the initial request).  @default 3 */
+  maxAttempts?: number;
+  /** Base delay in milliseconds before the first retry.          @default 1000 */
+  baseDelayMs?: number;
+  /** Maximum delay cap in milliseconds.                          @default 10000 */
+  maxDelayMs?: number;
+  /** Request timeout in milliseconds.                            @default 30000 */
+  timeoutMs?: number;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 1000;
+const DEFAULT_MAX_DELAY_MS = 10000;
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/** Calculate delay with exponential backoff and jitter. */
+function calculateDelay(attempt: number, baseMs: number, maxMs: number): number {
+  // Exponential: baseMs * 2^attempt
+  const exponential = baseMs * Math.pow(2, attempt);
+  // Add jitter: 0-50% of the exponential value
+  const jitter = exponential * Math.random() * 0.5;
+  return Math.min(exponential + jitter, maxMs);
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status >= 500 && status < 600;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch with timeout and exponential backoff retry.
+ *
+ * @param input  - Fetch input (URL string or Request)
+ * @param init   - Fetch init options
+ * @param config - Retry and timeout configuration
+ * @returns The fetch Response (from the last successful or final attempt)
+ */
+export async function resilientFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  config?: RetryConfig,
+): Promise<Response> {
+  const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const baseDelayMs = config?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const maxDelayMs = config?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const timeoutMs = config?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    // Merge caller's signal with our timeout signal
+    const callerSignal = init?.signal;
+    if (callerSignal?.aborted) {
+      clearTimeout(timeoutId);
+      throw callerSignal.reason ?? new DOMException("Aborted", "AbortError");
+    }
+
+    const onCallerAbort = () => controller.abort(callerSignal?.reason);
+    callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
+
+    try {
+      const response = await fetch(input, {
+        ...init,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+
+      // Don't retry client errors (4xx)
+      if (!isRetryableStatus(response.status)) {
+        return response;
+      }
+
+      // 5xx - retry if we have attempts left
+      lastError = new Error(`Server error: ${response.status} ${response.statusText}`);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+
+      // Don't retry if the caller explicitly aborted
+      if (callerSignal?.aborted) {
+        throw err;
+      }
+
+      lastError = err;
+    }
+
+    // Wait before retrying (except on the last attempt)
+    if (attempt < maxAttempts - 1) {
+      const delay = calculateDelay(attempt, baseDelayMs, maxDelayMs);
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
## Summary
- Add `resilientFetch()` wrapper (`ui/src/ui/resilient-fetch.ts`)
- Configurable timeout via AbortController (default: 30s)
- Exponential backoff retry with jitter (default: 3 attempts, 1-10s delay)
- Only retries on network errors and 5xx server responses
- 4xx client errors are NOT retried
- Respects caller's AbortSignal

## Test plan
- [x] Unit tests for successful first attempt
- [x] Test 4xx errors are not retried
- [x] Test 5xx errors trigger retry
- [x] Test network errors trigger retry
- [x] Test exhausted retries throw

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `resilientFetch()` wrapper with timeout and exponential backoff retry for frontend API calls. The implementation correctly handles timeouts (30s default), implements exponential backoff with jitter, and appropriately distinguishes between retryable (5xx, network errors) and non-retryable (4xx) failures. The AbortSignal merging logic properly respects caller aborts.

**Issues found:**
- Critical: when 5xx retries are exhausted, throws `Error` instead of returning the final `Response`, preventing callers from inspecting status/body
- Missing test coverage for exhausted 5xx retries scenario

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the 5xx response handling issue
- The implementation is well-structured with solid retry logic and signal handling, but has a logical issue where 5xx responses aren't properly returned after retry exhaustion. This could break error handling in production.
- Pay close attention to `ui/src/ui/resilient-fetch.ts` lines 91-92 and 112 for the response handling fix

<sub>Last reviewed commit: a72c5e7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->