### PR TITLE
security: sandbox dynamic import in hook transforms with symlink validation

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -353,7 +353,12 @@ async function loadTransform(transform: HookMappingTransformResolved): Promise<H
       throw new Error(`hook transforms directory not found: ${transform.containingDir}`);
     }
     const relative = path.relative(realContainingDir, realModulePath);
-    if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    if (
+      !relative ||
+      relative === ".." ||
+      relative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relative)
+    ) {
       throw new Error(
         `hook transform module escapes transforms directory via symlink: ${transform.modulePath}`,
       );


### PR DESCRIPTION
## Summary
- Add `fs.realpathSync()` validation before `import()` in `loadTransform`
- After resolving symlinks, re-validate that the real path stays within the transforms directory
- Pass `containingDir` in `HookMappingTransformResolved` for post-symlink containment checks
- Complements the existing `resolveContainedPath` pre-check with a runtime symlink guard

## Security Impact
Prevents symlink-based escapes where a symbolic link inside the transforms directory could point to arbitrary code on the filesystem, bypassing the existing path traversal checks.

## Test plan
- [x] Existing path traversal tests still pass
- [ ] Test symlink outside transforms directory is rejected
- [ ] Verify legitimate transform modules still load correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

added symlink validation in `loadTransform` to prevent path traversal attacks where a symbolic link inside the transforms directory could point to arbitrary filesystem locations

**Key changes:**
- imports `fs` for `realpathSync()` calls
- added `containingDir` field to `HookMappingTransformResolved` type to track the transforms directory
- before dynamic `import()`, resolves symlinks for both module path and containing directory
- validates that the real module path stays within the real containing directory using `path.relative()`

**Issues found:**
- critical logic bug in the containment check at line 354-355 that allows symlink escape when the symlink points to the containing directory itself (empty relative path bypasses all conditions)

<h3>Confidence Score: 1/5</h3>

- This PR contains a critical security bug that undermines the symlink protection it's trying to add
- the containment validation at lines 354-355 has a logic error where an empty relative path (when symlink points to the containing directory itself) bypasses all security checks, allowing attackers to escape the transforms directory and execute arbitrary code from the filesystem. This completely defeats the purpose of the security fix.
- Pay close attention to `src/gateway/hooks-mapping.ts` lines 354-355 - the containment check logic is incorrect

<sub>Last reviewed commit: 4729df3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->