### PR TITLE
security: add encrypted localStorage wrapper using Web Crypto API

### DIFF
--- a/ui/src/ui/secure-storage.test.ts
+++ b/ui/src/ui/secure-storage.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { secureGet, secureRemove, secureSet } from "./secure-storage.ts";
+
+describe("secure-storage", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("encrypts and decrypts a value round-trip", async () => {
+    await secureSet("test-key", "secret-value");
+    const result = await secureGet("test-key");
+    expect(result).toBe("secret-value");
+  });
+
+  it("stores values with enc: prefix", async () => {
+    await secureSet("test-key", "hello");
+    const raw = localStorage.getItem("test-key");
+    expect(raw).not.toBeNull();
+    expect(raw!.startsWith("enc:")).toBe(true);
+  });
+
+  it("returns null for missing keys", async () => {
+    const result = await secureGet("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("handles unencrypted values gracefully (migration)", async () => {
+    localStorage.setItem("legacy-key", "plain-value");
+    const result = await secureGet("legacy-key");
+    expect(result).toBe("plain-value");
+  });
+
+  it("removes values", async () => {
+    await secureSet("remove-me", "value");
+    secureRemove("remove-me");
+    const result = await secureGet("remove-me");
+    expect(result).toBeNull();
+  });
+
+  it("handles empty string values", async () => {
+    await secureSet("empty", "");
+    const result = await secureGet("empty");
+    expect(result).toBe("");
+  });
+
+  it("handles unicode values", async () => {
+    const unicode = "日本語テスト 🔑🔒";
+    await secureSet("unicode-key", unicode);
+    const result = await secureGet("unicode-key");
+    expect(result).toBe(unicode);
+  });
+
+  it("produces different ciphertexts for same value (random IV)", async () => {
+    await secureSet("key1", "same-value");
+    const ct1 = localStorage.getItem("key1");
+    localStorage.removeItem("key1");
+    await secureSet("key1", "same-value");
+    const ct2 = localStorage.getItem("key1");
+    // Different IVs should produce different ciphertexts
+    expect(ct1).not.toBe(ct2);
+  });
+});

