### PR TITLE
docs: add Agent Dashboard to community tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,16 @@ by Peter Steinberger and the community.
 - [steipete.me](https://steipete.me)
 - [@openclaw](https://x.com/openclaw)
 
+## Community Tools
+
+Open-source tools built by the community to extend the OpenClaw ecosystem:
+
+| Tool | Description | Author |
+|------|-------------|--------|
+| [Agent Dashboard](https://github.com/aiwithabidi/agent-dash) | Real-time surveillance dashboard for Claude Code Agent Teams — monitor agents, tasks, and messages live | [Mohammad-Ali Abidi](https://agxntsix.ai) |
+
+Built something on top of OpenClaw? Open a PR to add it here.
+
 ## Community
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, maintainers, and how to submit PRs.


### PR DESCRIPTION
## Summary

- Adds a **Community Tools** section to the README (just before the existing Community section)
- Lists [Agent Dashboard](https://github.com/aiwithabidi/agent-dash) — an open-source real-time surveillance dashboard for Claude Code Agent Teams
- Includes an open invitation for others to contribute their own tools

## What is Agent Dashboard?

Agent Dashboard is a Next.js app that reads Claude Code's local SQLite database and streams live updates via SSE, giving you a real-time view of:

- Active agent teams and their status
- Task progress (pending → in_progress → completed)
- Agent-to-agent message feed
- Session history and replay

It was built while running OpenClaw on top of Claude Code with agent teams — the two tools pair naturally.

**Stack:** Next.js 16, React 19, Tailwind CSS v4, Zustand, better-sqlite3, SSE

## Why a Community Tools section?

OpenClaw is becoming an ecosystem. A lightweight table in the README gives community-built tools a visible home and signals to contributors that building on top of OpenClaw is welcome.

Built by [Mohammad-Ali Abidi](https://agxntsix.ai) — [agxntsix.ai](https://agxntsix.ai)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new "Community Tools" section to the README between the "Molty" and "Community" sections. The section introduces a markdown table listing community-built tools, starting with [Agent Dashboard](https://github.com/aiwithabidi/agent-dash) — a real-time monitoring dashboard for Claude Code Agent Teams. It also includes an open invitation for others to add their tools via PR.

- Documentation-only change — no code, config, or build impact
- The listed tool (Agent Dashboard) monitors Claude Code agents rather than OpenClaw-specific functionality, though the PR author notes it was built while using OpenClaw with Claude Code agent teams
- The new section is cleanly placed and follows existing README formatting conventions

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds a documentation section to the README with no code changes.
- Documentation-only change that adds a well-formatted markdown section. No code, configuration, or build files are modified. The markdown syntax is correct, links are properly formatted, and the section is placed in a logical location within the README.
- No files require special attention.

<sub>Last reviewed commit: 128c4b9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->