### PR TITLE
fix(telegram): add INFO-level logging at inbound message drop paths

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1042,6 +1042,10 @@ export const registerTelegramHandlers = ({
         return;
       }
       if (shouldSkipUpdate(ctx)) {
+        logger.info(
+          { chatId: msg.chat.id, messageId: msg.message_id },
+          "telegram message handler: update skipped",
+        );
         return;
       }
 

--- a/src/telegram/bot-message-context.drop-logging.test.ts
+++ b/src/telegram/bot-message-context.drop-logging.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildTelegramMessageContext } from "./bot-message-context.js";
+
+describe("buildTelegramMessageContext drop logging", () => {
+  function baseParams(overrides: Record<string, unknown> = {}) {
+    const logger = { info: vi.fn() };
+    return {
+      primaryCtx: {
+        message: {
+          message_id: 1,
+          chat: { id: 100, type: "private" as const },
+          date: 1700000000,
+          text: "hello",
+          from: { id: 42, first_name: "Alice", username: "alice" },
+        },
+        me: { id: 7, username: "bot" },
+      } as never,
+      allMedia: [],
+      storeAllowFrom: [],
+      options: {},
+      bot: {
+        api: {
+          sendChatAction: vi.fn(),
+          setMessageReaction: vi.fn(),
+          sendMessage: vi.fn(),
+        },
+      } as never,
+      cfg: {
+        agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+        channels: { telegram: {} },
+        messages: { groupChat: { mentionPatterns: [] } },
+      } as never,
+      account: { accountId: "default" } as never,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      dmPolicy: "open" as const,
+      allowFrom: [] as Array<string | number>,
+      groupAllowFrom: [] as Array<string | number>,
+      ackReactionScope: "off" as const,
+      logger,
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: undefined,
+        topicConfig: undefined,
+      }),
+      ...overrides,
+    };
+  }
+
+  it("logs when DM policy is disabled", async () => {
+    const params = baseParams({ dmPolicy: "disabled" });
+    const result = await buildTelegramMessageContext(params as never);
+
+    expect(result).toBeNull();
+    expect(params.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "dm-disabled" }),
+      "telegram inbound message dropped",
+    );
+  });
+
+  it("logs when DM sender is not allowed (allowlist policy)", async () => {
+    const params = baseParams({
+      dmPolicy: "allowlist",
+      allowFrom: [999],
+    });
+    const result = await buildTelegramMessageContext(params as never);
+
+    expect(result).toBeNull();
+    expect(params.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "dm-not-allowed", dmPolicy: "allowlist" }),
+      "telegram inbound message dropped",
+    );
+  });
+
+  it("logs when message has no text and no media", async () => {
+    const params = baseParams();
+    (params.primaryCtx as { message: { text?: string } }).message.text = undefined;
+    const result = await buildTelegramMessageContext(params as never);
+
+    expect(result).toBeNull();
+    expect(params.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "empty-message" }),
+      "telegram inbound message dropped",
+    );
+  });
+
+  it("logs when group is disabled", async () => {
+    const params = baseParams({
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { enabled: false },
+        topicConfig: undefined,
+      }),
+    });
+    (params.primaryCtx as { message: { chat: { id: number; type: string } } }).message.chat = {
+      id: -200,
+      type: "supergroup",
+    };
+    const result = await buildTelegramMessageContext(params as never);
+
+    expect(result).toBeNull();
+    expect(params.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "group-disabled" }),
+      "telegram inbound message dropped",
+    );
+  });
+});

