### PR TITLE
Honor configured heartbeat model overrides in all heartbeat runners

### DIFF
--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   isHeartbeatContentEffectivelyEmpty,
+  resolveHeartbeatModelPrimary,
   stripHeartbeatToken,
 } from "./heartbeat.js";
 import { HEARTBEAT_TOKEN } from "./tokens.js";
@@ -179,5 +180,27 @@ Check the server logs
 ### Subsection
 `;
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
+  });
+});
+
+describe("resolveHeartbeatModelPrimary", () => {
+  it("returns trimmed string models", () => {
+    expect(resolveHeartbeatModelPrimary("  openai/gpt-4o-mini  ")).toBe("openai/gpt-4o-mini");
+  });
+
+  it("returns model.primary when heartbeat model is an object", () => {
+    expect(
+      resolveHeartbeatModelPrimary({
+        primary: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+        fallbacks: ["openrouter/anthropic/claude-haiku-4.5"],
+      }),
+    ).toBe("openrouter/meta-llama/llama-3.3-70b-instruct:free");
+  });
+
+  it("returns undefined for blank or malformed values", () => {
+    expect(resolveHeartbeatModelPrimary("  ")).toBeUndefined();
+    expect(resolveHeartbeatModelPrimary({ primary: " " })).toBeUndefined();
+    expect(resolveHeartbeatModelPrimary({})).toBeUndefined();
+    expect(resolveHeartbeatModelPrimary(undefined)).toBeUndefined();
   });
 });

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -56,6 +56,22 @@ export function resolveHeartbeatPrompt(raw?: string): string {
   return trimmed || HEARTBEAT_PROMPT;
 }
 
+export function resolveHeartbeatModelPrimary(raw?: unknown): string | undefined {
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    return trimmed || undefined;
+  }
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const primary = (raw as { primary?: unknown }).primary;
+  if (typeof primary !== "string") {
+    return undefined;
+  }
+  const trimmedPrimary = primary.trim();
+  return trimmedPrimary || undefined;
+}
+
 export type StripHeartbeatMode = "heartbeat" | "message";
 
 function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -14,6 +14,7 @@ import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
+import { resolveHeartbeatModelPrimary } from "../heartbeat.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { resolveDefaultModel } from "./directive-handling.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
@@ -79,7 +80,10 @@ export async function getReplyFromConfig(
   let provider = defaultProvider;
   let model = defaultModel;
   if (opts?.isHeartbeat) {
-    const heartbeatRaw = agentCfg?.heartbeat?.model?.trim() ?? "";
+    const heartbeatRaw =
+      opts.heartbeatModelOverride?.trim() ??
+      resolveHeartbeatModelPrimary(agentCfg?.heartbeat?.model) ??
+      "";
     const heartbeatRef = heartbeatRaw
       ? resolveModelRefFromString({
           raw: heartbeatRaw,

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -1,0 +1,222 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
+import { setTelegramRuntime } from "../../extensions/telegram/src/runtime.js";
+import { whatsappPlugin } from "../../extensions/whatsapp/src/channel.js";
+import { setWhatsAppRuntime } from "../../extensions/whatsapp/src/runtime.js";
+import * as replyModule from "../auto-reply/reply.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentMainSessionKey, resolveMainSessionKey } from "../config/sessions.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+
+// Avoid pulling optional runtime deps during isolated runs.
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+type SeedSessionInput = {
+  lastChannel: string;
+  lastTo: string;
+  updatedAt?: number;
+};
+
+async function withHeartbeatFixture(
+  run: (ctx: {
+    tmpDir: string;
+    storePath: string;
+    seedSession: (sessionKey: string, input: SeedSessionInput) => Promise<void>;
+  }) => Promise<unknown>,
+): Promise<unknown> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-model-"));
+  const storePath = path.join(tmpDir, "sessions.json");
+
+  const seedSession = async (sessionKey: string, input: SeedSessionInput) => {
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: input.updatedAt ?? Date.now(),
+            lastChannel: input.lastChannel,
+            lastTo: input.lastTo,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  };
+
+  try {
+    return await run({ tmpDir, storePath, seedSession });
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+beforeEach(() => {
+  const runtime = createPluginRuntime();
+  setTelegramRuntime(runtime);
+  setWhatsAppRuntime(runtime);
+  setActivePluginRegistry(
+    createTestRegistry([
+      { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
+      { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+    ]),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runHeartbeatOnce – heartbeat model override", () => {
+  async function runDefaultsHeartbeat(params: {
+    model?: string | { primary?: string; fallbacks?: string[] };
+    suppressToolErrorWarnings?: boolean;
+  }) {
+    return withHeartbeatFixture(async ({ tmpDir, storePath, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+              model: params.model,
+              suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedSession(sessionKey, { lastChannel: "whatsapp", lastTo: "+1555" });
+
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      return replySpy.mock.calls[0]?.[1];
+    });
+  }
+
+  it("passes heartbeatModelOverride from defaults heartbeat config", async () => {
+    const replyOpts = await runDefaultsHeartbeat({ model: "ollama/llama3.2:1b" });
+    expect(replyOpts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+        heartbeatModelOverride: "ollama/llama3.2:1b",
+        suppressToolErrorWarnings: false,
+      }),
+    );
+  });
+
+  it("passes heartbeatModelOverride from defaults heartbeat model object", async () => {
+    const replyOpts = await runDefaultsHeartbeat({
+      model: {
+        primary: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+        fallbacks: ["openrouter/anthropic/claude-haiku-4.5"],
+      },
+    });
+    expect(replyOpts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+        heartbeatModelOverride: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+      }),
+    );
+  });
+
+  it("passes suppressToolErrorWarnings when configured", async () => {
+    const replyOpts = await runDefaultsHeartbeat({ suppressToolErrorWarnings: true });
+    expect(replyOpts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+        suppressToolErrorWarnings: true,
+      }),
+    );
+  });
+
+  it("passes per-agent heartbeat model override (merged with defaults)", async () => {
+    await withHeartbeatFixture(async ({ storePath, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            heartbeat: {
+              every: "30m",
+              model: "openai/gpt-4o-mini",
+            },
+          },
+          list: [
+            { id: "main", default: true },
+            {
+              id: "ops",
+              heartbeat: {
+                every: "5m",
+                target: "whatsapp",
+                model: "ollama/llama3.2:1b",
+              },
+            },
+          ],
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveAgentMainSessionKey({ cfg, agentId: "ops" });
+      await seedSession(sessionKey, { lastChannel: "whatsapp", lastTo: "+1555" });
+
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        agentId: "ops",
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          isHeartbeat: true,
+          heartbeatModelOverride: "ollama/llama3.2:1b",
+        }),
+        cfg,
+      );
+    });
+  });
+
+  it("does not pass heartbeatModelOverride when no heartbeat model is configured", async () => {
+    const replyOpts = await runDefaultsHeartbeat({ model: undefined });
+    expect(replyOpts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+      }),
+    );
+  });
+
+  it("trims heartbeat model override before passing it downstream", async () => {
+    const replyOpts = await runDefaultsHeartbeat({ model: "  ollama/llama3.2:1b  " });
+    expect(replyOpts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+        heartbeatModelOverride: "ollama/llama3.2:1b",
+      }),
+    );
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   DEFAULT_HEARTBEAT_EVERY,
   isHeartbeatContentEffectivelyEmpty,
+  resolveHeartbeatModelPrimary,
   resolveHeartbeatPrompt as resolveHeartbeatPromptText,
   stripHeartbeatToken,
 } from "../auto-reply/heartbeat.js";
@@ -618,7 +619,12 @@ export async function runHeartbeatOnce(opts: {
   };
 
   try {
-    const replyResult = await getReplyFromConfig(ctx, { isHeartbeat: true }, cfg);
+    const heartbeatModelOverride = resolveHeartbeatModelPrimary(heartbeat?.model);
+    const suppressToolErrorWarnings = heartbeat?.suppressToolErrorWarnings === true;
+    const replyOpts = heartbeatModelOverride
+      ? { isHeartbeat: true, heartbeatModelOverride, suppressToolErrorWarnings }
+      : { isHeartbeat: true, suppressToolErrorWarnings };
+    const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
     const reasoningPayloads = includeReasoning

--- a/src/web/auto-reply/heartbeat-runner.test.ts
+++ b/src/web/auto-reply/heartbeat-runner.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { getReplyFromConfig } from "../../auto-reply/reply.js";
+import { HEARTBEAT_TOKEN } from "../../auto-reply/tokens.js";
+import type { sendMessageWhatsApp } from "../outbound.js";
+
+const state = vi.hoisted(() => ({
+  visibility: { showAlerts: true, showOk: true, useIndicator: false },
+  store: {} as Record<string, { updatedAt?: number; sessionId?: string }>,
+  snapshot: {
+    key: "k",
+    entry: { sessionId: "s1", updatedAt: 123 },
+    fresh: false,
+    resetPolicy: { mode: "none", atHour: null, idleMinutes: null },
+    dailyResetAt: null as number | null,
+    idleExpiresAt: null as number | null,
+  },
+  events: [] as unknown[],
+}));
+
+vi.mock("../../agents/current-time.js", () => ({
+  appendCronStyleCurrentTimeLine: (body: string) =>
+    `${body}\nCurrent time: 2026-02-15T00:00:00Z (mock)`,
+}));
+
+// Perf: this module otherwise pulls a large dependency graph that we don't need
+// for these unit tests.
+vi.mock("../../auto-reply/reply.js", () => ({
+  getReplyFromConfig: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../channels/plugins/whatsapp-heartbeat.js", () => ({
+  resolveWhatsAppHeartbeatRecipients: () => [],
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => ({ agents: { defaults: {} }, session: {} }),
+}));
+
+vi.mock("../../routing/session-key.js", () => ({
+  normalizeMainKey: () => null,
+}));
+
+vi.mock("../../infra/heartbeat-visibility.js", () => ({
+  resolveHeartbeatVisibility: () => state.visibility,
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: () => state.store,
+  resolveSessionKey: () => "k",
+  resolveStorePath: () => "/tmp/store.json",
+  updateSessionStore: async (_path: string, updater: (store: typeof state.store) => void) => {
+    updater(state.store);
+  },
+}));
+
+vi.mock("./session-snapshot.js", () => ({
+  getSessionSnapshot: () => state.snapshot,
+}));
+
+vi.mock("../../infra/heartbeat-events.js", () => ({
+  emitHeartbeatEvent: (event: unknown) => state.events.push(event),
+  resolveIndicatorType: (status: string) => `indicator:${status}`,
+}));
+
+vi.mock("../../logging.js", () => ({
+  getChildLogger: () => ({
+    info: () => {},
+    warn: () => {},
+  }),
+}));
+
+vi.mock("./loggers.js", () => ({
+  whatsappHeartbeatLog: {
+    info: () => {},
+    warn: () => {},
+  },
+}));
+
+vi.mock("../reconnect.js", () => ({
+  newConnectionId: () => "run-1",
+}));
+
+vi.mock("../outbound.js", () => ({
+  sendMessageWhatsApp: vi.fn(async () => ({ messageId: "m1" })),
+}));
+
+vi.mock("../session.js", () => ({
+  formatError: (err: unknown) => `ERR:${String(err)}`,
+}));
+
+describe("runWebHeartbeatOnce", () => {
+  let senderMock: ReturnType<typeof vi.fn>;
+  let sender: typeof sendMessageWhatsApp;
+  let replyResolverMock: ReturnType<typeof vi.fn>;
+  let replyResolver: typeof getReplyFromConfig;
+
+  const getModules = async () => await import("./heartbeat-runner.js");
+
+  beforeEach(() => {
+    state.visibility = { showAlerts: true, showOk: true, useIndicator: false };
+    state.store = { k: { updatedAt: 999, sessionId: "s1" } };
+    state.snapshot = {
+      key: "k",
+      entry: { sessionId: "s1", updatedAt: 123 },
+      fresh: false,
+      resetPolicy: { mode: "none", atHour: null, idleMinutes: null },
+      dailyResetAt: null,
+      idleExpiresAt: null,
+    };
+    state.events = [];
+
+    senderMock = vi.fn(async () => ({ messageId: "m1" }));
+    sender = senderMock as unknown as typeof sendMessageWhatsApp;
+    replyResolverMock = vi.fn(async () => undefined);
+    replyResolver = replyResolverMock as unknown as typeof getReplyFromConfig;
+  });
+
+  it("supports manual override body dry-run without sending", async () => {
+    const { runWebHeartbeatOnce } = await getModules();
+    await runWebHeartbeatOnce({
+      cfg: { agents: { defaults: {} }, session: {} } as never,
+      to: "+123",
+      sender,
+      replyResolver,
+      overrideBody: "hello",
+      dryRun: true,
+    });
+    expect(senderMock).not.toHaveBeenCalled();
+    expect(state.events).toHaveLength(0);
+  });
+
+  it("sends HEARTBEAT_OK when reply is empty and showOk is enabled", async () => {
+    const { runWebHeartbeatOnce } = await getModules();
+    await runWebHeartbeatOnce({
+      cfg: { agents: { defaults: {} }, session: {} } as never,
+      to: "+123",
+      sender,
+      replyResolver,
+    });
+    expect(senderMock).toHaveBeenCalledWith("+123", HEARTBEAT_TOKEN, { verbose: false });
+    expect(state.events).toEqual(
+      expect.arrayContaining([expect.objectContaining({ status: "ok-empty", silent: false })]),
+    );
+  });
+
+  it("injects a cron-style Current time line into the heartbeat prompt", async () => {
+    const { runWebHeartbeatOnce } = await getModules();
+    await runWebHeartbeatOnce({
+      cfg: { agents: { defaults: { heartbeat: { prompt: "Ops check" } } }, session: {} } as never,
+      to: "+123",
+      sender,
+      replyResolver,
+      dryRun: true,
+    });
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    const ctx = replyResolverMock.mock.calls[0]?.[0];
+    expect(ctx?.Body).toContain("Ops check");
+    expect(ctx?.Body).toContain("Current time: 2026-02-15T00:00:00Z (mock)");
+  });
+
+  it("passes heartbeat model override and suppressToolErrorWarnings to reply resolver", async () => {
+    const { runWebHeartbeatOnce } = await getModules();
+    await runWebHeartbeatOnce({
+      cfg: {
+        agents: {
+          defaults: {
+            heartbeat: {
+              model: {
+                primary: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+                fallbacks: ["openrouter/anthropic/claude-haiku-4.5"],
+              },
+              suppressToolErrorWarnings: true,
+            },
+          },
+        },
+        session: {},
+      } as never,
+      to: "+123",
+      sender,
+      replyResolver,
+      dryRun: true,
+    });
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    const opts = replyResolverMock.mock.calls[0]?.[1];
+    expect(opts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+        heartbeatModelOverride: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+        suppressToolErrorWarnings: true,
+      }),
+    );
+  });
+
+  it("treats heartbeat token-only replies as ok-token and preserves session updatedAt", async () => {
+    replyResolverMock.mockResolvedValue({ text: HEARTBEAT_TOKEN });
+    const { runWebHeartbeatOnce } = await getModules();
+    await runWebHeartbeatOnce({
+      cfg: { agents: { defaults: {} }, session: {} } as never,
+      to: "+123",
+      sender,
+      replyResolver,
+    });
+    expect(state.store.k?.updatedAt).toBe(123);
+    expect(senderMock).toHaveBeenCalledWith("+123", HEARTBEAT_TOKEN, { verbose: false });
+    expect(state.events).toEqual(
+      expect.arrayContaining([expect.objectContaining({ status: "ok-token", silent: false })]),
+    );
+  });
+
+  it("skips sending alerts when showAlerts is disabled but still emits a skipped event", async () => {
+    state.visibility = { showAlerts: false, showOk: true, useIndicator: true };
+    replyResolverMock.mockResolvedValue({ text: "ALERT" });
+    const { runWebHeartbeatOnce } = await getModules();
+    await runWebHeartbeatOnce({
+      cfg: { agents: { defaults: {} }, session: {} } as never,
+      to: "+123",
+      sender,
+      replyResolver,
+    });
+    expect(senderMock).not.toHaveBeenCalled();
+    expect(state.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "skipped", reason: "alerts-disabled", preview: "ALERT" }),
+      ]),
+    );
+  });
+
+  it("emits failed events when sending throws and rethrows the error", async () => {
+    replyResolverMock.mockResolvedValue({ text: "ALERT" });
+    senderMock.mockRejectedValueOnce(new Error("nope"));
+    const { runWebHeartbeatOnce } = await getModules();
+    await expect(
+      runWebHeartbeatOnce({
+        cfg: { agents: { defaults: {} }, session: {} } as never,
+        to: "+123",
+        sender,
+        replyResolver,
+      }),
+    ).rejects.toThrow("nope");
+    expect(state.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "failed", reason: "ERR:Error: nope" }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `resolveHeartbeatModelPrimary()` so heartbeat model resolution supports both string and object configs consistently
- pass `heartbeatModelOverride` and `suppressToolErrorWarnings` through web heartbeat runs (previously omitted), matching core heartbeat runner behavior
- update reply/model selection fallback handling and add regression tests for heartbeat model forwarding and object-form config parsing

## Testing
- targeted test execution was not possible in this environment (`pnpm` is unavailable)

Fixes #19445
