### PR TITLE
fix: remove hardcoded disableBlockStreaming to honor agent config for TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
+- Gateway/TUI: honor `agents.defaults.blockStreamingDefault` for `chat.send` by removing the hardcoded block-streaming disable override, so replies can use configured block-mode delivery. (#19693) Thanks @neipor.
 - Protocol/Apple: regenerate Swift gateway models for `push.test` so `pnpm protocol:check` stays green on main. Thanks @mbelinky.
 - Canvas/A2UI: improve bundled-asset resolution and empty-state handling so UI fallbacks render reliably. (#20312) Thanks @mbelinky.
 - UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -898,7 +898,6 @@ export const chatHandlers: GatewayRequestHandlers = {
           runId: clientRunId,
           abortSignal: abortController.signal,
           images: parsedImages.length > 0 ? parsedImages : undefined,
-          disableBlockStreaming: true,
           onAgentRunStart: (runId) => {
             agentRunStarted = true;
             const connId = typeof client?.connId === "string" ? client.connId : undefined;

--- a/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
+import type { GetReplyOptions } from "../auto-reply/types.js";
 import { __setMaxChatHistoryMessagesBytesForTest } from "./server-constants.js";
 import {
   connectOk,
@@ -138,7 +139,7 @@ describe("gateway server chat", () => {
 
   test("chat.send does not force-disable block streaming", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
-      const spy = vi.mocked(getReplyFromConfig);
+      const spy = vi.mocked(getReplyFromConfig) as unknown as ReturnType<typeof vi.fn>;
       await connectOk(ws);
 
       await createSessionDir();
@@ -146,8 +147,8 @@ describe("gateway server chat", () => {
       testState.agentConfig = { blockStreamingDefault: "on" };
       try {
         spy.mockReset();
-        let capturedOpts: Parameters<typeof getReplyFromConfig>[1];
-        spy.mockImplementationOnce(async (_ctx, opts) => {
+        let capturedOpts: GetReplyOptions | undefined;
+        spy.mockImplementationOnce(async (_ctx: unknown, opts?: GetReplyOptions) => {
           capturedOpts = opts;
         });
 

--- a/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
@@ -139,7 +139,7 @@ describe("gateway server chat", () => {
 
   test("chat.send does not force-disable block streaming", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
-      const spy = vi.mocked(getReplyFromConfig) as unknown as ReturnType<typeof vi.fn>;
+      const spy = getReplyFromConfig;
       await connectOk(ws);
 
       await createSessionDir();
@@ -288,7 +288,7 @@ describe("gateway server chat", () => {
 
   test("smoke: supports abort and idempotent completion", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
-      const spy = vi.mocked(getReplyFromConfig) as unknown as ReturnType<typeof vi.fn>;
+      const spy = getReplyFromConfig;
       let aborted = false;
       await connectOk(ws);
 

--- a/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
@@ -138,7 +138,7 @@ describe("gateway server chat", () => {
 
   test("chat.send does not force-disable block streaming", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
-      const spy = vi.mocked(getReplyFromConfig) as unknown as ReturnType<typeof vi.fn>;
+      const spy = vi.mocked(getReplyFromConfig);
       await connectOk(ws);
 
       await createSessionDir();
@@ -146,9 +146,9 @@ describe("gateway server chat", () => {
       testState.agentConfig = { blockStreamingDefault: "on" };
       try {
         spy.mockReset();
-        let capturedOpts: Record<string, unknown> | undefined;
+        let capturedOpts: Parameters<typeof getReplyFromConfig>[1];
         spy.mockImplementationOnce(async (_ctx, opts) => {
-          capturedOpts = opts as Record<string, unknown> | undefined;
+          capturedOpts = opts;
         });
 
         const sendRes = await rpcReq(ws, "chat.send", {

--- a/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
@@ -136,6 +136,42 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.send does not force-disable block streaming", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const spy = vi.mocked(getReplyFromConfig) as unknown as ReturnType<typeof vi.fn>;
+      await connectOk(ws);
+
+      await createSessionDir();
+      await writeMainSessionStore();
+      testState.agentConfig = { blockStreamingDefault: "on" };
+      try {
+        spy.mockReset();
+        let capturedOpts: Record<string, unknown> | undefined;
+        spy.mockImplementationOnce(async (_ctx, opts) => {
+          capturedOpts = opts as Record<string, unknown> | undefined;
+        });
+
+        const sendRes = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "hello",
+          idempotencyKey: "idem-block-streaming",
+        });
+        expect(sendRes.ok).toBe(true);
+
+        await vi.waitFor(
+          () => {
+            expect(spy.mock.calls.length).toBeGreaterThan(0);
+          },
+          { timeout: 2_000, interval: 10 },
+        );
+
+        expect(capturedOpts?.disableBlockStreaming).toBeUndefined();
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
   test("chat.history hard-caps single oversized nested payloads", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const historyMaxBytes = 64 * 1024;

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -4,7 +4,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Mock, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { GetReplyOptions, ReplyPayload } from "../auto-reply/types.js";
 import type { ChannelPlugin, ChannelOutboundAdapter } from "../channels/plugins/types.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { AgentBinding } from "../config/types.agents.js";
 import type { HooksConfig } from "../config/types.hooks.js";
@@ -18,6 +21,12 @@ type StubChannelOptions = {
   label: string;
   summary?: Record<string, unknown>;
 };
+
+type GetReplyFromConfigFn = (
+  ctx: MsgContext,
+  opts?: GetReplyOptions,
+  configOverride?: OpenClawConfig,
+) => Promise<ReplyPayload | ReplyPayload[] | undefined>;
 
 const createStubOutboundAdapter = (channelId: ChannelPlugin["id"]): ChannelOutboundAdapter => ({
   deliveryMode: "direct",
@@ -169,7 +178,7 @@ const hoisted = vi.hoisted(() => ({
     waitResults: new Map<string, boolean>(),
   },
   testTailscaleWhois: { value: null as TailscaleWhoisIdentity | null },
-  getReplyFromConfig: vi.fn().mockResolvedValue(undefined),
+  getReplyFromConfig: vi.fn<GetReplyFromConfigFn>().mockResolvedValue(undefined),
   sendWhatsAppMock: vi.fn().mockResolvedValue({ messageId: "msg-1", toJid: "jid-1" }),
 }));
 
@@ -202,7 +211,7 @@ export const testTailscaleWhois = hoisted.testTailscaleWhois;
 export const piSdkMock = hoisted.piSdkMock;
 export const cronIsolatedRun = hoisted.cronIsolatedRun;
 export const agentCommand: Mock<() => void> = hoisted.agentCommand;
-export const getReplyFromConfig: Mock<() => void> = hoisted.getReplyFromConfig;
+export const getReplyFromConfig: Mock<GetReplyFromConfigFn> = hoisted.getReplyFromConfig;
 
 export const testState = {
   agentConfig: undefined as Record<string, unknown> | undefined,


### PR DESCRIPTION
## Summary

The chat.send handler was hardcoding `disableBlockStreaming: true`, which overrode the `agents.defaults.blockStreamingDefault` config setting. This caused TUI to ignore the blockStreamingDefault config and always stream token-by-token, overwriting previous content.

## Root Cause

In `src/gateway/server-methods/chat.ts` at line 901, the webchat dispatch was setting:
```typescript
disableBlockStreaming: true,
```

This hardcoded value prevented users from using `blockStreamingDefault: on` to get complete response blocks in TUI, unlike Telegram which respects this config.

## Fix

Remove the hardcoded `disableBlockStreaming: true` so that the agent configuration `agents.defaults.blockStreamingDefault` is respected for TUI/webchat just like other channels.

Now users can set `blockStreamingDefault: on` in their config to get complete response blocks instead of streaming token-by-token.

## Fixes

- Fixes #19643

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes three distinct changes:

1. **Removes hardcoded `disableBlockStreaming: true`** from the TUI/webchat chat handler (`chat.ts`), allowing the `blockStreamingDefault` agent config to take effect for webchat — consistent with how other channels (e.g., Telegram) already behave.

2. **Removes dynamic timestamp generation from system prompt params** (`system-prompt-params.ts`), removing imports of `formatUserTime`/`resolveUserTimeFormat` and no longer returning `userTime`/`userTimeFormat`. This is done intentionally to avoid breaking Anthropic prompt caching. The `SystemPromptRuntimeParams` type still declares these as optional, and all callers gracefully handle `undefined`, so this is safe. Agents can use `session_status` to get the current time instead.

3. **Changes the `elevatedDefault` fallback from `"on"` to `"off"`** in `get-reply-directives.ts`. This is a behavioral change that means elevated mode will default to off when no explicit config is set.

- The `elevatedDefault` fallback change introduces an inconsistency: `directive-handling.persist.ts:73` and `status.ts:391` still fall back to `"on"`, which may cause the status display to report a different elevated level than what is actually applied at runtime.

<h3>Confidence Score: 3/5</h3>

- The core `disableBlockStreaming` fix is straightforward and safe, but the `elevatedDefault` fallback change introduces inconsistency with other code paths.
- The main fix (removing `disableBlockStreaming: true`) and the prompt caching improvement (removing `userTime`) are clean and correct. However, changing the `elevatedDefault` fallback from "on" to "off" in only one of three locations that resolve this value creates a behavioral inconsistency where status reporting and change-detection logic disagree with the actual runtime behavior.
- Pay close attention to `src/auto-reply/reply/get-reply-directives.ts` — the `elevatedDefault` fallback change has inconsistencies with `src/auto-reply/reply/directive-handling.persist.ts` and `src/auto-reply/status.ts`.

<sub>Last reviewed commit: 32d64a4</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->