### PR TITLE
style: run oxfmt on files with formatting drift

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,8 +1,8 @@
 import { Type } from "@sinclair/typebox";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
-import type { AnyAgentTool } from "./common.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import { spawnSubagentDirect } from "../subagent-spawn.js";
+import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 
 const SessionsSpawnToolSchema = Type.Object({

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -1,5 +1,4 @@
 import type { Command } from "commander";
-import type { DaemonInstallOptions, GatewayRpcOpts } from "./types.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import {
   runDaemonInstall,
@@ -9,6 +8,7 @@ import {
   runDaemonStop,
   runDaemonUninstall,
 } from "./runners.js";
+import type { DaemonInstallOptions, GatewayRpcOpts } from "./types.js";
 
 function resolveInstallOptions(
   cmdOpts: DaemonInstallOptions,

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -1,8 +1,7 @@
-import type { Command } from "commander";
 import fs from "node:fs";
 import path from "node:path";
+import type { Command } from "commander";
 import type { GatewayAuthMode } from "../../config/config.js";
-import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import {
   CONFIG_PATH,
   loadConfig,
@@ -12,6 +11,7 @@ import {
 } from "../../config/config.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
 import { startGatewayServer } from "../../gateway/server.js";
+import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";


### PR DESCRIPTION
Three files on main have formatting that doesn't match oxfmt 0.33. This cleans them up.

Files:
- `src/agents/tools/sessions-spawn-tool.ts`
- `src/cli/daemon-cli/register-service-commands.ts`
- `src/cli/gateway-cli/run.ts`

Found while rebasing [#19329](https://github.com/openclaw/openclaw/pull/19329) — these are unrelated to that PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Applies oxfmt 0.33 import sorting to three files that had formatting drift from main. All changes are purely cosmetic - reordering import statements according to the repository's configured import sorting rules (`experimentalSortImports` in `.oxfmtrc.jsonc`). No logic, functionality, or behavior changes.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- All changes are purely formatting-related import reordering produced by oxfmt 0.33. No logic, functionality, type definitions, or runtime behavior has been modified. The changes align perfectly with the repository's configured import sorting rules.
- No files require special attention

<sub>Last reviewed commit: 7eb968a</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->