### PR TITLE
Feat/foropenclaw bootstrapfiles clean

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -577,6 +577,21 @@ Disables automatic creation of workspace bootstrap files (`AGENTS.md`, `SOUL.md`
 }
 ```
 
+### `agents.defaults.bootstrapFiles`
+
+Extra workspace paths or glob patterns to include in bootstrap context injection.
+Only recognized bootstrap filenames are loaded (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`, `memory.md`).
+
+```json5
+{
+  agents: {
+    defaults: {
+      bootstrapFiles: ["packages/*/AGENTS.md", "profiles/default/TOOLS.md"],
+    },
+  },
+}
+```
+
 ### `agents.defaults.bootstrapMaxChars`
 
 Max characters per workspace bootstrap file before truncation. Default: `20000`.

--- a/src/agents/bootstrap-files.e2e.test.ts
+++ b/src/agents/bootstrap-files.e2e.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -31,6 +32,33 @@ describe("resolveBootstrapFilesForRun", () => {
     const files = await resolveBootstrapFilesForRun({ workspaceDir });
 
     expect(files.some((file) => file.path === path.join(workspaceDir, "EXTRA.md"))).toBe(true);
+  });
+
+  it("loads extra files from agents.defaults.bootstrapFiles", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const packageDir = path.join(workspaceDir, "packages", "core");
+    await fs.mkdir(packageDir, { recursive: true });
+    await fs.writeFile(path.join(packageDir, "TOOLS.md"), "team tools", "utf-8");
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: {
+        agents: {
+          defaults: {
+            bootstrapFiles: ["packages/*/*"],
+          },
+        },
+      } as never,
+    });
+
+    expect(
+      files.some(
+        (file) =>
+          file.name === "TOOLS.md" &&
+          file.path.endsWith(path.join("packages", "core", "TOOLS.md")) &&
+          file.content === "team tools",
+      ),
+    ).toBe(true);
   });
 });
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -162,6 +162,8 @@ export const FIELD_HELP: Record<string, string> = {
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
   "agents.defaults.bootstrapMaxChars":
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
+  "agents.defaults.bootstrapFiles":
+    "Extra workspace paths/globs to include as bootstrap context (only recognized bootstrap filenames are loaded).",
   "agents.defaults.bootstrapTotalMaxChars":
     "Max total characters across all injected workspace bootstrap files (default: 150000).",
   "agents.defaults.repoRoot":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -129,6 +129,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "skills.load.watchDebounceMs": "Skills Watch Debounce (ms)",
   "agents.defaults.workspace": "Workspace",
   "agents.defaults.repoRoot": "Repo Root",
+  "agents.defaults.bootstrapFiles": "Bootstrap Files",
   "agents.defaults.bootstrapMaxChars": "Bootstrap Max Chars",
   "agents.defaults.bootstrapTotalMaxChars": "Bootstrap Total Max Chars",
   "agents.defaults.envelopeTimezone": "Envelope Timezone",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -134,6 +134,8 @@ export type AgentDefaultsConfig = {
   repoRoot?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
   skipBootstrap?: boolean;
+  /** Extra workspace files/glob patterns to inject as bootstrap context. */
+  bootstrapFiles?: string[];
   /** Max chars for injected bootstrap files before truncation (default: 20000). */
   bootstrapMaxChars?: number;
   /** Max total chars across all injected bootstrap files (default: 150000). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -45,6 +45,7 @@ export const AgentDefaultsSchema = z
     workspace: z.string().optional(),
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
+    bootstrapFiles: z.array(z.string()).optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
     userTimezone: z.string().optional(),


### PR DESCRIPTION
# OpenClaw Contribution Summary

This document summarizes the recent changes implemented on branch `feat/foropenclaw-integration`.

## What Changed

### 1. New config option: `agents.defaults.bootstrapFiles`

Added support for a new agent default config field:

- `agents.defaults.bootstrapFiles: string[]`

This lets you provide extra workspace file paths/glob patterns that should be injected into bootstrap context during agent runs.

Implemented in:

- `src/config/types.agent-defaults.ts`
- `src/config/zod-schema.agent-defaults.ts`
- `src/agents/bootstrap-files.ts`
- `src/config/schema.help.ts`
- `src/config/schema.labels.ts`
- `docs/gateway/configuration-reference.md`

### 2. Tests added/updated

Added coverage for config-driven bootstrap file loading:

- `src/agents/bootstrap-files.e2e.test.ts`

### 3. Quality fixes after checks

After formatting/lint checks:

- formatted:
  - `src/agents/tools/telegram-actions.ts`
  - `src/telegram/send.ts`
- fixed one lint error (duplicate key) in:
  - `src/agents/tools/message-tool.ts`

## Benefits

- Config-first customization of bootstrap context without writing custom hook code.
- Easier team/repo setup by injecting project-specific bootstrap files from subfolders.
- Keeps existing safety model:
  - only recognized bootstrap filenames are loaded
  - path traversal protections remain in place
- Better maintainability and onboarding for users with multi-folder workspace structures.

## Validation and Results

All relevant checks passed after fixes:

1. `pnpm vitest run src/agents/workspace.load-extra-bootstrap-files.test.ts`
2. `pnpm vitest run --config vitest.e2e.config.ts src/agents/bootstrap-files.e2e.test.ts`
3. `pnpm format:check`
4. `pnpm lint`

Status: all passed.

## Commits

- `593c590cb` - `feat(config): support agents.defaults.bootstrapFiles`
- `45a656d94` - `chore: fix lint and formatting issues`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new config option `agents.defaults.bootstrapFiles` that allows specifying extra workspace file paths or glob patterns to inject into bootstrap context during agent runs. It also includes a second commit that regenerates Swift protocol models to add a `threadId` field to `SendParams`.

- The `bootstrapFiles` config option reuses the existing `loadExtraBootstrapFiles` infrastructure, with proper path traversal protection and bootstrap filename validation
- Type definitions, Zod schema, field help, field labels, and docs are all updated consistently
- An e2e test covers the new config-driven glob pattern loading
- The Swift model changes (`threadid` on `SendParams`) are a separate protocol regeneration, unrelated to the bootstrap feature
- The new config-driven approach overlaps with the existing `bootstrap-extra-files` bundled hook — both call `loadExtraBootstrapFiles` and there is no deduplication, so users with both configured could see duplicate bootstrap files in context

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it adds a clean config-driven feature that follows existing patterns
- The changes are well-structured and follow existing patterns. The feature reuses battle-tested infrastructure (loadExtraBootstrapFiles with path traversal guards and filename validation). The main concern is the potential for duplicate file loading when used alongside the existing bootstrap-extra-files hook, but this is a design overlap rather than a correctness bug. The Swift model regeneration is straightforward.
- `src/agents/bootstrap-files.ts` — the unnecessary type assertion and potential duplicate loading with the bootstrap-extra-files hook

<sub>Last reviewed commit: 273fe81</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->