### PR TITLE
fix(macos): handle .gateway deep link route in DeepLinkHandler

### DIFF
--- a/apps/macos/Sources/OpenClaw/DeepLinks.swift
+++ b/apps/macos/Sources/OpenClaw/DeepLinks.swift
@@ -67,6 +67,8 @@ final class DeepLinkHandler {
         switch route {
         case let .agent(link):
             await self.handleAgent(link: link, originalURL: url)
+        case .gateway:
+            break
         }
     }
 


### PR DESCRIPTION
## Summary
- The `DeepLinkRoute` enum gained a `.gateway(GatewayConnectDeepLink)` case but the macOS `DeepLinkHandler.handle(url:)` switch was not updated, causing a Swift build error: `switch must be exhaustive`
- Adds `case .gateway: break` to match the existing iOS implementation in `NodeAppModel.handleDeepLink`
- Without this fix, the macOS app fails to compile after pulling recent changes

## Test plan
- [ ] Verify `swift build` succeeds in `apps/macos/`
- [ ] Verify deep link handling still works for `.agent` routes
- [ ] Verify `.gateway` deep links are gracefully ignored (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds handling for the `.gateway` case to the macOS `DeepLinkHandler.handle(url:)` switch statement to fix a Swift build error.

- The `DeepLinkRoute` enum gained a `.gateway(GatewayConnectDeepLink)` case in the shared `OpenClawKit` module
- The macOS `DeepLinkHandler` was missing this case, causing a "switch must be exhaustive" compiler error
- The fix adds `case .gateway: break` to match the iOS implementation in `NodeAppModel.handleDeepLink`
- Gateway deep links are intentionally ignored on macOS (no-op), consistent with iOS behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a minimal exhaustive-switch fix that adds a no-op case for `.gateway` deep links, matching the existing iOS implementation. The fix unblocks the macOS build without changing any functional behavior.
- No files require special attention

<sub>Last reviewed commit: 2596c5e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->