### PR TITLE
fix: pass sessionsDir to resolveSessionFilePath in agentCommand

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -507,6 +508,7 @@ export async function agentCommand(
     }
     const sessionFile = resolveSessionFilePath(sessionId, sessionEntry, {
       agentId: sessionAgentId,
+      sessionsDir: path.dirname(storePath),
     });
 
     const startedAt = Date.now();


### PR DESCRIPTION
## Summary

`agentCommand()` in `src/commands/agent.ts` calls `resolveSessionFilePath()` without passing `sessionsDir`, causing the path resolver to fall back to a default sessions directory. When a session entry contains an absolute `sessionFile` path that lives outside the default directory, `resolvePathWithinSessionsDir()` throws:

```
Error: Session file path must be within sessions directory
```

This also causes downstream ENOENT errors when tools try to read the resolved (incorrect) session transcript path.

## Fix

Pass `sessionsDir: path.dirname(storePath)` to `resolveSessionFilePath()`, matching the pattern used by other callers (`commands-export-session.ts`, `heartbeat-runner.ts`, `transcript.ts`).

## Other callers

Several other call sites also omit `sessionsDir` but have lower impact:
- `src/infra/session-cost-usage.ts` (3 sites) — often receives `sessionFile` directly
- `src/auto-reply/reply/agent-runner.ts` — fire-and-forget transcript cleanup
- `src/commands/doctor-state-integrity.ts` (2 sites) — advisory warnings only
- `extensions/voice-call/src/response-generator.ts` — injected dependency

These could be addressed in a follow-up if desired.

## Test plan

- [x] `pnpm tsgo` passes (no new type errors)
- [ ] Verify `openclaw doctor` no longer reports "Session file path must be within sessions directory"
- [ ] Verify session transcript reads succeed for sessions with absolute paths in their store entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug where `agentCommand()` called `resolveSessionFilePath()` without passing the `sessionsDir` parameter. When session entries contain absolute `sessionFile` paths outside the default sessions directory, the path resolver would throw "Session file path must be within sessions directory" errors.

The fix adds `sessionsDir: path.dirname(storePath)` to the `resolveSessionFilePath()` call, matching the pattern consistently used by other callers (`commands-export-session.ts:131`, `heartbeat-runner.ts:423`, `transcript.ts:113`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a minimal, targeted bug fix
- The change is a straightforward bug fix that adds a missing parameter. The pattern matches identical usages across the codebase (commands-export-session.ts, heartbeat-runner.ts, transcript.ts), the implementation is correct (storePath is available in scope at line 279), and the fix directly addresses the error described in the PR description
- No files require special attention

<sub>Last reviewed commit: 6ac26b2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->