### PR TITLE
feat(hooks): add message:received and message:sent hook events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Core/
 apps/ios/*.xcodeproj/
 apps/ios/*.xcworkspace/
 apps/ios/.swiftpm/
+apps/ios/.derivedData/
 apps/ios/.local-signing.xcconfig
 vendor/
 apps/ios/Clawdbot.xcodeproj/

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { dispatchInboundMessage, withReplyDispatcher } from "./dispatch.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
+import { clearInternalHooks, registerInternalHook } from "../hooks/internal-hooks.js";
+import { dispatchInboundMessage, withReplyDispatcher } from "./dispatch.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
 
 function createDispatcher(record: string[]): ReplyDispatcher {
@@ -18,6 +19,55 @@ function createDispatcher(record: string[]): ReplyDispatcher {
     },
   };
 }
+
+describe("message:received hook regression", () => {
+  beforeEach(() => {
+    clearInternalHooks();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+  });
+
+  it("dispatchInboundMessage triggers message:received hook before processing", async () => {
+    const hookHandler = vi.fn();
+    registerInternalHook("message:received", hookHandler);
+
+    const order: string[] = [];
+    const dispatcher = {
+      sendToolResult: () => true,
+      sendBlockReply: () => true,
+      sendFinalReply: () => {
+        order.push("sendFinalReply");
+        return true;
+      },
+      getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      markComplete: () => {
+        order.push("markComplete");
+      },
+      waitForIdle: async () => {
+        order.push("waitForIdle");
+      },
+    } satisfies ReplyDispatcher;
+
+    await dispatchInboundMessage({
+      ctx: buildTestCtx({ Body: "test message", Provider: "signal" }),
+      cfg: {} as OpenClawConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    // Hook MUST fire — this is the regression test for the upstream refactor
+    // that silently dropped the triggerMessageReceived() call (commit d5e25e0ad).
+    expect(hookHandler).toHaveBeenCalledTimes(1);
+
+    const event = hookHandler.mock.calls[0][0];
+    expect(event.type).toBe("message");
+    expect(event.action).toBe("received");
+    expect(event.context.message).toBe("test message");
+    expect(event.context.channel).toBe("signal");
+  });
+});
 
 describe("withReplyDispatcher", () => {
   it("always marks complete and waits for idle after success", async () => {

--- a/src/hooks/hooks.ts
+++ b/src/hooks/hooks.ts
@@ -1,4 +1,5 @@
 export * from "./internal-hooks.js";
+export * from "./message-hooks.js";
 
 export type HookEventType = import("./internal-hooks.js").InternalHookEventType;
 export type HookEvent = import("./internal-hooks.js").InternalHookEvent;

--- a/src/hooks/message-hooks.test.ts
+++ b/src/hooks/message-hooks.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FinalizedMsgContext } from "../auto-reply/templating.js";
+import {
+  clearInternalHooks,
+  registerInternalHook,
+  type InternalHookEvent,
+} from "./internal-hooks.js";
+import {
+  triggerMessageReceived,
+  triggerMessageSent,
+  type MessageReceivedContext,
+  type MessageSentContext,
+} from "./message-hooks.js";
+
+describe("message-hooks", () => {
+  beforeEach(() => {
+    clearInternalHooks();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+  });
+
+  describe("triggerMessageReceived", () => {
+    it("triggers message:received hook with correct context", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:received", handler);
+
+      const ctx = {
+        Body: "Hello world",
+        RawBody: "Hello world",
+        SenderId: "+1234567890",
+        SenderName: "Test User",
+        Provider: "signal",
+        MessageSid: "msg-123",
+        ChatType: "dm" as const,
+        From: "+1234567890",
+        SessionKey: "agent:main:signal",
+        Timestamp: 1700000000,
+        CommandAuthorized: true,
+      };
+
+      await triggerMessageReceived("agent:main:signal", ctx as unknown as FinalizedMsgContext);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const event = handler.mock.calls[0][0] as InternalHookEvent;
+      expect(event.type).toBe("message");
+      expect(event.action).toBe("received");
+      expect(event.sessionKey).toBe("agent:main:signal");
+
+      const eventContext = event.context as MessageReceivedContext;
+      expect(eventContext.message).toBe("Hello world");
+      expect(eventContext.rawBody).toBe("Hello world");
+      expect(eventContext.senderId).toBe("+1234567890");
+      expect(eventContext.senderName).toBe("Test User");
+      expect(eventContext.channel).toBe("signal");
+      expect(eventContext.messageId).toBe("msg-123");
+      expect(eventContext.isGroup).toBe(false);
+      expect(eventContext.commandAuthorized).toBe(true);
+    });
+
+    it("sets isGroup=true and groupId for group messages", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:received", handler);
+
+      const ctx = {
+        Body: "Group message",
+        ChatType: "group" as const,
+        From: "group-abc-123",
+        SessionKey: "agent:main:signal:group",
+      };
+
+      await triggerMessageReceived(
+        "agent:main:signal:group",
+        ctx as unknown as FinalizedMsgContext,
+      );
+
+      const event = handler.mock.calls[0][0] as InternalHookEvent;
+      const eventContext = event.context as MessageReceivedContext;
+      expect(eventContext.isGroup).toBe(true);
+      expect(eventContext.groupId).toBe("group-abc-123");
+    });
+
+    it("does not fire if no handlers registered", async () => {
+      // Should not throw when no handlers are registered
+      const ctx = { Body: "test", SessionKey: "test" };
+      await expect(
+        triggerMessageReceived("test", ctx as unknown as FinalizedMsgContext),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("triggerMessageSent", () => {
+    it("triggers message:sent hook with correct context", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:sent", handler);
+
+      const payload = { text: "Hello back!" };
+      const context = {
+        target: "signal:+1234567890",
+        channel: "signal",
+        kind: "final",
+      };
+
+      await triggerMessageSent("agent:main:main", payload, context);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const event = handler.mock.calls[0][0] as InternalHookEvent;
+      expect(event.type).toBe("message");
+      expect(event.action).toBe("sent");
+      expect(event.sessionKey).toBe("agent:main:main");
+
+      const eventContext = event.context as MessageSentContext;
+      expect(eventContext.text).toBe("Hello back!");
+      expect(eventContext.target).toBe("signal:+1234567890");
+      expect(eventContext.channel).toBe("signal");
+      expect(eventContext.kind).toBe("final");
+    });
+
+    it("handles payload with media", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:sent", handler);
+
+      const payload = {
+        text: "Check this out",
+        mediaUrl: "/tmp/image.png",
+      };
+
+      await triggerMessageSent("test-session", payload, { channel: "telegram" });
+
+      const event = handler.mock.calls[0][0] as InternalHookEvent;
+      const context = event.context as MessageSentContext;
+      expect(context.mediaUrl).toBe("/tmp/image.png");
+    });
+  });
+});

--- a/src/hooks/message-hooks.ts
+++ b/src/hooks/message-hooks.ts
@@ -1,0 +1,91 @@
+/**
+ * Message hook events for message:received and message:sent
+ *
+ * These hooks enable automation around the message lifecycle:
+ * - message:received — fires when an inbound message is about to be processed
+ * - message:sent — fires after an outbound message is successfully delivered
+ */
+
+import type { FinalizedMsgContext } from "../auto-reply/templating.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+
+export type MessageReceivedContext = {
+  /** The finalized inbound message context */
+  message: string;
+  /** Raw message body before envelope formatting */
+  rawBody?: string;
+  /** Sender identifier (phone, username, etc.) */
+  senderId?: string;
+  /** Sender display name */
+  senderName?: string;
+  /** Channel the message came from (signal, telegram, etc.) */
+  channel?: string;
+  /** Platform message ID */
+  messageId?: string;
+  /** Whether this is a group message */
+  isGroup?: boolean;
+  /** Group ID if applicable */
+  groupId?: string;
+  /** Timestamp of the message */
+  timestamp?: number;
+  /** Whether the sender is authorized for commands */
+  commandAuthorized?: boolean;
+};
+
+export type MessageSentContext = {
+  /** The reply text that was sent */
+  text?: string;
+  /** Media URL if any */
+  mediaUrl?: string;
+  /** Target recipient */
+  target?: string;
+  /** Channel the message was sent to */
+  channel?: string;
+  /** Delivery kind (tool, block, final) */
+  kind?: string;
+};
+
+/**
+ * Trigger message:received hook
+ * Call this when an inbound message is about to be processed by the agent
+ */
+export async function triggerMessageReceived(
+  sessionKey: string,
+  ctx: FinalizedMsgContext,
+): Promise<void> {
+  const hookEvent = createInternalHookEvent("message", "received", sessionKey, {
+    message: ctx.Body ?? "",
+    rawBody: ctx.RawBody,
+    senderId: ctx.SenderId,
+    senderName: ctx.SenderName,
+    channel: ctx.Provider,
+    messageId: ctx.MessageSid,
+    isGroup: ctx.ChatType === "group",
+    groupId: ctx.ChatType === "group" ? ctx.From : undefined,
+    timestamp: ctx.Timestamp,
+    commandAuthorized: ctx.CommandAuthorized,
+  } satisfies MessageReceivedContext);
+
+  await triggerInternalHook(hookEvent);
+}
+
+/**
+ * Trigger message:sent hook
+ * Call this after an outbound message is successfully delivered
+ */
+export async function triggerMessageSent(
+  sessionKey: string,
+  payload: ReplyPayload,
+  context: { target?: string; channel?: string; kind?: string },
+): Promise<void> {
+  const hookEvent = createInternalHookEvent("message", "sent", sessionKey, {
+    text: payload.text,
+    mediaUrl: payload.mediaUrl,
+    target: context.target,
+    channel: context.channel,
+    kind: context.kind,
+  } satisfies MessageSentContext);
+
+  await triggerInternalHook(hookEvent);
+}


