### PR TITLE
fix(feishu): update bitable tools to support multi-account config

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -3,7 +3,6 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { resolveToolsConfig } from "./tools-config.js";
-import type { FeishuConfig } from "./types.js";
 
 // ============ Helpers ============
 
@@ -557,12 +556,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
   }
 
   // Create client using the resolved account config
-  const getClient = () =>
-    createFeishuClient({
-      appId: firstAccount.appId!,
-      appSecret: firstAccount.appSecret!,
-      domain: firstAccount.domain,
-    });
+  const getClient = () => createFeishuClient(firstAccount);
 
   // Tool 0: feishu_bitable_get_meta (helper to parse URLs)
   api.registerTool(

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -86,6 +86,7 @@ const FeishuToolsConfigSchema = z
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
+    bitable: z.boolean().optional(), // Multidimensional table operations (default: true)
   })
   .strict()
   .optional();

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -11,6 +11,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  bitable: true,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -71,6 +71,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  bitable?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {


### PR DESCRIPTION
## Problem

The bitable tools (introduced in #17963) were not registering when using the new multi-account Feishu configuration format.

**Root cause**: `registerFeishuBitableTools` was directly reading `config.channels.feishu.appId` and `config.channels.feishu.appSecret`, which only works for the legacy single-account format.

## Solution

Updated `registerFeishuBitableTools` to:
- Import and use `listEnabledFeishuAccounts()` (same as docx.ts, wiki.ts, drive.ts)
- Import and use `resolveToolsConfig()` to support `tools.bitable` enable/disable option
- Create client using the resolved account (aligned with other tool modules)
- Add `bitable` to FeishuToolsConfig type, schema, and defaults

## Changes

### Initial commit:
- `extensions/feishu/src/bitable.ts`:
  - Added imports for `listEnabledFeishuAccounts` and `resolveToolsConfig`
  - Replaced legacy config access with multi-account-aware logic
  - Added support for `tools.bitable` config option

### Code review fixes:
- `extensions/feishu/src/types.ts`: Added `bitable?: boolean` to `FeishuToolsConfig`
- `extensions/feishu/src/tools-config.ts`: Added `bitable: true` to defaults
- `extensions/feishu/src/config-schema.ts`: Added `bitable` to schema
- `extensions/feishu/src/bitable.ts`: Use `firstAccount` directly, remove unused import

## Testing

Verified that:
- ✅ Bitable tools now register correctly with multi-account config
- ✅ Successfully created bitable apps, fields, and records via the tools
- ✅ Pattern is consistent with other Feishu tool modules (docx, wiki, drive)
- ✅ Supports explicit enable/disable via `tools.bitable` option

## Related

- Fixes the tool registration issue for users using the new multi-account config format
- Builds on top of #17963