--- a/src/telegram/bot-message.test.ts
+++ b/src/telegram/bot-message.test.ts
@@ -30,7 +30,7 @@ describe("telegram bot message processor", () => {
     allowFrom: [],
     groupAllowFrom: [],
     ackReactionScope: "none",
-    logger: {},
+    logger: { info: vi.fn() },
     resolveGroupActivation: () => true,
     resolveGroupRequireMention: () => false,
     resolveTelegramGroupConfig: () => ({}),

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -72,6 +72,10 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       resolveTelegramGroupConfig,
     });
     if (!context) {
+      logger.info(
+        { chatId: primaryCtx.message?.chat?.id, reason: "context-rejected" },
+        "telegram inbound message dropped",
+      );
       return;
     }
     await dispatchTelegramMessage({

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -166,13 +166,14 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     const updateId = resolveTelegramUpdateId(ctx);
     if (typeof updateId === "number" && lastUpdateId !== null) {
       if (updateId <= lastUpdateId) {
+        logger.info({ updateId, lastUpdateId, reason: "offset" }, "telegram update skipped");
         return true;
       }
     }
     const key = buildTelegramUpdateKey(ctx);
     const skipped = recentUpdates.check(key);
-    if (skipped && key && shouldLogVerbose()) {
-      logVerbose(`telegram dedupe: skipped ${key}`);
+    if (skipped && key) {
+      logger.info({ updateId, key, reason: "dedupe" }, "telegram update skipped");
     }
     return skipped;
   };


### PR DESCRIPTION
## Summary
- **Problem**: When Telegram inbound messages are dropped (access control, empty message, deduplication), the only logging is at verbose level, making it impossible to diagnose why messages are not reaching the agent session.
- **Why it matters**: Users report messages not being dispatched (#19454) but see no errors — silent drops are unacceptable for a messaging platform.
- **What changed**: Added INFO-level structured logging (`{ chatId, senderId, reason }`) at every `return null` path in `buildTelegramMessageContext`, in `processMessage` when context is null, and in `shouldSkipUpdate` with reason discrimination (offset vs dedupe). Added logging in the message handler after skip detection.
- **What did NOT change**: No behavioral changes — only observability improvements. All existing logic paths remain identical.

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #19454

## Testing
- 4 new tests verify logging at drop points (DM disabled, DM not allowed, empty message, group disabled)
- All 475 telegram tests pass
- Quality gates: `pnpm build && pnpm check && pnpm test` ✅

## AI Disclosure
- AI-assisted: Yes (OpenClaw agent)
- Testing level: fully tested locally
- Understanding: confirmed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades Telegram inbound message drop logging from verbose/debug level to structured INFO-level `logger.info` calls with discriminated `reason` fields. Every `return null` path in `buildTelegramMessageContext` and the `shouldSkipUpdate` function now emits structured logs including `chatId`, `senderId`, and a specific `reason` string, making it straightforward to diagnose why messages are not reaching the agent session.

- Replaced `logVerbose` and `logInboundDrop` calls in `bot-message-context.ts` with `logger.info` structured logging at all drop points (group-disabled, topic-disabled, group-allowFrom, dm-disabled, dm-not-allowed, empty-message, control-command-unauthorized, no-mention)
- Added reason discrimination (`"offset"` vs `"dedupe"`) in `shouldSkipUpdate` and removed the `shouldLogVerbose()` guard so skip logs are always emitted
- Added logging in `bot-message.ts` and `bot-handlers.ts` at the caller level after context/skip checks
- Two instances of **redundant double-logging** were introduced: `bot-message.ts` logs `"context-rejected"` after `buildTelegramMessageContext` already logged the specific reason, and `bot-handlers.ts` logs after `shouldSkipUpdate` already logged internally. These should be removed to avoid doubling log volume on every drop
- Added 4 new tests and updated existing test mocks to match new logger interface

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it only adds observability logging with no behavioral changes, though the double-logging should ideally be cleaned up.
- The changes are observability-only with no behavioral modifications. All existing logic paths remain identical. The two double-logging instances are a minor issue that would increase log noise but not affect correctness. Tests are thorough and cover the key drop paths.
- `src/telegram/bot-message.ts` and `src/telegram/bot-handlers.ts` have redundant double-logging that should be removed.

<sub>Last reviewed commit: f6af682</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->