### PR TITLE
fix(whatsapp): normalize Brazilian mobile numbers in JID conversion

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -80,6 +80,34 @@ describe("normalizeE164 & toWhatsappJid", () => {
     expect(toWhatsappJid("whatsapp:123456789-987654321@g.us")).toBe("123456789-987654321@g.us");
     expect(toWhatsappJid("1555123@s.whatsapp.net")).toBe("1555123@s.whatsapp.net");
   });
+
+  it("normalizes Brazilian mobile numbers (strips extra 9 after DDD)", () => {
+    // +55 69 9 96021005 (13 digits after +) -> 55 69 96021005 (12 digits)
+    expect(toWhatsappJid("+5569996021005")).toBe("556996021005@s.whatsapp.net");
+    // +55 11 9 99887766 (13 digits after +) -> 55 11 99887766 (12 digits)
+    expect(toWhatsappJid("+5511999887766")).toBe("551199887766@s.whatsapp.net");
+    // With whatsapp: prefix
+    expect(toWhatsappJid("whatsapp:+5521987654321")).toBe("552187654321@s.whatsapp.net");
+  });
+
+  it("does not modify non-Brazilian or landline numbers", () => {
+    // US number (not +55)
+    expect(toWhatsappJid("+12025551234")).toBe("12025551234@s.whatsapp.net");
+    // Argentine number
+    expect(toWhatsappJid("+5491155551234")).toBe("5491155551234@s.whatsapp.net");
+    // Brazilian landline (12 digits after +, no extra 9)
+    expect(toWhatsappJid("+551133224455")).toBe("551133224455@s.whatsapp.net");
+    // Already-correct Brazilian mobile (12 digits after +)
+    expect(toWhatsappJid("+556996021005")).toBe("556996021005@s.whatsapp.net");
+  });
+
+  it("normalizes Brazilian mobile from raw digits without +", () => {
+    expect(toWhatsappJid("5569996021005")).toBe("556996021005@s.whatsapp.net");
+  });
+
+  it("normalizes Brazilian mobile with formatting characters", () => {
+    expect(toWhatsappJid("+55 69 9 9602-1005")).toBe("556996021005@s.whatsapp.net");
+  });
 });
 
 describe("jidToE164", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,6 +131,22 @@ export function isSelfChatMode(
   });
 }
 
+/**
+ * Brazilian mobile numbers carry an extra "9" after the 2-digit area code (DDD)
+ * that WhatsApp does not use in its JID format.
+ * 55 + DD(2) + 9 + XXXXXXXX(8) = 13 digits  ->  strip the "9"  ->  12 digits.
+ * Landlines (no leading 9 after DDD) and non-BR numbers pass through unchanged.
+ */
+function normalizeBrazilianMobile(digits: string): string {
+  if (digits.length !== 13 || !digits.startsWith("55")) {
+    return digits;
+  }
+  if (digits[4] !== "9") {
+    return digits;
+  }
+  return digits.slice(0, 4) + digits.slice(5);
+}
+
 export function toWhatsappJid(number: string): string {
   const withoutPrefix = number.replace(/^whatsapp:/, "").trim();
   if (withoutPrefix.includes("@")) {
@@ -138,7 +154,8 @@ export function toWhatsappJid(number: string): string {
   }
   const e164 = normalizeE164(withoutPrefix);
   const digits = e164.replace(/\D/g, "");
-  return `${digits}@s.whatsapp.net`;
+  const normalized = normalizeBrazilianMobile(digits);
+  return `${normalized}@s.whatsapp.net`;
 }
 
 export type JidToE164Options = {


### PR DESCRIPTION
## Summary
Brazilian mobile numbers carry an extra '9' after the 2-digit area code (DDD) that WhatsApp does not use in its JID format. This PR strips it during JID conversion.

## Problem
When sending outbound messages to Brazilian numbers entered with the full national format (e.g. `+55 69 9 9602-1005` or `+5569996021005`), the resulting JID `5569996021005@s.whatsapp.net` is invalid. WhatsApp expects 12-digit Brazilian JIDs (`556996021005@s.whatsapp.net`).

## Solution
Add `normalizeBrazilianMobile()` helper in `toWhatsappJid()`:
- Detects 13-digit numbers starting with `55` where the 5th digit is `9`
- Strips the extra `9` to produce the 12-digit WhatsApp format
- Landlines (no leading 9 after DDD) and non-Brazilian numbers pass through unchanged

## Tests
Comprehensive test cases covering:
- Brazilian mobile normalization (multiple DDDs)
- `whatsapp:` prefix handling
- Non-Brazilian numbers (US, Argentine) unchanged
- Brazilian landlines unchanged
- Already-correct 12-digit Brazilian numbers
- Raw digits without `+`
- Numbers with formatting characters

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds normalization for Brazilian mobile numbers in WhatsApp JID conversion. Brazilian mobile numbers include an extra '9' digit after the 2-digit area code that WhatsApp doesn't use in its JID format (13 digits → 12 digits).

**Key changes:**
- Added `normalizeBrazilianMobile()` helper function in `src/utils.ts:140-148` that detects 13-digit numbers starting with `55` and strips the extra '9' at position 4
- Integrated into `toWhatsappJid()` to normalize before constructing the JID
- Added comprehensive test coverage for Brazilian mobiles, landlines, non-Brazilian numbers, and edge cases
- Landlines and already-correct 12-digit numbers pass through unchanged

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and focused. The logic correctly identifies Brazilian mobile numbers (13 digits starting with 55 where position 4 is '9') and strips the extra digit. All edge cases are covered: non-Brazilian numbers, landlines, already-correct numbers, and various input formats. The function is pure with no side effects, and the change is isolated to the WhatsApp JID conversion path.
- No files require special attention

<sub>Last reviewed commit: 8aa1845</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->