### PR TITLE
feat: contextScripts pre-spawn hook for sub-agent sessions (rebased on v2026.2.17)

### DIFF
--- a/docs/concepts/context-scripts.md
+++ b/docs/concepts/context-scripts.md
@@ -1,0 +1,310 @@
+---
+summary: "Pre-spawn context scripts: inject identity, context, or metadata into sub-agent tasks before execution"
+title: Context Scripts
+read_when:
+  - Configuring pre-spawn hooks for sub-agents
+  - Injecting identity or context into spawned sessions
+  - Dynamically overriding the target agent at spawn time
+status: active
+---
+
+# Context Scripts
+
+Context scripts run **before** a sub-agent session is spawned via `sessions_spawn`. They can inject context (identity files, charters, instructions) into the task message and optionally override which agent the session runs under.
+
+## Why?
+
+When spawning sub-agents, only `AGENTS.md` and `TOOLS.md` are included by default. Identity files like `SOUL.md`, `IDENTITY.md`, or custom governance documents are not passed through. Context scripts solve this by running a script that resolves the right context for the target agent and injects it into the task.
+
+They also solve a common multi-agent pattern: **unregistered agent aliases**. If you have lightweight agent roles (e.g. specialist personas under a parent agent), context scripts can detect the alias, inject the right identity, and redirect the spawn to the parent agent for auth and model resolution.
+
+## How It Works
+
+1. Agent calls `sessions_spawn` with a `targetAgentId` and `task`
+2. Context scripts execute **before** auth, config, and session key resolution
+3. Each script receives spawn variables (agent ID, task, label, etc.) as arguments or JSON
+4. Script output is parsed and prepended/appended to the task message
+5. If a script returns an `agentIdOverride`, the target agent is swapped before auth resolution
+6. The overridden agent ID is validated against the gateway config — only real, configured agents are accepted
+
+## Configuration
+
+Context scripts are configured at two levels:
+
+### Global Defaults
+
+Applied to all `sessions_spawn` calls:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "subagents": {
+        "contextScripts": {
+          "run": [
+            {
+              "id": "my-identity-script",
+              "uri": "~/scripts/inject-identity.sh",
+              "format": "arguments",
+              "priority": 100,
+              "position": "prepend",
+              "log": true,
+              "errorHandling": "continue",
+              "returnKey": "message",
+              "agentIdOverrideKey": "targetAgentId",
+              "argMap": {
+                "targetAgentId": "targetAgentId"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Per-Agent Overrides
+
+Add scripts or ignore global ones for a specific agent:
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "my-agent",
+        "subagents": {
+          "contextScripts": {
+            "run": [
+              {
+                "id": "agent-specific-script",
+                "uri": "https://example.com/api/context",
+                "format": "json",
+                "method": "POST",
+                "priority": 50
+              }
+            ],
+            "ignore": ["my-identity-script"]
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+### Resolution Order
+
+1. Start with `defaults.subagents.contextScripts.run[]`
+2. Remove any IDs listed in `agent.subagents.contextScripts.ignore[]`
+3. Append `agent.subagents.contextScripts.run[]`
+4. Deduplicate by `id` (agent-specific entries override defaults with the same ID)
+5. Sort by `priority` (highest first, stable sort)
+
+## Script Entry Schema
+
+| Field                | Type                         | Default       | Description                                                                |
+| -------------------- | ---------------------------- | ------------- | -------------------------------------------------------------------------- |
+| `id`                 | `string`                     | _required_    | Unique identifier for dedup and ignore lists                               |
+| `uri`                | `string`                     | _required_    | File path or HTTP(S) URL                                                   |
+| `format`             | `"arguments" \| "json"`      | `"arguments"` | How variables are passed to the script                                     |
+| `method`             | `string`                     | `"GET"`       | HTTP method (only for URL scripts)                                         |
+| `priority`           | `number`                     | `0`           | Execution/sort order. Higher runs first. Negative values OK.               |
+| `position`           | `"prepend" \| "append"`      | `"append"`    | Where to inject output in the task message                                 |
+| `log`                | `false \| true \| "verbose"` | `false`       | `false`: silent. `true`: summary line. `"verbose"`: full command + output. |
+| `errorHandling`      | `"continue" \| "stop"`       | `"continue"`  | What to do when the script fails                                           |
+| `returnKey`          | `string`                     | —             | Extract this key from JSON output as the content to inject                 |
+| `errorKey`           | `string`                     | —             | Check this key in JSON output for error conditions                         |
+| `agentIdOverrideKey` | `string`                     | —             | Extract this key from JSON output to override the target agent ID          |
+| `argMap`             | `Record<string, string>`     | —             | Map spawn variables to script arguments                                    |
+
+## Variable Passing
+
+### Format: `arguments`
+
+Variables from `argMap` are passed as CLI arguments in `key="value"` format:
+
+```bash
+~/scripts/inject-identity.sh targetAgentId="my-agent"
+```
+
+### Format: `json`
+
+Variables from `argMap` are passed as a JSON object on stdin:
+
+```json
+{ "targetAgentId": "my-agent" }
+```
+
+### Available Variables
+
+These are the spawn variables available for mapping via `argMap`. The key in `argMap` becomes the argument name; the value must be one of these variable names.
+
+| Variable              | Type                              | Description                                                                                                                                                                             |
+| --------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `targetAgentId`       | `string`                          | The requested agent ID (before any override). This is the `agentId` passed to `sessions_spawn`, or the requester's own agent ID if none was specified.                                  |
+| `task`                | `string`                          | The raw task message as provided by the caller (before any context script injection).                                                                                                   |
+| `label`               | `string \| undefined`             | The spawn label, if provided. Useful for display, logging, or routing decisions in the script.                                                                                          |
+| `requesterAgentId`    | `string`                          | The agent ID of the session that called `sessions_spawn`.                                                                                                                               |
+| `requesterSessionKey` | `string \| undefined`             | The full session key of the requester (e.g. `agent:my-agent:telegram:direct:12345`).                                                                                                    |
+| `cleanup`             | `"delete" \| "keep" \| undefined` | Session cleanup mode. `"delete"` removes the session after completion; `"keep"` preserves it.                                                                                           |
+| `cfg`                 | `object`                          | The full gateway configuration object. Only useful with `format: "json"` — allows scripts to inspect agent config, model settings, etc. Large; avoid passing via `format: "arguments"`. |
+
+**Example `argMap` configurations:**
+
+Pass just the target agent:
+
+```json
+{
+  "argMap": {
+    "targetAgentId": "targetAgentId"
+  }
+}
+```
+
+→ Script receives: `targetAgentId="my-agent"`
+
+Pass multiple variables:
+
+```json
+{
+  "argMap": {
+    "agent": "targetAgentId",
+    "spawner": "requesterAgentId",
+    "tag": "label"
+  }
+}
+```
+
+→ Script receives: `agent="my-agent" spawner="parent-agent" tag="my-label"`
+
+Note: The `argMap` key is the **argument name** the script sees; the value is the **variable name** from the table above. This lets you rename variables to match your script's expectations.
+
+## Script Output
+
+### Plain Text
+
+If the script outputs plain text (not JSON), it's used as-is for injection.
+
+### JSON Output
+
+If the script outputs JSON, the response parsing pipeline processes it:
+
+1. If `errorKey` is set and that key exists in the output → treated as an error
+2. Standard error detection (OpenAI/Anthropic/REST error patterns)
+3. If `returnKey` is set → extract that key as the content
+4. If `agentIdOverrideKey` is set → extract that key as the agent ID override
+5. Auto-detect common content keys: `message`, `content`, `text`, `result`
+6. Fallback: stringify the entire object
+
+Example JSON output from a script:
+
+```json
+{
+  "message": "## Identity\n\nYou are the High Steward...",
+  "targetAgentId": "parent-agent",
+  "spawnType": "unregistered",
+  "agentName": "parent-agent",
+  "subAgentName": "steward"
+}
+```
+
+With `returnKey: "message"` and `agentIdOverrideKey: "targetAgentId"`, the system extracts `"## Identity\n\nYou are the High Steward..."` as prepend content and overrides the agent to `"parent-agent"`.
+
+## Agent ID Override
+
+The `agentIdOverrideKey` feature enables **dynamic agent resolution** at spawn time. This is useful when:
+
+- You have lightweight agent roles (personas, specialists) that aren't full registered agents
+- The script knows which parent agent should handle auth and model resolution
+- You want to spawn by role name and let the script resolve the runtime agent
+
+### Validation
+
+Override candidates are validated against the gateway config. Only agent IDs that resolve to a configured agent (with auth credentials) are accepted. If no valid override is found, the original `targetAgentId` is used.
+
+### Multi-Script Conflict Resolution
+
+When multiple scripts propose different overrides:
+
+1. Candidates are collected with their script ID and priority
+2. Each candidate is validated against the gateway config
+3. The **highest-priority valid candidate** wins (scripts are already sorted by priority)
+4. If no candidate is valid, the original agent ID is preserved
+
+Verbose logging shows all candidates with validation status:
+
+```
+[context-script] agentIdOverride candidates: [script-a→agent-x (pri:100 ✓), script-b→agent-y (pri:50 ✗)] → winner: script-a→agent-x
+```
+
+## Logging
+
+| Level       | Output                                                                        |
+| ----------- | ----------------------------------------------------------------------------- |
+| `false`     | Silent — no log output                                                        |
+| `true`      | Summary: `[context-script] my-script (~/path) → 2821 chars`                   |
+| `"verbose"` | Full command with resolved args, full output, override candidates, and winner |
+
+## Error Handling
+
+| Mode         | Behavior                                                                           |
+| ------------ | ---------------------------------------------------------------------------------- |
+| `"continue"` | Log warning, skip this script, continue with remaining scripts                     |
+| `"stop"`     | Log warning, stop executing remaining scripts (content from prior scripts is kept) |
+
+If a script produces no output (empty string), it's silently skipped — no content is injected. This makes scripts safe as no-ops when they have nothing to contribute.
+
+## Example: Identity Injection Script
+
+A shell script that resolves agent identity based on an agent topology:
+
+```bash
+#!/usr/bin/env bash
+# inject-identity.sh — resolve agent identity for spawning
+
+AGENT_ID=""
+for arg in "$@"; do
+  case "$arg" in
+    targetAgentId=*) AGENT_ID="${arg#targetAgentId=}" ;;
+  esac
+done
+
+# Check if this is a registered agent or an alias
+if is_registered "$AGENT_ID"; then
+  MESSAGE=$(cat "agents/$AGENT_ID/SOUL.md")
+  echo "{\"message\": $(echo "$MESSAGE" | jq -Rs .), \"targetAgentId\": \"$AGENT_ID\"}"
+elif is_alias "$AGENT_ID"; then
+  PARENT=$(resolve_parent "$AGENT_ID")
+  CHARTER=$(cat "agents/$AGENT_ID/charter.md")
+  echo "{\"message\": $(echo "$CHARTER" | jq -Rs .), \"targetAgentId\": \"$PARENT\"}"
+else
+  # Unknown agent — no-op (empty output)
+  exit 0
+fi
+```
+
+## Execution Flow
+
+```
+sessions_spawn(agentId: "steward", task: "Review the architecture")
+    │
+    ├─ Resolve context scripts (defaults + agent overrides)
+    ├─ Execute scripts in priority order
+    │   ├─ Script returns: { message: "## Charter...", targetAgentId: "main-agent" }
+    │   ├─ Extract content → prepend to task
+    │   └─ Extract override → candidate: main-agent (pri:100)
+    │
+    ├─ Validate override candidates against config
+    │   └─ main-agent → resolveAgentConfig() ✓
+    │
+    ├─ Apply override: targetAgentId = "main-agent"
+    │
+    ├─ Auth resolution (uses "main-agent" credentials) ✓
+    ├─ Build childSessionKey: agent:main-agent:subagent:<uuid>
+    ├─ Resolve model + thinking from "main-agent" config
+    │
+    └─ Spawn session with prepended task:
+        "## Charter...\n\nReview the architecture"
+```

--- a/src/agents/context-scripts.ts
+++ b/src/agents/context-scripts.ts
@@ -1,0 +1,466 @@
+import { execFile, spawn } from "node:child_process";
+import { homedir } from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface ContextScriptEntry {
+  id: string;
+  uri: string;
+  format?: "json" | "arguments";
+  method?: string;
+  priority?: number;
+  position?: "append" | "prepend";
+  log?: boolean | "verbose";
+  errorHandling?: "continue" | "stop";
+  returnKey?: string;
+  errorKey?: string;
+  agentIdOverrideKey?: string;
+  argMap?: Record<string, string>;
+}
+
+export interface ResolvedScript {
+  id: string;
+  uri: string;
+  format: "json" | "arguments";
+  method?: string;
+  priority: number;
+  position: "append" | "prepend";
+  log: false | true | "verbose";
+  errorHandling: "continue" | "stop";
+  returnKey?: string;
+  errorKey?: string;
+  agentIdOverrideKey?: string;
+  argMap?: Record<string, string>;
+}
+
+export function resolveContextScripts(
+  defaultScripts: ContextScriptEntry[],
+  agentScripts: ContextScriptEntry[],
+  agentIgnore: string[],
+): ResolvedScript[] {
+  const ignoreSet = new Set(agentIgnore);
+
+  // Filter defaultScripts — remove any where script.id is in agentIgnore set
+  const filteredDefaults = defaultScripts.filter((script) => !ignoreSet.has(script.id));
+
+  // Merge: [...filteredDefaults, ...agentScripts]
+  const merged = [...filteredDefaults, ...agentScripts];
+
+  // Dedupe by id — last occurrence wins (agent scripts override defaults with same id)
+  const dedupMap = new Map<string, ContextScriptEntry>();
+  for (const script of merged) {
+    dedupMap.set(script.id, script);
+  }
+  const deduped: ContextScriptEntry[] = Array.from(dedupMap.values());
+
+  // Apply defaults for optional fields
+  const resolved: ResolvedScript[] = deduped.map((script) => ({
+    id: script.id,
+    uri: script.uri,
+    format: script.format ?? "arguments",
+    method: script.method,
+    priority: script.priority ?? 0,
+    position: script.position ?? "append",
+    log: script.log ?? false,
+    errorHandling: script.errorHandling ?? "continue",
+    returnKey: script.returnKey,
+    errorKey: script.errorKey,
+    agentIdOverrideKey: script.agentIdOverrideKey,
+    argMap: script.argMap,
+  }));
+
+  // Sort by priority descending (highest first). Stable sort.
+  resolved.sort((a, b) => b.priority - a.priority);
+
+  return resolved;
+}
+
+/**
+ * Execute resolved context scripts and return prepend/append content + optional agentId override.
+ *
+ * @param validateAgentId - Optional validator function. When provided, override candidates are
+ *   checked against it; only candidates that return true are eligible. If no validator is given,
+ *   all overrides are accepted (first wins by priority order).
+ */
+export async function executeContextScripts(
+  scripts: ResolvedScript[],
+  variables: Record<string, unknown>,
+  validateAgentId?: (agentId: string) => boolean,
+): Promise<{ prepend: string; append: string; agentIdOverride?: string }> {
+  const prepend: string[] = [];
+  const append: string[] = [];
+
+  interface OverrideCandidate {
+    scriptId: string;
+    agentId: string;
+    priority: number;
+  }
+  const overrideCandidates: OverrideCandidate[] = [];
+
+  for (const script of scripts) {
+    try {
+      const result = await executeScriptWithMetadata(script, variables);
+
+      if (script.log) {
+        console.log(
+          `[context-script] ${script.id} (${script.uri}) → ${result.output.length} chars`,
+        );
+        if (script.log === "verbose") {
+          const argDesc = script.argMap
+            ? Object.entries(script.argMap)
+                .map(([k, v]) => `${k}=${JSON.stringify(variables[v])}`)
+                .join(" ")
+            : "(no args)";
+          console.log(`[context-script] ${script.id} command: ${script.uri} ${argDesc}`);
+          console.log(`[context-script] ${script.id} output:\n${result.output}`);
+        }
+      }
+
+      if (result.agentIdOverride) {
+        overrideCandidates.push({
+          scriptId: script.id,
+          agentId: result.agentIdOverride,
+          priority: script.priority,
+        });
+        if (script.log === "verbose") {
+          console.log(
+            `[context-script] ${script.id} proposed agentIdOverride: ${result.agentIdOverride}`,
+          );
+        }
+      }
+
+      if (result.output) {
+        if (script.position === "prepend") {
+          prepend.push(result.output);
+        } else {
+          append.push(result.output);
+        }
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.warn(`[context-script] ${script.id} failed: ${errorMessage}`);
+
+      if (script.errorHandling === "stop") {
+        break;
+      }
+    }
+  }
+
+  // Resolve best agentId override: highest priority, validated
+  let agentIdOverride: string | undefined;
+  if (overrideCandidates.length > 0) {
+    // Already sorted by priority (scripts run in priority order), so iterate in order
+    const winner = validateAgentId
+      ? overrideCandidates.find((c) => validateAgentId(c.agentId))
+      : overrideCandidates[0];
+
+    if (winner) {
+      agentIdOverride = winner.agentId;
+    }
+
+    // Log resolution in verbose mode (check any script with verbose logging)
+    const anyVerbose = scripts.some((s) => s.log === "verbose");
+    if (anyVerbose) {
+      const candidateDesc = overrideCandidates
+        .map(
+          (c) =>
+            `${c.scriptId}→${c.agentId} (pri:${c.priority}${validateAgentId ? (validateAgentId(c.agentId) ? " ✓" : " ✗") : ""})`,
+        )
+        .join(", ");
+      console.log(
+        `[context-script] agentIdOverride candidates: [${candidateDesc}]` +
+          (winner ? ` → winner: ${winner.scriptId}→${winner.agentId}` : " → none valid"),
+      );
+    }
+  }
+
+  return {
+    prepend: prepend.join("\n\n"),
+    append: append.join("\n\n"),
+    agentIdOverride,
+  };
+}
+
+async function executeScriptWithMetadata(
+  script: ResolvedScript,
+  variables: Record<string, unknown>,
+): Promise<{ output: string; agentIdOverride?: string }> {
+  const rawOutput = await executeScriptRaw(script, variables);
+
+  // If agentIdOverrideKey is set, try to extract it from JSON before parsing
+  let agentIdOverride: string | undefined;
+  if (script.agentIdOverrideKey && rawOutput) {
+    try {
+      const parsed = JSON.parse(rawOutput);
+      if (typeof parsed === "object" && parsed !== null && script.agentIdOverrideKey in parsed) {
+        const val = (parsed as Record<string, unknown>)[script.agentIdOverrideKey];
+        if (typeof val === "string" && val.trim()) {
+          agentIdOverride = val.trim();
+        }
+      }
+    } catch {
+      // Not JSON — no override possible
+    }
+  }
+
+  const output = parseScriptOutput(rawOutput, script);
+  return { output, agentIdOverride };
+}
+
+async function executeScriptRaw(
+  script: ResolvedScript,
+  variables: Record<string, unknown>,
+): Promise<string> {
+  // Build args from argMap
+  const argObject: Record<string, unknown> = {};
+
+  if (script.argMap) {
+    for (const [key, varName] of Object.entries(script.argMap)) {
+      argObject[key] = variables[varName];
+    }
+  }
+
+  // Determine if URI is a file or HTTP
+  const isHttp = script.uri.startsWith("http://") || script.uri.startsWith("https://");
+
+  let output: string;
+
+  if (isHttp) {
+    output = await executeHttpScript(script, argObject);
+  } else {
+    output = await executeLocalScript(script, argObject);
+  }
+
+  return output;
+}
+
+/**
+ * Parse script output through the response parsing pipeline:
+ * 1. Plain text (not JSON) → use as-is
+ * 2. JSON with errorKey → check for custom error field
+ * 3. JSON error detection → standard patterns (error, errors, ok:false, status:"error")
+ * 4. JSON with returnKey → extract specific key
+ * 5. JSON without returnKey → auto-detect: message → content → text → result → stringify
+ */
+function parseScriptOutput(output: string, script: ResolvedScript): string {
+  if (!output) {
+    return "";
+  }
+
+  // Try to parse as JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    // Not JSON — plain text, use as-is
+    return output;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return output;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  // Check custom errorKey first
+  if (script.errorKey && obj[script.errorKey]) {
+    const errorVal = obj[script.errorKey];
+    const errorMsg = typeof errorVal === "string" ? errorVal : JSON.stringify(errorVal);
+    throw new Error(`Script ${script.id} returned error (${script.errorKey}): ${errorMsg}`);
+  }
+
+  // Standard error detection patterns (OpenAI, Anthropic, REST conventions)
+  detectStandardErrors(obj, script.id);
+
+  // Extract content with returnKey
+  if (script.returnKey) {
+    if (script.returnKey in obj) {
+      const extracted = obj[script.returnKey];
+      return typeof extracted === "string" ? extracted : JSON.stringify(extracted);
+    }
+    throw new Error(`Script ${script.id}: returnKey "${script.returnKey}" not found in response`);
+  }
+
+  // Auto-detect content from standard fields
+  const contentKeys = ["message", "content", "text", "result"];
+  for (const key of contentKeys) {
+    if (key in obj && obj[key] != null) {
+      const val = obj[key];
+      return typeof val === "string" ? val : JSON.stringify(val);
+    }
+  }
+
+  // No standard field found — stringify the whole object
+  return JSON.stringify(obj);
+}
+
+/**
+ * Detect errors using standard API conventions:
+ * - error (string or object with .message)
+ * - errors (array)
+ * - status === "error"
+ * - ok === false
+ */
+function detectStandardErrors(obj: Record<string, unknown>, scriptId: string): void {
+  // Check for error field
+  if (obj.error) {
+    if (typeof obj.error === "string") {
+      throw new Error(`Script ${scriptId} returned error: ${obj.error}`);
+    }
+    if (typeof obj.error === "object" && obj.error !== null) {
+      const errObj = obj.error as Record<string, unknown>;
+      const rawMsg = errObj.message ?? errObj.type;
+      const msg = typeof rawMsg === "string" ? rawMsg : JSON.stringify(obj.error);
+      throw new Error(`Script ${scriptId} returned error: ${msg}`);
+    }
+  }
+
+  // Check for errors array
+  if (Array.isArray(obj.errors) && obj.errors.length > 0) {
+    const messages = obj.errors
+      .map((e: unknown) => {
+        if (typeof e === "string") {
+          return e;
+        }
+        if (typeof e === "object" && e !== null && "message" in e) {
+          return (e as Record<string, unknown>).message;
+        }
+        return JSON.stringify(e);
+      })
+      .join("; ");
+    throw new Error(`Script ${scriptId} returned errors: ${messages}`);
+  }
+
+  // Check for status === "error"
+  if (obj.status === "error") {
+    const msg = typeof obj.message === "string" ? obj.message : "status=error";
+    throw new Error(`Script ${scriptId} returned error: ${msg}`);
+  }
+
+  // Check for ok === false
+  if (obj.ok === false) {
+    const msg = typeof obj.message === "string" ? obj.message : "ok=false";
+    throw new Error(`Script ${scriptId} returned error: ${msg}`);
+  }
+}
+
+async function executeLocalScript(
+  script: ResolvedScript,
+  argObject: Record<string, unknown>,
+): Promise<string> {
+  // Resolve ~ in URI path
+  let resolvedPath = script.uri;
+  if (resolvedPath.startsWith("~/")) {
+    resolvedPath = path.join(homedir(), resolvedPath.slice(2));
+  } else if (resolvedPath === "~") {
+    resolvedPath = homedir();
+  }
+
+  if (script.format === "arguments") {
+    // Spawn the script with named key="value" arguments from argMap
+    const args = Object.entries(argObject).map(([k, v]) => {
+      const val = typeof v === "string" ? v : v == null ? "" : JSON.stringify(v);
+      return `${k}=${val}`;
+    });
+    const result = await execFileAsync(resolvedPath, args, {
+      timeout: 10000,
+      encoding: "utf-8",
+    });
+    return result.stdout.trim();
+  } else {
+    // format: "json" — pipe JSON to stdin
+    const jsonInput = JSON.stringify(argObject);
+    return await executeLocalScriptWithStdin(resolvedPath, jsonInput);
+  }
+}
+
+function executeLocalScriptWithStdin(scriptPath: string, input: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(scriptPath, [], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const chunks: Buffer[] = [];
+    const errorChunks: Buffer[] = [];
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      errorChunks.push(chunk);
+    });
+
+    child.on("error", (error) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
+      if (code !== 0) {
+        const stderr = Buffer.concat(errorChunks).toString("utf-8");
+        reject(new Error(`Script exited with code ${code}: ${stderr}`));
+        return;
+      }
+
+      const stdout = Buffer.concat(chunks).toString("utf-8");
+      resolve(stdout.trim());
+    });
+
+    // Set timeout
+    timeoutId = setTimeout(() => {
+      child.kill();
+      reject(new Error("Script execution timed out after 10 seconds"));
+    }, 10000);
+
+    // Write input to stdin and close it
+    child.stdin.write(input);
+    child.stdin.end();
+  });
+}
+
+async function executeHttpScript(
+  script: ResolvedScript,
+  argObject: Record<string, unknown>,
+): Promise<string> {
+  const method = (script.method || "GET").toUpperCase();
+
+  let url = script.uri;
+  let body: string | undefined;
+  const headers: Record<string, string> = {};
+
+  if (method === "GET" && script.argMap && Object.keys(script.argMap).length > 0) {
+    // GET: argMap values as query params
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(argObject)) {
+      params.append(key, String(value));
+    }
+    const separator = url.includes("?") ? "&" : "?";
+    url = `${url}${separator}${params.toString()}`;
+  } else if ((method === "POST" || method === "PUT") && script.argMap) {
+    // POST/PUT: argMap as JSON body
+    body = JSON.stringify(argObject);
+    headers["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body,
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return await response.text();
+}

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -143,8 +143,7 @@ export async function spawnSubagentDirect(
     const defaultSubagents = cfg.agents?.defaults?.subagents as
       | (Record<string, unknown> & { contextScripts?: { run?: ContextScriptEntry[] } })
       | undefined;
-    const defaultContextScripts: ContextScriptEntry[] =
-      defaultSubagents?.contextScripts?.run ?? [];
+    const defaultContextScripts: ContextScriptEntry[] = defaultSubagents?.contextScripts?.run ?? [];
     const initialTargetConfig = resolveAgentConfig(cfg, initialTargetAgentId);
     const agentSubagents = (initialTargetConfig ?? resolveAgentConfig(cfg, requesterAgentId))
       ?.subagents as

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -162,6 +162,31 @@ export const AgentDefaultsSchema = z
         archiveAfterMinutes: z.number().int().positive().optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
+        contextScripts: z
+          .object({
+            run: z
+              .array(
+                z
+                  .object({
+                    id: z.string(),
+                    uri: z.string(),
+                    format: z.union([z.literal("json"), z.literal("arguments")]).optional(),
+                    method: z.string().optional(),
+                    priority: z.number().optional(),
+                    position: z.union([z.literal("append"), z.literal("prepend")]).optional(),
+                    log: z.union([z.boolean(), z.literal("verbose")]).optional(),
+                    errorHandling: z.union([z.literal("continue"), z.literal("stop")]).optional(),
+                    returnKey: z.string().optional(),
+                    errorKey: z.string().optional(),
+                    agentIdOverrideKey: z.string().optional(),
+                    argMap: z.record(z.string(), z.string()).optional(),
+                  })
+                  .strict(),
+              )
+              .optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -609,6 +609,32 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        contextScripts: z
+          .object({
+            run: z
+              .array(
+                z
+                  .object({
+                    id: z.string(),
+                    uri: z.string(),
+                    format: z.union([z.literal("json"), z.literal("arguments")]).optional(),
+                    method: z.string().optional(),
+                    priority: z.number().optional(),
+                    position: z.union([z.literal("append"), z.literal("prepend")]).optional(),
+                    log: z.union([z.boolean(), z.literal("verbose")]).optional(),
+                    errorHandling: z.union([z.literal("continue"), z.literal("stop")]).optional(),
+                    returnKey: z.string().optional(),
+                    errorKey: z.string().optional(),
+                    agentIdOverrideKey: z.string().optional(),
+                    argMap: z.record(z.string(), z.string()).optional(),
+                  })
+                  .strict(),
+              )
+              .optional(),
+            ignore: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Rebased version of #13965, updated for the v2026.2.17 refactor that extracted spawn logic into `subagent-spawn.ts` (`spawnSubagentDirect`).

### What changed from #13965
- **Schema**: already merged upstream — no schema changes in this PR
- **Implementation**: `context-scripts.ts` unchanged
- **Wiring**: hook now lives in `subagent-spawn.ts` instead of the old inline `sessions-spawn-tool.ts`
- **Allowlist**: checks both original requested ID and any script-overridden ID

### Files
| File | Change |
|------|--------|
| `src/agents/context-scripts.ts` | New — execution engine (resolve, dedupe, execute) |
| `src/agents/subagent-spawn.ts` | Modified — hook after targetAgentId resolution, before allowlist |
| `docs/concepts/context-scripts.md` | New — concept documentation |

### How it works
1. Before the allowlist check, resolves context scripts from both default and agent-specific config
2. Executes scripts with spawn variables (targetAgentId, task, label, etc.)
3. Scripts can prepend/append to the task and override the target agent ID
4. Allowlist validates both the original and overridden agent IDs

Supersedes #13965.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a pre-spawn hook system ("context scripts") for sub-agent sessions, allowing scripts to inject context (identity, charters, instructions) into the task message and optionally override the target agent ID before session creation.

- **New file `context-scripts.ts`**: Implements the full context script lifecycle — resolution (merge defaults + per-agent, dedupe, sort by priority), execution (local scripts via `execFile`/`spawn`, HTTP via `fetch`), and output parsing (JSON response pipeline with error detection, content extraction, agent ID override).
- **Modified `subagent-spawn.ts`**: Wires the context scripts hook into `spawnSubagentDirect`, executing between target agent resolution and allowlist validation. The allowlist now checks both the original requested ID and any script-overridden ID.
- **New docs `context-scripts.md`**: Comprehensive concept documentation covering configuration, variable passing, output parsing, and override resolution.
- The HTTP script execution path in `context-scripts.ts` lacks a timeout (`fetch` without `AbortSignal`), which could block spawns indefinitely on unresponsive endpoints — the local script paths correctly enforce a 10-second timeout.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge; the missing HTTP timeout is the main concern that should be addressed before merging.
- The core logic is sound — script resolution, deduplication, priority sorting, and the spawn integration are all well-implemented. The allowlist correctly validates both original and overridden agent IDs. However, the missing timeout on HTTP fetch calls in context scripts is a real issue that could cause indefinite hangs during spawn. The outer try/catch in subagent-spawn.ts would not help since the await would never resolve. No tests are included for the new context-scripts module.
- `src/agents/context-scripts.ts` — missing HTTP fetch timeout; `src/agents/subagent-spawn.ts` — minor unreachable code in allowlist error message

<sub>Last reviewed commit: 10359fe</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->