### PR TITLE
fix: hide metadata envelope in TUI and Mac app

### DIFF
--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,4 +1,8 @@
-import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
+import {
+  stripEnvelope,
+  stripMessageIdHints,
+  stripUntrustedMetadataBlocks,
+} from "../shared/chat-envelope.js";
 
 export { stripEnvelope };
 
@@ -12,7 +16,7 @@ function stripEnvelopeFromContent(content: unknown[]): { content: unknown[]; cha
     if (entry.type !== "text" || typeof entry.text !== "string") {
       return item;
     }
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripMessageIdHints(stripUntrustedMetadataBlocks(stripEnvelope(entry.text)));
     if (stripped === entry.text) {
       return item;
     }
@@ -39,7 +43,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   const next: Record<string, unknown> = { ...entry };
 
   if (typeof entry.content === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.content));
+    const stripped = stripMessageIdHints(
+      stripUntrustedMetadataBlocks(stripEnvelope(entry.content)),
+    );
     if (stripped !== entry.content) {
       next.content = stripped;
       changed = true;
@@ -51,7 +57,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripMessageIdHints(stripUntrustedMetadataBlocks(stripEnvelope(entry.text)));
     if (stripped !== entry.text) {
       next.text = stripped;
       changed = true;

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,15 +1,24 @@
-import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
+import {
+  stripEnvelope,
+  stripUntrustedMetadataBlocks,
+} from "../../../../src/shared/chat-envelope.js";
 import { stripThinkingTags } from "../format.ts";
 
 const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
+
+/** Strips envelope and untrusted metadata blocks from user messages */
+function stripUserMessageContent(text: string): string {
+  return stripUntrustedMetadataBlocks(stripEnvelope(text));
+}
 
 export function extractText(message: unknown): string | null {
   const m = message as Record<string, unknown>;
   const role = typeof m.role === "string" ? m.role : "";
   const content = m.content;
   if (typeof content === "string") {
-    const processed = role === "assistant" ? stripThinkingTags(content) : stripEnvelope(content);
+    const processed =
+      role === "assistant" ? stripThinkingTags(content) : stripUserMessageContent(content);
     return processed;
   }
   if (Array.isArray(content)) {
@@ -24,12 +33,14 @@ export function extractText(message: unknown): string | null {
       .filter((v): v is string => typeof v === "string");
     if (parts.length > 0) {
       const joined = parts.join("\n");
-      const processed = role === "assistant" ? stripThinkingTags(joined) : stripEnvelope(joined);
+      const processed =
+        role === "assistant" ? stripThinkingTags(joined) : stripUserMessageContent(joined);
       return processed;
     }
   }
   if (typeof m.text === "string") {
-    const processed = role === "assistant" ? stripThinkingTags(m.text) : stripEnvelope(m.text);
+    const processed =
+      role === "assistant" ? stripThinkingTags(m.text) : stripUserMessageContent(m.text);
     return processed;
   }
   return null;


### PR DESCRIPTION
Fixes #19718

## What changed
- Added a new function `stripUntrustedMetadataBlocks` in `src/shared/chat-envelope.ts` that removes untrusted metadata blocks (like "Conversation info (untrusted metadata):") from user messages before they are displayed in the TUI and Mac app.
- Updated `src/gateway/chat-sanitize.ts` to apply this stripping to user messages.

## AI-assisted contribution
- This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build && pnpm check && pnpm test
- The fix addresses the root cause described in the issue by stripping the untrusted metadata blocks from messages before they are rendered in the UI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `stripUntrustedMetadataBlocks` function to strip auto-injected metadata blocks (e.g., "Conversation info (untrusted metadata):", "Sender (untrusted metadata):") from user messages before they are displayed in the TUI and Mac app. The stripping is integrated into the existing `chat-sanitize.ts` pipeline that already handles envelope headers and message ID hints.

The implementation correctly identifies the 6 metadata block types generated by `src/auto-reply/reply/inbound-meta.ts` and uses a multiline regex with a lazy quantifier to remove them. The composition order in the sanitization pipeline is correct.

- **Regex specificity concern**: The `[^:]*` segment in the regex matches any non-colon text after keyword prefixes, which is broader than the actual labels (`(untrusted metadata)` / `(untrusted, for context)`). Combined with the `text.includes("untrusted")` fast-path guard that checks the entire message, this can cause false positives where user-authored content is incorrectly stripped.
- **No tests added**: The new function has no unit tests despite containing non-trivial regex logic with edge cases.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe but has a regex specificity issue that could strip legitimate user content in edge cases.
- The core approach is sound and the sanitization pipeline integration is correct. However, the regex is broader than needed (`[^:]*` instead of matching actual parenthesized labels) and the `text.includes("untrusted")` guard is a whole-message check, creating a path for false positives. The lack of tests for the new function is also a concern for a regex-based stripping function.
- Pay close attention to `src/shared/chat-envelope.ts` — the `UNTRUSTED_METADATA_BLOCK` regex and `stripUntrustedMetadataBlocks` function need tightened matching and test coverage.

<sub>Last reviewed commit: 98b0ebe</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->