### PR TITLE
fix: hide untrusted metadata blocks in TUI and Mac app UI

### DIFF
--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,4 +1,8 @@
-import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
+import {
+  stripEnvelope,
+  stripMessageIdHints,
+  stripUntrustedMetadataBlocks,
+} from "../shared/chat-envelope.js";
 
 export { stripEnvelope };
 
@@ -12,7 +16,7 @@ function stripEnvelopeFromContent(content: unknown[]): { content: unknown[]; cha
     if (entry.type !== "text" || typeof entry.text !== "string") {
       return item;
     }
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripMessageIdHints(stripUntrustedMetadataBlocks(stripEnvelope(entry.text)));
     if (stripped === entry.text) {
       return item;
     }
@@ -39,7 +43,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   const next: Record<string, unknown> = { ...entry };
 
   if (typeof entry.content === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.content));
+    const stripped = stripMessageIdHints(
+      stripUntrustedMetadataBlocks(stripEnvelope(entry.content)),
+    );
     if (stripped !== entry.content) {
       next.content = stripped;
       changed = true;
@@ -51,7 +57,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripMessageIdHints(stripUntrustedMetadataBlocks(stripEnvelope(entry.text)));
     if (stripped !== entry.text) {
       next.text = stripped;
       changed = true;

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,15 +1,24 @@
-import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
+import {
+  stripEnvelope,
+  stripUntrustedMetadataBlocks,
+} from "../../../../src/shared/chat-envelope.js";
 import { stripThinkingTags } from "../format.ts";
 
 const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
+
+/** Strips envelope and untrusted metadata blocks from user messages */
+function stripUserMessageContent(text: string): string {
+  return stripUntrustedMetadataBlocks(stripEnvelope(text));
+}
 
 export function extractText(message: unknown): string | null {
   const m = message as Record<string, unknown>;
   const role = typeof m.role === "string" ? m.role : "";
   const content = m.content;
   if (typeof content === "string") {
-    const processed = role === "assistant" ? stripThinkingTags(content) : stripEnvelope(content);
+    const processed =
+      role === "assistant" ? stripThinkingTags(content) : stripUserMessageContent(content);
     return processed;
   }
   if (Array.isArray(content)) {
@@ -24,12 +33,14 @@ export function extractText(message: unknown): string | null {
       .filter((v): v is string => typeof v === "string");
     if (parts.length > 0) {
       const joined = parts.join("\n");
-      const processed = role === "assistant" ? stripThinkingTags(joined) : stripEnvelope(joined);
+      const processed =
+        role === "assistant" ? stripThinkingTags(joined) : stripUserMessageContent(joined);
       return processed;
     }
   }
   if (typeof m.text === "string") {
-    const processed = role === "assistant" ? stripThinkingTags(m.text) : stripEnvelope(m.text);
+    const processed =
+      role === "assistant" ? stripThinkingTags(m.text) : stripUserMessageContent(m.text);
     return processed;
   }
   return null;

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,5 +1,6 @@
 import {
   stripEnvelope,
+  stripMessageIdHints,
   stripUntrustedMetadataBlocks,
 } from "../../../../src/shared/chat-envelope.js";
 import { stripThinkingTags } from "../format.ts";
@@ -7,9 +8,9 @@ import { stripThinkingTags } from "../format.ts";
 const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
-/** Strips envelope and untrusted metadata blocks from user messages */
+/** Strips envelope, message ID hints, and untrusted metadata blocks from user messages */
 function stripUserMessageContent(text: string): string {
-  return stripUntrustedMetadataBlocks(stripEnvelope(text));
+  return stripMessageIdHints(stripUntrustedMetadataBlocks(stripEnvelope(text)));
 }
 
 export function extractText(message: unknown): string | null {


### PR DESCRIPTION
Fixes #19718

## What changed
The UI's message extraction in  was only stripping the envelope prefix (e.g., [WebChat]) but not the untrusted metadata blocks (e.g., 'Conversation info (untrusted metadata):'). This fix adds the  call in the UI's message extraction to match the behavior in  (gateway).

The fix includes:
1. Import  from the shared chat-envelope module
2. Create a helper function  that applies both envelope and untrusted metadata stripping
3. Apply this stripping to all user message content in the  function

## AI-assisted contribution
This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build
- The fix addresses the root cause described in the issue by ensuring the UI uses the same stripping logic as the gateway for user messages

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `stripUntrustedMetadataBlocks` to both the gateway (`chat-sanitize.ts`) and the UI (`message-extract.ts`) stripping pipelines, ensuring untrusted metadata blocks (e.g., "Conversation info (untrusted metadata):") are hidden from users in the TUI and Mac app. A new shared function and regex are added to `chat-envelope.ts` to handle the stripping.

- Adds `stripUntrustedMetadataBlocks` to `src/shared/chat-envelope.ts` with a regex matching all known untrusted metadata label formats
- Integrates the new function into the gateway's `chat-sanitize.ts` at all three stripping sites (string content, array content entries, and text fields)
- Creates a `stripUserMessageContent` helper in the UI's `message-extract.ts` that composes `stripEnvelope` + `stripUntrustedMetadataBlocks`
- **Note:** The UI's stripping pipeline omits `stripMessageIdHints`, which the gateway includes — this is a pre-existing gap but could be closed in this PR for full parity

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds display-layer stripping of metadata blocks with no risk to data integrity or security
- Score of 4 reflects well-structured changes with correct regex usage and proper composition of stripping functions. One point deducted for the minor inconsistency where the UI pipeline omits `stripMessageIdHints` while the gateway includes it — not a bug introduced by this PR, but a missed opportunity to fully align the two pipelines as intended.
- `ui/src/ui/chat/message-extract.ts` — the `stripUserMessageContent` helper could include `stripMessageIdHints` for full gateway parity

<sub>Last reviewed commit: 6fc14ce</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->