### PR TITLE
Logging: Add configurable log dir

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -282,6 +282,8 @@ pgrep -af signal-cli
 grep -i "signal" "/tmp/openclaw/openclaw-$(date +%Y-%m-%d).log" | tail -20
 ```
 
+This log path is the default; if you set `logging.dir` or `logging.file`, use that path instead.
+
 For triage flow: [/channels/troubleshooting](/channels/troubleshooting).
 
 ## Security notes

--- a/docs/diagnostics/flags.md
+++ b/docs/diagnostics/flags.md
@@ -60,7 +60,7 @@ Flags emit logs into the standard diagnostics log file. By default:
 /tmp/openclaw/openclaw-YYYY-MM-DD.log
 ```
 
-If you set `logging.file`, use that path instead. Logs are JSONL (one JSON object per line). Redaction still applies based on `logging.redactSensitive`.
+If you set `logging.file` or `logging.dir`, use that path instead. Logs are JSONL (one JSON object per line). Redaction still applies based on `logging.redactSensitive`.
 
 ## Extract logs
 

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -93,6 +93,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
   // Logging
   logging: {
     level: "info",
+    dir: "/tmp/openclaw",
     file: "/tmp/openclaw/openclaw.log",
     consoleLevel: "info",
     consoleStyle: "pretty",

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2783,6 +2783,7 @@ Notes:
 {
   logging: {
     level: "info",
+    dir: "/tmp/openclaw",
     file: "/tmp/openclaw/openclaw.log",
     consoleLevel: "info",
     consoleStyle: "pretty", // pretty | compact | json
@@ -2793,7 +2794,8 @@ Notes:
 ```
 
 - Default log file: `/tmp/openclaw/openclaw-YYYY-MM-DD.log`.
-- Set `logging.file` for a stable path.
+- Set `logging.dir` to change where daily rolling logs are written.
+- Set `logging.file` for an exact stable path. `logging.file` overrides `logging.dir`.
 - `consoleLevel` bumps to `debug` when `--verbose`.
 
 ---

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -16,7 +16,7 @@ Short guide to verify channel connectivity without guessing.
 - `openclaw status --deep` — also probes the running Gateway (per-channel probes when supported).
 - `openclaw health --json` — asks the running Gateway for a full health snapshot (WS-only; no direct Baileys socket).
 - Send `/status` as a standalone message in WhatsApp/WebChat to get a status reply without invoking the agent.
-- Logs: tail `/tmp/openclaw/openclaw-*.log` and filter for `web-heartbeat`, `web-reconnect`, `web-auto-reply`, `web-inbound`.
+- Logs: tail `/tmp/openclaw/openclaw-*.log` (default), or your `logging.file` / `logging.dir` destination, and filter for `web-heartbeat`, `web-reconnect`, `web-auto-reply`, `web-inbound`.
 
 ## Deep diagnostics
 

--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -20,7 +20,9 @@ OpenClaw has two log “surfaces”:
 - Default rolling log file is under `/tmp/openclaw/` (one file per day): `openclaw-YYYY-MM-DD.log`
   - Date uses the gateway host's local timezone.
 - The log file path and level can be configured via `~/.openclaw/openclaw.json`:
+  - `logging.dir` (directory for rolling daily files)
   - `logging.file`
+    - `logging.file` takes precedence over `logging.dir` when both are set.
   - `logging.level`
 
 The file format is one JSON object per line.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -1144,7 +1144,7 @@ If your AI does something bad:
 
 ### Audit
 
-1. Check Gateway logs: `/tmp/openclaw/openclaw-YYYY-MM-DD.log` (or `logging.file`).
+1. Check Gateway logs: `/tmp/openclaw/openclaw-YYYY-MM-DD.log` (default), `logging.file`, or the rolling file under `logging.dir`.
 2. Review the relevant transcript(s): `~/.openclaw/agents/<agentId>/sessions/*.jsonl`.
 3. Review recent config changes (anything that could have widened access: `gateway.bind`, `gateway.auth`, dm/group policies, `tools.elevated`, plugin changes).
 4. Re-run `openclaw security audit --deep` and confirm critical findings are resolved.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -246,6 +246,8 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
    tail -f "$(ls -t /tmp/openclaw/openclaw-*.log | head -1)"
    ```
 
+   If you set `logging.dir` or `logging.file`, tail that path instead.
+
    File logs are separate from service logs; see [Logging](/logging) and [Troubleshooting](/gateway/troubleshooting).
 
 6. **Run the doctor (repairs)**
@@ -2581,7 +2583,7 @@ File logs (structured):
 /tmp/openclaw/openclaw-YYYY-MM-DD.log
 ```
 
-You can set a stable path via `logging.file`. File log level is controlled by `logging.level`. Console verbosity is controlled by `--verbose` and `logging.consoleLevel`.
+By default this file is under `/tmp/openclaw/`. Set `logging.dir` to change the rolling log directory, or `logging.file` for an exact path (`logging.file` takes precedence over `logging.dir`). File log level is controlled by `logging.level`. Console verbosity is controlled by `--verbose` and `logging.consoleLevel`.
 
 Fastest log tail:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -25,15 +25,18 @@ By default, the Gateway writes a rolling log file under:
 
 The date uses the gateway host's local timezone.
 
-You can override this in `~/.openclaw/openclaw.json`:
+You can customize this in `~/.openclaw/openclaw.json`:
 
 ```json
 {
   "logging": {
-    "file": "/path/to/openclaw.log"
+    "dir": "/path/to/openclaw-logs"
   }
 }
 ```
+
+Set `logging.file` if you want an exact file path instead of daily rolling files.
+When both are set, `logging.file` takes precedence over `logging.dir`.
 
 ## How to read logs
 
@@ -104,6 +107,7 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
 {
   "logging": {
     "level": "info",
+    "dir": "/tmp/openclaw",
     "file": "/tmp/openclaw/openclaw-YYYY-MM-DD.log",
     "consoleLevel": "info",
     "consoleStyle": "pretty",
@@ -113,10 +117,12 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
 }
 ```
 
-### Log levels
+### Log levels and destinations
 
 - `logging.level`: **file logs** (JSONL) level.
 - `logging.consoleLevel`: **console** verbosity level.
+- `logging.dir`: directory for rolling daily logs (`openclaw-YYYY-MM-DD.log`).
+- `logging.file`: exact log file path (overrides `logging.dir`) and disables rolling.
 
 You can override both via the **`OPENCLAW_LOG_LEVEL`** environment variable (e.g. `OPENCLAW_LOG_LEVEL=debug`). The env var takes precedence over the config file, so you can raise verbosity for a single run without editing `openclaw.json`. You can also pass the global CLI option **`--log-level <level>`** (for example, `openclaw --log-level debug gateway run`), which overrides the environment variable for that command.
 
@@ -217,7 +223,7 @@ OPENCLAW_DIAGNOSTICS=telegram.http,telegram.payload
 
 Notes:
 
-- Flag logs go to the standard log file (same as `logging.file`).
+- Flag logs go to the standard resolved log file (`logging.file`, or the rolling file under `logging.dir`).
 - Output is still redacted according to `logging.redactSensitive`.
 - Full guide: [/diagnostics/flags](/diagnostics/flags).
 
@@ -339,7 +345,7 @@ Queues + sessions:
 
 ### Log export behavior
 
-- OTLP logs use the same structured records written to `logging.file`.
+- OTLP logs use the same structured records written to the resolved log file (`logging.file`, or the rolling file under `logging.dir`).
 - Respect `logging.level` (file log level). Console redaction does **not** apply
   to OTLP logs.
 - High-volume installs should prefer OTLP collector sampling/filtering.
@@ -348,5 +354,5 @@ Queues + sessions:
 
 - **Gateway not reachable?** Run `openclaw doctor` first.
 - **Logs empty?** Check that the Gateway is running and writing to the file path
-  in `logging.file`.
+  in `logging.file` (or the rolling file under `logging.dir`).
 - **Need more detail?** Set `logging.level` to `debug` or `trace` and retry.

--- a/docs/platforms/mac/health.md
+++ b/docs/platforms/mac/health.md
@@ -31,4 +31,4 @@ How to see whether the linked channel is healthy from the menu bar app.
 
 ## When in doubt
 
-- You can still use the CLI flow in [Gateway health](/gateway/health) (`openclaw status`, `openclaw status --deep`, `openclaw health --json`) and tail `/tmp/openclaw/openclaw-*.log` for `web-heartbeat` / `web-reconnect`.
+- You can still use the CLI flow in [Gateway health](/gateway/health) (`openclaw status`, `openclaw status --deep`, `openclaw health --json`) and tail `/tmp/openclaw/openclaw-*.log` (default) or your `logging.file` / `logging.dir` destination for `web-heartbeat` / `web-reconnect`.

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -201,7 +201,7 @@ openclaw status --deep   # adds gateway health probes (Telegram + Discord)
 openclaw health --json   # gateway health snapshot (WS)
 ```
 
-Logs live under `/tmp/openclaw/` (default: `openclaw-YYYY-MM-DD.log`).
+Logs live under `/tmp/openclaw/` by default (`openclaw-YYYY-MM-DD.log`). Set `logging.dir` to change the rolling logfile directory or `logging.file` to set an exact log path.
 
 ## Next steps
 

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -120,7 +120,7 @@ openclaw health
 - **Where state lives:**
   - Credentials: `~/.openclaw/credentials/`
   - Sessions: `~/.openclaw/agents/<agentId>/sessions/`
-  - Logs: `/tmp/openclaw/`
+  - Logs: `/tmp/openclaw/` (default; configurable via `logging.dir` or `logging.file`)
 
 ## Credential storage map
 

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -167,6 +167,7 @@ export type SessionMaintenanceConfig = {
 
 export type LoggingConfig = {
   level?: "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace";
+  dir?: string;
   file?: string;
   /** Maximum size of a single log file in bytes before writes are suppressed. Default: 500 MB. */
   maxFileBytes?: number;

--- a/src/logging/logger.test.ts
+++ b/src/logging/logger.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_LOG_DIR,
+  getLogger,
+  getResolvedLoggerSettings,
+  resetLogger,
+  setLoggerOverride,
+  type LoggerSettings,
+} from "./logger.js";
+
+function expectedRollingFileFor(dir: string): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return path.join(dir, `openclaw-${year}-${month}-${day}.log`);
+}
+
+function mockLoggerFileSystem() {
+  vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+  vi.spyOn(fs, "readdirSync").mockReturnValue([]);
+  return vi.spyOn(fs, "appendFileSync").mockImplementation(() => undefined);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setLoggerOverride(null);
+  resetLogger();
+});
+
+describe("logger directory resolution", () => {
+  it("writes to DEFAULT_LOG_DIR when dir is not specified", () => {
+    const appendSpy = mockLoggerFileSystem();
+    setLoggerOverride({ level: "info" });
+
+    const resolved = getResolvedLoggerSettings();
+    getLogger().info("default-dir");
+
+    expect(resolved.file).toBe(expectedRollingFileFor(DEFAULT_LOG_DIR));
+    expect(appendSpy).toHaveBeenCalled();
+    expect(appendSpy.mock.calls[0]?.[0]).toBe(expectedRollingFileFor(DEFAULT_LOG_DIR));
+  });
+
+  it("writes to configured directory when dir is specified", () => {
+    const customDir = path.join(process.cwd(), ".tmp-logger-test");
+    const appendSpy = mockLoggerFileSystem();
+    const settings: LoggerSettings = { level: "info", dir: customDir };
+    setLoggerOverride(settings);
+
+    const resolved = getResolvedLoggerSettings();
+    getLogger().info("custom-dir");
+
+    expect(resolved.file).toBe(expectedRollingFileFor(customDir));
+    expect(appendSpy).toHaveBeenCalled();
+    expect(appendSpy.mock.calls[0]?.[0]).toBe(expectedRollingFileFor(customDir));
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -24,6 +24,7 @@ const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
 export type LoggerSettings = {
   level?: LogLevel;
+  dir?: string;
   file?: string;
   maxFileBytes?: number;
   consoleLevel?: LogLevel;
@@ -77,7 +78,7 @@ function resolveSettings(): ResolvedSettings {
   if (canUseSilentVitestFileLogFastPath(envLevel)) {
     return {
       level: "silent",
-      file: defaultRollingPathForToday(),
+      file: rollingPathForToday(cfg?.dir),
       maxFileBytes: DEFAULT_MAX_LOG_FILE_BYTES,
     };
   }
@@ -100,7 +101,7 @@ function resolveSettings(): ResolvedSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? defaultRollingPathForToday();
+  const file = cfg?.file ?? rollingPathForToday(cfg?.dir);
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }
@@ -306,9 +307,13 @@ function formatLocalDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function defaultRollingPathForToday(): string {
+function resolveLogDir(loggingDir: string | undefined): string {
+  return loggingDir ?? DEFAULT_LOG_DIR;
+}
+
+function rollingPathForToday(loggingDir: string | undefined): string {
   const today = formatLocalDate(new Date());
-  return path.join(DEFAULT_LOG_DIR, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
+  return path.join(resolveLogDir(loggingDir), `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
 }
 
 function isRollingPath(file: string): boolean {


### PR DESCRIPTION
- Adds a new logging.dir config field
- Adds unit tests for the default case (`logging.dir` unspecified) and the new case (`logging.dir` set)
- Update all associated logging path discussion in the docs

## Summary

This PR allows users to set a configurable logging directory while preserving the default logfile rotation behavior.

- Problem: Logfiles only rotate automatically with the default logging configuration. Users can hardcode a logfile name, but this file is no longer rotated.
- Why it matters: Automatic logfile rotation is important for keeping disk usage for logfiles under control. It doesn't guarantee unbounded growth in logfile disk utilization, but it can help reclaim space after disk usage spikes.
- What changed: Added a `dir` field to the logging config object, updated how the logging file dir is computed, and updated docs.
- What did NOT change (scope boundary): Everything else is as-is, this is just changing what logging directory the config resolves to

## Change Type (select all)

- [ ] Bug fix
- [ x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None

## User-visible / Behavior Changes

No behavior change in the default config. If the user specifies `logging.dir`, the standard rotating logfile will be written to that directory, instead.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: n/a

## Repro + Verification

n/a

Attach at least one:

```
% pnpm test src/logging/logger.test.ts

> openclaw@2026.2.18 test /Users/pdav/source/paudav_openclaw
> node scripts/test-parallel.mjs src/logging/logger.test.ts


 RUN  v4.0.18 /Users/pdav/source/paudav_openclaw

 ✓ src/logging/logger.test.ts (2 tests) 5ms
   ✓ logger directory resolution (2)
     ✓ writes to DEFAULT_LOG_DIR when dir is not specified 4ms
     ✓ writes to configured directory when dir is specified 0ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  23:52:24
   Duration  170ms (transform 62ms, setup 73ms, import 2ms, tests 5ms, environment 0ms)

%
```

## Human Verification (required)

Unit tests

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes, new config option exposed
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Just revert it
- Files/config to restore: Ideally, then entire commit, but at a minimum `src/logging/logger.ts`, `src/config/types.base.ts`, and `src/logging/logger.test.ts`
- Known bad symptoms reviewers should watch for: none

## Risks and Mitigations

None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added configurable `logging.dir` field to control the directory where rolling daily log files are written, while preserving automatic log rotation. The implementation correctly maintains backward compatibility (defaults to `/tmp/openclaw/`) and ensures `logging.file` takes precedence over `logging.dir` when both are set. Documentation has been comprehensively updated across all affected files to explain the new field and its interaction with `logging.file`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and maintains backward compatibility. The precedence logic (`file` over `dir`) is correctly implemented, and all documentation has been comprehensively updated. The tests properly mock filesystem operations, addressing the existing review comment.
- No files require special attention

<sub>Last reviewed commit: cb16ec5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->