### PR TITLE
docs: add permctl to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -42,3 +42,10 @@ Use this format when adding entries:
   npm: `@scope/package`
   repo: `https://github.com/org/repo`
   install: `openclaw plugins install @scope/package`
+
+## Plugins
+
+- **permctl** — macOS TCC permission error detection + agent remediation skill
+  npm: `@stakeswky/openclaw-permctl`
+  repo: `https://github.com/stakeswky/openclaw-plugin-permctl`
+  install: `openclaw plugins install @stakeswky/openclaw-permctl`


### PR DESCRIPTION
Adds the **permctl** plugin to the community plugins page.

- **npm:** `@stakeswky/openclaw-permctl`
- **repo:** https://github.com/stakeswky/openclaw-plugin-permctl
- **install:** `openclaw plugins install @stakeswky/openclaw-permctl`

Detects macOS TCC permission errors in agent exec output and guides remediation via the bundled permctl skill.

This was originally submitted as PR #18996 (core changes). Per @steipete's feedback, it has been refactored as a standalone community plugin.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the `permctl` plugin to the community plugins documentation page. This is the first plugin entry in the newly created community plugins registry. The entry follows the documented format with plugin name, npm package, repository URL, description, and install command.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a documentation-only change that adds a single plugin entry following the exact format specified in the community plugins template. The commit message follows conventions (`docs:`), formatting is consistent, and no code or logic is modified.
- No files require special attention

<sub>Last reviewed commit: 36fe739</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->