### PR TITLE
Signal/UI/Docker: reduce Signal lock contention and harden gateway URL handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,15 @@ OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token
 # OPENCLAW_SHELL_ENV_TIMEOUT_MS=15000
 
 # -----------------------------------------------------------------------------
+# Docker Signal runtime tuning (optional, for docker-compose deployments)
+# -----------------------------------------------------------------------------
+# OPENCLAW_SIGNAL_IMAGE_TAG=0.97
+# OPENCLAW_SIGNAL_MODE=native   # supported: native, normal, json-rpc
+# OPENCLAW_SIGNAL_CPUS=0.5
+# OPENCLAW_SIGNAL_MEM_LIMIT=1g
+# OPENCLAW_SIGNAL_JAVA_OPTS=-XX:TieredStopAtLevel=1 -XX:CICompilerCount=2
+
+# -----------------------------------------------------------------------------
 # Model provider API keys (set at least one)
 # -----------------------------------------------------------------------------
 # OPENAI_API_KEY=sk-...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,15 @@ services:
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+#      SIGNAL_ACCOUNT: "+15550001111"
+#      SIGNAL_REST_URL: "http://signal:8080"
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
     ports:
-      - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
-      - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+      - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
+      - "127.0.0.1:${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+#    network_mode: host
     init: true
     restart: unless-stopped
     command:
@@ -44,3 +47,12 @@ services:
     tty: true
     init: true
     entrypoint: ["node", "dist/index.js"]
+
+  signal:
+    image: bbernhard/signal-cli-rest-api:latest
+    environment:
+      - MODE=normal
+#      - AUTO_RECEIVE_SCHEDULE=0 0/1 * 1/1 * ? *
+    volumes:
+      - ${OPENCLAW_CONFIG_DIR}/signal:/home/signal/.local/share/signal-cli
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,16 @@ services:
       - "127.0.0.1:${OPENCLAW_BRIDGE_PORT:-18790}:18790"
     init: true
     restart: unless-stopped
-    command: [ "node", "dist/index.js", "gateway", "--bind", "${OPENCLAW_GATEWAY_BIND:-lan}", "--port", "18789" ]
+    command:
+      [
+        "node",
+        "dist/index.js",
+        "gateway",
+        "--bind",
+        "${OPENCLAW_GATEWAY_BIND:-lan}",
+        "--port",
+        "18789",
+      ]
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
@@ -34,12 +43,19 @@ services:
     stdin_open: true
     tty: true
     init: true
-    entrypoint: [ "node", "dist/index.js" ]
+    entrypoint: ["node", "dist/index.js"]
 
   signal:
-    image: bbernhard/signal-cli-rest-api:latest
+    # Pin to a known-good tag; avoid :latest drift in production.
+    image: bbernhard/signal-cli-rest-api:${OPENCLAW_SIGNAL_IMAGE_TAG:-0.97}
     environment:
-      - MODE=normal
+      # Prefer native mode by default to reduce JVM spawn/lock churn in normal mode.
+      MODE: ${OPENCLAW_SIGNAL_MODE:-native}
+      # Use JAVA_OPTS (not JAVA_TOOL_OPTIONS) so JVM flags don't pollute stdout JSON payloads.
+      JAVA_OPTS: "${OPENCLAW_SIGNAL_JAVA_OPTS:--XX:TieredStopAtLevel=1 -XX:CICompilerCount=2}"
+    # Cap container CPU so signal-cli bursts don't starve the host.
+    cpus: ${OPENCLAW_SIGNAL_CPUS:-0.5}
+    mem_limit: ${OPENCLAW_SIGNAL_MEM_LIMIT:-1g}
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}/signal:/home/signal/.local/share/signal-cli
+      - ${OPENCLAW_CONFIG_DIR}/signal:/home/.local/share/signal-cli
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,27 +8,15 @@ services:
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
-#      SIGNAL_ACCOUNT: "+15550001111"
-#      SIGNAL_REST_URL: "http://signal:8080"
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
     ports:
       - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "127.0.0.1:${OPENCLAW_BRIDGE_PORT:-18790}:18790"
-#    network_mode: host
     init: true
     restart: unless-stopped
-    command:
-      [
-        "node",
-        "dist/index.js",
-        "gateway",
-        "--bind",
-        "${OPENCLAW_GATEWAY_BIND:-lan}",
-        "--port",
-        "18789",
-      ]
+    command: [ "node", "dist/index.js", "gateway", "--bind", "${OPENCLAW_GATEWAY_BIND:-lan}", "--port", "18789" ]
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
@@ -46,13 +34,12 @@ services:
     stdin_open: true
     tty: true
     init: true
-    entrypoint: ["node", "dist/index.js"]
+    entrypoint: [ "node", "dist/index.js" ]
 
   signal:
     image: bbernhard/signal-cli-rest-api:latest
     environment:
       - MODE=normal
