### PR TITLE
fix(discord): register select menu handlers (unique customId)

### DIFF
--- a/src/discord/monitor/agent-components.registration.test.ts
+++ b/src/discord/monitor/agent-components.registration.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  parseDiscordComponentCustomIdForCarbon,
+  parseDiscordModalCustomIdForCarbon,
+} from "../components.js";
+import type { AgentComponentContext } from "./agent-components.js";
+import {
+  createDiscordComponentButton,
+  createDiscordComponentChannelSelect,
+  createDiscordComponentMentionableSelect,
+  createDiscordComponentModal,
+  createDiscordComponentRoleSelect,
+  createDiscordComponentStringSelect,
+  createDiscordComponentUserSelect,
+} from "./agent-components.js";
+
+describe("discord agent-components registration", () => {
+  it("uses unique customId values for each Discord component handler (avoid Carbon de-dupe)", () => {
+    const ctx = {
+      cfg: {} as unknown as OpenClawConfig,
+      accountId: "test",
+    } satisfies AgentComponentContext;
+
+    const componentHandlers = [
+      createDiscordComponentButton(ctx),
+      createDiscordComponentStringSelect(ctx),
+      createDiscordComponentUserSelect(ctx),
+      createDiscordComponentRoleSelect(ctx),
+      createDiscordComponentMentionableSelect(ctx),
+      createDiscordComponentChannelSelect(ctx),
+    ];
+
+    const customIds = componentHandlers.map((c) => c.customId);
+    expect(customIds).not.toContain("*");
+    expect(new Set(customIds).size).toBe(customIds.length);
+
+    for (const customId of customIds) {
+      expect(parseDiscordComponentCustomIdForCarbon(customId).key).toBe("*");
+    }
+
+    const modal = createDiscordComponentModal(ctx);
+    expect(modal.customId).not.toBe("*");
+    expect(parseDiscordModalCustomIdForCarbon(modal.customId).key).toBe("*");
+  });
+});

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -42,6 +42,8 @@ import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import { resolveDiscordComponentEntry, resolveDiscordModalEntry } from "../components-registry.js";
 import {
   createDiscordFormModal,
+  DISCORD_COMPONENT_CUSTOM_ID_KEY,
+  DISCORD_MODAL_CUSTOM_ID_KEY,
   formatDiscordComponentEventText,
   parseDiscordComponentCustomId,
   parseDiscordComponentCustomIdForCarbon,
@@ -1361,7 +1363,9 @@ export class AgentSelectMenu extends StringSelectMenu {
 
 class DiscordComponentButton extends Button {
   label = "component";
-  customId = "*";
+  // Must be unique across component handlers. Carbon's ComponentHandler de-dupes by customId.
+  // Keep the occomp prefix so parseDiscordComponentCustomIdForCarbon returns key="*".
+  customId = `${DISCORD_COMPONENT_CUSTOM_ID_KEY}:handler=button`;
   style = ButtonStyle.Primary;
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
@@ -1393,7 +1397,8 @@ class DiscordComponentButton extends Button {
 }
 
 class DiscordComponentStringSelect extends StringSelectMenu {
-  customId = "*";
+  // Must be unique across component handlers. Carbon's ComponentHandler de-dupes by customId.
+  customId = `${DISCORD_COMPONENT_CUSTOM_ID_KEY}:handler=string-select`;
   options: APIStringSelectComponent["options"] = [];
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
@@ -1416,7 +1421,8 @@ class DiscordComponentStringSelect extends StringSelectMenu {
 }
 
 class DiscordComponentUserSelect extends UserSelectMenu {
-  customId = "*";
+  // Must be unique across component handlers. Carbon's ComponentHandler de-dupes by customId.
+  customId = `${DISCORD_COMPONENT_CUSTOM_ID_KEY}:handler=user-select`;
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1438,7 +1444,8 @@ class DiscordComponentUserSelect extends UserSelectMenu {
 }
 
 class DiscordComponentRoleSelect extends RoleSelectMenu {
-  customId = "*";
+  // Must be unique across component handlers. Carbon's ComponentHandler de-dupes by customId.
+  customId = `${DISCORD_COMPONENT_CUSTOM_ID_KEY}:handler=role-select`;
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1460,7 +1467,8 @@ class DiscordComponentRoleSelect extends RoleSelectMenu {
 }
 
 class DiscordComponentMentionableSelect extends MentionableSelectMenu {
-  customId = "*";
+  // Must be unique across component handlers. Carbon's ComponentHandler de-dupes by customId.
+  customId = `${DISCORD_COMPONENT_CUSTOM_ID_KEY}:handler=mentionable-select`;
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1482,7 +1490,8 @@ class DiscordComponentMentionableSelect extends MentionableSelectMenu {
 }
 
 class DiscordComponentChannelSelect extends ChannelSelectMenu {
-  customId = "*";
+  // Must be unique across component handlers. Carbon's ComponentHandler de-dupes by customId.
+  customId = `${DISCORD_COMPONENT_CUSTOM_ID_KEY}:handler=channel-select`;
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1505,7 +1514,9 @@ class DiscordComponentChannelSelect extends ChannelSelectMenu {
 
 class DiscordComponentModal extends Modal {
   title = "OpenClaw form";
-  customId = "*";
+  // Must be unique across modal handlers. Carbon's ModalHandler de-dupes by customId.
+  // Keep the ocmodal prefix so parseDiscordModalCustomIdForCarbon returns key="*".
+  customId = `${DISCORD_MODAL_CUSTOM_ID_KEY}:handler=modal`;
   components = [];
   customIdParser = parseDiscordModalCustomIdForCarbon;
   private ctx: AgentComponentContext;


### PR DESCRIPTION
## Problem
Discord select menus (component type 3) sent via OpenClaw components can fail with “This interaction failed”. Gateway logs show:

```
Unknown component with type 3 and custom ID occomp:cid=sel_... was received, did you forget to register the component?
```

Buttons and modals continue to work.

## Root cause
Carbon de-dupes component registrations by `customId`. OpenClaw registered multiple Discord component handlers (button / string select / user select / role select / mentionable select / channel select) all with `customId="*"`, so only the first handler is registered; the select handlers never get registered.

## Fix
Assign unique `customId` values to each handler while keeping the `occomp:` / `ocmodal:` prefix so `parseDiscordComponentCustomIdForCarbon` / `parseDiscordModalCustomIdForCarbon` still normalize to `key="*"` for wildcard matching.

## Tests
Add a unit test to ensure:
- each handler uses a unique, non-`"*"` `customId`
- the Carbon parser still yields `key="*"`

This prevents regressions where handlers accidentally share the same customId again.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Discord select menu interactions failing with "This interaction failed" because Carbon's `ComponentHandler` de-duplicates handlers by `customId`. All six component handlers (button plus five select types) and the modal handler previously shared the same wildcard `customId`, so only the first-registered handler (button) was active. Select menu interactions were silently dropped.

The fix assigns unique `customId` values to each handler while preserving the `occomp`/`ocmodal` prefix so the Carbon custom-ID parsers still normalize to wildcard matching at runtime.

- Consistent with how `AgentComponentButton` and `AgentSelectMenu` already use unique custom IDs
- New regression test verifies uniqueness and parser round-trip for all handlers
- No behavioral changes to how interactions are dispatched; only the registration identity changes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a targeted, well-tested fix for a clear registration bug with no risk of side effects.
- The change is minimal and precise: it replaces hardcoded wildcard customId values with unique prefixed strings that still pass through the existing parser correctly. The fix is consistent with the pattern already used by AgentComponentButton and AgentSelectMenu. A regression test validates both the uniqueness constraint and the parser round-trip. No logic paths are altered beyond the registration identity.
- No files require special attention.

<sub>Last reviewed commit: 9a7c320</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->