### PR TITLE
fix(agents): harden overflow recovery observability + subagent terminal fallback

### DIFF
--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { expectsSubagentFollowup, isLikelyInterimCronMessage } from "./subagent-followup.js";
+
+describe("subagent follow-up phrase detection", () => {
+  it("treats 'will report back' phrasing as expected follow-up", () => {
+    expect(expectsSubagentFollowup("I'll report back once both subagents finish.")).toBe(true);
+    expect(expectsSubagentFollowup("I will report back when done.")).toBe(true);
+  });
+
+  it("classifies short 'will report back' updates as interim", () => {
+    expect(isLikelyInterimCronMessage("Will report back after the subagent completes.")).toBe(true);
+  });
+
+  it("does not classify detailed, final updates as interim", () => {
+    const detailedUpdate =
+      "I will report back is no longer relevant because the work already completed: " +
+      "we extracted all requested records, verified each entry against source logs, " +
+      "resolved mismatched timestamps, produced a reconciled summary for each source, " +
+      "and confirmed there are no remaining active subagent runs. " +
+      "The final report includes exact totals, anomaly notes, remediation status, " +
+      "and handoff details for the next scheduled operation.";
+    expect(isLikelyInterimCronMessage(detailedUpdate)).toBe(false);
+  });
+});

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -36,6 +36,9 @@ export function isLikelyInterimCronMessage(value: string): boolean {
     "auto-announce when done",
     "both subagents are running",
     "wait for them to report back",
+    "i'll report back",
+    "i will report back",
+    "will report back",
   ];
   return words <= 45 && interimHints.some((hint) => normalized.includes(hint));
 }
@@ -51,6 +54,9 @@ export function expectsSubagentFollowup(value: string): boolean {
     "auto-announce when done",
     "both subagents are running",
     "wait for them to report back",
+    "i'll report back",
+    "i will report back",
+    "will report back",
   ];
   return hints.some((hint) => normalized.includes(hint));
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -147,6 +147,33 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   pairedToolName?: string;
 };
 
+export type DiagnosticOverflowRecoveryEvent = DiagnosticBaseEvent & {
+  type: "overflow.recovery";
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+  stage: "detected" | "decision" | "action" | "result" | "finalized";
+  branch?:
+    | "retry_after_in_attempt_compaction"
+    | "compact"
+    | "truncate_tool_results"
+    | "give_up"
+    | "reset_after_compaction_failure"
+    | "fallback_payload_returned"
+    | "fallback_payload_injected_after_empty";
+  outcome?: "retrying" | "compacted" | "truncated" | "failed" | "returned_error_payload";
+  attempt?: number;
+  maxAttempts?: number;
+  errorKind?: "context_overflow" | "compaction_failure";
+  reasonClass?:
+    | "prompt_error"
+    | "assistant_error"
+    | "embedded_meta_error"
+    | "empty_payload_after_error";
+};
+
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
   | DiagnosticWebhookReceivedEvent
@@ -160,7 +187,8 @@ export type DiagnosticEventPayload =
   | DiagnosticLaneDequeueEvent
   | DiagnosticRunAttemptEvent
   | DiagnosticHeartbeatEvent
-  | DiagnosticToolLoopEvent;
+  | DiagnosticToolLoopEvent
+  | DiagnosticOverflowRecoveryEvent;
 
 export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   ? Event extends DiagnosticEventPayload

--- a/src/infra/infra-store.test.ts
+++ b/src/infra/infra-store.test.ts
@@ -105,6 +105,30 @@ describe("infra store", () => {
 
       expect(types).toEqual(["webhook.received", "message.queued", "session.state"]);
     });
