### PR TITLE
fix: clean tool schemas and thinking blocks for google-antigravity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Antigravity: preserve unsigned Claude thinking blocks as plain text instead of dropping them during transcript sanitization, preventing reasoning context loss while avoiding `thinking.signature` request rejections.
 - Agents/Google: clean tool JSON Schemas for `google-antigravity` the same as `google-gemini-cli` before Cloud Code Assist requests, preventing Claude tool calls from failing with `patternProperties` 400 errors. (#19860)
 - Tests/Telegram: add regression coverage for command-menu sync that asserts all `setMyCommands` entries are Telegram-safe and hyphen-normalized across native/custom/plugin command sources. (#19703) Thanks @obviyus.
 - Agents/Image: collapse resize diagnostics to one line per image and include visible pixel/byte size details in the log message for faster triage.

--- a/src/agents/pi-embedded-runner.google-sanitize-thinking.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.google-sanitize-thinking.e2e.test.ts
@@ -91,7 +91,7 @@ describe("sanitizeSessionHistory (google thinking)", () => {
     expect(assistant.content?.[0]?.thinking).toBe("reasoning");
   });
 
-  it("drops unsigned thinking blocks for Antigravity Claude", async () => {
+  it("converts unsigned thinking blocks to text for Antigravity Claude", async () => {
     const out = await sanitizeSimpleSession({
       modelApi: "google-antigravity",
       modelId: "anthropic/claude-3.5-sonnet",
@@ -99,8 +99,10 @@ describe("sanitizeSessionHistory (google thinking)", () => {
       content: [{ type: "thinking", thinking: "reasoning" }],
     });
 
-    const assistant = out.find((msg) => (msg as { role?: string }).role === "assistant");
-    expect(assistant).toBeUndefined();
+    const assistant = out.find((msg) => (msg as { role?: string }).role === "assistant") as {
+      content?: Array<{ type?: string; text?: string }>;
+    };
+    expect(assistant.content).toEqual([{ type: "text", text: "reasoning" }]);
   });
 
   it("maps base64 signatures to thinkingSignature for Antigravity Claude", async () => {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -101,6 +101,12 @@ export function sanitizeAntigravityThinkingBlocks(messages: AgentMessage[]): Age
       const candidate =
         rec.thinkingSignature ?? rec.signature ?? rec.thought_signature ?? rec.thoughtSignature;
       if (!isValidAntigravitySignature(candidate)) {
+        // Preserve reasoning content as plain text when signatures are invalid/missing.
+        // Antigravity Claude rejects unsigned thinking blocks, but dropping them loses context.
+        const thinkingText = (block as { thinking?: unknown }).thinking;
+        if (typeof thinkingText === "string" && thinkingText.trim()) {
+          nextContent.push({ type: "text", text: thinkingText } as AssistantContentBlock);
+        }
         contentChanged = true;
         continue;
       }


### PR DESCRIPTION
## Summary

Fixes three errors when using `google-antigravity/claude-*-thinking` models:

- `Unknown name "patternProperties"` — from `Type.Record` in exec tool schema
- `Unknown name "anyOf"` — from TypeBox union types (e.g. image tool)
- `thinking.signature: Field required` — unsigned thinking blocks forwarded to Anthropic

## Root cause

PR #18499 (now reverted) introduced a provider-aware bypass in `normalizeToolParameters` that skipped `cleanSchemaForGemini` for `google-antigravity`, assuming Anthropic models accept full JSON Schema. However, **Google's Cloud Code Assist API validates tool schemas against a restricted JSON Schema subset BEFORE forwarding to the downstream model**. So even though Anthropic accepts `patternProperties`/`anyOf`/`oneOf`, Google's API rejects them first.

The revert also removed `google-antigravity` from `sanitizeToolsForGoogle`, leaving **zero schema cleaning** for antigravity requests.

## Changes

- **`normalizeToolParameters`**: Remove provider-aware bypass — always apply `cleanSchemaForGemini` (idempotent, only strips Google-rejected keywords)
- **`sanitizeToolsForGoogle`**: Re-add `google-antigravity` to the provider guard
- **`clean-for-gemini.ts`**: Re-add `flattenUnionFallback` for anyOf/oneOf unions that survive `simplifyUnionVariants`
- **`sanitizeAntigravityThinkingBlocks`**: Convert unsigned thinking blocks to plain text instead of dropping — prevents `thinking.signature: Field required` without needing an upstream `@mariozechner/pi-ai` fix

## Why this approach (vs. PR #18499)

PR #18499's approach of "skip cleaning for Anthropic models" was wrong because Google's API has its own validation layer. This PR takes the opposite approach: **always clean**, since the cleaning is idempotent and the stripped keywords (constraints like `minimum`/`maximum`, structural keywords like `patternProperties`) don't affect the LLM's ability to understand tool parameters.

## Test plan

- [x] Verified `cleanSchemaForGemini` strips `patternProperties` from `Type.Record` schemas
- [x] Verified `flattenUnionFallback` reduces nested `anyOf`/`oneOf` to accepted schemas
- [x] Verified unsigned thinking blocks are converted to text (not dropped)
- [ ] No regressions for `google-gemini-cli` provider
- [ ] No regressions for non-Google providers (OpenAI, Anthropic direct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three errors when using `google-antigravity/claude-*-thinking` models by reverting the provider-aware bypass from PR #18499 and applying a more correct approach: always clean tool schemas through `cleanSchemaForGemini`, since Google's Cloud Code Assist API validates schemas before forwarding to the downstream model (even when that model is Anthropic).

Key changes:
- `normalizeToolParameters` no longer accepts an `options` parameter — schema cleaning is always applied (the cleaning is idempotent and only strips keywords Google rejects)
- `sanitizeToolsForGoogle` re-adds `google-antigravity` to its provider guard so both Google providers get cleaned
- `flattenUnionFallback` added as a last-resort flattener for `anyOf`/`oneOf` unions that survive `simplifyUnionVariants`
- `sanitizeAntigravityThinkingBlocks` now converts unsigned thinking blocks to plain text blocks instead of silently dropping them, preventing `thinking.signature: Field required` errors
- Import reordering in `pi-tools.ts` and `google.ts` (type imports moved before value imports) — no functional change

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes real API errors, the cleaning is idempotent, and the approach is more correct than the reverted PR #18499.
- The changes are well-reasoned and address real errors. The schema cleaning is idempotent so double-cleaning (in normalizeToolParameters and sanitizeToolsForGoogle) is harmless. The thinking-block-to-text conversion preserves content. The flattenUnionFallback is lossy by design but pragmatic. Deducting one point because the flattenUnionFallback discards property information for multi-variant unions with the same type, and the PR lacks unit tests for the new flattenUnionFallback function.
- `src/agents/schema/clean-for-gemini.ts` — the new `flattenUnionFallback` function discards structural schema information when flattening multi-variant unions, and has no dedicated test coverage.

<sub>Last reviewed commit: 1f3b95b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->