--- a/ui/src/ui/secure-storage.ts
+++ b/ui/src/ui/secure-storage.ts
@@ -1,0 +1,124 @@
+/**
+ * Encrypted localStorage wrapper using Web Crypto API.
+ *
+ * Provides AES-GCM encryption for sensitive values stored in the browser.
+ * The encryption key is derived from a stable origin-based fingerprint
+ * using PBKDF2, so the same browser+origin always produces the same key.
+ *
+ * Graceful migration: if a value cannot be decrypted (e.g., it was stored
+ * before encryption was enabled), the raw value is returned and
+ * transparently re-encrypted on the next write.
+ */
+
+const SALT_KEY = "openclaw.secure-storage.salt";
+const KEY_ALGO = "AES-GCM";
+const KEY_LENGTH = 256;
+const PBKDF2_ITERATIONS = 100_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getOrCreateSalt(): Uint8Array {
+  const existing = localStorage.getItem(SALT_KEY);
+  if (existing) {
+    return Uint8Array.from(atob(existing), (c) => c.charCodeAt(0));
+  }
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  localStorage.setItem(SALT_KEY, btoa(String.fromCharCode(...salt)));
+  return salt;
+}
+
+/** Derive a stable encryption key from origin + user-agent. */
+async function deriveKey(): Promise<CryptoKey> {
+  const fingerprint = `${location.origin}|${navigator.userAgent}`;
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(fingerprint),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  const salt = getOrCreateSalt();
+  return crypto.subtle.deriveKey(
+    { name: "PBKDF2", salt, iterations: PBKDF2_ITERATIONS, hash: "SHA-256" },
+    keyMaterial,
+    { name: KEY_ALGO, length: KEY_LENGTH },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+let cachedKey: CryptoKey | null = null;
+
+async function getKey(): Promise<CryptoKey> {
+  if (!cachedKey) {
+    cachedKey = await deriveKey();
+  }
+  return cachedKey;
+}
+
+async function encrypt(plaintext: string): Promise<string> {
+  const key = await getKey();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(plaintext);
+  const ciphertext = await crypto.subtle.encrypt({ name: KEY_ALGO, iv }, key, encoded);
+  // Store as: base64(iv) + "." + base64(ciphertext)
+  const ivB64 = btoa(String.fromCharCode(...iv));
+  const ctB64 = btoa(String.fromCharCode(...new Uint8Array(ciphertext)));
+  return `enc:${ivB64}.${ctB64}`;
+}
+
+async function decrypt(stored: string): Promise<string> {
+  if (!stored.startsWith("enc:")) {
+    // Not encrypted – return raw value (migration path)
+    return stored;
+  }
+  const key = await getKey();
+  const [ivB64, ctB64] = stored.slice(4).split(".");
+  if (!ivB64 || !ctB64) {
+    throw new Error("malformed encrypted value");
+  }
+  const iv = Uint8Array.from(atob(ivB64), (c) => c.charCodeAt(0));
+  const ciphertext = Uint8Array.from(atob(ctB64), (c) => c.charCodeAt(0));
+  const plainBuffer = await crypto.subtle.decrypt({ name: KEY_ALGO, iv }, key, ciphertext);
+  return new TextDecoder().decode(plainBuffer);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Store a value encrypted in localStorage.
+ */
+export async function secureSet(key: string, value: string): Promise<void> {
+  const encrypted = await encrypt(value);
+  localStorage.setItem(key, encrypted);
+}
+
+/**
+ * Read and decrypt a value from localStorage.
+ * Returns null if the key doesn't exist.
+ * If the value cannot be decrypted, returns the raw value (migration).
+ */
+export async function secureGet(key: string): Promise<string | null> {
+  const raw = localStorage.getItem(key);
+  if (raw === null) {
+    return null;
+  }
+  try {
+    return await decrypt(raw);
+  } catch {
+    // Graceful migration: return raw unencrypted value
+    return raw;
+  }
+}
+
+/**
+ * Remove a value from localStorage.
+ */
+export function secureRemove(key: string): void {
+  localStorage.removeItem(key);
+}

--- a/ui/src/ui/secure-storage.ts
+++ b/ui/src/ui/secure-storage.ts
@@ -2,50 +2,100 @@
  * Encrypted localStorage wrapper using Web Crypto API.
  *
  * Provides AES-GCM encryption for sensitive values stored in the browser.
- * The encryption key is derived from a stable origin-based fingerprint
- * using PBKDF2, so the same browser+origin always produces the same key.
+ * The encryption key is a non-extractable CryptoKey generated once and
+ * persisted in IndexedDB, so it survives page reloads but never leaves
+ * the browser's crypto sandbox.
  *
- * Graceful migration: if a value cannot be decrypted (e.g., it was stored
- * before encryption was enabled), the raw value is returned and
- * transparently re-encrypted on the next write.
+ * Graceful migration: if a value was stored before encryption was enabled
+ * (i.e. it does NOT carry the "enc:" prefix), it is returned as-is and
+ * will be re-encrypted on the next write.
+ *
+ * If decryption of an "enc:"-prefixed value fails (corrupt data, key
+ * rotation, etc.), the entry is treated as lost and null is returned
+ * rather than leaking ciphertext to callers.
  */
 
-const SALT_KEY = "openclaw.secure-storage.salt";
+const DB_NAME = "openclaw-secure-storage";
+const DB_STORE = "keys";
+const DB_KEY_ID = "master";
 const KEY_ALGO = "AES-GCM";
 const KEY_LENGTH = 256;
-const PBKDF2_ITERATIONS = 100_000;
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Base64 helpers – safe for arbitrarily large buffers
 // ---------------------------------------------------------------------------
 
-function getOrCreateSalt(): Uint8Array {
-  const existing = localStorage.getItem(SALT_KEY);
-  if (existing) {
-    return Uint8Array.from(atob(existing), (c) => c.charCodeAt(0));
+function bytesToBase64(bytes: Uint8Array): string {
+  const chunks: string[] = [];
+  // Process 8 KiB at a time to avoid exceeding the max call-stack size
+  // that `String.fromCharCode(...spread)` hits at ~48 KiB.
+  const CHUNK = 8192;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, i + CHUNK);
+    let binary = "";
+    for (let j = 0; j < slice.length; j++) {
+      binary += String.fromCharCode(slice[j]);
+    }
+    chunks.push(binary);
   }
-  const salt = crypto.getRandomValues(new Uint8Array(16));
-  localStorage.setItem(SALT_KEY, btoa(String.fromCharCode(...salt)));
-  return salt;
+  return btoa(chunks.join(""));
 }
 
-/** Derive a stable encryption key from origin + user-agent. */
-async function deriveKey(): Promise<CryptoKey> {
-  const fingerprint = `${location.origin}|${navigator.userAgent}`;
-  const encoder = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(fingerprint),
-    "PBKDF2",
-    false,
-    ["deriveKey"],
-  );
-  const salt = getOrCreateSalt();
-  return crypto.subtle.deriveKey(
-    { name: "PBKDF2", salt, iterations: PBKDF2_ITERATIONS, hash: "SHA-256" },
-    keyMaterial,
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// IndexedDB key persistence
+// ---------------------------------------------------------------------------
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(DB_STORE)) {
+        db.createObjectStore(DB_STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function idbGet(db: IDBDatabase, key: string): Promise<CryptoKey | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DB_STORE, "readonly");
+    const store = tx.objectStore(DB_STORE);
+    const req = store.get(key);
+    req.onsuccess = () => resolve(req.result as CryptoKey | undefined);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function idbPut(db: IDBDatabase, key: string, value: CryptoKey): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DB_STORE, "readwrite");
+    const store = tx.objectStore(DB_STORE);
+    const req = store.put(value, key);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Key management
+// ---------------------------------------------------------------------------
+
+async function generateKey(): Promise<CryptoKey> {
+  return crypto.subtle.generateKey(
     { name: KEY_ALGO, length: KEY_LENGTH },
-    false,
+    false, // non-extractable
     ["encrypt", "decrypt"],
   );
 }
@@ -53,35 +103,58 @@ async function deriveKey(): Promise<CryptoKey> {
 let cachedKey: CryptoKey | null = null;
 
 async function getKey(): Promise<CryptoKey> {
-  if (!cachedKey) {
-    cachedKey = await deriveKey();
+  if (cachedKey) {
+    return cachedKey;
   }
-  return cachedKey;
+
+  const db = await openDb();
+  try {
+    const existing = await idbGet(db, DB_KEY_ID);
+    if (existing) {
+      cachedKey = existing;
+      return existing;
+    }
+    const key = await generateKey();
+    await idbPut(db, DB_KEY_ID, key);
+    cachedKey = key;
+    return key;
+  } finally {
+    db.close();
+  }
 }
+
+// ---------------------------------------------------------------------------
+// Encrypt / decrypt
+// ---------------------------------------------------------------------------
 
 async function encrypt(plaintext: string): Promise<string> {
   const key = await getKey();
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const encoded = new TextEncoder().encode(plaintext);
   const ciphertext = await crypto.subtle.encrypt({ name: KEY_ALGO, iv }, key, encoded);
-  // Store as: base64(iv) + "." + base64(ciphertext)
-  const ivB64 = btoa(String.fromCharCode(...iv));
-  const ctB64 = btoa(String.fromCharCode(...new Uint8Array(ciphertext)));
+  const ivB64 = bytesToBase64(iv);
+  const ctB64 = bytesToBase64(new Uint8Array(ciphertext));
   return `enc:${ivB64}.${ctB64}`;
 }
 
 async function decrypt(stored: string): Promise<string> {
   if (!stored.startsWith("enc:")) {
-    // Not encrypted – return raw value (migration path)
+    // Not encrypted – return raw value (migration path for legacy data)
     return stored;
   }
   const key = await getKey();
-  const [ivB64, ctB64] = stored.slice(4).split(".");
+  const payload = stored.slice(4);
+  const dotIdx = payload.indexOf(".");
+  if (dotIdx === -1) {
+    throw new Error("malformed encrypted value");
+  }
+  const ivB64 = payload.slice(0, dotIdx);
+  const ctB64 = payload.slice(dotIdx + 1);
   if (!ivB64 || !ctB64) {
     throw new Error("malformed encrypted value");
   }
-  const iv = Uint8Array.from(atob(ivB64), (c) => c.charCodeAt(0));
-  const ciphertext = Uint8Array.from(atob(ctB64), (c) => c.charCodeAt(0));
+  const iv = base64ToBytes(ivB64);
+  const ciphertext = base64ToBytes(ctB64);
   const plainBuffer = await crypto.subtle.decrypt({ name: KEY_ALGO, iv }, key, ciphertext);
   return new TextDecoder().decode(plainBuffer);
 }
@@ -100,8 +173,13 @@ export async function secureSet(key: string, value: string): Promise<void> {
 
 /**
  * Read and decrypt a value from localStorage.
- * Returns null if the key doesn't exist.
- * If the value cannot be decrypted, returns the raw value (migration).
+ *
+ * Returns `null` when:
+ * - the key doesn't exist, or
+ * - an `enc:`-prefixed value cannot be decrypted (corrupt / key mismatch).
+ *
+ * Returns the raw plaintext for legacy (non-`enc:`) values so the caller
+ * can transparently re-encrypt on the next write.
  */
 export async function secureGet(key: string): Promise<string | null> {
   const raw = localStorage.getItem(key);
@@ -111,7 +189,13 @@ export async function secureGet(key: string): Promise<string | null> {
   try {
     return await decrypt(raw);
   } catch {
-    // Graceful migration: return raw unencrypted value
+    // If the stored value carries the enc: prefix, decryption genuinely
+    // failed (corrupt data, key rotation, etc.) – treat as lost rather
+    // than leaking ciphertext to the caller.
+    if (raw.startsWith("enc:")) {
+      return null;
+    }
+    // No enc: prefix → legacy unencrypted value (migration path)
     return raw;
   }
 }
@@ -121,4 +205,16 @@ export async function secureGet(key: string): Promise<string | null> {
  */
 export function secureRemove(key: string): void {
   localStorage.removeItem(key);
+}
+
+// ---------------------------------------------------------------------------
+// Testing utilities – only used by test suites
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset the cached key so each test gets a fresh key from IndexedDB.
+ * **Test-only** – never call in production code.
+ */
+export function __resetForTesting(): void {
+  cachedKey = null;
 }


### PR DESCRIPTION
## Summary
- Add `secure-storage.ts` module with AES-GCM encryption for localStorage
- PBKDF2 key derivation from origin + user-agent fingerprint
- Random IV per encryption (no ciphertext reuse)
- Graceful migration: unencrypted values are returned as-is and re-encrypted on next write
- API: `secureSet(key, value)`, `secureGet(key)`, `secureRemove(key)`

## Security Impact
Provides encryption layer for sensitive data (private keys, auth tokens) stored in browser localStorage. Mitigates exposure via DevTools or XSS attacks.

## Test plan
- [x] Encrypt/decrypt round-trip
- [x] enc: prefix verification
- [x] Graceful migration from unencrypted values
- [x] Unicode support
- [x] Random IV produces different ciphertexts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `secure-storage.ts`, an AES-GCM encrypted wrapper for `localStorage` intended to protect sensitive values like private keys and auth tokens. The cryptographic implementation has several serious issues that prevent it from delivering its stated security guarantees.

**Critical issues:**

- **Key material is fully public:** The PBKDF2 "password" is `location.origin + navigator.userAgent`—both are observable in every HTTP request and fully reconstructable by any attacker who can read `localStorage`. Because no secret is involved, the encryption provides no confidentiality. An attacker with XSS or DevTools access can derive the exact key in one PBKDF2 call.

- **User-agent in key material causes silent data loss:** `navigator.userAgent` changes silently on browser updates, OS updates, or across devices. After any such change, a different key is derived, all previously encrypted values become undecryptable, and `secureGet` returns the raw `enc:…` ciphertext blob to callers without error—silently corrupting any credentials or tokens stored here.

- **`secureGet` catch block returns ciphertext as a migration value:** The catch in `secureGet` is only reached when a value with the `enc:` prefix fails to decrypt (the legitimate plaintext-migration path is handled inside `decrypt()` itself without throwing). When decryption fails due to key mismatch or tampering, callers silently receive the raw encrypted string as if it were valid data.

- **`btoa(String.fromCharCode(...new Uint8Array(ciphertext)))` throws for values over ~48 KB:** Spreading all ciphertext bytes as separate function arguments exceeds the JS engine argument limit, producing a hard `RangeError`.

**Additional issues:**

- Module-level `cachedKey` is never reset between tests; the test suite passes coincidentally by reusing a stale key rather than exercising real cross-load behaviour.
- The `enc:` prefix is not cryptographically bound to the ciphertext (not included as AES-GCM AAD), allowing prefix-stripping or prefix-injection attacks.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge: the encryption scheme provides no real confidentiality, and using user-agent as key material will silently destroy stored data on browser updates.
- Two independent critical issues each independently disqualify this PR: (1) the "password" fed to PBKDF2 is fully public so the scheme is effectively obfuscation rather than encryption, and (2) user-agent in key material is a silent data-loss time bomb triggered by routine browser updates. The `secureGet` fallback additionally hides failures from callers, and the `btoa` spread pattern will crash on any non-trivial payload. The module is not yet imported by any other code, so merging it now would ship broken security infrastructure that other PRs could build on.
- Both files need attention: `secure-storage.ts` has fundamental cryptographic design issues, and `secure-storage.test.ts` does not cover the failure modes that would catch them.

<sub>Last reviewed commit: 3759d64</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->