### PR TITLE
fix(slack): exclude archived channels from startup channel resolution

### DIFF
--- a/src/slack/resolve-channels.ts
+++ b/src/slack/resolve-channels.ts
@@ -51,7 +51,7 @@ async function listSlackChannels(client: WebClient): Promise<SlackChannelLookup[
   do {
     const res = (await client.conversations.list({
       types: "public_channel,private_channel",
-      exclude_archived: false,
+      exclude_archived: true,
       limit: 1000,
       cursor,
     })) as SlackListResponse;


### PR DESCRIPTION
## Summary

`listSlackChannels()` in `resolve-channels.ts` calls `conversations.list` with `exclude_archived: false`, which paginates through **every** channel in the workspace including archived ones.

For workspaces with thousands of archived channels (e.g., a 10-year-old Slack install), this:
- Burns through Slack's rate limit on every gateway startup
- Causes `rate_limit_exceeded` warnings with 30-second retry delays
- Compounds when the gateway restarts multiple times (each restart re-fetches the full list)

## Fix

One-line change: `exclude_archived: false` → `exclude_archived: true`

This is safe because `resolveByName()` already prefers active channels over archived ones (line 89), and channels referenced by ID don't need the list at all — they're matched directly.

## Test plan

- [x] Verified channel resolution still works when channels are referenced by ID (e.g., `C02LFRN0V`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

One-line change in `src/slack/resolve-channels.ts` that sets `exclude_archived: true` in the Slack `conversations.list` API call, preventing the gateway from paginating through thousands of archived channels on startup. This reduces Slack API rate limit pressure for workspaces with large numbers of archived channels.

- Channel resolution by ID still works (ID-based lookups set `resolved: true` regardless of the list contents)
- Name-based resolution via `resolveByName()` already preferred active channels; excluding archived channels from the API response avoids fetching data that was deprioritized anyway
- Minor diagnostic change: archived channels referenced by ID will no longer show `(archived)` in startup log output since their metadata won't be in the fetched list

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a single boolean flag change with clear performance benefits and minimal behavioral impact.
- The change is a one-line boolean flip in a Slack API parameter. ID-based channel resolution is unaffected (it always resolves). Name-based resolution already preferred active channels. The only observable difference is that archived channels will no longer appear in the fetched list, which is the intended fix. All callers handle the absence of archived channels gracefully.
- No files require special attention.

<sub>Last reviewed commit: 53c84be</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->