### PR TITLE
Fix HTML entity decoding for astral code points and surrogate-safe truncation

### DIFF
--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { htmlToMarkdown, truncateText } from "./web-fetch-utils.js";
+
+describe("htmlToMarkdown", () => {
+  it("decodes basic HTML entities", () => {
+    const result = htmlToMarkdown("<p>&amp; &lt; &gt; &quot; &#39;</p>");
+    expect(result.text).toBe("& < > \" '");
+  });
+
+  it("decodes numeric HTML entities for ASCII", () => {
+    const result = htmlToMarkdown("<p>&#65;&#66;&#67;</p>");
+    expect(result.text).toBe("ABC");
+  });
+
+  it("decodes hex HTML entities for BMP characters", () => {
+    const result = htmlToMarkdown("<p>&#x41;&#x42;&#x43;</p>");
+    expect(result.text).toBe("ABC");
+  });
+
+  it("decodes hex HTML entities for astral code points (emoji)", () => {
+    // &#x1F600; = 😀 (U+1F600, grinning face)
+    const result = htmlToMarkdown("<p>&#x1F600;</p>");
+    expect(result.text).toBe("😀");
+  });
+
+  it("decodes decimal HTML entities for astral code points (emoji)", () => {
+    // &#128512; = 😀 (U+1F600)
+    const result = htmlToMarkdown("<p>&#128512;</p>");
+    expect(result.text).toBe("😀");
+  });
+
+  it("handles invalid code points gracefully", () => {
+    // Code point beyond Unicode max
+    const result = htmlToMarkdown("<p>&#x110000;</p>");
+    expect(result.text).toBe("");
+  });
+
+  it("extracts title", () => {
+    const result = htmlToMarkdown(
+      "<html><head><title>Hello</title></head><body>World</body></html>",
+    );
+    expect(result.title).toBe("Hello");
+    expect(result.text).toContain("World");
+  });
+
+  it("strips script and style tags", () => {
+    const result = htmlToMarkdown(
+      "<p>visible</p><script>alert(1)</script><style>.x{}</style><p>also visible</p>",
+    );
+    expect(result.text).not.toContain("alert");
+    expect(result.text).not.toContain(".x{}");
+    expect(result.text).toContain("visible");
+    expect(result.text).toContain("also visible");
+  });
+});
+
+describe("truncateText", () => {
+  it("returns unchanged text when within limit", () => {
+    const result = truncateText("hello", 10);
+    expect(result).toEqual({ text: "hello", truncated: false });
+  });
+
+  it("truncates text at the limit", () => {
+    const result = truncateText("hello world", 5);
+    expect(result.text).toBe("hello");
+    expect(result.truncated).toBe(true);
+  });
+
+  it("does not split a surrogate pair", () => {
+    // 😀 is "\uD83D\uDE00" (2 UTF-16 code units)
+    const input = "a😀b";
+    // input.length === 4: 'a'(1) + surrogate pair(2) + 'b'(1)
+    // Cutting at 2 would land between the high and low surrogate
+    const result = truncateText(input, 2);
+    expect(result.truncated).toBe(true);
+    // Should step back to avoid splitting the pair
+    expect(result.text).toBe("a");
+    expect(result.text.length).toBe(1);
+  });
+
+  it("preserves a surrogate pair when limit includes both units", () => {
+    const input = "a😀b";
+    const result = truncateText(input, 3);
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe("a😀");
+  });
+
+  it("handles empty string", () => {
+    const result = truncateText("", 5);
+    expect(result).toEqual({ text: "", truncated: false });
+  });
+
+  it("handles zero maxChars", () => {
+    const result = truncateText("hello", 0);
+    expect(result.text).toBe("");
+    expect(result.truncated).toBe(true);
+  });
+});

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -40,8 +40,14 @@ function decodeEntities(value: string): string {
     .replace(/&#39;/gi, "'")
     .replace(/&lt;/gi, "<")
     .replace(/&gt;/gi, ">")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCharCode(Number.parseInt(hex, 16)))
-    .replace(/&#(\d+);/gi, (_, dec) => String.fromCharCode(Number.parseInt(dec, 10)));
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => {
+      const cp = Number.parseInt(hex, 16);
+      return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
+    })
+    .replace(/&#(\d+);/gi, (_, dec) => {
+      const cp = Number.parseInt(dec, 10);
+      return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
+    });
 }
 
 function stripTags(value: string): string {
@@ -109,7 +115,16 @@ export function truncateText(
   if (value.length <= maxChars) {
     return { text: value, truncated: false };
   }
-  return { text: value.slice(0, maxChars), truncated: true };
+  // Avoid splitting a UTF-16 surrogate pair: if the char at the cut point is a
+  // high surrogate (0xD800–0xDBFF), step back one position so the pair stays intact.
+  let end = maxChars;
+  if (end > 0 && end < value.length) {
+    const code = value.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return { text: value.slice(0, end), truncated: true };
 }
 
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {


### PR DESCRIPTION
## Problem

Two bugs in `web-fetch-utils.ts`:

**1. `decodeEntities` corrupts emoji HTML entities**

`String.fromCharCode` silently produces garbage for code points above U+FFFF. For example, `&#x1F600;` (😀) or `&#128512;` get decoded into lone surrogates instead of the actual emoji. This affects any fetched page that uses numeric HTML entities for emoji or CJK Extension B characters.

**Fix:** Replace with `String.fromCodePoint` and add a bounds check for valid Unicode range (0–0x10FFFF).

**2. `truncateText` splits UTF-16 surrogate pairs**

`.slice(0, maxChars)` can cut between a high surrogate (0xD800–0xDBFF) and its low surrogate, producing an invalid string with a lone surrogate. Downstream consumers (JSON serialization, logging, LLM APIs) may choke on or silently corrupt the result.

**Fix:** Detect when the last character before the cut is a high surrogate and step back one position.

## Tests

Added `web-fetch-utils.test.ts` with 14 tests covering:
- Basic HTML entity decoding (`&amp;`, `&lt;`, etc.)
- Numeric entities for BMP and astral code points
- Invalid code point handling
- Title extraction and script/style stripping
- Surrogate pair preservation during truncation
- Edge cases (empty string, zero maxChars)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two real bugs in `web-fetch-utils.ts`: (1) `decodeEntities` now uses `String.fromCodePoint` instead of `String.fromCharCode` to correctly decode astral code points (emoji, CJK Extension B, etc.), and (2) `truncateText` now avoids splitting UTF-16 surrogate pairs when truncating.

- Both fixes are well-targeted and correct for the common cases
- A new test file with 14 tests provides good coverage of the changes
- **Issue found**: The `decodeEntities` bounds check (`cp >= 0 && cp <= 0x10ffff`) allows surrogate code points (0xD800–0xDFFF) through, which will cause `String.fromCodePoint` to throw a `RangeError` — crashing the function on malformed HTML entities like `&#xD800;`

<h3>Confidence Score: 3/5</h3>

- PR improves correctness for common cases but introduces a crash path on surrogate code point entities that should be fixed before merge.
- The core changes (fromCharCode → fromCodePoint, surrogate-safe truncation) are correct and well-tested. However, the missing exclusion of surrogate code points (0xD800–0xDFFF) from the bounds check means `String.fromCodePoint` can throw on malformed HTML, which is a regression in robustness since the old `String.fromCharCode` would silently produce garbage rather than crash.
- `src/agents/tools/web-fetch-utils.ts` — the `decodeEntities` function needs surrogate code point exclusion in both regex replacements

<sub>Last reviewed commit: 95a78df</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->