### PR TITLE
Doctor/Security: fix telegram numeric ID + symlink config permission warnings

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/src/channels/telegram/allow-from.test.ts
+++ b/src/channels/telegram/allow-from.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isNumericTelegramUserId, normalizeTelegramAllowFromEntry } from "./allow-from.js";
+
+describe("telegram allow-from helpers", () => {
+  it("normalizes tg/telegram prefixes", () => {
+    expect(normalizeTelegramAllowFromEntry(" TG:123 ")).toBe("123");
+    expect(normalizeTelegramAllowFromEntry("telegram:@someone")).toBe("@someone");
+  });
+
+  it("accepts signed numeric IDs", () => {
+    expect(isNumericTelegramUserId("123456789")).toBe(true);
+    expect(isNumericTelegramUserId("-1001234567890")).toBe(true);
+    expect(isNumericTelegramUserId("@someone")).toBe(false);
+    expect(isNumericTelegramUserId("12 34")).toBe(false);
+  });
+});

--- a/src/channels/telegram/allow-from.ts
+++ b/src/channels/telegram/allow-from.ts
@@ -7,5 +7,5 @@ export function normalizeTelegramAllowFromEntry(raw: unknown): string {
 }
 
 export function isNumericTelegramUserId(raw: string): boolean {
-  return /^\d+$/.test(raw);
+  return /^-?\d+$/.test(raw);
 }

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -223,8 +223,10 @@ export async function noteStateIntegrity(
 
   if (configPath && existsFile(configPath) && process.platform !== "win32") {
     try {
+      const linkStat = fs.lstatSync(configPath);
       const stat = fs.statSync(configPath);
-      if ((stat.mode & 0o077) !== 0) {
+      const isSymlink = linkStat.isSymbolicLink();
+      if (!isSymlink && (stat.mode & 0o077) !== 0) {
         warnings.push(
           `- Config file is group/world readable (${displayConfigPath ?? configPath}). Recommend chmod 600.`,
         );

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -186,6 +186,7 @@ async function collectFilesystemFindings(params: {
     exec: params.execIcacls,
   });
   if (configPerms.ok) {
+    const skipReadablePermWarnings = configPerms.isSymlink;
     if (configPerms.isSymlink) {
       findings.push({
         checkId: "fs.config.symlink",
@@ -208,7 +209,7 @@ async function collectFilesystemFindings(params: {
           env: params.env,
         }),
       });
-    } else if (configPerms.worldReadable) {
+    } else if (!skipReadablePermWarnings && configPerms.worldReadable) {
       findings.push({
         checkId: "fs.config.perms_world_readable",
         severity: "critical",
@@ -222,7 +223,7 @@ async function collectFilesystemFindings(params: {
           env: params.env,
         }),
       });
-    } else if (configPerms.groupReadable) {
+    } else if (!skipReadablePermWarnings && configPerms.groupReadable) {
       findings.push({
         checkId: "fs.config.perms_group_readable",
         severity: "warn",


### PR DESCRIPTION
## Summary
- accept signed numeric Telegram IDs (`-100...`) in allowFrom validation
- stop reporting symlinked Nix-managed config files as world/group-readable based on symlink mode bits
- evaluate permission checks against symlink targets for config audit checks
- keep explicit symlink trust warning, but avoid noisy readable-perm findings for symlink config paths

## Commits
- `b8482c5` doctor: accept signed numeric telegram allowFrom ids
- `7d98614` doctor/security: use symlink targets for config permission checks

## Validation
- `pnpm vitest src/channels/telegram/allow-from.test.ts`
- `pnpm vitest src/security/audit.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Two targeted fixes for the `openclaw doctor` / security audit tooling:

1. **Telegram signed numeric IDs**: The `isNumericTelegramUserId` regex now accepts negative numbers (`/^-?\d+$/`), fixing false "invalid allowFrom entry" warnings for Telegram group/supergroup/channel IDs (which use negative prefixes like `-100...`).

2. **Symlink config permission checks**: Both `doctor-state-integrity` and the security audit now detect symlinked config files (via `lstat`) and avoid reporting misleading group/world-readable permission warnings for them. This is particularly relevant for Nix-managed configs where files in `/nix/store` are inherently world-readable. The audit still flags writable symlink targets as critical, and emits a trust boundary warning for all symlinked configs. The `inspectPathPermissions` helper in `audit-fs.ts` now resolves symlink targets via `fs.stat` so that mode bits, `isDir`, and derived permission flags reflect the actual target rather than the symlink inode.

Both changes include new test coverage.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — both changes are well-scoped diagnostic/advisory fixes with solid test coverage.
- Score of 4 reflects clean, focused changes to non-critical diagnostic code (doctor/audit) with appropriate test coverage. The regex fix is straightforward and the symlink handling correctly differentiates lstat vs stat. No security-sensitive codepaths are weakened — writable targets are still flagged.
- No files require special attention.

<sub>Last reviewed commit: 7d98614</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->