### PR TITLE
feat: add Helm chart for Kubernetes deployment and Vertex AI streaming

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -11,6 +11,7 @@
   "ignorePatterns": [
     "apps/",
     "assets/",
+    "deploy/helm/",
     "docker-compose.yml",
     "dist/",
     "docs/_layouts/",

--- a/deploy/helm/openclaw/.helmignore
+++ b/deploy/helm/openclaw/.helmignore
@@ -1,0 +1,17 @@
+.DS_Store
+.git
+.gitignore
+.bzr
+.bzrignore
+.hg
+.hgignore
+.svn
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea
+*.tmproj
+.vscode

--- a/deploy/helm/openclaw/Chart.yaml
+++ b/deploy/helm/openclaw/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: openclaw
+description: A Helm chart for deploying the OpenClaw gateway on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/openclaw/openclaw
+sources:
+  - https://github.com/openclaw/openclaw
+maintainers:
+  - name: openclaw
+    url: https://github.com/openclaw
+keywords:
+  - openclaw
+  - ai
+  - gateway
+  - llm

--- a/deploy/helm/openclaw/templates/NOTES.txt
+++ b/deploy/helm/openclaw/templates/NOTES.txt
@@ -1,0 +1,79 @@
+OpenClaw gateway has been deployed.
+
+1. Get the gateway URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "openclaw.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "openclaw.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "openclaw.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  echo "Gateway available at http://127.0.0.1:{{ .Values.service.port }}"
+{{- end }}
+
+2. Verify the deployment:
+  kubectl --namespace {{ .Release.Namespace }} get pods -l "{{ include "openclaw.selectorLabels" . | replace "\n" "," | replace ": " "=" }}"
+
+3. Run the built-in connectivity test:
+  helm test {{ .Release.Name }} --namespace {{ .Release.Namespace }}
+{{- if .Values.openclawConfig.enabled }}
+
+4. Model provider configuration:
+  openclaw.json is seeded automatically from Helm values via the
+  openclawConfig.content field. Changes take effect on the next
+  helm upgrade (the pod restarts automatically).
+{{- else }}
+
+4. Model provider configuration:
+  No openclawConfig was provided. To configure a model provider via
+  Helm values (avoiding manual kubectl exec), set openclawConfig.enabled=true
+  and provide openclawConfig.content in your values file. Examples:
+
+  # Anthropic API (direct)
+  openclawConfig:
+    enabled: true
+    content:
+      agents:
+        defaults:
+          model:
+            primary: "anthropic/claude-sonnet-4-20250514"
+
+  # Google Vertex AI
+  openclawConfig:
+    enabled: true
+    content:
+      agents:
+        defaults:
+          model:
+            primary: "google-vertex/claude-opus-4-6"
+      models:
+        providers:
+          google-vertex:
+            baseUrl: "https://us-east5-aiplatform.googleapis.com"
+            api: "anthropic-messages"
+            auth: "oauth"
+
+  # OpenAI-compatible provider
+  openclawConfig:
+    enabled: true
+    content:
+      agents:
+        defaults:
+          model:
+            primary: "openrouter/gpt-4o"
+      models:
+        providers:
+          openrouter:
+            baseUrl: "https://openrouter.ai/api"
+            api: "openai-completions"
+{{- end }}
+{{- if and .Values.vertexAI.enabled .Values.vertexAI.credentials.create }}
+
+  GCP credentials Secret created by this chart: {{ include "openclaw.gcpSecretName" . }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/_helpers.tpl
+++ b/deploy/helm/openclaw/templates/_helpers.tpl
@@ -1,0 +1,95 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openclaw.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "openclaw.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openclaw.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "openclaw.labels" -}}
+helm.sh/chart: {{ include "openclaw.chart" . }}
+{{ include "openclaw.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "openclaw.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openclaw.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "openclaw.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openclaw.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret name (managed or existing).
+*/}}
+{{- define "openclaw.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- include "openclaw.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+GCP credentials Secret name (managed or existing).
+*/}}
+{{- define "openclaw.gcpSecretName" -}}
+{{- if .Values.vertexAI.credentials.create -}}
+{{ include "openclaw.fullname" . }}-gcp-credentials
+{{- else if .Values.vertexAI.existingSecret -}}
+{{ .Values.vertexAI.existingSecret }}
+{{- else -}}
+{{- fail "vertexAI.enabled requires either vertexAI.credentials.create=true or vertexAI.existingSecret to be set" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+PVC name (managed or existing).
+*/}}
+{{- define "openclaw.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- include "openclaw.fullname" . }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/configmap.yaml
+++ b/deploy/helm/openclaw/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/deploy/helm/openclaw/templates/deployment.yaml
+++ b/deploy/helm/openclaw/templates/deployment.yaml
@@ -1,0 +1,175 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  {{- if and .Values.persistence.enabled (has "ReadWriteOnce" .Values.persistence.accessModes) }}
+  strategy:
+    type: Recreate
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "openclaw.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.secrets.create }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.openclawConfig.enabled }}
+        checksum/openclaw-config: {{ include (print $.Template.BasePath "/openclaw-config.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "openclaw.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "openclaw.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.openclawConfig.enabled }}
+      initContainers:
+        - name: seed-config
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["sh", "-c", "mkdir -p /data/.openclaw && cp /etc/openclaw-config/openclaw.json /data/.openclaw/openclaw.json"]
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: openclaw-config
+              mountPath: /etc/openclaw-config
+              readOnly: true
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "openclaw.fullname" . }}
+            - secretRef:
+                name: {{ include "openclaw.secretName" . }}
+          {{- if or .Values.vertexAI.enabled .Values.extraEnv }}
+          env:
+            {{- if .Values.vertexAI.enabled }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/secrets/google/credentials.json"
+            {{- if .Values.vertexAI.projectId }}
+            - name: GOOGLE_CLOUD_PROJECT
+              value: {{ .Values.vertexAI.projectId | quote }}
+            {{- end }}
+            {{- if .Values.vertexAI.region }}
+            - name: GOOGLE_CLOUD_LOCATION
+              value: {{ .Values.vertexAI.region | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: gateway
+              containerPort: 18789
+              protocol: TCP
+            {{- if gt (int .Values.service.bridgePort) 0 }}
+            - name: bridge
+              containerPort: 18790
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: gateway
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: gateway
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: gateway
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 12
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /data
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+            - name: npm-cache
+              mountPath: /home/node/.npm
+            {{- if .Values.vertexAI.enabled }}
+            - name: gcp-credentials
+              mountPath: /var/secrets/google
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "openclaw.pvcName" . }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+        - name: npm-cache
+          emptyDir: {}
+        {{- if .Values.vertexAI.enabled }}
+        - name: gcp-credentials
+          secret:
+            secretName: {{ include "openclaw.gcpSecretName" . }}
+            items:
+              - key: credentials.json
+                path: credentials.json
+        {{- end }}
+        {{- if .Values.openclawConfig.enabled }}
+        - name: openclaw-config
+          configMap:
+            name: {{ include "openclaw.fullname" . }}-config
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/openclaw/templates/gcp-credentials-secret.yaml
+++ b/deploy/helm/openclaw/templates/gcp-credentials-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.vertexAI.enabled .Values.vertexAI.credentials.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openclaw.fullname" . }}-gcp-credentials
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  credentials.json: {{ .Values.vertexAI.credentials.json | quote }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/hpa.yaml
+++ b/deploy/helm/openclaw/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "openclaw.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/ingress.yaml
+++ b/deploy/helm/openclaw/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "openclaw.fullname" $ }}
+                port:
+                  name: gateway
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/networkpolicy.yaml
+++ b/deploy/helm/openclaw/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openclaw.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - port: gateway
+          protocol: TCP
+        {{- if gt (int .Values.service.bridgePort) 0 }}
+        - port: bridge
+          protocol: TCP
+        {{- end }}
+  egress:
+    - {}
+{{- end }}

--- a/deploy/helm/openclaw/templates/openclaw-config.yaml
+++ b/deploy/helm/openclaw/templates/openclaw-config.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.openclawConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openclaw.fullname" . }}-config
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+data:
+  openclaw.json: {{ .Values.openclawConfig.content | toJson | quote }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/pvc.yaml
+++ b/deploy/helm/openclaw/templates/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/sandbox-template.yaml
+++ b/deploy/helm/openclaw/templates/sandbox-template.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.sandbox.enabled }}
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          image: {{ .Values.sandbox.image | quote }}
+          {{- with .Values.sandbox.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.vertexAI.enabled }}
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/secrets/google/credentials.json"
+            {{- if .Values.vertexAI.projectId }}
+            - name: GOOGLE_CLOUD_PROJECT
+              value: {{ .Values.vertexAI.projectId | quote }}
+            {{- end }}
+            {{- if .Values.vertexAI.region }}
+            - name: GOOGLE_CLOUD_LOCATION
+              value: {{ .Values.vertexAI.region | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: gcp-credentials
+              mountPath: /var/secrets/google
+              readOnly: true
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      {{- if .Values.vertexAI.enabled }}
+      volumes:
+        - name: gcp-credentials
+          secret:
+            secretName: {{ include "openclaw.gcpSecretName" . }}
+            items:
+              - key: credentials.json
+                path: credentials.json
+      {{- end }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/sandbox-warmpool.yaml
+++ b/deploy/helm/openclaw/templates/sandbox-warmpool.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.sandbox.enabled }}
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  templateRef:
+    name: {{ include "openclaw.fullname" . }}
+  size: {{ .Values.sandbox.warmPoolSize }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/secret.yaml
+++ b/deploy/helm/openclaw/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.secrets.gatewayToken }}
+  OPENCLAW_GATEWAY_TOKEN: {{ .Values.secrets.gatewayToken | quote }}
+  {{- end }}
+  {{- if .Values.secrets.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ .Values.secrets.anthropicApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secrets.geminiApiKey }}
+  GEMINI_API_KEY: {{ .Values.secrets.geminiApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secrets.openaiApiKey }}
+  OPENAI_API_KEY: {{ .Values.secrets.openaiApiKey | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.secrets.extra }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/service.yaml
+++ b/deploy/helm/openclaw/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: gateway
+      protocol: TCP
+      name: gateway
+    {{- if gt (int .Values.service.bridgePort) 0 }}
+    - port: {{ .Values.service.bridgePort }}
+      targetPort: bridge
+      protocol: TCP
+      name: bridge
+    {{- end }}
+  selector:
+    {{- include "openclaw.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/openclaw/templates/serviceaccount.yaml
+++ b/deploy/helm/openclaw/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openclaw.serviceAccountName" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/openclaw/templates/tests/test-connection.yaml
+++ b/deploy/helm/openclaw/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "openclaw.fullname" . }}-test-connection"
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command: ['wget']
+      args: ['--spider', '--timeout=5', '{{ include "openclaw.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/deploy/helm/openclaw/values.yaml
+++ b/deploy/helm/openclaw/values.yaml
@@ -1,0 +1,215 @@
+# -- Number of replicas. Keep at 1 when using ReadWriteOnce persistence.
+replicaCount: 1
+
+image:
+  # -- Container image repository
+  repository: ghcr.io/openclaw/openclaw
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Image tag (defaults to appVersion)
+  tag: ""
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+# -- Override the chart name
+nameOverride: ""
+# -- Override the full release name
+fullnameOverride: ""
+
+# -- Gateway command arguments passed to the container
+command:
+  - node
+  - openclaw.mjs
+  - gateway
+  - --allow-unconfigured
+  - --bind
+  - lan
+  - --port
+  - "18789"
+
+# -- Non-secret environment variables injected via ConfigMap
+config:
+  NODE_ENV: production
+  HOME: /data
+  OPENCLAW_STATE_DIR: /data/.openclaw
+
+# -- Secret values. Set either secrets.create or secrets.existingSecret, not both.
+secrets:
+  # -- Create a Kubernetes Secret managed by this chart
+  create: true
+  # -- Use an existing Secret instead of creating one
+  existingSecret: ""
+  # -- Gateway authentication token
+  gatewayToken: ""
+  # -- Anthropic API key
+  anthropicApiKey: ""
+  # -- Gemini / Google Cloud Vertex API key
+  geminiApiKey: ""
+  # -- OpenAI-compatible API key
+  openaiApiKey: ""
+  # -- Additional secret key-value pairs (added to the managed Secret as-is)
+  extra: {}
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: true
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+  # -- ServiceAccount name (auto-generated if empty)
+  name: ""
+  # -- Automount the service account token
+  automountServiceAccountToken: false
+
+# -- Pod-level annotations
+podAnnotations: {}
+# -- Pod-level labels
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Gateway HTTP/WS port
+  port: 18789
+  # -- Bridge port (set to 0 to disable)
+  bridgePort: 18790
+
+ingress:
+  # -- Enable Ingress
+  enabled: false
+  # -- Ingress class name
+  className: ""
+  # -- Ingress annotations (e.g. for WebSocket support)
+  annotations: {}
+  #   nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+  #   nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  #   nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+  #   nginx.ingress.kubernetes.io/upstream-hash-by: "$remote_addr"
+  hosts:
+    - host: openclaw.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS configuration
+  tls: []
+  #  - secretName: openclaw-tls
+  #    hosts:
+  #      - openclaw.local
+
+persistence:
+  # -- Enable persistent storage
+  enabled: true
+  # -- Use an existing PVC
+  existingClaim: ""
+  # -- Storage class (empty = cluster default)
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Volume size
+  size: 5Gi
+
+# -- Resource requests and limits
+resources: {}
+#  requests:
+#    cpu: 250m
+#    memory: 512Mi
+#  limits:
+#    cpu: "1"
+#    memory: 1536Mi
+
+autoscaling:
+  # -- Enable HPA (disabled by default; stateful workload)
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+networkPolicy:
+  # -- Enable NetworkPolicy
+  enabled: false
+
+# -- Node selector constraints
+nodeSelector: {}
+# -- Tolerations
+tolerations: []
+# -- Affinity rules
+affinity: {}
+
+# -- Extra environment variables added directly to the pod spec
+extraEnv: []
+
+# -- Extra volume mounts added to the container
+extraVolumeMounts: []
+
+# -- Extra volumes added to the pod
+extraVolumes: []
+
+# -- OpenClaw application config (rendered as openclaw.json)
+openclawConfig:
+  # -- Enable seeding openclaw.json from Helm values
+  enabled: false
+  # -- Full openclaw.json content as YAML (converted to JSON)
+  content: {}
+  #   agents:
+  #     defaults:
+  #       model:
+  #         primary: "google-vertex/claude-opus-4-6"
+  #   models:
+  #     providers:
+  #       google-vertex:
+  #         baseUrl: "https://us-east5-aiplatform.googleapis.com"
+  #         api: "anthropic-messages"
+  #         auth: "oauth"
+  #         models:
+  #           - id: "claude-opus-4-6"
+  #             name: "Claude Opus 4.6"
+  #             ...
+
+# -- Google Vertex AI configuration (for accessing Claude via Vertex)
+vertexAI:
+  # -- Enable Vertex AI credentials mounting
+  enabled: false
+  # -- Name of a pre-existing Secret containing credentials.json (ignored when credentials.create is true)
+  existingSecret: ""
+  # -- GCP project ID for Vertex AI
+  projectId: ""
+  # -- GCP region for Vertex AI (e.g. us-east5)
+  region: ""
+  credentials:
+    # -- Create a Secret for GCP credentials (alternative to existingSecret)
+    create: false
+    # -- Raw JSON content of the GCP service account key
+    json: ""
+
+# -- kubernetes-sigs/agent-sandbox integration
+sandbox:
+  # -- Enable agent-sandbox CRDs (SandboxTemplate + SandboxWarmPool)
+  enabled: false
+  # -- Container image for sandbox pods
+  image: ghcr.io/openclaw/openclaw:latest
+  # -- Sandbox resource requests
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  # -- Warm pool size (pre-created sandbox pods)
+  warmPoolSize: 2

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "file-type": "^21.3.0",
+    "google-auth-library": "^10.5.0",
     "grammy": "^1.40.0",
     "https-proxy-agent": "^7.0.6",
     "jiti": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       file-type:
         specifier: ^21.3.0
         version: 21.3.0
+      google-auth-library:
+        specifier: ^10.5.0
+        version: 10.5.0
       grammy:
         specifier: ^1.40.0
         version: 1.40.0

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -70,6 +70,7 @@ import {
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
+import { createVertexAnthropicStreamFn } from "../../vertex-anthropic-stream.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
@@ -634,6 +635,16 @@ export async function runEmbeddedAttempt(
           typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
         const ollamaBaseUrl = modelBaseUrl || providerBaseUrl || OLLAMA_NATIVE_BASE_URL;
         activeSession.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl);
+      } else if (
+        params.model.provider === "google-vertex" &&
+        params.model.api === "anthropic-messages"
+      ) {
+        // Vertex AI rawPredict: send Anthropic messages format directly to
+        // Vertex AI's streamRawPredict endpoint, bypassing the Anthropic SDK
+        // which constructs incompatible URLs.
+        const project = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || "";
+        const location = process.env.GOOGLE_CLOUD_LOCATION || "";
+        activeSession.agent.streamFn = createVertexAnthropicStreamFn(project, location);
       } else {
         // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
         activeSession.agent.streamFn = streamSimple;

--- a/src/agents/vertex-anthropic-stream.ts
+++ b/src/agents/vertex-anthropic-stream.ts
@@ -1,0 +1,379 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type {
+  AssistantMessage,
+  StopReason,
+  TextContent,
+  ToolCall,
+  Usage,
+} from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { GoogleAuth } from "google-auth-library";
+
+// ── Anthropic SSE event types ───────────────────────────────────────────────
+
+interface AnthropicContentBlockStart {
+  type: "content_block_start";
+  index: number;
+  content_block: {
+    type: "text" | "tool_use";
+    id?: string;
+    text?: string;
+    name?: string;
+    input?: string;
+  };
+}
+
+interface AnthropicContentBlockDelta {
+  type: "content_block_delta";
+  index: number;
+  delta: {
+    type: "text_delta" | "input_json_delta";
+    text?: string;
+    partial_json?: string;
+  };
+}
+
+interface AnthropicMessageStart {
+  type: "message_start";
+  message: {
+    id: string;
+    model: string;
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+}
+
+interface AnthropicMessageDelta {
+  type: "message_delta";
+  delta: {
+    stop_reason: string;
+  };
+  usage?: {
+    output_tokens: number;
+  };
+}
+
+type AnthropicSSEEvent =
+  | AnthropicMessageStart
+  | AnthropicContentBlockStart
+  | AnthropicContentBlockDelta
+  | AnthropicMessageDelta
+  | { type: "content_block_stop"; index: number }
+  | { type: "message_stop" }
+  | { type: "ping" }
+  | { type: "error"; error: { type: string; message: string } };
+
+// ── SSE parser ──────────────────────────────────────────────────────────────
+
+async function* parseSSEStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): AsyncGenerator<AnthropicSSEEvent> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+
+    const parts = buffer.split("\n\n");
+    buffer = parts.pop() ?? "";
+
+    for (const part of parts) {
+      const lines = part.split("\n");
+      let eventData = "";
+
+      for (const line of lines) {
+        if (line.startsWith("data: ")) {
+          eventData += line.slice(6);
+        }
+      }
+
+      if (!eventData) {
+        continue;
+      }
+
+      try {
+        yield JSON.parse(eventData) as AnthropicSSEEvent;
+      } catch {
+        console.warn(
+          "[vertex-anthropic-stream] Skipping malformed SSE data:",
+          eventData.slice(0, 120),
+        );
+      }
+    }
+  }
+
+  // Process remaining buffer
+  if (buffer.trim()) {
+    const lines = buffer.split("\n");
+    let eventData = "";
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        eventData += line.slice(6);
+      }
+    }
+    if (eventData) {
+      try {
+        yield JSON.parse(eventData) as AnthropicSSEEvent;
+      } catch {
+        console.warn(
+          "[vertex-anthropic-stream] Skipping malformed trailing SSE data:",
+          eventData.slice(0, 120),
+        );
+      }
+    }
+  }
+}
+
+// ── Main StreamFn factory ───────────────────────────────────────────────────
+
+export function createVertexAnthropicStreamFn(project: string, location: string): StreamFn {
+  if (!project || !location) {
+    throw new Error(
+      "Vertex AI requires GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION environment variables",
+    );
+  }
+  const auth = new GoogleAuth({ scopes: "https://www.googleapis.com/auth/cloud-platform" });
+
+  return (model, context, options) => {
+    const stream = createAssistantMessageEventStream();
+
+    const run = async () => {
+      try {
+        const client = await auth.getClient();
+        const tokenResponse = await client.getAccessToken();
+        const accessToken =
+          typeof tokenResponse === "string" ? tokenResponse : tokenResponse?.token;
+        if (!accessToken) {
+          throw new Error("Failed to obtain Google Cloud access token from ADC");
+        }
+
+        const modelId = model.id;
+        const url =
+          `https://${location}-aiplatform.googleapis.com/v1/projects/${project}` +
+          `/locations/${location}/publishers/anthropic/models/${modelId}:streamRawPredict`;
+
+        // Build Anthropic messages body
+        const messages = (context.messages ?? []).map((msg) => ({
+          role: msg.role as string,
+          content: msg.content,
+        }));
+
+        const body: Record<string, unknown> = {
+          anthropic_version: "vertex-2023-10-16",
+          stream: true,
+          messages,
+        };
+
+        if (context.systemPrompt) {
+          body.system = context.systemPrompt;
+        }
+
+        if (options?.maxTokens) {
+          body.max_tokens = options.maxTokens;
+        } else if (model.maxTokens) {
+          body.max_tokens = model.maxTokens;
+        } else {
+          body.max_tokens = 8192;
+        }
+
+        if (typeof options?.temperature === "number") {
+          body.temperature = options.temperature;
+        }
+
+        if (context.tools && context.tools.length > 0) {
+          body.tools = context.tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description ?? "",
+            input_schema: tool.parameters ?? { type: "object", properties: {} },
+          }));
+        }
+
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+          ...options?.headers,
+        };
+
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+          signal: options?.signal,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "unknown error");
+          throw new Error(`Vertex AI rawPredict error ${response.status}: ${errorText}`);
+        }
+
+        if (!response.body) {
+          throw new Error("Vertex AI rawPredict returned empty response body");
+        }
+
+        const reader = response.body.getReader();
+
+        // Accumulate content blocks from streaming events
+        const contentBlocks: Array<{
+          type: "text" | "tool_use";
+          text?: string;
+          id?: string;
+          name?: string;
+          inputJson?: string;
+        }> = [];
+
+        let inputTokens = 0;
+        let outputTokens = 0;
+        let cacheReadTokens = 0;
+        let cacheWriteTokens = 0;
+        let stopReason = "stop";
+
+        for await (const event of parseSSEStream(reader)) {
+          switch (event.type) {
+            case "message_start": {
+              const u = event.message.usage;
+              inputTokens += u.input_tokens ?? 0;
+              outputTokens += u.output_tokens ?? 0;
+              cacheReadTokens += u.cache_read_input_tokens ?? 0;
+              cacheWriteTokens += u.cache_creation_input_tokens ?? 0;
+              break;
+            }
+            case "content_block_start": {
+              const block = event.content_block;
+              contentBlocks[event.index] = {
+                type: block.type,
+                text: block.text ?? "",
+                id: block.id,
+                name: block.name,
+                inputJson: "",
+              };
+              break;
+            }
+            case "content_block_delta": {
+              const cb = contentBlocks[event.index];
+              if (!cb) {
+                break;
+              }
+              if (event.delta.type === "text_delta" && event.delta.text) {
+                cb.text = (cb.text ?? "") + event.delta.text;
+              } else if (event.delta.type === "input_json_delta" && event.delta.partial_json) {
+                cb.inputJson = (cb.inputJson ?? "") + event.delta.partial_json;
+              }
+              break;
+            }
+            case "message_delta": {
+              stopReason = event.delta.stop_reason ?? "stop";
+              if (event.usage?.output_tokens) {
+                outputTokens = event.usage.output_tokens;
+              }
+              break;
+            }
+            case "error": {
+              throw new Error(`Anthropic streaming error: ${event.error.message}`);
+            }
+            default:
+              break;
+          }
+        }
+
+        // Build AssistantMessage content
+        const content: (TextContent | ToolCall)[] = [];
+        for (const block of contentBlocks) {
+          if (!block) {
+            continue;
+          }
+          if (block.type === "text" && block.text) {
+            content.push({ type: "text", text: block.text });
+          } else if (block.type === "tool_use" && block.name) {
+            let args: Record<string, unknown> = {};
+            if (block.inputJson) {
+              try {
+                args = JSON.parse(block.inputJson) as Record<string, unknown>;
+              } catch {
+                console.warn(
+                  "[vertex-anthropic-stream] Failed to parse tool input JSON:",
+                  block.inputJson.slice(0, 120),
+                );
+              }
+            }
+            content.push({
+              type: "toolCall",
+              id: block.id ?? `vertex_call_${Date.now()}`,
+              name: block.name,
+              arguments: args,
+            });
+          }
+        }
+
+        const hasToolCalls = content.some((c) => c.type === "toolCall");
+        const mappedStopReason: StopReason =
+          stopReason === "tool_use" || hasToolCalls ? "toolUse" : "stop";
+
+        const usage: Usage = {
+          input: inputTokens,
+          output: outputTokens,
+          cacheRead: cacheReadTokens,
+          cacheWrite: cacheWriteTokens,
+          totalTokens: inputTokens + outputTokens,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        };
+
+        const assistantMessage: AssistantMessage = {
+          role: "assistant",
+          content,
+          stopReason: mappedStopReason,
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage,
+          timestamp: Date.now(),
+        };
+
+        const reason: Extract<StopReason, "stop" | "length" | "toolUse"> =
+          mappedStopReason === "toolUse" ? "toolUse" : "stop";
+
+        stream.push({
+          type: "done",
+          reason,
+          message: assistantMessage,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        stream.push({
+          type: "error",
+          reason: "error",
+          error: {
+            role: "assistant" as const,
+            content: [],
+            stopReason: "error" as StopReason,
+            errorMessage,
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        });
+      } finally {
+        stream.end();
+      }
+    };
+
+    queueMicrotask(() => void run());
+    return stream;
+  };
+}

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -3,6 +3,7 @@ export type ModelApi =
   | "openai-responses"
   | "anthropic-messages"
   | "google-generative-ai"
+  | "google-vertex"
   | "github-copilot"
   | "bedrock-converse-stream"
   | "ollama";

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -8,6 +8,7 @@ export const ModelApiSchema = z.union([
   z.literal("openai-responses"),
   z.literal("anthropic-messages"),
   z.literal("google-generative-ai"),
+  z.literal("google-vertex"),
   z.literal("github-copilot"),
   z.literal("bedrock-converse-stream"),
   z.literal("ollama"),


### PR DESCRIPTION
## Summary

- Adds a production-ready Helm chart under `deploy/helm/openclaw/` that supports all model provider configurations (Anthropic, Vertex AI, OpenAI-compatible) purely through Helm values — no manual `kubectl exec` needed to seed `openclaw.json`
- Adds Vertex AI `rawPredict` streaming support so Claude can be accessed through Google Vertex AI's Anthropic integration
- Integrates with [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) via `SandboxTemplate` CRD

## Helm chart details

**`openclawConfig`**: Seeds `openclaw.json` from Helm values via an init container that copies a ConfigMap to the writable PVC on each startup. Config stays writable for runtime changes and is always re-synced on `helm upgrade`.

**`vertexAI.credentials.create`**: Optionally creates a GCP credentials Secret from inline JSON (alternative to referencing a pre-existing Secret via `vertexAI.existingSecret`).

**`secrets.openaiApiKey`**: Adds `OPENAI_API_KEY` env var for OpenAI-compatible providers.

**No hardcoded org-specific values**: All `vertexAI` fields (`projectId`, `region`, `existingSecret`) default to empty strings.

### Example: Vertex AI

```yaml
openclawConfig:
  enabled: true
  content:
    agents:
      defaults:
        model:
          primary: "google-vertex/claude-opus-4-6"
    models:
      providers:
        google-vertex:
          baseUrl: "https://us-east5-aiplatform.googleapis.com"
          api: "anthropic-messages"
          auth: "oauth"
          models:
            - id: "claude-opus-4-6"
              name: "Claude Opus 4.6"
              reasoning: true
              input: ["text", "image"]
              contextWindow: 1000000
              maxTokens: 32000

vertexAI:
  enabled: true
  projectId: "my-gcp-project"
  region: "us-east5"
  credentials:
    create: true
    json: |
      { "type": "service_account", ... }
```

### Example: Anthropic direct

```yaml
openclawConfig:
  enabled: true
  content:
    agents:
      defaults:
        model:
          primary: "anthropic/claude-sonnet-4-20250514"

secrets:
  create: true
  anthropicApiKey: "sk-ant-..."
```

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders correctly for all provider modes (default, Anthropic, Vertex AI with credentials.create, OpenAI)
- [x] Built Docker image locally, loaded into Kind cluster
- [x] Init container creates `/data/.openclaw/` and seeds `openclaw.json`
- [x] Config file is writable on PVC (required for runtime changes)
- [x] Pod reaches 1/1 Running with Anthropic config
- [x] `helm upgrade` re-seeds config and triggers pod restart via checksum annotation
- [x] GCP credentials Secret created correctly when `vertexAI.credentials.create=true`
- [x] `gcpSecretName` helper resolves to chart-managed or existing Secret correctly
- [x] No Vertex/GCP references rendered when `vertexAI.enabled=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two main pieces: a comprehensive Helm chart for deploying the OpenClaw gateway on Kubernetes (`deploy/helm/openclaw/`), and a Vertex AI `rawPredict` streaming implementation (`src/agents/vertex-anthropic-stream.ts`) that enables Claude access through Google Vertex AI's Anthropic integration.

The Helm chart is well-structured with proper security contexts, checksum-based rollout annotations, init container config seeding, and support for multiple provider modes (Anthropic, Vertex AI, OpenAI-compatible). It also integrates with the `kubernetes-sigs/agent-sandbox` CRD.

The Vertex AI stream implementation follows the established pattern from `ollama-stream.ts`, correctly handling SSE parsing, content block accumulation, tool call assembly, and error propagation.

- **Bug**: `createVertexAnthropicStreamFn` does not validate that `project` and `location` are non-empty, producing a malformed Vertex AI URL when `GOOGLE_CLOUD_PROJECT`/`GOOGLE_CLOUD_LOCATION` env vars are not set
- **Bug**: The `gcpSecretName` Helm helper returns an empty string when `vertexAI.enabled=true` without `credentials.create` or `existingSecret` configured, producing an invalid Kubernetes volume spec that will prevent pod startup
- Adds `google-vertex` as a new `ModelApi` type and corresponding Zod schema literal
- Adds `google-auth-library` as a new dependency for OAuth token acquisition
- Minor changes in `runner.entries.ts` add non-null assertions after existing null guards (safe) and reorder imports

<h3>Confidence Score: 3/5</h3>

- Two bugs should be fixed before merging: missing env var validation in the Vertex AI stream factory and empty secretName in the Helm gcpSecretName helper.
- The two identified issues will cause runtime failures in common misconfiguration scenarios — empty project/location producing a malformed URL, and missing Vertex AI secret configuration producing an invalid Kubernetes manifest. Both are straightforward fixes but will impact users who deploy with incomplete configuration.
- Pay close attention to `src/agents/vertex-anthropic-stream.ts` (missing parameter validation) and `deploy/helm/openclaw/templates/_helpers.tpl` (empty secretName bug).

<sub>Last reviewed commit: e4e8be0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->