### PR TITLE
fix(telegram): restart polling runner on unhandled network errors (fetch failed)

### DIFF
--- a/src/agents/pi-embedded-runner/google.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/google.e2e.test.ts
@@ -33,4 +33,70 @@ describe("sanitizeToolsForGoogle", () => {
     expect(params.additionalProperties).toBeUndefined();
     expect(params.properties?.foo?.format).toBeUndefined();
   });
+
+  it("preserves properties whose names match unsupported schema keywords", () => {
+    const tool = {
+      name: "test",
+      description: "test",
+      parameters: {
+        type: "object",
+        properties: {
+          format: { type: "string" },
+          pattern: { type: "string" },
+          minimum: { type: "number" },
+        },
+      },
+      execute: async () => ({ ok: true, content: [] }),
+    } as unknown as AgentTool;
+
+    const [sanitized] = sanitizeToolsForGoogle({
+      tools: [tool],
+      provider: "google-gemini-cli",
+    });
+
+    const params = sanitized.parameters as {
+      properties?: Record<string, unknown>;
+    };
+
+    // Property NAMES that happen to match unsupported keywords must be preserved.
+    // Only the keywords themselves (at the schema level) should be stripped.
+    expect(params.properties?.format).toEqual({ type: "string" });
+    expect(params.properties?.pattern).toEqual({ type: "string" });
+    expect(params.properties?.minimum).toEqual({ type: "number" });
+  });
+
+  it("preserves keyword-named properties inside nested schemas", () => {
+    const tool = {
+      name: "test",
+      description: "test",
+      parameters: {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                format: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      execute: async () => ({ ok: true, content: [] }),
+    } as unknown as AgentTool;
+
+    const [sanitized] = sanitizeToolsForGoogle({
+      tools: [tool],
+      provider: "google-gemini-cli",
+    });
+
+    const params = sanitized.parameters as {
+      properties?: Record<string, { items?: { properties?: Record<string, unknown> } }>;
+    };
+
+    expect(params.properties?.items?.items?.properties?.format).toEqual({
+      type: "string",
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -248,7 +248,23 @@ function stripUnsupportedSchemaKeywords(schema: unknown): unknown {
     return schema.map((item) => stripUnsupportedSchemaKeywords(item));
   }
   const record = { ...(schema as Record<string, unknown>) };
+  // Recurse into properties values without checking property names against the keyword set,
+  // mirroring the approach in findUnsupportedSchemaKeywords.
+  if (
+    record.properties &&
+    typeof record.properties === "object" &&
+    !Array.isArray(record.properties)
+  ) {
+    const props = { ...(record.properties as Record<string, unknown>) };
+    for (const key of Object.keys(props)) {
+      props[key] = stripUnsupportedSchemaKeywords(props[key]);
+    }
+    record.properties = props;
+  }
   for (const key of Object.keys(record)) {
+    if (key === "properties") {
+      continue;
+    }
     if (GOOGLE_SCHEMA_UNSUPPORTED_KEYWORDS.has(key)) {
       delete record[key];
       continue;

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -217,6 +217,8 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           }
         }
       } catch (err) {
+        // Reset flag so a stale forceRestarted doesn't cause a spurious restart next iteration.
+        forceRestarted = false;
         if (opts.abortSignal?.aborted) {
           throw err;
         }


### PR DESCRIPTION
## Problem
When using the Telegram polling mode with Node 18+ (undici/fetch), transient network errors like `TypeError: fetch failed` or `EAI_AGAIN` can bubble up as **unhandled rejections** instead of being caught by the `grammy/runner` loop.

When this happens, the current runner instance enters a zombie state where it stops polling but doesn't exit, causing the bot to go "deaf" indefinitely until the process is restarted.

## Fix
This patch updates the unhandled rejection handler in `monitorTelegramProvider` to:
1.  Detect recoverable network errors (using existing `isRecoverableTelegramNetworkError`).
2.  Check if the active runner is running.
3.  Explicitly call `activeRunner.stop()` if a critical network error occurred outside the runner's catch block.

Stopping the runner causes the main `runner.task()` promise to resolve/reject, allowing the surrounding `while` loop to catch the event, apply backoff, and **restart** a fresh runner instance.

## Testing
- Verified locally by simulating unhandled fetch errors.
- Prevents the need for external process restarts when Telegram connectivity flakes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens resilience across three areas: Telegram polling recovery, Google Gemini tool schema sanitization, and embedded agent streaming stability.

- **Telegram polling**: Adds detection of unhandled `TypeError: fetch failed` rejections (from undici/fetch in Node 18+) that leave the grammyjs runner in a zombie state. The rejection handler now sets a `forceRestarted` flag, stops the runner, and the main loop restarts with exponential backoff. The flag is properly consumed in both the try and catch paths to prevent spurious double-restarts.
- **Google tool schema fix**: `stripUnsupportedSchemaKeywords` now mirrors `findUnsupportedSchemaKeywords` by recursing into `properties` values without treating property **names** as schema keywords. Previously, tool properties named `format`, `pattern`, `minimum`, etc. would be silently deleted. Two new tests verify preservation of keyword-named properties in flat and nested schemas.
- **Streaming inactivity watchdog**: A new watchdog in `attempt.ts` aborts runs that receive no SSE events for 90 seconds, preventing silent hangs. A `streamWatchdogDone` flag prevents rescheduling after run completion, and cleanup is handled in the `finally` block.
- **`onPromptCycleStart` callback**: Threaded from `RunEmbeddedPiAgentParams` through `run.ts` into `attempt.ts`, triggering typing indicator refresh before each prompt cycle.
- **Stall notifications**: Users now receive "Response stalled — retrying..." messages (with incrementing retry counts) when profile rotation occurs due to timeouts.
- **Tool-active timeout guard**: Timeouts during active tool use (exec, sub-agents) no longer trigger profile rotation, preventing unnecessary auth cooldowns.
- **Import cleanup**: Deduplicated `resolveEnforceFinalTag` import in `agent-runner-execution.ts` (merge artifact).
- **Antigravity thinking block sanitization**: `transformContext` hook now set via `Record<string, unknown>` with a runtime reference check to detect upstream API changes.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — all prior review issues have been addressed, and the changes add resilience without altering existing successful-path behavior.
- Score of 4 reflects that the changes are well-structured hardening improvements with proper edge case handling (flag resets in both try/catch, watchdog cleanup in finally blocks), backed by new tests for the schema fix. The streaming watchdog and forced-restart patterns are inherently racy by nature but are implemented with appropriate guards. No new issues found beyond those already addressed in prior review threads.
- `src/telegram/monitor.ts` and `src/agents/pi-embedded-runner/run/attempt.ts` warrant careful attention as they contain the most complex new control flow (rejection-handler-driven restart and streaming inactivity watchdog).

<sub>Last reviewed commit: 0e1111f</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->