+
+    it("emits overflow recovery events", async () => {
+      resetDiagnosticEventsForTest();
+      const types: string[] = [];
+      const stop = onDiagnosticEvent((evt) => types.push(evt.type));
+
+      emitDiagnosticEvent({
+        type: "overflow.recovery",
+        runId: "run-1",
+        sessionKey: "main",
+        sessionId: "session-1",
+        provider: "anthropic",
+        model: "claude",
+        stage: "finalized",
+        branch: "give_up",
+        outcome: "returned_error_payload",
+        errorKind: "context_overflow",
+        reasonClass: "prompt_error",
+      });
+
+      stop();
+
+      expect(types).toEqual(["overflow.recovery"]);
+    });
   });
 
   describe("channel activity", () => {


### PR DESCRIPTION
## Summary
- Fix deterministic overflow fallback behavior when error payloads are missing or normalize to empty.
- Add structured `overflow.recovery` diagnostics to make branch/outcome triage queryable.
- Surface a terminal, idempotent requester callback when subagent completion announce retries give up.
- Improve follow-up phrase detection (`"I'll report back"` variants) so interim updates are not misclassified as final.

## Change Type
- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue
- Closes #19629

## Why this is still needed after v2026.2.17
Upstream includes multiple subagent announce improvements; this PR keeps only additive behavior not present on current `upstream/main` markers:
- requester-visible give-up callback fallback + idempotent persistence markers
- overflow deterministic fallback coverage + observability assertions across targeted paths
- follow-up phrase handling for `will report back` variants

## User-visible / Behavior Changes
- On terminal subagent announce give-up, requester now receives an explicit system fallback callback (once).
- Overflow recovery remains functionally stable but now has better deterministic fallback and diagnostics classification.
- No new CLI command/config surface.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: Ubuntu 25.10
- Runtime: Node 22 + pnpm workspace checkout
- Repo state: clean, branch `fix/overflow-recovery-observability-wave1`

### Verification commands (passing)
```bash
pnpm check
pnpm build
pnpm vitest run --config vitest.unit.config.ts \
  src/auto-reply/reply/agent-runner.runreplyagent.test.ts \
  src/auto-reply/reply/reply-state.test.ts \
  src/infra/infra-store.test.ts \
  src/agents/subagent-announce-queue.test.ts \
  src/agents/subagent-registry.announce-loop-guard.test.ts \
  src/agents/subagent-registry.steer-restart.test.ts \
  src/agents/subagent-registry.nested.test.ts \
  src/cron/isolated-agent/subagent-followup.test.ts
pnpm vitest run --config vitest.e2e.config.ts \
  src/agents/pi-embedded-runner/run.overflow-compaction.e2e.test.ts \
  src/agents/subagent-registry.persistence.e2e.test.ts
pnpm vitest run --config vitest.unit.config.ts \
  src/browser/server.auth-token-gates-http.test.ts \
  src/web/media.test.ts
pnpm vitest run --config vitest.gateway.config.ts \
  src/gateway/auth.test.ts \
  src/gateway/net.test.ts
```

### Controlled live smoke (post-restart)
- Session: `smoke-post-restart-1771388006`
- Run ID: `cdcd0950-ba6f-4f4b-a326-91d038b2433f`
- Output: `ok`
- Gateway remained healthy and RPC reachable.

## Evidence
- [x] Targeted tests before/after behavior assertions
- [x] Runtime/log smoke evidence
- [ ] Screenshot/recording
- [ ] Perf benchmark

## Human Verification
Personally verified:
- deterministic overflow fallback assertions pass
- overflow diagnostics events emitted/queried in infra-store tests
- retry-budget give-up callback persistence/idempotency behavior in subagent loop-guard tests
- post-restart live agent run succeeded end-to-end

Not fully verified locally:
- full `pnpm test` suite (intentionally skipped under server-safe policy; upstream CI is expected full-suite gate)

## Compatibility / Migration
- Backward compatible: Yes
- Config/env changes required: No
- Migration needed: No

## Failure Recovery
- Revert this PR commits in order if needed.
- Primary touched modules:
  - `src/auto-reply/reply/agent-runner.ts`
  - `src/infra/diagnostic-events.ts`
  - `src/agents/subagent-registry.ts`
  - `src/cron/isolated-agent/subagent-followup.ts`

## Risks and Mitigations
- Risk: extra diagnostics volume
  - Mitigation: structured events and targeted assertions; no new external call surface.
- Risk: callback duplication noise
  - Mitigation: persisted `announceGiveUpNotifiedAt` + idempotency key.

## AI-assisted disclosure
- [x] AI-assisted contribution
- Testing level: fully tested on targeted + sentinel suites, build pass, controlled live smoke pass
- Confirmed understanding of changed code paths and behavior
