### PR TITLE
Fix: tighten Slack multi-account event filtering via api_app_id

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -55,6 +55,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   id: "slack",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: slackOnboardingAdapter,
   pairing: {

--- a/src/agents/tools/sessions-announce-target.test.ts
+++ b/src/agents/tools/sessions-announce-target.test.ts
@@ -51,6 +51,26 @@ const installRegistry = async () => {
           },
         },
       },
+      {
+        pluginId: "slack",
+        source: "test",
+        plugin: {
+          id: "slack",
+          meta: {
+            id: "slack",
+            label: "Slack",
+            selectionLabel: "Slack",
+            docsPath: "/channels/slack",
+            blurb: "Slack test stub.",
+            preferSessionLookupForAnnounceTarget: true,
+          },
+          capabilities: { chatTypes: ["direct", "channel", "thread"] },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+        },
+      },
     ]),
   );
 };
@@ -94,6 +114,36 @@ describe("resolveAnnounceTarget", () => {
     expect(target).toEqual({
       channel: "whatsapp",
       to: "123@g.us",
+      accountId: "work",
+    });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const first = callGatewayMock.mock.calls[0]?.[0] as { method?: string } | undefined;
+    expect(first).toBeDefined();
+    expect(first?.method).toBe("sessions.list");
+  });
+
+  it("hydrates Slack accountId from sessions.list when available", async () => {
+    const { resolveAnnounceTarget } = await loadResolveAnnounceTarget();
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:slack:channel:C0123ABC",
+          deliveryContext: {
+            channel: "slack",
+            to: "C0123ABC",
+            accountId: "work",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:slack:channel:C0123ABC",
+      displayKey: "agent:main:slack:channel:C0123ABC",
+    });
+    expect(target).toEqual({
+      channel: "slack",
+      to: "C0123ABC",
       accountId: "work",
     });
     expect(callGatewayMock).toHaveBeenCalledTimes(1);

--- a/src/slack/monitor/context.multi-account.test.ts
+++ b/src/slack/monitor/context.multi-account.test.ts
@@ -1,0 +1,135 @@
+import type { App } from "@slack/bolt";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { createSlackMonitorContext } from "./context.js";
+
+describe("createSlackMonitorContext - multi-account filtering", () => {
+  const createTestContext = (accountId: string, apiAppId: string, teamId = "T0123") => {
+    return createSlackMonitorContext({
+      cfg: {} as OpenClawConfig,
+      accountId,
+      botToken: "xoxb-test",
+      app: { client: {} } as App,
+      runtime: {} as RuntimeEnv,
+      botUserId: `U${accountId.toUpperCase()}`,
+      teamId,
+      apiAppId,
+      historyLimit: 0,
+      sessionScope: "per-sender",
+      mainKey: "main",
+      dmEnabled: true,
+      dmPolicy: "open",
+      allowFrom: [],
+      groupDmEnabled: false,
+      groupDmChannels: [],
+      groupPolicy: "open",
+      useAccessGroups: false,
+      reactionMode: "own",
+      reactionAllowlist: [],
+      replyToMode: "all",
+      threadHistoryScope: "thread",
+      threadInheritParent: false,
+      slashCommand: {
+        enabled: false,
+        name: "openclaw",
+        sessionPrefix: "slack:slash",
+        ephemeral: true,
+      },
+      textLimit: 4000,
+      ackReactionScope: "group-mentions",
+      mediaMaxBytes: 20 * 1024 * 1024,
+      removeAckAfterReply: false,
+    });
+  };
+
+  it("drops events with mismatched api_app_id when apiAppId is set", () => {
+    const ctx = createTestContext("og", "A0OG123");
+    const eventBody = {
+      api_app_id: "A0MAKILALA456",
+      team_id: "T0123",
+      event: { type: "message" },
+    };
+
+    expect(ctx.shouldDropMismatchedSlackEvent(eventBody)).toBe(true);
+  });
+
+  it("accepts events with matching api_app_id", () => {
+    const ctx = createTestContext("og", "A0OG123");
+    const eventBody = {
+      api_app_id: "A0OG123",
+      team_id: "T0123",
+      event: { type: "message" },
+    };
+
+    expect(ctx.shouldDropMismatchedSlackEvent(eventBody)).toBe(false);
+  });
+
+  it("drops events with missing api_app_id when apiAppId is set (multi-account safety)", () => {
+    const ctx = createTestContext("og", "A0OG123");
+    const eventBody = {
+      team_id: "T0123",
+      event: { type: "message" },
+    };
+
+    // When we have apiAppId configured, we REQUIRE incoming events to have it
+    expect(ctx.shouldDropMismatchedSlackEvent(eventBody)).toBe(true);
+  });
+
+  it("accepts events without api_app_id when apiAppId is not set (backward compat)", () => {
+    const ctx = createTestContext("default", ""); // empty apiAppId
+    const eventBody = {
+      team_id: "T0123",
+      event: { type: "message" },
+    };
+
+    // Backward compatibility: if we don't have apiAppId, we can't filter on it
+    expect(ctx.shouldDropMismatchedSlackEvent(eventBody)).toBe(false);
+  });
+
+  it("multiple accounts with different api_app_ids only process their own events", () => {
+    const ogCtx = createTestContext("og", "A0OG123");
+    const makilalaCtx = createTestContext("makilala", "A0MAKILALA456");
+
+    const ogEvent = {
+      api_app_id: "A0OG123",
+      team_id: "T0123",
+      event: { type: "app_mention" },
+    };
+
+    const makilalaEvent = {
+      api_app_id: "A0MAKILALA456",
+      team_id: "T0123",
+      event: { type: "app_mention" },
+    };
+
+    // og context accepts og events, drops makilala events
+    expect(ogCtx.shouldDropMismatchedSlackEvent(ogEvent)).toBe(false);
+    expect(ogCtx.shouldDropMismatchedSlackEvent(makilalaEvent)).toBe(true);
+
+    // makilala context accepts makilala events, drops og events
+    expect(makilalaCtx.shouldDropMismatchedSlackEvent(makilalaEvent)).toBe(false);
+    expect(makilalaCtx.shouldDropMismatchedSlackEvent(ogEvent)).toBe(true);
+  });
+
+  it("drops events with mismatched team_id when apiAppId is not available", () => {
+    const ctx = createTestContext("og", "", "T0OG123");
+    const eventBody = {
+      team_id: "T0DIFFERENT",
+      event: { type: "message" },
+    };
+
+    // Fallback to team_id filtering when api_app_id is not available
+    expect(ctx.shouldDropMismatchedSlackEvent(eventBody)).toBe(true);
+  });
+
+  it("accepts events with matching team_id when apiAppId is not available", () => {
+    const ctx = createTestContext("og", "", "T0OG123");
+    const eventBody = {
+      team_id: "T0OG123",
+      event: { type: "message" },
+    };
+
+    expect(ctx.shouldDropMismatchedSlackEvent(eventBody)).toBe(false);
+  });
+});

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -160,13 +160,22 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     botUserId = auth.user_id ?? "";
     teamId = auth.team_id ?? "";
     apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
-  } catch {
+  } catch (err) {
     // auth test failing is non-fatal; message handler falls back to regex mentions.
+    runtime.error?.(
+      `slack[${account.accountId}]: auth.test failed: ${String(err)}. Multi-account routing may not work correctly.`,
+    );
+  }
+
+  if (!apiAppId) {
+    runtime.log?.(
+      `slack[${account.accountId}]: warning: api_app_id not available from auth.test. Multi-account setups may experience routing issues.`,
+    );
   }
 
   if (apiAppId && expectedApiAppIdFromAppToken && apiAppId !== expectedApiAppIdFromAppToken) {
     runtime.error?.(
-      `slack token mismatch: bot token api_app_id=${apiAppId} but app token looks like api_app_id=${expectedApiAppIdFromAppToken}`,
+      `slack[${account.accountId}]: token mismatch: bot token api_app_id=${apiAppId} but app token looks like api_app_id=${expectedApiAppIdFromAppToken}`,
     );
   }
 


