### PR TITLE
feat(webchat): add cursor-based pagination to chat.history

### DIFF
--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -27,6 +27,7 @@ export const ChatHistoryParamsSchema = Type.Object(
   {
     sessionKey: NonEmptyString,
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+    before: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
 );

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -809,6 +809,7 @@ export function renderApp(state: AppViewState) {
                 thinkingLevel: state.chatThinkingLevel,
                 showThinking,
                 loading: state.chatLoading,
+                loadingOlder: state.chatLoadingOlder,
                 sending: state.chatSending,
                 compactionStatus: state.compactionStatus,
                 assistantAvatarUrl: chatAvatarUrl,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -45,6 +45,7 @@ function createScrollHost(
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
     topbarObserver: null as ResizeObserver | null,
+    onLoadOlderMessages: null as (() => void) | null,
   };
 
   return { host, container };

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -13,6 +13,7 @@ type ScrollHost = {
   logsScrollFrame: number | null;
   logsAtBottom: boolean;
   topbarObserver: ResizeObserver | null;
+  onLoadOlderMessages?: (() => void) | null;
 };
 
 export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
@@ -119,6 +120,9 @@ export function scheduleLogsScroll(host: ScrollHost, force = false) {
   });
 }
 
+/** Distance (px) from the top within which we trigger loading older messages. */
+const NEAR_TOP_THRESHOLD = 200;
+
 export function handleChatScroll(host: ScrollHost, event: Event) {
   const container = event.currentTarget as HTMLElement | null;
   if (!container) {
@@ -129,6 +133,10 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   // Clear the "new messages below" indicator when user scrolls back to bottom.
   if (host.chatUserNearBottom) {
     host.chatNewMessagesBelow = false;
+  }
+  // Trigger loading older messages when user scrolls near the top.
+  if (container.scrollTop < NEAR_TOP_THRESHOLD && host.onLoadOlderMessages) {
+    host.onLoadOlderMessages();
   }
 }
 

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -52,6 +52,7 @@ export type AppViewState = {
   assistantAgentId: string | null;
   sessionKey: string;
   chatLoading: boolean;
+  chatLoadingOlder: boolean;
   chatSending: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
@@ -60,6 +61,8 @@ export type AppViewState = {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
+  chatCursor: number | null;
+  chatHasMore: boolean;
   compactionStatus: CompactionStatus | null;
   chatAvatarUrl: string | null;
   chatThinkingLevel: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -16,6 +16,7 @@ import {
 } from "./app-channels.ts";
 import {
   handleAbortChat as handleAbortChatInternal,
+  handleLoadOlderChat as handleLoadOlderChatInternal,
   handleSendChat as handleSendChatInternal,
   removeQueuedMessage as removeQueuedMessageInternal,
 } from "./app-chat.ts";
@@ -132,6 +133,7 @@ export class OpenClawApp extends LitElement {
 
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;
+  @state() chatLoadingOlder = false;
   @state() chatSending = false;
   @state() chatMessage = "";
   @state() chatMessages: unknown[] = [];
@@ -139,6 +141,8 @@ export class OpenClawApp extends LitElement {
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
+  @state() chatCursor: number | null = null;
+  @state() chatHasMore = false;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
@@ -353,6 +357,10 @@ export class OpenClawApp extends LitElement {
   private themeMedia: MediaQueryList | null = null;
   private themeMediaHandler: ((event: MediaQueryListEvent) => void) | null = null;
   private topbarObserver: ResizeObserver | null = null;
+  onLoadOlderMessages: (() => void) | null = () =>
+    void handleLoadOlderChatInternal(
+      this as unknown as Parameters<typeof handleLoadOlderChatInternal>[0],
+    );
 
   createRenderRoot() {
     return this;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -5,6 +5,7 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
   return {
     chatAttachments: [],
     chatLoading: false,
+    chatLoadingOlder: false,
     chatMessage: "",
     chatMessages: [],
     chatRunId: null,
@@ -12,6 +13,8 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     chatStream: null,
     chatStreamStartedAt: null,
     chatThinkingLevel: null,
+    chatCursor: null,
+    chatHasMore: false,
     client: null,
     connected: true,
     lastError: null,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -57,6 +57,7 @@ export type ChatProps = {
   // Scroll control
   showNewMessages?: boolean;
   onScrollToBottom?: () => void;
+  loadingOlder?: boolean;
   // Event handlers
   onRefresh: () => void;
   onToggleFocusMode: () => void;
@@ -214,6 +215,13 @@ export function renderChat(props: ChatProps) {
       aria-live="polite"
       @scroll=${props.onChatScroll}
     >
+      ${
+        props.loadingOlder
+          ? html`
+              <div class="muted">Loading older messages…</div>
+            `
+          : nothing
+      }
       ${
         props.loading
           ? html`


### PR DESCRIPTION
## Summary

The `chat.history` endpoint previously returned only the last 200 messages (hard-capped at 1000) with no way to fetch older ones. Users with long conversations could not scroll back to the beginning.

This adds backward pagination:

- **Server**: New optional `before` parameter on `chat.history` — returns messages preceding the given index. Response now includes `cursor` (index of first returned message) and `hasMore` (whether older messages exist).
- **Client**: Detects when user scrolls near the top of the chat thread and automatically fetches the previous page of messages, preserving scroll position. Shows a "Loading older messages..." indicator during fetch.

Backward-compatible: existing callers that don't send `before` get the same behavior as before, plus the new `cursor`/`hasMore` metadata.

## Test plan

- [ ] Extended existing e2e test (300 messages) to verify `before` cursor returns messages 0-99 after initial load returns 100-299
- [ ] Verified `cursor` and `hasMore` fields in both default and paginated responses
- [ ] Updated `ChatState` type and all test stubs to include new fields
- [ ] TypeScript compiles cleanly (0 errors)
- [ ] All 439 gateway tests pass

**Note**: Full build and e2e tests require Node >= 22 (environment has Node 20). TypeScript type-checking and gateway unit tests confirmed clean.

**Related upstream issues**: #19060 (beginning truncation), #13703 (mid-sentence truncation), PR #19343 (chat state refactor), PR #16020 (virtual scrolling — complementary future work)

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)