### PR TITLE
fix(matrix): messages silently dropped when homeserver clock is behind gateway

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -130,6 +130,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const eventTs = event.origin_server_ts;
       const eventAge = event.unsigned?.age;
       if (typeof eventTs === "number" && eventTs < startupMs - startupGraceMs) {
+        logVerboseMessage(
+          `ignoring pre-startup event in ${roomId} (eventTs=${eventTs}, startupMs=${startupMs}, graceMs=${startupGraceMs})`,
+        );
         return;
       }
       if (
@@ -137,6 +140,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         typeof eventAge === "number" &&
         eventAge > startupGraceMs
       ) {
+        logVerboseMessage(
+          `ignoring old event in ${roomId} (eventAge=${eventAge}, graceMs=${startupGraceMs})`,
+        );
         return;
       }
 

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -255,7 +255,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const mediaMaxMb = opts.mediaMaxMb ?? accountConfig.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
   const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const startupMs = Date.now();
-  const startupGraceMs = 0;
+  const startupGraceMs = 30_000;
   const directTracker = createDirectRoomTracker(client, { log: logVerboseMessage });
   registerMatrixAutoJoin({ client, cfg, runtime });
   const warnedEncryptedRooms = new Set<string>();


### PR DESCRIPTION
## Problem

The Matrix message handler uses `startupGraceMs = 0` to filter pre-startup events. When the Matrix homeserver's clock is even slightly behind the OpenClaw host (common in distributed setups), **every incoming message** is silently discarded with no log output at default verbosity.

This is an extremely difficult silent failure — the bot appears to connect successfully but never responds.

## Root Cause

In `monitor/index.ts`:
```ts
const startupGraceMs = 0;
```

The handler checks `eventTs < startupMs - startupGraceMs`. With grace = 0, any event whose `origin_server_ts` is before the gateway's `Date.now()` at startup is dropped. Even 1–3 seconds of clock skew triggers this for every message.

## Fix

- Set `startupGraceMs` to **30 seconds** (consistent with `channel-health-monitor.ts` which uses 60s)
- Add verbose-level logging when events are dropped, so the failure is at least observable

## Changes

| File | Change |
|------|--------|
| `monitor/index.ts` | `startupGraceMs`: 0 → 30\_000 |
| `monitor/handler.ts` | Log dropped events via `logVerboseMessage` |

Closes #19843

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes silent message drops in the Matrix provider when the homeserver's clock is slightly behind the gateway host. Previously, `startupGraceMs` was set to `0`, causing every event with an `origin_server_ts` before the gateway's `Date.now()` at startup to be silently discarded — a common scenario in distributed setups with even 1–3 seconds of clock skew.

- `startupGraceMs` increased from `0` to `30_000` (30 seconds) in `monitor/index.ts`, consistent with the 60s grace used by `channel-health-monitor.ts`
- Added verbose-level logging in `handler.ts` for both pre-startup timestamp drops and age-based drops, making this failure mode observable when debugging
- Both log calls are gated behind `shouldLogVerbose()`, so no impact at default log levels

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — minimal, well-scoped fix with no behavioral risk.
- The change is a two-file, four-line diff that adjusts a numeric constant and adds diagnostic logging. The grace period value is reasonable (30s vs the 60s used elsewhere), the logging is properly gated behind verbose mode, and the fix directly addresses a documented silent failure mode. No new dependencies, no API changes, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 29386bf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->