### PR TITLE
fix(gateway): allow health method for all authenticated roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.
 - Gateway/Hooks: include transform export name in hook-transform cache keys so distinct exports from the same module do not reuse the wrong cached transform function. (#13855) thanks @mcaxtr.
 - Gateway/Control UI: return 404 for missing static-asset paths instead of serving SPA fallback HTML, while preserving client-route fallback behavior for extensionless and non-asset dotted paths. (#12060) thanks @mcaxtr.
 - Gateway/Pairing: prevent device-token rotate scope escalation by enforcing an approved-scope baseline, preserving approved scopes across metadata updates, and rejecting rotate requests that exceed approved role scope implications. (#20703) thanks @coygeek.

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -39,6 +39,9 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
   if (!client?.connect) {
     return null;
   }
+  if (method === "health") {
+    return null;
+  }
   const role = client.connect.role ?? "operator";
   const scopes = client.connect.scopes ?? [];
   if (isNodeRoleMethod(method)) {

--- a/src/gateway/server.roles-allowlist-update.e2e.test.ts
+++ b/src/gateway/server.roles-allowlist-update.e2e.test.ts
@@ -96,6 +96,9 @@ describe("gateway role enforcement", () => {
       const statusRes = await rpcReq(nodeWs, "status", {});
       expect(statusRes.ok).toBe(false);
       expect(statusRes.error?.message ?? "").toContain("unauthorized role");
+
+      const healthRes = await rpcReq(nodeWs, "health", {});
+      expect(healthRes.ok).toBe(true);
     } finally {
       nodeWs.close();
     }


### PR DESCRIPTION
## Summary
- `authorizeGatewayMethod` rejects `health` calls from connections with role `node` or `operator` without admin scope
- Paired devices (macOS/iOS apps) connect as role `node` and spam `unauthorized role: node` errors on every health check, flooding the gateway log and breaking node<->gateway communication
- Fix: add early return for `method === "health"` before role checks — health is a read-only status probe and should be allowed for any authenticated connection

## Reproduction
1. Pair a macOS app with the gateway
2. The app connects with role `node` and periodically sends `health` RPC
3. Gateway rejects every health call → log floods with `unauthorized role: node`
4. App shows "thinking..." but never receives replies

## Test plan
- [ ] Verify paired macOS/iOS node can successfully call `health` 
- [ ] Verify `health` no longer produces `unauthorized role` log spam
- [ ] Verify role restrictions still apply to other methods (send, agent, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Allows `health` method calls from any authenticated role by adding an early return before role checks. This fixes log spam and broken communication when paired macOS/iOS devices (with role `node`) send periodic health checks to the gateway.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a legitimate authorization issue
- The fix correctly allows health checks from node-role connections, which are read-only status probes. The change is minimal (3 lines), well-scoped, and consistent with `health` being in `READ_METHODS`
- No files require special attention

<sub>Last reviewed commit: 520da47</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->