### PR TITLE
fix(models): allow forward-compat models in allowlist gate

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -276,6 +276,69 @@ function resolveAntigravityOpus46ForwardCompatModel(
   });
 }
 
+export function isForwardCompatModelId(provider: string, modelId: string): boolean {
+  const normalizedProvider = normalizeProviderId(provider);
+  const trimmed = modelId.trim();
+  const lower = trimmed.toLowerCase();
+
+  // OpenAI Codex
+  if (normalizedProvider === "openai-codex") {
+    if (lower === OPENAI_CODEX_GPT_53_MODEL_ID) {
+      return true;
+    }
+  }
+
+  // Anthropic Opus 4.6
+  if (normalizedProvider === "anthropic") {
+    if (
+      lower === ANTHROPIC_OPUS_46_MODEL_ID ||
+      lower === ANTHROPIC_OPUS_46_DOT_MODEL_ID ||
+      lower.startsWith(`${ANTHROPIC_OPUS_46_MODEL_ID}-`) ||
+      lower.startsWith(`${ANTHROPIC_OPUS_46_DOT_MODEL_ID}-`)
+    ) {
+      return true;
+    }
+    // Anthropic Sonnet 4.6
+    if (
+      lower === ANTHROPIC_SONNET_46_MODEL_ID ||
+      lower === ANTHROPIC_SONNET_46_DOT_MODEL_ID ||
+      lower.startsWith(`${ANTHROPIC_SONNET_46_MODEL_ID}-`) ||
+      lower.startsWith(`${ANTHROPIC_SONNET_46_DOT_MODEL_ID}-`)
+    ) {
+      return true;
+    }
+  }
+
+  // Z.ai GLM-5
+  if (normalizedProvider === "zai") {
+    if (lower === ZAI_GLM5_MODEL_ID || lower.startsWith(`${ZAI_GLM5_MODEL_ID}-`)) {
+      return true;
+    }
+  }
+
+  // Antigravity Opus 4.6
+  if (normalizedProvider === "google-antigravity") {
+    if (
+      lower === ANTIGRAVITY_OPUS_46_MODEL_ID ||
+      lower === ANTIGRAVITY_OPUS_46_DOT_MODEL_ID ||
+      lower.startsWith(`${ANTIGRAVITY_OPUS_46_MODEL_ID}-`) ||
+      lower.startsWith(`${ANTIGRAVITY_OPUS_46_DOT_MODEL_ID}-`)
+    ) {
+      return true;
+    }
+    if (
+      lower === ANTIGRAVITY_OPUS_46_THINKING_MODEL_ID ||
+      lower === ANTIGRAVITY_OPUS_46_DOT_THINKING_MODEL_ID ||
+      lower.startsWith(`${ANTIGRAVITY_OPUS_46_THINKING_MODEL_ID}-`) ||
+      lower.startsWith(`${ANTIGRAVITY_OPUS_46_DOT_THINKING_MODEL_ID}-`)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function resolveForwardCompatModel(
   provider: string,
   modelId: string,

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ModelCatalogEntry } from "./model-catalog.js";
+import { buildAllowedModelSet } from "./model-selection.js";
+
+describe("buildAllowedModelSet", () => {
+  it("allows forward-compat models when configured in allowlist", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": {},
+            "anthropic/claude-opus-4-6": {},
+            "google-antigravity/claude-opus-4-6-thinking": {},
+            "zai/glm-5": {},
+            "openai-codex/gpt-5.3-codex": {},
+          },
+        },
+      },
+      models: {
+        providers: {}, // No configured providers
+      },
+    } as unknown as OpenClawConfig;
+
+    const catalog: ModelCatalogEntry[] = [
+      { provider: "anthropic", id: "claude-3-5-sonnet-20240620", name: "Claude 3.5 Sonnet" },
+    ];
+
+    const result = buildAllowedModelSet({
+      cfg,
+      catalog,
+      defaultProvider: "anthropic",
+    });
+
+    expect(result.allowedKeys.has("anthropic/claude-sonnet-4-6")).toBe(true);
+    expect(result.allowedKeys.has("anthropic/claude-opus-4-6")).toBe(true);
+    expect(result.allowedKeys.has("google-antigravity/claude-opus-4-6-thinking")).toBe(true);
+    expect(result.allowedKeys.has("zai/glm-5")).toBe(true);
+    expect(result.allowedKeys.has("openai-codex/gpt-5.3-codex")).toBe(true);
+  });
+
+  it("does not allow random models not in forward-compat list", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-random-9-9": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const catalog: ModelCatalogEntry[] = [];
+
+    const result = buildAllowedModelSet({
+      cfg,
+      catalog,
+      defaultProvider: "anthropic",
+    });
+
+    expect(result.allowedKeys.has("anthropic/claude-random-9-9")).toBe(false);
+  });
+
+  it("allows models in catalog", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-3-5-sonnet-20240620": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const catalog: ModelCatalogEntry[] = [
+      { provider: "anthropic", id: "claude-3-5-sonnet-20240620", name: "Claude 3.5 Sonnet" },
+    ];
+
+    const result = buildAllowedModelSet({
+      cfg,
+      catalog,
+      defaultProvider: "anthropic",
+    });
+
+    expect(result.allowedKeys.has("anthropic/claude-3-5-sonnet-20240620")).toBe(true);
+  });
+});

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentConfig, resolveAgentModelPrimary } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
+import { isForwardCompatModelId } from "./model-forward-compat.js";
 import { normalizeGoogleModelId } from "./models-config.providers.js";
 
 export type ModelRef = {
@@ -398,6 +399,8 @@ export function buildAllowedModelSet(params: {
     } else if (configuredProviders[providerKey] != null) {
       // Explicitly configured providers should be allowlist-able even when
       // they don't exist in the curated model catalog.
+      allowedKeys.add(key);
+    } else if (isForwardCompatModelId(parsed.provider, parsed.model)) {
       allowedKeys.add(key);
     }
   }


### PR DESCRIPTION
## Problem

Forward-compat models (`claude-sonnet-4-6`, `claude-opus-4-6`, `gpt-5.3-codex`, `glm-5`, etc.) are blocked with **"Model not allowed"** when configured in the user's model allowlist, even though `resolveForwardCompatModel()` can successfully resolve them at runtime.

### Root cause

`buildAllowedModelSet()` in `model-selection.ts` only adds a model to `allowedKeys` if it:
1. Exists in the pi-ai model catalog snapshot, OR
2. Belongs to a CLI provider, OR
3. Belongs to an explicitly configured provider in `models.providers`

Forward-compat models fail all three checks — they're not in the catalog yet (that's the whole point of forward-compat), built-in providers like `anthropic` aren't in `configuredProviders`, and they're not CLI providers. The model resolves fine downstream via `resolveForwardCompatModel`, but never gets past the allowlist gate.

