### PR TITLE
fix(macos): set release bundle ID so Sparkle auto-update works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS/Build: default release packaging to `BUNDLE_ID=ai.openclaw.mac` in `scripts/package-mac-dist.sh`, so Sparkle feed URL is retained and auto-update no longer fails with an empty appcast feed. (#19750) thanks @loganprit.
+
 - Signal/Outbound: preserve case for Base64 group IDs during outbound target normalization so cross-context routing and policy checks no longer break when group IDs include uppercase characters. (#5578) Thanks @heyhudson.
 - Providers/Copilot: add `claude-sonnet-4.6` and `claude-sonnet-4.5` to the default GitHub Copilot model catalog and add coverage for model-list/definition helpers. (#20270, fixes #20091) Thanks @Clawborn.
 - Dependencies/Agents: bump embedded Pi SDK packages (`@mariozechner/pi-agent-core`, `@mariozechner/pi-ai`, `@mariozechner/pi-coding-agent`, `@mariozechner/pi-tui`) to `0.54.0`. (#21578) Thanks @Takhoffman.

--- a/scripts/package-mac-dist.sh
+++ b/scripts/package-mac-dist.sh
@@ -16,6 +16,10 @@ BUILD_CONFIG="${BUILD_CONFIG:-release}"
 # Default to universal binary for distribution builds (supports both Apple Silicon and Intel Macs)
 export BUILD_ARCHS="${BUILD_ARCHS:-all}"
 
+# Use release bundle ID (not .debug) so Sparkle auto-update works.
+# The .debug suffix in package-mac-app.sh blanks SUFeedURL intentionally for dev builds.
+export BUNDLE_ID="${BUNDLE_ID:-ai.openclaw.mac}"
+
 "$ROOT_DIR/scripts/package-mac-app.sh"
 
 APP="$ROOT_DIR/dist/OpenClaw.app"


### PR DESCRIPTION
## Summary

- **Problem:** macOS app Sparkle auto-updater fails with "Appcast feed () after trimming it of quotes is empty"
- **Why it matters:** Users cannot receive auto-updates and must manually download DMGs
- **What changed:** Added `BUNDLE_ID=ai.openclaw.mac` export in `package-mac-dist.sh` before calling `package-mac-app.sh`
- **What did NOT change:** No changes to `package-mac-app.sh` logic, just setting the env var for release builds

## Change Type

- [x] Bug fix

## Scope

- [x] CI/CD / infra

## Linked Issue/PR

- Fixes #19748

## User-visible / Behavior Changes

- macOS release builds will now have correct bundle ID (`ai.openclaw.mac` instead of `ai.openclaw.mac.debug`)
- `SUFeedURL` will be populated with the appcast URL instead of blank
- Auto-update will work for macOS app users

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Tahoe (Apple Silicon)
- Installed OpenClaw 2026.2.17 DMG from GitHub releases

### Steps

1. Check installed app: `plutil -p /Applications/OpenClaw.app/Contents/Info.plist | grep -E "CFBundleIdentifier|SUFeedURL"`
2. Observe `CFBundleIdentifier` is `ai.openclaw.mac.debug` and `SUFeedURL` is empty
3. Try to update via app menu → see "Appcast feed () is empty" error

### Expected

- `CFBundleIdentifier` should be `ai.openclaw.mac`
- `SUFeedURL` should be `https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml`

### Actual

- `CFBundleIdentifier` is `ai.openclaw.mac.debug`
- `SUFeedURL` is empty string

## Evidence

- [x] Screenshot of error dialog provided in issue #19748
- [x] `plutil` output showing empty `SUFeedURL`

## Human Verification

- **Verified scenarios:** Traced the bug from error message → Info.plist → package-mac-app.sh logic → package-mac-dist.sh missing BUNDLE_ID
- **Edge cases checked:** Confirmed `.debug` suffix condition in package-mac-app.sh intentionally blanks SUFeedURL for dev builds
- **What you did NOT verify:** Did not build a full release to confirm (requires signing certs)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- **How to disable/revert:** Revert the commit, or explicitly set `BUNDLE_ID=ai.openclaw.mac.debug` in release workflow
- **Files/config to restore:** `scripts/package-mac-dist.sh`
- **Known bad symptoms:** If this breaks, release builds would have wrong bundle ID (but that is already the current state)

## Risks and Mitigations

- **Risk:** Changing bundle ID might affect existing TCC permissions for users upgrading
  - **Mitigation:** Users may need to re-grant permissions once, but this is expected when fixing bundle ID; the alternative is broken auto-update forever

## AI Disclosure

- [x] AI-assisted (OpenClaw/Claude)
- **Testing:** Lightly tested (code review + traced logic, no full build)
- The fix was identified by tracing the error through the build scripts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Sets the release `BUNDLE_ID` to `ai.openclaw.mac` in `package-mac-dist.sh` so that when `package-mac-app.sh` runs as a subprocess, it no longer falls back to its `ai.openclaw.mac.debug` default. This prevents the `.debug` suffix check from blanking `SUFeedURL`, fixing the Sparkle auto-update "empty appcast feed" error for macOS release builds.

- Exports `BUNDLE_ID="${BUNDLE_ID:-ai.openclaw.mac}"` before invoking `package-mac-app.sh`, following the same `export` + default pattern used for `BUILD_ARCHS`
- Preserves overridability via `${BUNDLE_ID:-...}` so callers can still set a custom bundle ID
- Adds a changelog entry under the 2026.2.17 Fixes section

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, correct one-line fix that adds a missing environment variable export.
- The change is a single export statement that follows an established pattern already used for BUILD_ARCHS in the same file. The fix correctly addresses the root cause: package-mac-app.sh defaults BUNDLE_ID to the .debug variant, which intentionally blanks the Sparkle feed URL. By exporting the release bundle ID from the distribution wrapper script, the subprocess receives the correct value. The fix preserves overridability and doesn't modify any existing logic. No issues found.
- No files require special attention.

<sub>Last reviewed commit: eb8ce7c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->