### PR TITLE
fix: support group JIDs in groupAllowFrom allowlist

### DIFF
--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -73,10 +73,11 @@ export async function checkInboundAccessControl(params: {
       ? allowFrom.filter((entry) => entry !== "*").map(normalizeE164)
       : [];
   const groupHasWildcard = groupAllowFrom?.includes("*") ?? false;
+  const groupAllowFromEntries = groupAllowFrom?.filter((e) => e !== "*") ?? [];
+  const groupJidEntries = groupAllowFromEntries.filter((e) => e.endsWith("@g.us"));
+  const groupSenderEntries = groupAllowFromEntries.filter((e) => !e.endsWith("@g.us"));
   const normalizedGroupAllowFrom =
-    groupAllowFrom && groupAllowFrom.length > 0
-      ? groupAllowFrom.filter((entry) => entry !== "*").map(normalizeE164)
-      : [];
+    groupSenderEntries.length > 0 ? groupSenderEntries.map(normalizeE164) : [];
 
   // Group policy filtering:
   // - "open": groups bypass allowFrom, only mention-gating applies
@@ -103,8 +104,10 @@ export async function checkInboundAccessControl(params: {
         resolvedAccountId: account.accountId,
       };
     }
+    const groupJidAllowed = groupJidEntries.includes(params.from);
     const senderAllowed =
       groupHasWildcard ||
+      groupJidAllowed ||
       (params.senderE164 != null && normalizedGroupAllowFrom.includes(params.senderE164));
     if (!senderAllowed) {
       logVerbose(


### PR DESCRIPTION
## Summary
`groupAllowFrom` entries ending with `@g.us` are now matched against the group JID instead of being (incorrectly) normalized as phone numbers. Phone-number entries continue to work as before.

## Problem
When configuring `groupAllowFrom` with group JIDs (e.g. `120363424771379436@g.us`), the entries were being passed through `normalizeE164()` which mangled them into invalid phone numbers. This meant group-level allowlisting by JID never worked.

## Solution
- Split `groupAllowFrom` entries into JID entries (`@g.us` suffix) and sender entries
- JID entries are matched directly against `params.from` (the group JID)
- Sender entries continue to be normalized as E.164 phone numbers
- Wildcard `*` behavior is unchanged

## Testing
Tested with mixed allowlist containing both group JIDs and phone numbers. Group JID matching works correctly while phone number matching remains unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes group JID matching in `groupAllowFrom` allowlists by distinguishing between group JIDs (ending in `@g.us`) and phone numbers. Previously, group JIDs were incorrectly passed through `normalizeE164()`, which stripped the `@g.us` suffix and mangled them into invalid phone numbers, breaking group-level allowlisting.

The fix splits `groupAllowFrom` entries into two categories: JID entries are matched directly against `params.from` (the group JID), while phone number entries continue to be normalized and matched against individual senders. This preserves backward compatibility for phone-number-based allowlisting while enabling the intended group JID functionality.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-focused, fixes a clear bug, preserves backward compatibility, and follows a similar pattern used in the telegram implementation. The logic correctly distinguishes between group JIDs and phone numbers based on the `@g.us` suffix, which is a reliable indicator in WhatsApp's architecture.
- No files require special attention

<sub>Last reviewed commit: 58f664f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->