### PR DESCRIPTION
#### Summary

In multi-account Slack setups, all inbound messages were routing to the same agent regardless of which bot was @mentioned. The `shouldDropMismatchedSlackEvent` guard in `context.ts` only dropped events when **both** the provider and the incoming event had a non-empty `api_app_id` that differed — so events missing `api_app_id` passed silently to every provider instance.

lobster-biscuit

#### Repro Steps

1. Configure two Slack accounts (e.g. `og` and `makilala`) in `openclaw.config.yaml`
2. @mention the `og` bot in Slack
3. **Expected:** routed to `og` agent
4. **Actual:** routed to `makilala` agent (or whichever provider wins the race)

#### Root Cause

`shouldDropMismatchedSlackEvent` (`src/slack/monitor/context.ts:367`):

```ts
// Before — only drops when both values are present and differ
if (params.apiAppId && incomingApiAppId && incomingApiAppId !== params.apiAppId) {
  return true;
}
```

When `incomingApiAppId` is empty/absent the condition short-circuits to `false`, so the event is accepted by every provider.

#### Behavior Changes

- When a provider has `apiAppId` (from `auth.test()`), events **without** `api_app_id` are now dropped (previously accepted). Slack always includes `api_app_id` in Socket Mode and Events API envelopes, so this should not affect normal operation.
- Once `api_app_id` is verified as matching, the `team_id` check is skipped (short-circuit `return false`).
- `auth.test()` failures are now logged as errors at startup (previously silent).
- Missing `api_app_id` after a successful `auth.test()` emits a warning.
- All relevant log messages now include `accountId` for easier multi-account debugging.