## Solution

Added a lightweight `isForwardCompatModelId(provider, modelId)` function to `model-forward-compat.ts` that pattern-matches against all known forward-compat model IDs, and a single `else if` in `buildAllowedModelSet` to check it.

### Why this approach?

- **Minimal footprint**: 2 lines changed in `model-selection.ts`, no signature changes to `buildAllowedModelSet`
- **Zero call-site changes**: `buildAllowedModelSet` has 7 call sites across the codebase — threading `modelRegistry` through all of them would be invasive and risky for a targeted fix
- **Pattern matching is sufficient**: the allowlist gate only needs to answer "could this model resolve?" — the actual resolution (with full registry access) already happens later in `resolveModel`. Pattern matching against the same constants the resolvers use gives the same answer without the dependency.
- **Mirrors resolver logic exactly**: `isForwardCompatModelId` checks the same provider + model ID patterns as each `resolve*ForwardCompatModel` function, ensuring consistency

## Related

- #19533 — attempted the same fix but was incomplete: added `isForwardCompatModelId` for sonnet-4-6 without a corresponding resolver, meaning models would pass the gate but crash downstream with "Unknown model". That's now fixed on main (`resolveAnthropicSonnet46ForwardCompatModel` was merged in `ae2c8f2`), so the only remaining gap is the allowlist gate — which this PR closes.
- Affects all forward-compat models, not just sonnet-4-6 (opus-4-6, glm-5, gpt-5.3-codex, antigravity variants)

## Changes

| File | Change |
|---|---|
| `src/agents/model-forward-compat.ts` | Added `isForwardCompatModelId()` export |
| `src/agents/model-selection.ts` | Added forward-compat check in `buildAllowedModelSet` |
| `src/agents/model-selection.test.ts` | New tests: forward-compat allowed, random model rejected, catalog model allowed |

## Testing

- `pnpm build` ✅
- New vitest tests pass ✅
- Existing `model.test.ts` tests pass ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `isForwardCompatModelId()` function to allow forward-compat models (`claude-sonnet-4-6`, `claude-opus-4-6`, `gpt-5.3-codex`, `glm-5`, etc.) to pass the allowlist gate in `buildAllowedModelSet()`, fixing "Model not allowed" errors when these models are configured but not yet in the pi-ai catalog.

- The new function pattern-matches against all known forward-compat model IDs using the same logic as the existing resolver functions
- Minimal 2-line change to `buildAllowedModelSet()` adds forward-compat check as a final fallback after CLI providers, catalog, and configured providers
- Comprehensive test coverage validates all forward-compat models pass the gate while random models are correctly rejected
- Aligns the allowlist gate with the downstream resolution logic that already handles these models via `resolveForwardCompatModel()`

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- The implementation correctly mirrors the existing resolver logic with pattern matching, uses a minimal and well-tested approach, and includes comprehensive test coverage for all forward-compat model variants. The change is isolated to the allowlist gate and doesn't affect existing model resolution behavior.
- No files require special attention

<sub>Last reviewed commit: 1f9b12f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->