### PR TITLE
fix(protocol): regenerate Swift protocol files for SendParams.threadId

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }


### PR DESCRIPTION
## Problem

`pnpm protocol:check` fails on `main` and all PRs rebased onto it.

Introduced by commit `0bf1b38cc` ("Agents: fix subagent completion thread routing") which added `threadId` to `SendParamsSchema` in `src/gateway/protocol/schema/agent.ts` but did not regenerate the Swift protocol files.

Verified: running `pnpm protocol:check` on clean `upstream/main` reproduces the failure.

## Fix

Run `pnpm protocol:gen:swift` to regenerate both Swift files:
- `apps/macos/Sources/OpenClawProtocol/GatewayModels.swift`
- `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`

## Impact

Blocks CI for all open PRs rebased to current `main` (including #19041, #16960, #12692). Unblocking this fixes `protocol:check` for all of them.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Regenerates the two Swift protocol files (`GatewayModels.swift` in `apps/macos/` and `apps/shared/`) to include the `threadId` optional field on `SendParams`, which was added to `SendParamsSchema` in `src/gateway/protocol/schema/agent.ts` by a prior commit but not propagated to the generated Swift code.

- Adds `public let threadid: String?` property, matching init parameter, assignment, and `CodingKeys` mapping (`threadid = "threadId"`) to the `SendParams` struct in both files
- Both output files remain identical, consistent with the generation script writing the same content to both paths
- The new field is optional (`String?`), so no existing callers break — and there are no Swift call-sites that instantiate `SendParams` directly
- Fixes `pnpm protocol:check` CI failure on `main` and all PRs rebased onto it

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a mechanical regeneration of protocol files with no hand-written logic changes.
- The change is entirely auto-generated Swift code adding a single optional field to a struct. Both files are identical as expected from the generation script. The new field is optional so it cannot break existing decoders or callers. The diff precisely matches what the source schema requires.
- No files require special attention.

<sub>Last reviewed commit: 66c3dd1</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->