### PR TITLE
fix(ui): prevent chat auto-scroll from fighting user scroll during streaming

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -213,6 +213,10 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
         payload.sessionKey,
       );
     }
+    // Preserve stream text so the bubble stays visible until history replaces it.
+    // handleChatEvent clears chatStream on "final", which collapses scroll height
+    // and can corrupt chatUserNearBottom before loadChatHistory fills in the real message.
+    const streamBeforeFinal = (host as unknown as OpenClawApp).chatStream;
     const state = handleChatEvent(host as unknown as OpenClawApp, payload);
     if (state === "final" || state === "error" || state === "aborted") {
       resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
@@ -228,7 +232,11 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
       }
     }
     if (state === "final") {
-      void loadChatHistory(host as unknown as OpenClawApp);
+      // Keep stream bubble visible to prevent scroll collapse while history loads.
+      (host as unknown as OpenClawApp).chatStream = streamBeforeFinal;
+      void loadChatHistory(host as unknown as OpenClawApp, { skipLoading: true }).then(() => {
+        (host as unknown as OpenClawApp).chatStream = null;
+      });
     }
     return;
   }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -336,7 +336,6 @@ export class OpenClawApp extends LitElement {
 
   client: GatewayBrowserClient | null = null;
   private chatScrollFrame: number | null = null;
-  private chatScrollTimeout: number | null = null;
   private chatHasAutoScrolled = false;
   private chatUserNearBottom = true;
   @state() chatNewMessagesBelow = false;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -27,11 +27,13 @@ export type ChatEventPayload = {
   errorMessage?: string;
 };
 
-export async function loadChatHistory(state: ChatState) {
+export async function loadChatHistory(state: ChatState, opts?: { skipLoading?: boolean }) {
   if (!state.client || !state.connected) {
     return;
   }
-  state.chatLoading = true;
+  if (!opts?.skipLoading) {
+    state.chatLoading = true;
+  }
   state.lastError = null;
   try {
     const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
@@ -46,7 +48,9 @@ export async function loadChatHistory(state: ChatState) {
   } catch (err) {
     state.lastError = String(err);
   } finally {
-    state.chatLoading = false;
+    if (!opts?.skipLoading) {
+      state.chatLoading = false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces the `chatScrollPending` boolean guard with a dual-threshold approach that cleanly separates auto-scroll re-engage (50px) from the "new messages below" indicator (450px)
- Removes the `distanceFromBottom` fallback from `shouldStick` in `scheduleChatScroll` — `chatUserNearBottom` is now the sole authority for whether to auto-scroll
- Adds `skipLoading` option to `loadChatHistory` so post-stream history refresh doesn't flash a loading indicator

## Problem

During agent streaming responses, each token update triggers `scheduleChatScroll` → `scrollTo()` → browser fires scroll event → `handleChatScroll` resets `chatUserNearBottom = true` (using the same 450px threshold as the "should we auto-scroll?" check) → next `scheduleChatScroll` sees user as "near bottom" and scrolls again. This creates a feedback loop that prevents users from scrolling up while a response is streaming.

## Approach

Use two separate thresholds in `handleChatScroll`:
- **`SCROLL_LOCK_THRESHOLD` (50px)**: Controls `chatUserNearBottom`. Kept tight so any deliberate upward scroll immediately disengages auto-scroll, while the browser's own programmatic-scroll events (which land at distance ≈ 0) keep it active.
- **`NEAR_BOTTOM_THRESHOLD` (450px)**: Only controls dismissal of the "new messages below" indicator.

In `scheduleChatScroll`, `shouldStick` is simplified to `effectiveForce || host.chatUserNearBottom` — no distance fallback. This means `handleChatScroll`'s 50px threshold is the single source of truth for auto-scroll behavior.

The `chatScrollPending` flag is removed entirely — it's no longer needed because the tight 50px threshold naturally distinguishes programmatic scrolls (distance ≈ 0) from user scrolls (distance > 50px).

## Test plan

- [ ] Open chat, start a long agent response streaming
- [ ] Scroll up while streaming — viewport should stay where user scrolled
- [ ] "New messages below" indicator should appear
- [ ] Scroll back to bottom — auto-scroll resumes
- [ ] Initial page load still auto-scrolls to bottom
- [ ] Unit tests updated with dual-threshold coverage

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)