-#      - AUTO_RECEIVE_SCHEDULE=0 0/1 * 1/1 * ? *
     volumes:
       - ${OPENCLAW_CONFIG_DIR}/signal:/home/signal/.local/share/signal-cli
     restart: unless-stopped

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -262,7 +262,9 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
     }),
     probeAccount: async ({ account, timeoutMs }) => {
       const baseUrl = account.baseUrl;
-      return await getSignalRuntime().channel.signal.probeSignal(baseUrl, timeoutMs);
+      return await getSignalRuntime().channel.signal.probeSignal(baseUrl, timeoutMs, {
+        account: account.config.account,
+      });
     },
     buildAccountSnapshot: ({ account, runtime, probe }) => ({
       accountId: account.accountId,

--- a/scripts/check-signal-runtime.sh
+++ b/scripts/check-signal-runtime.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-signal-runtime.sh [options]
+
+Options:
+  --samples <n>      Number of docker stats samples (default: 20)
+  --interval <sec>   Seconds between samples (default: 2)
+  --since <window>   Log window for docker compose logs (default: 5m)
+  --signal <name>    Signal docker compose service name (default: signal)
+  --gateway <name>   Gateway docker compose service name (default: openclaw-gateway)
+  -h, --help         Show this help
+EOF
+}
+
+SAMPLES=20
+INTERVAL=2
+SINCE="5m"
+SIGNAL_SERVICE="signal"
+GATEWAY_SERVICE="openclaw-gateway"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --samples)
+      SAMPLES="${2:-}"
+      shift 2
+      ;;
+    --interval)
+      INTERVAL="${2:-}"
+      shift 2
+      ;;
+    --since)
+      SINCE="${2:-}"
+      shift 2
+      ;;
+    --signal)
+      SIGNAL_SERVICE="${2:-}"
+      shift 2
+      ;;
+    --gateway)
+      GATEWAY_SERVICE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$SAMPLES" =~ ^[0-9]+$ ]] || ! [[ "$INTERVAL" =~ ^[0-9]+$ ]]; then
+  echo "--samples and --interval must be non-negative integers" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Avoid noisy docker compose warnings when these optional vars are unset.
+export CLAUDE_AI_SESSION_KEY="${CLAUDE_AI_SESSION_KEY-}"
+export CLAUDE_WEB_SESSION_KEY="${CLAUDE_WEB_SESSION_KEY-}"
+export CLAUDE_WEB_COOKIE="${CLAUDE_WEB_COOKIE-}"
+
+echo "== Signal About ($(date -u +%Y-%m-%dT%H:%M:%SZ)) =="
+docker compose exec -T "${GATEWAY_SERVICE}" sh -lc "curl -sS http://${SIGNAL_SERVICE}:8080/v1/about || true"
+echo
+
+signal_cid="$(docker compose ps -q "${SIGNAL_SERVICE}")"
+gateway_cid="$(docker compose ps -q "${GATEWAY_SERVICE}")"
+if [[ -z "${signal_cid}" || -z "${gateway_cid}" ]]; then
+  echo "Could not resolve container IDs for services: ${SIGNAL_SERVICE}, ${GATEWAY_SERVICE}" >&2
+  exit 1
+fi
+
+echo "== CPU/Memory Samples (${SAMPLES}x every ${INTERVAL}s) =="
+for _ in $(seq 1 "${SAMPLES}"); do
+  printf "%s " "$(date +%H:%M:%S)"
+  docker stats --no-stream --format "{{.Name}} {{.CPUPerc}} {{.MemUsage}} {{.PIDs}}" "${signal_cid}" "${gateway_cid}" \
+    | tr '\n' '|' || true
+  echo
+  sleep "${INTERVAL}"
+done
+echo
+
+echo "== Signal Logs (${SINCE}) =="
+docker compose logs --since "${SINCE}" "${SIGNAL_SERVICE}" \
+  | rg -n 'GET\s+"/v1/receive|Config file is in use|lock acquired|ERROR|WARN' \
+  | tail -n 120 || true
+echo
+
+echo "== Gateway Signal Errors (${SINCE}) =="
+docker compose logs --since "${SINCE}" "${GATEWAY_SERVICE}" \
+  | rg -n '\[signal\].*(error|failed|timeout|lost)|Signal receive failed|non-JSON payload|Signal REST send timed out|lane wait exceeded' \
+  | tail -n 120 || true

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -31,6 +31,6 @@ export const getHandshakeTimeoutMs = () => {
   return DEFAULT_HANDSHAKE_TIMEOUT_MS;
 };
 export const TICK_INTERVAL_MS = 30_000;
-export const HEALTH_REFRESH_INTERVAL_MS = 60_000;
+export const HEALTH_REFRESH_INTERVAL_MS = 300_000;
 export const DEDUPE_TTL_MS = 5 * 60_000;
 export const DEDUPE_MAX = 1000;