### PR DESCRIPTION
## Summary

Add hook events for the message lifecycle, enabling workspace hooks to trigger on incoming and outgoing messages (e.g., memory extraction, semantic recall, logging).

### Changes

- **`src/hooks/message-hooks.ts`** — New file with `triggerMessageReceived` and `triggerMessageSent` helpers
- **`src/auto-reply/dispatch.ts`** — Wire `message:received` trigger before agent processing in `dispatchInboundMessage()`
- **`src/auto-reply/reply/reply-dispatcher.ts`** — Wire `message:sent` trigger after successful delivery; add `hookContext` option to `ReplyDispatcherOptions`
- **`src/hooks/hooks.ts`** — Export message hook types
- **`src/hooks/message-hooks.test.ts`** — Unit tests for both triggers
- **`src/auto-reply/dispatch.test.ts`** — **Regression test** ensuring `dispatchInboundMessage` calls `triggerMessageReceived` (prevents silent removal by future refactors)

### Context

Supersedes #6797. The original PR was merged into our fork but the `triggerMessageReceived()` call site was silently dropped by commit d5e25e0ad ("refactor: centralize dispatcher lifecycle ownership") when `dispatch.ts` was rewritten. This went undetected because there was no regression test.

This updated PR:
1. Rebases cleanly onto current `main`
2. Adapts to the new `withReplyDispatcher` pattern in `dispatch.ts`
3. Adds a dedicated regression test to prevent recurrence

