### PR TITLE
fix: strict silent-reply detection to prevent false positives with CJK text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ package-lock.json
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
+openclaw-*.log

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "./tokens.js";
+import { isSilentReplyText } from "./tokens.js";
 
 describe("isSilentReplyText", () => {
   it("matches exact token", () => {
@@ -10,6 +10,18 @@ describe("isSilentReplyText", () => {
     expect(isSilentReplyText("  NO_REPLY  ")).toBe(true);
   });
 
+  it("matches token with ASCII annotation", () => {
+    expect(isSilentReplyText("NO_REPLY -- nope")).toBe(true);
+  });
+
+  it("matches token preceded by ASCII punctuation", () => {
+    expect(isSilentReplyText("interject.NO_REPLY")).toBe(true);
+  });
+
+  it("matches token with ASCII reason in parens", () => {
+    expect(isSilentReplyText("NO_REPLY -- (why am I here?)")).toBe(true);
+  });
+
   it("rejects undefined", () => {
     expect(isSilentReplyText(undefined)).toBe(false);
   });
@@ -18,7 +30,7 @@ describe("isSilentReplyText", () => {
     expect(isSilentReplyText("")).toBe(false);
   });
 
-  it("does not match token embedded in CJK text", () => {
+  it("does not match token followed by CJK text", () => {
     expect(isSilentReplyText("NO_REPLY 这是中文消息")).toBe(false);
   });
 
@@ -28,10 +40,6 @@ describe("isSilentReplyText", () => {
 
   it("does not match token surrounded by CJK text", () => {
     expect(isSilentReplyText("中文NO_REPLY消息")).toBe(false);
-  });
-
-  it("does not match token in a longer English sentence", () => {
-    expect(isSilentReplyText("Here is NO_REPLY for you")).toBe(false);
   });
 
   it("does not match token as substring", () => {

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "./tokens.js";
+
+describe("isSilentReplyText", () => {
+  it("matches exact token", () => {
+    expect(isSilentReplyText("NO_REPLY")).toBe(true);
+  });
+
+  it("matches token with surrounding whitespace", () => {
+    expect(isSilentReplyText("  NO_REPLY  ")).toBe(true);
+  });
+
+  it("rejects undefined", () => {
+    expect(isSilentReplyText(undefined)).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isSilentReplyText("")).toBe(false);
+  });
+
+  it("does not match token embedded in CJK text", () => {
+    expect(isSilentReplyText("NO_REPLY 这是中文消息")).toBe(false);
+  });
+
+  it("does not match token preceded by CJK text", () => {
+    expect(isSilentReplyText("中文消息 NO_REPLY")).toBe(false);
+  });
+
+  it("does not match token surrounded by CJK text", () => {
+    expect(isSilentReplyText("中文NO_REPLY消息")).toBe(false);
+  });
+
+  it("does not match token in a longer English sentence", () => {
+    expect(isSilentReplyText("Here is NO_REPLY for you")).toBe(false);
+  });
+
+  it("does not match token as substring", () => {
+    expect(isSilentReplyText("NO_REPLY_EXTRA")).toBe(false);
+  });
+
+  it("works with custom token", () => {
+    expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
+    expect(isSilentReplyText("HEARTBEAT_OK 还有中文", "HEARTBEAT_OK")).toBe(false);
+  });
+});

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from "../utils.js";
+
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
 
@@ -8,5 +10,26 @@ export function isSilentReplyText(
   if (!text) {
     return false;
   }
-  return text.trim() === token;
+  const trimmed = text.trim();
+  if (trimmed === token) {
+    return true;
+  }
+  const escaped = escapeRegExp(token);
+  // Token at start, NOT followed by a word char, and rest is ASCII-only
+  const prefixRe = new RegExp(`^\\s*${escaped}(?![a-zA-Z0-9_])`);
+  if (prefixRe.test(text)) {
+    const rest = text.replace(new RegExp(`^\\s*${escaped}`), "");
+    if (/^[\x00-\x7f]*$/.test(rest)) {
+      return true;
+    }
+  }
+  // Token at end, NOT preceded by a word char, and prefix is ASCII-only
+  const suffixRe = new RegExp(`(?<![a-zA-Z0-9_])${escaped}\\s*$`);
+  if (suffixRe.test(text)) {
+    const before = text.replace(new RegExp(`${escaped}\\s*$`), "");
+    if (/^[\x00-\x7f]*$/.test(before)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -10,11 +10,5 @@ export function isSilentReplyText(
   if (!text) {
     return false;
   }
-  const escaped = escapeRegExp(token);
-  const prefix = new RegExp(`^\\s*${escaped}(?=$|\\W)`);
-  if (prefix.test(text)) {
-    return true;
-  }
-  const suffix = new RegExp(`\\b${escaped}\\b\\W*$`);
-  return suffix.test(text);
+  return text.trim() === token;
 }

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -1,5 +1,3 @@
-import { escapeRegExp } from "../utils.js";
-
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -15,19 +15,19 @@ export function isSilentReplyText(
     return true;
   }
   const escaped = escapeRegExp(token);
-  // Token at start, NOT followed by a word char, and rest is ASCII-only
+  // Token at start, followed only by ASCII (allows "NO_REPLY -- explanation" but not CJK)
   const prefixRe = new RegExp(`^\\s*${escaped}(?![a-zA-Z0-9_])`);
   if (prefixRe.test(text)) {
     const rest = text.replace(new RegExp(`^\\s*${escaped}`), "");
-    if (/^[\x00-\x7f]*$/.test(rest)) {
+    if (/^[\t\n\r\x20-\x7e]*$/.test(rest)) {
       return true;
     }
   }
-  // Token at end, NOT preceded by a word char, and prefix is ASCII-only
+  // Token at end, preceded only by ASCII
   const suffixRe = new RegExp(`(?<![a-zA-Z0-9_])${escaped}\\s*$`);
   if (suffixRe.test(text)) {
     const before = text.replace(new RegExp(`${escaped}\\s*$`), "");
-    if (/^[\x00-\x7f]*$/.test(before)) {
+    if (/^[\t\n\r\x20-\x7e]*$/.test(before)) {
       return true;
     }
   }


### PR DESCRIPTION
Fixes #24773

## Summary

**Problem:** `isSilentReplyText()` uses `\b` and `\W` regex anchors to detect silent reply tokens (NO_REPLY, HEARTBEAT_OK). In JavaScript, `\W` matches any non-`[a-zA-Z0-9_]` character — including all CJK (Chinese/Japanese/Korean) characters. This causes any assistant reply containing `NO_REPLY` followed by CJK text to be falsely detected as a silent reply and silently swallowed.

**Why it matters:** CJK-language users lose messages. The assistant generates a valid reply mentioning NO_REPLY in context, but it never gets delivered. This is a data-loss bug affecting all CJK locales across all channels (Discord, Telegram, Slack, etc.).

**What changed:** Replace the broad `\W` regex with a printable ASCII range check `[\t\n\r\x20-\x7e]*` that explicitly allows only ASCII whitespace and printable characters after the token — rejecting CJK and other non-ASCII content. The token must appear either at the start or end of the trimmed text with only ASCII surrounding it.

## Test coverage

Added tests in `tokens.test.ts` covering:
- CJK text before/after token → not silent
- Mixed ASCII + CJK → not silent  
- Pure token → silent
- Token with ASCII trailing content → silent

## Notes

This PR was previously closed as a duplicate of #8504, but #8504 is now stale-labeled and appears unlikely to land. Reopening this as the cleaner alternative.