--- a/src/signal/client.test.ts
+++ b/src/signal/client.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { signalCheck, signalRpcRequest, streamSignalEvents } from "./client.js";
+
+const resolveFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../infra/fetch.js", () => ({
+  resolveFetch: () => resolveFetchMock(),
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("signal client backend compatibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses jsonrpc health check when /api/v1/check is available", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    resolveFetchMock.mockReturnValue(fetchMock);
+
+    const res = await signalCheck("http://signal-jsonrpc:8080", 1000);
+
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe("http://signal-jsonrpc:8080/api/v1/check");
+  });
+
+  it("falls back to REST health checks when /api/v1/check is missing", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ versions: ["v1", "v2"], version: "0.97" }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(jsonResponse(["+15551110000"]));
+    resolveFetchMock.mockReturnValue(fetchMock);
+
+    const res = await signalCheck("http://signal-rest:8080", 1000);
+
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(204);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe("http://signal-rest:8080/v1/about");
+    expect(String(fetchMock.mock.calls[2]?.[0])).toBe("http://signal-rest:8080/v1/health");
+    expect(String(fetchMock.mock.calls[3]?.[0])).toBe("http://signal-rest:8080/v1/accounts");
+  });
+
+  it("reports REST health as not ready when no accounts are registered", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ versions: ["v1", "v2"], version: "0.97" }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(jsonResponse([]));
+    resolveFetchMock.mockReturnValue(fetchMock);
+
+    const res = await signalCheck("http://signal-rest-no-accounts:8080", 1000);
+
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(204);
+    expect(res.error).toContain("no account is registered");
+  });
+
+  it("returns REST about payload for version requests", async () => {
+    const about = { versions: ["v1", "v2"], version: "0.97", mode: "normal" };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse(about))
+      .mockResolvedValueOnce(jsonResponse(about));
+    resolveFetchMock.mockReturnValue(fetchMock);
+
+    const result = await signalRpcRequest("version", undefined, {
+      baseUrl: "http://signal-rest-version:8080",
+    });
+
+    expect(result).toEqual(about);
+  });
+
+  it("maps send RPC to /v2/send with inferred account from /v1/accounts", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ versions: ["v1", "v2"] }))
+      .mockResolvedValueOnce(jsonResponse(["+15551110000"]))
+      .mockResolvedValueOnce(jsonResponse({ timestamp: 1730000000000 }));
+    resolveFetchMock.mockReturnValue(fetchMock);
+
+    const result = await signalRpcRequest<{ timestamp?: number }>(
+      "send",
+      {
+        message: "hello",
+        recipient: ["+15552220000"],
+      },
+      {
+        baseUrl: "http://signal-rest-send:8080",
+      },
+    );
+
+    expect(result.timestamp).toBe(1730000000000);
+    expect(String(fetchMock.mock.calls[3]?.[0])).toBe("http://signal-rest-send:8080/v2/send");
+    const sendInit = fetchMock.mock.calls[3]?.[1] as { body?: string } | undefined;
+    expect(sendInit?.body).toBeDefined();
+    const body = JSON.parse(sendInit?.body ?? "{}") as Record<string, unknown>;
+    expect(body["number"]).toBe("+15551110000");
+    expect(body["recipients"]).toEqual(["+15552220000"]);
+    expect(body["message"]).toBe("hello");
+  });
+
+  it("falls back to /v1/send when /v2/send is unavailable", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ versions: ["v1", "v2"] }))
+      .mockResolvedValueOnce(jsonResponse(["+15553330000"]))
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ timestamp: 1730000000100 }));
+    resolveFetchMock.mockReturnValue(fetchMock);
+
+    const result = await signalRpcRequest<{ timestamp?: number }>(
+      "send",
+      {
+        message: "hello",
+        recipient: ["+15554440000"],
+      },
+      {
+        baseUrl: "http://signal-rest-send-v1:8080",
+      },
+    );
+
+    expect(result.timestamp).toBe(1730000000100);
+    expect(String(fetchMock.mock.calls[3]?.[0])).toBe("http://signal-rest-send-v1:8080/v2/send");
+    expect(String(fetchMock.mock.calls[4]?.[0])).toBe("http://signal-rest-send-v1:8080/v1/send");
+  });
+
+  it("streams REST receive payloads as receive events", async () => {
+    const abortController = new AbortController();
+    const received: Array<{ event?: string; data?: string }> = [];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ versions: ["v1", "v2"] }))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            envelope: {
+              sourceNumber: "+15550001111",
+              dataMessage: { message: "hello" },
+            },
+          },
+        ]),
+      );
+    resolveFetchMock.mockReturnValue(fetchMock);
+
+    await streamSignalEvents({
+      baseUrl: "http://signal-rest-receive:8080",
+      account: "+15559990000",
+      abortSignal: abortController.signal,
+      onEvent: (event) => {
+        received.push(event);
+        abortController.abort();
+      },
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.event).toBe("receive");
+    const payload = JSON.parse(received[0]?.data ?? "{}") as Record<string, unknown>;
+    expect(payload["envelope"]).toBeTruthy();
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain(
+      "http://signal-rest-receive:8080/v1/receive/%2B15559990000?timeout=5",
+    );
+  });
+
+  it("uses a longer default timeout for REST sends and returns a timeout-specific error", async () => {
+    const abortError = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ versions: ["v1", "v2"] }))
+      .mockResolvedValueOnce(jsonResponse(["+15551110000"]))
+      .mockRejectedValueOnce(abortError);
+    resolveFetchMock.mockReturnValue(fetchMock);
+
+    await expect(
+      signalRpcRequest(
+        "send",
+        {
+          message: "hello",
+          recipient: ["+15552220000"],
+        },
+        {
+          baseUrl: "http://signal-rest-send-timeout:8080",
+        },
+      ),
+    ).rejects.toThrow("Signal REST send timed out after 30000ms (/v2/send)");
+  });
+
+  it("respects explicit timeout overrides for REST send timeout errors", async () => {
+    const abortError = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ versions: ["v1", "v2"] }))
+      .mockResolvedValueOnce(jsonResponse(["+15551110000"]))
+      .mockRejectedValueOnce(abortError);
+    resolveFetchMock.mockReturnValue(fetchMock);
+
+    await expect(
+      signalRpcRequest(
+        "send",
+        {
+          message: "hello",
+          recipient: ["+15552220000"],
+        },
+        {
+          baseUrl: "http://signal-rest-send-timeout-override:8080",
+          timeoutMs: 45_000,
+        },
+      ),
+    ).rejects.toThrow("Signal REST send timed out after 45000ms (/v2/send)");
+  });
+});

--- a/src/signal/client.ts
+++ b/src/signal/client.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { resolveFetch } from "../infra/fetch.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 
@@ -27,6 +28,98 @@ export type SignalSseEvent = {
 };
 
 const DEFAULT_TIMEOUT_MS = 10_000;
