### PR TITLE
fix(docker): fix playwright browser permissions for node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,15 @@ RUN pnpm install --frozen-lockfile
 # Build with: docker build --build-arg OPENCLAW_INSTALL_BROWSER=1 ...
 # Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
 # Must run after pnpm install so playwright-core is available in node_modules.
+
+# Persist the browser path for runtime discovery and build installation
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
+
 ARG OPENCLAW_INSTALL_BROWSER=""
 RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
       mkdir -p /home/node/.cache && \
-      PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
       chown -R node:node /home/node/.cache && \
       apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ ARG OPENCLAW_INSTALL_BROWSER=""
 RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
+      mkdir -p /home/node/.cache && \
+      PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
+      chown -R node:node /home/node/.cache && \
       apt-get clean && \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** Playwright browsers were installed to a directory owned by `root` (default behavior), causing `Permission Denied` errors when the container runs as the non-root `node` user.
- **Why it matters:** Without execute permissions on the browser binaries, the application fails to launch the browser instance, breaking any automation or scraping features.
- **What changed:** The `Dockerfile` now explicitly sets `PLAYWRIGHT_BROWSERS_PATH` to `/home/node/.cache/ms-playwright`, creates the directory, installs the browser there, and recursively changes ownership (`chown`) to `node:node`.
- **What did NOT change (scope boundary):** The browser version (chromium), the dependencies installed via `apt-get`, or the application logic triggering the browser launch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #18449

## User-visible / Behavior Changes

None. This fixes an internal runtime error within the Docker container.

## Security Impact (required)

- New permissions/capabilities? (`Yes`) - Explicitly grants file ownership to the `node` user for the browser cache directory.
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Changing ownership allows the non-root user to manage browser binaries. This is the intended secure configuration (running as non-root) and mitigates the risk of running the browser process as root.

## Repro + Verification

### Environment

- OS: Linux (Docker container)
- Runtime/container: Node.js Docker Image
- Model/provider: N/A
- Integration/channel (if any): Playwright
- Relevant config (redacted): `OPENCLAW_INSTALL_BROWSER=true`

### Steps

1. Build the Docker image with `OPENCLAW_INSTALL_BROWSER` set.
2. Run the container as the `node` user (default for many node images).
3. Execute a script that attempts to launch Chromium via Playwright.

### Expected

- The browser launches successfully without permission errors.

### Actual

- (Before fix) Browser launch fails with `EACCES: permission denied` or similar error trying to access browser executable/cache.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets (Git diff provided shows the fix implementation)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Reviewed Dockerfile logic to ensure the directory is created before installation and ownership is changed after installation.
- Edge cases checked: Ensured `mkdir -p` prevents failure if directory exists; ensured `chown -R` covers all installed browser files.
- What you did **not** verify: Did not run a live build of the Docker image to confirm runtime behavior (static analysis only).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit or remove the `chown` and `PLAYWRIGHT_BROWSERS_PATH` lines.
- Files/config to restore: Previous `Dockerfile` state.
- Known bad symptoms reviewers should watch for: If the build fails, it might be due to `/home/node` not existing in the base image; however, `mkdir -p` handles this.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- **Risk: Application-level binary modification.** Granting ownership (`chown`) of the browser cache to the `node` user allows the application process to modify or replace browser binaries (e.g., replacing `chromium` with a malicious executable) if the application itself is compromised.
  - **Mitigation:** This is an accepted trade-off for running the container as a non-root user. The alternative (running as root to access root-owned binaries) presents a much higher security risk (container escape). Since the `node` user is unprivileged, the impact of modifying these binaries is scoped to the user namespace and does not grant root privileges. Furthermore, Docker containers are ephemeral; any modification to the binaries at runtime is lost when the container restarts.
- **Risk: Directory availability.** The `/home/node` directory might not exist in all base image versions, potentially causing the installation to fail.
  - **Mitigation:** Added `mkdir -p /home/node/.cache` to ensure the path exists before installation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `Permission Denied` error that occurred when Playwright attempted to launch Chromium in a Docker container running as the non-root `node` user. Previously, the browser was installed to `/root/.cache/ms-playwright` (the default for the `root` user running the `RUN` layer), which the `node` runtime user could not access.

The fix redirects the Playwright install destination to `/home/node/.cache/ms-playwright` via an inline `PLAYWRIGHT_BROWSERS_PATH` variable, pre-creates the target directory with `mkdir -p`, and transfers ownership to `node:node` with `chown -R`.

**Key observations:**
- The fix is correct and addresses the root cause. The `node` user will have read/execute access to the Chromium binary at runtime.
- `mkdir -p /home/node/.cache` safely handles the case where `/home/node` may not pre-exist in a given base image variant.
- `chown -R node:node /home/node/.cache` correctly covers all files recursively installed by `--with-deps`.
- One improvement opportunity: `PLAYWRIGHT_BROWSERS_PATH` is only set as an inline shell variable for the `RUN` command, not as a Docker `ENV` directive. The runtime browser discovery currently works because playwright-core's default Linux path (`$HOME/.cache/ms-playwright`) coincidentally matches the install location for the `node` user. Adding an explicit `ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright` would make this dependency explicit and guard against breakage if the container is run as a different user or if playwright's default path changes.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it correctly fixes a browser permission error with a minimal, targeted change.
- The change is small and surgical, addresses a well-understood root cause, and is backward compatible. The only concern is that `PLAYWRIGHT_BROWSERS_PATH` is not persisted as a Docker `ENV` directive — meaning runtime browser discovery relies on playwright's default path coinciding with the install path for the `node` user. This works today but is fragile. No logic, security, or syntax errors are introduced.
- No files require special attention beyond the noted style suggestion on `Dockerfile` line 35.

<sub>Last reviewed commit: 2539600</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->