### PR TITLE
fix: don't trigger immediate heartbeat on background exec exit

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -32,6 +32,7 @@ export interface ProcessSession {
   sessionKey?: string;
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
+  notifyOnExitHeartbeat?: boolean;
   exitNotified?: boolean;
   child?: ChildProcessWithoutNullStreams;
   stdin?: SessionStdin;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -82,6 +82,7 @@ export type ExecToolDefaults = {
   messageProvider?: string;
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
+  notifyOnExitHeartbeat?: boolean;
   cwd?: string;
 };
 
@@ -230,6 +231,7 @@ export function createExecTool(
   const safeBins = resolveSafeBins(defaults?.safeBins);
   const notifyOnExit = defaults?.notifyOnExit !== false;
   const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess === true;
+  const notifyOnExitHeartbeat = defaults?.notifyOnExitHeartbeat === true;
   const notifySessionKey = defaults?.sessionKey?.trim() || undefined;
   const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
   // Derive agentId only when sessionKey is an agent session key.
@@ -985,6 +987,7 @@ export function createExecTool(
         pendingMaxOutput,
         notifyOnExit,
         notifyOnExitEmptySuccess,
+        notifyOnExitHeartbeat,
         scopeKey: defaults?.scopeKey,
         sessionKey: notifySessionKey,
         timeoutSec: effectiveTimeout,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -112,6 +112,8 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
     notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
     notifyOnExitEmptySuccess:
       agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
+    notifyOnExitHeartbeat:
+      agentExec?.notifyOnExitHeartbeat ?? globalExec?.notifyOnExitHeartbeat,
     applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
   };
 }
@@ -370,6 +372,8 @@ export function createOpenClawCodingTools(options?: {
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     notifyOnExitEmptySuccess:
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
+    notifyOnExitHeartbeat:
+      options?.exec?.notifyOnExitHeartbeat ?? execConfig.notifyOnExitHeartbeat,
     sandbox: sandbox
       ? {
           containerName: sandbox.containerName,

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -332,6 +332,7 @@ export async function handleBashChatCommand(params: {
     const timeoutSec = params.cfg.tools?.exec?.timeoutSec;
     const notifyOnExit = params.cfg.tools?.exec?.notifyOnExit;
     const notifyOnExitEmptySuccess = params.cfg.tools?.exec?.notifyOnExitEmptySuccess;
+    const notifyOnExitHeartbeat = params.cfg.tools?.exec?.notifyOnExitHeartbeat;
     const execTool = createExecTool({
       scopeKey: CHAT_BASH_SCOPE_KEY,
       allowBackground: true,
@@ -339,6 +340,7 @@ export async function handleBashChatCommand(params: {
       sessionKey: params.sessionKey,
       notifyOnExit,
       notifyOnExitEmptySuccess,
+      notifyOnExitHeartbeat,
       elevated: {
         enabled: params.elevated.enabled,
         allowed: params.elevated.allowed,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -81,9 +81,11 @@ export const FIELD_HELP: Record<string, string> = {
     "Enable known poll tool no-progress loop detection (default: true).",
   "tools.loopDetection.detectors.pingPong": "Enable ping-pong loop detection (default: true).",
   "tools.exec.notifyOnExit":
-    "When true (default), backgrounded exec sessions enqueue a system event and request a heartbeat on exit.",
+    "When true (default), backgrounded exec sessions enqueue a system event on exit. The event is consumed at the next natural checkpoint unless notifyOnExitHeartbeat is also enabled.",
   "tools.exec.notifyOnExitEmptySuccess":
     "When true, successful backgrounded exec exits with empty output still enqueue a completion system event (default: false).",
+  "tools.exec.notifyOnExitHeartbeat":
+    "When true, backgrounded exec exits also trigger an immediate heartbeat, causing the agent to relay the result to the user right away. Default false — events are silently enqueued and consumed at the next natural checkpoint.",
   "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",
   "tools.exec.safeBins":
     "Allow stdin-only safe binaries to run without explicit allowlist entries.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -85,6 +85,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.sessions.visibility": "Session Tools Visibility",
   "tools.exec.notifyOnExit": "Exec Notify On Exit",
   "tools.exec.notifyOnExitEmptySuccess": "Exec Notify On Empty Success",
+  "tools.exec.notifyOnExitHeartbeat": "Exec Notify Heartbeat On Exit",
   "tools.exec.approvalRunningNoticeMs": "Exec Approval Running Notice (ms)",
   "tools.exec.host": "Exec Host",
   "tools.exec.security": "Exec Security",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -214,6 +214,15 @@ export type ExecToolConfig = {
    * Default false to reduce context noise.
    */
   notifyOnExitEmptySuccess?: boolean;
+  /**
+   * Trigger an immediate heartbeat when a backgrounded exec exits.
+   * When false (default), the exit event is silently enqueued and consumed at
+   * the next natural checkpoint (interval heartbeat or user message), preventing
+   * internal agent exec completions from spamming the user's messaging channel.
+   * Set to true only when you want immediate user-facing notification of every
+   * backgrounded exec completion.
+   */
+  notifyOnExitHeartbeat?: boolean;
   /** apply_patch subtool configuration (experimental). */
   applyPatch?: {
     /** Enable apply_patch for OpenAI models (default: false). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -337,6 +337,7 @@ const ToolExecBaseShape = {
   cleanupMs: z.number().int().positive().optional(),
   notifyOnExit: z.boolean().optional(),
   notifyOnExitEmptySuccess: z.boolean().optional(),
+  notifyOnExitHeartbeat: z.boolean().optional(),
   applyPatch: ToolExecApplyPatchSchema,
 } as const;
 


### PR DESCRIPTION
## Problem

When an AI agent runs multiple background exec commands (e.g. retrying `launchctl` operations), each completion triggers:
1. `enqueueSystemEvent()` — queues the result
2. `requestHeartbeatNow()` — forces an immediate heartbeat
3. Agent receives heartbeat → generates reply → sends to user's WhatsApp/LINE

This results in the user receiving a flood of unwanted notifications like:
`⚠️ 🛠️ Exec: ... failed: Unload failed: 5: Input/output error`

## Solution

Make `maybeNotifyOnExit()` conditionally trigger heartbeats. By default, the system event is silently enqueued and consumed at the next natural checkpoint (interval heartbeat or user message).

### New config option
```yaml
tools:
  exec:
    notifyOnExitHeartbeat: true  # restore immediate heartbeat (default: false)
```

### What's NOT affected
- **Approval-flow execs** — use `emitExecSystemEvent()` with their own `requestHeartbeatNow()`
- **Node exec completions** — use `server-node-events.ts` independent path

### Files changed (9)
- `src/agents/bash-tools.exec-runtime.ts` — core fix: conditional heartbeat in `maybeNotifyOnExit()`
- `src/agents/bash-process-registry.ts` — ProcessSession interface
- `src/agents/bash-tools.exec.ts` — ExecToolDefaults + createExecTool
- `src/agents/pi-tools.ts` — config passthrough
- `src/auto-reply/reply/bash-command.ts` — chat-bash path
- `src/config/types.tools.ts` — type definition
- `src/config/zod-schema.agent-runtime.ts` — Zod validation
- `src/config/schema.help.ts` + `schema.labels.ts` — docs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR decouples the immediate heartbeat trigger from background exec exit notifications. Previously, every backgrounded exec completion called both `enqueueSystemEvent()` and `requestHeartbeatNow()`, causing a flood of user-facing messages when agents ran multiple background commands. Now, the system event is always enqueued but the immediate heartbeat is gated behind a new `notifyOnExitHeartbeat` config option (default: `false`). Events are consumed at the next natural checkpoint (interval heartbeat or user message) instead.

- The core behavioral change in `maybeNotifyOnExit()` is clean and minimal — wraps `requestHeartbeatNow()` in a conditional without touching the event-enqueue path
- Config plumbing follows the established `notifyOnExitEmptySuccess` pattern consistently across all 9 files (types, zod schema, help/labels, config resolution, tool creation, and both the agent and chat-bash paths)
- Approval-flow execs and node exec completions are unaffected, as they use `emitExecSystemEvent()` which has its own `requestHeartbeatNow()` call
- Minor doc inconsistency: the JSDoc for `notifyOnExit` in `types.tools.ts` still says "and heartbeat" — the `schema.help.ts` text was correctly updated but the JSDoc was missed

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it changes a default from opt-out to opt-in for an immediate heartbeat trigger, with no impact on the event enqueue path or approval flows.
- The change is well-scoped and follows established patterns. The only finding is a stale JSDoc comment on notifyOnExit that still mentions "heartbeat" — a minor documentation inconsistency, not a functional issue. All config paths are properly threaded.
- `src/config/types.tools.ts` has a stale JSDoc for `notifyOnExit` that still says "and heartbeat".

<sub>Last reviewed commit: d260505</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->