### PR TITLE
Fix/context window provider keying

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -74,6 +74,7 @@ export async function runMemoryFlushIfNeeded(params: {
         params.sessionEntry ??
         (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined),
       contextWindowTokens: resolveMemoryFlushContextWindowTokens({
+        provider: params.followupRun.run.provider,
         modelId: params.followupRun.run.model ?? params.defaultModel,
         agentCfgContextTokens: params.agentCfgContextTokens,
       }),

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -419,7 +419,7 @@ export async function runReplyAgent(params: {
       : undefined;
     const contextTokensUsed =
       agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
+      lookupContextTokens({ provider: providerUsed, modelId: modelUsed }) ??
       activeSessionEntry?.contextTokens ??
       DEFAULT_CONTEXT_TOKENS;
 

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -212,7 +212,7 @@ export async function persistInlineDirectives(params: {
   return {
     provider,
     model,
-    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens({ provider, modelId: model }) ?? DEFAULT_CONTEXT_TOKENS,
   };
 }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -198,7 +198,7 @@ export function createFollowupRunner(params: {
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
       const contextTokensUsed =
         agentCfgContextTokens ??
-        lookupContextTokens(modelUsed) ??
+        lookupContextTokens({ provider: fallbackProvider, modelId: modelUsed }) ??
         sessionEntry?.contextTokens ??
         DEFAULT_CONTEXT_TOKENS;
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -391,6 +391,7 @@ export async function resolveReplyDirectives(params: {
 
   let contextTokens = resolveContextTokens({
     agentCfg,
+    provider,
     model,
   });
 

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -102,11 +102,14 @@ function ensureNoReplyHint(text: string): string {
 }
 
 export function resolveMemoryFlushContextWindowTokens(params: {
+  provider?: string;
   modelId?: string;
   agentCfgContextTokens?: number;
 }): number {
   return (
-    lookupContextTokens(params.modelId) ?? params.agentCfgContextTokens ?? DEFAULT_CONTEXT_TOKENS
+    lookupContextTokens({ provider: params.provider, modelId: params.modelId }) ??
+    params.agentCfgContextTokens ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -583,9 +583,12 @@ export function resolveModelDirectiveSelection(params: {
 
 export function resolveContextTokens(params: {
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
+  provider?: string;
   model: string;
 }): number {
   return (
-    params.agentCfg?.contextTokens ?? lookupContextTokens(params.model) ?? DEFAULT_CONTEXT_TOKENS
+    params.agentCfg?.contextTokens ??
+    lookupContextTokens({ provider: params.provider, modelId: params.model }) ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -344,7 +344,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   let contextTokens =
     entry?.contextTokens ??
     args.agent?.contextTokens ??
-    lookupContextTokens(model) ??
+    lookupContextTokens({ provider, modelId: model }) ??
     DEFAULT_CONTEXT_TOKENS;
 
   let inputTokens = entry?.inputTokens;
@@ -370,7 +370,7 @@ export function buildStatusMessage(args: StatusArgs): string {
         model = logUsage.model ?? model;
       }
       if (!contextTokens && logUsage.model) {
-        contextTokens = lookupContextTokens(logUsage.model) ?? contextTokens;
+        contextTokens = lookupContextTokens({ provider, modelId: logUsage.model }) ?? contextTokens;
       }
       if (!inputTokens || inputTokens === 0) {
         inputTokens = logUsage.input;

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -42,7 +42,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
   const contextTokens =
-    params.contextTokensOverride ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+    params.contextTokensOverride ?? lookupContextTokens({ provider: providerUsed, modelId: modelUsed }) ?? DEFAULT_CONTEXT_TOKENS;
 
   const entry = sessionStore[sessionKey] ?? {
     sessionId,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -32,6 +32,7 @@ type SessionRow = {
   outputTokens?: number;
   totalTokens?: number;
   totalTokensFresh?: boolean;
+  modelProvider?: string;
   model?: string;
   contextTokens?: number;
 };
@@ -152,6 +153,7 @@ function toRows(store: Record<string, SessionEntry>): SessionRow[] {
         outputTokens: entry?.outputTokens,
         totalTokens: entry?.totalTokens,
         totalTokensFresh: entry?.totalTokensFresh,
+        modelProvider: entry?.modelProvider,
         model: entry?.model,
         contextTokens: entry?.contextTokens,
       } satisfies SessionRow;
@@ -171,7 +173,7 @@ export async function sessionsCommand(
   });
   const configContextTokens =
     cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(resolved.model) ??
+    lookupContextTokens({ provider: resolved.provider, modelId: resolved.model }) ??
     DEFAULT_CONTEXT_TOKENS;
   const configModel = resolved.model ?? DEFAULT_MODEL;
   const storePath = resolveStorePath(opts.store ?? cfg.session?.store);
@@ -211,7 +213,7 @@ export async function sessionsCommand(
             totalTokensFresh:
               typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
             contextTokens:
-              r.contextTokens ?? lookupContextTokens(r.model) ?? configContextTokens ?? null,
+              r.contextTokens ?? lookupContextTokens({ provider: r.modelProvider, modelId: r.model }) ?? configContextTokens ?? null,
             model: r.model ?? configModel ?? null,
           })),
         },
@@ -246,7 +248,7 @@ export async function sessionsCommand(
 
   for (const row of rows) {
     const model = row.model ?? configModel;
-    const contextTokens = row.contextTokens ?? lookupContextTokens(model) ?? configContextTokens;
+    const contextTokens = row.contextTokens ?? lookupContextTokens({ provider: row.modelProvider, modelId: model }) ?? configContextTokens;
     const total = resolveFreshSessionTotalTokens(row);
 
     const keyLabel = truncateKey(row.key).padEnd(KEY_PAD);

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -102,7 +102,7 @@ export async function getStatusSummary(
   const configModel = resolved.model ?? DEFAULT_MODEL;
   const configContextTokens =
     cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(configModel) ??
+    lookupContextTokens({ provider: resolved.provider, modelId: configModel }) ??
     DEFAULT_CONTEXT_TOKENS;
 
   const now = Date.now();
@@ -127,7 +127,7 @@ export async function getStatusSummary(
         const age = updatedAt ? now - updatedAt : null;
         const model = entry?.model ?? configModel ?? null;
         const contextTokens =
-          entry?.contextTokens ?? lookupContextTokens(model) ?? configContextTokens ?? null;
+          entry?.contextTokens ?? lookupContextTokens({ provider: entry?.modelProvider, modelId: model }) ?? configContextTokens ?? null;
         const total = resolveFreshSessionTotalTokens(entry);
         const totalTokensFresh =
           typeof entry?.totalTokens === "number" ? entry?.totalTokensFresh !== false : false;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -513,7 +513,7 @@ export async function runCronIsolatedAgentTurn(params: {
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
-      agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+      agentCfg?.contextTokens ?? lookupContextTokens({ provider: providerUsed, modelId: modelUsed }) ?? DEFAULT_CONTEXT_TOKENS;
 
     cronSession.sessionEntry.modelProvider = providerUsed;
     cronSession.sessionEntry.model = modelUsed;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -632,7 +632,7 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
   });
   const contextTokens =
     cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(resolved.model) ??
+    lookupContextTokens({ provider: resolved.provider, modelId: resolved.model }) ??
     DEFAULT_CONTEXT_TOKENS;
   return {
     modelProvider: resolved.provider ?? null,


### PR DESCRIPTION
## Summary

- **Problem:** The model context-window cache used bare model IDs as keys, so the same model ID from multiple providers (e.g. `claude-sonnet-4-5` via both Anthropic and a custom provider) would collide, causing one provider's configured limit to silently overwrite another's.
- **Why it matters:** Incorrect token budgets cause premature context compaction (too-small) or context overflow errors (too-large), with no warning surfaced to the user. Affected any deployment using custom providers or OpenRouter alongside native providers with overlapping model IDs.
- **What changed:** Cache keys are now `provider/modelId` (two-tier lookup: qualified first, bare fallback). Provider is threaded through to all `lookupContextTokens` call sites. A `_lookupFromCache` pure helper was extracted for testability. Tests were updated to match new key format and cover the two-tier logic.
- **What did NOT change:** The fallback to bare model-ID keys is preserved for callers without provider context. `DEFAULT_CONTEXT_TOKENS` fallback behavior is unchanged. No config schema changes, no API surface changes, no behavior change for single-provider deployments.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #19608

## User-visible / Behavior Changes

None for single-provider deployments. For multi-provider deployments with overlapping model IDs: context window sizing will now correctly use the per-provider configured value rather than whichever provider happened to write to the cache last.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: All (logic is platform-independent)
- Runtime/container: Node 22+
- Model/provider: Any deployment with multiple providers sharing a model ID (e.g. custom provider + Anthropic both exposing `claude-sonnet-4-5`)
- Integration/channel: Any
- Relevant config (redacted): `models.json` with a provider entry overriding `contextWindow` for a model also discoverable from another provider

### Steps

1. Configure a custom provider in `models.json` with `claude-sonnet-4-5` and `contextWindow: 65536`
2. Also have native Anthropic provider enabled (discovers the same model at 200k)
3. Start an agent session on the custom provider
4. Observe context window used for budget calculations (previously: 200k or 65k depending on load order; now: 65k as configured)

### Expected

- Custom provider's 64k limit is used for sessions on that provider
- Anthropic's 200k limit is used for sessions on Anthropic

### Actual (before fix)

- Cache collision caused one provider's limit to overwrite the other's depending on load order

## Evidence

### Config
  "models": {
    "mode": "merge",
    "providers": {
      "jabberwocky-anthropic": {
        "baseUrl": "https://api.anthropic.com",
        "apiKey": "",
        "api": "anthropic-messages",
        "models": [
          {
            "id": "claude-sonnet-4-5",
            "name": "Claude Sonnet 4.5 (96k limit)",
            "reasoning": true,
            "input": [
              "text",
              "image"
            ],
            "cost": {
              "input": 3,
              "output": 15,
              "cacheRead": 0.3,
              "cacheWrite": 3.75
            },
            "contextWindow": 96000,
            "maxTokens": 8192
          }
        ]
      },
      "main-anthropic": { 
        "baseUrl": "https://api.anthropic.com",
        "apiKey": "",
        "api": "anthropic-messages",
        "models": [
          {
            "id": "claude-sonnet-4-5",
            "name": "Claude Sonnet 4.5 (200k)",
            "reasoning": true,
            "input": [
              "text",
              "image"
            ],
            "cost": {
              "input": 3,
              "output": 15,
              "cacheRead": 0.3,
              "cacheWrite": 3.75
            },
            "contextWindow": 200000,
            "maxTokens": 8192
          }
        ]
      },
      "butterfly-anthropic": {
        "baseUrl": "https://api.anthropic.com",
        "apiKey": "",
        "api": "anthropic-messages",
        "models": [
          {
            "id": "claude-haiku-4-5",
            "name": "Claude Haiku 4.5 (64k limit)",
            "reasoning": false,
            "input": [
              "text",
              "image"
            ],
            "cost": {
              "input": 0.8,
              "output": 4,
              "cacheRead": 0.08,
              "cacheWrite": 1
            },
            "contextWindow": 64000,
            "maxTokens": 8192
          }
        ]
      }
    }
  }

### Gateway status Before

 - agent:main:matrix:channel:!uqnevfivnomrmhtcsp:example.com [group] | 39m ago | model claude-sonnet-4-5 | tokens 69k/200k (131k left, 35%) | flags: system, id:31f9dda9-35f6-49e5-b21b-adcf0faffff7
 - agent:jabberwocky:matrix:channel:!uqnevfivnomrmhtcsp:example.com [group] | 2h ago | model claude-sonnet-4-5 | tokens 12k/200k (188k left, 6%) | flags: system, id:36b50386-2cb9-493d-a3da-b72a2ef36c55
 - agent:butterfly:matrix:channel:!uqnevfivnomrmhtcsp:example.com [group] | 2h ago | model claude-haiku-4-5 | tokens 16k/200k (184k left, 8%) | flags: system, id:c443e762-f5ca-48f4-8292-78483de08f78

### Gateway status After
 - agent:main:matrix:channel:!uqnevfivnomrmhtcsp:example.com [group] | 58m ago | model claude-sonnet-4-5 | tokens 69k/200k (131k left, 35%) | flags: system, id:31f9dda9-35f6-49e5-b21b-adcf0faffff7               
 - agent:jabberwocky:matrix:channel:!uqnevfivnomrmhtcsp:example.com [group] | 2h ago | model claude-sonnet-4-5 | tokens 12k/96k (84k left, 12%) | flags: system, id:36b50386-2cb9-493d-a3da-b72a2ef36c55           
 - agent:butterfly:matrix:channel:!uqnevfivnomrmhtcsp:example.com [group] | 2h ago | model claude-haiku-4-5 | tokens 16k/64k (48k left, 25%) | flags: system, id:c443e762-f5ca-48f4-8292-78483de08f78

## Human Verification (required)

- Verified scenarios: Function calls are working properly from unit tests.
- ContextWindow size is correctly reported by `status` commands and used correctly for compaction.
- *Note*: There is a separate issue with the tag in the agent's system prompt that lets it know its context window size. This probably isn't a big deal, and it seems that it's not something in the OpenClaw code, but rather upstream, possibly specific to the providers.
- *Also Note*: There is another issue that causes the model name displayed in the TUI to be incorrect. I have not done any troubleshooting on that issue, but it's not directly related to this fix.

## Compatibility / Migration

- Backward compatible? `Yes`
  - *Note*: Change does require a reset of the agent's session and a hard reboot to take effect.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commits `560c3fc8`, `a39eaf1f`, `9fa5d93a`, `4eae006d`, `5d0a3961` (or revert the PR merge commit)
- Known bad symptoms to watch for: Context window unexpectedly reverting to `DEFAULT_CONTEXT_TOKENS` for a model that was previously being resolved correctly (would indicate a provider string is not being passed through at a call site)

### Files/config to restore:

**Core:**
- context.ts
- context.test.ts

**Auto-reply (6 files):**
- agent-runner.ts
- agent-runner-memory.ts
- directive-handling.persist.ts
- followup-runner.ts
- get-reply-directives.ts
- memory-flush.ts
- model-selection.ts
- status.ts

**Commands (3 files):**
- session-store.ts
- sessions.ts
- status.summary.ts

**Gateway/Cron (2 files):**
- session-utils.ts
- run.ts

## Risks and Mitigations

- Risk: A call site that uses `lookupContextTokens` from agents/context.ts was not updated to pass the updated params argument:

```typescript
// Old:
export function lookupContextTokens(modelId: string | undefined): number | undefined

// New:
export function lookupContextTokens(params: {
  provider?: string;
  modelId?: string;
}): number | undefined
```

I have made a concerted effort to locate all call sites and update them. In testing on my live gateway server I saw no errors, so I think I got them all.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed context window cache keying from bare model IDs to `provider/modelId` format, preventing cache collisions when multiple providers expose the same model ID with different context window limits. Threaded provider parameter through 15 files to all `lookupContextTokens` call sites. Added two-tier lookup (qualified key first, bare fallback) to maintain compatibility with discovered models. Tests verify the separation logic and fallback behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured refactor that solves a real collision bug. All 15 call sites properly updated to new signature. Comprehensive test coverage for two-tier lookup and provider separation. Backward compatible via bare model-id fallback. No breaking API changes.
- No files require special attention

<sub>Last reviewed commit: fbbb2b7</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->