#### Codebase and GitHub Search

- Searched `shouldDropMismatchedSlackEvent` — only called in `src/slack/monitor/provider.ts` and the existing test files.
- Searched for other per-account event filtering patterns — no equivalent logic in extension channels (Teams, Matrix, etc.) uses the same guard.

#### Tests

New file: `src/slack/monitor/context.multi-account.test.ts` — 7 unit tests:

| Test | Result |
|---|---|
| drops events with mismatched `api_app_id` when `apiAppId` is set | ✅ |
| accepts events with matching `api_app_id` | ✅ |
| drops events with missing `api_app_id` when `apiAppId` is set (multi-account safety) | ✅ |
| accepts events without `api_app_id` when `apiAppId` is not set (backward compat) | ✅ |
| multiple accounts with different `api_app_id`s only process their own events | ✅ |
| drops events with mismatched `team_id` when `apiAppId` is not available | ✅ |
| accepts events with matching `team_id` when `apiAppId` is not available | ✅ |

Full suite: `pnpm test` — 270 tests, 45 files, all passing.

**Sign-Off**

- Models used: claude-sonnet-4-6
- Submitter effort: assisted (reviewed diff, confirmed approach, approved PR)
- Agent notes: root cause confirmed by reading `shouldDropMismatchedSlackEvent` logic; fix verified by unit tests covering all filtering branches; backward compat maintained via `apiAppId`-absent fallback path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes multi-account Slack event routing by tightening the `shouldDropMismatchedSlackEvent` guard in `context.ts`. Previously, events missing `api_app_id` slipped past the filter and were accepted by every provider instance, causing cross-account routing. Now, when a provider has a known `api_app_id`, events without it are dropped for safety.

- **Core fix** (`context.ts`): Restructured `shouldDropMismatchedSlackEvent` to require `api_app_id` on incoming events when the provider has one configured, with `team_id` fallback when `api_app_id` is unavailable.
- **Improved diagnostics** (`provider.ts`): `auth.test()` failures now log errors at startup, and missing `api_app_id` emits a warning. All log messages include `accountId`.
- **Announce target routing** (`channel.ts`): Added `preferSessionLookupForAnnounceTarget: true` to the Slack plugin metadata so announce targets resolve the correct `accountId` from session data in multi-account setups.
- **Tests**: New `context.multi-account.test.ts` with 7 tests covering all filtering branches. Additional test in `sessions-announce-target.test.ts` for Slack `accountId` hydration.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor style suggestions; the core logic change is correct and well-tested.
- The fix correctly addresses the root cause of cross-account event routing. The new filtering logic is sound — it tightens the guard without breaking backward compatibility (when `apiAppId` is absent, behavior is unchanged). All branches are covered by new unit tests. The only findings are minor style nits (unused type cast property, redundant warning log on auth failure).
- No files require special attention. `src/slack/monitor/context.ts` has a minor unused type property, and `src/slack/monitor/provider.ts` has a redundant warning log, but neither affects correctness.

<sub>Last reviewed commit: 7a268f4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->