### PR TITLE
fix(feishu): keep message chunks in topic/thread context

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -170,7 +170,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               cfg,
               to: chatId,
               text: chunk,
-              replyToMessageId,
+              replyToMessageId: first ? replyToMessageId : undefined,
               mentions: first ? mentionTargets : undefined,
               accountId,
             });
@@ -187,7 +187,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               cfg,
               to: chatId,
               text: chunk,
-              replyToMessageId,
+              replyToMessageId: first ? replyToMessageId : undefined,
               mentions: first ? mentionTargets : undefined,
               accountId,
             });


### PR DESCRIPTION
# Fix: Keep message chunks in Feishu topic/thread context

## Problem Description

When sending long messages that exceed Feishu's message length limit and get chunked into multiple messages, **only the first chunk remains in the topic/thread context**. Subsequent chunks are incorrectly sent to the main chat instead of staying within the topic.

### Reproduction Steps

1. In Feishu, create a topic/thread by replying to a bot's message
2. Send a long message (>4000 characters) that triggers OpenClaw's message chunking mechanism
3. Observe the message delivery:
   - ✅ First chunk: Correctly appears in the topic/thread
   - ❌ Subsequent chunks: Appear in the main chat instead of the topic

### Root Cause Analysis

In `extensions/feishu/src/reply-dispatcher.ts`, the message chunking loop passes the same `replyToMessageId` to all chunks:

```typescript
for (const chunk of chunks) {
  await sendMarkdownCardFeishu({
    replyToMessageId,  // ← Same ID for ALL chunks
    ...
  });
}
```

**Why this causes the bug:**
- Feishu's message threading works by associating messages with a `reply_to` reference
- When the first chunk uses `replyToMessageId`, it correctly creates/replies in the topic
- When subsequent chunks **also** use the same `replyToMessageId`, Feishu interprets them as replies to the **first chunk** rather than continuing in the same topic context
- This causes Feishu to place subsequent chunks in the parent chat instead of the topic

## Solution

**Only the first chunk should specify `replyToMessageId`.** Subsequent chunks should omit this parameter, allowing Feishu to naturally continue the message sequence within the established topic context.

### Code Changes

```typescript
// extensions/feishu/src/reply-dispatcher.ts

let first = true;
if (useCard) {
  for (const chunk of core.channel.text.chunkTextWithMode(...)) {
    await sendMarkdownCardFeishu({
      cfg,
      to: chatId,
      text: chunk,
      replyToMessageId: first ? replyToMessageId : undefined,  // ← Only first chunk
      mentions: first ? mentionTargets : undefined,
      accountId,
    });
    first = false;
  }
} else {
  // Same pattern for non-card messages
  for (const chunk of core.channel.text.chunkTextWithMode(...)) {
    await sendMessageFeishu({
      cfg,
      to: chatId,
      text: chunk,
      replyToMessageId: first ? replyToMessageId : undefined,  // ← Only first chunk
      mentions: first ? mentionTargets : undefined,
      accountId,
    });
    first = false;
  }
}
```

### Why This Works

1. **First chunk**: Uses `replyToMessageId` to establish/reply to the topic
2. **Subsequent chunks**: No `replyToMessageId`, so Feishu treats them as a natural continuation of the message sequence
3. **Result**: All chunks stay within the topic context

## Testing

- [x] Verified bug exists: Long messages in topics have chunks appearing in main chat
- [x] Applied fix: Modified `reply-dispatcher.ts` as shown above
- [x] Tested: Subsequent chunks now correctly stay in topic context

## Related

This is a separate bug fix from PR #18529, which adds `parentId`/`rootId` support for quoted messages. This PR specifically addresses the topic/thread chunking issue.

## Checklist

- [x] Bug identified and reproduced
- [x] Root cause analyzed
- [x] Fix implemented with minimal changes
- [x] Tested and verified working
- [ ] Code review requested

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where long messages that get chunked into multiple parts were incorrectly sent outside of Feishu topics/threads. The fix ensures only the first chunk uses `replyToMessageId` to establish the thread context, while subsequent chunks omit it to stay within the established thread. The implementation follows the same pattern used in other channels (e.g., Zalo extension) and correctly applies to both card and non-card message paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-explained, and follows established patterns in the codebase. It correctly addresses the root cause by only passing `replyToMessageId` on the first chunk. The logic is symmetric across both code paths (card and non-card), and the implementation matches similar chunking behavior in other channel extensions.
- No files require special attention

<sub>Last reviewed commit: fe98cae</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->