### PR TITLE
feat(docker): add init script support via /openclaw-init.d/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,12 @@ RUN chown -R node:node /app
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
 
+# Init script support: runs user scripts from /openclaw-init.d/ before the main process.
+# Mount a directory of executable scripts to customize container startup:
+#   volumes:
+#     - ./my-init-scripts:/openclaw-init.d:ro
+ENTRYPOINT ["scripts/docker-entrypoint.sh"]
+
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.
 #

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# OpenClaw Docker entrypoint with init script support.
+#
+# Runs any executable scripts found in /openclaw-init.d/ before starting
+# the main process. This allows users to mount custom initialization
+# scripts (e.g., install dependencies, apply patches, start services)
+# without overriding the entire entrypoint.
+#
+# Usage in docker-compose.yml:
+#   volumes:
+#     - ./my-init-scripts:/openclaw-init.d:ro
+
+INIT_DIR="/openclaw-init.d"
+
+if [ -d "$INIT_DIR" ] && [ "$(ls -A "$INIT_DIR" 2>/dev/null)" ]; then
+  echo "[openclaw-init] Running init scripts from $INIT_DIR..."
+  for script in "$INIT_DIR"/*; do
+    [ -f "$script" ] || continue
+    if [ -x "$script" ]; then
+      echo "[openclaw-init] Running $(basename "$script")..."
+      output=$("$script" 2>&1)
+      rc=$?
+      if [ -n "$output" ]; then
+        printf '%s\n' "$output" | sed 's/^/  /'
+      fi
+      if [ $rc -ne 0 ]; then
+        echo "[openclaw-init] WARNING: $(basename "$script") exited with status $rc"
+      fi
+    else
+      echo "[openclaw-init] SKIP: $(basename "$script") (not executable)"
+    fi
+  done
+  echo "[openclaw-init] Init complete."
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Adds a Docker ENTRYPOINT that runs user scripts from `/openclaw-init.d/` before starting the gateway
- Standard Docker pattern (nginx, postgres, etc.) for customizing container startup
- No change to default behavior when no init scripts are mounted

## Fix from #18450
The previous PR (#18450) was reverted because init script exit codes were silently swallowed by the `sed` pipe (POSIX `sh` has no `pipefail`). 

This version captures the exit code **before** piping output to `sed`:
```sh
output=$("$script" 2>&1)
rc=$?
printf '%s\n' "$output" | sed 's/^/  /'
if [ $rc -ne 0 ]; then
  echo "[openclaw-init] WARNING: $(basename "$script") exited with status $rc"
fi
```

This properly detects and logs init script failures while still indenting output.

## Test plan
- [ ] No init scripts mounted → gateway starts normally (no output from entrypoint)
- [ ] Mount a dir with executable scripts → scripts run in order before gateway
- [ ] Non-executable files → skipped with warning message
- [ ] Init script fails → exit code detected and warning logged
- [ ] `docker run openclaw echo hello` → init scripts run, then echo (exec passthrough works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-introduces Docker init script support (`/openclaw-init.d/`) that was reverted from PR #18450. The fix correctly captures init script exit codes before piping output to `sed`, resolving the original POSIX `pipefail` issue. The entrypoint follows the standard Docker pattern of running user-mounted scripts before `exec`-ing the main CMD.

- The exit code capture fix (`output=$("$script" 2>&1); rc=$?`) properly addresses the reason for the revert — exit codes are no longer swallowed by the sed pipe
- Init script failures are **non-fatal** (only a WARNING is logged), which diverges from the postgres/nginx patterns cited in the PR description where init failures typically abort startup via `set -e`
- The `docker-compose.yml` CLI service overrides `entrypoint` entirely, so init scripts only apply to the gateway service — this is consistent with intended behavior
- The `ENTRYPOINT` uses a relative path (`scripts/docker-entrypoint.sh`) which works because `WORKDIR /app` is set, though the original PR used an absolute path (`/app/scripts/docker-entrypoint.sh`)

<h3>Confidence Score: 3/5</h3>

- This PR is generally safe to merge but has a design decision around non-fatal init script failures that should be intentionally confirmed
- The core exit-code-capture fix is correct and addresses the revert reason. The script is well-structured POSIX shell. However, the non-fatal handling of init script failures diverges from the cited postgres/nginx patterns (which use set -e and abort on failure), meaning users could have init scripts silently fail while the gateway starts in a potentially broken state. This is a design choice that should be explicitly confirmed rather than a bug.
- Pay close attention to `scripts/docker-entrypoint.sh` — the non-fatal error handling on lines 26-28 is the key design decision to evaluate

<sub>Last reviewed commit: fce976c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->