### PR TITLE
fix: suppressToolErrors now suppresses exec tool failure notifications

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -241,15 +241,13 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads).toHaveLength(0);
   });
 
-  it("still shows mutating tool errors when messages.suppressToolErrors is enabled", () => {
+  it("suppresses mutating tool errors when messages.suppressToolErrors is enabled", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "write", error: "connection timeout" },
       config: { messages: { suppressToolErrors: true } },
     });
 
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.isError).toBe(true);
-    expect(payloads[0]?.text).toContain("connection timeout");
+    expect(payloads).toHaveLength(0);
   });
 
   it("suppresses mutating tool errors when suppressToolErrorWarnings is enabled", () => {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -56,7 +56,7 @@ function shouldShowToolErrorWarning(params: {
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
-    return true;
+    return !params.suppressToolErrors;
   }
   if (params.suppressToolErrors) {
     return false;
@@ -255,7 +255,8 @@ export function buildEmbeddedRunPayloads(params: {
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
     });
 
-    // Always surface mutating tool failures so we do not silently confirm actions that did not happen.
+    // Surface mutating tool failures unless suppressToolErrors is enabled,
+    // so we do not silently confirm actions that did not happen.
     // Otherwise, keep the previous behavior and only surface non-recoverable failures when no reply exists.
     if (shouldShowToolError) {
       const toolSummary = formatToolAggregate(


### PR DESCRIPTION
## Summary

- Problem: messages.suppressToolErrors: true did not suppress exec tool failure notifications (e.g., git push SSH failures, git commit errors) in Discord channels.
- Why it matters: Users who explicitly enable this config expect all tool errors to be suppressed from messaging surfaces, but exec errors were leaking through.
- What changed: shouldShowToolErrorWarning in payloads.ts now respects suppressToolErrors for mutating tools (exec, write, bash, etc.) instead of unconditionally showing them.
- What did NOT change (scope boundary): Default behavior without suppressToolErrors is unchanged — mutating tool errors are still always shown by default. The separate suppressToolErrorWarnings (heartbeat-level) config is unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

Closes #19494

## User-visible / Behavior Changes
When messages.suppressToolErrors: true is set, mutating tool errors (including exec) are now suppressed from Discord/messaging channels. Previously they were always shown regardless of this setting.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No


## Repro + Verification

### Environment

- OS: macOS / Windows
- Runtime/container: Node.js
- Model/provider: Any
- Integration/channel: Discord
- Relevant config (redacted):

``` json
"messages": {
  "suppressToolErrors": true
}
```
### Steps

1. Set messages.suppressToolErrors: true in openclaw.json
2. Have the agent run an exec command that fails (e.g., git push with SSH key issues)
3. Observe whether the  Exec: ... failed notification appears in Discord

### Expected

- Error notification is not sent to Discord

### Actual

- Before fix: Error notification was sent despite suppressToolErrors: true
- After fix: Error notification is suppressed 

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test "suppresses mutating tool errors when messages.suppressToolErrors is enabled" passes — 21/21 tests in 
payloads.e2e.test.ts pass.

## Human Verification (required)

- Verified scenarios: Ran payloads.e2e.test.ts e2e test suite — 21/21 tests pass. The test "suppresses mutating tool errors when messages.suppressToolErrors is enabled" directly verifies that buildEmbeddedRunPayloads returns zero payloads for mutating tool errors when suppressToolErrors: true, confirming no  failed messages are sent to Discord.
- Edge cases checked: Non-mutating tool errors still suppressed; mutating tool errors still shown when suppressToolErrors is not set; suppressToolErrorWarnings (heartbeat-level) still works independently; recoverable tool errors for mutating tools still shown.
- What you did not verify: Live Discord bot end-to-end test. However, buildEmbeddedRunPayloads is the single code path that produces   failed messages — zero payloads means nothing is sent to Discord.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert line 59 of payloads.ts back to return true;
- Files/config to restore: src/agents/pi-embedded-runner/run/payloads.ts
- Known bad symptoms: Mutating tool errors being silently suppressed when users haven't opted in. This cannot happen because the fix only changes behavior when suppressToolErrors is explicitly set to true.

## Risks and Mitigations
- Risk: Users with suppressToolErrors: true might miss genuine mutating tool failures (e.g., a write that failed silently).
- Mitigation: This is an explicit opt-in setting — users who enable it have deliberately chosen to suppress these warnings. The agent still sees errors in context and can retry. The default behavior (show all mutating errors) is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `messages.suppressToolErrors: true` did not suppress mutating tool error notifications (e.g., `exec`, `write`, `bash` failures) in messaging channels like Discord. The fix is a single-line change in `shouldShowToolErrorWarning` that returns `!params.suppressToolErrors` instead of unconditionally `true` for mutating tool errors.

- **Bug fix**: Mutating tool errors are now correctly suppressed when `suppressToolErrors` is explicitly enabled, matching user expectations for this opt-in config
- **Default behavior preserved**: Without `suppressToolErrors`, mutating tool errors are still always shown (the `!false` → `true` path)
- **Test updated**: The existing test was updated from asserting mutating errors are shown with `suppressToolErrors: true` to asserting they are suppressed (0 payloads)
- **Minor**: A code comment on line 258 of `payloads.ts` ("Always surface mutating tool failures") is now stale and should be updated to reflect the conditional behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix with no risk to default behavior.
- The change is a single-line logic fix that only affects behavior when `suppressToolErrors` is explicitly set to `true`. Default behavior is completely unchanged. The test suite covers the fix and all existing tests pass. The code path is straightforward with no edge cases that could cause regressions.
- No files require special attention.

<sub>Last reviewed commit: 16c1f9d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->