### PR TITLE
feat(webchat): cursor-based pagination + virtual scrolling for chat history

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,6 +572,9 @@ importers:
 
   ui:
     dependencies:
+      '@lit-labs/virtualizer':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@noble/ed25519':
         specifier: 3.0.0
         version: 3.0.0
@@ -1358,6 +1361,9 @@ packages:
 
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+
+  '@lit-labs/virtualizer@2.1.1':
+    resolution: {integrity: sha512-JWxMwnlouLdwpw8spLTuax53WMnSP3xt0dCyxAS7GJr5Otda9MGgR/ghAdfwhSY75TmjbE1T2TqChwoGCw3ggw==}
 
   '@lit/context@1.1.6':
     resolution: {integrity: sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==}
@@ -6912,7 +6918,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6928,7 +6934,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6938,6 +6944,11 @@ snapshots:
       signal-polyfill: 0.2.2
 
   '@lit-labs/ssr-dom-shim@1.5.1': {}
+
+  '@lit-labs/virtualizer@2.1.1':
+    dependencies:
+      lit: 3.3.2
+      tslib: 2.8.1
 
   '@lit/context@1.1.6':
     dependencies:
@@ -7132,7 +7143,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8079,7 +8090,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8125,7 +8136,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -9013,14 +9024,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9599,8 +9602,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -27,6 +27,7 @@ export const ChatHistoryParamsSchema = Type.Object(
   {
     sessionKey: NonEmptyString,
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+    before: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -574,9 +574,10 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { sessionKey, limit } = params as {
+    const { sessionKey, limit, before } = params as {
       sessionKey: string;
       limit?: number;
+      before?: number;
     };
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
     const sessionId = entry?.sessionId;
@@ -586,7 +587,21 @@ export const chatHandlers: GatewayRequestHandlers = {
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
     const max = Math.min(hardMax, requested);
-    const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
+    let sliced: unknown[];
+    let cursor: number;
+    let hasMore: boolean;
+    if (typeof before === "number") {
+      const end = Math.min(before, rawMessages.length);
+      const start = Math.max(0, end - max);
+      sliced = rawMessages.slice(start, end);
+      cursor = start;
+      hasMore = start > 0;
+    } else {
+      const start = rawMessages.length > max ? rawMessages.length - max : 0;
+      sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
+      cursor = start;
+      hasMore = start > 0;
+    }
     const sanitized = stripEnvelopeFromMessages(sliced);
     const normalized = sanitizeChatHistoryMessages(sanitized);
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
@@ -597,6 +612,13 @@ export const chatHandlers: GatewayRequestHandlers = {
     });
     const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
     const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
+    // Byte capping drops items from the front — adjust cursor so those messages
+    // remain reachable on the next paginated request.
+    const droppedCount = sliced.length - bounded.messages.length;
+    if (droppedCount > 0) {
+      cursor += droppedCount;
+      hasMore = cursor > 0;
+    }
     const placeholderCount = replaced.replacedCount + bounded.placeholderCount;
     if (placeholderCount > 0) {
       chatHistoryPlaceholderEmitCount += placeholderCount;
@@ -626,6 +648,8 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionKey,
       sessionId,
       messages: bounded.messages,
+      cursor,
+      hasMore,
       thinkingLevel,
       verboseLevel,
     });

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
+    "@lit-labs/virtualizer": "^2.1.1",
     "@noble/ed25519": "3.0.0",
     "dompurify": "^3.3.1",
     "lit": "^3.3.2",

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -809,6 +809,7 @@ export function renderApp(state: AppViewState) {
                 thinkingLevel: state.chatThinkingLevel,
                 showThinking,
                 loading: state.chatLoading,
+                loadingOlder: state.chatLoadingOlder,
                 sending: state.chatSending,
                 compactionStatus: state.compactionStatus,
                 assistantAvatarUrl: chatAvatarUrl,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -45,6 +45,7 @@ function createScrollHost(
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
     topbarObserver: null as ResizeObserver | null,
+    onLoadOlderMessages: null as (() => void) | null,
   };
 
   return { host, container };

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -1,6 +1,11 @@
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
 
+/** Cooldown (ms) after triggering a load-older fetch before allowing another. */
+const LOAD_OLDER_COOLDOWN_MS = 500;
+
+let lastLoadOlderTriggeredAt = 0;
+
 type ScrollHost = {
   updateComplete: Promise<unknown>;
   querySelector: (selectors: string) => Element | null;
@@ -13,6 +18,7 @@ type ScrollHost = {
   logsScrollFrame: number | null;
   logsAtBottom: boolean;
   topbarObserver: ResizeObserver | null;
+  onLoadOlderMessages?: (() => void) | null;
 };
 
 export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
@@ -119,6 +125,9 @@ export function scheduleLogsScroll(host: ScrollHost, force = false) {
   });
 }
 
+/** Distance (px) from the top within which we trigger loading older messages. */
+const NEAR_TOP_THRESHOLD = 200;
+
 export function handleChatScroll(host: ScrollHost, event: Event) {
   const container = event.currentTarget as HTMLElement | null;
   if (!container) {
@@ -129,6 +138,14 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   // Clear the "new messages below" indicator when user scrolls back to bottom.
   if (host.chatUserNearBottom) {
     host.chatNewMessagesBelow = false;
+  }
+  // Trigger loading older messages when user scrolls near the top (with cooldown).
+  if (container.scrollTop < NEAR_TOP_THRESHOLD && host.onLoadOlderMessages) {
+    const now = Date.now();
+    if (now - lastLoadOlderTriggeredAt >= LOAD_OLDER_COOLDOWN_MS) {
+      lastLoadOlderTriggeredAt = now;
+      host.onLoadOlderMessages();
+    }
   }
 }
 

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -52,6 +52,7 @@ export type AppViewState = {
   assistantAgentId: string | null;
   sessionKey: string;
   chatLoading: boolean;
+  chatLoadingOlder: boolean;
   chatSending: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
@@ -60,6 +61,8 @@ export type AppViewState = {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
+  chatCursor: number | null;
+  chatHasMore: boolean;
   compactionStatus: CompactionStatus | null;
   chatAvatarUrl: string | null;
   chatThinkingLevel: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -16,6 +16,7 @@ import {
 } from "./app-channels.ts";
 import {
   handleAbortChat as handleAbortChatInternal,
+  handleLoadOlderChat as handleLoadOlderChatInternal,
   handleSendChat as handleSendChatInternal,
   removeQueuedMessage as removeQueuedMessageInternal,
 } from "./app-chat.ts";
@@ -132,6 +133,7 @@ export class OpenClawApp extends LitElement {
 
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;
+  @state() chatLoadingOlder = false;
   @state() chatSending = false;
   @state() chatMessage = "";
   @state() chatMessages: unknown[] = [];
@@ -139,6 +141,8 @@ export class OpenClawApp extends LitElement {
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
+  @state() chatCursor: number | null = null;
+  @state() chatHasMore = false;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
@@ -353,6 +357,10 @@ export class OpenClawApp extends LitElement {
   private themeMedia: MediaQueryList | null = null;
   private themeMediaHandler: ((event: MediaQueryListEvent) => void) | null = null;
   private topbarObserver: ResizeObserver | null = null;
+  onLoadOlderMessages: (() => void) | null = () =>
+    void handleLoadOlderChatInternal(
+      this as unknown as Parameters<typeof handleLoadOlderChatInternal>[0],
+    );
 
   createRenderRoot() {
     return this;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -5,6 +5,7 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
   return {
     chatAttachments: [],
     chatLoading: false,
+    chatLoadingOlder: false,
     chatMessage: "",
     chatMessages: [],
     chatRunId: null,
@@ -12,6 +13,8 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     chatStream: null,
     chatStreamStartedAt: null,
     chatThinkingLevel: null,
+    chatCursor: null,
+    chatHasMore: false,
     client: null,
     connected: true,
     lastError: null,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -57,6 +57,7 @@ export type ChatProps = {
   // Scroll control
   showNewMessages?: boolean;
   onScrollToBottom?: () => void;
+  loadingOlder?: boolean;
   // Event handlers
   onRefresh: () => void;
   onToggleFocusMode: () => void;
@@ -214,6 +215,13 @@ export function renderChat(props: ChatProps) {
       aria-live="polite"
       @scroll=${props.onChatScroll}
     >
+      ${
+        props.loadingOlder
+          ? html`
+              <div class="muted">Loading older messages…</div>
+            `
+          : nothing
+      }
       ${
         props.loading
           ? html`
@@ -427,8 +435,6 @@ export function renderChat(props: ChatProps) {
   `;
 }
 
-const CHAT_HISTORY_RENDER_LIMIT = 200;
-
 function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];
   let currentGroup: MessageGroup | null = null;
@@ -474,19 +480,7 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
   const history = Array.isArray(props.messages) ? props.messages : [];
   const tools = Array.isArray(props.toolMessages) ? props.toolMessages : [];
-  const historyStart = Math.max(0, history.length - CHAT_HISTORY_RENDER_LIMIT);
-  if (historyStart > 0) {
-    items.push({
-      kind: "message",
-      key: "chat:history:notice",
-      message: {
-        role: "system",
-        content: `Showing last ${CHAT_HISTORY_RENDER_LIMIT} messages (${historyStart} hidden).`,
-        timestamp: Date.now(),
-      },
-    });
-  }
-  for (let i = historyStart; i < history.length; i++) {
+  for (let i = 0; i < history.length; i++) {
     const msg = history[i];
     const normalized = normalizeMessage(msg);
     const raw = msg as Record<string, unknown>;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,6 +1,6 @@
+import { virtualize } from "@lit-labs/virtualizer/virtualize.js";
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { repeat } from "lit/directives/repeat.js";
 import {
   renderMessageGroup,
   renderReadingIndicatorGroup,
@@ -229,10 +229,10 @@ export function renderChat(props: ChatProps) {
             `
           : nothing
       }
-      ${repeat(
-        buildChatItems(props),
-        (item) => item.key,
-        (item) => {
+      ${virtualize({
+        items: buildChatItems(props),
+        keyFunction: (item) => item.key,
+        renderItem: (item) => {
           if (item.kind === "divider") {
             return html`
               <div class="chat-divider" role="separator" data-ts=${String(item.timestamp)}>
@@ -265,9 +265,9 @@ export function renderChat(props: ChatProps) {
             });
           }
 
-          return nothing;
+          return html``;
         },
-      )}
+      })}
     </div>
   `;
 


### PR DESCRIPTION
## Summary

Combines two complementary improvements to chat history handling:

- **Cursor-based pagination** (#19754): Adds a `before` parameter to `chat.history` so clients can load older messages in pages rather than receiving a hard-capped window. Includes scroll-near-top detection, scroll-position preservation, and a "Loading older messages…" indicator.
- **Virtual scrolling** (#16020): Replaces `repeat()` with `@lit-labs/virtualizer` so only visible messages are rendered in the DOM, preventing UI freezes in long conversations.

Together they form a complete solution — pagination loads history from the server in pages, while virtualization ensures only visible messages are rendered regardless of how much history has been loaded.

This PR exists as a combined branch in case #16020 merges first and the pagination work needs to rebase on top, or vice versa. Either PR can also be merged independently.

## Changes

### Server (pagination)
- Add optional `before` integer parameter to `chat.history` schema
- Implement cursor-based slicing in the chat history handler
- Return `cursor` and `hasMore` metadata in responses
- Extended e2e test coverage for pagination

### Client (pagination)
- Add `loadOlderChatHistory()` with session-switch safety guard
- Scroll-near-top detection in `app-scroll.ts`
- Scroll position preservation after prepending older messages
- "Loading older messages…" indicator in chat view

### Client (virtual scrolling)
- Replace `repeat()` with `virtualize()` from `@lit-labs/virtualizer`
- Remove 200-message render limit (virtualization handles unlimited messages)

## Related

- #19754 — cursor-based pagination (standalone)
- #16020 — virtual scrolling (standalone)
- Discussion #19753 — feature proposal

## Test plan

- [ ] Verify `chat.history` returns `cursor` and `hasMore` fields
- [ ] Verify `before` parameter loads older messages correctly
- [ ] Verify scroll-near-top triggers loading of older messages
- [ ] Verify scroll position is preserved when older messages are prepended
- [ ] Verify virtualization renders only visible messages
- [ ] Run gateway tests: `pnpm vitest run --config vitest.gateway.config.ts`

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)