### PR TITLE
fix: prevent media token regex from matching markdown bold text

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -206,6 +206,30 @@ describe("extractToolResultMediaPaths", () => {
     expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/tts-output.opus"]);
   });
 
+  it("does not match markdown bold **Media:** as a file path", () => {
+    const result = {
+      content: [
+        {
+          type: "text",
+          text: "**Media:** 1 photo attached",
+        },
+      ],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual([]);
+  });
+
+  it("does not extract non-path/non-URL strings after MEDIA:", () => {
+    const result = {
+      content: [
+        {
+          type: "text",
+          text: "MEDIA: some random text that is not a path",
+        },
+      ],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual([]);
+  });
+
   it("extracts multiple MEDIA: lines from a single text block", () => {
     const result = {
       content: [

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -1,6 +1,6 @@
 import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
 import { normalizeTargetForProvider } from "../infra/outbound/target-normalization.js";
-import { MEDIA_TOKEN_RE } from "../media/parse.js";
+import { MEDIA_TOKEN_RE, isValidMedia } from "../media/parse.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { type MessagingToolSend } from "./pi-embedded-messaging.js";
 
@@ -167,7 +167,7 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
             ?.replace(/^[`"'[{(]+/, "")
             .replace(/[`"'\]})\\,]+$/, "")
             .trim();
-          if (p && p.length <= 4096) {
+          if (p && isValidMedia(p, { allowSpaces: true })) {
             paths.push(p);
           }
         }

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -33,7 +33,7 @@ function isLikelyLocalPath(candidate: string): boolean {
   );
 }
 
-function isValidMedia(
+export function isValidMedia(
   candidate: string,
   opts?: { allowSpaces?: boolean; allowBareFilename?: boolean },
 ) {


### PR DESCRIPTION
Fixes #19847

## Problem
`extractToolResultMediaPaths` matched markdown bold markers (`**text**`) as media tokens, causing false positives like `**I` being treated as a file path.

## Changes
- **src/media/parse.ts**: Export `isValidMedia()` function that validates extracted paths against known media extensions and patterns
- **src/agents/pi-embedded-subscribe.tools.ts**: Add `isValidMedia()` validation before accepting extracted paths
- **src/media/parse.test.ts**: Add regression tests for bold text false positives

## Testing
- 2 regression tests added verifying `**text**` patterns are rejected
- Existing tests pass

---
*Replaces #19855 which was closed due to an accidentally committed log file. This PR has clean history — no PII.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes false positives in `extractToolResultMediaPaths` where any non-empty string under 4096 characters after a `MEDIA:` token was accepted as a valid media path. The fix reuses the existing `isValidMedia()` validator from `src/media/parse.ts` (previously module-private, now exported) to ensure extracted strings are structurally valid media references (URLs, local file paths, or bare filenames with extensions). This aligns `extractToolResultMediaPaths` with the same validation already used in `splitMediaFromOutput`.

- Replaced weak `p.length <= 4096` guard with `isValidMedia(p, { allowSpaces: true })` in `extractToolResultMediaPaths`
- Exported `isValidMedia` from `src/media/parse.ts` (no logic changes to the function itself)
- Added 2 regression tests covering markdown bold patterns and non-path strings

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it tightens validation using an existing, well-tested function with no behavioral regressions.
- The change is minimal and well-scoped: it replaces a weak length-only guard with an existing structural validator (`isValidMedia`) that was already battle-tested in `splitMediaFromOutput`. The function's logic is unchanged — only its visibility is widened via `export`. The new validation is strictly more restrictive than the old check (anything passing `isValidMedia` also passes `length <= 4096`), so no existing valid media paths are rejected. Regression tests are included.
- No files require special attention

<sub>Last reviewed commit: 6557c99</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->