### PR TITLE
feat(web-search): add SerpAPI search provider support

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -668,6 +668,7 @@ async function runSerpApiSearch(params: {
     title: string;
     url: string;
     description: string;
+    published?: string;
     siteName?: string;
   }>
 > {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -389,8 +389,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", or "grok"). */
-      provider?: "brave" | "perplexity" | "grok";
+      /** Search provider ("brave", "perplexity", "grok", or "serpapi"). */
+      provider?: "brave" | "perplexity" | "grok" | "serpapi";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -416,6 +416,13 @@ export type ToolsConfig = {
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */
         inlineCitations?: boolean;
+      };
+      /** SerpAPI-specific configuration (used when provider="serpapi"). */
+      serpapi?: {
+        /** API key for SerpAPI (defaults to SERPAPI_API_KEY env var). */
+        apiKey?: string;
+        /** SerpAPI search engine (default: "google"). */
+        engine?: string;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -227,7 +227,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("grok")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("grok"), z.literal("serpapi")])
+      .optional(),
     apiKey: z.string().optional().register(sensitive),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -245,6 +247,13 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional().register(sensitive),
         model: z.string().optional(),
         inlineCitations: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    serpapi: z
+      .object({
+        apiKey: z.string().optional().register(sensitive),
+        engine: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Add SerpAPI as a fourth web search provider alongside Brave, Perplexity, and Grok.

- Add 'serpapi' to provider union type and zod schema
- Add serpapi config block (apiKey, engine) to types and validation
- Implement runSerpApiSearch following the Brave pattern
- Support SERPAPI_API_KEY env var and config-based key resolution
- Map freshness shortcuts (pd/pw/pm/py) to SerpAPI tbs params
- Add 18 test cases for config resolution and freshness mapping

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds SerpAPI as a fourth web search provider alongside Brave, Perplexity, and Grok. The implementation closely follows existing patterns: config resolution mirrors the Grok/Perplexity approach, result mapping follows the Brave pattern, and freshness shortcuts (pd/pw/pm/py) are mapped to SerpAPI's `tbs` query parameter.

- Adds `serpapi` to provider union type, Zod schema, and all provider resolution/dispatch paths
- Implements `runSerpApiSearch` with proper error handling, timeout, caching, and content wrapping
- Adds `resolveSerpApiApiKey` (config-first, `SERPAPI_API_KEY` env fallback) and `resolveSerpApiEngine` (default: `"google"`)
- Includes 18 test cases covering config resolution and freshness mapping
- Minor type annotation issue: `runSerpApiSearch` return type omits the `published` field that is actually returned in result objects

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a new search provider following well-established patterns with no changes to existing provider behavior.
- The implementation is clean and consistent with existing providers. The only finding is a minor return type annotation omission (missing `published` field) that doesn't affect runtime behavior. All four changed files are straightforward additive changes with no risk to existing functionality.
- Minor attention needed for `src/agents/tools/web-search.ts` — the `runSerpApiSearch` return type annotation is missing the `published` field.

<sub>Last reviewed commit: f4d8160</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->