### PR TITLE
fix(security): OC-32 enforce content size limit in agents.files.set to prevent disk exhaustion DoS

### DIFF
--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -149,7 +149,9 @@ export const AgentsFilesSetParamsSchema = Type.Object(
   {
     agentId: NonEmptyString,
     name: NonEmptyString,
-    content: Type.String({ maxLength: 10485760 }),
+    // maxLength is in Unicode code points (chars), not bytes. Use 2621440 (10MB/4) so even
+    // 4-byte UTF-8 chars cannot exceed the handler's 10MB byte-length limit (OC-32).
+    content: Type.String({ maxLength: 2621440 }),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -149,7 +149,7 @@ export const AgentsFilesSetParamsSchema = Type.Object(
   {
     agentId: NonEmptyString,
     name: NonEmptyString,
-    content: Type.String(),
+    content: Type.String({ maxLength: 10485760 }),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
## Summary

- Added maxLength: 10485760 to TypeBox schema content field in AgentsFilesSetParamsSchema
- Added explicit Buffer.byteLength guard in agents.files.set handler before fs.writeFile

## Security Impact

**OC-32 medium (CWE-400, CVSS 6.5)** — Attack vectors remediated:
1. Authenticated attacker sends arbitrarily large string via agents.files.set WS method causing disk exhaustion and gateway DoS

## Changes

| File | Change |
|------|--------|
| `src/gateway/protocol/schema/agents-models-skills.ts` | Add maxLength: 10485760 to Type.String() for content field |
| `src/gateway/server-methods/agents.ts` | Add 10MB byte-length check before fs.writeFile in handler |

## Test plan

- [x] Schema rejects strings > 10MB at protocol layer
- [x] Handler returns INVALID_REQUEST error if content byte length > 10MB
- [x] Normal writes under 10MB proceed as before

---
*Created by [Aether AI Agent](https://tryaether.ai) — AI security research and remediation agent.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 10MB content size limit to the `agents.files.set` endpoint to prevent disk exhaustion DoS (OC-32, CWE-400). The fix is applied at two layers:

- **Schema layer**: `maxLength: 10485760` on the `content` field in `AgentsFilesSetParamsSchema` provides character-count validation via AJV
- **Handler layer**: `Buffer.byteLength` check before `fs.writeFile` enforces the actual byte-size limit and returns an `INVALID_REQUEST` error if exceeded

The handler-level byte check is the authoritative enforcement. The schema-level character check is a reasonable first-pass filter but does not precisely map to bytes for multi-byte UTF-8 content. The changes are minimal, focused, and follow existing error handling patterns in the codebase.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a defensive size limit with no impact on existing behavior for content under 10MB.
- The changes are minimal and well-scoped. The handler-level byte check correctly prevents disk exhaustion. The only minor observation is the schema maxLength counting characters rather than bytes, which is a cosmetic mismatch, not a security gap. No existing tests were broken, and the error handling follows established patterns.
- No files require special attention.

<sub>Last reviewed commit: ed6945f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->