### PR TITLE
refactor: organize app.ts component with section comments

### DIFF
--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -114,6 +114,10 @@ export class OpenClawApp extends LitElement {
       void i18n.setLocale(this.settings.locale);
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Core / Connection state
+  // ---------------------------------------------------------------------------
   @state() password = "";
   @state() tab: Tab = "chat";
   @state() onboarding = resolveOnboardingMode();
@@ -127,10 +131,16 @@ export class OpenClawApp extends LitElement {
   private toolStreamSyncTimer: number | null = null;
   private sidebarCloseTimer: number | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Assistant identity
+  // ---------------------------------------------------------------------------
   @state() assistantName = bootAssistantIdentity.name;
   @state() assistantAvatar = bootAssistantIdentity.avatar;
   @state() assistantAgentId = bootAssistantIdentity.agentId ?? null;
 
+  // ---------------------------------------------------------------------------
+  // Chat state
+  // ---------------------------------------------------------------------------
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;
   @state() chatSending = false;
@@ -153,6 +163,9 @@ export class OpenClawApp extends LitElement {
   @state() sidebarError: string | null = null;
   @state() splitRatio = this.settings.splitRatio;
 
+  // ---------------------------------------------------------------------------
+  // Nodes & Devices state
+  // ---------------------------------------------------------------------------
   @state() nodesLoading = false;
   @state() nodes: Array<Record<string, unknown>> = [];
   @state() devicesLoading = false;
@@ -171,6 +184,9 @@ export class OpenClawApp extends LitElement {
   @state() execApprovalError: string | null = null;
   @state() pendingGatewayUrl: string | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Configuration state
+  // ---------------------------------------------------------------------------
   @state() configLoading = false;
   @state() configRaw = "{\n}\n";
   @state() configRawOriginal = "";
@@ -193,6 +209,9 @@ export class OpenClawApp extends LitElement {
   @state() configActiveSection: string | null = null;
   @state() configActiveSubsection: string | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Channels state (WhatsApp, Nostr, etc.)
+  // ---------------------------------------------------------------------------
   @state() channelsLoading = false;
   @state() channelsSnapshot: ChannelsStatusSnapshot | null = null;
   @state() channelsError: string | null = null;
@@ -204,11 +223,17 @@ export class OpenClawApp extends LitElement {
   @state() nostrProfileFormState: NostrProfileFormState | null = null;
   @state() nostrProfileAccountId: string | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Presence state
+  // ---------------------------------------------------------------------------
   @state() presenceLoading = false;
   @state() presenceEntries: PresenceEntry[] = [];
   @state() presenceError: string | null = null;
   @state() presenceStatus: string | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Agents state
+  // ---------------------------------------------------------------------------
   @state() agentsLoading = false;
   @state() agentsList: AgentsListResult | null = null;
   @state() agentsError: string | null = null;
@@ -230,6 +255,9 @@ export class OpenClawApp extends LitElement {
   @state() agentSkillsReport: SkillStatusReport | null = null;
   @state() agentSkillsAgentId: string | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Sessions state
+  // ---------------------------------------------------------------------------
   @state() sessionsLoading = false;
   @state() sessionsResult: SessionsListResult | null = null;
   @state() sessionsError: string | null = null;
@@ -238,6 +266,9 @@ export class OpenClawApp extends LitElement {
   @state() sessionsIncludeGlobal = true;
   @state() sessionsIncludeUnknown = false;
 
+  // ---------------------------------------------------------------------------
+  // Usage / Analytics state
+  // ---------------------------------------------------------------------------
   @state() usageLoading = false;
   @state() usageResult: import("./types.js").SessionsUsageResult | null = null;
   @state() usageCostSummary: import("./types.js").CostUsageSummary | null = null;
@@ -293,6 +324,9 @@ export class OpenClawApp extends LitElement {
   // Non-reactive (don’t trigger renders just for timer bookkeeping).
   usageQueryDebounceTimer: number | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Cron state
+  // ---------------------------------------------------------------------------
   @state() cronLoading = false;
   @state() cronJobs: CronJob[] = [];
   @state() cronStatus: CronStatus | null = null;
@@ -304,6 +338,9 @@ export class OpenClawApp extends LitElement {
 
   @state() updateAvailable: import("./types.js").UpdateAvailable | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Skills state
+  // ---------------------------------------------------------------------------
   @state() skillsLoading = false;
   @state() skillsReport: SkillStatusReport | null = null;
   @state() skillsError: string | null = null;
@@ -312,6 +349,9 @@ export class OpenClawApp extends LitElement {
   @state() skillsBusyKey: string | null = null;
   @state() skillMessages: Record<string, SkillMessage> = {};
 
+  // ---------------------------------------------------------------------------
+  // Debug state
+  // ---------------------------------------------------------------------------
   @state() debugLoading = false;
   @state() debugStatus: StatusSummary | null = null;
   @state() debugHealth: HealthSnapshot | null = null;
@@ -322,6 +362,9 @@ export class OpenClawApp extends LitElement {
   @state() debugCallResult: string | null = null;
   @state() debugCallError: string | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Logs state
+  // ---------------------------------------------------------------------------
   @state() logsLoading = false;
   @state() logsError: string | null = null;
   @state() logsFile: string | null = null;
@@ -338,6 +381,9 @@ export class OpenClawApp extends LitElement {
   @state() logsMaxBytes = 250_000;
   @state() logsAtBottom = true;
 
+  // ---------------------------------------------------------------------------
+  // Internal / non-reactive state
+  // ---------------------------------------------------------------------------
   client: GatewayBrowserClient | null = null;
   private chatScrollFrame: number | null = null;
   private chatScrollTimeout: number | null = null;
@@ -358,6 +404,9 @@ export class OpenClawApp extends LitElement {
   private themeMediaHandler: ((event: MediaQueryListEvent) => void) | null = null;
   private topbarObserver: ResizeObserver | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
   createRenderRoot() {
     return this;
   }
@@ -380,6 +429,9 @@ export class OpenClawApp extends LitElement {
     handleUpdated(this as unknown as Parameters<typeof handleUpdated>[0], changed);
   }
 
+  // ---------------------------------------------------------------------------
+  // Public methods (delegated to external modules)
+  // ---------------------------------------------------------------------------
   connect() {
     connectGatewayInternal(this as unknown as Parameters<typeof connectGatewayInternal>[0]);
   }


### PR DESCRIPTION
## Summary
- Add clear section markers to the monolithic `OpenClawApp` component (581 lines, ~100 `@state` properties)
- Group state properties into 14 logical sections: Core, Assistant, Chat, Nodes/Devices, Config, Channels, Presence, Agents, Sessions, Usage, Cron, Skills, Debug, Logs

## Motivation
The component is large but already well-modularized (logic lives in `app-chat.ts`, `app-channels.ts`, etc.). The section comments improve navigation and lay groundwork for future extraction into Lit reactive controllers.

## Future refactoring opportunities
- Extract each section into a `ReactiveController` (e.g., `ChatController`, `UsageController`)
- Replace `as unknown as` casts with a shared `AppState` interface
- Consider state management library for cross-component state

## Test plan
- [x] No functional changes - pure comment additions
- [ ] Verify app still builds and renders correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 14 section comment blocks to organize the 581-line `OpenClawApp` component's ~100 `@state` properties into logical groups (Core/Connection, Assistant, Chat, Nodes/Devices, Config, Channels, Presence, Agents, Sessions, Usage, Cron, Skills, Debug, Logs), plus sections for internal state, lifecycle methods, and public methods.

- Pure refactor: zero functional changes, only comment additions
- Improves navigation in a large but already well-modularized component (logic lives in `app-chat.ts`, `app-channels.ts`, etc.)
- Lays groundwork for future extraction into Lit ReactiveControllers

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- Perfect score because this is a pure documentation change with only comment additions - no code logic, behavior, or functionality modified. The 52 added lines are all section divider comments that organize existing state properties into 14 logical groups. Since comments don't affect runtime behavior and the PR explicitly states no functional changes, there's no risk of introducing bugs or breaking changes.
- No files require special attention

<sub>Last reviewed commit: cc9e7ff</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->