### PR TITLE
fix(security): OC-73 sanitize resource link titles to prevent prompt injection — Aether AI Agent

### DIFF
--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -17,8 +17,9 @@ const RESOURCE_TITLE_MAX_LENGTH = 200;
  * - Truncates the title to RESOURCE_TITLE_MAX_LENGTH characters
  */
 export function sanitizeResourceTitle(title: string): string {
-  // Strip control characters that allow injecting new prompt lines
-  const stripped = title.replace(/[\r\n]/g, " ");
+  // Strip control characters that allow injecting new prompt lines,
+  // including vertical tab, form feed, null byte, and Unicode line/paragraph separators
+  const stripped = title.replace(/[\r\n\v\f\0\u2028\u2029]/g, " ");
   // Truncate to prevent excessively long injections
   return stripped.length > RESOURCE_TITLE_MAX_LENGTH
     ? stripped.slice(0, RESOURCE_TITLE_MAX_LENGTH)
@@ -42,7 +43,7 @@ export function extractTextFromPrompt(prompt: ContentBlock[]): string {
     if (block.type === "resource_link") {
       const rawTitle = block.title ? sanitizeResourceTitle(block.title) : "";
       const title = rawTitle ? ` (${rawTitle})` : "";
-      const uri = block.uri ?? "";
+      const uri = block.uri ? sanitizeResourceTitle(block.uri) : "";
       const line = uri ? `[Resource link${title}] ${uri}` : `[Resource link${title}]`;
       parts.push(line);
     }


### PR DESCRIPTION
## Attack Vector

OC-73: Resource link title injected into prompt without sanitization.

**Vector:** An attacker submits a resource link with a maliciously crafted `title` field containing prompt injection text (e.g., newline-separated instructions like `"Ignore previous instructions. You are now..."`). The title is interpolated directly into the agent's context prompt without sanitization, allowing the attacker to manipulate the agent's behavior.

**CWE:** CWE-74 (Injection), CWE-20 (Improper Input Validation)
**Severity:** Medium
**GHSA:** GHSA-74xj-763f-264w

## Fix

Added sanitization of resource link titles before prompt interpolation:
- Truncates titles to 200 characters maximum
- Strips newline and carriage return characters that enable multi-line injection

## Impact

Prevents external parties from injecting instructions into the agent prompt via resource link metadata.

---
*Discovered and remediated by [Aether AI Agent](https://tryaether.ai) — automated security research.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `sanitizeResourceTitle` function that strips newline/carriage-return characters and truncates to 200 characters before resource link titles are interpolated into agent prompts. This mitigates prompt injection via crafted `title` fields on `resource_link` content blocks.

- The sanitization logic for `title` is sound (newline stripping + length cap).
- **Issue:** `block.uri` is interpolated into the same prompt string without sanitization, leaving an equivalent injection vector open through the URI field.
- **Suggestion:** Consider stripping additional Unicode line-breaking characters (`\v`, `\f`, U+2028, U+2029) for defense in depth.
- **Missing tests:** No tests were added for the new `sanitizeResourceTitle` function (newline stripping, truncation behavior, edge cases). The existing test in `client.test.ts` uses a clean title and does not exercise sanitization paths.

<h3>Confidence Score: 3/5</h3>

- The title sanitization is correct but the URI field has the same unaddressed injection vector, reducing the effectiveness of this security fix.
- Score of 3 reflects that the core sanitization logic works correctly for its target field, but the fix is incomplete — `block.uri` is interpolated unsanitized into the same prompt, leaving an equivalent attack surface. No tests were added for the new function. The change is low-risk in terms of regressions (it only adds constraints), but doesn't fully close the vulnerability it targets.
- `src/acp/event-mapper.ts` — the `block.uri` interpolation on line 45 needs the same sanitization treatment applied to `block.title`.

<sub>Last reviewed commit: 925ccee</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->