### PR TITLE
fix: tighten isSilentReplyText to match whole-text only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/Streaming: suppress only exact `NO_REPLY` final replies while still filtering streaming partial sentinel fragments (`NO_`, `NO_RE`, `HEARTBEAT_...`) so substantive replies ending with `NO_REPLY` are delivered and partial silent tokens do not leak during streaming. (#19576) Thanks @aldoeliacim.
 - Doctor/State integrity: ignore metadata-only slash routing sessions when checking recent missing transcripts so `openclaw doctor` no longer reports false-positive transcript-missing warnings for `*:slash:*` keys. (#27375) thanks @gumadeiras.
 - Channels/Multi-account config: when adding a non-default channel account to a single-account top-level channel setup, move existing account-scoped top-level single-account values into `channels.<channel>.accounts.default` before writing the new account so the original account keeps working without duplicated account values at channel root; `openclaw doctor --fix` now repairs previously mixed channel account shapes the same way. (#27334) thanks @gumadeiras.
 - Telegram/Inline buttons: allow callback-query button handling in groups (including `/models` follow-up buttons) when group policy authorizes the sender, by removing the redundant callback allowlist gate that blocked open-policy groups. (#27343) Thanks @GodsBoy.

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -28,7 +28,12 @@ import {
 import { stripHeartbeatToken } from "../heartbeat.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
-import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import {
+  HEARTBEAT_TOKEN,
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+} from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildEmbeddedRunBaseParams,
@@ -139,6 +144,12 @@ export async function runAgentTurnWithFallback(params: {
           text = stripped.text;
         }
         if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+          return { skip: true };
+        }
+        if (
+          isSilentReplyPrefixText(text, SILENT_REPLY_TOKEN) ||
+          isSilentReplyPrefixText(text, HEARTBEAT_TOKEN)
+        ) {
           return { skip: true };
         }
         if (!text) {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1099,18 +1099,20 @@ describe("followup queue collect routing", () => {
 const emptyCfg = {} as OpenClawConfig;
 
 describe("createReplyDispatcher", () => {
-  it("drops empty payloads and silent tokens without media", async () => {
+  it("drops empty payloads and exact silent tokens without media", async () => {
     const deliver = vi.fn().mockResolvedValue(undefined);
     const dispatcher = createReplyDispatcher({ deliver });
 
     expect(dispatcher.sendFinalReply({})).toBe(false);
     expect(dispatcher.sendFinalReply({ text: " " })).toBe(false);
     expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(false);
-    expect(dispatcher.sendFinalReply({ text: `${SILENT_REPLY_TOKEN} -- nope` })).toBe(false);
-    expect(dispatcher.sendFinalReply({ text: `interject.${SILENT_REPLY_TOKEN}` })).toBe(false);
+    expect(dispatcher.sendFinalReply({ text: `${SILENT_REPLY_TOKEN} -- nope` })).toBe(true);
+    expect(dispatcher.sendFinalReply({ text: `interject.${SILENT_REPLY_TOKEN}` })).toBe(true);
 
     await dispatcher.waitForIdle();
-    expect(deliver).not.toHaveBeenCalled();
+    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(deliver.mock.calls[0]?.[0]?.text).toBe(`${SILENT_REPLY_TOKEN} -- nope`);
+    expect(deliver.mock.calls[1]?.[0]?.text).toBe(`interject.${SILENT_REPLY_TOKEN}`);
   });
 
   it("strips heartbeat tokens and applies responsePrefix", async () => {
@@ -1162,7 +1164,7 @@ describe("createReplyDispatcher", () => {
     expect(deliver).toHaveBeenCalledTimes(3);
     expect(deliver.mock.calls[0][0].text).toBe("PFX already");
     expect(deliver.mock.calls[1][0].text).toBe("");
-    expect(deliver.mock.calls[2][0].text).toBe("");
+    expect(deliver.mock.calls[2][0].text).toBe(`PFX ${SILENT_REPLY_TOKEN} -- explanation`);
   });
 
   it("preserves ordering across tool, block, and final replies", async () => {

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -168,7 +168,7 @@ describe("routeReply", () => {
     expect(mocks.sendMessageSlack).not.toHaveBeenCalled();
   });
 
-  it("drops payloads that start with the silent token", async () => {
+  it("does not drop payloads that merely start with the silent token", async () => {
     mocks.sendMessageSlack.mockClear();
     const res = await routeReply({
       payload: { text: `${SILENT_REPLY_TOKEN} -- (why am I here?)` },
@@ -177,7 +177,11 @@ describe("routeReply", () => {
       cfg: {} as never,
     });
     expect(res.ok).toBe(true);
-    expect(mocks.sendMessageSlack).not.toHaveBeenCalled();
+    expect(mocks.sendMessageSlack).toHaveBeenCalledWith(
+      "channel:C123",
+      `${SILENT_REPLY_TOKEN} -- (why am I here?)`,
+      expect.any(Object),
+    );
   });
 
   it("applies responsePrefix when routing", async () => {

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -1,6 +1,6 @@
 import { splitMediaFromOutput } from "../../media/parse.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { ReplyDirectiveParseResult } from "./reply-directives.js";
 
 type PendingReplyState = {
@@ -47,7 +47,8 @@ const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChun
   }
 
   const silentToken = options?.silentToken ?? SILENT_REPLY_TOKEN;
-  const isSilent = isSilentReplyText(text, silentToken);
+  const isSilent =
+    isSilentReplyText(text, silentToken) || isSilentReplyPrefixText(text, silentToken);
   if (isSilent) {
     text = "";
   }

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -1,5 +1,5 @@
 import { createTypingKeepaliveLoop } from "../../channels/typing-lifecycle.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 
 export type TypingController = {
   onReplyStart: () => Promise<void>;
@@ -163,7 +163,10 @@ export function createTypingController(params: {
     if (!trimmed) {
       return;
     }
-    if (silentToken && isSilentReplyText(trimmed, silentToken)) {
+    if (
+      silentToken &&
+      (isSilentReplyText(trimmed, silentToken) || isSilentReplyPrefixText(trimmed, silentToken))
+    ) {
       return;
     }
     refreshTypingTtl();

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isSilentReplyText } from "./tokens.js";
+
+describe("isSilentReplyText", () => {
+  it("returns true for exact token", () => {
+    expect(isSilentReplyText("NO_REPLY")).toBe(true);
+  });
+
+  it("returns true for token with surrounding whitespace", () => {
+    expect(isSilentReplyText("  NO_REPLY  ")).toBe(true);
+    expect(isSilentReplyText("\nNO_REPLY\n")).toBe(true);
+  });
+
+  it("returns false for undefined/empty", () => {
+    expect(isSilentReplyText(undefined)).toBe(false);
+    expect(isSilentReplyText("")).toBe(false);
+  });
+
+  it("returns false for substantive text ending with token (#19537)", () => {
+    const text = "Here is a helpful response.\n\nNO_REPLY";
+    expect(isSilentReplyText(text)).toBe(false);
+  });
+
+  it("returns false for substantive text starting with token", () => {
+    const text = "NO_REPLY but here is more content";
+    expect(isSilentReplyText(text)).toBe(false);
+  });
+
+  it("returns false for token embedded in text", () => {
+    expect(isSilentReplyText("Please NO_REPLY to this")).toBe(false);
+  });
+
+  it("works with custom token", () => {
+    expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
+    expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+  });
+});

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isSilentReplyText } from "./tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText } from "./tokens.js";
 
 describe("isSilentReplyText", () => {
   it("returns true for exact token", () => {
@@ -33,5 +33,26 @@ describe("isSilentReplyText", () => {
   it("works with custom token", () => {
     expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
     expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+  });
+});
+
+describe("isSilentReplyPrefixText", () => {
+  it("matches uppercase underscore prefixes", () => {
+    expect(isSilentReplyPrefixText("NO_")).toBe(true);
+    expect(isSilentReplyPrefixText("NO_RE")).toBe(true);
+    expect(isSilentReplyPrefixText("NO_REPLY")).toBe(true);
+    expect(isSilentReplyPrefixText("  HEARTBEAT_", "HEARTBEAT_OK")).toBe(true);
+  });
+
+  it("rejects ambiguous natural-language prefixes", () => {
+    expect(isSilentReplyPrefixText("N")).toBe(false);
+    expect(isSilentReplyPrefixText("No")).toBe(false);
+    expect(isSilentReplyPrefixText("Hello")).toBe(false);
+  });
+
+  it("rejects non-prefixes and mixed characters", () => {
+    expect(isSilentReplyPrefixText("NO_X")).toBe(false);
+    expect(isSilentReplyPrefixText("NO_REPLY more")).toBe(false);
+    expect(isSilentReplyPrefixText("NO-")).toBe(false);
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -11,8 +11,8 @@ export function isSilentReplyText(
     return false;
   }
   const escaped = escapeRegExp(token);
-  // Only match when the entire response (trimmed) is the silent token,
-  // optionally surrounded by whitespace. This prevents
+  // Match only the exact silent token with optional surrounding whitespace.
+  // This prevents
   // substantive replies ending with NO_REPLY from being suppressed (#19537).
   return new RegExp(`^\\s*${escaped}\\s*$`).test(text);
 }

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -11,12 +11,10 @@ export function isSilentReplyText(
     return false;
   }
   const escaped = escapeRegExp(token);
-  const prefix = new RegExp(`^\\s*${escaped}(?=$|\\W)`);
-  if (prefix.test(text)) {
-    return true;
-  }
-  const suffix = new RegExp(`\\b${escaped}\\b\\W*$`);
-  return suffix.test(text);
+  // Only match when the entire response (trimmed) is the silent token,
+  // optionally surrounded by whitespace/punctuation. This prevents
+  // substantive replies ending with NO_REPLY from being suppressed (#19537).
+  return new RegExp(`^\\s*${escaped}\\s*$`).test(text);
 }
 
 export function isSilentReplyPrefixText(

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -12,7 +12,7 @@ export function isSilentReplyText(
   }
   const escaped = escapeRegExp(token);
   // Only match when the entire response (trimmed) is the silent token,
-  // optionally surrounded by whitespace/punctuation. This prevents
+  // optionally surrounded by whitespace. This prevents
   // substantive replies ending with NO_REPLY from being suppressed (#19537).
   return new RegExp(`^\\s*${escaped}\\s*$`).test(text);
 }


### PR DESCRIPTION
## Problem

`isSilentReplyText()` uses a suffix regex (`\bNO_REPLY\b\W*$`) that matches `NO_REPLY` at the **end** of any response text, even when preceded by substantive content. This causes legitimate replies to be silently suppressed and never delivered to the user.

Observed with Gemini 3 Pro which appends `NO_REPLY` to conversational replies, but any model could trigger this.

## Fix

Replace the prefix + suffix regex pair with a single whole-string match: `^\s*TOKEN\s*$`. Only responses that are **entirely** the silent token (with optional whitespace) are now treated as silent.

## Tests

Added `src/auto-reply/tokens.test.ts` with 7 test cases covering:
- Exact token match
- Whitespace variants  
- Substantive text ending with token (the regression case)
- Substantive text starting with token
- Embedded token
- Custom token parameter

All tests pass: `npx vitest run src/auto-reply/tokens.test.ts`

Fixes #19537

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces overly permissive prefix/suffix regex matching with strict whole-string matching for silent reply detection. The old implementation used `\bNO_REPLY\b\W*$` suffix pattern that matched `NO_REPLY` at the end of any text, causing legitimate replies ending with the token to be silently suppressed. The new `^\s*TOKEN\s*$` pattern only treats responses that are entirely the silent token (with optional whitespace) as silent, fixing the regression where models like Gemini 3 Pro append `NO_REPLY` to conversational responses.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The fix correctly addresses a critical bug where legitimate replies were being suppressed. The change is minimal, well-tested with 7 comprehensive test cases covering the regression and edge cases, and the logic change is straightforward and correct.
- No files require special attention

<sub>Last reviewed commit: a6e4442</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->