### PR TITLE
fix: schedule nextWakeAtMs for isolated sessionTarget cron jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1035,6 +1035,7 @@ Docs: https://docs.openclaw.ai
 - Feishu: detect bot mentions in post messages with embedded docs when `message.mentions` is empty. (#18074) Thanks @popomore.
 - Agents/Sessions: align session lock watchdog hold windows with run and compaction timeout budgets (plus grace), preventing valid long-running turns from being force-unlocked mid-run while still recovering hung lock owners. (#18060)
 - Cron: preserve default model fallbacks for cron agent runs when only `model.primary` is overridden, so failover still follows configured fallbacks unless explicitly cleared with `fallbacks: []`. (#18210) Thanks @mahsumaktas.
+- Cron/Isolation: treat non-finite `nextRunAtMs` as missing and repair isolated `every` anchor fallback so legacy jobs without valid timestamps self-heal and scheduler wake timing remains valid. (#19469) Thanks @guirguispierre.
 - Cron: route text-only announce output through the main session announce flow via runSubagentAnnounceFlow so cron text-only output remains visible to the initiating session. Thanks @tyler6204.
 - Cron: treat `timeoutSeconds: 0` as no-timeout (not clamped to 1), ensuring long-running cron runs are not prematurely terminated. Thanks @tyler6204.
 - Cron announce injection now targets the session determined by delivery config (`to` + channel) instead of defaulting to the current session. Thanks @tyler6204.

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -63,15 +63,22 @@ function computeStaggeredCronNextRunAtMs(job: CronJob, nowMs: number) {
   return undefined;
 }
 
+function isFiniteTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
 function resolveEveryAnchorMs(params: {
   schedule: { everyMs: number; anchorMs?: number };
   fallbackAnchorMs: number;
 }) {
   const raw = params.schedule.anchorMs;
-  if (typeof raw === "number" && Number.isFinite(raw)) {
+  if (isFiniteTimestamp(raw)) {
     return Math.max(0, Math.floor(raw));
   }
-  return Math.max(0, Math.floor(params.fallbackAnchorMs));
+  if (isFiniteTimestamp(params.fallbackAnchorMs)) {
+    return Math.max(0, Math.floor(params.fallbackAnchorMs));
+  }
+  return 0;
 }
 
 export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "payload">) {
@@ -144,11 +151,13 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
         return nextFromLastRun;
       }
     }
+    const fallbackAnchorMs = isFiniteTimestamp(job.createdAtMs) ? job.createdAtMs : nowMs;
     const anchorMs = resolveEveryAnchorMs({
       schedule: job.schedule,
-      fallbackAnchorMs: job.createdAtMs,
+      fallbackAnchorMs,
     });
-    return computeNextRunAtMs({ ...job.schedule, everyMs, anchorMs }, nowMs);
+    const next = computeNextRunAtMs({ ...job.schedule, everyMs, anchorMs }, nowMs);
+    return isFiniteTimestamp(next) ? next : undefined;
   }
   if (job.schedule.kind === "at") {
     // One-shot jobs stay due until they successfully finish.
@@ -167,14 +176,14 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
           : typeof schedule.at === "string"
             ? parseAbsoluteTimeMs(schedule.at)
             : null;
-    return atMs !== null ? atMs : undefined;
+    return atMs !== null && Number.isFinite(atMs) ? atMs : undefined;
   }
   const next = computeStaggeredCronNextRunAtMs(job, nowMs);
   if (next === undefined && job.schedule.kind === "cron") {
     const nextSecondMs = Math.floor(nowMs / 1000) * 1000 + 1000;
     return computeStaggeredCronNextRunAtMs(job, nextSecondMs);
   }
-  return next;
+  return isFiniteTimestamp(next) ? next : undefined;
 }
 
 /** Maximum consecutive schedule errors before auto-disabling a job. */
@@ -231,6 +240,11 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
       changed = true;
     }
     return { changed, skip: true };
+  }
+
+  if (!isFiniteTimestamp(job.state.nextRunAtMs) && job.state.nextRunAtMs !== undefined) {
+    job.state.nextRunAtMs = undefined;
+    changed = true;
   }
 
   const runningAt = job.state.runningAtMs;
@@ -298,7 +312,7 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
     // Preserving a still-future nextRunAtMs avoids accidentally advancing
     // a job that hasn't fired yet (e.g. during restart recovery).
     const nextRun = job.state.nextRunAtMs;
