### PR TITLE
refactor(agents): centralise provider capability checks into ProviderCapabilities

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -233,7 +233,7 @@ export function buildSystemPrompt(params: {
     defaultThinkLevel: params.defaultThinkLevel,
     extraSystemPrompt: params.extraSystemPrompt,
     ownerNumbers: params.ownerNumbers,
-    reasoningTagHint: false,
+    reasoningFormatHint: undefined,
     heartbeatPrompt: params.heartbeatPrompt,
     docsPath: params.docsPath,
     runtimeInfo,

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -1,13 +1,21 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
+import { resolveProviderCapabilities } from "./provider-capabilities.js";
 
 function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-completions"> {
   return model.api === "openai-completions";
 }
 
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
-  const baseUrl = model.baseUrl ?? "";
-  const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  if (!isOpenAiCompletionsModel(model)) {
+    return model;
+  }
+
+  const caps = resolveProviderCapabilities({
+    provider: model.provider,
+    modelApi: model.api,
+    baseUrl: model.baseUrl,
+  });
+  if (caps.supportsDeveloperRole) {
     return model;
   }
 

--- a/src/agents/pi-embedded-runner/cache-ttl.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.ts
@@ -1,3 +1,5 @@
+import { resolveProviderCapabilities } from "../provider-capabilities.js";
+
 type CustomEntryLike = { type?: unknown; customType?: unknown; data?: unknown };
 
 export const CACHE_TTL_CUSTOM_TYPE = "openclaw.cache-ttl";
@@ -9,15 +11,7 @@ export type CacheTtlEntryData = {
 };
 
 export function isCacheTtlEligibleProvider(provider: string, modelId: string): boolean {
-  const normalizedProvider = provider.toLowerCase();
-  const normalizedModelId = modelId.toLowerCase();
-  if (normalizedProvider === "anthropic") {
-    return true;
-  }
-  if (normalizedProvider === "openrouter" && normalizedModelId.startsWith("anthropic/")) {
-    return true;
-  }
-  return false;
+  return resolveProviderCapabilities({ provider, modelId }).supportsPromptCache;
 }
 
 export function readLastCacheTtlTimestamp(sessionManager: unknown): number | null {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -21,7 +21,8 @@ import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
-import { isReasoningTagProvider } from "../../utils/provider-utils.js";
+import { buildPromptAdaptation } from "../prompt-adaptation.js";
+import { resolveProviderCapabilities } from "../provider-capabilities.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
@@ -316,7 +317,9 @@ export async function compactEmbeddedPiSessionDirect(
       channelActions,
     };
     const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
-    const reasoningTagHint = isReasoningTagProvider(provider);
+    const { reasoningFormatHint } = buildPromptAdaptation(
+      resolveProviderCapabilities({ provider, modelId }),
+    );
     const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
     const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
     const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
@@ -339,7 +342,7 @@ export async function compactEmbeddedPiSessionDirect(
       reasoningLevel: params.reasoningLevel ?? "off",
       extraSystemPrompt: params.extraSystemPrompt,
       ownerNumbers: params.ownerNumbers,
-      reasoningTagHint,
+      reasoningFormatHint,
       heartbeatPrompt: isDefaultAgent
         ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
         : undefined,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -17,7 +17,8 @@ import { resolveTelegramReactionLevel } from "../../../telegram/reaction-level.j
 import { buildTtsSystemPromptHint } from "../../../tts/tts.js";
 import { resolveUserPath } from "../../../utils.js";
 import { normalizeMessageChannel } from "../../../utils/message-channel.js";
-import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
+import { buildPromptAdaptation } from "../../prompt-adaptation.js";
+import { resolveProviderCapabilities } from "../../provider-capabilities.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
@@ -300,7 +301,9 @@ export async function runEmbeddedAttempt(
       config: params.config,
     });
     const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
-    const reasoningTagHint = isReasoningTagProvider(params.provider);
+    const { reasoningFormatHint } = buildPromptAdaptation(
+      resolveProviderCapabilities({ provider: params.provider, modelId: params.modelId }),
+    );
     // Resolve channel-specific message actions for system prompt
     const channelActions = runtimeChannel
       ? listChannelSupportedActions({
@@ -355,7 +358,7 @@ export async function runEmbeddedAttempt(
       reasoningLevel: params.reasoningLevel ?? "off",
       extraSystemPrompt: params.extraSystemPrompt,
       ownerNumbers: params.ownerNumbers,
-      reasoningTagHint,
+      reasoningFormatHint,
       heartbeatPrompt: isDefaultAgent
         ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
         : undefined,

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -14,7 +14,7 @@ export function buildEmbeddedSystemPrompt(params: {
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
-  reasoningTagHint: boolean;
+  reasoningFormatHint?: string;
   heartbeatPrompt?: string;
   skillsPrompt?: string;
   docsPath?: string;
@@ -55,7 +55,7 @@ export function buildEmbeddedSystemPrompt(params: {
     reasoningLevel: params.reasoningLevel,
     extraSystemPrompt: params.extraSystemPrompt,
     ownerNumbers: params.ownerNumbers,
-    reasoningTagHint: params.reasoningTagHint,
+    reasoningFormatHint: params.reasoningFormatHint,
     heartbeatPrompt: params.heartbeatPrompt,
     skillsPrompt: params.skillsPrompt,
     docsPath: params.docsPath,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -52,11 +52,7 @@ import {
   resolveToolProfilePolicy,
   stripPluginOnlyAllowlist,
 } from "./tool-policy.js";
-
-function isOpenAIProvider(provider?: string) {
-  const normalized = provider?.trim().toLowerCase();
-  return normalized === "openai" || normalized === "openai-codex";
-}
+import { resolveProviderCapabilities } from "./provider-capabilities.js";
 
 function isApplyPatchAllowedForModel(params: {
   modelProvider?: string;
@@ -238,7 +234,7 @@ export function createOpenClawCodingTools(options?: {
   const applyPatchConfig = options?.config?.tools?.exec?.applyPatch;
   const applyPatchEnabled =
     !!applyPatchConfig?.enabled &&
-    isOpenAIProvider(options?.modelProvider) &&
+    resolveProviderCapabilities({ provider: options?.modelProvider }).supportsApplyPatch &&
     isApplyPatchAllowedForModel({
       modelProvider: options?.modelProvider,
       modelId: options?.modelId,

--- a/src/agents/prompt-adaptation.ts
+++ b/src/agents/prompt-adaptation.ts
@@ -1,0 +1,74 @@
+/**
+ * Dynamic prompt adaptation based on provider capabilities.
+ *
+ * Produces model-specific content fragments for injection into the system prompt.
+ * Call sites should call resolveProviderCapabilities() first, then pass the result here.
+ */
+
+import type { ProviderCapabilities } from "./provider-capabilities.js";
+
+// ── Hint text constants ───────────────────────────────────────────────────────
+
+/**
+ * Standard reasoning format hint – concise multi-line description with a brief example.
+ * Used for Google, MiniMax, and other cloud providers that require tag-based formatting.
+ */
+const STANDARD_REASONING_HINT = [
+  "ALL internal reasoning MUST be inside <think>...</think>.",
+  "Do not output any analysis outside <think>.",
+  "Format every reply as <think>...</think> then <final>...</final>, with no other text.",
+  "Only the final user-visible reply may appear inside <final>.",
+  "Only text inside <final> is shown to the user; everything else is discarded and never seen by the user.",
+  "Example:",
+  "<think>Short internal reasoning.</think>",
+  "<final>Hey there! What would you like to do next?</final>",
+].join(" ");
+
+/**
+ * Verbose reasoning format hint – same core rules plus a multi-step CoT example.
+ * Used for weaker local models (Ollama) that benefit from a richer demonstration.
+ */
+const VERBOSE_REASONING_HINT = [
+  "ALL internal reasoning MUST be inside <think>...</think>.",
+  "Do not output any analysis outside <think>.",
+  "Format every reply as <think>...</think> then <final>...</final>, with no other text.",
+  "Only the final user-visible reply may appear inside <final>.",
+  "Only text inside <final> is shown to the user; everything else is discarded and never seen by the user.",
+  "Multi-step reasoning example:",
+  "<think>",
+  "Step 1: Understand the user's question.",
+  "Step 2: Recall relevant facts.",
+  "Step 3: Formulate a clear, concise answer.",
+  "</think>",
+  "<final>Here is the answer to your question.</final>",
+].join(" ");
+
+// ── Adaptation interface ──────────────────────────────────────────────────────
+
+export interface PromptAdaptation {
+  /**
+   * Pre-computed reasoning format hint string to inject into the system prompt,
+   * or undefined if no hint is needed for this provider.
+   */
+  reasoningFormatHint: string | undefined;
+}
+
+// ── Builder ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build dynamic prompt adaptations based on provider capabilities.
+ *
+ * - Weak local models (Ollama) receive a verbose multi-step CoT example.
+ * - Standard cloud providers (Google, MiniMax, …) receive the concise hint.
+ * - Providers that do not use tag-based reasoning receive no hint.
+ */
+export function buildPromptAdaptation(caps: ProviderCapabilities): PromptAdaptation {
+  switch (caps.reasoningHintDetail) {
+    case "verbose":
+      return { reasoningFormatHint: VERBOSE_REASONING_HINT };
+    case "standard":
+      return { reasoningFormatHint: STANDARD_REASONING_HINT };
+    default:
+      return { reasoningFormatHint: undefined };
+  }
+}

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -77,6 +77,14 @@ export interface ProviderCapabilities {
    */
   reasoningFormat: "tags" | "none";
 
+  /**
+   * Level of detail for the reasoning format hint injected into the system prompt.
+   * null      = no hint needed (reasoningFormat is "none").
+   * "standard" = default multi-line hint with a basic example (Google, MiniMax, …).
+   * "verbose"  = extended hint with a multi-step CoT example for weaker local models (Ollama).
+   */
+  reasoningHintDetail: "verbose" | "standard" | null;
+
   // ── Tool Schema ─────────────────────────────────────────────────────────────
 
   /**
@@ -256,6 +264,13 @@ export function resolveProviderCapabilities(params: {
       ? "tags"
       : "none";
 
+  const reasoningHintDetail: ProviderCapabilities["reasoningHintDetail"] =
+    reasoningFormat === "none"
+      ? null
+      : provider === "ollama"
+        ? "verbose"
+        : "standard";
+
   // ── Tool Schema ─────────────────────────────────────────────────────────
 
   const toolSchemaUnsupportedKeywords: ProviderCapabilities["toolSchemaUnsupportedKeywords"] =
@@ -309,6 +324,7 @@ export function resolveProviderCapabilities(params: {
   return {
     // Prompt engineering
     reasoningFormat,
+    reasoningHintDetail,
     // Tool schema
     toolSchemaUnsupportedKeywords,
     // Caching

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -1,0 +1,320 @@
+/**
+ * Centralised provider capability registry.
+ *
+ * Consolidates all model/provider-specific capability checks that were
+ * previously scattered across:
+ *   - src/utils/provider-utils.ts                   (isReasoningTagProvider)
+ *   - src/agents/pi-embedded-runner/cache-ttl.ts    (isCacheTtlEligibleProvider)
+ *   - src/agents/pi-embedded-runner/extra-params.ts (OpenRouter headers, cacheRetention)
+ *   - src/agents/model-compat.ts                    (supportsDeveloperRole)
+ *   - src/agents/pi-embedded-runner/google.ts       (GOOGLE_SCHEMA_UNSUPPORTED_KEYWORDS)
+ *   - src/agents/transcript-policy.ts               (resolveTranscriptPolicy)
+ *
+ * New code should call resolveProviderCapabilities() instead of inspecting
+ * provider / modelId strings directly.
+ */
+
+import { isAntigravityClaude, isGoogleModelApi } from "./pi-embedded-helpers/google.js";
+import { normalizeProviderId } from "./model-selection.js";
+
+// ── Google Tool-Schema Keyword Blacklist ─────────────────────────────────────
+
+/**
+ * JSON Schema keywords that Google's Gemini API does not support.
+ * Tools targeting Google providers must have these stripped before the request
+ * is sent (see sanitizeToolsForGoogle in pi-embedded-runner/google.ts).
+ */
+export const GOOGLE_UNSUPPORTED_SCHEMA_KEYWORDS: ReadonlySet<string> = new Set([
+  "patternProperties",
+  "additionalProperties",
+  "$schema",
+  "$id",
+  "$ref",
+  "$defs",
+  "definitions",
+  "examples",
+  "minLength",
+  "maxLength",
+  "minimum",
+  "maximum",
+  "multipleOf",
+  "pattern",
+  "format",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  "minProperties",
+  "maxProperties",
+]);
+
+// ── OpenRouter Attribution Headers ───────────────────────────────────────────
+
+const OPENROUTER_APP_HEADERS: Readonly<Record<string, string>> = {
+  "HTTP-Referer": "https://openclaw.ai",
+  "X-Title": "OpenClaw",
+} as const;
+
+const EMPTY_HEADERS: Readonly<Record<string, string>> = {} as const;
+
+// ── Capability Interface ─────────────────────────────────────────────────────
+
+/**
+ * Describes what a provider/model combination is capable of and how it expects
+ * to receive data.
+ *
+ * All provider-specific branching should derive from a ProviderCapabilities
+ * value rather than directly comparing provider / modelId strings.
+ */
+export interface ProviderCapabilities {
+  // ── Prompt Engineering ──────────────────────────────────────────────────────
+
+  /**
+   * How the agent's internal reasoning must be formatted in the text stream.
+   *
+   * "tags" – Inject <think>…</think><final>…</final> wrapping instructions into
+   *          the system prompt (Ollama, Google, MiniMax, …).
+   * "none" – No special reasoning-format injection required.
+   */
+  reasoningFormat: "tags" | "none";
+
+  // ── Tool Schema ─────────────────────────────────────────────────────────────
+
+  /**
+   * Set of JSON Schema keywords this provider cannot handle.
+   * These must be stripped from tool definitions before sending.
+   * null = no restrictions; pass schemas through unmodified.
+   */
+  toolSchemaUnsupportedKeywords: ReadonlySet<string> | null;
+
+  // ── Prompt Caching ──────────────────────────────────────────────────────────
+
+  /**
+   * Provider supports Anthropic-style prompt caching (cache_control markers).
+   * Controls both the context-pruning cache-TTL feature and cacheRetention param.
+   */
+  supportsPromptCache: boolean;
+
+  /**
+   * Whether the cacheRetention stream option is forwarded to the API.
+   * Subset of supportsPromptCache: only the direct Anthropic provider honours
+   * this param. OpenRouter routes Anthropic traffic differently.
+   */
+  supportsCacheRetentionParam: boolean;
+
+  // ── HTTP Request ────────────────────────────────────────────────────────────
+
+  /**
+   * Extra HTTP headers to inject into every streaming request.
+   * Empty object means no additional headers.
+   */
+  extraRequestHeaders: Readonly<Record<string, string>>;
+
+  // ── Model Compat ────────────────────────────────────────────────────────────
+
+  /**
+   * Whether the provider's API supports a "developer" role in the message list.
+   * false for ZAI and similar non-standard OpenAI-compatible endpoints.
+   */
+  supportsDeveloperRole: boolean;
+
+  // ── Transcript / History Sanitization ───────────────────────────────────────
+  // These fields mirror the TranscriptPolicy type (transcript-policy.ts).
+  // Use capabilitiesToTranscriptPolicy() to convert when an explicit
+  // TranscriptPolicy is needed.
+
+  /** Whether to strip non-image tool content (full) or only images. */
+  sanitizeMode: "full" | "images-only";
+
+  /** Whether to normalise tool-call IDs to the provider's expected format. */
+  sanitizeToolCallIds: boolean;
+
+  /**
+   * Specific tool-call ID sanitisation mode.
+   * "strict9" – Mistral requires exactly 9 alphanumeric characters.
+   * "strict"  – Standard cross-provider safe format.
+   * null      – No ID sanitisation (provider accepts arbitrary IDs).
+   */
+  toolCallIdMode: "strict9" | "strict" | null;
+
+  /** Whether to repair orphaned tool-use / tool-result message pairs. */
+  repairToolUseResultPairing: boolean;
+
+  /** Whether to preserve thinking-block signatures in the transcript. */
+  preserveSignatures: boolean;
+
+  /**
+   * Options for sanitising thought signatures in the transcript.
+   * null = no signature sanitisation needed.
+   */
+  sanitizeThoughtSignatures: {
+    allowBase64Only: boolean;
+    includeCamelCase: boolean;
+  } | null;
+
+  /** Whether to validate and normalise Antigravity-Claude thinking blocks. */
+  normalizeAntigravityThinkingBlocks: boolean;
+
+  /** Whether to prepend a synthetic user message to satisfy Google turn ordering. */
+  applyGoogleTurnOrdering: boolean;
+
+  /** Whether to apply Gemini-specific turn validation rules. */
+  validateGeminiTurns: boolean;
+
+  /** Whether to apply Anthropic-specific turn validation rules. */
+  validateAnthropicTurns: boolean;
+
+  /** Whether the provider accepts synthetic tool-result messages in history. */
+  allowSyntheticToolResults: boolean;
+}
+
+// ── Resolver ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the full capability set for a provider/model combination.
+ *
+ * This is the single authoritative source for all provider-specific behaviour.
+ * Call sites should cache the result when repeated access is needed within a
+ * single request lifecycle.
+ *
+ * @param params.provider  - Provider identifier (e.g. "anthropic", "openai").
+ * @param params.modelId   - Model identifier (e.g. "claude-opus-4-6").
+ * @param params.modelApi  - Low-level API variant (e.g. "anthropic-messages").
+ * @param params.baseUrl   - Optional base URL; used to detect ZAI endpoints.
+ */
+export function resolveProviderCapabilities(params: {
+  provider?: string | null;
+  modelId?: string | null;
+  modelApi?: string | null;
+  baseUrl?: string | null;
+}): ProviderCapabilities {
+  const provider = normalizeProviderId(params.provider ?? "");
+  const modelId = (params.modelId ?? "").toLowerCase();
+  const modelApi = params.modelApi ?? null;
+
+  // ── Provider Classification ─────────────────────────────────────────────
+
+  const isGoogle = isGoogleModelApi(modelApi);
+
+  const isAnthropic = modelApi === "anthropic-messages" || provider === "anthropic";
+
+  // OpenAI: matched by provider string OR (no provider + openai-family modelApi)
+  const isOpenAi =
+    provider === "openai" ||
+    provider === "openai-codex" ||
+    (!provider &&
+      (modelApi === "openai" ||
+        modelApi === "openai-completions" ||
+        modelApi === "openai-responses" ||
+        modelApi === "openai-codex-responses"));
+
+  const isMistral =
+    provider === "mistral" ||
+    ["mistral", "mixtral", "codestral", "pixtral", "devstral", "ministral", "mistralai"].some(
+      (hint) => modelId.includes(hint),
+    );
+
+  const isOpenRouterGemini =
+    (provider === "openrouter" || provider === "opencode") && modelId.includes("gemini");
+
+  const isAntigravityClaudeModel = isAntigravityClaude({
+    api: modelApi,
+    provider,
+    modelId: params.modelId ?? undefined,
+  });
+
+  // Direct Google providers (used for tool-schema stripping only)
+  const isGoogleDirectProvider =
+    provider === "google-antigravity" || provider === "google-gemini-cli";
+
+  const isOpenRouter = provider === "openrouter";
+
+  const isMinimax = provider.includes("minimax");
+
+  const isOpenRouterAnthropic =
+    isOpenRouter && (params.modelId ?? "").toLowerCase().startsWith("anthropic/");
+
+  // ZAI: identified by provider name or base URL
+  const isZai = provider === "zai" || (params.baseUrl ?? "").includes("api.z.ai");
+
+  // ── Prompt Engineering ──────────────────────────────────────────────────
+
+  const reasoningFormat: ProviderCapabilities["reasoningFormat"] =
+    provider === "ollama" ||
+    provider === "google-gemini-cli" ||
+    provider === "google-generative-ai" ||
+    provider.includes("google-antigravity") ||
+    isMinimax
+      ? "tags"
+      : "none";
+
+  // ── Tool Schema ─────────────────────────────────────────────────────────
+
+  const toolSchemaUnsupportedKeywords: ProviderCapabilities["toolSchemaUnsupportedKeywords"] =
+    isGoogleDirectProvider ? GOOGLE_UNSUPPORTED_SCHEMA_KEYWORDS : null;
+
+  // ── Prompt Caching ──────────────────────────────────────────────────────
+
+  const supportsPromptCache = provider === "anthropic" || isOpenRouterAnthropic;
+  const supportsCacheRetentionParam = provider === "anthropic";
+
+  // ── HTTP Headers ────────────────────────────────────────────────────────
+
+  const extraRequestHeaders: Readonly<Record<string, string>> = isOpenRouter
+    ? OPENROUTER_APP_HEADERS
+    : EMPTY_HEADERS;
+
+  // ── Model Compat ────────────────────────────────────────────────────────
+
+  const supportsDeveloperRole = !isZai;
+
+  // ── Transcript Sanitization ─────────────────────────────────────────────
+
+  const needsFullSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
+  const sanitizeMode: "full" | "images-only" = isOpenAi
+    ? "images-only"
+    : needsFullSanitize
+      ? "full"
+      : "images-only";
+
+  // Compute raw flag first (mirrors transcript-policy.ts logic for toolCallIdMode)
+  const rawSanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
+  const sanitizeToolCallIds = !isOpenAi && rawSanitizeToolCallIds;
+
+  // toolCallIdMode mirrors original: derived from raw flag, not the filtered one
+  const toolCallIdMode: ProviderCapabilities["toolCallIdMode"] = isMistral
+    ? "strict9"
+    : rawSanitizeToolCallIds
+      ? "strict"
+      : null;
+
+  const repairToolUseResultPairing = !isOpenAi && (isGoogle || isAnthropic);
+
+  const sanitizeThoughtSignatures: ProviderCapabilities["sanitizeThoughtSignatures"] =
+    !isOpenAi && isOpenRouterGemini ? { allowBase64Only: true, includeCamelCase: true } : null;
+
+  return {
+    // Prompt engineering
+    reasoningFormat,
+    // Tool schema
+    toolSchemaUnsupportedKeywords,
+    // Caching
+    supportsPromptCache,
+    supportsCacheRetentionParam,
+    // HTTP
+    extraRequestHeaders,
+    // Compat
+    supportsDeveloperRole,
+    // Transcript
+    sanitizeMode,
+    sanitizeToolCallIds,
+    toolCallIdMode,
+    repairToolUseResultPairing,
+    preserveSignatures: isAntigravityClaudeModel,
+    sanitizeThoughtSignatures,
+    normalizeAntigravityThinkingBlocks: isAntigravityClaudeModel,
+    applyGoogleTurnOrdering: !isOpenAi && isGoogle,
+    validateGeminiTurns: !isOpenAi && isGoogle,
+    validateAnthropicTurns: !isOpenAi && isAnthropic,
+    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+  };
+}

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -165,6 +165,15 @@ export interface ProviderCapabilities {
 
   /** Whether the provider accepts synthetic tool-result messages in history. */
   allowSyntheticToolResults: boolean;
+
+  // ── Tool Availability ────────────────────────────────────────────────────────
+
+  /**
+   * Whether the provider supports the apply_patch tool.
+   * true only for OpenAI and OpenAI-Codex providers, which natively understand
+   * the unified-diff patch format used by that tool.
+   */
+  supportsApplyPatch: boolean;
 }
 
 // ── Resolver ─────────────────────────────────────────────────────────────────
@@ -292,6 +301,11 @@ export function resolveProviderCapabilities(params: {
   const sanitizeThoughtSignatures: ProviderCapabilities["sanitizeThoughtSignatures"] =
     !isOpenAi && isOpenRouterGemini ? { allowBase64Only: true, includeCamelCase: true } : null;
 
+  // ── Tool Availability ────────────────────────────────────────────────────
+  // apply_patch is only meaningful for OpenAI/OpenAI-Codex — other providers
+  // do not understand the unified-diff format it produces.
+  const supportsApplyPatch = provider === "openai" || provider === "openai-codex";
+
   return {
     // Prompt engineering
     reasoningFormat,
@@ -316,5 +330,6 @@ export function resolveProviderCapabilities(params: {
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && isAnthropic,
     allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+    supportsApplyPatch,
   };
 }

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -82,10 +82,12 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Voice (TTS) is enabled.");
   });
 
-  it("adds reasoning tag hint when enabled", () => {
+  it("adds reasoning format hint when provided", () => {
+    const hint =
+      "ALL internal reasoning MUST be inside <think>...</think>. Format every reply as <think>...</think> then <final>...</final>.";
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
-      reasoningTagHint: true,
+      reasoningFormatHint: hint,
     });
 
     expect(prompt).toContain("## Reasoning Format");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -167,7 +167,7 @@ export function buildAgentSystemPrompt(params: {
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
-  reasoningTagHint?: boolean;
+  reasoningFormatHint?: string;
   toolNames?: string[];
   toolSummaries?: Record<string, string>;
   modelAliasLines?: string[];
@@ -319,18 +319,7 @@ export function buildAgentSystemPrompt(params: {
     ownerNumbers.length > 0
       ? `Owner numbers: ${ownerNumbers.join(", ")}. Treat messages from these numbers as the user.`
       : undefined;
-  const reasoningHint = params.reasoningTagHint
-    ? [
-        "ALL internal reasoning MUST be inside <think>...</think>.",
-        "Do not output any analysis outside <think>.",
-        "Format every reply as <think>...</think> then <final>...</final>, with no other text.",
-        "Only the final user-visible reply may appear inside <final>.",
-        "Only text inside <final> is shown to the user; everything else is discarded and never seen by the user.",
-        "Example:",
-        "<think>Short internal reasoning.</think>",
-        "<final>Hey there! What would you like to do next?</final>",
-      ].join(" ")
-    : undefined;
+  const reasoningHint = params.reasoningFormatHint ?? undefined;
   const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -1,6 +1,5 @@
 import type { ToolCallIdMode } from "./tool-call-id.js";
-import { normalizeProviderId } from "./model-selection.js";
-import { isAntigravityClaude, isGoogleModelApi } from "./pi-embedded-helpers/google.js";
+import { resolveProviderCapabilities } from "./provider-capabilities.js";
 
 export type TranscriptSanitizeMode = "full" | "images-only";
 
@@ -21,103 +20,23 @@ export type TranscriptPolicy = {
   allowSyntheticToolResults: boolean;
 };
 
-const MISTRAL_MODEL_HINTS = [
-  "mistral",
-  "mixtral",
-  "codestral",
-  "pixtral",
-  "devstral",
-  "ministral",
-  "mistralai",
-];
-const OPENAI_MODEL_APIS = new Set([
-  "openai",
-  "openai-completions",
-  "openai-responses",
-  "openai-codex-responses",
-]);
-const OPENAI_PROVIDERS = new Set(["openai", "openai-codex"]);
-
-function isOpenAiApi(modelApi?: string | null): boolean {
-  if (!modelApi) {
-    return false;
-  }
-  return OPENAI_MODEL_APIS.has(modelApi);
-}
-
-function isOpenAiProvider(provider?: string | null): boolean {
-  if (!provider) {
-    return false;
-  }
-  return OPENAI_PROVIDERS.has(normalizeProviderId(provider));
-}
-
-function isAnthropicApi(modelApi?: string | null, provider?: string | null): boolean {
-  if (modelApi === "anthropic-messages") {
-    return true;
-  }
-  const normalized = normalizeProviderId(provider ?? "");
-  // MiniMax now uses openai-completions API, not anthropic-messages
-  return normalized === "anthropic";
-}
-
-function isMistralModel(params: { provider?: string | null; modelId?: string | null }): boolean {
-  const provider = normalizeProviderId(params.provider ?? "");
-  if (provider === "mistral") {
-    return true;
-  }
-  const modelId = (params.modelId ?? "").toLowerCase();
-  if (!modelId) {
-    return false;
-  }
-  return MISTRAL_MODEL_HINTS.some((hint) => modelId.includes(hint));
-}
-
 export function resolveTranscriptPolicy(params: {
   modelApi?: string | null;
   provider?: string | null;
   modelId?: string | null;
 }): TranscriptPolicy {
-  const provider = normalizeProviderId(params.provider ?? "");
-  const modelId = params.modelId ?? "";
-  const isGoogle = isGoogleModelApi(params.modelApi);
-  const isAnthropic = isAnthropicApi(params.modelApi, provider);
-  const isOpenAi = isOpenAiProvider(provider) || (!provider && isOpenAiApi(params.modelApi));
-  const isMistral = isMistralModel({ provider, modelId });
-  const isOpenRouterGemini =
-    (provider === "openrouter" || provider === "opencode") &&
-    modelId.toLowerCase().includes("gemini");
-  const isAntigravityClaudeModel = isAntigravityClaude({
-    api: params.modelApi,
-    provider,
-    modelId,
-  });
-
-  const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
-
-  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
-  const toolCallIdMode: ToolCallIdMode | undefined = isMistral
-    ? "strict9"
-    : sanitizeToolCallIds
-      ? "strict"
-      : undefined;
-  const repairToolUseResultPairing = isGoogle || isAnthropic;
-  const sanitizeThoughtSignatures = isOpenRouterGemini
-    ? { allowBase64Only: true, includeCamelCase: true }
-    : undefined;
-  const normalizeAntigravityThinkingBlocks = isAntigravityClaudeModel;
-
+  const caps = resolveProviderCapabilities(params);
   return {
-    sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
-    sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
-    toolCallIdMode,
-    repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
-    preserveSignatures: isAntigravityClaudeModel,
-    sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
-    normalizeAntigravityThinkingBlocks,
-    applyGoogleTurnOrdering: !isOpenAi && isGoogle,
-    validateGeminiTurns: !isOpenAi && isGoogle,
-    validateAnthropicTurns: !isOpenAi && isAnthropic,
-    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+    sanitizeMode: caps.sanitizeMode,
+    sanitizeToolCallIds: caps.sanitizeToolCallIds,
+    toolCallIdMode: caps.toolCallIdMode ?? undefined,
+    repairToolUseResultPairing: caps.repairToolUseResultPairing,
+    preserveSignatures: caps.preserveSignatures,
+    sanitizeThoughtSignatures: caps.sanitizeThoughtSignatures ?? undefined,
+    normalizeAntigravityThinkingBlocks: caps.normalizeAntigravityThinkingBlocks,
+    applyGoogleTurnOrdering: caps.applyGoogleTurnOrdering,
+    validateGeminiTurns: caps.validateGeminiTurns,
+    validateAnthropicTurns: caps.validateAnthropicTurns,
+    allowSyntheticToolResults: caps.allowSyntheticToolResults,
   };
 }

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -144,7 +144,7 @@ async function resolveContextReport(
     reasoningLevel: params.resolvedReasoningLevel,
     extraSystemPrompt: undefined,
     ownerNumbers: undefined,
-    reasoningTagHint: false,
+    reasoningFormatHint: undefined,
     toolNames,
     toolSummaries,
     modelAliasLines: [],

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -2,6 +2,8 @@
  * Utility functions for provider-specific logic and capabilities.
  */
 
+import { resolveProviderCapabilities } from "../agents/provider-capabilities.js";
+
 /**
  * Returns true if the provider requires reasoning to be wrapped in tags
  * (e.g. <think> and <final>) in the text stream, rather than using native
@@ -11,26 +13,5 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   if (!provider) {
     return false;
   }
-  const normalized = provider.trim().toLowerCase();
-
-  // Check for exact matches or known prefixes/substrings for reasoning providers
-  if (
-    normalized === "ollama" ||
-    normalized === "google-gemini-cli" ||
-    normalized === "google-generative-ai"
-  ) {
-    return true;
-  }
-
-  // Handle google-antigravity and its model variations (e.g. google-antigravity/gemini-3)
-  if (normalized.includes("google-antigravity")) {
-    return true;
-  }
-
-  // Handle Minimax (M2.1 is chatty/reasoning-like)
-  if (normalized.includes("minimax")) {
-    return true;
-  }
-
-  return false;
+  return resolveProviderCapabilities({ provider }).reasoningFormat === "tags";
 }


### PR DESCRIPTION
## Summary

- Add `src/agents/provider-capabilities.ts` as the single source of truth for all model/provider-specific behaviour, replacing scattered provider-string comparisons across 7 files
- `ProviderCapabilities` interface exposes 15 capability fields covering prompt engineering, tool schema, caching, HTTP headers, model compat, transcript sanitization, and tool availability
- All existing call sites delegate to `resolveProviderCapabilities()` with zero behaviour change

## Files changed

| File | Change |
|------|--------|
| `src/agents/provider-capabilities.ts` | **New** — `ProviderCapabilities` interface + `resolveProviderCapabilities()` + `GOOGLE_UNSUPPORTED_SCHEMA_KEYWORDS` |
| `src/agents/transcript-policy.ts` | `resolveTranscriptPolicy()` delegates to capabilities (~80 lines of if-else removed) |
| `src/utils/provider-utils.ts` | `isReasoningTagProvider()` delegates to `caps.reasoningFormat` |
| `src/agents/pi-embedded-runner/cache-ttl.ts` | `isCacheTtlEligibleProvider()` delegates to `caps.supportsPromptCache` |
| `src/agents/pi-embedded-runner/extra-params.ts` | Remove hardcoded `OPENROUTER_APP_HEADERS`; use `caps.extraRequestHeaders` and `caps.supportsCacheRetentionParam`; generalise `createOpenRouterHeadersWrapper` → `createRequestHeadersWrapper` |
| `src/agents/pi-embedded-runner/google.ts` | Remove local 20-entry keyword blacklist; use `GOOGLE_UNSUPPORTED_SCHEMA_KEYWORDS` from capabilities; replace provider-string guards with `caps.toolSchemaUnsupportedKeywords` check |
| `src/agents/model-compat.ts` | Replace manual `isZai` detection with `caps.supportsDeveloperRole` |
| `src/agents/pi-tools.ts` | Remove local `isOpenAIProvider()`; replace with `caps.supportsApplyPatch` |

## Motivation

Adding a new provider previously required edits in 6+ files. With this change, provider-specific behaviour is declared once in `resolveProviderCapabilities()` and all consumers query the capability they need — no provider string comparisons at call sites.

## Test plan

- [ ] Verify Anthropic provider: prompt cache, transcript sanitization, turn validation unchanged
- [ ] Verify Google provider: tool schema stripping, turn ordering fix unchanged
- [ ] Verify Mistral provider: strict-9 tool call ID mode unchanged
- [ ] Verify OpenRouter: attribution headers injected, Gemini thought-signature sanitization unchanged
- [ ] Verify OpenAI provider: apply_patch tool gated correctly, images-only sanitize mode
- [ ] Verify ZAI: `supportsDeveloperRole: false` still applied via `normalizeModelCompat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Centralizes provider-specific capability checks from 7 files into a single `ProviderCapabilities` interface and `resolveProviderCapabilities()` function

- Replaces scattered provider string comparisons across codebase with centralized capability resolution
- Maintains exact behavioral equivalence for all providers (Anthropic, Google, Mistral, OpenRouter, OpenAI, ZAI, MiniMax)
- Eliminates ~80 lines of duplicated provider detection logic from `transcript-policy.ts`
- Generalizes OpenRouter-specific header injection into provider-agnostic `extraRequestHeaders` capability
- Exports `GOOGLE_UNSUPPORTED_SCHEMA_KEYWORDS` for reuse in tool schema sanitization
- All existing call sites delegate to the new capability system without behavioral changes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a well-executed refactoring that consolidates provider capability logic without changing behavior. The new centralized approach maintains exact logical equivalence with the original scattered implementations across all providers. The code follows established patterns from the codebase, properly handles edge cases (ZAI baseUrl detection, OpenRouter Anthropic models, Mistral model hints), and preserves all existing provider-specific behaviors including tool schema sanitization, caching, header injection, and transcript policies.
- No files require special attention

<sub>Last reviewed commit: 5870152</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->