### PR TITLE
feat: add agent lifecycle hook events (session, message, error)

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -17,7 +17,7 @@ Hooks are small scripts that run when something happens. There are two kinds:
 - **Hooks** (this page): run inside the Gateway when agent events fire, like `/new`, `/reset`, `/stop`, or lifecycle events.
 - **Webhooks**: external HTTP webhooks that let other systems trigger work in OpenClaw. See [Webhook Hooks](/automation/webhook) or use `openclaw webhooks` for Gmail helper commands.
 
-Hooks can also be bundled inside plugins; see [Plugin hooks](/plugins/architecture#provider-runtime-hooks).
+Hooks can also be bundled inside plugins; see [Plugins](/tools/plugin#plugin-hooks).
 
 Common uses:
 
@@ -103,12 +103,7 @@ Hook packs are standard npm packages that export one or more hooks via `openclaw
 openclaw hooks install <path-or-spec>
 ```
 
-Npm specs are registry-only (package name + optional exact version or dist-tag).
-Git/URL/file specs and semver ranges are rejected.
-
-Bare specs and `@latest` stay on the stable track. If npm resolves either of
-those to a prerelease, OpenClaw stops and asks you to opt in explicitly with a
-prerelease tag such as `@beta`/`@rc` or an exact prerelease version.
+Npm specs are registry-only (package name + optional version/tag). Git/URL/file specs are rejected.
 
 Example `package.json`:
 
@@ -124,8 +119,6 @@ Example `package.json`:
 
 Each entry points to a hook directory containing `HOOK.md` and `handler.ts` (or `index.ts`).
 Hook packs can ship dependencies; they will be installed under `~/.openclaw/hooks/<id>`.
-Each `openclaw.hooks` entry must stay inside the package directory after symlink
-resolution; entries that escape are rejected.
 
 Security note: `openclaw hooks install` installs dependencies with `npm install --ignore-scripts`
 (no lifecycle scripts). Keep hook pack dependency trees "pure JS/TS" and avoid packages that rely
@@ -187,7 +180,9 @@ The `metadata.openclaw` object supports:
 The `handler.ts` file exports a `HookHandler` function:
 
 ```typescript
-const myHandler = async (event) => {
+import type { HookHandler } from "../../src/hooks/hooks.js";
+
+const myHandler: HookHandler = async (event) => {
   // Only trigger on 'new' command
   if (event.type !== "command" || event.action !== "new") {
     return;
@@ -212,13 +207,12 @@ Each event includes:
 
 ```typescript
 {
-  type: 'command' | 'session' | 'agent' | 'gateway' | 'message',
-  action: string,              // e.g., 'new', 'reset', 'stop', 'received', 'sent'
+  type: 'command' | 'session' | 'agent' | 'gateway',
+  action: string,              // e.g., 'new', 'reset', 'stop'
   sessionKey: string,          // Session identifier
   timestamp: Date,             // When the event occurred
   messages: string[],          // Push messages here to send to user
   context: {
-    // Command events:
     sessionEntry?: SessionEntry,
     sessionId?: string,
     sessionFile?: string,
@@ -226,13 +220,7 @@ Each event includes:
     senderId?: string,
     workspaceDir?: string,
     bootstrapFiles?: WorkspaceBootstrapFile[],
-    cfg?: OpenClawConfig,
-    // Message events (see Message Events section for full details):
-    from?: string,             // message:received
-    to?: string,               // message:sent
-    content?: string,
-    channelId?: string,
-    success?: boolean,         // message:sent
+    cfg?: OpenClawConfig
   }
 }
 ```
@@ -250,15 +238,22 @@ Triggered when agent commands are issued:
 
 ### Session Events
 
-- **`session:compact:before`**: Right before compaction summarizes history
-- **`session:compact:after`**: After compaction completes with summary metadata
+Triggered during session lifecycle:
 
-Internal hook payloads emit these as `type: "session"` with `action: "compact:before"` / `action: "compact:after"`; listeners subscribe with the combined keys above.
-Specific handler registration uses the literal key format `${type}:${action}`. For these events, register `session:compact:before` and `session:compact:after`.
+- **`session:start`**: When a new session begins (fired after `/new` or `/reset`)
+- **`session:end`**: When a session is stopped (fired after `/stop`)
 
 ### Agent Events
 
 - **`agent:bootstrap`**: Before workspace bootstrap files are injected (hooks may mutate `context.bootstrapFiles`)
+- **`agent:error`**: When the agent encounters an error during processing (LLM error, tool error)
+
+### Message Events
+
+Triggered when messages are sent or received:
+
+- **`message:received`**: When a message arrives from the user
+- **`message:sent`**: When the agent sends a message to the user
 
 ### Gateway Events
 
@@ -266,118 +261,11 @@ Triggered when the gateway starts:
 
 - **`gateway:startup`**: After channels start and hooks are loaded
 
-### Message Events
-
-Triggered when messages are received or sent:
-
-- **`message`**: All message events (general listener)
-- **`message:received`**: When an inbound message is received from any channel. Fires early in processing before media understanding. Content may contain raw placeholders like `<media:audio>` for media attachments that haven't been processed yet.
-- **`message:transcribed`**: When a message has been fully processed, including audio transcription and link understanding. At this point, `transcript` contains the full transcript text for audio messages. Use this hook when you need access to transcribed audio content.
-- **`message:preprocessed`**: Fires for every message after all media + link understanding completes, giving hooks access to the fully enriched body (transcripts, image descriptions, link summaries) before the agent sees it.
-- **`message:sent`**: When an outbound message is successfully sent
-
-#### Message Event Context
-
-Message events include rich context about the message:
-
-```typescript
-// message:received context
-{
-  from: string,           // Sender identifier (phone number, user ID, etc.)
-  content: string,        // Message content
-  timestamp?: number,     // Unix timestamp when received
-  channelId: string,      // Channel (e.g., "whatsapp", "telegram", "discord")
-  accountId?: string,     // Provider account ID for multi-account setups
-  conversationId?: string, // Chat/conversation ID
-  messageId?: string,     // Message ID from the provider
-  metadata?: {            // Additional provider-specific data
-    to?: string,
-    provider?: string,
-    surface?: string,
-    threadId?: string,
-    senderId?: string,
-    senderName?: string,
-    senderUsername?: string,
-    senderE164?: string,
-  }
-}
-
-// message:sent context
-{
-  to: string,             // Recipient identifier
-  content: string,        // Message content that was sent
-  success: boolean,       // Whether the send succeeded
-  error?: string,         // Error message if sending failed
-  channelId: string,      // Channel (e.g., "whatsapp", "telegram", "discord")
-  accountId?: string,     // Provider account ID
-  conversationId?: string, // Chat/conversation ID
-  messageId?: string,     // Message ID returned by the provider
-  isGroup?: boolean,      // Whether this outbound message belongs to a group/channel context
-  groupId?: string,       // Group/channel identifier for correlation with message:received
-}
-
-// message:transcribed context
-{
-  body?: string,          // Raw inbound body before enrichment
-  bodyForAgent?: string,  // Enriched body visible to the agent
-  transcript: string,     // Audio transcript text
-  channelId: string,      // Channel (e.g., "telegram", "whatsapp")
-  conversationId?: string,
-  messageId?: string,
-}
-
-// message:preprocessed context
-{
-  body?: string,          // Raw inbound body
-  bodyForAgent?: string,  // Final enriched body after media/link understanding
-  transcript?: string,    // Transcript when audio was present
-  channelId: string,      // Channel (e.g., "telegram", "whatsapp")
-  conversationId?: string,
-  messageId?: string,
-  isGroup?: boolean,
-  groupId?: string,
-}
-```
-
-#### Example: Message Logger Hook
-
-```typescript
-const isMessageReceivedEvent = (event: { type: string; action: string }) =>
-  event.type === "message" && event.action === "received";
-const isMessageSentEvent = (event: { type: string; action: string }) =>
-  event.type === "message" && event.action === "sent";
-
-const handler = async (event) => {
-  if (isMessageReceivedEvent(event as { type: string; action: string })) {
-    console.log(`[message-logger] Received from ${event.context.from}: ${event.context.content}`);
-  } else if (isMessageSentEvent(event as { type: string; action: string })) {
-    console.log(`[message-logger] Sent to ${event.context.to}: ${event.context.content}`);
-  }
-};
-
-export default handler;
-```
-
 ### Tool Result Hooks (Plugin API)
 
 These hooks are not event-stream listeners; they let plugins synchronously adjust tool results before OpenClaw persists them.
 
 - **`tool_result_persist`**: transform tool results before they are written to the session transcript. Must be synchronous; return the updated tool result payload or `undefined` to keep it as-is. See [Agent Loop](/concepts/agent-loop).
-
-### Plugin Hook Events
-
-Compaction lifecycle hooks exposed through the plugin hook runner:
-
-- **`before_compaction`**: Runs before compaction with count/token metadata
-- **`after_compaction`**: Runs after compaction with compaction summary metadata
-
-### Future Events
-
-Planned event types:
-
-- **`session:start`**: When a new session begins
-- **`session:end`**: When a session ends
-- **`agent:error`**: When an agent encounters an error
 
 ## Creating Custom Hooks
 
@@ -410,7 +298,9 @@ This hook does something useful when you issue `/new`.
 ### 4. Create handler.ts
 
 ```typescript
-const handler = async (event) => {
+import type { HookHandler } from "../../src/hooks/hooks.js";
+
+const handler: HookHandler = async (event) => {
   if (event.type !== "command" || event.action !== "new") {
     return;
   }
@@ -837,17 +727,13 @@ Test your handlers in isolation:
 
 ```typescript
 import { test } from "vitest";
+import { createHookEvent } from "./src/hooks/hooks.js";
 import myHandler from "./hooks/my-hook/handler.js";
 
 test("my handler works", async () => {
-  const event = {
-    type: "command",
-    action: "new",
-    sessionKey: "test-session",
-    timestamp: new Date(),
-    messages: [],
-    context: { foo: "bar" },
-  };
+  const event = createHookEvent("command", "new", "test-session", {
+    foo: "bar",
+  });
 
   await myHandler(event);
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -1,3 +1,4 @@
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
@@ -78,6 +79,14 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
         error: safeErrorText,
       },
     });
+
+    // Fire agent:error internal hook
+    void triggerInternalHook(
+      createInternalHookEvent("agent", "error", ctx.params.sessionKey ?? "", {
+        error: friendlyError || lastAssistant.errorMessage || "LLM request failed.",
+        runId: ctx.params.runId,
+      }),
+    ).catch(() => {});
   } else {
     ctx.log.debug(`embedded run agent end: runId=${ctx.params.runId} isError=${isError}`);
     emitAgentEvent({

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,17 +1,12 @@
 import fs from "node:fs/promises";
-import { resetConfiguredBindingTargetInPlace } from "../../channels/plugins/binding-targets.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { isAcpSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
-import { handleAcpCommand } from "./commands-acp.js";
-import { resolveBoundAcpThreadSessionKey } from "./commands-acp/targets.js";
 import { handleAllowlistCommand } from "./commands-allowlist.js";
 import { handleApproveCommand } from "./commands-approve.js";
 import { handleBashCommand } from "./commands-bash.js";
-import { handleBtwCommand } from "./commands-btw.js";
 import { handleCompactCommand } from "./commands-compact.js";
 import { handleConfigCommand, handleDebugCommand } from "./commands-config.js";
 import {
@@ -22,16 +17,13 @@ import {
   handleStatusCommand,
   handleWhoamiCommand,
 } from "./commands-info.js";
-import { handleMcpCommand } from "./commands-mcp.js";
+import { handleMeshCommand } from "./commands-mesh.js";
 import { handleModelsCommand } from "./commands-models.js";
 import { handlePluginCommand } from "./commands-plugin.js";
-import { handlePluginsCommand } from "./commands-plugins.js";
 import {
   handleAbortTrigger,
   handleActivationCommand,
-  handleFastCommand,
   handleRestartCommand,
-  handleSessionCommand,
   handleSendPolicyCommand,
   handleStopCommand,
   handleUsageCommand,
@@ -47,157 +39,27 @@ import { routeReply } from "./route-reply.js";
 
 let HANDLERS: CommandHandler[] | null = null;
 
-export type ResetCommandAction = "new" | "reset";
-
-export async function emitResetCommandHooks(params: {
-  action: ResetCommandAction;
-  ctx: HandleCommandsParams["ctx"];
-  cfg: HandleCommandsParams["cfg"];
-  command: Pick<
-    HandleCommandsParams["command"],
-    "surface" | "senderId" | "channel" | "from" | "to" | "resetHookTriggered"
-  >;
-  sessionKey?: string;
-  sessionEntry?: HandleCommandsParams["sessionEntry"];
-  previousSessionEntry?: HandleCommandsParams["previousSessionEntry"];
-  workspaceDir: string;
-}): Promise<void> {
-  const hookEvent = createInternalHookEvent("command", params.action, params.sessionKey ?? "", {
-    sessionEntry: params.sessionEntry,
-    previousSessionEntry: params.previousSessionEntry,
-    commandSource: params.command.surface,
-    senderId: params.command.senderId,
-    workspaceDir: params.workspaceDir,
-    cfg: params.cfg, // Pass config for LLM slug generation
-  });
-  await triggerInternalHook(hookEvent);
-  params.command.resetHookTriggered = true;
-
-  // Send hook messages immediately if present
-  if (hookEvent.messages.length > 0) {
-    // Use OriginatingChannel/To if available, otherwise fall back to command channel/from
-    // oxlint-disable-next-line typescript/no-explicit-any
-    const channel = params.ctx.OriginatingChannel || (params.command.channel as any);
-    // For replies, use 'from' (the sender) not 'to' (which might be the bot itself)
-    const to = params.ctx.OriginatingTo || params.command.from || params.command.to;
-
-    if (channel && to) {
-      const hookReply = { text: hookEvent.messages.join("\n\n") };
-      await routeReply({
-        payload: hookReply,
-        channel: channel,
-        to: to,
-        sessionKey: params.sessionKey,
-        accountId: params.ctx.AccountId,
-        threadId: params.ctx.MessageThreadId,
-        cfg: params.cfg,
-      });
-    }
-  }
-
-  // Fire before_reset plugin hook — extract memories before session history is lost
-  const hookRunner = getGlobalHookRunner();
-  if (hookRunner?.hasHooks("before_reset")) {
-    const prevEntry = params.previousSessionEntry;
-    const sessionFile = prevEntry?.sessionFile;
-    // Fire-and-forget: read old session messages and run hook
-    void (async () => {
-      try {
-        const messages: unknown[] = [];
-        if (sessionFile) {
-          const content = await fs.readFile(sessionFile, "utf-8");
-          for (const line of content.split("\n")) {
-            if (!line.trim()) {
-              continue;
-            }
-            try {
-              const entry = JSON.parse(line);
-              if (entry.type === "message" && entry.message) {
-                messages.push(entry.message);
-              }
-            } catch {
-              // skip malformed lines
-            }
-          }
-        } else {
-          logVerbose("before_reset: no session file available, firing hook with empty messages");
-        }
-        await hookRunner.runBeforeReset(
-          { sessionFile, messages, reason: params.action },
-          {
-            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
-            sessionKey: params.sessionKey,
-            sessionId: prevEntry?.sessionId,
-            workspaceDir: params.workspaceDir,
-          },
-        );
-      } catch (err: unknown) {
-        logVerbose(`before_reset hook failed: ${String(err)}`);
-      }
-    })();
-  }
-}
-
-function applyAcpResetTailContext(ctx: HandleCommandsParams["ctx"], resetTail: string): void {
-  const mutableCtx = ctx as Record<string, unknown>;
-  mutableCtx.Body = resetTail;
-  mutableCtx.RawBody = resetTail;
-  mutableCtx.CommandBody = resetTail;
-  mutableCtx.BodyForCommands = resetTail;
-  mutableCtx.BodyForAgent = resetTail;
-  mutableCtx.BodyStripped = resetTail;
-  mutableCtx.AcpDispatchTailAfterReset = true;
-}
-
-function resolveSessionEntryForHookSessionKey(
-  sessionStore: HandleCommandsParams["sessionStore"] | undefined,
-  sessionKey: string,
-): HandleCommandsParams["sessionEntry"] | undefined {
-  if (!sessionStore) {
-    return undefined;
-  }
-  const directEntry = sessionStore[sessionKey];
-  if (directEntry) {
-    return directEntry;
-  }
-  const normalizedTarget = sessionKey.trim().toLowerCase();
-  if (!normalizedTarget) {
-    return undefined;
-  }
-  for (const [candidateKey, candidateEntry] of Object.entries(sessionStore)) {
-    if (candidateKey.trim().toLowerCase() === normalizedTarget) {
-      return candidateEntry;
-    }
-  }
-  return undefined;
-}
-
 export async function handleCommands(params: HandleCommandsParams): Promise<CommandHandlerResult> {
   if (HANDLERS === null) {
     HANDLERS = [
       // Plugin commands are processed first, before built-in commands
       handlePluginCommand,
-      handleBtwCommand,
       handleBashCommand,
       handleActivationCommand,
       handleSendPolicyCommand,
-      handleFastCommand,
       handleUsageCommand,
-      handleSessionCommand,
       handleRestartCommand,
       handleTtsCommands,
       handleHelpCommand,
       handleCommandsListCommand,
       handleStatusCommand,
+      handleMeshCommand,
       handleAllowlistCommand,
       handleApproveCommand,
       handleContextCommand,
       handleExportSessionCommand,
       handleWhoamiCommand,
       handleSubagentsCommand,
-      handleAcpCommand,
-      handleMcpCommand,
-      handlePluginsCommand,
       handleConfigCommand,
       handleDebugCommand,
       handleModelsCommand,
@@ -217,85 +79,89 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
 
   // Trigger internal hook for reset/new commands
   if (resetRequested && params.command.isAuthorizedSender) {
-    const commandAction: ResetCommandAction = resetMatch?.[1] === "reset" ? "reset" : "new";
-    const resetTail =
-      resetMatch != null
-        ? params.command.commandBodyNormalized.slice(resetMatch[0].length).trimStart()
-        : "";
-    const boundAcpSessionKey = resolveBoundAcpThreadSessionKey(params);
-    const boundAcpKey =
-      boundAcpSessionKey && isAcpSessionKey(boundAcpSessionKey)
-        ? boundAcpSessionKey.trim()
-        : undefined;
-    if (boundAcpKey) {
-      const resetResult = await resetConfiguredBindingTargetInPlace({
-        cfg: params.cfg,
-        sessionKey: boundAcpKey,
-        reason: commandAction,
-      });
-      if (!resetResult.ok && !resetResult.skipped) {
-        logVerbose(
-          `acp reset-in-place failed for ${boundAcpKey}: ${resetResult.error ?? "unknown error"}`,
-        );
-      }
-      if (resetResult.ok) {
-        const hookSessionEntry =
-          boundAcpKey === params.sessionKey
-            ? params.sessionEntry
-            : resolveSessionEntryForHookSessionKey(params.sessionStore, boundAcpKey);
-        const hookPreviousSessionEntry =
-          boundAcpKey === params.sessionKey
-            ? params.previousSessionEntry
-            : resolveSessionEntryForHookSessionKey(params.sessionStore, boundAcpKey);
-        await emitResetCommandHooks({
-          action: commandAction,
-          ctx: params.ctx,
-          cfg: params.cfg,
-          command: params.command,
-          sessionKey: boundAcpKey,
-          sessionEntry: hookSessionEntry,
-          previousSessionEntry: hookPreviousSessionEntry,
-          workspaceDir: params.workspaceDir,
-        });
-        if (resetTail) {
-          applyAcpResetTailContext(params.ctx, resetTail);
-          if (params.rootCtx && params.rootCtx !== params.ctx) {
-            applyAcpResetTailContext(params.rootCtx, resetTail);
-          }
-          return {
-            shouldContinue: false,
-          };
-        }
-        return {
-          shouldContinue: false,
-          reply: { text: "✅ ACP session reset in place." },
-        };
-      }
-      if (resetResult.skipped) {
-        return {
-          shouldContinue: false,
-          reply: {
-            text: "⚠️ ACP session reset unavailable for this bound conversation. Rebind with /acp bind or /acp spawn.",
-          },
-        };
-      }
-      return {
-        shouldContinue: false,
-        reply: {
-          text: "⚠️ ACP session reset failed. Check /acp status and try again.",
-        },
-      };
-    }
-    await emitResetCommandHooks({
-      action: commandAction,
-      ctx: params.ctx,
-      cfg: params.cfg,
-      command: params.command,
-      sessionKey: params.sessionKey,
+    const commandAction = resetMatch?.[1] ?? "new";
+    const hookEvent = createInternalHookEvent("command", commandAction, params.sessionKey ?? "", {
       sessionEntry: params.sessionEntry,
       previousSessionEntry: params.previousSessionEntry,
-      workspaceDir: params.workspaceDir,
+      commandSource: params.command.surface,
+      senderId: params.command.senderId,
+      cfg: params.cfg, // Pass config for LLM slug generation
     });
+    await triggerInternalHook(hookEvent);
+
+    // Fire session:start internal hook for new sessions
+    const sessionStartEvent = createInternalHookEvent("session", "start", params.sessionKey ?? "", {
+      commandSource: params.command.surface,
+      senderId: params.command.senderId,
+      reason: commandAction,
+    });
+    void triggerInternalHook(sessionStartEvent).catch((err) => {
+      logVerbose(`session:start internal hook failed: ${String(err)}`);
+    });
+
+    // Send hook messages immediately if present
+    if (hookEvent.messages.length > 0) {
+      // Use OriginatingChannel/To if available, otherwise fall back to command channel/from
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const channel = params.ctx.OriginatingChannel || (params.command.channel as any);
+      // For replies, use 'from' (the sender) not 'to' (which might be the bot itself)
+      const to = params.ctx.OriginatingTo || params.command.from || params.command.to;
+
+      if (channel && to) {
+        const hookReply = { text: hookEvent.messages.join("\n\n") };
+        await routeReply({
+          payload: hookReply,
+          channel: channel,
+          to: to,
+          sessionKey: params.sessionKey,
+          accountId: params.ctx.AccountId,
+          threadId: params.ctx.MessageThreadId,
+          cfg: params.cfg,
+        });
+      }
+    }
+
+    // Fire before_reset plugin hook — extract memories before session history is lost
+    const hookRunner = getGlobalHookRunner();
+    if (hookRunner?.hasHooks("before_reset")) {
+      const prevEntry = params.previousSessionEntry;
+      const sessionFile = prevEntry?.sessionFile;
+      // Fire-and-forget: read old session messages and run hook
+      void (async () => {
+        try {
+          const messages: unknown[] = [];
+          if (sessionFile) {
+            const content = await fs.readFile(sessionFile, "utf-8");
+            for (const line of content.split("\n")) {
+              if (!line.trim()) {
+                continue;
+              }
+              try {
+                const entry = JSON.parse(line);
+                if (entry.type === "message" && entry.message) {
+                  messages.push(entry.message);
+                }
+              } catch {
+                // skip malformed lines
+              }
+            }
+          } else {
+            logVerbose("before_reset: no session file available, firing hook with empty messages");
+          }
+          await hookRunner.runBeforeReset(
+            { sessionFile, messages, reason: commandAction },
+            {
+              agentId: params.sessionKey?.split(":")[0] ?? "main",
+              sessionKey: params.sessionKey,
+              sessionId: prevEntry?.sessionId,
+              workspaceDir: params.workspaceDir,
+            },
+          );
+        } catch (err: unknown) {
+          logVerbose(`before_reset hook failed: ${String(err)}`);
+        }
+      })();
+    }
   }
 
   const allowTextCommands = shouldHandleTextCommands({

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -1,124 +1,80 @@
-import { resolveFastModeState } from "../../agents/fast-mode.js";
-import { formatThreadBindingDurationLabel } from "../../channels/thread-bindings-messages.js";
-import { parseDurationMs } from "../../cli/parse-duration.js";
-import { isRestartEnabled } from "../../config/commands.js";
+import { abortEmbeddedPiRun } from "../../agents/pi-embedded.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { updateSessionStore } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
-import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
-import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { scheduleGatewaySigusr1Restart, triggerOpenClawRestart } from "../../infra/restart.js";
 import { loadCostUsageSummary, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
-import { createPluginRuntime } from "../../plugins/runtime/index.js";
 import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 import { parseActivationCommand } from "../group-activation.js";
 import { parseSendPolicyCommand } from "../send-policy.js";
-import { normalizeFastMode, normalizeUsageDisplay, resolveResponseUsageMode } from "../thinking.js";
-import { isDiscordSurface, isTelegramSurface, resolveChannelAccountId } from "./channel-context.js";
-import { handleAbortTrigger, handleStopCommand } from "./commands-session-abort.js";
-import { persistSessionEntry } from "./commands-session-store.js";
+import { normalizeUsageDisplay, resolveResponseUsageMode } from "../thinking.js";
+import {
+  formatAbortReplyText,
+  isAbortTrigger,
+  setAbortMemory,
+  stopSubagentsForRequester,
+} from "./abort.js";
 import type { CommandHandler } from "./commands-types.js";
-import { resolveTelegramConversationId } from "./telegram-context.js";
+import { clearSessionQueues } from "./queue.js";
 
-const SESSION_COMMAND_PREFIX = "/session";
-const SESSION_DURATION_OFF_VALUES = new Set(["off", "disable", "disabled", "none", "0"]);
-const SESSION_ACTION_IDLE = "idle";
-const SESSION_ACTION_MAX_AGE = "max-age";
-let cachedChannelRuntime: ReturnType<typeof createPluginRuntime>["channel"] | undefined;
-
-function getChannelRuntime() {
-  cachedChannelRuntime ??= createPluginRuntime().channel;
-  return cachedChannelRuntime;
+function resolveSessionEntryForKey(
+  store: Record<string, SessionEntry> | undefined,
+  sessionKey: string | undefined,
+) {
+  if (!store || !sessionKey) {
+    return {};
+  }
+  const direct = store[sessionKey];
+  if (direct) {
+    return { entry: direct, key: sessionKey };
+  }
+  return {};
 }
 
-function resolveSessionCommandUsage() {
-  return "Usage: /session idle <duration|off> | /session max-age <duration|off> (example: /session idle 24h)";
+function resolveAbortTarget(params: {
+  ctx: { CommandTargetSessionKey?: string | null };
+  sessionKey?: string;
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+}) {
+  const targetSessionKey = params.ctx.CommandTargetSessionKey?.trim() || params.sessionKey;
+  const { entry, key } = resolveSessionEntryForKey(params.sessionStore, targetSessionKey);
+  if (entry && key) {
+    return { entry, key, sessionId: entry.sessionId };
+  }
+  if (params.sessionEntry && params.sessionKey) {
+    return {
+      entry: params.sessionEntry,
+      key: params.sessionKey,
+      sessionId: params.sessionEntry.sessionId,
+    };
+  }
+  return { entry: undefined, key: targetSessionKey, sessionId: undefined };
 }
 
-function parseSessionDurationMs(raw: string): number {
-  const normalized = raw.trim().toLowerCase();
-  if (!normalized) {
-    throw new Error("missing duration");
+async function applyAbortTarget(params: {
+  abortTarget: ReturnType<typeof resolveAbortTarget>;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  abortKey?: string;
+}) {
+  const { abortTarget } = params;
+  if (abortTarget.sessionId) {
+    abortEmbeddedPiRun(abortTarget.sessionId);
   }
-  if (SESSION_DURATION_OFF_VALUES.has(normalized)) {
-    return 0;
-  }
-  if (/^\d+(?:\.\d+)?$/.test(normalized)) {
-    const hours = Number(normalized);
-    if (!Number.isFinite(hours) || hours < 0) {
-      throw new Error("invalid duration");
+  if (abortTarget.entry && params.sessionStore && abortTarget.key) {
+    abortTarget.entry.abortedLastRun = true;
+    abortTarget.entry.updatedAt = Date.now();
+    params.sessionStore[abortTarget.key] = abortTarget.entry;
+    if (params.storePath) {
+      await updateSessionStore(params.storePath, (store) => {
+        store[abortTarget.key] = abortTarget.entry;
+      });
     }
-    return Math.round(hours * 60 * 60 * 1000);
+  } else if (params.abortKey) {
+    setAbortMemory(params.abortKey, true);
   }
-  return parseDurationMs(normalized, { defaultUnit: "h" });
-}
-
-function formatSessionExpiry(expiresAt: number) {
-  return new Date(expiresAt).toISOString();
-}
-
-function resolveTelegramBindingDurationMs(
-  binding: SessionBindingRecord,
-  key: "idleTimeoutMs" | "maxAgeMs",
-  fallbackMs: number,
-): number {
-  const raw = binding.metadata?.[key];
-  if (typeof raw !== "number" || !Number.isFinite(raw)) {
-    return fallbackMs;
-  }
-  return Math.max(0, Math.floor(raw));
-}
-
-function resolveTelegramBindingLastActivityAt(binding: SessionBindingRecord): number {
-  const raw = binding.metadata?.lastActivityAt;
-  if (typeof raw !== "number" || !Number.isFinite(raw)) {
-    return binding.boundAt;
-  }
-  return Math.max(Math.floor(raw), binding.boundAt);
-}
-
-function resolveTelegramBindingBoundBy(binding: SessionBindingRecord): string {
-  const raw = binding.metadata?.boundBy;
-  return typeof raw === "string" ? raw.trim() : "";
-}
-
-type UpdatedLifecycleBinding = {
-  boundAt: number;
-  lastActivityAt: number;
-  idleTimeoutMs?: number;
-  maxAgeMs?: number;
-};
-
-function resolveUpdatedBindingExpiry(params: {
-  action: typeof SESSION_ACTION_IDLE | typeof SESSION_ACTION_MAX_AGE;
-  bindings: UpdatedLifecycleBinding[];
-}): number | undefined {
-  const expiries = params.bindings
-    .map((binding) => {
-      if (params.action === SESSION_ACTION_IDLE) {
-        const idleTimeoutMs =
-          typeof binding.idleTimeoutMs === "number" && Number.isFinite(binding.idleTimeoutMs)
-            ? Math.max(0, Math.floor(binding.idleTimeoutMs))
-            : 0;
-        if (idleTimeoutMs <= 0) {
-          return undefined;
-        }
-        return Math.max(binding.lastActivityAt, binding.boundAt) + idleTimeoutMs;
-      }
-
-      const maxAgeMs =
-        typeof binding.maxAgeMs === "number" && Number.isFinite(binding.maxAgeMs)
-          ? Math.max(0, Math.floor(binding.maxAgeMs))
-          : 0;
-      if (maxAgeMs <= 0) {
-        return undefined;
-      }
-      return binding.boundAt + maxAgeMs;
-    })
-    .filter((expiresAt): expiresAt is number => typeof expiresAt === "number");
-
-  if (expiries.length === 0) {
-    return undefined;
-  }
-  return Math.min(...expiries);
 }
 
 export const handleActivationCommand: CommandHandler = async (params, allowTextCommands) => {
@@ -150,7 +106,13 @@ export const handleActivationCommand: CommandHandler = async (params, allowTextC
   if (params.sessionEntry && params.sessionStore && params.sessionKey) {
     params.sessionEntry.groupActivation = activationCommand.mode;
     params.sessionEntry.groupActivationNeedsSystemIntro = true;
-    await persistSessionEntry(params);
+    params.sessionEntry.updatedAt = Date.now();
+    params.sessionStore[params.sessionKey] = params.sessionEntry;
+    if (params.storePath) {
+      await updateSessionStore(params.storePath, (store) => {
+        store[params.sessionKey] = params.sessionEntry as SessionEntry;
+      });
+    }
   }
   return {
     shouldContinue: false,
@@ -186,7 +148,13 @@ export const handleSendPolicyCommand: CommandHandler = async (params, allowTextC
     } else {
       params.sessionEntry.sendPolicy = sendPolicyCommand.mode;
     }
-    await persistSessionEntry(params);
+    params.sessionEntry.updatedAt = Date.now();
+    params.sessionStore[params.sessionKey] = params.sessionEntry;
+    if (params.storePath) {
+      await updateSessionStore(params.storePath, (store) => {
+        store[params.sessionKey] = params.sessionEntry as SessionEntry;
+      });
+    }
   }
   const label =
     sendPolicyCommand.mode === "inherit"
@@ -275,7 +243,13 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
     } else {
       params.sessionEntry.responseUsage = next;
     }
-    await persistSessionEntry(params);
+    params.sessionEntry.updatedAt = Date.now();
+    params.sessionStore[params.sessionKey] = params.sessionEntry;
+    if (params.storePath) {
+      await updateSessionStore(params.storePath, (store) => {
+        store[params.sessionKey] = params.sessionEntry as SessionEntry;
+      });
+    }
   }
 
   return {
@@ -286,311 +260,6 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
   };
 };
 
-export const handleFastCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalized = params.command.commandBodyNormalized;
-  if (normalized !== "/fast" && !normalized.startsWith("/fast ")) {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /fast from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-
-  const rawArgs = normalized === "/fast" ? "" : normalized.slice("/fast".length).trim();
-  const rawMode = rawArgs.toLowerCase();
-  if (!rawMode || rawMode === "status") {
-    const state = resolveFastModeState({
-      cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
-      sessionEntry: params.sessionEntry,
-    });
-    const suffix =
-      state.source === "config" ? " (config)" : state.source === "default" ? " (default)" : "";
-    return {
-      shouldContinue: false,
-      reply: { text: `⚙️ Current fast mode: ${state.enabled ? "on" : "off"}${suffix}.` },
-    };
-  }
-
-  const nextMode = normalizeFastMode(rawMode);
-  if (nextMode === undefined) {
-    return {
-      shouldContinue: false,
-      reply: { text: "⚙️ Usage: /fast status|on|off" },
-    };
-  }
-
-  if (params.sessionEntry && params.sessionStore && params.sessionKey) {
-    params.sessionEntry.fastMode = nextMode;
-    await persistSessionEntry(params);
-  }
-
-  return {
-    shouldContinue: false,
-    reply: { text: `⚙️ Fast mode ${nextMode ? "enabled" : "disabled"}.` },
-  };
-};
-
-export const handleSessionCommand: CommandHandler = async (params, allowTextCommands) => {
-  if (!allowTextCommands) {
-    return null;
-  }
-  const normalized = params.command.commandBodyNormalized;
-  if (!/^\/session(?:\s|$)/.test(normalized)) {
-    return null;
-  }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /session from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
-  }
-
-  const rest = normalized.slice(SESSION_COMMAND_PREFIX.length).trim();
-  const tokens = rest.split(/\s+/).filter(Boolean);
-  const action = tokens[0]?.toLowerCase();
-  if (action !== SESSION_ACTION_IDLE && action !== SESSION_ACTION_MAX_AGE) {
-    return {
-      shouldContinue: false,
-      reply: { text: resolveSessionCommandUsage() },
-    };
-  }
-
-  const onDiscord = isDiscordSurface(params);
-  const onTelegram = isTelegramSurface(params);
-  if (!onDiscord && !onTelegram) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: "⚠️ /session idle and /session max-age are currently available for Discord and Telegram bound sessions.",
-      },
-    };
-  }
-
-  const accountId = resolveChannelAccountId(params);
-  const sessionBindingService = getSessionBindingService();
-  const threadId =
-    params.ctx.MessageThreadId != null ? String(params.ctx.MessageThreadId).trim() : "";
-  const telegramConversationId = onTelegram ? resolveTelegramConversationId(params) : undefined;
-  const channelRuntime = getChannelRuntime();
-
-  const discordManager = onDiscord
-    ? channelRuntime.discord.threadBindings.getManager(accountId)
-    : null;
-  if (onDiscord && !discordManager) {
-    return {
-      shouldContinue: false,
-      reply: { text: "⚠️ Discord thread bindings are unavailable for this account." },
-    };
-  }
-
-  const discordBinding =
-    onDiscord && threadId ? discordManager?.getByThreadId(threadId) : undefined;
-  const telegramBinding =
-    onTelegram && telegramConversationId
-      ? sessionBindingService.resolveByConversation({
-          channel: "telegram",
-          accountId,
-          conversationId: telegramConversationId,
-        })
-      : null;
-  if (onDiscord && !discordBinding) {
-    if (onDiscord && !threadId) {
-      return {
-        shouldContinue: false,
-        reply: {
-          text: "⚠️ /session idle and /session max-age must be run inside a focused Discord thread.",
-        },
-      };
-    }
-    return {
-      shouldContinue: false,
-      reply: { text: "ℹ️ This thread is not currently focused." },
-    };
-  }
-  if (onTelegram && !telegramBinding) {
-    if (!telegramConversationId) {
-      return {
-        shouldContinue: false,
-        reply: {
-          text: "⚠️ /session idle and /session max-age on Telegram require a topic context in groups, or a direct-message conversation.",
-        },
-      };
-    }
-    return {
-      shouldContinue: false,
-      reply: { text: "ℹ️ This conversation is not currently focused." },
-    };
-  }
-
-  const idleTimeoutMs = onDiscord
-    ? channelRuntime.discord.threadBindings.resolveIdleTimeoutMs({
-        record: discordBinding!,
-        defaultIdleTimeoutMs: discordManager!.getIdleTimeoutMs(),
-      })
-    : resolveTelegramBindingDurationMs(telegramBinding!, "idleTimeoutMs", 24 * 60 * 60 * 1000);
-  const idleExpiresAt = onDiscord
-    ? channelRuntime.discord.threadBindings.resolveInactivityExpiresAt({
-        record: discordBinding!,
-        defaultIdleTimeoutMs: discordManager!.getIdleTimeoutMs(),
-      })
-    : idleTimeoutMs > 0
-      ? resolveTelegramBindingLastActivityAt(telegramBinding!) + idleTimeoutMs
-      : undefined;
-  const maxAgeMs = onDiscord
-    ? channelRuntime.discord.threadBindings.resolveMaxAgeMs({
-        record: discordBinding!,
-        defaultMaxAgeMs: discordManager!.getMaxAgeMs(),
-      })
-    : resolveTelegramBindingDurationMs(telegramBinding!, "maxAgeMs", 0);
-  const maxAgeExpiresAt = onDiscord
-    ? channelRuntime.discord.threadBindings.resolveMaxAgeExpiresAt({
-        record: discordBinding!,
-        defaultMaxAgeMs: discordManager!.getMaxAgeMs(),
-      })
-    : maxAgeMs > 0
-      ? telegramBinding!.boundAt + maxAgeMs
-      : undefined;
-
-  const durationArgRaw = tokens.slice(1).join("");
-  if (!durationArgRaw) {
-    if (action === SESSION_ACTION_IDLE) {
-      if (
-        typeof idleExpiresAt === "number" &&
-        Number.isFinite(idleExpiresAt) &&
-        idleExpiresAt > Date.now()
-      ) {
-        return {
-          shouldContinue: false,
-          reply: {
-            text: `ℹ️ Idle timeout active (${formatThreadBindingDurationLabel(idleTimeoutMs)}, next auto-unfocus at ${formatSessionExpiry(idleExpiresAt)}).`,
-          },
-        };
-      }
-      return {
-        shouldContinue: false,
-        reply: { text: "ℹ️ Idle timeout is currently disabled for this focused session." },
-      };
-    }
-
-    if (
-      typeof maxAgeExpiresAt === "number" &&
-      Number.isFinite(maxAgeExpiresAt) &&
-      maxAgeExpiresAt > Date.now()
-    ) {
-      return {
-        shouldContinue: false,
-        reply: {
-          text: `ℹ️ Max age active (${formatThreadBindingDurationLabel(maxAgeMs)}, hard auto-unfocus at ${formatSessionExpiry(maxAgeExpiresAt)}).`,
-        },
-      };
-    }
-    return {
-      shouldContinue: false,
-      reply: { text: "ℹ️ Max age is currently disabled for this focused session." },
-    };
-  }
-
-  const senderId = params.command.senderId?.trim() || "";
-  const boundBy = onDiscord
-    ? discordBinding!.boundBy
-    : resolveTelegramBindingBoundBy(telegramBinding!);
-  if (boundBy && boundBy !== "system" && senderId && senderId !== boundBy) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: onDiscord
-          ? `⚠️ Only ${boundBy} can update session lifecycle settings for this thread.`
-          : `⚠️ Only ${boundBy} can update session lifecycle settings for this conversation.`,
-      },
-    };
-  }
-
-  let durationMs: number;
-  try {
-    durationMs = parseSessionDurationMs(durationArgRaw);
-  } catch {
-    return {
-      shouldContinue: false,
-      reply: { text: resolveSessionCommandUsage() },
-    };
-  }
-
-  const updatedBindings = (() => {
-    if (onDiscord) {
-      return action === SESSION_ACTION_IDLE
-        ? channelRuntime.discord.threadBindings.setIdleTimeoutBySessionKey({
-            targetSessionKey: discordBinding!.targetSessionKey,
-            accountId,
-            idleTimeoutMs: durationMs,
-          })
-        : channelRuntime.discord.threadBindings.setMaxAgeBySessionKey({
-            targetSessionKey: discordBinding!.targetSessionKey,
-            accountId,
-            maxAgeMs: durationMs,
-          });
-    }
-    return action === SESSION_ACTION_IDLE
-      ? channelRuntime.telegram.threadBindings.setIdleTimeoutBySessionKey({
-          targetSessionKey: telegramBinding!.targetSessionKey,
-          accountId,
-          idleTimeoutMs: durationMs,
-        })
-      : channelRuntime.telegram.threadBindings.setMaxAgeBySessionKey({
-          targetSessionKey: telegramBinding!.targetSessionKey,
-          accountId,
-          maxAgeMs: durationMs,
-        });
-  })();
-  if (updatedBindings.length === 0) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text:
-          action === SESSION_ACTION_IDLE
-            ? "⚠️ Failed to update idle timeout for the current binding."
-            : "⚠️ Failed to update max age for the current binding.",
-      },
-    };
-  }
-
-  if (durationMs <= 0) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text:
-          action === SESSION_ACTION_IDLE
-            ? `✅ Idle timeout disabled for ${updatedBindings.length} binding${updatedBindings.length === 1 ? "" : "s"}.`
-            : `✅ Max age disabled for ${updatedBindings.length} binding${updatedBindings.length === 1 ? "" : "s"}.`,
-      },
-    };
-  }
-
-  const nextExpiry = resolveUpdatedBindingExpiry({
-    action,
-    bindings: updatedBindings,
-  });
-  const expiryLabel =
-    typeof nextExpiry === "number" && Number.isFinite(nextExpiry)
-      ? formatSessionExpiry(nextExpiry)
-      : "n/a";
-
-  return {
-    shouldContinue: false,
-    reply: {
-      text:
-        action === SESSION_ACTION_IDLE
-          ? `✅ Idle timeout set to ${formatThreadBindingDurationLabel(durationMs)} for ${updatedBindings.length} binding${updatedBindings.length === 1 ? "" : "s"} (next auto-unfocus at ${expiryLabel}).`
-          : `✅ Max age set to ${formatThreadBindingDurationLabel(durationMs)} for ${updatedBindings.length} binding${updatedBindings.length === 1 ? "" : "s"} (hard auto-unfocus at ${expiryLabel}).`,
-    },
-  };
-};
 export const handleRestartCommand: CommandHandler = async (params, allowTextCommands) => {
   if (!allowTextCommands) {
     return null;
@@ -604,11 +273,11 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
     );
     return { shouldContinue: false };
   }
-  if (!isRestartEnabled(params.cfg)) {
+  if (params.cfg.commands?.restart !== true) {
     return {
       shouldContinue: false,
       reply: {
-        text: "⚠️ /restart is disabled (commands.restart=false).",
+        text: "⚠️ /restart is disabled. Set commands.restart=true to enable.",
       },
     };
   }
@@ -640,4 +309,93 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
   };
 };
 
-export { handleAbortTrigger, handleStopCommand };
+export const handleStopCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  if (params.command.commandBodyNormalized !== "/stop") {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /stop from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+  const abortTarget = resolveAbortTarget({
+    ctx: params.ctx,
+    sessionKey: params.sessionKey,
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore,
+  });
+  const cleared = clearSessionQueues([abortTarget.key, abortTarget.sessionId]);
+  if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
+    logVerbose(
+      `stop: cleared followups=${cleared.followupCleared} lane=${cleared.laneCleared} keys=${cleared.keys.join(",")}`,
+    );
+  }
+  await applyAbortTarget({
+    abortTarget,
+    sessionStore: params.sessionStore,
+    storePath: params.storePath,
+    abortKey: params.command.abortKey,
+  });
+
+  // Trigger internal hook for stop command
+  const hookEvent = createInternalHookEvent(
+    "command",
+    "stop",
+    abortTarget.key ?? params.sessionKey ?? "",
+    {
+      sessionEntry: abortTarget.entry ?? params.sessionEntry,
+      sessionId: abortTarget.sessionId,
+      commandSource: params.command.surface,
+      senderId: params.command.senderId,
+    },
+  );
+  await triggerInternalHook(hookEvent);
+
+  // Fire session:end internal hook
+  const sessionEndEvent = createInternalHookEvent(
+    "session",
+    "end",
+    abortTarget.key ?? params.sessionKey ?? "",
+    {
+      sessionId: abortTarget.sessionId,
+      commandSource: params.command.surface,
+      senderId: params.command.senderId,
+    },
+  );
+  void triggerInternalHook(sessionEndEvent).catch((err) => {
+    logVerbose(`session:end internal hook failed: ${String(err)}`);
+  });
+
+  const { stopped } = stopSubagentsForRequester({
+    cfg: params.cfg,
+    requesterSessionKey: abortTarget.key ?? params.sessionKey,
+  });
+
+  return { shouldContinue: false, reply: { text: formatAbortReplyText(stopped) } };
+};
+
+export const handleAbortTrigger: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  if (!isAbortTrigger(params.command.rawBodyNormalized)) {
+    return null;
+  }
+  const abortTarget = resolveAbortTarget({
+    ctx: params.ctx,
+    sessionKey: params.sessionKey,
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore,
+  });
+  await applyAbortTarget({
+    abortTarget,
+    sessionStore: params.sessionStore,
+    storePath: params.storePath,
+    abortKey: params.command.abortKey,
+  });
+  return { shouldContinue: false, reply: { text: "⚙️ Agent was aborted." } };
+};

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,61 +1,27 @@
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import {
-  resolveConversationBindingRecord,
-  touchConversationBindingRecord,
-} from "../../bindings/records.js";
-import { shouldSuppressLocalExecApprovalPrompt } from "../../channels/plugins/exec-approval-local.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  loadSessionStore,
-  parseSessionThreadInfo,
-  resolveSessionStoreEntry,
-  resolveStorePath,
-  type SessionEntry,
-} from "../../config/sessions.js";
+import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
-import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
-import {
-  deriveInboundMessageHookContext,
-  toPluginInboundClaimContext,
-  toPluginInboundClaimEvent,
-  toInternalMessageReceivedContext,
-  toPluginMessageContext,
-  toPluginMessageReceivedEvent,
-} from "../../hooks/message-hook-mappers.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import {
   logMessageProcessed,
   logMessageQueued,
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
-import {
-  buildPluginBindingDeclinedText,
-  buildPluginBindingErrorText,
-  buildPluginBindingUnavailableText,
-  hasShownPluginBindingFallbackNotice,
-  isPluginOwnedSessionBindingRecord,
-  markPluginBindingFallbackNoticeShown,
-  toPluginConversationBinding,
-} from "../../plugins/conversation-binding.js";
-import { getGlobalHookRunner, getGlobalPluginRegistry } from "../../plugins/hook-runner-global.js";
-import { resolveSendPolicy } from "../../sessions/send-policy.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
-import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
-import { shouldBypassAcpDispatchForCommand, tryDispatchAcpReply } from "./dispatch-acp.js";
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
-import { shouldSuppressReasoningPayload } from "./reply-payloads.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
-import { resolveRunTypingPolicy } from "./typing-policy.js";
 
 const AUDIO_PLACEHOLDER_RE = /^<media:audio>(\s*\([^)]*\))?$/i;
 const AUDIO_HEADER_RE = /^\[Audio\b/i;
+
 const normalizeMediaType = (value: string): string => value.split(";")[0]?.trim().toLowerCase();
 
 const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
@@ -88,31 +54,24 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
   return AUDIO_HEADER_RE.test(trimmed);
 };
 
-const resolveSessionStoreLookup = (
+const resolveSessionTtsAuto = (
   ctx: FinalizedMsgContext,
   cfg: OpenClawConfig,
-): {
-  sessionKey?: string;
-  entry?: SessionEntry;
-} => {
+): string | undefined => {
   const targetSessionKey =
     ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
   const sessionKey = (targetSessionKey ?? ctx.SessionKey)?.trim();
   if (!sessionKey) {
-    return {};
+    return undefined;
   }
   const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
   try {
     const store = loadSessionStore(storePath);
-    return {
-      sessionKey,
-      entry: resolveSessionStoreEntry({ store, sessionKey }).existing,
-    };
+    const entry = store[sessionKey.toLowerCase()] ?? store[sessionKey];
+    return normalizeTtsAutoMode(entry?.ttsAuto);
   } catch {
-    return {
-      sessionKey,
-    };
+    return undefined;
   }
 };
 
@@ -187,31 +146,79 @@ export async function dispatchReplyFromConfig(params: {
     return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
   }
 
-  const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
-  const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
-  // Restore route thread context only from the active turn or the thread-scoped session key.
-  // Do not read thread ids from the normalised session store here: `origin.threadId` can be
-  // folded back into lastThreadId/deliveryContext during store normalisation and resurrect a
-  // stale route after thread delivery was intentionally cleared.
-  const routeThreadId =
-    ctx.MessageThreadId ?? parseSessionThreadInfo(acpDispatchSessionKey).threadId;
   const inboundAudio = isInboundAudioContext(ctx);
-  const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
+  const sessionTtsAuto = resolveSessionTtsAuto(ctx, cfg);
   const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_received")) {
+    const timestamp =
+      typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp)
+        ? ctx.Timestamp
+        : undefined;
+    const messageIdForHook =
+      ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+    const content =
+      typeof ctx.BodyForCommands === "string"
+        ? ctx.BodyForCommands
+        : typeof ctx.RawBody === "string"
+          ? ctx.RawBody
+          : typeof ctx.Body === "string"
+            ? ctx.Body
+            : "";
+    const channelId = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
+    const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
 
-  // Extract message context for hooks (plugin and internal)
-  const timestamp =
-    typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
-  const messageIdForHook =
-    ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
-  const hookContext = deriveInboundMessageHookContext(ctx, { messageId: messageIdForHook });
-  const { isGroup, groupId } = hookContext;
-  const inboundClaimContext = toPluginInboundClaimContext(hookContext);
-  const inboundClaimEvent = toPluginInboundClaimEvent(hookContext, {
-    commandAuthorized:
-      typeof ctx.CommandAuthorized === "boolean" ? ctx.CommandAuthorized : undefined,
-    wasMentioned: typeof ctx.WasMentioned === "boolean" ? ctx.WasMentioned : undefined,
-  });
+    void hookRunner
+      .runMessageReceived(
+        {
+          from: ctx.From ?? "",
+          content,
+          timestamp,
+          metadata: {
+            to: ctx.To,
+            provider: ctx.Provider,
+            surface: ctx.Surface,
+            threadId: ctx.MessageThreadId,
+            originatingChannel: ctx.OriginatingChannel,
+            originatingTo: ctx.OriginatingTo,
+            messageId: messageIdForHook,
+            senderId: ctx.SenderId,
+            senderName: ctx.SenderName,
+            senderUsername: ctx.SenderUsername,
+            senderE164: ctx.SenderE164,
+          },
+        },
+        {
+          channelId,
+          accountId: ctx.AccountId,
+          conversationId,
+        },
+      )
+      .catch((err) => {
+        logVerbose(`dispatch-from-config: message_received hook failed: ${String(err)}`);
+      });
+  }
+
+  // Fire internal hook for message:received (workspace/managed hooks)
+  {
+    const hookEvent = createInternalHookEvent("message", "received", sessionKey ?? "", {
+      from: ctx.From,
+      content:
+        typeof ctx.BodyForCommands === "string"
+          ? ctx.BodyForCommands
+          : typeof ctx.RawBody === "string"
+            ? ctx.RawBody
+            : typeof ctx.Body === "string"
+              ? ctx.Body
+              : "",
+      channel: (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase(),
+      senderId: ctx.SenderId,
+      senderName: ctx.SenderName,
+      messageId: ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast,
+    });
+    void triggerInternalHook(hookEvent).catch((err) => {
+      logVerbose(`dispatch-from-config: message:received internal hook failed: ${String(err)}`);
+    });
+  }
 
   // Check if we should route replies to originating channel instead of dispatcher.
   // Only route when the originating channel is DIFFERENT from the current surface.
@@ -220,24 +227,11 @@ export async function dispatchReplyFromConfig(params: {
   // flow when the provider handles its own messages.
   //
   // Debug: `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts`
-  const originatingChannel = normalizeMessageChannel(ctx.OriginatingChannel);
+  const originatingChannel = ctx.OriginatingChannel;
   const originatingTo = ctx.OriginatingTo;
-  const providerChannel = normalizeMessageChannel(ctx.Provider);
-  const surfaceChannel = normalizeMessageChannel(ctx.Surface);
-  // Prefer provider channel because surface may carry origin metadata in relayed flows.
-  const currentSurface = providerChannel ?? surfaceChannel;
-  const isInternalWebchatTurn =
-    currentSurface === INTERNAL_MESSAGE_CHANNEL &&
-    (surfaceChannel === INTERNAL_MESSAGE_CHANNEL || !surfaceChannel) &&
-    ctx.ExplicitDeliverRoute !== true;
-  const shouldRouteToOriginating = Boolean(
-    !isInternalWebchatTurn &&
-    isRoutableChannel(originatingChannel) &&
-    originatingTo &&
-    originatingChannel !== currentSurface,
-  );
-  const shouldSuppressTyping =
-    shouldRouteToOriginating || originatingChannel === INTERNAL_MESSAGE_CHANNEL;
+  const currentSurface = (ctx.Surface ?? ctx.Provider)?.toLowerCase();
+  const shouldRouteToOriginating =
+    isRoutableChannel(originatingChannel) && originatingTo && originatingChannel !== currentSurface;
   const ttsChannel = shouldRouteToOriginating ? originatingChannel : currentSurface;
 
   /**
@@ -265,155 +259,15 @@ export async function dispatchReplyFromConfig(params: {
       to: originatingTo,
       sessionKey: ctx.SessionKey,
       accountId: ctx.AccountId,
-      threadId: routeThreadId,
+      threadId: ctx.MessageThreadId,
       cfg,
       abortSignal,
       mirror,
-      isGroup,
-      groupId,
     });
     if (!result.ok) {
       logVerbose(`dispatch-from-config: route-reply failed: ${result.error ?? "unknown error"}`);
     }
   };
-
-  const sendBindingNotice = async (
-    payload: ReplyPayload,
-    mode: "additive" | "terminal",
-  ): Promise<boolean> => {
-    if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-      const result = await routeReply({
-        payload,
-        channel: originatingChannel,
-        to: originatingTo,
-        sessionKey: ctx.SessionKey,
-        accountId: ctx.AccountId,
-        threadId: routeThreadId,
-        cfg,
-        isGroup,
-        groupId,
-      });
-      if (!result.ok) {
-        logVerbose(
-          `dispatch-from-config: route-reply (plugin binding notice) failed: ${result.error ?? "unknown error"}`,
-        );
-      }
-      return result.ok;
-    }
-    return mode === "additive"
-      ? dispatcher.sendToolResult(payload)
-      : dispatcher.sendFinalReply(payload);
-  };
-
-  const pluginOwnedBindingRecord =
-    inboundClaimContext.conversationId && inboundClaimContext.channelId
-      ? resolveConversationBindingRecord({
-          channel: inboundClaimContext.channelId,
-          accountId: inboundClaimContext.accountId ?? "default",
-          conversationId: inboundClaimContext.conversationId,
-          parentConversationId: inboundClaimContext.parentConversationId,
-        })
-      : null;
-  const pluginOwnedBinding = isPluginOwnedSessionBindingRecord(pluginOwnedBindingRecord)
-    ? toPluginConversationBinding(pluginOwnedBindingRecord)
-    : null;
-
-  let pluginFallbackReason:
-    | "plugin-bound-fallback-missing-plugin"
-    | "plugin-bound-fallback-no-handler"
-    | undefined;
-
-  if (pluginOwnedBinding) {
-    touchConversationBindingRecord(pluginOwnedBinding.bindingId);
-    logVerbose(
-      `plugin-bound inbound routed to ${pluginOwnedBinding.pluginId} conversation=${pluginOwnedBinding.conversationId}`,
-    );
-    const targetedClaimOutcome = hookRunner?.runInboundClaimForPluginOutcome
-      ? await hookRunner.runInboundClaimForPluginOutcome(
-          pluginOwnedBinding.pluginId,
-          inboundClaimEvent,
-          inboundClaimContext,
-        )
-      : (() => {
-          const pluginLoaded =
-            getGlobalPluginRegistry()?.plugins.some(
-              (plugin) => plugin.id === pluginOwnedBinding.pluginId && plugin.status === "loaded",
-            ) ?? false;
-          return pluginLoaded
-            ? ({ status: "no_handler" } as const)
-            : ({ status: "missing_plugin" } as const);
-        })();
-
-    switch (targetedClaimOutcome.status) {
-      case "handled": {
-        markIdle("plugin_binding_dispatch");
-        recordProcessed("completed", { reason: "plugin-bound-handled" });
-        return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
-      }
-      case "missing_plugin":
-      case "no_handler": {
-        pluginFallbackReason =
-          targetedClaimOutcome.status === "missing_plugin"
-            ? "plugin-bound-fallback-missing-plugin"
-            : "plugin-bound-fallback-no-handler";
-        if (!hasShownPluginBindingFallbackNotice(pluginOwnedBinding.bindingId)) {
-          const didSendNotice = await sendBindingNotice(
-            { text: buildPluginBindingUnavailableText(pluginOwnedBinding) },
-            "additive",
-          );
-          if (didSendNotice) {
-            markPluginBindingFallbackNoticeShown(pluginOwnedBinding.bindingId);
-          }
-        }
-        break;
-      }
-      case "declined": {
-        await sendBindingNotice(
-          { text: buildPluginBindingDeclinedText(pluginOwnedBinding) },
-          "terminal",
-        );
-        markIdle("plugin_binding_declined");
-        recordProcessed("completed", { reason: "plugin-bound-declined" });
-        return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
-      }
-      case "error": {
-        logVerbose(
-          `plugin-bound inbound claim failed for ${pluginOwnedBinding.pluginId}: ${targetedClaimOutcome.error}`,
-        );
-        await sendBindingNotice(
-          { text: buildPluginBindingErrorText(pluginOwnedBinding) },
-          "terminal",
-        );
-        markIdle("plugin_binding_error");
-        recordProcessed("completed", { reason: "plugin-bound-error" });
-        return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
-      }
-    }
-  }
-
-  // Trigger plugin hooks (fire-and-forget)
-  if (hookRunner?.hasHooks("message_received")) {
-    fireAndForgetHook(
-      hookRunner.runMessageReceived(
-        toPluginMessageReceivedEvent(hookContext),
-        toPluginMessageContext(hookContext),
-      ),
-      "dispatch-from-config: message_received plugin hook failed",
-    );
-  }
-
-  // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
-  if (sessionKey) {
-    fireAndForgetHook(
-      triggerInternalHook(
-        createInternalHookEvent("message", "received", sessionKey, {
-          ...toInternalMessageReceivedContext(hookContext),
-          timestamp,
-        }),
-      ),
-      "dispatch-from-config: message_received internal hook failed",
-    );
-  }
 
   markProcessing();
 
@@ -432,10 +286,8 @@ export async function dispatchReplyFromConfig(params: {
           to: originatingTo,
           sessionKey: ctx.SessionKey,
           accountId: ctx.AccountId,
-          threadId: routeThreadId,
+          threadId: ctx.MessageThreadId,
           cfg,
-          isGroup,
-          groupId,
         });
         queuedFinal = result.ok;
         if (result.ok) {
@@ -456,102 +308,31 @@ export async function dispatchReplyFromConfig(params: {
       return { queuedFinal, counts };
     }
 
-    const bypassAcpForCommand = shouldBypassAcpDispatchForCommand(ctx, cfg);
-
-    const sendPolicy = resolveSendPolicy({
-      cfg,
-      entry: sessionStoreEntry.entry,
-      sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
-      channel:
-        sessionStoreEntry.entry?.channel ??
-        ctx.OriginatingChannel ??
-        ctx.Surface ??
-        ctx.Provider ??
-        undefined,
-      chatType: sessionStoreEntry.entry?.chatType,
-    });
-    if (sendPolicy === "deny" && !bypassAcpForCommand) {
-      logVerbose(
-        `Send blocked by policy for session ${sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"}`,
-      );
-      const counts = dispatcher.getQueuedCounts();
-      recordProcessed("completed", { reason: "send_policy_deny" });
-      markIdle("message_completed");
-      return { queuedFinal: false, counts };
-    }
-
-    const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
-    const acpDispatch = await tryDispatchAcpReply({
-      ctx,
-      cfg,
-      dispatcher,
-      sessionKey: acpDispatchSessionKey,
-      inboundAudio,
-      sessionTtsAuto,
-      ttsChannel,
-      shouldRouteToOriginating,
-      originatingChannel,
-      originatingTo,
-      shouldSendToolSummaries,
-      bypassForCommand: bypassAcpForCommand,
-      onReplyStart: params.replyOptions?.onReplyStart,
-      recordProcessed,
-      markIdle,
-    });
-    if (acpDispatch) {
-      return acpDispatch;
-    }
-
     // Track accumulated block text for TTS generation after streaming completes.
     // When block streaming succeeds, there's no final reply, so we need to generate
     // TTS audio separately from the accumulated block content.
     let accumulatedBlockText = "";
     let blockCount = 0;
 
+    const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
+
     const resolveToolDeliveryPayload = (payload: ReplyPayload): ReplyPayload | null => {
-      if (
-        shouldSuppressLocalExecApprovalPrompt({
-          channel: normalizeMessageChannel(ctx.Surface ?? ctx.Provider),
-          cfg,
-          accountId: ctx.AccountId,
-          payload,
-        })
-      ) {
-        return null;
-      }
       if (shouldSendToolSummaries) {
-        return payload;
-      }
-      const execApproval =
-        payload.channelData &&
-        typeof payload.channelData === "object" &&
-        !Array.isArray(payload.channelData)
-          ? payload.channelData.execApproval
-          : undefined;
-      if (execApproval && typeof execApproval === "object" && !Array.isArray(execApproval)) {
         return payload;
       }
       // Group/native flows intentionally suppress tool summary text, but media-only
       // tool results (for example TTS audio) must still be delivered.
-      const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
+      const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
       if (!hasMedia) {
         return null;
       }
       return { ...payload, text: undefined };
     };
-    const typing = resolveRunTypingPolicy({
-      requestedPolicy: params.replyOptions?.typingPolicy,
-      suppressTyping: params.replyOptions?.suppressTyping === true || shouldSuppressTyping,
-      originatingChannel,
-      systemEvent: shouldRouteToOriginating,
-    });
 
     const replyResult = await (params.replyResolver ?? getReplyFromConfig)(
       ctx,
       {
         ...params.replyOptions,
-        typingPolicy: typing.typingPolicy,
-        suppressTyping: typing.suppressTyping,
         onToolResult: (payload: ReplyPayload) => {
           const run = async () => {
             const ttsPayload = await maybeApplyTtsToPayload({
@@ -576,12 +357,6 @@ export async function dispatchReplyFromConfig(params: {
         },
         onBlockReply: (payload: ReplyPayload, context) => {
           const run = async () => {
-            // Suppress reasoning payloads — channels using this generic dispatch
-            // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
-            // Telegram has its own dispatch path that handles reasoning splitting.
-            if (shouldSuppressReasoningPayload(payload)) {
-              return;
-            }
             // Accumulate block text for TTS generation after streaming
             if (payload.text) {
               if (accumulatedBlockText.length > 0) {
@@ -610,42 +385,11 @@ export async function dispatchReplyFromConfig(params: {
       cfg,
     );
 
-    if (ctx.AcpDispatchTailAfterReset === true) {
-      // Command handling prepared a trailing prompt after ACP in-place reset.
-      // Route that tail through ACP now (same turn) instead of embedded dispatch.
-      ctx.AcpDispatchTailAfterReset = false;
-      const acpTailDispatch = await tryDispatchAcpReply({
-        ctx,
-        cfg,
-        dispatcher,
-        sessionKey: acpDispatchSessionKey,
-        inboundAudio,
-        sessionTtsAuto,
-        ttsChannel,
-        shouldRouteToOriginating,
-        originatingChannel,
-        originatingTo,
-        shouldSendToolSummaries,
-        bypassForCommand: false,
-        onReplyStart: params.replyOptions?.onReplyStart,
-        recordProcessed,
-        markIdle,
-      });
-      if (acpTailDispatch) {
-        return acpTailDispatch;
-      }
-    }
-
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
 
     let queuedFinal = false;
     let routedFinalCount = 0;
     for (const reply of replies) {
-      // Suppress reasoning payloads from channel delivery — channels using this
-      // generic dispatch path do not have a dedicated reasoning lane.
-      if (shouldSuppressReasoningPayload(reply)) {
-        continue;
-      }
       const ttsReply = await maybeApplyTtsToPayload({
         payload: reply,
         cfg,
@@ -662,10 +406,8 @@ export async function dispatchReplyFromConfig(params: {
           to: originatingTo,
           sessionKey: ctx.SessionKey,
           accountId: ctx.AccountId,
-          threadId: routeThreadId,
+          threadId: ctx.MessageThreadId,
           cfg,
-          isGroup,
-          groupId,
         });
         if (!result.ok) {
           logVerbose(
@@ -714,10 +456,8 @@ export async function dispatchReplyFromConfig(params: {
               to: originatingTo,
               sessionKey: ctx.SessionKey,
               accountId: ctx.AccountId,
-              threadId: routeThreadId,
+              threadId: ctx.MessageThreadId,
               cfg,
-              isGroup,
-              groupId,
             });
             queuedFinal = result.ok || queuedFinal;
             if (result.ok) {
@@ -742,10 +482,7 @@ export async function dispatchReplyFromConfig(params: {
 
     const counts = dispatcher.getQueuedCounts();
     counts.final += routedFinalCount;
-    recordProcessed(
-      "completed",
-      pluginFallbackReason ? { reason: pluginFallbackReason } : undefined,
-    );
+    recordProcessed("completed");
     markIdle("message_completed");
     return { queuedFinal, counts };
   } catch (err) {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1,53 +1,62 @@
 import {
-  resolveSendableOutboundReplyParts,
-  sendMediaWithLeadingCaption,
-} from "openclaw/plugin-sdk/reply-payload";
-import {
   chunkByParagraph,
   chunkMarkdownTextWithMode,
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "../../auto-reply/chunk.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import { resolveChannelMediaMaxBytes } from "../../channels/plugins/media-limits.js";
 import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.js";
 import type {
   ChannelOutboundAdapter,
   ChannelOutboundContext,
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import {
   appendAssistantMessageToSessionTranscript,
   resolveMirroredTranscriptText,
 } from "../../config/sessions.js";
-import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
+import type { sendMessageDiscord } from "../../discord/send.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
-import {
-  buildCanonicalSentMessageHookContext,
-  toInternalMessageSentContext,
-  toPluginMessageContext,
-  toPluginMessageSentEvent,
-} from "../../hooks/message-hook-mappers.js";
-import { hasReplyPayloadContent } from "../../interactive/payload.js";
-import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { sendMessageIMessage } from "../../imessage/send.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { markdownToSignalTextChunks, type SignalTextStyleRange } from "../../signal/format.js";
+import { sendMessageSignal } from "../../signal/send.js";
+import type { sendMessageSlack } from "../../slack/send.js";
+import type { sendMessageTelegram } from "../../telegram/send.js";
+import type { sendMessageWhatsApp } from "../../web/outbound.js";
 import { throwIfAborted } from "./abort.js";
-import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
 import type { OutboundIdentity } from "./identity.js";
-import type { DeliveryMirror } from "./mirror.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
-import { isPlainTextSurface, sanitizeForPlainText } from "./sanitize-text.js";
-import { resolveOutboundSendDep, type OutboundSendDeps } from "./send-deps.js";
-import type { OutboundSessionContext } from "./session-context.js";
 import type { OutboundChannel } from "./targets.js";
 
 export type { NormalizedOutboundPayload } from "./payloads.js";
 export { normalizeOutboundPayloads } from "./payloads.js";
-export { resolveOutboundSendDep, type OutboundSendDeps } from "./send-deps.js";
 
-const log = createSubsystemLogger("outbound/deliver");
+type SendMatrixMessage = (
+  to: string,
+  text: string,
+  opts?: { mediaUrl?: string; replyToId?: string; threadId?: string; timeoutMs?: number },
+) => Promise<{ messageId: string; roomId: string }>;
+
+export type OutboundSendDeps = {
+  sendWhatsApp?: typeof sendMessageWhatsApp;
+  sendTelegram?: typeof sendMessageTelegram;
+  sendDiscord?: typeof sendMessageDiscord;
+  sendSlack?: typeof sendMessageSlack;
+  sendSignal?: typeof sendMessageSignal;
+  sendIMessage?: typeof sendMessageIMessage;
+  sendMatrix?: SendMatrixMessage;
+  sendMSTeams?: (
+    to: string,
+    text: string,
+    opts?: { mediaUrl?: string },
+  ) => Promise<{ messageId: string; conversationId: string }>;
+};
 
 export type OutboundDeliveryResult = {
   channel: Exclude<OutboundChannel, "none">;
@@ -69,27 +78,8 @@ type ChannelHandler = {
   chunker: Chunker | null;
   chunkerMode?: "text" | "markdown";
   textChunkLimit?: number;
-  supportsMedia: boolean;
-  normalizePayload?: (payload: ReplyPayload) => ReplyPayload | null;
-  shouldSkipPlainTextSanitization?: (payload: ReplyPayload) => boolean;
-  resolveEffectiveTextChunkLimit?: (fallbackLimit?: number) => number | undefined;
   sendPayload?: (
     payload: ReplyPayload,
-    overrides?: {
-      replyToId?: string | null;
-      threadId?: string | number | null;
-    },
-  ) => Promise<OutboundDeliveryResult>;
-  sendFormattedText?: (
-    text: string,
-    overrides?: {
-      replyToId?: string | null;
-      threadId?: string | number | null;
-    },
-  ) => Promise<OutboundDeliveryResult[]>;
-  sendFormattedMedia?: (
-    caption: string,
-    mediaUrl: string,
     overrides?: {
       replyToId?: string | null;
       threadId?: string | number | null;
@@ -122,20 +112,12 @@ type ChannelHandlerParams = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
-  forceDocument?: boolean;
   silent?: boolean;
   mediaLocalRoots?: readonly string[];
 };
 
 // Channel docking: outbound delivery delegates to plugin.outbound adapters.
 async function createChannelHandler(params: ChannelHandlerParams): Promise<ChannelHandler> {
-  // Recover channel plugins the same way target resolution does so direct cron
-  // delivery still works when a prior test or lazy path left the active plugin
-  // registry empty.
-  resolveOutboundChannelPlugin({
-    channel: params.channel,
-    cfg: params.cfg,
-  });
   const outbound = await loadChannelOutboundAdapter(params.channel);
   const handler = createPluginHandler({ ...params, outbound });
   if (!handler) {
@@ -148,7 +130,7 @@ function createPluginHandler(
   params: ChannelHandlerParams & { outbound?: ChannelOutboundAdapter },
 ): ChannelHandler | null {
   const outbound = params.outbound;
-  if (!outbound?.sendText) {
+  if (!outbound?.sendText || !outbound?.sendMedia) {
     return null;
   }
   const baseCtx = createChannelOutboundContextBase(params);
@@ -168,21 +150,6 @@ function createPluginHandler(
     chunker,
     chunkerMode,
     textChunkLimit: outbound.textChunkLimit,
-    supportsMedia: Boolean(sendMedia),
-    normalizePayload: outbound.normalizePayload
-      ? (payload) => outbound.normalizePayload!({ payload })
-      : undefined,
-    shouldSkipPlainTextSanitization: outbound.shouldSkipPlainTextSanitization
-      ? (payload) => outbound.shouldSkipPlainTextSanitization!({ payload })
-      : undefined,
-    resolveEffectiveTextChunkLimit: outbound.resolveEffectiveTextChunkLimit
-      ? (fallbackLimit) =>
-          outbound.resolveEffectiveTextChunkLimit!({
-            cfg: params.cfg,
-            accountId: params.accountId ?? undefined,
-            fallbackLimit,
-          })
-      : undefined,
     sendPayload: outbound.sendPayload
       ? async (payload, overrides) =>
           outbound.sendPayload!({
@@ -192,39 +159,17 @@ function createPluginHandler(
             payload,
           })
       : undefined,
-    sendFormattedText: outbound.sendFormattedText
-      ? async (text, overrides) =>
-          outbound.sendFormattedText!({
-            ...resolveCtx(overrides),
-            text,
-          })
-      : undefined,
-    sendFormattedMedia: outbound.sendFormattedMedia
-      ? async (caption, mediaUrl, overrides) =>
-          outbound.sendFormattedMedia!({
-            ...resolveCtx(overrides),
-            text: caption,
-            mediaUrl,
-          })
-      : undefined,
     sendText: async (text, overrides) =>
       sendText({
         ...resolveCtx(overrides),
         text,
       }),
-    sendMedia: async (caption, mediaUrl, overrides) => {
-      if (sendMedia) {
-        return sendMedia({
-          ...resolveCtx(overrides),
-          text: caption,
-          mediaUrl,
-        });
-      }
-      return sendText({
+    sendMedia: async (caption, mediaUrl, overrides) =>
+      sendMedia({
         ...resolveCtx(overrides),
         text: caption,
-      });
-    },
+        mediaUrl,
+      }),
   };
 }
 
@@ -239,7 +184,6 @@ function createChannelOutboundContextBase(
     threadId: params.threadId,
     identity: params.identity,
     gifPlayback: params.gifPlayback,
-    forceDocument: params.forceDocument,
     deps: params.deps,
     silent: params.silent,
     mediaLocalRoots: params.mediaLocalRoots,
@@ -259,218 +203,25 @@ type DeliverOutboundPayloadsCoreParams = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
-  forceDocument?: boolean;
   abortSignal?: AbortSignal;
   bestEffort?: boolean;
   onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
   onPayload?: (payload: NormalizedOutboundPayload) => void;
-  /** Session/agent context used for hooks and media local-root scoping. */
-  session?: OutboundSessionContext;
-  mirror?: DeliveryMirror;
+  /** Active agent id for media local-root scoping. */
+  agentId?: string;
+  mirror?: {
+    sessionKey: string;
+    agentId?: string;
+    text?: string;
+    mediaUrls?: string[];
+  };
   silent?: boolean;
 };
 
-export type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & {
+type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & {
   /** @internal Skip write-ahead queue (used by crash-recovery to avoid re-enqueueing). */
   skipQueue?: boolean;
 };
-
-type MessageSentEvent = {
-  success: boolean;
-  content: string;
-  error?: string;
-  messageId?: string;
-};
-
-function normalizeEmptyPayloadForDelivery(payload: ReplyPayload): ReplyPayload | null {
-  const text = typeof payload.text === "string" ? payload.text : "";
-  if (!text.trim()) {
-    if (!hasReplyPayloadContent({ ...payload, text })) {
-      return null;
-    }
-    if (text) {
-      return {
-        ...payload,
-        text: "",
-      };
-    }
-  }
-  return payload;
-}
-
-function normalizePayloadsForChannelDelivery(
-  payloads: ReplyPayload[],
-  channel: Exclude<OutboundChannel, "none">,
-  handler: ChannelHandler,
-): ReplyPayload[] {
-  const normalizedPayloads: ReplyPayload[] = [];
-  for (const payload of normalizeReplyPayloadsForDelivery(payloads)) {
-    let sanitizedPayload = payload;
-    // Strip HTML tags for plain-text surfaces (WhatsApp, Signal, etc.)
-    // Models occasionally produce <br>, <b>, etc. that render as literal text.
-    // See https://github.com/openclaw/openclaw/issues/31884
-    if (isPlainTextSurface(channel) && sanitizedPayload.text) {
-      if (!handler.shouldSkipPlainTextSanitization?.(sanitizedPayload)) {
-        sanitizedPayload = {
-          ...sanitizedPayload,
-          text: sanitizeForPlainText(sanitizedPayload.text),
-        };
-      }
-    }
-    const normalizedPayload = handler.normalizePayload
-      ? handler.normalizePayload(sanitizedPayload)
-      : sanitizedPayload;
-    const normalized = normalizedPayload
-      ? normalizeEmptyPayloadForDelivery(normalizedPayload)
-      : null;
-    if (normalized) {
-      normalizedPayloads.push(normalized);
-    }
-  }
-  return normalizedPayloads;
-}
-
-function buildPayloadSummary(payload: ReplyPayload): NormalizedOutboundPayload {
-  const parts = resolveSendableOutboundReplyParts(payload);
-  return {
-    text: parts.text,
-    mediaUrls: parts.mediaUrls,
-    interactive: payload.interactive,
-    channelData: payload.channelData,
-  };
-}
-
-function createMessageSentEmitter(params: {
-  hookRunner: ReturnType<typeof getGlobalHookRunner>;
-  channel: Exclude<OutboundChannel, "none">;
-  to: string;
-  accountId?: string;
-  sessionKeyForInternalHooks?: string;
-  mirrorIsGroup?: boolean;
-  mirrorGroupId?: string;
-}): { emitMessageSent: (event: MessageSentEvent) => void; hasMessageSentHooks: boolean } {
-  const hasMessageSentHooks = params.hookRunner?.hasHooks("message_sent") ?? false;
-  const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
-  const emitMessageSent = (event: MessageSentEvent) => {
-    if (!hasMessageSentHooks && !canEmitInternalHook) {
-      return;
-    }
-    const canonical = buildCanonicalSentMessageHookContext({
-      to: params.to,
-      content: event.content,
-      success: event.success,
-      error: event.error,
-      channelId: params.channel,
-      accountId: params.accountId ?? undefined,
-      conversationId: params.to,
-      messageId: event.messageId,
-      isGroup: params.mirrorIsGroup,
-      groupId: params.mirrorGroupId,
-    });
-    if (hasMessageSentHooks) {
-      fireAndForgetHook(
-        params.hookRunner!.runMessageSent(
-          toPluginMessageSentEvent(canonical),
-          toPluginMessageContext(canonical),
-        ),
-        "deliverOutboundPayloads: message_sent plugin hook failed",
-        (message) => {
-          log.warn(message);
-        },
-      );
-    }
-    if (!canEmitInternalHook) {
-      return;
-    }
-    fireAndForgetHook(
-      triggerInternalHook(
-        createInternalHookEvent(
-          "message",
-          "sent",
-          params.sessionKeyForInternalHooks!,
-          toInternalMessageSentContext(canonical),
-        ),
-      ),
-      "deliverOutboundPayloads: message:sent internal hook failed",
-      (message) => {
-        log.warn(message);
-      },
-    );
-  };
-  return { emitMessageSent, hasMessageSentHooks };
-}
-
-async function applyMessageSendingHook(params: {
-  hookRunner: ReturnType<typeof getGlobalHookRunner>;
-  enabled: boolean;
-  payload: ReplyPayload;
-  payloadSummary: NormalizedOutboundPayload;
-  to: string;
-  channel: Exclude<OutboundChannel, "none">;
-  accountId?: string;
-}): Promise<{
-  cancelled: boolean;
-  payload: ReplyPayload;
-  payloadSummary: NormalizedOutboundPayload;
-}> {
-  if (!params.enabled) {
-    return {
-      cancelled: false,
-      payload: params.payload,
-      payloadSummary: params.payloadSummary,
-    };
-  }
-  try {
-    const sendingResult = await params.hookRunner!.runMessageSending(
-      {
-        to: params.to,
-        content: params.payloadSummary.text,
-        metadata: {
-          channel: params.channel,
-          accountId: params.accountId,
-          mediaUrls: params.payloadSummary.mediaUrls,
-        },
-      },
-      {
-        channelId: params.channel,
-        accountId: params.accountId ?? undefined,
-      },
-    );
-    if (sendingResult?.cancel) {
-      return {
-        cancelled: true,
-        payload: params.payload,
-        payloadSummary: params.payloadSummary,
-      };
-    }
-    if (sendingResult?.content == null) {
-      return {
-        cancelled: false,
-        payload: params.payload,
-        payloadSummary: params.payloadSummary,
-      };
-    }
-    const payload = {
-      ...params.payload,
-      text: sendingResult.content,
-    };
-    return {
-      cancelled: false,
-      payload,
-      payloadSummary: {
-        ...params.payloadSummary,
-        text: sendingResult.content,
-      },
-    };
-  } catch {
-    // Don't block delivery on hook failure.
-    return {
-      cancelled: false,
-      payload: params.payload,
-      payloadSummary: params.payloadSummary,
-    };
-  }
-}
 
 export async function deliverOutboundPayloads(
   params: DeliverOutboundPayloadsParams,
@@ -489,7 +240,6 @@ export async function deliverOutboundPayloads(
         replyToId: params.replyToId,
         bestEffort: params.bestEffort,
         gifPlayback: params.gifPlayback,
-        forceDocument: params.forceDocument,
         silent: params.silent,
         mirror: params.mirror,
       }).catch(() => null); // Best-effort — don't block delivery if queue write fails.
@@ -541,9 +291,10 @@ async function deliverOutboundPayloadsCore(
   const accountId = params.accountId;
   const deps = params.deps;
   const abortSignal = params.abortSignal;
+  const sendSignal = params.deps?.sendSignal ?? sendMessageSignal;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(
     cfg,
-    params.session?.agentId ?? params.mirror?.agentId,
+    params.agentId ?? params.mirror?.agentId,
   );
   const results: OutboundDeliveryResult[] = [];
   const handler = await createChannelHandler({
@@ -556,19 +307,28 @@ async function deliverOutboundPayloadsCore(
     threadId: params.threadId,
     identity: params.identity,
     gifPlayback: params.gifPlayback,
-    forceDocument: params.forceDocument,
     silent: params.silent,
     mediaLocalRoots,
   });
-  const configuredTextLimit = handler.chunker
+  const textLimit = handler.chunker
     ? resolveTextChunkLimit(cfg, channel, accountId, {
         fallbackLimit: handler.textChunkLimit,
       })
     : undefined;
-  const textLimit = handler.resolveEffectiveTextChunkLimit
-    ? handler.resolveEffectiveTextChunkLimit(configuredTextLimit)
-    : configuredTextLimit;
   const chunkMode = handler.chunker ? resolveChunkMode(cfg, channel, accountId) : "length";
+  const isSignalChannel = channel === "signal";
+  const signalTableMode = isSignalChannel
+    ? resolveMarkdownTableMode({ cfg, channel: "signal", accountId })
+    : "code";
+  const signalMaxBytes = isSignalChannel
+    ? resolveChannelMediaMaxBytes({
+        cfg,
+        resolveChannelLimitMb: ({ cfg, accountId }) =>
+          cfg.channels?.signal?.accounts?.[accountId]?.mediaMaxMb ??
+          cfg.channels?.signal?.mediaMaxMb,
+        accountId,
+      })
+    : undefined;
 
   const sendTextChunks = async (
     text: string,
@@ -607,148 +367,183 @@ async function deliverOutboundPayloadsCore(
       results.push(await handler.sendText(chunk, overrides));
     }
   };
-  const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel, handler);
-  const hookRunner = getGlobalHookRunner();
-  const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
-  const mirrorIsGroup = params.mirror?.isGroup;
-  const mirrorGroupId = params.mirror?.groupId;
-  const { emitMessageSent, hasMessageSentHooks } = createMessageSentEmitter({
-    hookRunner,
-    channel,
-    to,
-    accountId,
-    sessionKeyForInternalHooks,
-    mirrorIsGroup,
-    mirrorGroupId,
+
+  const sendSignalText = async (text: string, styles: SignalTextStyleRange[]) => {
+    throwIfAborted(abortSignal);
+    return {
+      channel: "signal" as const,
+      ...(await sendSignal(to, text, {
+        maxBytes: signalMaxBytes,
+        accountId: accountId ?? undefined,
+        textMode: "plain",
+        textStyles: styles,
+      })),
+    };
+  };
+
+  const sendSignalTextChunks = async (text: string) => {
+    throwIfAborted(abortSignal);
+    let signalChunks =
+      textLimit === undefined
+        ? markdownToSignalTextChunks(text, Number.POSITIVE_INFINITY, {
+            tableMode: signalTableMode,
+          })
+        : markdownToSignalTextChunks(text, textLimit, { tableMode: signalTableMode });
+    if (signalChunks.length === 0 && text) {
+      signalChunks = [{ text, styles: [] }];
+    }
+    for (const chunk of signalChunks) {
+      throwIfAborted(abortSignal);
+      results.push(await sendSignalText(chunk.text, chunk.styles));
+    }
+  };
+
+  const sendSignalMedia = async (caption: string, mediaUrl: string) => {
+    throwIfAborted(abortSignal);
+    const formatted = markdownToSignalTextChunks(caption, Number.POSITIVE_INFINITY, {
+      tableMode: signalTableMode,
+    })[0] ?? {
+      text: caption,
+      styles: [],
+    };
+    return {
+      channel: "signal" as const,
+      ...(await sendSignal(to, formatted.text, {
+        mediaUrl,
+        maxBytes: signalMaxBytes,
+        accountId: accountId ?? undefined,
+        textMode: "plain",
+        textStyles: formatted.styles,
+        mediaLocalRoots,
+      })),
+    };
+  };
+  const normalizeWhatsAppPayload = (payload: ReplyPayload): ReplyPayload | null => {
+    const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+    const rawText = typeof payload.text === "string" ? payload.text : "";
+    const normalizedText = rawText.replace(/^(?:[ \t]*\r?\n)+/, "");
+    if (!normalizedText.trim()) {
+      if (!hasMedia) {
+        return null;
+      }
+      return {
+        ...payload,
+        text: "",
+      };
+    }
+    return {
+      ...payload,
+      text: normalizedText,
+    };
+  };
+  const normalizedPayloads = normalizeReplyPayloadsForDelivery(payloads).flatMap((payload) => {
+    if (channel !== "whatsapp") {
+      return [payload];
+    }
+    const normalized = normalizeWhatsAppPayload(payload);
+    return normalized ? [normalized] : [];
   });
-  const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
-  if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
-    log.warn(
-      "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
-      {
-        channel,
-        to,
-        agentId: params.session.agentId,
-      },
-    );
-  }
+  const hookRunner = getGlobalHookRunner();
   for (const payload of normalizedPayloads) {
-    let payloadSummary = buildPayloadSummary(payload);
+    const payloadSummary: NormalizedOutboundPayload = {
+      text: payload.text ?? "",
+      mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
+      channelData: payload.channelData,
+    };
+    const emitMessageSent = (success: boolean, error?: string) => {
+      // Fire internal hook for message:sent (workspace/managed hooks)
+      void triggerInternalHook(
+        createInternalHookEvent("message", "sent", params.mirror?.sessionKey ?? "", {
+          to,
+          content: payloadSummary.text,
+          channel,
+          success,
+          ...(error ? { error } : {}),
+        }),
+      ).catch(() => {});
+
+      if (!hookRunner?.hasHooks("message_sent")) {
+        return;
+      }
+      void hookRunner
+        .runMessageSent(
+          {
+            to,
+            content: payloadSummary.text,
+            success,
+            ...(error ? { error } : {}),
+          },
+          {
+            channelId: channel,
+            accountId: accountId ?? undefined,
+          },
+        )
+        .catch(() => {});
+    };
     try {
       throwIfAborted(abortSignal);
 
       // Run message_sending plugin hook (may modify content or cancel)
-      const hookResult = await applyMessageSendingHook({
-        hookRunner,
-        enabled: hasMessageSendingHooks,
-        payload,
-        payloadSummary,
-        to,
-        channel,
-        accountId,
-      });
-      if (hookResult.cancelled) {
-        continue;
+      let effectivePayload = payload;
+      if (hookRunner?.hasHooks("message_sending")) {
+        try {
+          const sendingResult = await hookRunner.runMessageSending(
+            {
+              to,
+              content: payloadSummary.text,
+              metadata: { channel, accountId, mediaUrls: payloadSummary.mediaUrls },
+            },
+            {
+              channelId: channel,
+              accountId: accountId ?? undefined,
+            },
+          );
+          if (sendingResult?.cancel) {
+            continue;
+          }
+          if (sendingResult?.content != null) {
+            effectivePayload = { ...payload, text: sendingResult.content };
+            payloadSummary.text = sendingResult.content;
+          }
+        } catch {
+          // Don't block delivery on hook failure
+        }
       }
-      const effectivePayload = hookResult.payload;
-      payloadSummary = hookResult.payloadSummary;
 
       params.onPayload?.(payloadSummary);
       const sendOverrides = {
         replyToId: effectivePayload.replyToId ?? params.replyToId ?? undefined,
         threadId: params.threadId ?? undefined,
-        forceDocument: params.forceDocument,
       };
-      if (
-        handler.sendPayload &&
-        hasReplyPayloadContent({
-          interactive: effectivePayload.interactive,
-          channelData: effectivePayload.channelData,
-        })
-      ) {
-        const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
-        results.push(delivery);
-        emitMessageSent({
-          success: true,
-          content: payloadSummary.text,
-          messageId: delivery.messageId,
-        });
+      if (handler.sendPayload && effectivePayload.channelData) {
+        results.push(await handler.sendPayload(effectivePayload, sendOverrides));
+        emitMessageSent(true);
         continue;
       }
       if (payloadSummary.mediaUrls.length === 0) {
-        const beforeCount = results.length;
-        if (handler.sendFormattedText) {
-          results.push(...(await handler.sendFormattedText(payloadSummary.text, sendOverrides)));
+        if (isSignalChannel) {
+          await sendSignalTextChunks(payloadSummary.text);
         } else {
           await sendTextChunks(payloadSummary.text, sendOverrides);
         }
-        const messageId = results.at(-1)?.messageId;
-        emitMessageSent({
-          success: results.length > beforeCount,
-          content: payloadSummary.text,
-          messageId,
-        });
+        emitMessageSent(true);
         continue;
       }
 
-      if (!handler.supportsMedia) {
-        log.warn(
-          "Plugin outbound adapter does not implement sendMedia; media URLs will be dropped and text fallback will be used",
-          {
-            channel,
-            to,
-            mediaCount: payloadSummary.mediaUrls.length,
-          },
-        );
-        const fallbackText = payloadSummary.text.trim();
-        if (!fallbackText) {
-          throw new Error(
-            "Plugin outbound adapter does not implement sendMedia and no text fallback is available for media payload",
-          );
+      let first = true;
+      for (const url of payloadSummary.mediaUrls) {
+        throwIfAborted(abortSignal);
+        const caption = first ? payloadSummary.text : "";
+        first = false;
+        if (isSignalChannel) {
+          results.push(await sendSignalMedia(caption, url));
+        } else {
+          results.push(await handler.sendMedia(caption, url, sendOverrides));
         }
-        const beforeCount = results.length;
-        await sendTextChunks(fallbackText, sendOverrides);
-        const messageId = results.at(-1)?.messageId;
-        emitMessageSent({
-          success: results.length > beforeCount,
-          content: payloadSummary.text,
-          messageId,
-        });
-        continue;
       }
-
-      let lastMessageId: string | undefined;
-      await sendMediaWithLeadingCaption({
-        mediaUrls: payloadSummary.mediaUrls,
-        caption: payloadSummary.text,
-        send: async ({ mediaUrl, caption }) => {
-          throwIfAborted(abortSignal);
-          if (handler.sendFormattedMedia) {
-            const delivery = await handler.sendFormattedMedia(
-              caption ?? "",
-              mediaUrl,
-              sendOverrides,
-            );
-            results.push(delivery);
-            lastMessageId = delivery.messageId;
-            return;
-          }
-          const delivery = await handler.sendMedia(caption ?? "", mediaUrl, sendOverrides);
-          results.push(delivery);
-          lastMessageId = delivery.messageId;
-        },
-      });
-      emitMessageSent({
-        success: true,
-        content: payloadSummary.text,
-        messageId: lastMessageId,
-      });
+      emitMessageSent(true);
     } catch (err) {
-      emitMessageSent({
-        success: false,
-        content: payloadSummary.text,
-        error: err instanceof Error ? err.message : String(err),
-      });
+      emitMessageSent(false, err instanceof Error ? err.message : String(err));
       if (!params.bestEffort) {
         throw err;
       }
@@ -765,10 +560,8 @@ async function deliverOutboundPayloadsCore(
         agentId: params.mirror.agentId,
         sessionKey: params.mirror.sessionKey,
         text: mirrorText,
-        idempotencyKey: params.mirror.idempotencyKey,
       });
     }
   }
-
   return results;
 }


### PR DESCRIPTION
## Summary

Adds five new internal hook event types for agent lifecycle, enabling workspace/managed hooks to react to the full agent work loop — not just slash commands.

## New Events

| Event | Fires When | Location |
|-------|-----------|----------|
| `session:start` | After `/new` or `/reset` creates a new session | `commands-core.ts` |
| `session:end` | After `/stop` command | `commands-session.ts` |
| `agent:error` | Agent encounters LLM/tool error | `pi-embedded-subscribe.handlers.lifecycle.ts` |
| `message:received` | Inbound message arrives from user | `dispatch-from-config.ts` |
| `message:sent` | Outbound message delivered to user | `deliver.ts` |

## Changes

- **`src/hooks/internal-hooks.ts`**: Added `message` to `InternalHookEventType` union
- **`src/auto-reply/reply/commands-core.ts`**: Fire `session:start` after /new and /reset
- **`src/auto-reply/reply/commands-session.ts`**: Fire `session:end` after /stop  
- **`src/agents/pi-embedded-subscribe.handlers.lifecycle.ts`**: Fire `agent:error` on agent errors
- **`src/auto-reply/reply/dispatch-from-config.ts`**: Fire `message:received` on inbound messages
- **`src/infra/outbound/deliver.ts`**: Fire `message:sent` on outbound delivery
- **`docs/automation/hooks.md`**: Moved events from 'Future Events' to documented sections

## Design

- All new hooks are fire-and-forget (`void triggerInternalHook(...).catch()`) to avoid blocking the main message/agent flow
- Events are emitted alongside existing plugin hooks where applicable (e.g., `message_received` plugin hook)
- Minimal changes — no refactoring of unrelated code

## Testing

- `npm run build` ✅ compiles clean
- All existing hook tests pass (`npx vitest run src/hooks/` — 86 tests, 9 files)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds five new internal hook event types (`session:start`, `session:end`, `agent:error`, `message:received`, `message:sent`) to enable workspace/managed hooks to react to the full agent lifecycle. All hooks follow the existing fire-and-forget pattern and are placed alongside existing plugin hooks.

- The `message:sent` hook in `deliver.ts` derives its `sessionKey` from `params.mirror?.sessionKey`, but `mirror` is optional and absent at the majority of call sites (~61%). This causes the hook to fire with an empty session key in many delivery paths (heartbeat, cron, CLI sends), which limits usefulness for session-aware hook consumers.
- The Event Context type example in the docs (`hooks.md` line 210) still shows the old 4-type union and is missing the newly added `'message'` type.
- Code changes are otherwise clean: deduplication is respected for `message:received`, hook placement is correct relative to existing hooks, and error handling is consistent.

<h3>Confidence Score: 3/5</h3>

- Generally safe — hooks are fire-and-forget and won't block the main flow, but the `message:sent` session key gap warrants a fix before merging.
- Most of the hook additions are clean and well-placed. However, the `message:sent` hook will frequently fire with an empty `sessionKey` due to `mirror` being absent at most call sites, and the docs have a stale type definition. These issues reduce confidence from what would otherwise be a straightforward feature addition.
- `src/infra/outbound/deliver.ts` (empty sessionKey in most delivery paths), `docs/automation/hooks.md` (stale Event Context type)

<sub>Last reviewed commit: 5f57b02</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->