### PR TITLE
fix: show actual model used after fallback in /status and session_status [AI-assisted]

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -295,7 +295,10 @@ export function createSessionStatusTool(opts?: {
       }
 
       const agentDir = resolveAgentDir(cfg, agentId);
-      const providerForCard = resolved.entry.providerOverride?.trim() || configured.provider;
+      const providerForCard =
+        resolved.entry.providerOverride?.trim() ||
+        resolved.entry.modelProvider?.trim() ||
+        configured.provider;
       const usageProvider = resolveUsageProviderId(providerForCard);
       let usageLine: string | undefined;
       if (usageProvider) {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -214,6 +214,28 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Model: openai/gpt-4.1-mini");
   });
 
+  it("shows last-run model from fallback when no user override is set", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "openai-codex/gpt-5.2",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "fallback-1",
+        updatedAt: 0,
+        modelProvider: "anthropic",
+        model: "claude-opus-4-6",
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(normalizeTestText(text)).toContain("Model: anthropic/claude-opus-4-6");
+  });
+
   it("keeps provider prefix from configured model", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -339,8 +339,9 @@ export function buildStatusMessage(args: StatusArgs): string {
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const provider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
-  let model = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
+  const provider =
+    entry?.providerOverride ?? entry?.modelProvider ?? resolved.provider ?? DEFAULT_PROVIDER;
+  let model = entry?.modelOverride ?? entry?.model ?? resolved.model ?? DEFAULT_MODEL;
   let contextTokens =
     entry?.contextTokens ??
     args.agent?.contextTokens ??


### PR DESCRIPTION
## Summary

Fixes #19810.

`/status` and `session_status` were reporting the *configured* primary model even when a silent fallback had switched to a different model mid-session. Users had no way to know a fallback had occurred — the status tools lied while the system prompt told the LLM the truth.

**Root cause:** Both `buildStatusMessage()` and the `session_status` tool resolved the display model from `providerOverride`/`modelOverride` (user-set sticky overrides) and fell straight back to the configured default. They never consulted `modelProvider`/`model`, which are the fields written by `persistSessionUsageUpdate()` after each real LLM call — including after fallbacks.

**Fix:** Insert `entry.modelProvider` / `entry.model` into the resolution chain, between the user overrides and the configured default:

```
providerOverride → modelProvider (actual last-run) → configured default
```

This preserves the correct precedence: an explicit `/model` override always wins, but when no override is set the status now reflects what actually served the last request.

### Changed files

- `src/auto-reply/status.ts` — `buildStatusMessage()`: add `entry?.modelProvider` and `entry?.model` to provider/model resolution
- `src/agents/tools/session-status-tool.ts` — `createSessionStatusTool` execute: add `resolved.entry.modelProvider` to `providerForCard` resolution
- `src/auto-reply/status.test.ts` — new test: `"shows last-run model from fallback when no user override is set"`

## Test plan

- [x] New unit test covering the fallback case (no override, `modelProvider`/`model` set from a fallback run)
- [x] Existing test `"prefers model overrides over last-run model"` still passes (override precedence unchanged)
- [x] `pnpm build` — clean
- [x] `pnpm check` — our 3 files format-clean (pre-existing unrelated format issues in `tts.ts` and untracked files)
- [x] `pnpm test` — 860 test files, 7458 tests, all passing

## AI disclosure

- 🤖 Built with Claude Code (claude-sonnet-4-6)
- Testing: fully tested (unit tests + full suite)
- The fix was identified by the original issue reporter (#19810) — we implemented and validated it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `/status` and `session_status` reported the *configured* primary model instead of the actual model used after a silent fallback. The fix inserts `entry.modelProvider` / `entry.model` (the fields written by `persistSessionUsageUpdate` after each real LLM call) into the resolution chain between user-set overrides and the configured default, so the precedence becomes: `providerOverride → modelProvider (actual last-run) → configured default`.

- `src/auto-reply/status.ts`: `buildStatusMessage()` now checks `entry?.modelProvider` and `entry?.model` before falling back to the configured defaults
- `src/agents/tools/session-status-tool.ts`: `providerForCard` resolution now includes `resolved.entry.modelProvider` for accurate provider-level lookups (usage tracking, auth label)
- `src/auto-reply/status.test.ts`: New test verifies the fallback model is displayed when no user override is set; existing test confirms overrides still take priority

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-targeted fix with correct precedence logic and good test coverage.
- The change is small (3 lines of logic + 1 test), correctly inserts the actual-last-run model fields into the resolution chain between user overrides and configured defaults, the precedence is well-reasoned and verified against the data model, and both override-priority and fallback-display test cases pass. No regressions or edge cases identified.
- No files require special attention.

<sub>Last reviewed commit: 35f96c8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->