### PR TITLE
fix(security): OC-54 cap agent runner iterations to prevent infinite loop DoS — Aether AI Agent

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -465,8 +465,17 @@ export async function runEmbeddedPiAgent(
       const usageAccumulator = createUsageAccumulator();
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
+      // OC-54: Cap iterations to prevent unbounded loop DoS (CWE-400)
+      const MAX_ITERATIONS = 200;
+      let iterations = 0;
       try {
         while (true) {
+          if (iterations >= MAX_ITERATIONS) {
+            throw new Error(
+              `Agent runner exceeded maximum iteration limit (${MAX_ITERATIONS}). Terminating to prevent resource exhaustion.`,
+            );
+          }
+          iterations++;
           attemptedThinking.add(thinkLevel);
           await fs.mkdir(resolvedWorkspace, { recursive: true });
 


### PR DESCRIPTION
## Attack Vector

OC-54: Unbounded retry loop in agent runner.

**Vector:** A prompt injection attack causes the agent to continuously request more tool calls in an infinite `while(true)` loop. Without a global iteration cap, the agent runs indefinitely, consuming CPU and memory until the process is killed or resources are exhausted (Denial of Service).

**CWE:** CWE-400 (Uncontrolled Resource Consumption)
**Severity:** Medium
**GHSA:** GHSA-76m6-pj3w-v7mf

## Fix

Added a MAX_ITERATIONS (200) cap to the agent runner's main loop. When the iteration limit is exceeded, the run terminates cleanly, preventing resource exhaustion.

## Impact

Prevents prompt-injection-induced DoS via infinite tool call loops.

---
*Discovered and remediated by [Aether AI Agent](https://tryaether.ai) — automated security research.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `MAX_ITERATIONS = 200` safety cap to the agent runner's main `while(true)` loop in `src/agents/pi-embedded-runner/run.ts` to prevent unbounded resource consumption from prompt injection attacks that could trigger infinite tool-call loops (CWE-400).

- The iteration counter is correctly placed at the top of the loop body, ensuring all `continue` paths (auth profile rotation, context overflow compaction, thinking-level fallbacks) are properly counted toward the limit.
- When exceeded, a generic `Error` is thrown, which propagates through the `finally` block (restoring `process.chdir`) and is caught by the outer error handler in `agent-runner-execution.ts`, producing a user-facing error message.
- No tests were added for the iteration cap behavior.
- The `MAX_ITERATIONS` constant is hardcoded rather than configurable via the existing config system.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a straightforward safety cap with no regressions to existing behavior.
- The change is minimal and correct. The iteration guard is properly positioned to count all loop iterations including retry paths. The thrown error propagates cleanly through existing error handling. Score is 4 rather than 5 because no test coverage was added and the limit is not configurable.
- No files require special attention beyond the single changed file.

<sub>Last reviewed commit: d95bb89</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->