+const SIGNAL_REST_SEND_TIMEOUT_MS = 30_000;
+const SIGNAL_BACKEND_DETECT_TIMEOUT_MS = 2_000;
+const SIGNAL_REST_POLL_TIMEOUT_SECONDS = 5;
+const SIGNAL_REST_ACCOUNT_RETRY_DELAY_MS = 5_000;
+
+type SignalRestAbout = {
+  versions?: unknown;
+  build?: unknown;
+  mode?: unknown;
+  version?: unknown;
+  capabilities?: unknown;
+};
+
+type SignalBackend =
+  | { kind: "jsonrpc" }
+  | {
+      kind: "rest";
+      about: SignalRestAbout | null;
+    };
+
+const signalBackendCache = new Map<string, Promise<SignalBackend>>();
+
+function trimString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => trimString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+}
+
+function parseSignalRestAccountEntry(entry: unknown): string | null {
+  const direct = trimString(entry);
+  if (direct) {
+    return direct;
+  }
+  const obj = asObject(entry);
+  if (!obj) {
+    return null;
+  }
+  const candidates = [obj["number"], obj["account"], obj["id"], obj["username"]];
+  for (const candidate of candidates) {
+    const value = trimString(candidate);
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function extractTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const extracted = extractTimestamp(entry);
+      if (typeof extracted === "number") {
+        return extracted;
+      }
+    }
+    return undefined;
+  }
+  const obj = asObject(value);
+  if (!obj) {
+    return undefined;
+  }
+  const direct = extractTimestamp(obj["timestamp"]);
+  if (typeof direct === "number") {
+    return direct;
+  }
+  const nestedKeys = ["results", "result", "data", "messages"];
+  for (const key of nestedKeys) {
+    const nested = extractTimestamp(obj[key]);
+    if (typeof nested === "number") {
+      return nested;
+    }
+  }
+  return undefined;
+}
 
 function normalizeBaseUrl(url: string): string {
   const trimmed = url.trim();
@@ -47,12 +140,193 @@ function getRequiredFetch(): typeof fetch {
   return fetchImpl;
 }
 
-export async function signalRpcRequest<T = unknown>(
+function isAbortError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  if (
+    typeof DOMException !== "undefined" &&
+    error instanceof DOMException &&
+    error.name === "AbortError"
+  ) {
+    return true;
+  }
+  const name = "name" in error ? (error as { name?: unknown }).name : undefined;
+  if (name === "AbortError") {
+    return true;
+  }
+  const code = "code" in error ? (error as { code?: unknown }).code : undefined;
+  return code === "ABORT_ERR";
+}
+
+async function readResponseSnippet(res: Response): Promise<string | null> {
+  try {
+    const text = (await res.text()).trim();
+    if (!text) {
+      return null;
+    }
+    if (text.length <= 220) {
+      return text;
+    }
+    return `${text.slice(0, 220)}...`;
+  } catch {
+    return null;
+  }
+}
+
+async function sleepAbortable(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const onDone = () => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    const onAbort = () => {
+      clearTimeout(timer);
+      onDone();
+    };
+    const timer = setTimeout(onDone, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function fetchSignalRestAbout(baseUrl: string, timeoutMs: number): Promise<SignalRestAbout> {
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/about`,
+    { method: "GET" },
+    timeoutMs,
+    getRequiredFetch(),
+  );
+  if (!res.ok) {
+    const details = await readResponseSnippet(res);
+    throw new Error(
+      details
+        ? `Signal REST about failed (${res.status}): ${details}`
+        : `Signal REST about failed (${res.status})`,
+    );
+  }
+  try {
+    const parsed = (await res.json()) as SignalRestAbout;
+    return parsed;
+  } catch (err) {
+    throw new Error(`Signal REST about returned invalid JSON: ${String(err)}`);
+  }
+}
+
+async function listSignalRestAccounts(baseUrl: string, timeoutMs: number): Promise<string[]> {
+  try {
+    const res = await fetchWithTimeout(
+      `${baseUrl}/v1/accounts`,
+      { method: "GET" },
+      timeoutMs,
+      getRequiredFetch(),
+    );
+    if (!res.ok) {
+      return [];
+    }
+    const parsed = (await res.json()) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((entry) => parseSignalRestAccountEntry(entry))
+      .filter((entry): entry is string => Boolean(entry));
+  } catch {
+    return [];
+  }
+}
+
+async function resolveSignalRestAccount(params: {
+  baseUrl: string;
+  account?: string;
+  timeoutMs: number;
+}): Promise<string> {
+  const preferred = trimString(params.account);
+  if (preferred) {
+    return preferred;
+  }
+  const accounts = await listSignalRestAccounts(params.baseUrl, params.timeoutMs);
+  if (accounts.length === 1) {
+    return accounts[0]!;
+  }
+  if (accounts.length === 0) {
+    throw new Error(
+      "Signal REST backend requires channels.signal.account (E.164 sender). No account found at /v1/accounts.",
+    );
+  }
+  throw new Error(
+    "Signal REST backend requires channels.signal.account when multiple accounts are present.",
+  );
+}
+
+async function detectSignalBackend(baseUrl: string): Promise<SignalBackend> {
+  const cached = signalBackendCache.get(baseUrl);
+  if (cached) {
+    return await cached;
+  }
+  const pending = (async () => {
+    const fetchImpl = getRequiredFetch();
+    const checkRes = await fetchWithTimeout(
+      `${baseUrl}/api/v1/check`,
+      { method: "GET" },
+      SIGNAL_BACKEND_DETECT_TIMEOUT_MS,
+      fetchImpl,
+    ).catch(() => null);
+    if (checkRes?.ok) {
+      return { kind: "jsonrpc" } as const;
+    }
+
+    const aboutRes = await fetchWithTimeout(
+      `${baseUrl}/v1/about`,
+      { method: "GET" },
+      SIGNAL_BACKEND_DETECT_TIMEOUT_MS,
+      fetchImpl,
+    ).catch(() => null);
+    if (aboutRes?.ok) {
+      let about: SignalRestAbout | null = null;
+      try {
+        about = (await aboutRes.json()) as SignalRestAbout;
+      } catch {
+        about = null;
+      }
+      return {
+        kind: "rest",
+        about,
+      } as const;
+    }
+
+    if (checkRes) {
+      const details = await readResponseSnippet(checkRes);
+      throw new Error(
+        details
+          ? `Signal backend detection failed (api/v1/check ${checkRes.status}): ${details}`
+          : `Signal backend detection failed (api/v1/check ${checkRes.status})`,
+      );
+    }
+    if (aboutRes) {
+      const details = await readResponseSnippet(aboutRes);
+      throw new Error(
+        details
+          ? `Signal backend detection failed (/v1/about ${aboutRes.status}): ${details}`
+          : `Signal backend detection failed (/v1/about ${aboutRes.status})`,
+      );
+    }
+    throw new Error("Signal backend detection failed");
+  })().catch((err) => {
+    signalBackendCache.delete(baseUrl);
+    throw err;
+  });
+  signalBackendCache.set(baseUrl, pending);
+  return await pending;
+}
+
+async function signalRpcRequestJsonRpc<T = unknown>(
   method: string,
   params: Record<string, unknown> | undefined,
   opts: SignalRpcOptions,
 ): Promise<T> {
-  const baseUrl = normalizeBaseUrl(opts.baseUrl);
   const id = randomUUID();
   const body = JSON.stringify({
     jsonrpc: "2.0",
@@ -61,7 +335,7 @@ export async function signalRpcRequest<T = unknown>(
     id,
   });
   const res = await fetchWithTimeout(
-    `${baseUrl}/api/v1/rpc`,
+    `${opts.baseUrl}/api/v1/rpc`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -86,47 +360,177 @@ export async function signalRpcRequest<T = unknown>(
   return parsed.result as T;
 }
 
-export async function signalCheck(
-  baseUrl: string,
-  timeoutMs = DEFAULT_TIMEOUT_MS,
-): Promise<{ ok: boolean; status?: number | null; error?: string | null }> {
-  const normalized = normalizeBaseUrl(baseUrl);
-  try {
-    const res = await fetchWithTimeout(
-      `${normalized}/api/v1/check`,
-      { method: "GET" },
-      timeoutMs,
-      getRequiredFetch(),
-    );
-    if (!res.ok) {
-      return { ok: false, status: res.status, error: `HTTP ${res.status}` };
-    }
-    return { ok: true, status: res.status, error: null };
-  } catch (err) {
-    return {
-      ok: false,
-      status: null,
-      error: err instanceof Error ? err.message : String(err),
-    };
+async function signalRestSendRequest(params: {
+  baseUrl: string;
+  timeoutMs: number;
+  account: string;
+  message: string;
+  recipients: string[];
+  attachments: string[];
+}): Promise<{ timestamp?: number }> {
+  const attachmentBodies = await Promise.all(
+    params.attachments.map(async (filePath) => {
+      const buffer = await readFile(filePath);
+      return buffer.toString("base64");
+    }),
+  );
+
+  const payload: Record<string, unknown> = {
+    number: params.account,
+    recipients: params.recipients,
+    message: params.message,
+  };
+  if (attachmentBodies.length > 0) {
+    payload["base64_attachments"] = attachmentBodies;
   }
+
+  const sendPaths = ["/v2/send", "/v1/send"];
+  for (const path of sendPaths) {
+    let res: Response;
+    try {
+      res = await fetchWithTimeout(
+        `${params.baseUrl}${path}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+        params.timeoutMs,
+        getRequiredFetch(),
+      );
+    } catch (err) {
+      if (isAbortError(err)) {
+        throw new Error(
+          `Signal REST send timed out after ${params.timeoutMs}ms (${path}). Consider increasing timeoutMs.`,
+        );
+      }
+      throw err;
+    }
+    if (res.status === 404) {
+      continue;
+    }
+    if (!res.ok) {
+      const details = await readResponseSnippet(res);
+      throw new Error(
+        details
+          ? `Signal REST send failed (${res.status}): ${details}`
+          : `Signal REST send failed (${res.status})`,
+      );
+    }
+    const text = await res.text();
+    if (!text.trim()) {
+      return {};
+    }
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      const timestamp = extractTimestamp(parsed);
+      return typeof timestamp === "number" ? { timestamp } : {};
+    } catch {
+      return {};
+    }
+  }
+
+  throw new Error("Signal REST send endpoint not found (/v2/send or /v1/send)");
 }
 
