### PR TITLE
fix(respawn): detect OpenClaw service env supervisor hints

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -26,6 +26,8 @@ function clearSupervisorHints() {
   delete process.env.INVOCATION_ID;
   delete process.env.SYSTEMD_EXEC_PID;
   delete process.env.JOURNAL_STREAM;
+  delete process.env.OPENCLAW_LAUNCHD_LABEL;
+  delete process.env.OPENCLAW_SYSTEMD_UNIT;
 }
 
 describe("restartGatewayProcessWithFreshPid", () => {
@@ -38,6 +40,20 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when launchd/systemd hints are present", () => {
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns supervised when OpenClaw launchd service hint is present", () => {
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns supervised when OpenClaw systemd service hint is present", () => {
+    process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
     expect(spawnMock).not.toHaveBeenCalled();

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -14,6 +14,8 @@ const SUPERVISOR_HINT_ENV_VARS = [
   "INVOCATION_ID",
   "SYSTEMD_EXEC_PID",
   "JOURNAL_STREAM",
+  "OPENCLAW_LAUNCHD_LABEL",
+  "OPENCLAW_SYSTEMD_UNIT",
 ];
 
 function isTruthy(value: string | undefined): boolean {


### PR DESCRIPTION
## Summary
Treat OpenClaw-managed service env vars as supervisor hints in gateway respawn detection.

Changes:
- add `OPENCLAW_LAUNCHD_LABEL` and `OPENCLAW_SYSTEMD_UNIT` to `SUPERVISOR_HINT_ENV_VARS`
- extend tests in `src/infra/process-respawn.test.ts`

## Why
On Nimbus (macOS LaunchAgent), SIGUSR1 restart was detected as non-supervised and used detached spawn mode:
- `signal SIGUSR1 received`
- `restart mode: full process restart (spawned pid 61868)`

Then the spawned process collided with the already supervised gateway and produced repeated:
- `Gateway failed to start: gateway already running ... lock timeout`

Launchd environment for the running job includes `OPENCLAW_LAUNCHD_LABEL`, but `process-respawn` currently only checks native hints (`LAUNCH_JOB_LABEL`, etc.).

## Verification
- `pnpm vitest run src/infra/process-respawn.test.ts`

## Related
- restart instability context in #14161

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `OPENCLAW_LAUNCHD_LABEL` and `OPENCLAW_SYSTEMD_UNIT` to the supervisor hint env var list in `process-respawn.ts`, so that OpenClaw-managed service environments (launchd on macOS, systemd on Linux) are correctly detected as supervised during gateway SIGUSR1 restart. Previously, only native supervisor hints (e.g. `LAUNCH_JOB_LABEL`, `INVOCATION_ID`) were checked, causing Nimbus (macOS LaunchAgent) restarts to incorrectly spawn a detached child that collided with the already-supervised gateway.

- The fix aligns `process-respawn.ts` with `service-env.ts`, which already injects these env vars into managed service environments
- Two new test cases verify the supervised detection path for each env var
- `clearSupervisorHints()` test helper properly updated to clean up both new vars

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds two env var entries to an existing allowlist and corresponding tests, with no behavioral risk.
- The change is minimal (two string additions to a const array), well-tested (two new test cases plus cleanup helper update), and directly addresses a documented bug. The env vars are already set by service-env.ts and consumed by restart.ts, so adding them to respawn detection is a straightforward alignment fix with no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: f12f8c4</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->