### Hook Events

| Event | Fires when | Location |
|---|---|---|
| `message:received` | Inbound message about to be processed | `dispatchInboundMessage()` |
| `message:sent` | Outbound reply successfully delivered | `createReplyDispatcher()` delivery callback |

### Use Cases

- Memory extraction from incoming messages
- Semantic recall injection into agent context
- Activity tracking and logging
- Message analytics

Closes #5053

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `message:received` and `message:sent` hook events to the internal hook system, enabling workspace hooks to trigger on inbound and outbound messages. The `message:received` hook is wired into `dispatchInboundMessage()` and fires correctly before agent processing. A regression test is included to prevent the call site from being silently dropped again.

**Key issues found:**

- **Conflicting context shapes:** The new `MessageReceivedContext` and `MessageSentContext` types in `message-hooks.ts` use different field names (`message`, `senderId`, `channel`, `text`, `target`) than the existing `MessageReceivedHookContext` and `MessageSentHookContext` types in `internal-hooks.ts` (`from`, `content`, `channelId`, `to`, `success`). The existing type guards (`isMessageReceivedEvent`, `isMessageSentEvent`) will **never match** events produced by the new triggers, which could break consumers relying on those guards.
- **`message:sent` hook is dead code in production:** The `hookContext` option was added to `ReplyDispatcherOptions`, but no channel dispatcher (Signal, Slack, Discord, iMessage, webchat) passes it. The `message:sent` hook will never fire until callers are wired up.
- The `.gitignore` addition for `openclaw-*.tgz` is unrelated housekeeping.

<h3>Confidence Score: 2/5</h3>

- This PR has functional issues — conflicting type shapes break existing type guards, and the message:sent hook is effectively dead code.
- Score of 2 reflects two significant issues: (1) the new hook context shapes are incompatible with existing type guards in internal-hooks.ts, which will cause isMessageReceivedEvent/isMessageSentEvent to return false for events from these triggers, and (2) the message:sent hook is never triggered in production because no dispatcher caller passes hookContext.
- Pay close attention to `src/hooks/message-hooks.ts` (conflicting context types) and `src/auto-reply/reply/reply-dispatcher.ts` (unwired hookContext option).

<sub>Last reviewed commit: 871a678</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->