-export async function streamSignalEvents(params: {
+async function signalRestGetAttachment(params: {
+  baseUrl: string;
+  timeoutMs: number;
+  id: string;
+}): Promise<{ data?: string }> {
+  const encodedId = encodeURIComponent(params.id);
+  const res = await fetchWithTimeout(
+    `${params.baseUrl}/v1/attachments/${encodedId}`,
+    { method: "GET" },
+    params.timeoutMs,
+    getRequiredFetch(),
+  );
+  if (!res.ok) {
+    const details = await readResponseSnippet(res);
+    throw new Error(
+      details
+        ? `Signal REST attachment fetch failed (${res.status}): ${details}`
+        : `Signal REST attachment fetch failed (${res.status})`,
+    );
+  }
+  const bytes = Buffer.from(await res.arrayBuffer());
+  return { data: bytes.toString("base64") };
+}
+
+async function signalRpcRequestRest<T = unknown>(
+  method: string,
+  params: Record<string, unknown> | undefined,
+  opts: SignalRpcOptions,
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (method === "version") {
+    return (await fetchSignalRestAbout(opts.baseUrl, timeoutMs)) as T;
+  }
+  if (method === "send") {
+    const sendTimeoutMs = opts.timeoutMs ?? SIGNAL_REST_SEND_TIMEOUT_MS;
+    const account = await resolveSignalRestAccount({
+      baseUrl: opts.baseUrl,
+      account: params?.["account"] as string | undefined,
+      timeoutMs: sendTimeoutMs,
+    });
+    const message = trimString(params?.["message"]) ?? "";
+    const directRecipients = toStringArray(params?.["recipient"]);
+    const usernames = toStringArray(params?.["username"]);
+    const groupId = trimString(params?.["groupId"]);
+    const attachments = toStringArray(params?.["attachments"]);
+    const recipients = [
+      ...directRecipients,
+      ...usernames,
+      ...(groupId ? [`group.${groupId}`] : []),
+    ];
+    if (recipients.length === 0) {
+      throw new Error("Signal REST send requires at least one recipient");
+    }
+    if (!message && attachments.length === 0) {
+      throw new Error("Signal send requires text or media");
+    }
+    return (await signalRestSendRequest({
+      baseUrl: opts.baseUrl,
+      timeoutMs: sendTimeoutMs,
+      account,
+      message,
+      recipients,
+      attachments,
+    })) as T;
+  }
+  if (method === "getAttachment") {
+    const id = trimString(params?.["id"]);
+    if (!id) {
+      throw new Error("Signal attachment id is required");
+    }
+    return (await signalRestGetAttachment({
+      baseUrl: opts.baseUrl,
+      timeoutMs,
+      id,
+    })) as T;
+  }
+  if (method === "sendTyping" || method === "sendReceipt") {
+    // signal-cli-rest-api compatibility mode: typing/read receipts are best-effort no-op.
+    return undefined as T;
+  }
+  throw new Error(`Signal REST backend does not support RPC method "${method}"`);
+}
+
+async function streamSignalEventsSse(params: {
   baseUrl: string;
   account?: string;
   abortSignal?: AbortSignal;
   onEvent: (event: SignalSseEvent) => void;
 }): Promise<void> {
-  const baseUrl = normalizeBaseUrl(params.baseUrl);
-  const url = new URL(`${baseUrl}/api/v1/events`);
-  if (params.account) {
-    url.searchParams.set("account", params.account);
-  }
-
   const fetchImpl = resolveFetch();
   if (!fetchImpl) {
     throw new Error("fetch is not available");
   }
+  const url = new URL(`${params.baseUrl}/api/v1/events`);
+  if (params.account) {
+    url.searchParams.set("account", params.account);
+  }
+
   const res = await fetchImpl(url, {
     method: "GET",
     headers: { Accept: "text/event-stream" },
@@ -192,4 +596,161 @@ export async function streamSignalEvents(params: {
   }
 
   flushEvent();
+}
+
+export async function signalRpcRequest<T = unknown>(
+  method: string,
+  params: Record<string, unknown> | undefined,
+  opts: SignalRpcOptions,
+): Promise<T> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const backend = await detectSignalBackend(baseUrl);
+  if (backend.kind === "jsonrpc") {
+    return await signalRpcRequestJsonRpc<T>(method, params, {
+      baseUrl,
+      timeoutMs: opts.timeoutMs,
+    });
+  }
+  return await signalRpcRequestRest<T>(method, params, {
+    baseUrl,
+    timeoutMs: opts.timeoutMs,
+  });
+}
+
+export async function signalCheck(
+  baseUrl: string,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<{ ok: boolean; status?: number | null; error?: string | null }> {
+  const normalized = normalizeBaseUrl(baseUrl);
+  try {
+    const backend = await detectSignalBackend(normalized);
+    if (backend.kind === "jsonrpc") {
+      const res = await fetchWithTimeout(
+        `${normalized}/api/v1/check`,
+        { method: "GET" },
+        timeoutMs,
+        getRequiredFetch(),
+      );
+      if (!res.ok) {
+        return { ok: false, status: res.status, error: `HTTP ${res.status}` };
+      }
+      return { ok: true, status: res.status, error: null };
+    }
+
+    const res = await fetchWithTimeout(
+      `${normalized}/v1/health`,
+      { method: "GET" },
+      timeoutMs,
+      getRequiredFetch(),
+    );
+    if (!res.ok) {
+      const details = await readResponseSnippet(res);
+      return {
+        ok: false,
+        status: res.status,
+        error: details ? `HTTP ${res.status}: ${details}` : `HTTP ${res.status}`,
+      };
+    }
+    const accounts = await listSignalRestAccounts(normalized, timeoutMs);
+    if (accounts.length === 0) {
+      return {
+        ok: false,
+        status: res.status,
+        error:
+          "Signal REST is reachable, but no account is registered yet. Link a device first (for example via /v1/qrcodelink).",
+      };
+    }
+    if (accounts.length > 1) {
+      return {
+        ok: false,
+        status: res.status,
+        error: "Signal REST has multiple accounts; set channels.signal.account to choose one.",
+      };
+    }
+    return { ok: true, status: res.status, error: null };
+  } catch (err) {
+    return {
+      ok: false,
+      status: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function streamSignalEvents(params: {
+  baseUrl: string;
+  account?: string;
+  abortSignal?: AbortSignal;
+  onEvent: (event: SignalSseEvent) => void;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(params.baseUrl);
+  const backend = await detectSignalBackend(baseUrl);
+  if (backend.kind === "jsonrpc") {
+    await streamSignalEventsSse({
+      baseUrl,
+      account: params.account,
+      abortSignal: params.abortSignal,
+      onEvent: params.onEvent,
+    });
+    return;
+  }
+
+  let account = trimString(params.account);
+  const fetchImpl = getRequiredFetch();
+  while (!params.abortSignal?.aborted) {
+    if (!account) {
+      const accounts = await listSignalRestAccounts(baseUrl, DEFAULT_TIMEOUT_MS);
+      if (accounts.length === 1) {
+        account = accounts[0]!;
+      } else if (accounts.length > 1) {
+        throw new Error(
+          "Signal REST backend requires channels.signal.account when multiple accounts are present.",
+        );
+      } else {
+        await sleepAbortable(SIGNAL_REST_ACCOUNT_RETRY_DELAY_MS, params.abortSignal);
+        continue;
+      }
+    }
+    const url = new URL(`${baseUrl}/v1/receive/${encodeURIComponent(account)}`);
+    url.searchParams.set("timeout", String(SIGNAL_REST_POLL_TIMEOUT_SECONDS));
+    const res = await fetchImpl(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: params.abortSignal,
+    });
+    if (params.abortSignal?.aborted) {
+      return;
+    }
+    if (!res.ok) {
+      const details = await readResponseSnippet(res);
+      throw new Error(
+        details
+          ? `Signal receive failed (${res.status}): ${details}`
+          : `Signal receive failed (${res.status})`,
+      );
+    }
+
+    const text = (await res.text()).trim();
+    if (!text) {
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text) as unknown;
+    } catch (err) {
+      throw new Error(`Signal receive returned non-JSON payload: ${String(err)}`);
+    }
+
+    const events = Array.isArray(parsed) ? parsed : [parsed];
+    for (const eventPayload of events) {
+      if (eventPayload === null || typeof eventPayload === "undefined") {
+        continue;
+      }
+      params.onEvent({
+        event: "receive",
+        data: JSON.stringify(eventPayload),
+      });
+    }
+  }
 }

--- a/src/signal/probe.test.ts
+++ b/src/signal/probe.test.ts
@@ -28,6 +28,9 @@ describe("probeSignal", () => {
     expect(res.ok).toBe(true);
     expect(res.version).toBe("0.13.22");
     expect(res.status).toBe(200);
+    expect(signalCheckMock).toHaveBeenCalledWith("http://127.0.0.1:8080", 1000, {
+      account: undefined,
+    });
   });
 
   it("returns ok=false when /check fails", async () => {
@@ -42,6 +45,24 @@ describe("probeSignal", () => {
     expect(res.ok).toBe(false);
     expect(res.status).toBe(503);
     expect(res.version).toBe(null);
+  });
+
+  it("forwards configured account to signal health checks", async () => {
+    signalCheckMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      error: null,
+    });
+    signalRpcRequestMock.mockResolvedValueOnce({ version: "0.13.22" });
+
+    const res = await probeSignal("http://127.0.0.1:8080", 1000, {
+      account: "+15550001111",
+    });
+
+    expect(res.ok).toBe(true);
+    expect(signalCheckMock).toHaveBeenCalledWith("http://127.0.0.1:8080", 1000, {
+      account: "+15550001111",
+    });
   });
 });
 

--- a/src/signal/probe.ts
+++ b/src/signal/probe.ts
@@ -20,7 +20,11 @@ function parseSignalVersion(value: unknown): string | null {
   return null;
 }
 
-export async function probeSignal(baseUrl: string, timeoutMs: number): Promise<SignalProbe> {
+export async function probeSignal(
+  baseUrl: string,
+  timeoutMs: number,
+  opts: { account?: string } = {},
+): Promise<SignalProbe> {
   const started = Date.now();
   const result: SignalProbe = {
     ok: false,
@@ -29,7 +33,7 @@ export async function probeSignal(baseUrl: string, timeoutMs: number): Promise<S
     elapsedMs: 0,
     version: null,
   };
-  const check = await signalCheck(baseUrl, timeoutMs);
+  const check = await signalCheck(baseUrl, timeoutMs, { account: opts.account });
   if (!check.ok) {
     return {
       ...result,

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -12,6 +12,7 @@ import {
   refreshActiveTab,
   setLastActiveSessionKey,
 } from "./app-settings.ts";
+import { defaultGatewayUrlFromLocation, normalizeGatewayUrl } from "./gateway-url.ts";
 import { handleAgentEvent, resetToolStream, type AgentEventPayload } from "./app-tool-stream.ts";
 import { loadAgents } from "./controllers/agents.ts";
 import { loadAssistantIdentity } from "./controllers/assistant-identity.ts";
@@ -122,9 +123,18 @@ export function connectGateway(host: GatewayHost) {
   host.execApprovalQueue = [];
   host.execApprovalError = null;
 
+  const fallbackGatewayUrl = defaultGatewayUrlFromLocation();
+  const gatewayUrl = normalizeGatewayUrl(host.settings.gatewayUrl, fallbackGatewayUrl);
+  if (gatewayUrl !== host.settings.gatewayUrl) {
+    applySettings(host as unknown as Parameters<typeof applySettings>[0], {
+      ...host.settings,
+      gatewayUrl,
+    });
+  }
+
   const previousClient = host.client;
   const client = new GatewayBrowserClient({
-    url: host.settings.gatewayUrl,
+    url: gatewayUrl,
     token: host.settings.token.trim() ? host.settings.token : undefined,
     password: host.password.trim() ? host.password : undefined,
     clientName: "openclaw-control-ui",

--- a/ui/src/ui/gateway-url.test.ts
+++ b/ui/src/ui/gateway-url.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { defaultGatewayUrlFromLocation, normalizeGatewayUrl } from "./gateway-url.ts";
+
+describe("gateway URL helpers", () => {
+  it("builds ws default URL from http location", () => {
+    const url = defaultGatewayUrlFromLocation({
+      protocol: "http:",
+      host: "localhost:28789",
+    });
+    expect(url).toBe("ws://localhost:28789");
+  });
+
+  it("builds wss default URL from https location", () => {
+    const url = defaultGatewayUrlFromLocation({
+      protocol: "https:",
+      host: "example.com",
+    });
+    expect(url).toBe("wss://example.com");
+  });
+
+  it("normalizes http URL to ws URL", () => {
+    const normalized = normalizeGatewayUrl("http://localhost:18789", "ws://fallback:1");
+    expect(normalized).toBe("ws://localhost:18789/");
+  });
+
+  it("normalizes https URL to wss URL", () => {
+    const normalized = normalizeGatewayUrl("https://example.com/gateway", "ws://fallback:1");
+    expect(normalized).toBe("wss://example.com/gateway");
+  });
+
+  it("accepts host-only shorthand", () => {
+    const normalized = normalizeGatewayUrl("localhost:18789", "ws://fallback:1");
+    expect(normalized).toBe("ws://localhost:18789");
+  });
+
+  it("falls back for invalid values", () => {
+    const normalized = normalizeGatewayUrl("not a url !!!", "ws://fallback:1");
+    expect(normalized).toBe("ws://fallback:1");
+  });
+});

--- a/ui/src/ui/gateway-url.ts
+++ b/ui/src/ui/gateway-url.ts
@@ -1,0 +1,34 @@
+export function defaultGatewayUrlFromLocation(
+  locationLike: Pick<Location, "protocol" | "host"> = location,
+): string {
+  const proto = locationLike.protocol === "https:" ? "wss" : "ws";
+  return `${proto}://${locationLike.host}`;
+}
+
+export function normalizeGatewayUrl(raw: string | null | undefined, fallback: string): string {
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  if (!trimmed) {
+    return fallback;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "http:") {
+      parsed.protocol = "ws:";
+    } else if (parsed.protocol === "https:") {
+      parsed.protocol = "wss:";
+    }
+    if (parsed.protocol === "ws:" || parsed.protocol === "wss:") {
+      return parsed.toString();
+    }
+  } catch {
+    // Fall through and try host-only forms below.
+  }
+
+  const hostLike = trimmed.replace(/^\/\//, "");
+  if (/^[A-Za-z0-9.-]+(?::\d+)?(?:\/.*)?$/.test(hostLike)) {
+    return `ws://${hostLike}`;
+  }
+
+  return fallback;
+}

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -94,17 +94,29 @@ export class GatewayBrowserClient {
     if (this.closed) {
       return;
     }
-    this.ws = new WebSocket(this.opts.url);
-    this.ws.addEventListener("open", () => this.queueConnect());
-    this.ws.addEventListener("message", (ev) => this.handleMessage(String(ev.data ?? "")));
-    this.ws.addEventListener("close", (ev) => {
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(this.opts.url);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      this.ws = null;
+      this.flushPending(new Error(`gateway websocket init failed: ${reason}`));
+      this.opts.onClose?.({ code: CONNECT_FAILED_CLOSE_CODE, reason: `connect failed: ${reason}` });
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.ws = ws;
+    ws.addEventListener("open", () => this.queueConnect());
+    ws.addEventListener("message", (ev) => this.handleMessage(String(ev.data ?? "")));
+    ws.addEventListener("close", (ev) => {
       const reason = String(ev.reason ?? "");
       this.ws = null;
       this.flushPending(new Error(`gateway closed (${ev.code}): ${reason}`));
       this.opts.onClose?.({ code: ev.code, reason });
       this.scheduleReconnect();
     });
-    this.ws.addEventListener("error", () => {
+    ws.addEventListener("error", () => {
       // ignored; close handler will fire
     });
   }

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -2,6 +2,7 @@ const KEY = "openclaw.control.settings.v1";
 
 import type { ThemeMode } from "./theme.ts";
 import { isSupportedLocale } from "../i18n/index.ts";
+import { defaultGatewayUrlFromLocation, normalizeGatewayUrl } from "./gateway-url.ts";
 
 export type UiSettings = {
   gatewayUrl: string;
@@ -18,10 +19,7 @@ export type UiSettings = {
 };
 
 export function loadSettings(): UiSettings {
-  const defaultUrl = (() => {
-    const proto = location.protocol === "https:" ? "wss" : "ws";
-    return `${proto}://${location.host}`;
-  })();
+  const defaultUrl = defaultGatewayUrlFromLocation();
 
   const defaults: UiSettings = {
     gatewayUrl: defaultUrl,
@@ -43,10 +41,7 @@ export function loadSettings(): UiSettings {
     }
     const parsed = JSON.parse(raw) as Partial<UiSettings>;
     return {
-      gatewayUrl:
-        typeof parsed.gatewayUrl === "string" && parsed.gatewayUrl.trim()
-          ? parsed.gatewayUrl.trim()
-          : defaults.gatewayUrl,
+      gatewayUrl: normalizeGatewayUrl(parsed.gatewayUrl, defaults.gatewayUrl),
       token: typeof parsed.token === "string" ? parsed.token : defaults.token,
       sessionKey:
         typeof parsed.sessionKey === "string" && parsed.sessionKey.trim()


### PR DESCRIPTION
## Summary
- increase Signal REST send timeout and improve abort error clarity
- normalize/harden gateway URL handling in the control UI
- add Signal service wiring in Docker compose and simplify compose formatting
- pin Signal runtime mode/tag and add a runtime health check script
- reduce Signal REST probe lock contention to lower CPU spikes

## Notes
- commits were replayed on top of latest `main` from upstream
- commit author metadata was normalized to `openclaw-contributor`

## Testing
- not run in this temp sync clone (no dependency install in this environment)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reduced Signal REST probe lock contention by conditionally skipping `/v1/accounts` calls when account is configured, increased health refresh interval from 60s to 300s, and added REST send timeout from 10s to 90s with clearer abort error messages. Added gateway URL normalization to handle `http`/`https` to `ws`/`wss` conversion and host-only shorthand formats with comprehensive test coverage. Updated Docker compose to pin Signal image tag, add native mode default, expose health check script, and bind gateway ports to loopback.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor recommendations for documentation
- The changes are well-structured with comprehensive test coverage (282 lines of new tests for Signal client compatibility). The Signal lock contention fixes are sensible (skipping `/v1/accounts` when account is configured, caching health checks with TTLs). Gateway URL normalization has proper fallback handling and test coverage. Docker changes follow best practices (pinning versions, resource limits, loopback binding). The increased timeouts (90s for Signal REST send, 300s health refresh) are reasonable for the stated use case. Minor deduction for lack of inline documentation explaining the lock contention rationale and timeout value choices.
- No files require special attention - the implementation is solid across all changed files

<sub>Last reviewed commit: 058e1fa</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->