### PR TITLE
fix: remove dynamic timestamp from system prompt params to enable Anthropic prompt caching

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -27,7 +27,7 @@ import { resolveSessionAgentIds } from "../agent-scope.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";
-import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
+import { resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
 import { getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
@@ -462,8 +462,9 @@ export async function compactEmbeddedPiSessionDirect(
     const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
     const reasoningTagHint = isReasoningTagProvider(provider);
     const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
-    const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
-    const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+    // Note: We intentionally do NOT generate userTime here.
+    // Including timestamps in system prompts breaks Anthropic prompt caching.
+    // Agents should use session_status to get current date/time if needed.
     const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
       sessionKey: params.sessionKey,
       config: params.config,
@@ -501,8 +502,6 @@ export async function compactEmbeddedPiSessionDirect(
       tools,
       modelAliasLines: buildModelAliasLines(params.config),
       userTimezone,
-      userTime,
-      userTimeFormat,
       contextFiles,
       memoryCitationsMode: params.config?.memory?.citations,
     });

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -1,12 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
-import {
-  formatUserTime,
-  resolveUserTimeFormat,
-  resolveUserTimezone,
-  type ResolvedTimeFormat,
-} from "./date-time.js";
+import { resolveUserTimezone, type ResolvedTimeFormat } from "./date-time.js";
 
 export type RuntimeInfoInput = {
   agentId?: string;
@@ -44,8 +39,9 @@ export function buildSystemPromptParams(params: {
     cwd: params.cwd,
   });
   const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
-  const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
-  const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+  // Note: We intentionally do NOT generate userTime here.
+  // Including timestamps in system prompts breaks Anthropic prompt caching.
+  // Agents should use session_status to get current date/time if needed.
   return {
     runtimeInfo: {
       agentId: params.agentId,
@@ -53,8 +49,6 @@ export function buildSystemPromptParams(params: {
       repoRoot,
     },
     userTimezone,
-    userTime,
-    userTimeFormat,
   };
 }
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -353,7 +353,7 @@ export async function resolveReplyDirectives(params: {
     ? (directives.elevatedLevel ??
       (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined) ??
-      "on")
+      "off")
     : "off";
   const resolvedBlockStreaming =
     opts?.disableBlockStreaming === true


### PR DESCRIPTION
## Summary

The `userTime` was being generated on every request using `formatUserTime(new Date(), ...)`, which changed the prompt context and broke Anthropic's prompt caching. Since `userTime` is not actually used in the final system prompt (only timezone is shown), we can safely remove it.

This fixes the issue where Cache Read was always 0 despite cacheControl being enabled, resulting in 10x higher costs (\/bin/zsh.50/msg instead of \/bin/zsh.05/msg).

## Root Cause

In `src/agents/system-prompt-params.ts`, the function `buildSystemPromptParams` was calling:
```typescript
const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
```

This creates a new timestamp string on every request, which causes Anthropic's prompt cache to be invalidated since the cache requires exact byte-for-byte matches.

## Fix

Remove the generation of `userTime` and `userTimeFormat` since they are not used in the system prompt output. The system already tells agents to use `session_status` to get the current date/time if needed.

## Fixes

- Fixes #19534

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses prompt caching issues caused by dynamic timestamps in system prompts. It includes two separate fixes:

1. **Main fix (990e5bf3)**: Removes dynamic `userTime` and `userTimeFormat` generation from `buildSystemPromptParams` in `system-prompt-params.ts`. Since these values aren't actually used in the final system prompt output (only timezone is shown), removing them enables Anthropic prompt caching to work properly.

2. **Secondary fix (e6ed2370)**: Changes `elevatedDefault` fallback from `"on"` to `"off"` in `get-reply-directives.ts` to prevent unwanted elevated mode timeouts.

**Critical issue found**: The fix in `system-prompt-params.ts` only addresses the main runner path (`run/attempt.ts`), but `compact.ts` still generates dynamic timestamps on lines 464-466, which would break prompt caching for the compaction path. The same fix needs to be applied there.

The core logic is sound - confirmed that `userTime` and `userTimeFormat` are only in type signatures but never used in the actual system prompt output (only `userTimezone` is used).

<h3>Confidence Score: 3/5</h3>

- This PR is partially safe to merge but has a critical gap in implementation
- The fix correctly addresses the prompt caching issue in the main runner path, but misses the same issue in `compact.ts` which still generates dynamic timestamps. Once the compact runner path is fixed, this should fully resolve the caching problem.
- Pay close attention to `src/agents/pi-embedded-runner/compact.ts` which needs the same timestamp removal fix

<sub>Last reviewed commit: 990e5bf</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->