### PR TITLE
fix: elevatedDefault should default to off when tools.elevated.enabled is true

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.ignores-inline-model-uses-default-model.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.ignores-inline-model-uses-default-model.e2e.test.ts
@@ -139,7 +139,7 @@ describe("directive behavior", () => {
       expect(call?.bashElevated).toEqual({
         enabled: true,
         allowed: true,
-        defaultLevel: "on",
+        defaultLevel: "off",
       });
     });
   });

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -342,7 +342,7 @@ export async function handleBashChatCommand(params: {
       elevated: {
         enabled: params.elevated.enabled,
         allowed: params.elevated.allowed,
-        defaultLevel: "on",
+        defaultLevel: "off",
       },
     });
     const result = await execTool.execute("chat-bash", {

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -353,7 +353,7 @@ export async function resolveReplyDirectives(params: {
     ? (directives.elevatedLevel ??
       (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined) ??
-      "on")
+      "off")
     : "off";
   const resolvedBlockStreaming =
     opts?.disableBlockStreaming === true


### PR DESCRIPTION
## Summary

Fixes #19574

When `tools.elevated.enabled` is set to `true` but no explicit `elevatedDefault` is configured, the fallback was `"on"` — causing **all** exec commands to route through the elevated approval gate, which times out silently after 120s.

## Changes

- **`src/auto-reply/reply/get-reply-directives.ts`**: Changed the final fallback in the `resolvedElevatedLevel` resolution chain from `"on"` to `"off"`, making elevated mode opt-in per session.
- **`src/auto-reply/reply/bash-command.ts`**: Changed the hardcoded `defaultLevel: "on"` to `"off"` in the chat bash command elevated config.
- **Updated e2e test**: Adjusted the expected default from `"on"` to `"off"` in the directive behavior test.

## Behavior

- **Before**: Enabling `tools.elevated.enabled` without setting `elevatedDefault` caused all exec commands to require elevated approval (defaulting to `"on"`).
- **After**: Elevated mode defaults to `"off"`. Users must explicitly opt in via `/elevated on`, `/elevated ask`, or by setting `elevatedDefault` in their agent config.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed the fallback default for `elevatedDefault` from `"on"` to `"off"` when `tools.elevated.enabled` is `true` but no explicit `elevatedDefault` is configured. This fixes issue #19574 where all exec commands were routing through the elevated approval gate and timing out silently after 120 seconds.

The fix ensures elevated mode is now opt-in through:
- Explicit `/elevated on|ask|full` directives per session
- Setting `elevatedDefault` in agent config
- Inline `/elevated` directives per message

Changes are applied consistently across:
- Main directive resolution logic (`get-reply-directives.ts:356`)
- Chat bash command handler (`bash-command.ts:345`)
- E2E test expectations updated to reflect new default

The logic is correct and well-tested. The change makes elevated mode behavior more explicit and prevents unexpected approval gate timeouts.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it fixes a problematic default behavior where enabling elevated mode would cause silent timeouts
- The fix is straightforward, logically sound, and addresses a real UX issue. Score is 4 rather than 5 due to the documentation examples not being updated in this PR, which could cause minor confusion for users referencing the docs.
- No files require special attention - the changes are minimal and well-contained

<sub>Last reviewed commit: cf6fe4f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->