### PR TITLE
feat(skills): add overlap-check — search before filing issues or PRs

### DIFF
--- a/skills/overlap-check/SKILL.md
+++ b/skills/overlap-check/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: overlap-check
+description: "Check for existing issues and PRs before creating new ones. Fires automatically when agent intends to file an issue, open a PR, or comment on a thread. Searches the target repo for duplicates and shows matches so the agent can decide whether to proceed or contribute to an existing thread instead."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🔍",
+        "requires": { "bins": ["gh"] },
+      },
+  }
+---
+
+# Overlap Check
+
+Before creating a new issue or PR, search the target repo for existing threads that cover the same topic.
+
+## When This Fires
+
+- You are about to run `gh issue create`
+- You are about to run `gh pr create`
+- The user asks you to "file an issue", "open a PR", "report this bug", or "submit a fix"
+- You are drafting a comment on an issue or PR you haven't read yet
+
+## What to Do
+
+### 1. Identify the target repo and your topic
+
+Figure out which repo you're targeting. If you're inside a cloned repo, run:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+Summarize what your issue or PR is about in a few keywords.
+
+### 2. Search for existing threads
+
+Run both searches. Drop filler words (the, a, is, for, with, this, that, when, not, but, and, from) from your keywords.
+
+```bash
+gh search issues --repo OWNER/REPO "KEYWORDS" --limit 5 --json number,title,state,comments
+gh search prs --repo OWNER/REPO "KEYWORDS" --limit 5 --json number,title,state,comments
+```
+
+### 3. Evaluate matches
+
+Read the titles and comment counts. If any look related:
+
+- Open the thread: `gh issue view NUMBER --repo OWNER/REPO` or `gh pr view NUMBER`
+- Read enough to understand whether your topic is already covered
+- Check if the thread is active, stale, or closed
+
+### 4. Decide
+
+| Situation | Action |
+|-----------|--------|
+| Existing open thread covers your exact topic | Comment there instead of creating a new one |
+| Existing closed thread solved it | Don't reopen — link to it if relevant |
+| Existing thread is related but different | Proceed with new issue/PR, reference the related thread |
+| No matches | Proceed normally |
+
+### 5. If you find duplicates, tell the user
+
+Show what you found before proceeding:
+
+```
+Found existing threads that may cover this:
+  #13738 — WSL2 clipboard paste broken (16 comments, open)
+  #14635 — Paste not working in WSL (3 comments, open)
+
+Should I comment on an existing thread or create a new one?
+```
+
+## What NOT to Do
+
+- Don't skip this check because you're confident your topic is new
+- Don't create a new issue just because existing ones use slightly different wording
+- Don't run expensive analysis — two `gh search` calls is enough
+- Don't block the user — if they insist on creating a new thread after seeing duplicates, do it


### PR DESCRIPTION
Agents don't check what already exists before filing issues or opening PRs. This leads to duplicate threads, competing PRs for the same fix, and comments that rehash solved discussions.

Example: anthropics/claude-code#13738 has 16+ comments and community workarounds for WSL2 clipboard paste. Meanwhile #25935 filed a one-line fix for the same root cause and got auto-closed as a duplicate. #14635 covers overlapping ground too. Three threads, same problem, nobody searched first.

This skill teaches agents to search before creating. It fires when the agent is about to run `gh issue create` or `gh pr create`, runs two `gh search` queries (issues + PRs), and shows any matches. The agent then decides: comment on existing, or proceed with a new thread.

**What it does:**
- Extracts keywords from the proposed title
- Searches the target repo for open issues and PRs with those keywords
- Shows top 5 matches with comment counts
- Lets the agent (or user) decide what to do

**What it doesn't do:**
- No LLM calls, no semantic matching — just keyword search via gh
- No blocking — warns, doesn't prevent
- No heavy analysis — that's what upstream-recon is for (separate, manual tool)

Two gh search calls, under 5 seconds, zero cost.

I looked into delivering this as a PreToolUse hook (enforced gate instead of behavioral skill), but OpenClaw's hook system fires on gateway events (command:new, gateway:startup), not tool calls. Issue #1733 proposed tool:pre but it was closed without implementation. So this ships as a skill — agents are instructed to check, not forced to. If tool:pre lands later, this could upgrade to an enforced gate.

Refs #19606

Written by Claude Code, guided by SeMmy

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `overlap-check` skill that instructs agents to search for existing GitHub issues and PRs before creating new ones, reducing duplicate threads and competing PRs.

- The skill is well-structured: it identifies the target repo, runs two `gh search` queries (issues + PRs), evaluates matches, and lets the agent/user decide whether to proceed or contribute to an existing thread
- Follows existing skill conventions (frontmatter with `name`, `description`, `metadata`; concise markdown body)
- One bug: `gh pr view NUMBER` on line 50 is missing the `--repo OWNER/REPO` flag, inconsistent with the `gh issue view` command on the same line — this would cause failures when the agent is not inside the target repo's directory
- Lightweight addition (single markdown file, no scripts or dependencies beyond `gh`)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor fix needed — it's a behavioral skill (markdown instructions only) with no code execution risk.
- Single markdown file addition with no code changes. The skill is well-written and follows project conventions. One command inconsistency (missing --repo flag) could cause the agent to view the wrong PR when working outside the target repo, but this is a non-blocking behavioral instruction, not executable code.
- skills/overlap-check/SKILL.md — line 50 has a missing --repo flag on gh pr view

<sub>Last reviewed commit: 545c372</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->