### PR TITLE
feat(webchat): add cursor-based pagination to chat.history

### DIFF
--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -27,6 +27,7 @@ export const ChatHistoryParamsSchema = Type.Object(
   {
     sessionKey: NonEmptyString,
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+    before: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -574,9 +574,10 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { sessionKey, limit } = params as {
+    const { sessionKey, limit, before } = params as {
       sessionKey: string;
       limit?: number;
+      before?: number;
     };
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
     const sessionId = entry?.sessionId;
@@ -586,7 +587,21 @@ export const chatHandlers: GatewayRequestHandlers = {
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
     const max = Math.min(hardMax, requested);
-    const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
+    let sliced: unknown[];
+    let cursor: number;
+    let hasMore: boolean;
+    if (typeof before === "number") {
+      const end = Math.min(before, rawMessages.length);
+      const start = Math.max(0, end - max);
+      sliced = rawMessages.slice(start, end);
+      cursor = start;
+      hasMore = start > 0;
+    } else {
+      const start = rawMessages.length > max ? rawMessages.length - max : 0;
+      sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
+      cursor = start;
+      hasMore = start > 0;
+    }
     const sanitized = stripEnvelopeFromMessages(sliced);
     const normalized = sanitizeChatHistoryMessages(sanitized);
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
@@ -597,6 +612,13 @@ export const chatHandlers: GatewayRequestHandlers = {
     });
     const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
     const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
+    // Byte capping drops items from the front — adjust cursor so those messages
+    // remain reachable on the next paginated request.
+    const droppedCount = sliced.length - bounded.messages.length;
+    if (droppedCount > 0) {
+      cursor += droppedCount;
+      hasMore = cursor > 0;
+    }
     const placeholderCount = replaced.replacedCount + bounded.placeholderCount;
     if (placeholderCount > 0) {
       chatHistoryPlaceholderEmitCount += placeholderCount;
@@ -626,6 +648,8 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionKey,
       sessionId,
       messages: bounded.messages,
+      cursor,
+      hasMore,
       thinkingLevel,
       verboseLevel,
     });

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -809,6 +809,7 @@ export function renderApp(state: AppViewState) {
                 thinkingLevel: state.chatThinkingLevel,
                 showThinking,
                 loading: state.chatLoading,
+                loadingOlder: state.chatLoadingOlder,
                 sending: state.chatSending,
                 compactionStatus: state.compactionStatus,
                 assistantAvatarUrl: chatAvatarUrl,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -45,6 +45,7 @@ function createScrollHost(
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
     topbarObserver: null as ResizeObserver | null,
+    onLoadOlderMessages: null as (() => void) | null,
   };
 
   return { host, container };

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -1,6 +1,11 @@
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
 
+/** Cooldown (ms) after triggering a load-older fetch before allowing another. */
+const LOAD_OLDER_COOLDOWN_MS = 500;
+
+let lastLoadOlderTriggeredAt = 0;
+
 type ScrollHost = {
   updateComplete: Promise<unknown>;
   querySelector: (selectors: string) => Element | null;
@@ -13,6 +18,7 @@ type ScrollHost = {
   logsScrollFrame: number | null;
   logsAtBottom: boolean;
   topbarObserver: ResizeObserver | null;
+  onLoadOlderMessages?: (() => void) | null;
 };
 
 export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
@@ -119,6 +125,9 @@ export function scheduleLogsScroll(host: ScrollHost, force = false) {
   });
 }
 
+/** Distance (px) from the top within which we trigger loading older messages. */
+const NEAR_TOP_THRESHOLD = 200;
+
 export function handleChatScroll(host: ScrollHost, event: Event) {
   const container = event.currentTarget as HTMLElement | null;
   if (!container) {
@@ -129,6 +138,14 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   // Clear the "new messages below" indicator when user scrolls back to bottom.
   if (host.chatUserNearBottom) {
     host.chatNewMessagesBelow = false;
+  }
+  // Trigger loading older messages when user scrolls near the top (with cooldown).
+  if (container.scrollTop < NEAR_TOP_THRESHOLD && host.onLoadOlderMessages) {
+    const now = Date.now();
+    if (now - lastLoadOlderTriggeredAt >= LOAD_OLDER_COOLDOWN_MS) {
+      lastLoadOlderTriggeredAt = now;
+      host.onLoadOlderMessages();
+    }
   }
 }
 

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -52,6 +52,7 @@ export type AppViewState = {
   assistantAgentId: string | null;
   sessionKey: string;
   chatLoading: boolean;
+  chatLoadingOlder: boolean;
   chatSending: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
@@ -60,6 +61,8 @@ export type AppViewState = {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
+  chatCursor: number | null;
+  chatHasMore: boolean;
   compactionStatus: CompactionStatus | null;
   chatAvatarUrl: string | null;
   chatThinkingLevel: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -16,6 +16,7 @@ import {
 } from "./app-channels.ts";
 import {
   handleAbortChat as handleAbortChatInternal,
+  handleLoadOlderChat as handleLoadOlderChatInternal,
   handleSendChat as handleSendChatInternal,
   removeQueuedMessage as removeQueuedMessageInternal,
 } from "./app-chat.ts";
@@ -132,6 +133,7 @@ export class OpenClawApp extends LitElement {
 
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;
+  @state() chatLoadingOlder = false;
   @state() chatSending = false;
   @state() chatMessage = "";
   @state() chatMessages: unknown[] = [];
@@ -139,6 +141,8 @@ export class OpenClawApp extends LitElement {
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
+  @state() chatCursor: number | null = null;
+  @state() chatHasMore = false;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
@@ -353,6 +357,10 @@ export class OpenClawApp extends LitElement {
   private themeMedia: MediaQueryList | null = null;
   private themeMediaHandler: ((event: MediaQueryListEvent) => void) | null = null;
   private topbarObserver: ResizeObserver | null = null;
+  onLoadOlderMessages: (() => void) | null = () =>
+    void handleLoadOlderChatInternal(
+      this as unknown as Parameters<typeof handleLoadOlderChatInternal>[0],
+    );
 
   createRenderRoot() {
     return this;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -5,6 +5,7 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
   return {
     chatAttachments: [],
     chatLoading: false,
+    chatLoadingOlder: false,
     chatMessage: "",
     chatMessages: [],
     chatRunId: null,
@@ -12,6 +13,8 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     chatStream: null,
     chatStreamStartedAt: null,
     chatThinkingLevel: null,
+    chatCursor: null,
+    chatHasMore: false,
     client: null,
     connected: true,
     lastError: null,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -57,6 +57,7 @@ export type ChatProps = {
   // Scroll control
   showNewMessages?: boolean;
   onScrollToBottom?: () => void;
+  loadingOlder?: boolean;
   // Event handlers
   onRefresh: () => void;
   onToggleFocusMode: () => void;
@@ -214,6 +215,13 @@ export function renderChat(props: ChatProps) {
       aria-live="polite"
       @scroll=${props.onChatScroll}
     >
+      ${
+        props.loadingOlder
+          ? html`
+              <div class="muted">Loading older messages…</div>
+            `
+          : nothing
+      }
       ${
         props.loading
           ? html`
@@ -427,8 +435,6 @@ export function renderChat(props: ChatProps) {
   `;
 }
 
-const CHAT_HISTORY_RENDER_LIMIT = 200;
-
 function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];
   let currentGroup: MessageGroup | null = null;
@@ -474,19 +480,7 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
   const history = Array.isArray(props.messages) ? props.messages : [];
   const tools = Array.isArray(props.toolMessages) ? props.toolMessages : [];
-  const historyStart = Math.max(0, history.length - CHAT_HISTORY_RENDER_LIMIT);
-  if (historyStart > 0) {
-    items.push({
-      kind: "message",
-      key: "chat:history:notice",
-      message: {
-        role: "system",
-        content: `Showing last ${CHAT_HISTORY_RENDER_LIMIT} messages (${historyStart} hidden).`,
-        timestamp: Date.now(),
-      },
-    });
-  }
-  for (let i = historyStart; i < history.length; i++) {
+  for (let i = 0; i < history.length; i++) {
     const msg = history[i];
     const normalized = normalizeMessage(msg);
     const raw = msg as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Adds backward cursor-based pagination to `chat.history` so users can scroll back to the beginning of long conversations.

**Discussion**: #19753

- **Server**: New optional `before` parameter returns messages preceding a given index. Response now includes `cursor` (index of first returned message) and `hasMore` (whether older messages exist). Fully backward-compatible.
- **Client**: Detects when user scrolls near the top of the chat thread and automatically fetches the previous page, preserving scroll position. Shows a "Loading older messages..." indicator.

Bounded by the existing 1000-message hard max. Does not add virtual scrolling (see PR #16020).

Related: #19060, #13703, PR #19343

## Test plan

- [x] Extended existing e2e test (300 messages) to verify `before` cursor returns messages 0-99 after initial load returns 100-299
- [x] Verified `cursor` and `hasMore` fields in both default and paginated responses
- [x] Session-switch safety: stale responses discarded if session changes mid-fetch
- [x] TypeScript compiles cleanly (0 errors)
- [x] All 439 gateway tests pass

AI-assisted (Claude Code). Tested via TypeScript compilation and gateway unit/integration test suite. Full build + e2e require Node >= 22 (environment has Node 20).

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds backward cursor-based pagination to `chat.history`, allowing users to scroll back through long conversations. The server-side changes introduce `before`, `cursor`, and `hasMore` fields — well-structured and backward-compatible. The client detects when the user scrolls near the top and fetches older pages, preserving scroll position. Session-switch safety is handled via a session key check.

- **Critical**: The client-side `CHAT_HISTORY_RENDER_LIMIT` (200) in `buildChatItems` (`ui/src/ui/views/chat.ts:485`) renders only the last 200 messages from the `chatMessages` array. Since `loadOlderChatHistory` *prepends* older messages, they are immediately excluded by this render cap — making the pagination UI-invisible. This needs to be addressed for the feature to work as intended.
- **Minor**: The `onLoadOlderMessages` callback fires on every scroll event while near the top. After scroll-position restoration, this could trigger rapid successive fetches. A debounce or cooldown would be more robust.
- Server-side cursor math, schema changes, and test coverage look correct. The e2e test properly validates the `before` cursor and `hasMore` semantics.

<h3>Confidence Score: 2/5</h3>

- The server-side pagination is correct, but the client-side rendering bug means older messages will never be visible to users.
- The core client-side feature is broken: CHAT_HISTORY_RENDER_LIMIT in buildChatItems caps rendering to the last 200 messages, so prepended older messages from pagination are never displayed. The server-side changes are clean and well-tested, but the end-to-end feature does not work.
- ui/src/ui/views/chat.ts (render limit conflicts with pagination), ui/src/ui/app-scroll.ts (debounce concern)

<sub>Last reviewed commit: 5b5c695</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->