### PR TITLE
fix(skills): log skill YAML parsing diagnostics with skill name

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -256,7 +256,7 @@ function loadSkillEntries(
       // Log any diagnostics from skill loading (e.g., YAML parsing errors)
       for (const diagnostic of loaded.diagnostics ?? []) {
         // Extract skill name from path (e.g., /path/to/skills/my-skill/SKILL.md -> my-skill)
-        const skillName = diagnostic.path ? diagnostic.path.split("/").slice(-2)[0] : "unknown";
+        const skillName = diagnostic.path ? path.basename(path.dirname(diagnostic.path)) : "unknown";
         skillsLogger.warn(`Skill "${skillName}": ${diagnostic.message}`, {
           path: diagnostic.path,
           type: diagnostic.type,
@@ -316,7 +316,7 @@ function loadSkillEntries(
       // Log any diagnostics from skill loading (e.g., YAML parsing errors)
       for (const diagnostic of loaded.diagnostics ?? []) {
         // Extract skill name from path (e.g., /path/to/skills/my-skill/SKILL.md -> my-skill)
-        const skillName = diagnostic.path ? diagnostic.path.split("/").slice(-2)[0] : "unknown";
+        const skillName = diagnostic.path ? path.basename(path.dirname(diagnostic.path)) : "unknown";
         skillsLogger.warn(`Skill "${skillName}": ${diagnostic.message}`, {
           path: diagnostic.path,
           type: diagnostic.type,

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -253,6 +253,15 @@ function loadSkillEntries(
       }
 
       const loaded = loadSkillsFromDir({ dir: baseDir, source: params.source });
+      // Log any diagnostics from skill loading (e.g., YAML parsing errors)
+      for (const diagnostic of loaded.diagnostics ?? []) {
+        // Extract skill name from path (e.g., /path/to/skills/my-skill/SKILL.md -> my-skill)
+        const skillName = diagnostic.path ? diagnostic.path.split("/").slice(-2)[0] : "unknown";
+        skillsLogger.warn(`Skill "${skillName}": ${diagnostic.message}`, {
+          path: diagnostic.path,
+          type: diagnostic.type,
+        });
+      }
       return unwrapLoadedSkills(loaded);
     }
 
@@ -304,6 +313,15 @@ function loadSkillEntries(
       }
 
       const loaded = loadSkillsFromDir({ dir: skillDir, source: params.source });
+      // Log any diagnostics from skill loading (e.g., YAML parsing errors)
+      for (const diagnostic of loaded.diagnostics ?? []) {
+        // Extract skill name from path (e.g., /path/to/skills/my-skill/SKILL.md -> my-skill)
+        const skillName = diagnostic.path ? diagnostic.path.split("/").slice(-2)[0] : "unknown";
+        skillsLogger.warn(`Skill "${skillName}": ${diagnostic.message}`, {
+          path: diagnostic.path,
+          type: diagnostic.type,
+        });
+      }
       loadedSkills.push(...unwrapLoadedSkills(loaded));
 
       if (loadedSkills.length >= limits.maxSkillsLoadedPerSource) {
@@ -392,8 +410,11 @@ function loadSkillEntries(
     try {
       const raw = fs.readFileSync(skill.filePath, "utf-8");
       frontmatter = parseFrontmatter(raw);
-    } catch {
-      // ignore malformed skills
+    } catch (err) {
+      skillsLogger.warn("Failed to parse skill frontmatter", {
+        filePath: skill.filePath,
+        error: String(err),
+      });
     }
     return {
       skill,
@@ -477,7 +498,11 @@ export function buildWorkspaceSkillSnapshot(
     ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}. Run \`openclaw skills check\` to audit.`
     : "";
 
-  const prompt = [remoteNote, truncationNote, formatSkillsForPrompt(compactSkillPaths(skillsForPrompt))]
+  const prompt = [
+    remoteNote,
+    truncationNote,
+    formatSkillsForPrompt(compactSkillPaths(skillsForPrompt)),
+  ]
     .filter(Boolean)
     .join("\n");
   const skillFilter = normalizeSkillFilter(opts?.skillFilter);


### PR DESCRIPTION
## Problem

Previously, when a skill's SKILL.md had YAML parsing errors (e.g., unquoted colons in description), the error was silently ignored and the skill failed to load without any indication of what went wrong.

Example of broken YAML:
```yaml
---
name: my-skill
description: Transcribe podcasts: using tool X
---
```

This causes: `Nested mappings are not allowed in compact mappings`

## Solution

This change logs skill YAML parsing diagnostics with the skill name to help users identify and fix issues:

1. **Logs warnings when YAML parsing fails** in the catch block
2. **Logs diagnostics returned from pi-coding-agent's `loadSkillsFromDir()`** - the underlying library already returns diagnostics, but they were being ignored
3. **Includes the skill name in the warning message** for better debugging

Example warning output:
```
[skills] Skill "my-skill": Nested mappings are not allowed in compact mappings at line 2, column 14:
description: Transcribe podcasts: using tool X
```

## Testing

- Built the project successfully
- Ran unit tests (664 passed, 1 unrelated failure in Slack)
- Tested locally with a skill containing a colon in description - warning now shows skill name

## Related

- CONTRIBUTING.md notes: "Test locally with your OpenClaw instance"
- This is an alternative approach to fixing the root cause in pi-coding-agent

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds diagnostic logging for skill YAML parsing failures in `src/agents/skills/workspace.ts`. Previously, YAML parsing errors in skill files were silently swallowed, making it difficult for users to debug why a skill failed to load.

- Logs diagnostics returned by `loadSkillsFromDir()` (from the `pi-coding-agent` library) at both call sites, including the extracted skill name from the file path
- Replaces a silent `catch` block in frontmatter parsing with a `skillsLogger.warn()` call that includes the file path and error message
- Includes a minor formatting cleanup of a long array literal in `buildWorkspaceSkillSnapshot`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it only adds logging to previously silent error paths with no behavioral changes.
- The changes are straightforward additions of warning-level log messages to existing catch blocks and after library calls. No control flow is altered, no new dependencies are introduced, and the logging uses the established subsystem logger pattern. The only minor concern is the forward-slash-only path splitting for skill name extraction, but this only affects log output cosmetics on Windows, not functionality.
- No files require special attention

<sub>Last reviewed commit: b2286cf</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->