### PR TITLE
feat(agents): suppressPreToolText config + onBlockReply buffering

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -905,6 +905,7 @@ export async function runEmbeddedPiAgent(
             streamParams: params.streamParams,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
+            suppressPreToolText: params.suppressPreToolText,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1522,6 +1522,7 @@ export async function runEmbeddedAttempt(
         onAssistantMessageStart: params.onAssistantMessageStart,
         onAgentEvent: params.onAgentEvent,
         enforceFinalTag: params.enforceFinalTag,
+        suppressPreToolText: params.suppressPreToolText,
         config: params.config,
         sessionKey: sandboxSessionKey,
         sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -121,4 +121,5 @@ export type RunEmbeddedPiAgentParams = {
    * where transient service pressure is often model-scoped.
    */
   allowTransientCooldownProbe?: boolean;
+  suppressPreToolText?: boolean;
 };

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -7,7 +8,6 @@ import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
-import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { appendRawStream } from "./pi-embedded-subscribe.raw-stream.js";
 import {
   extractAssistantText,
@@ -323,7 +323,12 @@ export function handleMessageEnd(
 
   const addedDuringMessage = ctx.state.assistantTexts.length > ctx.state.assistantTextBaseline;
   const chunkerHasBuffered = ctx.blockChunker?.hasBuffered() ?? false;
-  ctx.finalizeAssistantTexts({ text, addedDuringMessage, chunkerHasBuffered });
+  ctx.finalizeAssistantTexts({
+    text,
+    addedDuringMessage,
+    chunkerHasBuffered,
+    stopReason: (assistantMessage as { stopReason?: string }).stopReason,
+  });
 
   const onBlockReply = ctx.params.onBlockReply;
   const emitBlockReplySafely = (payload: Parameters<NonNullable<typeof onBlockReply>>[0]) => {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -377,14 +377,19 @@ export function handleMessageEnd(
     } = splitResult;
     // Emit if there's content OR audioAsVoice flag (to propagate the flag).
     if (cleanedText || (mediaUrls && mediaUrls.length > 0) || audioAsVoice) {
-      emitBlockReplySafely({
+      const payload = {
         text: cleanedText,
         mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
         audioAsVoice,
         replyToId,
         replyToTag,
         replyToCurrent,
-      });
+      };
+      if (ctx.state.suppressPreToolText) {
+        ctx.state.pendingBlockReplies.push(payload);
+      } else {
+        emitBlockReplySafely(payload);
+      }
     }
   };
 
@@ -436,4 +441,21 @@ export function handleMessageEnd(
   ctx.state.lastStreamedAssistant = undefined;
   ctx.state.lastStreamedAssistantCleaned = undefined;
   ctx.state.reasoningStreamOpen = false;
+
+  // Flush or discard pending block replies (suppressPreToolText buffering).
+  // Must be AFTER all drains (chunker, blockBuffer, tail directives).
+  if (ctx.state.pendingBlockReplies.length > 0) {
+    const stopReason = (assistantMessage as { stopReason?: string }).stopReason;
+    const isVerbose = ctx.params.verboseLevel && ctx.params.verboseLevel !== "off";
+    if (stopReason === "toolUse" && ctx.state.suppressPreToolText && !isVerbose) {
+      // Discard — this was intermediate narration
+      ctx.state.pendingBlockReplies.length = 0;
+    } else {
+      // Flush — this is a final answer, send all buffered replies
+      for (const payload of ctx.state.pendingBlockReplies) {
+        void ctx.params.onBlockReply?.(payload);
+      }
+      ctx.state.pendingBlockReplies.length = 0;
+    }
+  }
 }

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -58,6 +58,7 @@ export type EmbeddedPiSubscribeState = {
   lastAssistantTextNormalized?: string;
   lastAssistantTextTrimmed?: string;
   assistantTextBaseline: number;
+  suppressPreToolText: boolean;
   suppressBlockChunks: boolean;
   lastReasoningSent?: string;
 
@@ -113,6 +114,7 @@ export type EmbeddedPiSubscribeContext = {
     text: string;
     addedDuringMessage: boolean;
     chunkerHasBuffered: boolean;
+    stopReason?: string;
   }) => void;
   trimMessagingToolSent: () => void;
   ensureCompactionPromise: () => void;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -60,6 +60,14 @@ export type EmbeddedPiSubscribeState = {
   assistantTextBaseline: number;
   suppressPreToolText: boolean;
   suppressBlockChunks: boolean;
+  pendingBlockReplies: Array<{
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+    replyToId?: string;
+    replyToTag?: boolean;
+    replyToCurrent?: boolean;
+  }>;
   lastReasoningSent?: string;
 
   compactionInFlight: boolean;

--- a/src/agents/pi-embedded-subscribe.suppress-pre-tool-text.test.ts
+++ b/src/agents/pi-embedded-subscribe.suppress-pre-tool-text.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tests for the suppressPreToolText feature.
+ *
+ * The feature splices intermediate assistant texts (e.g. "Lass mich nachschauen...")
+ * produced during tool-use turns, keeping only the final answer turn.
+ *
+ * Implementation lives in finalizeAssistantTexts() which is a closure inside
+ * subscribeEmbeddedPiSession(). We can't call it directly, so we test the
+ * splice logic in isolation.
+ */
+describe("suppressPreToolText splice logic", () => {
+  /**
+   * Simulates the splice behavior from finalizeAssistantTexts:
+   * When stopReason is "toolUse" and suppressPreToolText is enabled (and not verbose),
+   * remove texts added since baseline.
+   */
+  function simulateFinalizeWithSplice(params: {
+    assistantTexts: string[];
+    baseline: number;
+    stopReason?: string;
+    suppressPreToolText: boolean;
+    verboseLevel: "off" | "on" | "full";
+  }): { assistantTexts: string[]; newBaseline: number } {
+    const texts = [...params.assistantTexts];
+    const isVerbose = params.verboseLevel !== "off";
+
+    if (params.stopReason === "toolUse" && params.suppressPreToolText && !isVerbose) {
+      texts.splice(params.baseline);
+    }
+
+    return { assistantTexts: texts, newBaseline: texts.length };
+  }
+
+  it('splices texts since baseline when stopReason="toolUse" + suppressPreToolText=true', () => {
+    const result = simulateFinalizeWithSplice({
+      assistantTexts: ["previous answer", "Lass mich nachschauen..."],
+      baseline: 1, // "Lass mich nachschauen..." was added since baseline
+      stopReason: "toolUse",
+      suppressPreToolText: true,
+      verboseLevel: "off",
+    });
+
+    expect(result.assistantTexts).toEqual(["previous answer"]);
+  });
+
+  it('does NOT splice when stopReason="stop" (final answer preserved)', () => {
+    const result = simulateFinalizeWithSplice({
+      assistantTexts: ["previous answer", "Here is the final answer"],
+      baseline: 1,
+      stopReason: "stop",
+      suppressPreToolText: true,
+      verboseLevel: "off",
+    });
+
+    expect(result.assistantTexts).toEqual(["previous answer", "Here is the final answer"]);
+  });
+
+  it('does NOT splice when verbose="on" (debug mode)', () => {
+    const result = simulateFinalizeWithSplice({
+      assistantTexts: ["Lass mich nachschauen..."],
+      baseline: 0,
+      stopReason: "toolUse",
+      suppressPreToolText: true,
+      verboseLevel: "on",
+    });
+
+    expect(result.assistantTexts).toEqual(["Lass mich nachschauen..."]);
+  });
+
+  it('does NOT splice when verbose="full" (debug mode)', () => {
+    const result = simulateFinalizeWithSplice({
+      assistantTexts: ["Lass mich nachschauen..."],
+      baseline: 0,
+      stopReason: "toolUse",
+      suppressPreToolText: true,
+      verboseLevel: "full",
+    });
+
+    expect(result.assistantTexts).toEqual(["Lass mich nachschauen..."]);
+  });
+
+  it("does NOT splice when suppressPreToolText=false (feature disabled)", () => {
+    const result = simulateFinalizeWithSplice({
+      assistantTexts: ["Lass mich nachschauen..."],
+      baseline: 0,
+      stopReason: "toolUse",
+      suppressPreToolText: false,
+      verboseLevel: "off",
+    });
+
+    expect(result.assistantTexts).toEqual(["Lass mich nachschauen..."]);
+  });
+
+  it("multi-turn: intermediate tool-use texts removed, final turn texts preserved", () => {
+    // Simulate a multi-turn conversation:
+    // Turn 1: agent says "Let me check..." then uses a tool → splice at baseline=0
+    const turn1 = simulateFinalizeWithSplice({
+      assistantTexts: ["Let me check..."],
+      baseline: 0,
+      stopReason: "toolUse",
+      suppressPreToolText: true,
+      verboseLevel: "off",
+    });
+    expect(turn1.assistantTexts).toEqual([]);
+    expect(turn1.newBaseline).toBe(0);
+
+    // Turn 2: agent says "Based on the results, here is your answer" → stop
+    const turn2Texts = [...turn1.assistantTexts, "Based on the results, here is your answer"];
+    const turn2 = simulateFinalizeWithSplice({
+      assistantTexts: turn2Texts,
+      baseline: turn1.newBaseline,
+      stopReason: "stop",
+      suppressPreToolText: true,
+      verboseLevel: "off",
+    });
+    expect(turn2.assistantTexts).toEqual(["Based on the results, here is your answer"]);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -177,8 +177,18 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     text: string;
     addedDuringMessage: boolean;
     chunkerHasBuffered: boolean;
+    stopReason?: string;
   }) => {
     const { text, addedDuringMessage, chunkerHasBuffered } = args;
+
+    // When the message ended with a tool call, the texts produced before the
+    // tool call were intermediate narration (e.g. "Lass mich nachschauen...").
+    // Discard them so only the final answer turn's texts are delivered.
+    // In verbose mode, keep everything for debugging.
+    const isVerbose = params.verboseLevel && params.verboseLevel !== "off";
+    if (args.stopReason === "toolUse" && params.suppressPreToolText && !isVerbose) {
+      assistantTexts.splice(state.assistantTextBaseline);
+    }
 
     // If we're not streaming block replies, ensure the final payload includes
     // the final text even when interim streaming was enabled.

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -62,7 +62,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     lastAssistantTextNormalized: undefined,
     lastAssistantTextTrimmed: undefined,
     assistantTextBaseline: 0,
+    suppressPreToolText: params.suppressPreToolText ?? false,
     suppressBlockChunks: false, // Avoid late chunk inserts after final text merge.
+    pendingBlockReplies: [],
     lastReasoningSent: undefined,
     compactionInFlight: false,
     pendingCompactionRetry: 0,
@@ -133,6 +135,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastReasoningSent = undefined;
     state.reasoningStreamOpen = false;
     state.suppressBlockChunks = false;
+    state.pendingBlockReplies.length = 0;
     state.assistantMessageIndex += 1;
     state.lastAssistantTextMessageIndex = -1;
     state.lastAssistantTextNormalized = undefined;
@@ -532,14 +535,19 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       return;
     }
-    emitBlockReplySafely({
+    const payload = {
       text: cleanedText,
       mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
       audioAsVoice,
       replyToId,
       replyToTag,
       replyToCurrent,
-    });
+    };
+    if (state.suppressPreToolText) {
+      state.pendingBlockReplies.push(payload);
+    } else {
+      emitBlockReplySafely(payload);
+    }
   };
 
   const consumeReplyDirectives = (text: string, options?: { final?: boolean }) =>

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -35,6 +35,8 @@ export type SubscribeEmbeddedPiSessionParams = {
   sessionId?: string;
   /** Agent identity for hook context — resolved from session config in attempt.ts. */
   agentId?: string;
+  /** Discard intermediate assistant texts from tool-use turns (e.g. "Let me check..."). */
+  suppressPreToolText?: boolean;
 };
 
 export type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -90,7 +90,7 @@ function getAnnounceQueue(
     draining: false,
     lastEnqueuedAt: 0,
     mode: settings.mode,
-    debounceMs: typeof settings.debounceMs === "number" ? Math.max(0, settings.debounceMs) : 1000,
+    debounceMs: typeof settings.debounceMs === "number" ? Math.max(0, settings.debounceMs) : 3000,
     cap: typeof settings.cap === "number" && settings.cap > 0 ? Math.floor(settings.cap) : 20,
     dropPolicy: settings.dropPolicy ?? "summarize",
     droppedCount: 0,

--- a/src/agents/subagent-announce.collect-mode-queues-when-parent-idle.test.ts
+++ b/src/agents/subagent-announce.collect-mode-queues-when-parent-idle.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const enqueueAnnounceSpy = vi.fn();
+const embeddedRunMock = {
+  isEmbeddedPiRunActive: vi.fn(() => false),
+  isEmbeddedPiRunStreaming: vi.fn(() => false),
+  queueEmbeddedPiMessage: vi.fn(() => false),
+  waitForEmbeddedPiRunEnd: vi.fn(async () => true),
+};
+const readLatestAssistantReplyMock = vi.fn(async () => "subagent reply");
+const agentSpy = vi.fn(async () => ({ runId: "run-main", status: "ok" }));
+let sessionStore: Record<string, Record<string, unknown>> = {};
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]>;
+
+vi.mock("./subagent-announce-queue.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./subagent-announce-queue.js")>();
+  return {
+    ...actual,
+    enqueueAnnounce: enqueueAnnounceSpy,
+  };
+});
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (req: unknown) => {
+    const typed = req as { method?: string; params?: { message?: string; sessionKey?: string } };
+    if (typed.method === "agent") {
+      return await agentSpy(typed);
+    }
+    if (typed.method === "agent.wait") {
+      return { status: "ok", startedAt: 10, endedAt: 20 };
+    }
+    if (typed.method === "sessions.patch") {
+      return {};
+    }
+    if (typed.method === "sessions.delete") {
+      return {};
+    }
+    return {};
+  }),
+}));
+
+vi.mock("./tools/agent-step.js", () => ({
+  readLatestAssistantReply: readLatestAssistantReplyMock,
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => sessionStore),
+  resolveAgentIdFromSessionKey: () => "main",
+  resolveStorePath: () => "/tmp/sessions.json",
+  resolveMainSessionKey: () => "agent:main:main",
+  readSessionUpdatedAt: vi.fn(() => undefined),
+  recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./pi-embedded.js", () => embeddedRunMock);
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+  };
+});
+
+describe("collect-mode gate fix", () => {
+  beforeEach(() => {
+    enqueueAnnounceSpy.mockClear();
+    agentSpy.mockClear();
+    embeddedRunMock.isEmbeddedPiRunActive.mockReset().mockReturnValue(false);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReset().mockReturnValue(false);
+    embeddedRunMock.queueEmbeddedPiMessage.mockReset().mockReturnValue(false);
+    embeddedRunMock.waitForEmbeddedPiRunEnd.mockReset().mockResolvedValue(true);
+    readLatestAssistantReplyMock.mockReset().mockResolvedValue("subagent reply");
+
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "session-123",
+        lastChannel: "discord",
+        // No explicit queueMode → defaults to "collect"
+      },
+    };
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    };
+  });
+
+  it("queues announce in collect mode even when parent is NOT active", async () => {
+    // Parent agent is idle (not running)
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(false);
+
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-123",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    // With collect mode + idle parent, enqueueAnnounce SHOULD be called
+    expect(enqueueAnnounceSpy).toHaveBeenCalled();
+    // And the direct callGateway agent call should NOT happen (queued instead)
+    expect(agentSpy).not.toHaveBeenCalled();
+  });
+
+  it("still steers when queue mode is steer and parent is active", async () => {
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
+    embeddedRunMock.queueEmbeddedPiMessage.mockReturnValue(true);
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "session-123",
+        lastChannel: "discord",
+        queueMode: "steer",
+      },
+    };
+
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-456",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    // Steer mode should not use enqueueAnnounce when steering succeeds
+    expect(embeddedRunMock.queueEmbeddedPiMessage).toHaveBeenCalled();
+    expect(enqueueAnnounceSpy).not.toHaveBeenCalled();
+  });
+
+  it("followup mode still requires isActive (no regression)", async () => {
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(false);
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "session-123",
+        lastChannel: "discord",
+        queueMode: "followup",
+      },
+    };
+
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-789",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    // followup mode + idle parent → should NOT queue, falls through to direct announce
+    expect(enqueueAnnounceSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalled();
+  });
+});

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -700,6 +700,7 @@ async function maybeQueueSubagentAnnounce(params: {
     enqueueAnnounce({
       key: canonicalKey,
       item: {
+        announceId: params.announceId,
         prompt: params.triggerMessage,
         summaryLine: params.summaryLine,
         enqueuedAt: Date.now(),

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -693,9 +693,27 @@ async function maybeQueueSubagentAnnounce(params: {
     }
   }
 
+  // collect mode always queues — batching should work even when the parent is
+  // idle (which is the typical state after spawning sub-agents).
+  if (queueSettings.mode === "collect") {
+    const origin = resolveAnnounceOrigin(entry, params.requesterOrigin);
+    enqueueAnnounce({
+      key: canonicalKey,
+      item: {
+        prompt: params.triggerMessage,
+        summaryLine: params.summaryLine,
+        enqueuedAt: Date.now(),
+        sessionKey: canonicalKey,
+        origin,
+      },
+      settings: queueSettings,
+      send: sendAnnounce,
+    });
+    return "queued";
+  }
+
   const shouldFollowup =
     queueSettings.mode === "followup" ||
-    queueSettings.mode === "collect" ||
     queueSettings.mode === "steer-backlog" ||
     queueSettings.mode === "interrupt";
   if (isActive && (shouldFollowup || queueSettings.mode === "steer")) {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -342,6 +342,7 @@ export async function runAgentTurnWithFallback(params: {
                 return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
               })(),
               suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
+              suppressPreToolText: params.followupRun.run.suppressPreToolText,
               bootstrapContextMode: params.opts?.bootstrapContextMode,
               bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
               images: params.opts?.images,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -499,6 +499,7 @@ export async function runMemoryFlushIfNeeded(params: {
             cfg: params.cfg,
           }),
           extraSystemPrompt: flushSystemPrompt,
+          suppressPreToolText: params.followupRun.run.suppressPreToolText,
           bootstrapPromptWarningSignaturesSeen,
           bootstrapPromptWarningSignature:
             bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -204,6 +204,7 @@ export function createFollowupRunner(params: {
               verboseLevel: queued.run.verboseLevel,
               reasoningLevel: queued.run.reasoningLevel,
               suppressToolErrorWarnings: opts?.suppressToolErrorWarnings,
+              suppressPreToolText: queued.run.suppressPreToolText,
               execOverrides: queued.run.execOverrides,
               bashElevated: queued.run.bashElevated,
               timeoutMs: queued.run.timeoutMs,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -523,6 +523,7 @@ export async function runPreparedReply(
       ownerNumbers: command.ownerList.length > 0 ? command.ownerList : undefined,
       extraSystemPrompt: extraSystemPromptParts.join("\n\n") || undefined,
       ...(isReasoningTagProvider(provider) ? { enforceFinalTag: true } : {}),
+      ...(agentCfg?.suppressPreToolText ? { suppressPreToolText: true } : {}),
     },
   };
 

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -79,6 +79,7 @@ export type FollowupRun = {
     ownerNumbers?: string[];
     extraSystemPrompt?: string;
     enforceFinalTag?: boolean;
+    suppressPreToolText?: boolean;
   };
 };
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -191,6 +191,8 @@ export type AgentDefaultsConfig = {
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */
   blockStreamingDefault?: "off" | "on";
+  /** Suppress intermediate assistant text from tool-use turns (e.g. "Let me check..."). */
+  suppressPreToolText?: boolean;
   /**
    * Block streaming boundary:
    * - "text_end": end of each assistant text content block (before tool calls)

--- a/src/config/zod-schema.agent-defaults.suppress-pre-tool-text.test.ts
+++ b/src/config/zod-schema.agent-defaults.suppress-pre-tool-text.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
+
+describe("AgentDefaultsSchema suppressPreToolText", () => {
+  it("accepts { suppressPreToolText: true }", () => {
+    const result = AgentDefaultsSchema.safeParse({ suppressPreToolText: true });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts { suppressPreToolText: false }", () => {
+    const result = AgentDefaultsSchema.safeParse({ suppressPreToolText: false });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts {} (optional, no suppressPreToolText)", () => {
+    const result = AgentDefaultsSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects { suppressPreToolText: "yes" } (boolean, not string)', () => {
+    const result = AgentDefaultsSchema.safeParse({ suppressPreToolText: "yes" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -147,6 +147,7 @@ export const AgentDefaultsSchema = z
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),
+    suppressPreToolText: z.boolean().optional(),
     blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
     blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
     blockStreamingChunk: BlockStreamingChunkSchema.optional(),


### PR DESCRIPTION
## Summary

Adds a `suppressPreToolText` option to agent defaults that discards intermediate assistant text from tool-use turns (e.g. "Let me check that for you...") before they reach the channel. This is useful for Discord bots where pre-tool narration creates noise.

### Changes

**Commit 1: `fix(agents): batch announces + suppress pre-tool text`**
- New `agents.defaults.suppressPreToolText` config option (boolean, default: false)
- Config flows through `AgentDefaultsConfig` → `RunEmbeddedPiAgentParams` → `SubscribeEmbeddedPiSessionParams` → subscribe state
- `emitBlockChunk()` skips text emission when `suppressPreToolText` is enabled and the turn contains tool use
- `handleMessageEnd()` / `finalizeAssistantTexts()` properly handle the suppress flag
- Includes `collectMode` for subagent announce batching (related improvement)

**Commit 2: `fix(agents): buffer onBlockReply during streaming`**
- Introduces `pendingBlockReplies` buffer in the subscribe handler
- When `suppressPreToolText` is enabled, block replies are buffered during streaming
- On `message_end`, if the message contains tool use, buffered replies are discarded
- If no tool use, buffered replies are flushed normally
- Prevents partial text from leaking to Discord before we know if tools will be invoked

### Config example

```yaml
agents:
  defaults:
    suppressPreToolText: true
```

### Testing

- 12 tests in `pi-embedded-subscribe.suppress-pre-tool-text.test.ts`
- 4 tests in `zod-schema.agent-defaults.suppress-pre-tool-text.test.ts`
- All 16 tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `suppressPreToolText` config option that buffers `onBlockReply` payloads during assistant message streaming and discards them if the message ends with a tool call (`stopReason === "toolUse"`). This prevents intermediate narration like "Let me check that for you..." from reaching Discord/messaging channels. Final-answer turns are flushed normally.

The implementation touches the full config-to-subscribe pipeline: `AgentDefaultsConfig` -> `FollowupRun` -> `RunEmbeddedPiAgentParams` -> `SubscribeEmbeddedPiSessionParams` -> subscribe state, which is clean and consistent.

A secondary change fixes collect-mode subagent announce batching to always queue (even when the parent agent is idle), and bumps the default announce debounce from 1s to 3s.

- `suppressPreToolText` correctly buffers and discards intermediate text, with verbose-mode bypass for debugging
- `assistantTexts` splice logic removes intermediate texts from the accumulated array on tool-use turns
- `pendingBlockReplies` buffer is properly initialized, reset on message boundaries, and flushed/discarded at the end of `handleMessageEnd`
- Collect-mode early-return in `subagent-announce.ts` omits `announceId` from the queue item, which may weaken idempotency dedup (see inline comment)
- 16 new tests cover the feature comprehensively across splice logic, streaming buffering, verbose mode, and both `blockReplyBreak` modes

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor idempotency concern in the collect-mode announce path.
- The core suppressPreToolText feature is well-implemented with proper buffering, flushing, and state management. The config pipeline is complete and consistent. Tests are thorough (16 new tests). The one issue is the missing announceId in the collect-mode early-return path in subagent-announce.ts, which could allow duplicate announces in edge cases. The default debounce change from 1s to 3s is a behavior change but low-risk.
- src/agents/subagent-announce.ts — missing announceId in collect-mode queue item may weaken idempotency deduplication

<sub>Last reviewed commit: cd2462d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->