### PR TITLE
fix(launchd): self-heal restart when service is unloaded

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -71,6 +71,8 @@ describe("restart-helper", () => {
       const content = await fs.readFile(scriptPath!, "utf-8");
       expect(content).toContain("#!/bin/sh");
       expect(content).toContain("launchctl kickstart -k 'gui/501/ai.openclaw.gateway'");
+      expect(content).toContain("launchctl bootstrap 'gui/501'");
+      expect(content).toContain("launchctl enable 'gui/501/ai.openclaw.gateway'");
       expect(content).toContain('rm -f "$0"');
 
       if (scriptPath) {
@@ -90,6 +92,7 @@ describe("restart-helper", () => {
       expect(scriptPath).toBeTruthy();
       const content = await fs.readFile(scriptPath!, "utf-8");
       expect(content).toContain("launchctl kickstart -k 'gui/501/com.custom.openclaw'");
+      expect(content).toContain("com.custom.openclaw.plist");
 
       if (scriptPath) {
         await fs.unlink(scriptPath);

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -5,6 +5,7 @@ import {
   isLaunchAgentListed,
   parseLaunchctlPrint,
   repairLaunchAgentBootstrap,
+  restartLaunchAgent,
   resolveLaunchAgentPlistPath,
 } from "./launchd.js";
 
@@ -13,6 +14,8 @@ const state = vi.hoisted(() => ({
   listOutput: "",
   dirs: new Set<string>(),
   files: new Map<string, string>(),
+  failKickstartOnce: false,
+  failBootstrapOnce: false,
 }));
 
 function normalizeLaunchctlArgs(file: string, args: string[]): string[] {
@@ -32,6 +35,22 @@ vi.mock("./exec-file.js", () => ({
     state.launchctlCalls.push(call);
     if (call[0] === "list") {
       return { stdout: state.listOutput, stderr: "", code: 0 };
+    }
+    if (state.failKickstartOnce && call[0] === "kickstart") {
+      state.failKickstartOnce = false;
+      return {
+        stdout: "",
+        stderr: 'Could not find service "ai.openclaw.gateway" in domain for user gui',
+        code: 113,
+      };
+    }
+    if (state.failBootstrapOnce && call[0] === "bootstrap") {
+      state.failBootstrapOnce = false;
+      return {
+        stdout: "",
+        stderr: "launchctl bootstrap failed",
+        code: 1,
+      };
     }
     return { stdout: "", stderr: "", code: 0 };
   }),
@@ -68,6 +87,8 @@ beforeEach(() => {
   state.listOutput = "";
   state.dirs.clear();
   state.files.clear();
+  state.failKickstartOnce = false;
+  state.failBootstrapOnce = false;
   vi.clearAllMocks();
 });
 
@@ -150,6 +171,46 @@ describe("launchd install", () => {
     expect(enableIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
     expect(enableIndex).toBeLessThan(bootstrapIndex);
+  });
+});
+
+describe("launchd restart", () => {
+  it("bootstraps when kickstart reports service-not-loaded", async () => {
+    const env: Record<string, string | undefined> = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set(plistPath, "<plist/>");
+    state.failKickstartOnce = true;
+
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    expect(state.launchctlCalls).toContainEqual(["bootstrap", domain, plistPath]);
+    expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", `${domain}/${label}`]);
+  });
+
+  it("throws when kickstart fails and bootstrap fallback fails", async () => {
+    const env: Record<string, string | undefined> = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set(plistPath, "<plist/>");
+    state.failKickstartOnce = true;
+    state.failBootstrapOnce = true;
+
+    await expect(
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+      }),
+    ).rejects.toThrow(/bootstrap fallback failed/i);
   });
 });
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -141,6 +141,7 @@ describe("launchd bootstrap repair", () => {
     const plistPath = resolveLaunchAgentPlistPath(env);
 
     expect(state.launchctlCalls).toContainEqual(["bootstrap", domain, plistPath]);
+    expect(state.launchctlCalls).toContainEqual(["enable", `${domain}/${label}`]);
     expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", `${domain}/${label}`]);
   });
 });
@@ -192,6 +193,7 @@ describe("launchd restart", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
     expect(state.launchctlCalls).toContainEqual(["bootstrap", domain, plistPath]);
+    expect(state.launchctlCalls).toContainEqual(["enable", `${domain}/${label}`]);
     expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", `${domain}/${label}`]);
   });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -213,6 +213,8 @@ export async function repairLaunchAgentBootstrap(args: {
   if (boot.code !== 0) {
     return { ok: false, detail: (boot.stderr || boot.stdout).trim() || undefined };
   }
+  // Keep parity with restart helper fallback: clear persisted disabled state before kickstart.
+  await execLaunchctl(["enable", `${domain}/${label}`]);
   const kick = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
   if (kick.code !== 0) {
     return { ok: false, detail: (kick.stderr || kick.stdout).trim() || undefined };


### PR DESCRIPTION
## Summary
This hardens macOS service restarts for the post-update edge case where `launchctl kickstart -k` fails with "Could not find service ..." because the LaunchAgent is no longer loaded.

Changes:
- `src/cli/update-cli/restart-helper.ts`
  - update restart script now retries via `bootstrap + enable + kickstart` when plain `kickstart` fails and the plist exists.
- `src/daemon/launchd.ts`
  - `restartLaunchAgent()` now attempts `repairLaunchAgentBootstrap()` when `kickstart` fails with a "service not loaded" signature.

## Why
During update/restart flows, users can end up with a valid plist on disk but an unloaded launchd job. In that state, plain `kickstart` fails and recovery currently requires manual operator intervention (`launchctl bootstrap ...`).

This PR makes restart self-healing for that specific failure mode while keeping happy-path behavior unchanged.

## Tests
- `src/cli/update-cli/restart-helper.test.ts`
  - assert launchd restart script includes bootstrap/enable fallback
  - assert custom launchd label path is reflected in plist fallback
- `src/daemon/launchd.test.ts`
  - add restart fallback test for service-not-loaded kickstart failure
  - add failure-path test when bootstrap fallback itself fails

Ran:
- `pnpm vitest src/cli/update-cli/restart-helper.test.ts src/daemon/launchd.test.ts`

## Related context
- Open PR: #11327 (`fix(launchd): reload plist from disk on restartLaunchAgent`)
- Closed PR: #14178 (similar bootstrap fallback idea in infra path)

This PR is intentionally narrower: it targets the specific "service not loaded" failure path and update restart-script recovery.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds self-healing logic for macOS `launchctl` restarts when the LaunchAgent service is unloaded. It modifies two paths: the standalone shell restart script (`restart-helper.ts`) and the in-process daemon restart (`launchd.ts`). When a `kickstart` fails with a "service not loaded" error, both paths now fall back to `bootstrap` + `kickstart` to re-register and start the service.

- The shell script fallback in `restart-helper.ts` correctly follows the `bootstrap` → `enable` → `kickstart` sequence, matching the pattern used in `installLaunchAgent`.
- The daemon fallback in `restartLaunchAgent` delegates to the existing `repairLaunchAgentBootstrap`, which is missing an `enable` step between `bootstrap` and `kickstart`. This creates an inconsistency with both the shell script and the install flow, and may cause the repair to fail for services in a persisted-disabled state.
- Tests cover the happy path (kickstart fails → bootstrap succeeds) and the failure path (both kickstart and bootstrap fail), but don't test the persisted-disabled scenario.

<h3>Confidence Score: 3/5</h3>

- Mostly safe — the happy path is unchanged and the fallback logic is sound, but the missing `enable` step in the daemon repair path could cause the fallback to fail for previously-disabled services.
- The core approach is correct and well-tested for the basic case. However, the inconsistency between the shell script (which includes `enable`) and the daemon's `repairLaunchAgentBootstrap` (which omits it) means the daemon-side repair may not fully self-heal in all cases, specifically when launchd has persisted a "disabled" state for the service. The install flow has an explicit comment explaining why `enable` is needed, so this omission appears unintentional.
- `src/daemon/launchd.ts` — the `repairLaunchAgentBootstrap` function is missing an `enable` step that both the shell script and install flow include.

<sub>Last reviewed commit: 48b05f1</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->