### PR TITLE
fix(browser): stability improvements for headless Chrome

### DIFF
--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import {
+  cleanStaleSingletonFiles,
   decorateOpenClawProfile,
   ensureProfileCleanExit,
   findChromeExecutableMac,
@@ -198,6 +199,45 @@ describe("browser chrome profile decoration", () => {
     const prefs = await readJson(path.join(userDataDir, "Default", "Preferences"));
     const profile = prefs.profile as Record<string, unknown>;
     expect(profile.name).toBe(DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME);
+  });
+});
+
+describe("cleanStaleSingletonFiles", () => {
+  it("removes SingletonLock, SingletonSocket, and SingletonCookie", async () => {
+    const userDataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-chrome-test-"));
+    try {
+      for (const name of ["SingletonLock", "SingletonSocket", "SingletonCookie"]) {
+        await fsp.writeFile(path.join(userDataDir, name), "stale", "utf-8");
+      }
+      cleanStaleSingletonFiles(userDataDir);
+      for (const name of ["SingletonLock", "SingletonSocket", "SingletonCookie"]) {
+        expect(fs.existsSync(path.join(userDataDir, name))).toBe(false);
+      }
+    } finally {
+      await fsp.rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not throw when singleton files do not exist", async () => {
+    const userDataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-chrome-test-"));
+    try {
+      expect(() => cleanStaleSingletonFiles(userDataDir)).not.toThrow();
+    } finally {
+      await fsp.rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves other files untouched", async () => {
+    const userDataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-chrome-test-"));
+    try {
+      await fsp.writeFile(path.join(userDataDir, "SingletonLock"), "stale", "utf-8");
+      await fsp.writeFile(path.join(userDataDir, "Local State"), "{}", "utf-8");
+      cleanStaleSingletonFiles(userDataDir);
+      expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
+      expect(fs.existsSync(path.join(userDataDir, "Local State"))).toBe(true);
+    } finally {
+      await fsp.rm(userDataDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -57,6 +57,17 @@ function exists(filePath: string) {
   }
 }
 
+export function cleanStaleSingletonFiles(userDataDir: string) {
+  for (const name of ["SingletonLock", "SingletonSocket", "SingletonCookie"]) {
+    const filePath = path.join(userDataDir, name);
+    try {
+      fs.unlinkSync(filePath);
+    } catch {
+      // File doesn't exist or can't be removed — fine either way.
+    }
+  }
+}
+
 export type RunningChrome = {
   pid: number;
   exe: BrowserExecutable;
@@ -230,6 +241,7 @@ export async function launchOpenClawChrome(
 
   const userDataDir = resolveOpenClawUserDataDir(profile.name);
   fs.mkdirSync(userDataDir, { recursive: true });
+  cleanStaleSingletonFiles(userDataDir);
 
   const needsDecorate = !isProfileDecorated(
     userDataDir,

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -269,6 +269,11 @@ export async function launchOpenClawChrome(
       // Best-effort; older Chromes may ignore.
       args.push("--headless=new");
       args.push("--disable-gpu");
+      // Without a GPU, Chrome falls back to SwiftShader for WebGL — pure
+      // software rendering that can block the main thread indefinitely on
+      // heavy pages (e.g. TradingView charts).  Disabling WebGL forces
+      // sites to use Canvas2D, which keeps the renderer responsive.
+      args.push("--disable-webgl");
     }
     if (resolved.noSandbox) {
       args.push("--no-sandbox");

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -423,6 +423,10 @@ async function closeTargetsViaCdp(browserWsUrl: string, targetIds: string[]): Pr
 async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
   const normalized = normalizeCdpUrl(cdpUrl);
   if (cached?.cdpUrl === normalized) {
+    // Even with a cached connection, evict stuck pages whose renderer is
+    // unresponsive.  Playwright Page objects for closed targets get cleaned
+    // up automatically via Target.targetDestroyed events.
+    await evictStuckPagesViaCdp(normalized).catch(() => {});
     return cached;
   }
   if (connecting) {

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -320,6 +320,106 @@ function observeBrowser(browser: Browser) {
   }
 }
 
+/**
+ * Pre-connection health check: probe every page via raw CDP and close
+ * pages whose renderer doesn't respond within the timeout.
+ *
+ * Playwright's connectOverCDP() attaches to ALL pages during initialization.
+ * If any page's renderer is stuck (heavy/infinite JS), the entire connection
+ * hangs. By evicting stuck pages beforehand, connectOverCDP() succeeds.
+ */
+async function evictStuckPagesViaCdp(cdpUrl: string): Promise<void> {
+  const httpBase = normalizeCdpHttpBaseForJsonEndpoints(cdpUrl);
+  const listUrl = appendCdpPath(httpBase, "/json/list");
+
+  const pages = await fetchJson<
+    Array<{
+      id?: string;
+      url?: string;
+      webSocketDebuggerUrl?: string;
+      type?: string;
+    }>
+  >(listUrl, 2000).catch(() => null);
+
+  if (!pages || pages.length === 0) {
+    return;
+  }
+
+  const pageTargets = pages.filter(
+    (p) => (p.type === "page" || !p.type) && p.id && p.webSocketDebuggerUrl,
+  );
+
+  const stuckIds: string[] = [];
+
+  await Promise.all(
+    pageTargets.map(async (target) => {
+      const wsUrl = normalizeCdpWsUrl(String(target.webSocketDebuggerUrl), httpBase);
+      const responsive = await probePageViaCdp(wsUrl, 3000).catch(() => false);
+      if (!responsive) {
+        stuckIds.push(String(target.id));
+      }
+    }),
+  );
+
+  if (stuckIds.length === 0) {
+    return;
+  }
+
+  // Close stuck pages via browser-level CDP
+  const versionUrl = appendCdpPath(httpBase, "/json/version");
+  const version = await fetchJson<{ webSocketDebuggerUrl?: string }>(versionUrl, 2000).catch(
+    () => null,
+  );
+
+  const browserWs = version?.webSocketDebuggerUrl
+    ? normalizeCdpWsUrl(String(version.webSocketDebuggerUrl), httpBase)
+    : null;
+
+  if (!browserWs) {
+    return;
+  }
+
+  await closeTargetsViaCdp(browserWs, stuckIds).catch(() => {});
+}
+
+/** Probe a single page by sending Runtime.evaluate("1") via its page-level WS. */
+async function probePageViaCdp(wsUrl: string, timeoutMs: number): Promise<boolean> {
+  return await withCdpSocket(
+    wsUrl,
+    async (send) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("probe timeout")), timeoutMs);
+      });
+      try {
+        await Promise.race([
+          send("Runtime.evaluate", { expression: "1", returnByValue: true }),
+          timeoutPromise,
+        ]);
+        return true;
+      } finally {
+        if (timer) {
+          clearTimeout(timer);
+        }
+      }
+    },
+    { handshakeTimeoutMs: timeoutMs },
+  );
+}
+
+/** Close targets by ID via browser-level CDP WebSocket. */
+async function closeTargetsViaCdp(browserWsUrl: string, targetIds: string[]): Promise<void> {
+  await withCdpSocket(
+    browserWsUrl,
+    async (send) => {
+      for (const id of targetIds) {
+        await send("Target.closeTarget", { targetId: id }).catch(() => {});
+      }
+    },
+    { handshakeTimeoutMs: 2000 },
+  );
+}
+
 async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
   const normalized = normalizeCdpUrl(cdpUrl);
   if (cached?.cdpUrl === normalized) {
@@ -332,6 +432,8 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
   const connectWithRetry = async (): Promise<ConnectedBrowser> => {
     let lastErr: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
+      // Evict stuck pages that would block connectOverCDP()
+      await evictStuckPagesViaCdp(normalized).catch(() => {});
       try {
         const timeout = 5000 + attempt * 2000;
         const wsUrl = await getChromeWebSocketUrl(normalized, timeout).catch(() => null);


### PR DESCRIPTION
## Summary
- Clean stale Chrome singleton lock files before launch to prevent "already running" errors
- Evict stuck browser pages before Playwright connection (fixes hung sessions)
- Also evict stuck pages on cached (reused) connections
- Disable WebGL in headless mode to prevent GPU renderer hangs

## Context
These fixes address several browser stability issues encountered in production with headless Chrome (Playwright). Each fix targets a different failure mode:

1. **Stale singleton files** — after unclean shutdowns, Chrome leaves lock files that prevent new launches
2. **Stuck pages** — pages from previous sessions can remain in "loading" state indefinitely, blocking new connections
3. **Cached connections** — the stuck page issue also affected reused browser connections
4. **WebGL hangs** — GPU-accelerated rendering in headless mode can cause the renderer process to hang

## Test plan
- [x] Existing browser tests pass
- [ ] Verify in headless environment with multiple concurrent sessions
- [ ] Test recovery after forced Chrome kill (singleton cleanup)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four defensive measures to improve headless Chrome stability with Playwright:

- **Stale singleton cleanup**: Removes Chrome's `SingletonLock`, `SingletonSocket`, and `SingletonCookie` files before launch to prevent "already running" errors after unclean shutdowns. Well-tested with three unit tests covering happy path, no-op, and selectivity.
- **Stuck page eviction**: Probes all browser pages via raw CDP `Runtime.evaluate("1")` before Playwright's `connectOverCDP()` and closes unresponsive pages. This prevents the entire connection from hanging when any page's renderer is stuck.
- **Cached connection eviction**: Applies the same stuck-page eviction to reused (cached) Playwright connections, not just fresh ones.
- **WebGL disabled in headless**: Adds `--disable-webgl` to headless Chrome args to avoid SwiftShader software rendering hangs on heavy pages.

All new CDP operations are best-effort (wrapped in `.catch(() => {})`), following existing patterns in the codebase. The `evictStuckPagesViaCdp` helper is called on every `connectBrowser` invocation (both cached and fresh paths), which adds minor latency for health-checking but provides continuous protection against stuck pages.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — all changes are defensive, best-effort, and follow established patterns.
- Score of 4 reflects that all code changes are logically correct, follow existing patterns (best-effort `.catch(() => {})`, `withCdpSocket`, `fetchJson`), and include good test coverage for the singleton cleanup. Deducted 1 point because the CDP eviction functions lack unit tests and the eviction-on-every-cached-call adds latency worth monitoring in production.
- Pay attention to `src/browser/pw-session.ts` — the `evictStuckPagesViaCdp` function runs on every `connectBrowser` call (including cached path) and lacks unit test coverage.

<sub>Last reviewed commit: 262be2d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->