-    const isDueOrMissing = nextRun === undefined || now >= nextRun;
+    const isDueOrMissing = !isFiniteTimestamp(nextRun) || now >= nextRun;
     if (isDueOrMissing) {
       if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
         changed = true;
@@ -321,7 +335,7 @@ export function recomputeNextRunsForMaintenance(state: CronServiceState): boolea
     // Only compute missing nextRunAtMs, do NOT recompute existing ones.
     // If a job was past-due but not found by findDueJobs, recomputing would
     // cause it to be silently skipped.
-    if (job.state.nextRunAtMs === undefined) {
+    if (!isFiniteTimestamp(job.state.nextRunAtMs)) {
       if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
         changed = true;
       }
@@ -332,13 +346,13 @@ export function recomputeNextRunsForMaintenance(state: CronServiceState): boolea
 
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
-  const enabled = jobs.filter((j) => j.enabled && typeof j.state.nextRunAtMs === "number");
+  const enabled = jobs.filter((j) => j.enabled && isFiniteTimestamp(j.state.nextRunAtMs));
   if (enabled.length === 0) {
     return undefined;
   }
   return enabled.reduce(
-    (min, j) => Math.min(min, j.state.nextRunAtMs as number),
-    enabled[0].state.nextRunAtMs as number,
+    (min, j) => Math.min(min, j.state.nextRunAtMs),
+    enabled[0].state.nextRunAtMs,
   );
 }
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -350,10 +350,14 @@ export function nextWakeAtMs(state: CronServiceState) {
   if (enabled.length === 0) {
     return undefined;
   }
-  return enabled.reduce(
-    (min, j) => Math.min(min, j.state.nextRunAtMs),
-    enabled[0].state.nextRunAtMs,
-  );
+  const first = enabled[0]?.state.nextRunAtMs;
+  if (!isFiniteTimestamp(first)) {
+    return undefined;
+  }
+  return enabled.reduce((min, j) => {
+    const next = j.state.nextRunAtMs;
+    return isFiniteTimestamp(next) ? Math.min(min, next) : min;
+  }, first);
 }
 
 export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -255,8 +255,7 @@ export function armTimer(state: CronServiceState) {
           j.enabled &&
           typeof j.state.nextRunAtMs === "number" &&
           Number.isFinite(j.state.nextRunAtMs),
-      )
-        .length ?? 0;
+      ).length ?? 0;
     state.deps.log.debug(
       { jobCount, enabledCount, withNextRun },
       "cron: armTimer skipped - no jobs with nextRunAtMs",

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -250,7 +250,12 @@ export function armTimer(state: CronServiceState) {
     const jobCount = state.store?.jobs.length ?? 0;
     const enabledCount = state.store?.jobs.filter((j) => j.enabled).length ?? 0;
     const withNextRun =
-      state.store?.jobs.filter((j) => j.enabled && typeof j.state.nextRunAtMs === "number")
+      state.store?.jobs.filter(
+        (j) =>
+          j.enabled &&
+          typeof j.state.nextRunAtMs === "number" &&
+          Number.isFinite(j.state.nextRunAtMs),
+      )
         .length ?? 0;
     state.deps.log.debug(
       { jobCount, enabledCount, withNextRun },
@@ -476,7 +481,7 @@ function isRunnableJob(params: {
     return false;
   }
   const next = job.state.nextRunAtMs;
-  return typeof next === "number" && nowMs >= next;
+  return typeof next === "number" && Number.isFinite(next) && nowMs >= next;
 }
 
 function collectRunnableJobs(


### PR DESCRIPTION
## Summary
- repair cron scheduling when jobs carry non-finite `nextRunAtMs` values so the timer can arm and `nextWakeAtMs` is populated
- harden `every` schedule anchor fallback to use `nowMs` when external registrations omit `createdAtMs`
- treat invalid `nextRunAtMs` as missing during maintenance recompute so isolated jobs self-heal instead of silently stalling
- add a regression test covering isolated `every` jobs loaded without `createdAtMs`

## Testing
- `pnpm vitest run src/cron/service.issue-regressions.test.ts src/cron/service.every-jobs-fire.test.ts src/cron/service.issue-16156-list-skips-cron.test.ts src/cron/service.rearm-timer-when-running.test.ts src/cron/service.prevents-duplicate-timers.test.ts --config vitest.unit.config.ts`
- `pnpm vitest run src/cron/service/jobs.schedule-error-isolation.test.ts --config vitest.unit.config.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/gateway/server.cron.e2e.test.ts`

Fixes #19469

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed cron scheduling for isolated jobs with non-finite timestamp values

This PR addresses an issue where isolated `sessionTarget` cron jobs could have invalid (non-finite) `nextRunAtMs` values, preventing the timer from arming properly and causing jobs to stall silently.

**Key Changes:**
- Added `isFiniteTimestamp()` type guard for consistent finite number validation across the cron service
- Hardened `resolveEveryAnchorMs()` to fall back to `0` when both `anchorMs` and `fallbackAnchorMs` are non-finite, ensuring `every` schedules can always compute a valid anchor
- Modified `computeJobNextRunAtMs()` to validate all return paths and only return finite timestamps or `undefined`
- Added cleanup logic in `normalizeJobTickState()` to treat non-finite `nextRunAtMs` as missing during maintenance passes
- Updated `nextWakeAtMs()` and `armTimer()` to filter out jobs with non-finite timestamps
- Added regression test covering isolated jobs missing `createdAtMs` that validates self-healing behavior

The fix ensures legacy jobs with invalid timestamps self-heal on next service start and prevents future invalid values from propagating through the scheduling system.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are defensive additions that make the cron scheduler more robust. All modifications add validation guards without changing core scheduling logic. The fix includes comprehensive test coverage for the regression case and the implementation consistently applies `Number.isFinite()` checks across all relevant code paths.
- No files require special attention

<sub>Last reviewed commit: 052b306</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->