### PR TITLE
test: harden Telegram command menu sanitization coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Tests/Telegram: add regression coverage that asserts all `setMyCommands` entries are Telegram-safe and hyphen-normalized across native/custom/plugin command sources. (#19703) Thanks @obviyus.
 - Agents/Image: collapse resize diagnostics to one line per image and include visible pixel/byte size details in the log message for faster triage.
 - Agents/Subagents: preemptively guard accumulated tool-result context before model calls by truncating oversized outputs and compacting oldest tool-result messages to avoid context-window overflow crashes. Thanks @tyler6204.
 - Agents/Subagents: add explicit subagent guidance to recover from `[compacted: tool output removed to free context]` / `[truncated: output exceeded context limit]` markers by re-reading with smaller chunks instead of full-file `cat`. Thanks @tyler6204.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Tests/Telegram: add regression coverage that asserts all `setMyCommands` entries are Telegram-safe and hyphen-normalized across native/custom/plugin command sources. (#19703) Thanks @obviyus.
+- Tests/Telegram: add regression coverage for command-menu sync that asserts all `setMyCommands` entries are Telegram-safe and hyphen-normalized across native/custom/plugin command sources. (#19703) Thanks @obviyus.
 - Agents/Image: collapse resize diagnostics to one line per image and include visible pixel/byte size details in the log message for faster triage.
 - Agents/Subagents: preemptively guard accumulated tool-result context before model calls by truncating oversized outputs and compacting oldest tool-result messages to avoid context-window overflow crashes. Thanks @tyler6204.
 - Agents/Subagents: add explicit subagent guidance to recover from `[compacted: tool output removed to free context]` / `[truncated: output exceeded context limit]` markers by re-reading with smaller chunks instead of full-file `cat`. Thanks @tyler6204.

--- a/src/telegram/bot-native-command-menu.test.ts
+++ b/src/telegram/bot-native-command-menu.test.ts
@@ -50,6 +50,16 @@ describe("bot-native-command-menu", () => {
     expect(result.issues).toContain('Plugin command "/empty" is missing a description.');
   });
 
+  it("normalizes hyphenated plugin command names", () => {
+    const result = buildPluginTelegramMenuCommands({
+      specs: [{ name: "agent-run", description: "Run agent" }],
+      existingCommands: new Set<string>(),
+    });
+
+    expect(result.commands).toEqual([{ command: "agent_run", description: "Run agent" }]);
+    expect(result.issues).toEqual([]);
+  });
+
   it("deletes stale commands before setting new menu", async () => {
     const callOrder: string[] = [];
     const deleteMyCommands = vi.fn(async () => {

--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { STATE_DIR } from "../config/paths.js";
+import { TELEGRAM_COMMAND_NAME_PATTERN } from "../config/telegram-custom-commands.js";
 import type { TelegramAccountConfig } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
@@ -178,6 +179,53 @@ describe("registerTelegramNativeCommands", () => {
     const registeredHandlers = command.mock.calls.map(([name]) => name);
     expect(registeredHandlers).toContain("export_session");
     expect(registeredHandlers).not.toContain("export-session");
+  });
+
+  it("registers only Telegram-safe command names across native, custom, and plugin sources", async () => {
+    const setMyCommands = vi.fn().mockResolvedValue(undefined);
+
+    pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
+      { name: "plugin-status", description: "Plugin status" },
+      { name: "plugin@bad", description: "Bad plugin command" },
+    ] as never);
+
+    registerTelegramNativeCommands({
+      ...buildParams({}),
+      bot: {
+        api: {
+          setMyCommands,
+          sendMessage: vi.fn().mockResolvedValue(undefined),
+        },
+        command: vi.fn(),
+      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+      telegramCfg: {
+        customCommands: [
+          { command: "custom-backup", description: "Custom backup" },
+          { command: "custom!bad", description: "Bad custom command" },
+        ],
+      } as TelegramAccountConfig,
+    });
+
+    await vi.waitFor(() => {
+      expect(setMyCommands).toHaveBeenCalled();
+    });
+
+    const registeredCommands = setMyCommands.mock.calls[0]?.[0] as Array<{
+      command: string;
+      description: string;
+    }>;
+
+    expect(registeredCommands.length).toBeGreaterThan(0);
+    for (const entry of registeredCommands) {
+      expect(entry.command.includes("-")).toBe(false);
+      expect(TELEGRAM_COMMAND_NAME_PATTERN.test(entry.command)).toBe(true);
+    }
+
+    expect(registeredCommands.some((entry) => entry.command === "export_session")).toBe(true);
+    expect(registeredCommands.some((entry) => entry.command === "custom_backup")).toBe(true);
+    expect(registeredCommands.some((entry) => entry.command === "plugin_status")).toBe(true);
+    expect(registeredCommands.some((entry) => entry.command === "plugin-status")).toBe(false);
+    expect(registeredCommands.some((entry) => entry.command === "custom-bad")).toBe(false);
   });
 
   it("passes agent-scoped media roots for plugin command replies with media", async () => {


### PR DESCRIPTION
## Summary
- add an aggregate Telegram registration test that asserts every command sent to `setMyCommands` is Telegram-safe (`^[a-z0-9_]{1,32}$`) and contains no hyphens
- cover mixed command sources in one check (native + custom + plugin) and verify hyphenated names normalize to underscores
- add a focused unit test for plugin command hyphen normalization (`agent-run` -> `agent_run`)

## Testing
- pnpm exec vitest src/telegram/bot-native-commands.test.ts src/telegram/bot-native-command-menu.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive test coverage for Telegram command sanitization to ensure all command names conform to Telegram's naming requirements (`^[a-z0-9_]{1,32}$`).

The changes include:
- A focused unit test verifying hyphenated plugin command names are normalized to underscores (`agent-run` → `agent_run`)
- An aggregate integration test that validates all command sources (native, custom, and plugin) are sanitized correctly before registration with `setMyCommands`
- Coverage for edge cases including invalid characters and hyphen normalization across all command types

The tests properly exercise the existing `normalizeTelegramCommandName` function and verify its integration with the command registration flow.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Pure test additions with clear assertions, no behavior changes to production code, follows existing test patterns
- No files require special attention

<sub>Last reviewed commit: e094cc6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->