### PR TITLE
security: eliminate timing side-channel in safeEqualSecret via double-HMAC

### DIFF
--- a/src/security/secret-equal.ts
+++ b/src/security/secret-equal.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 
 export function safeEqualSecret(
   provided: string | undefined | null,
@@ -7,10 +7,8 @@ export function safeEqualSecret(
   if (typeof provided !== "string" || typeof expected !== "string") {
     return false;
   }
-  const providedBuffer = Buffer.from(provided);
-  const expectedBuffer = Buffer.from(expected);
-  if (providedBuffer.length !== expectedBuffer.length) {
-    return false;
-  }
-  return timingSafeEqual(providedBuffer, expectedBuffer);
+  const key = randomBytes(32);
+  const a = createHmac("sha256", key).update(provided).digest();
+  const b = createHmac("sha256", key).update(expected).digest();
+  return timingSafeEqual(a, b);
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates a timing side-channel vulnerability in `safeEqualSecret` by replacing the direct `Buffer.from` + length-check + `timingSafeEqual` approach with a double-HMAC technique. The old code returned early when buffer lengths differed, leaking information about whether the provided and expected secrets had the same length. The new code HMACs both inputs with an ephemeral random key, producing fixed 32-byte digests that are then compared via `timingSafeEqual`, removing the length-dependent timing leak.

- **Correct double-HMAC implementation**: Uses `randomBytes(32)` for a fresh key per comparison and SHA-256 HMAC, which is the standard approach for this pattern.
- **No functional regressions**: Existing callers (`gateway/auth.ts`, `server-http.ts`, `browser/http-auth.ts`, `infra/pairing-token.ts`) pass string pairs, and the null/undefined guard remains intact.
- **Note**: `extensions/bluebubbles/src/monitor.ts` contains a local `safeEqualSecret` function with the same old length-leak pattern — this was not updated by the PR and may warrant a follow-up.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a straightforward, correct security improvement with no behavioral regressions.
- The change is small (one file, 14 lines), uses a well-established cryptographic pattern (double-HMAC comparison), and all existing tests cover the same functional behavior. The null/undefined guard is preserved, and all callers continue to work identically. No new dependencies or APIs are introduced.
- No files in this PR require special attention. However, `extensions/bluebubbles/src/monitor.ts` has a local copy of the old vulnerable pattern and may warrant a separate follow-up.

<sub>Last reviewed commit: cd6bff0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->