### PR TITLE
test: allow optional session key in subagent announce mock

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -23,7 +23,7 @@ const subagentRegistryMock = {
   countActiveDescendantRuns: vi.fn((_sessionKey: string) => 0),
   resolveRequesterForChildSession: vi.fn((_sessionKey: string): RequesterResolution => null),
 };
-const chatHistoryMock = vi.fn(async (_sessionKey: string) => ({ messages: [] as Array<unknown> }));
+const chatHistoryMock = vi.fn(async (_sessionKey?: string) => ({ messages: [] as Array<unknown> }));
 let sessionStore: Record<string, Record<string, unknown>> = {};
 let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
   session: {


### PR DESCRIPTION
Fix TS2345 in subagent-announce.format.e2e.test by allowing undefined sessionKey in chatHistoryMock.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes TypeScript compilation error TS2345 in test mock by making the `sessionKey` parameter optional in `chatHistoryMock`. The mock is called with potentially `undefined` sessionKey (`typed.params?.sessionKey` on line 71), so the parameter type needed to accept optional values to match actual usage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line test-only change that fixes a legitimate TypeScript type error without affecting any production code or test behavior
- No files require special attention

<sub>Last reviewed commit: 365ac48</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->