### PR TITLE
feat(compaction): proactive handover before context overflow

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -10,6 +10,7 @@ import {
   markAuthProfileGood,
   markAuthProfileUsed,
 } from "../auth-profiles.js";
+import { estimateMessagesTokens } from "../compaction.js";
 import {
   CONTEXT_WINDOW_HARD_MIN_TOKENS,
   CONTEXT_WINDOW_WARN_BELOW_TOKENS,
@@ -465,6 +466,8 @@ export async function runEmbeddedPiAgent(
       const usageAccumulator = createUsageAccumulator();
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
+      let proactiveHandoverTriggered = false;
+      const PROACTIVE_MIN_TURNS = 5;
       try {
         while (true) {
           attemptedThinking.add(thinkLevel);
@@ -1011,6 +1014,84 @@ export async function runEmbeddedPiAgent(
           log.debug(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );
+
+          // --- PROACTIVE HANDOVER CHECK ---
+          if (
+            !proactiveHandoverTriggered &&
+            !aborted &&
+            !attempt.promptError &&
+            attempt.messagesSnapshot &&
+            attempt.messagesSnapshot.length > 0
+          ) {
+            const proactiveThreshold =
+              params.config?.agents?.defaults?.compaction?.proactiveThresholdTokens;
+
+            if (typeof proactiveThreshold === "number" && proactiveThreshold > 0) {
+              const userMsgCount = attempt.messagesSnapshot.filter((m) => m.role === "user").length;
+
+              if (userMsgCount >= PROACTIVE_MIN_TURNS) {
+                const currentTokens = estimateMessagesTokens(attempt.messagesSnapshot);
+                const remainingTokens = ctxInfo.tokens - currentTokens;
+                const usagePercent = Math.round((currentTokens / ctxInfo.tokens) * 100);
+
+                if (remainingTokens <= proactiveThreshold) {
+                  log.info(
+                    `[proactive-handover] Triggering: ${currentTokens}/${ctxInfo.tokens} tokens ` +
+                      `(${usagePercent}%), remaining=${remainingTokens}, threshold=${proactiveThreshold}, ` +
+                      `userMessages=${userMsgCount}`,
+                  );
+
+                  proactiveHandoverTriggered = true;
+
+                  const proactiveResult = await compactEmbeddedPiSessionDirect({
+                    sessionId: params.sessionId,
+                    sessionKey: params.sessionKey,
+                    messageChannel: params.messageChannel,
+                    messageProvider: params.messageProvider,
+                    agentAccountId: params.agentAccountId,
+                    authProfileId: lastProfileId,
+                    sessionFile: params.sessionFile,
+                    workspaceDir: resolvedWorkspace,
+                    agentDir,
+                    config: params.config,
+                    skillsSnapshot: params.skillsSnapshot,
+                    senderIsOwner: params.senderIsOwner,
+                    provider,
+                    model: modelId,
+                    thinkLevel,
+                    reasoningLevel: params.reasoningLevel,
+                    bashElevated: params.bashElevated,
+                    extraSystemPrompt: params.extraSystemPrompt,
+                    ownerNumbers: params.ownerNumbers,
+                  });
+
+                  if (proactiveResult.compacted) {
+                    autoCompactionCount += 1;
+                    log.info(`[proactive-handover] Compaction succeeded.`);
+
+                    try {
+                      const { SessionManager } = await import("@mariozechner/pi-coding-agent");
+                      const sm = SessionManager.open(params.sessionFile);
+                      sm.appendMessage({
+                        role: "user",
+                        content: `[System] ⚠️ Proactive handover triggered at ${usagePercent}% context usage. Memory compacted successfully.`,
+                      } as Parameters<typeof sm.appendMessage>[0]);
+                    } catch (noteErr) {
+                      log.warn(
+                        `[proactive-handover] Failed to inject system note: ${describeUnknownError(noteErr)}`,
+                      );
+                    }
+                  } else {
+                    log.warn(
+                      `[proactive-handover] Compaction failed: ${proactiveResult.reason ?? "unknown"}`,
+                    );
+                  }
+                }
+              }
+            }
+          }
+          // --- END PROACTIVE HANDOVER CHECK ---
+
           if (lastProfileId) {
             await markAuthProfileGood({
               store: authStore,
@@ -1031,6 +1112,7 @@ export async function runEmbeddedPiAgent(
               agentMeta,
               aborted,
               systemPromptReport: attempt.systemPromptReport,
+              proactiveHandover: proactiveHandoverTriggered || undefined,
               // Handle client tool calls (OpenResponses hosted tools)
               stopReason: attempt.clientToolCall ? "tool_calls" : undefined,
               pendingToolCalls: attempt.clientToolCall

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -39,6 +39,8 @@ export type EmbeddedPiRunMeta = {
     kind: "context_overflow" | "compaction_failure" | "role_ordering" | "image_size";
     message: string;
   };
+  /** True when proactive handover was triggered during this run. */
+  proactiveHandover?: boolean;
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */
   stopReason?: string;
   /** Pending tool calls when stopReason is "tool_calls". */

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -295,6 +295,8 @@ export type AgentCompactionConfig = {
   maxHistoryShare?: number;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
+  /** Trigger proactive handover when remaining tokens <= this value (default: disabled). */
+  proactiveThresholdTokens?: number;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -102,6 +102,7 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        proactiveThresholdTokens: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Proactive handover monitors token usage after each agent turn and triggers compaction **before** context overflow occurs, rather than waiting for the API to reject a prompt that's too large.

## Problem

Currently, compaction is only triggered reactively when the API returns a context overflow error. By that point the conversation may already be degraded — the agent loses continuity and the user experiences an unexpected interruption.

## Solution

After each successful agent turn, estimate current token usage and compare against a configurable threshold. If remaining tokens fall below the threshold, proactively trigger compaction to preserve conversation quality.

### How it works

1. After each turn completes (no error, not aborted), estimate total message tokens via \estimateMessagesTokens()\
2. Compare remaining tokens (\contextWindow - currentTokens\) against \compaction.proactiveThresholdTokens\
3. If below threshold **and** at least 5 user messages have occurred (minimum guard), trigger \compactEmbeddedPiSessionDirect()\
4. On success, inject a system note into the session so the agent is aware of the handover on the next turn
5. Set a cooldown flag to prevent re-triggering within the same run

### Safety guards

- **Minimum turn guard**: Requires at least 5 user messages before triggering (avoids compacting near-empty sessions)
- **Cooldown flag**: \proactiveHandoverTriggered\ prevents multiple compactions in the same run
- **Graceful failure**: If compaction fails, logs a warning and continues normally — no user-facing error
- **Opt-in**: Disabled by default; requires explicit configuration

## Configuration

\\\yaml
agents:
  defaults:
    compaction:
      proactiveThresholdTokens: 20000  # trigger when <= 20k tokens remain
\\\

Set to \

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements proactive context compaction that triggers before overflow occurs. After each successful agent turn, it estimates token usage and triggers compaction when remaining tokens fall below a configurable threshold.

**Key changes:**
- Added `proactiveThresholdTokens` config option to control when proactive handover triggers
- Implemented token estimation and threshold check after successful turns
- Added safety guards: minimum 5 user messages, cooldown flag, graceful failure handling
- Injects notification message into session after successful compaction
- Added `proactiveHandover` field to run metadata for observability

The implementation is opt-in (disabled by default) and follows existing patterns for reactive compaction. Guards prevent premature triggering on short sessions and multiple compactions within the same run.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with multiple safety guards, follows existing code patterns, handles errors gracefully, and is opt-in by default. The logic is straightforward and the changes are isolated to the agent runner.
- No files require special attention

<sub>Last reviewed commit: efdf074</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->