### PR TITLE
fix: respect suppressToolErrors for mutating tool error warnings

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -241,15 +241,13 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads).toHaveLength(0);
   });
 
-  it("still shows mutating tool errors when messages.suppressToolErrors is enabled", () => {
+  it("suppresses mutating tool errors when messages.suppressToolErrors is enabled", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "write", error: "connection timeout" },
       config: { messages: { suppressToolErrors: true } },
     });
 
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.isError).toBe(true);
-    expect(payloads[0]?.text).toContain("connection timeout");
+    expect(payloads).toHaveLength(0);
   });
 
   it("suppresses mutating tool errors when suppressToolErrorWarnings is enabled", () => {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -50,16 +50,18 @@ function shouldShowToolErrorWarning(params: {
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean;
 }): boolean {
-  if (params.suppressToolErrorWarnings) {
+  // Check suppression flags first — these should always take priority,
+  // even for mutating tools. Previously, mutating tool errors returned
+  // true before reaching the suppressToolErrors check, making the config
+  // option ineffective for tools like exec, write, edit, etc.
+  // See: https://github.com/openclaw/openclaw/issues/19321
+  if (params.suppressToolErrorWarnings || params.suppressToolErrors) {
     return false;
   }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
     return true;
-  }
-  if (params.suppressToolErrors) {
-    return false;
   }
   return !params.hasUserFacingReply && !isRecoverableToolError(params.lastToolError.error);
 }


### PR DESCRIPTION
## Problem

`shouldShowToolErrorWarning()` returns `true` for mutating tools (exec, write, edit, etc.) **before** checking the `suppressToolErrors` config flag, making the config option ineffective for the most common tool types that trigger warnings.

```ts
// Before (buggy):
if (isMutatingToolError) return true;   // exits before checking config
if (params.suppressToolErrors) return false;
```

This causes raw tool error warnings to leak into channel surfaces (Telegram, WhatsApp) even when `messages.suppressToolErrors: true` is configured.

## Fix

Move the suppression checks (`suppressToolErrors` and `suppressToolErrorWarnings`) before the mutating tool check, so they are always respected:

```ts
// After (fixed):
if (params.suppressToolErrorWarnings || params.suppressToolErrors) return false;
if (isMutatingToolError) return true;
```

## Test changes

Updated the existing test from asserting warnings **are shown** for mutating tools with `suppressToolErrors: true` to asserting they **are suppressed** — matching the intended behavior of the config flag.

## Related

- Fixes #19321
- Related: #19180, #19150, #19302
- Analysis by @borbbot in #19321 identified the root cause

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a priority-ordering bug in `shouldShowToolErrorWarning()` where mutating tool errors (from tools like `exec`, `write`, `edit`) were always shown regardless of the `messages.suppressToolErrors` config flag. The mutating-tool early return was checked **before** the `suppressToolErrors` flag, making the config option ineffective for the most common tool types.

- Reorders the `shouldShowToolErrorWarning()` guard clauses so `suppressToolErrorWarnings` and `suppressToolErrors` are checked first, before the mutating-tool early return
- Updates the test assertion from expecting mutating tool errors to **appear** with `suppressToolErrors: true` to expecting them to be **suppressed**, matching the documented config behavior
- Note: this changes the originally documented behavior from CHANGELOG (#16620) which said `suppressToolErrors` would "hide non-mutating tool-failure warnings… while still surfacing mutating failures." The current config help text and the referenced issue #19321 confirm suppression should apply to all tool types

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix with correct test coverage.
- The change is a simple reordering of guard clauses in a single function, fixing a clear precedence bug. The logic is straightforward, the fix aligns with the documented config behavior, the test is updated to match, and existing tests for other code paths remain valid. No risk of regressions.
- No files require special attention.

<sub>Last reviewed commit: 958f2a4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->