### PR TITLE
fix: security audit suppression, MoE false positive, and hook prefix awareness

### DIFF
--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -97,6 +97,7 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  security?: { acknowledged?: string[] };
 };
 
 export type ConfigValidationIssue = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -560,6 +560,10 @@ export const OpenClawSchema = z
       .strict()
       .optional(),
     memory: MemorySchema,
+    security: z
+      .object({ acknowledged: z.array(z.string()).optional() })
+      .strict()
+      .optional(),
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -684,6 +684,10 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
     });
   }
 
-  const summary = countBySeverity(findings);
-  return { ts: Date.now(), summary, findings, deep };
+  const acknowledged = new Set(
+    (cfg.security?.acknowledged ?? []).map((s) => s.trim()).filter(Boolean),
+  );
+  const active = findings.filter((f) => !acknowledged.has(f.checkId));
+  const summary = countBySeverity(active);
+  return { ts: Date.now(), summary, findings: active, deep };
 }

--- a/src/shared/model-param-b.ts
+++ b/src/shared/model-param-b.ts
@@ -1,3 +1,17 @@
+/**
+ * Detect MoE (Mixture-of-Experts) active params from model name patterns like "A22B".
+ * Returns the active param count in billions, or null if not a MoE model.
+ */
+export function inferMoEActiveParamB(text: string): number | null {
+  const raw = text.toLowerCase();
+  const match = raw.match(/(?:^|[^a-z0-9])a(\d+(?:\.\d+)?)b(?:[^a-z0-9]|$)/);
+  if (!match?.[1]) {
+    return null;
+  }
+  const value = Number(match[1]);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
 export function inferParamBFromIdOrName(text: string): number | null {
   const raw = text.toLowerCase();
   const matches = raw.matchAll(/(?:^|[^a-z0-9])[a-z]?(\d+(?:\.\d+)?)b(?:[^a-z0-9]|$)/g);


### PR DESCRIPTION
## Summary

- Problem: `openclaw security audit` has no suppression mechanism, flags large MoE models (235B) as "small", and ignores `allowedSessionKeyPrefixes` mitigation
- Why it matters: Users get noisy, irrelevant warnings on every audit run with no way to dismiss reviewed findings
- What changed: Added `security.acknowledged` config array, MoE-aware model size detection, hook warning severity downgrade when prefixes constrain session keys
- What did NOT change (scope boundary): No changes to `SecurityAuditReport` type, CLI commands, status command, or any other audit checks

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- Closes #17447

## User-visible / Behavior Changes

- New optional config field: `security.acknowledged` (array of checkId strings) suppresses matching audit findings
- MoE models with total params > 100B (e.g. Qwen3-235B-A22B) no longer flagged as "small models requiring sandboxing"
- `hooks.request_session_key_enabled` warning downgrades to `info` when `allowedSessionKeyPrefixes` is configured

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Docker), macOS
- Runtime/container: Node 22, devcontainer

### Steps

1. Configure a model like `Qwen3-235B-A22B-Instruct`
2. Run `openclaw security audit`
3. Observe false positive "small model" critical finding

### Expected

- Large MoE models not flagged as small

### Actual (before fix)

- 235B model flagged as "small" requiring sandboxing

## Evidence

- [x] Failing test/log before + passing after
- 6 new tests, 72/72 total passing
- `pnpm build && pnpm check && pnpm test` all pass

## Human Verification (required)

- Verified scenarios: All 6 new tests cover suppression, MoE skip, small MoE still flagged, hook prefix downgrade, no-config no-op
- Edge cases checked: Empty acknowledged array, whitespace in checkIds, small MoE models (3B-A1B) still caught
- What you did **not** verify: Live `openclaw security audit` CLI run (tested via unit tests only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? New optional `security.acknowledged` field (no action required)
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `security` key from config; all findings return to default behavior
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Findings unexpectedly missing from audit output

## Risks and Mitigations

- Risk: Users suppress critical findings and forget about them
  - Mitigation: Suppression is explicit per-checkId; no blanket "suppress all" option

AI-assisted (Claude), fully tested.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three security audit improvements: suppression mechanism, MoE model detection, and hook prefix awareness.

**Key Changes:**
- Added `security.acknowledged` config field (array of checkId strings) to suppress reviewed findings
- MoE models with total params >100B (e.g., Qwen3-235B-A22B) no longer incorrectly flagged as "small models requiring sandboxing"
- `hooks.request_session_key_enabled` warning downgraded from critical/warn to info when `allowedSessionKeyPrefixes` is configured, recognizing that prefix constraints mitigate the risk

**Implementation Details:**
- In `audit.ts:687-692`, findings are filtered against the acknowledged set before returning results
- In `audit-extra.sync.ts:877-882`, MoE detection uses threshold of SMALL_MODEL_PARAM_B_MAX/3 (100B) for active params
- In `audit-extra.sync.ts:485-498`, severity logic checks for prefix constraints to determine appropriate warning level

**Test Coverage:**
All 6 new tests pass and cover the main scenarios: large MoE skip, small MoE still flagged, suppression filtering, summary count accuracy, hook prefix downgrade, and no-config behavior.

The changes are backward compatible with no breaking changes to existing functionality.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- All changes are well-implemented with proper error handling, comprehensive test coverage (6 new tests, all passing), backward compatible optional config fields, and clear security improvements. The MoE detection logic correctly identifies frontier-class models, suppression mechanism safely filters acknowledged findings, and hook severity downgrade appropriately recognizes prefix constraints as risk mitigation.
- No files require special attention

<sub>Last reviewed commit: a7eba62</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->