### PR TITLE
fix(anthropic): preserve pi-ai default betas when injecting anthropic-beta header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Pairing: tolerate legacy paired devices missing `roles`/`scopes` metadata in websocket upgrade checks and backfill metadata on reconnect. (#21447, fixes #21236) Thanks @joshavant.
 - Docker: pin base images to SHA256 digests in Docker builds to prevent mutable tag drift. (#7734) Thanks @coygeek.
 - Provider/HTTP: treat HTTP 503 as failover-eligible for LLM provider errors. (#21086) Thanks @Protocol-zero-0.
+- Anthropic/Agents: preserve required pi-ai default OAuth beta headers when `context1m` injects `anthropic-beta`, preventing 401 auth failures for `sk-ant-oat-*` tokens. (#19789, fixes #19769) Thanks @minupla.
 - Slack: pass `recipient_team_id` / `recipient_user_id` through Slack native streaming calls so `chat.startStream`/`appendStream`/`stopStream` work reliably across DMs and Slack Connect setups, and disable block streaming when native streaming is active. (#20988) Thanks @Dithilli. Earlier recipient-ID groundwork was contributed in #20377 by @AsserAl1012.
 - CLI/Config: add canonical `--strict-json` parsing for `config set` and keep `--json` as a legacy alias to reduce help/behavior drift. (#21332) thanks @adhitShet.
 - CLI: keep `openclaw -v` as a root-only version alias so subcommand `-v, --verbose` flags (for example ACP/hooks/skills) are no longer intercepted globally. (#21303) thanks @adhitShet.

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -222,16 +222,46 @@ function mergeAnthropicBetaHeader(
   return merged;
 }
 
+// Betas that pi-ai's createClient injects for standard Anthropic API key calls.
+// Must be included when injecting anthropic-beta via options.headers, because
+// pi-ai's mergeHeaders uses Object.assign (last-wins), which would otherwise
+// overwrite the hardcoded defaultHeaders["anthropic-beta"].
+const PI_AI_DEFAULT_ANTHROPIC_BETAS = [
+  "fine-grained-tool-streaming-2025-05-14",
+  "interleaved-thinking-2025-05-14",
+] as const;
+
+// Additional betas pi-ai injects when the API key is an OAuth token (sk-ant-oat-*).
+// These are required for Anthropic to accept OAuth Bearer auth. Losing oauth-2025-04-20
+// causes a 401 "OAuth authentication is currently not supported".
+const PI_AI_OAUTH_ANTHROPIC_BETAS = [
+  "claude-code-20250219",
+  "oauth-2025-04-20",
+  ...PI_AI_DEFAULT_ANTHROPIC_BETAS,
+] as const;
+
+function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
+  return typeof apiKey === "string" && apiKey.includes("sk-ant-oat");
+}
+
 function createAnthropicBetaHeadersWrapper(
   baseStreamFn: StreamFn | undefined,
   betas: string[],
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
-  return (model, context, options) =>
-    underlying(model, context, {
+  return (model, context, options) => {
+    // Preserve the betas pi-ai's createClient would inject for the given token type.
+    // Without this, our options.headers["anthropic-beta"] overwrites the pi-ai
+    // defaultHeaders via Object.assign, stripping critical betas like oauth-2025-04-20.
+    const piAiBetas = isAnthropicOAuthApiKey(options?.apiKey)
+      ? (PI_AI_OAUTH_ANTHROPIC_BETAS as readonly string[])
+      : (PI_AI_DEFAULT_ANTHROPIC_BETAS as readonly string[]);
+    const allBetas = [...new Set([...piAiBetas, ...betas])];
+    return underlying(model, context, {
       ...options,
-      headers: mergeAnthropicBetaHeader(options?.headers, betas),
+      headers: mergeAnthropicBetaHeader(options?.headers, allBetas),
     });
+  };
 }
 
 /**


### PR DESCRIPTION
## Problem

After #19769 was reported, updating to v2026.2.17 causes all Anthropic API calls to fail with HTTP 401 when using an OAuth token (`sk-ant-oat-*`).

**Root cause:** When the `context1m` feature injects `anthropic-beta` via `options.headers`, `pi-ai`'s `mergeHeaders` uses `Object.assign` (last-wins). This overwrites `createClient`'s hardcoded `defaultHeaders["anthropic-beta"]`, stripping required betas like `oauth-2025-04-20`. Without that beta, Anthropic rejects OAuth Bearer auth with a 401.

## Fix

- Detect token type by checking for the `sk-ant-oat` prefix
- Pre-seed the appropriate pi-ai default betas (`PI_AI_DEFAULT_ANTHROPIC_BETAS` or `PI_AI_OAUTH_ANTHROPIC_BETAS`) before merging custom betas
- Deduplicate with `Set` to avoid duplicate entries

## Tests

Added a test case covering the OAuth token path with `context1m` enabled, verifying that `oauth-2025-04-20` and `claude-code-20250219` survive the header merge.

Fixes #19769

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a critical regression where `context1m` feature injection of the `anthropic-beta` header via `options.headers` would overwrite pi-ai's hardcoded `defaultHeaders["anthropic-beta"]` (due to `Object.assign` last-wins in pi-ai's `mergeHeaders`), stripping required betas like `oauth-2025-04-20` and causing HTTP 401 for OAuth token users.

- Adds `PI_AI_DEFAULT_ANTHROPIC_BETAS` and `PI_AI_OAUTH_ANTHROPIC_BETAS` constants mirroring pi-ai's internal defaults, pre-seeded into the merged beta header to prevent overwrite
- Detects OAuth tokens at runtime via `options?.apiKey` prefix matching to select the appropriate beta set
- Deduplicates betas with `Set` to avoid redundant entries
- Adds test coverage for the OAuth token path with `context1m` enabled
- **Note:** The hardcoded beta constants duplicate pi-ai internals and will need updating if the library changes its defaults — this coupling is documented in code comments

<h3>Confidence Score: 4/5</h3>

- This PR is a targeted, well-tested fix for a critical OAuth authentication regression and is safe to merge.
- The fix correctly addresses the root cause (Object.assign last-wins overwriting critical betas), has good test coverage for both OAuth and standard API key paths, and the implementation is straightforward. The one concern is the hardcoded duplication of pi-ai's internal beta constants, which creates a maintenance coupling — but this is clearly documented and is the pragmatic solution given the upstream library's design.
- src/agents/pi-embedded-runner/extra-params.ts — hardcoded beta constants will need updating if pi-ai changes its defaults

<sub>Last reviewed commit: 4b2db90</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->