### PR TITLE
fix: change elevatedDefault fallback from 'on' to 'off'

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -270,7 +270,7 @@ export async function handleDirectiveOnly(
   const prevElevatedLevel =
     currentElevatedLevel ??
     (sessionEntry.elevatedLevel as ElevatedLevel | undefined) ??
-    (elevatedAllowed ? ("on" as ElevatedLevel) : ("off" as ElevatedLevel));
+    (elevatedAllowed ? ("off" as ElevatedLevel) : ("off" as ElevatedLevel));
   const prevReasoningLevel =
     currentReasoningLevel ?? (sessionEntry.reasoningLevel as ReasoningLevel | undefined) ?? "off";
   let elevatedChanged =

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -70,7 +70,7 @@ export async function persistInlineDirectives(params: {
     const prevElevatedLevel =
       (sessionEntry.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined) ??
-      (elevatedAllowed ? ("on" as ElevatedLevel) : ("off" as ElevatedLevel));
+      (elevatedAllowed ? ("off" as ElevatedLevel) : ("off" as ElevatedLevel));
     const prevReasoningLevel = (sessionEntry.reasoningLevel as ReasoningLevel | undefined) ?? "off";
     let elevatedChanged =
       directives.hasElevatedDirective &&

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -353,7 +353,7 @@ export async function resolveReplyDirectives(params: {
     ? (directives.elevatedLevel ??
       (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined) ??
-      "on")
+      "off")
     : "off";
   const resolvedBlockStreaming =
     opts?.disableBlockStreaming === true


### PR DESCRIPTION
## Summary

When `tools.elevated.enabled` is set to `true` without explicit `elevatedDefault` configuration, the default value was `'on'` which caused all exec commands to route through elevated approval gate and silently timeout after 120 seconds.

This fix changes the default from `'on'` to `'off'`, making elevated mode opt-in per session rather than globally forced on.

## Fixes

- Fixes #19574

## Testing

- Manual testing: With `tools.elevated.enabled: true`, exec commands now run without requiring approval by default (until user explicitly enables elevated mode per-session)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a behavioral regression where the elevated mode fallback defaulted to `"on"` when `tools.elevated.enabled` was `true` without explicit `elevatedDefault` configuration. This caused all exec commands to silently route through the elevated approval gate and timeout after 120 seconds.

The fix changes the final fallback from `"on"` to `"off"` in all three resolution paths:
- `directive-handling.impl.ts` — `prevElevatedLevel` computation for directive-only handling
- `directive-handling.persist.ts` — `prevElevatedLevel` computation for inline directive persistence
- `get-reply-directives.ts` — `resolvedElevatedLevel` computation in the main reply directive resolution

This makes elevated mode opt-in (via explicit `elevatedDefault` config or per-session `/elevated on` directive) rather than implicitly forced on. The downstream consumers in `bash-tools.exec.ts` and `system-prompt.ts` that receive the resolved level remain unchanged and correctly handle all level values.

- Two files have redundant ternary expressions after this change (both branches now return `"off"`) — minor cleanup opportunity.

<h3>Confidence Score: 4/5</h3>

- This PR is a targeted, low-risk fix that corrects a default value across three files in a consistent manner.
- The change is small, focused, and consistent across all three locations. The resolution chain (directive → session → config → fallback) is properly maintained. The downstream exec handler in bash-tools.exec.ts already handles all elevated level values correctly. The only minor concern is the lack of new tests explicitly covering the fallback behavior, though existing e2e tests cover the broader elevated flow.
- No files require special attention — all three changes are mechanical and consistent.

<sub>Last reviewed commit: 18ae703</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->