### PR TITLE
feat(whatsapp): add sendAsSticker support

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -199,6 +199,7 @@ function buildSendSchema(options: {
     ),
     bestEffort: Type.Optional(Type.Boolean()),
     gifPlayback: Type.Optional(Type.Boolean()),
+    sendAsSticker: Type.Optional(Type.Boolean()),
     buttons: Type.Optional(
       Type.Array(
         Type.Array(

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -12,17 +12,18 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   pollMaxOptions: 12,
   resolveTarget: ({ to, allowFrom, mode }) =>
     resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
-  sendText: async ({ to, text, accountId, deps, gifPlayback }) => {
+  sendText: async ({ to, text, accountId, deps, gifPlayback, sendAsSticker }) => {
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
     const result = await send(to, text, {
       verbose: false,
       accountId: accountId ?? undefined,
       gifPlayback,
+      sendAsSticker,
     });
     return { channel: "whatsapp", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback }) => {
+  sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback, sendAsSticker }) => {
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
     const result = await send(to, text, {
@@ -31,6 +32,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
       mediaLocalRoots,
       accountId: accountId ?? undefined,
       gifPlayback,
+      sendAsSticker,
     });
     return { channel: "whatsapp", ...result };
   },

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -78,6 +78,7 @@ export type ChannelOutboundContext = {
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
   gifPlayback?: boolean;
+  sendAsSticker?: boolean;
   replyToId?: string | null;
   threadId?: string | number | null;
   accountId?: string | null;

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -112,6 +112,7 @@ type ChannelHandlerParams = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
+  sendAsSticker?: boolean;
   silent?: boolean;
   mediaLocalRoots?: readonly string[];
 };
@@ -184,6 +185,7 @@ function createChannelOutboundContextBase(
     threadId: params.threadId,
     identity: params.identity,
     gifPlayback: params.gifPlayback,
+    sendAsSticker: params.sendAsSticker,
     deps: params.deps,
     silent: params.silent,
     mediaLocalRoots: params.mediaLocalRoots,
@@ -203,6 +205,7 @@ type DeliverOutboundPayloadsCoreParams = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
+  sendAsSticker?: boolean;
   abortSignal?: AbortSignal;
   bestEffort?: boolean;
   onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
@@ -240,6 +243,7 @@ export async function deliverOutboundPayloads(
         replyToId: params.replyToId,
         bestEffort: params.bestEffort,
         gifPlayback: params.gifPlayback,
+        sendAsSticker: params.sendAsSticker,
         silent: params.silent,
         mirror: params.mirror,
       }).catch(() => null); // Best-effort — don't block delivery if queue write fails.
@@ -307,6 +311,7 @@ async function deliverOutboundPayloadsCore(
     threadId: params.threadId,
     identity: params.identity,
     gifPlayback: params.gifPlayback,
+    sendAsSticker: params.sendAsSticker,
     silent: params.silent,
     mediaLocalRoots,
   });

--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -4,6 +4,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
+  sendAsSticker?: boolean;
   accountId?: string;
   fileName?: string;
 };

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -35,7 +35,12 @@ export function createWebSendApi(params: {
       const jid = toWhatsappJid(to);
       let payload: AnyMessageContent;
       if (mediaBuffer && mediaType) {
-        if (mediaType.startsWith("image/")) {
+        if (sendOptions?.sendAsSticker && mediaType.startsWith("image/")) {
+          payload = {
+            sticker: mediaBuffer,
+            mimetype: mediaType,
+          };
+        } else if (mediaType.startsWith("image/")) {
           payload = {
             image: mediaBuffer,
             caption: text || undefined,

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -20,6 +20,7 @@ export async function sendMessageWhatsApp(
     mediaUrl?: string;
     mediaLocalRoots?: readonly string[];
     gifPlayback?: boolean;
+    sendAsSticker?: boolean;
     accountId?: string;
   },
 ): Promise<{ messageId: string; toJid: string }> {
@@ -75,9 +76,10 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId || documentFileName
+      options.gifPlayback || options.sendAsSticker || accountId || documentFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
+            ...(options.sendAsSticker ? { sendAsSticker: true } : {}),
             ...(documentFileName ? { fileName: documentFileName } : {}),
             accountId,
           }


### PR DESCRIPTION
## Summary

Adds a `sendAsSticker` boolean option to the message tool and WhatsApp outbound pipeline. When set to `true`, images sent via WhatsApp are converted and delivered as stickers instead of regular image messages.

## Motivation

WhatsApp stickers are a widely used messaging format. Currently, there is no way to send an image as a sticker through the message tool — images are always sent as regular image attachments. This PR adds first-class support for sticker delivery, enabling agents and API consumers to send sticker messages by simply setting `sendAsSticker: true`.

## Changes

The implementation threads a `sendAsSticker` boolean through the existing outbound pipeline:

- **Message tool schema** (`message-tool.ts`): Added `sendAsSticker` as an optional boolean parameter
- **WhatsApp outbound adapter** (`whatsapp.ts`): Passes `sendAsSticker` through to the send functions
- **Channel outbound context type** (`types.adapters.ts`): Added `sendAsSticker` to the shared context type
- **Delivery infrastructure** (`deliver.ts`): Threads `sendAsSticker` through handler params, context base, and delivery queue
- **Active listener types** (`active-listener.ts`): Added `sendAsSticker` to `ActiveWebSendOptions`
- **Send API** (`send-api.ts`): When `sendAsSticker` is true and the media is an image, constructs a sticker payload instead of an image payload
- **Outbound sender** (`outbound.ts`): Passes `sendAsSticker` into the send options

## Usage

```json
{
  "action": "send",
  "target": "<phone or group JID>",
  "media": "https://example.com/image.png",
  "sendAsSticker": true
}
```

The image will be sent as a WhatsApp sticker. When `sendAsSticker` is not set or `false`, behavior is unchanged — images are sent normally.

## Scope

- 7 files changed, ~21 lines added
- No breaking changes — the new parameter is optional and defaults to `false`/`undefined`
- Only affects WhatsApp channel; other channels ignore the parameter

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `sendAsSticker` boolean option to enable sending images as WhatsApp stickers through the message tool and outbound pipeline. The implementation correctly threads the parameter through all layers (message tool schema, channel adapters, delivery infrastructure, and send API). When enabled, images are sent as sticker payloads instead of image messages with captions.

- Threads `sendAsSticker` through 7 files across the outbound pipeline
- Only affects WhatsApp channel; other channels ignore the parameter
- No breaking changes - optional parameter defaults to false/undefined
- Implementation is clean and follows existing patterns (similar to `gifPlayback`)
- Note: WhatsApp stickers don't support captions, so any text passed with `sendAsSticker: true` will be ignored

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, non-breaking, and follows established patterns. The `sendAsSticker` parameter is optional, properly threaded through all layers, and only affects WhatsApp. The code is clean with no logical errors or security concerns. The only minor consideration is the implicit behavior that text/captions are ignored for stickers, which is standard WhatsApp behavior.
- No files require special attention

<sub>Last reviewed commit: d8a5b30</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->