### PR TITLE
fix: inject timestamp into channel message agent context (#16442)

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -297,6 +297,7 @@ export async function runPreparedReply(
             : {}),
         }
       : { ...sessionCtx, ThreadStarterBody: undefined },
+    { userTimezone: cfg.agents?.defaults?.userTimezone },
   );
   const baseBodyForPrompt = isBareSessionReset
     ? baseBodyFinal

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -2,6 +2,7 @@ import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveSenderLabel } from "../../channels/sender-label.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
 import type { TemplateContext } from "../templating.js";
+import { resolveUserTimezone } from "../../agents/date-time.js";
 
 function safeTrim(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -80,8 +81,29 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   ].join("\n");
 }
 
-export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
+export function buildInboundUserContextPrefix(
+  ctx: TemplateContext,
+  opts?: { userTimezone?: string },
+): string {
   const blocks: string[] = [];
+
+  // Inject timestamp for channel messages so the agent knows when the message
+  // was sent. TUI/web messages get timestamps via injectTimestamp() in
+  // agent-timestamp.ts; channel messages set ctx.Timestamp instead.
+  // See: https://github.com/openclaw/openclaw/issues/16442
+  if (typeof ctx.Timestamp === "number" && ctx.Timestamp > 0) {
+    const tz = resolveUserTimezone(opts?.userTimezone);
+    const msgDate = new Date(ctx.Timestamp);
+    const formatted = formatZonedTimestamp(msgDate, { timeZone: tz });
+    if (formatted) {
+      const dow = new Intl.DateTimeFormat("en-US", {
+        timeZone: tz,
+        weekday: "short",
+      }).format(msgDate);
+      blocks.push(`[${dow} ${formatted}]`);
+    }
+  }
+
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
 


### PR DESCRIPTION
## Summary

- Channel messages (Telegram, Discord, Signal, iMessage, LINE, Slack) lack timestamps in the agent prompt, breaking time-sensitive features (reminders, "what time is it?", scheduling)
- The envelope timestamp exists in `Body` but `BodyForAgent` is set to raw text, and the prompt reads `BodyForAgent` first — so `Body` is never reached
- This adds timestamp injection in `buildInboundUserContextPrefix()` using `ctx.Timestamp`, matching the `[DOW YYYY-MM-DD HH:MM TZ]` format used by `injectTimestamp()` for TUI/web messages

## Why this approach

All 6 channel handlers set `ctx.Timestamp` from their platform-specific message timestamps, but none of them surface it in the agent prompt. Rather than fixing `BodyForAgent` in each channel handler (6 files), this injects the timestamp centrally in `buildInboundUserContextPrefix()` (2 files).

No double-stamping risk: channel messages set `ctx.Timestamp` but don't go through `injectTimestamp()`; TUI/web messages go through `injectTimestamp()` but never set `ctx.Timestamp`.

## What changes

| File | Change |
|------|--------|
| `src/auto-reply/reply/inbound-meta.ts` | `buildInboundUserContextPrefix()` accepts optional `opts.userTimezone`, prepends `[DOW YYYY-MM-DD HH:MM TZ]` when `ctx.Timestamp` is set |
| `src/auto-reply/reply/get-reply-run.ts` | Passes `cfg.agents.defaults.userTimezone` to the function |

## Test plan

- [x] Built from source, deployed to personal OpenClaw instance (v2026.2.15)
- [x] Verified via Telegram DM — agent correctly sees message timestamp
- [x] No runtime errors after deployment
- [x] Confirmed no double-stamping with TUI/web path

Closes #16442

## Related issues

- #10841 — Reminders set for wrong times because agent doesn't know current time
- #21234 — Feature: Inject current timestamp into every agent message context
- #11703 — Batch WhatsApp messages by messageTimestamp instead of receive time

🤖 Generated with [Claude Code](https://claude.com/claude-code) — AI-assisted, fully tested on a live instance