### PR TITLE
test(gateway,browser): isolate tests from ambient OPENCLAW_GATEWAY_TOKEN

### DIFF
--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -50,6 +50,11 @@ describe("profile CRUD endpoints", () => {
     state.cdpBaseUrl = `http://127.0.0.1:${state.testPort + 1}`;
     state.prevGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
     process.env.OPENCLAW_GATEWAY_PORT = String(state.testPort - 2);
+    // Avoid auth coupling: if OPENCLAW_GATEWAY_TOKEN is set on the developer's
+    // machine, the browser control server would require auth and return 401
+    // instead of the 400/404 status codes these tests assert on.
+    state.prevGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
 
     vi.stubGlobal(
       "fetch",
@@ -70,6 +75,11 @@ describe("profile CRUD endpoints", () => {
       delete process.env.OPENCLAW_GATEWAY_PORT;
     } else {
       process.env.OPENCLAW_GATEWAY_PORT = state.prevGatewayPort;
+    }
+    if (state.prevGatewayToken === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = state.prevGatewayToken;
     }
     await stopBrowserControlServer();
   });

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 
 describe("resolveGatewayRuntimeConfig", () => {
@@ -78,6 +78,18 @@ describe("resolveGatewayRuntimeConfig", () => {
   });
 
   describe("token/password auth modes", () => {
+    // resolveGatewayAuth reads from process.env, so tests that rely on specific
+    // auth config must isolate against any OPENCLAW_GATEWAY_TOKEN/PASSWORD that
+    // may be present on a developer's machine.
+    beforeEach(() => {
+      vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "");
+      vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", "");
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
     it("should reject token mode without token configured", async () => {
       const cfg = {
         gateway: {


### PR DESCRIPTION
## Problem

Two test suites added in #15940 (feat: add trusted-proxy auth mode) fail on developer machines where OpenClaw is configured with a gateway token (`OPENCLAW_GATEWAY_TOKEN` set in the shell environment).

`resolveGatewayAuth` reads from `process.env` to pick up the token. When that env var is set on a developer's machine, the ambient token satisfies the auth check and changes the behavior the tests are asserting on.

**Affected tests:**

1. `src/gateway/server-runtime-config.test.ts` — `token/password auth modes > should reject token mode without token configured`
   - Expected: promise rejects with "gateway auth mode is token, but no token was configured"
   - Got: promise resolved successfully (because `OPENCLAW_GATEWAY_TOKEN` from env supplied a token)

2. `src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts` — `profile CRUD endpoints > validates profile create/delete endpoints`
   - Expected: HTTP 400 on invalid request body
   - Got: HTTP 401 (the browser control server required auth because the token from env was present)

Both tests pass on CI (no ambient token) but break on machines with OpenClaw configured.

## Fix

**`server-runtime-config.test.ts`:** Add `beforeEach`/`afterEach` in the `token/password auth modes` describe block to stub `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_PASSWORD` to empty strings via `vi.stubEnv`, clearing them for the duration of the tests.

**`server.post-tabs-open-profile-unknown-returns-404.test.ts`:** Save and delete `OPENCLAW_GATEWAY_TOKEN` in the `profile CRUD endpoints` `beforeEach`, and restore it in `afterEach`. This mirrors the pattern already used in `installBrowserControlServerHooks` for the same reason (comment: "Avoid flaky auth coupling").

## Test evidence

Both previously-failing tests now pass with `OPENCLAW_GATEWAY_TOKEN` explicitly set:

```
OPENCLAW_GATEWAY_TOKEN=some-real-token-value pnpm vitest run --config vitest.gateway.config.ts --pool=forks src/gateway/server-runtime-config.test.ts
  ✓ should allow lan binding with trusted-proxy auth mode
  ✓ should reject loopback binding with trusted-proxy auth mode
  ✓ should reject trusted-proxy without trustedProxies configured
  ✓ should reject token mode without token configured
  ✓ should allow lan binding with token
  Test Files  1 passed (1)
  Tests       5 passed (5)

OPENCLAW_GATEWAY_TOKEN=some-real-token-value pnpm vitest run --config vitest.unit.config.ts --pool=forks src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
  ✓ POST /tabs/open?profile=unknown returns 404
  ✓ validates profile create/delete endpoints
  Test Files  1 passed (1)
  Tests       2 passed (2)
```

Full quality gate (pnpm build + pnpm check + pnpm test): PASS.

## Disclosure

This fix was implemented with AI assistance (Claude). Changes are limited to test isolation — no production code was modified.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes test isolation for two test suites that fail when gateway auth env vars are set on developer machines. The approach is correct: clear env vars during test execution and restore them afterward.

- `server-runtime-config.test.ts`: Uses `vi.stubEnv`/`vi.unstubAllEnvs` to isolate both token and password env vars in the `token/password auth modes` describe block. Clean and correct.
- `server.post-tabs-open-profile-unknown-returns-404.test.ts`: Saves, deletes, and restores the gateway token env var in the `profile CRUD endpoints` describe block, matching the existing pattern in `installBrowserControlServerHooks`.
- **Issue found**: The browser test only clears the gateway token env var but not the gateway password env var. Since `resolveBrowserControlAuth` reads both via `resolveGatewayAuth`, a developer with only the password env var set would still hit 401 failures. The test harness's `installBrowserControlServerHooks` clears both — this fix should do the same for full coverage.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — test-only changes with one minor gap in env var cleanup coverage.
- The changes are test-only and correctly fix the reported issue. The gateway test file change is clean and complete. The browser test file has a minor gap: it doesn't clear the gateway password env var, which could still cause test failures for developers using password-based auth. This is a low-risk omission since token-based auth is the more common developer setup, but it leaves the same class of bug partially unfixed.
- `src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts` — missing cleanup for the gateway password env var

<sub>Last reviewed commit: b5f3368</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->