### PR TITLE
fix(agents): replace hardcoded Anthropic model IDs with pattern matching

### DIFF
--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -11,26 +11,11 @@ export type ResolvedCliBackend = {
   config: CliBackendConfig;
 };
 
+/** Bare family names only — version-specific patterns handled dynamically in normalizeCliModel */
 const CLAUDE_MODEL_ALIASES: Record<string, string> = {
   opus: "opus",
-  "opus-4.6": "opus",
-  "opus-4.5": "opus",
-  "opus-4": "opus",
-  "claude-opus-4-6": "opus",
-  "claude-opus-4-5": "opus",
-  "claude-opus-4": "opus",
   sonnet: "sonnet",
-  "sonnet-4.6": "sonnet",
-  "sonnet-4.5": "sonnet",
-  "sonnet-4.1": "sonnet",
-  "sonnet-4.0": "sonnet",
-  "claude-sonnet-4-6": "sonnet",
-  "claude-sonnet-4-5": "sonnet",
-  "claude-sonnet-4-1": "sonnet",
-  "claude-sonnet-4-0": "sonnet",
   haiku: "haiku",
-  "haiku-3.5": "haiku",
-  "claude-haiku-3-5": "haiku",
 };
 
 const CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG = "--dangerously-skip-permissions";

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -98,6 +98,9 @@ export function buildSystemPrompt(params: {
   });
 }
 
+/** Extracts Claude family name from any model ID variant (e.g. "claude-opus-4-6" → "opus") */
+const CLAUDE_FAMILY_RE = /^(?:claude-)?(opus|sonnet|haiku)(?:[.-]\d+)*/;
+
 export function normalizeCliModel(modelId: string, backend: CliBackendConfig): string {
   const trimmed = modelId.trim();
   if (!trimmed) {
@@ -111,6 +114,11 @@ export function normalizeCliModel(modelId: string, backend: CliBackendConfig): s
   const mapped = backend.modelAliases?.[lower];
   if (mapped) {
     return mapped;
+  }
+  // Dynamic fallback: extract Claude family from any version pattern
+  const claudeMatch = CLAUDE_FAMILY_RE.exec(lower);
+  if (claudeMatch) {
+    return claudeMatch[1];
   }
   return trimmed;
 }

--- a/src/agents/cloudflare-ai-gateway.ts
+++ b/src/agents/cloudflare-ai-gateway.ts
@@ -1,7 +1,7 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
 
 export const CLOUDFLARE_AI_GATEWAY_PROVIDER_ID = "cloudflare-ai-gateway";
-export const CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_ID = "claude-sonnet-4-5";
+export const CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_ID = "claude-sonnet-4-6";
 export const CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF = `${CLOUDFLARE_AI_GATEWAY_PROVIDER_ID}/${CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_ID}`;
 
 export const CLOUDFLARE_AI_GATEWAY_DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -22,7 +22,7 @@ export function buildCloudflareAiGatewayModelDefinition(params?: {
   const id = params?.id?.trim() || CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_ID;
   return {
     id,
-    name: params?.name ?? "Claude Sonnet 4.5",
+    name: params?.name ?? "Claude Sonnet 4.6",
     reasoning: params?.reasoning ?? true,
     input: params?.input ?? ["text", "image"],
     cost: CLOUDFLARE_AI_GATEWAY_DEFAULT_COST,

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -3,13 +3,8 @@ export type ModelRef = {
   id?: string | null;
 };
 
-const ANTHROPIC_PREFIXES = [
-  "claude-opus-4-6",
-  "claude-sonnet-4-6",
-  "claude-opus-4-5",
-  "claude-sonnet-4-5",
-  "claude-haiku-4-5",
-];
+/** Matches modern Claude model IDs: claude-{family}-{major}-{minor}[-suffix] */
+const ANTHROPIC_MODERN_RE = /^claude-(opus|sonnet|haiku)-\d+-\d+/;
 const OPENAI_MODELS = ["gpt-5.4", "gpt-5.2", "gpt-5.0"];
 const CODEX_MODELS = [
   "gpt-5.4",
@@ -42,7 +37,7 @@ export function isModernModelRef(ref: ModelRef): boolean {
   }
 
   if (provider === "anthropic") {
-    return matchesPrefix(id, ANTHROPIC_PREFIXES);
+    return ANTHROPIC_MODERN_RE.test(id);
   }
 
   if (provider === "openai") {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -22,12 +22,8 @@ export type ModelAliasIndex = {
   byKey: Map<string, string[]>;
 };
 
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
-};
+/** Matches shorthand Anthropic aliases: {family}-{major}.{minor} → claude-{family}-{major}-{minor} */
+const ANTHROPIC_ALIAS_RE = /^(opus|sonnet|haiku)-(\d+)\.(\d+)$/;
 const CLAUDE_46_MODEL_RE = /claude-(?:opus|sonnet)-4(?:\.|-)6(?:$|[-.])/i;
 
 function normalizeAliasKey(value: string): string {
@@ -118,8 +114,11 @@ function normalizeAnthropicModelId(model: string): string {
   if (!trimmed) {
     return trimmed;
   }
-  const lower = trimmed.toLowerCase();
-  return ANTHROPIC_MODEL_ALIASES[lower] ?? trimmed;
+  const match = ANTHROPIC_ALIAS_RE.exec(trimmed.toLowerCase());
+  if (match) {
+    return `claude-${match[1]}-${match[2]}-${match[3]}`;
+  }
+  return trimmed;
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {


### PR DESCRIPTION
## Summary

Static version lists (`claude-sonnet-4-5`, etc.) broke on every Anthropic model upgrade, requiring manual code changes. This PR replaces all hardcoded model ID lists with regex patterns that auto-match any future versions.

### Changes

- **live-model-filter**: `ANTHROPIC_PREFIXES[]` → `/^claude-(opus|sonnet|haiku)-\d+-\d+/`
- **model-selection**: `ANTHROPIC_MODEL_ALIASES{}` → dynamic `{family}-{major}.{minor}` parser via `ANTHROPIC_ALIAS_RE`
- **defaults**: Remove hardcoded Anthropic aliases (config aliases handle resolution)
- **cli-backends**: Strip version-specific aliases from `CLAUDE_MODEL_ALIASES`, keep only bare family names (`opus`, `sonnet`, `haiku`)
- **cloudflare-ai-gateway**: Update default to latest model
- **configure.gateway-auth**: Add latest model to OAuth model keys

### Why

Every time Anthropic releases a new model version (4.5 → 4.6, etc.), multiple files need manual updates to add the new IDs. With regex patterns, `claude-opus-5-0` or `claude-sonnet-4-7` would work automatically without any code changes.

### Testing

- Existing `model-alias-defaults.test.ts` passes (5 tests)
- Pattern `{family}-{major}.{minor}` correctly normalizes to `claude-{family}-{major}-{minor}` for any version

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces hardcoded Anthropic model ID lists with regex patterns across multiple files to avoid manual updates on each model release. It also bumps the Cloudflare AI Gateway default from `claude-sonnet-4-5` to `claude-sonnet-4-6`.

- **Duplicate entry**: `ANTHROPIC_OAUTH_MODEL_KEYS` in `configure.gateway-auth.ts` now contains `"anthropic/claude-sonnet-4-6"` twice (lines 32 and 35).
- **Breaking change for bare aliases**: Removing `opus` and `sonnet` from `DEFAULT_MODEL_ALIASES` in `defaults.ts` breaks resolution for users who set `model.primary: "opus"` or `model.primary: "sonnet"` without explicit alias config. These will now resolve to invalid model IDs like `anthropic/opus`.
- **Regex-based matching in `live-model-filter.ts` and `model-selection.ts`**: Correctly replaces static lists with regex patterns for future-proofing.
- **CLI model normalization**: New `CLAUDE_FAMILY_RE` fallback in `normalizeCliModel` correctly handles versioned model IDs.
- **Import reordering**: Several files have cosmetic import reordering (type imports moved before value imports), which is fine but unrelated to the stated purpose.

<h3>Confidence Score: 2/5</h3>

- This PR has a duplicate array entry and a potential breaking change for users relying on bare Anthropic aliases in their config.
- Two issues lower confidence: (1) a duplicate entry in ANTHROPIC_OAUTH_MODEL_KEYS that suggests an accidental copy-paste, and (2) removing opus/sonnet from DEFAULT_MODEL_ALIASES breaks backwards compatibility for configs using bare alias names without explicit alias definitions. The regex changes themselves are sound.
- Pay close attention to `src/config/defaults.ts` (breaking alias removal) and `src/commands/configure.gateway-auth.ts` (duplicate entry).

<sub>Last reviewed commit: 013b615</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->