### PR TITLE
fix(gateway): validate token/password auth modes and isolate gateway auth env in tests

### DIFF
--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -51,6 +51,15 @@ describe("profile CRUD endpoints", () => {
     state.prevGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
     process.env.OPENCLAW_GATEWAY_PORT = String(state.testPort - 2);
 
+    // Clear gateway auth env vars so the browser control server starts without
+    // auth requirements. Without this, ambient OPENCLAW_GATEWAY_TOKEN /
+    // OPENCLAW_GATEWAY_PASSWORD cause the server to return 401 instead of the
+    // expected 400/validation errors. Pattern mirrors installBrowserControlServerHooks.
+    state.prevGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    state.prevGatewayPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string) => {
@@ -70,6 +79,16 @@ describe("profile CRUD endpoints", () => {
       delete process.env.OPENCLAW_GATEWAY_PORT;
     } else {
       process.env.OPENCLAW_GATEWAY_PORT = state.prevGatewayPort;
+    }
+    if (state.prevGatewayToken === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = state.prevGatewayToken;
+    }
+    if (state.prevGatewayPassword === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+    } else {
+      process.env.OPENCLAW_GATEWAY_PASSWORD = state.prevGatewayPassword;
     }
     await stopBrowserControlServer();
   });

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 
 describe("resolveGatewayRuntimeConfig", () => {
@@ -78,6 +78,29 @@ describe("resolveGatewayRuntimeConfig", () => {
   });
 
   describe("token/password auth modes", () => {
+    // Clear ambient gateway auth env vars so these tests exercise config-only
+    // credential paths, independent of any token/password set in the shell.
+    let prevToken: string | undefined;
+    let prevPassword: string | undefined;
+    beforeEach(() => {
+      prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      prevPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+    });
+    afterEach(() => {
+      if (prevToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = prevToken;
+      }
+      if (prevPassword === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PASSWORD = prevPassword;
+      }
+    });
+
     it("should reject token mode without token configured", async () => {
       const cfg = {
         gateway: {

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -88,6 +88,21 @@ export async function resolveGatewayRuntimeConfig(params: {
   const trustedProxies = params.cfg.gateway?.trustedProxies ?? [];
 
   assertGatewayAuthConfigured(resolvedAuth);
+
+  // Explicit validation: if a specific credential-bearing auth mode is requested,
+  // the corresponding secret must be present regardless of bind host.
+  // This catches misconfiguration early and gives a clear error message.
+  if (authMode === "token" && !hasToken) {
+    throw new Error(
+      "gateway auth mode is token, but no token was configured (set gateway.auth.token or OPENCLAW_GATEWAY_TOKEN)",
+    );
+  }
+  if (authMode === "password" && !hasPassword) {
+    throw new Error(
+      "gateway auth mode is password, but no password was configured (set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)",
+    );
+  }
+
   if (tailscaleMode === "funnel" && authMode !== "password") {
     throw new Error(
       "tailscale funnel requires gateway auth mode=password (set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)",


### PR DESCRIPTION
## Problem

Two tests were consistently failing on `origin/main`, blocking the CI baseline (11+ consecutive runs):

### 1. `src/gateway/server-runtime-config.test.ts`
**"should reject token mode without token configured"** — promise resolved instead of rejecting.

Root causes:
- `resolveGatewayRuntimeConfig` was missing an explicit check that rejects when `authMode=token` is configured but no token credential exists (neither in config nor env).
- The test's `token/password auth modes` describe block did not isolate itself from ambient `OPENCLAW_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_PASSWORD` env vars — in environments where those are set (e.g. dev machines, CI with gateway configured), the env token satisfied the auth requirement and the promise resolved when it should have rejected.

### 2. `src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts`
**"validates profile create/delete endpoints"** — returned 401 instead of expected 400 (input-validation errors).

Root cause: The `profile CRUD endpoints` describe block's `beforeEach`/`afterEach` did not clear gateway auth env vars, so in environments with `OPENCLAW_GATEWAY_TOKEN` set the browser control server started with auth enforcement and rejected requests with 401 before reaching body validation.

Both failures trace to commit `c4a80f4` ("fix: require gateway auth by default") which tightened auth semantics but left ambient env leakage unaddressed in test isolation.

## Fix

**`src/gateway/server-runtime-config.ts`** — add explicit early validation:
- If `authMode=token` and no token is present → throw `"gateway auth mode is token, but no token was configured"`
- If `authMode=password` and no password is present → throw `"gateway auth mode is password, but no password was configured"`

**`src/gateway/server-runtime-config.test.ts`** — add `beforeEach`/`afterEach` to the `token/password auth modes` describe block that saves/clears/restores `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_PASSWORD`, matching the isolation pattern used in gateway e2e tests.

**`src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts`** — mirror the auth-env isolation from `installBrowserControlServerHooks` in the `profile CRUD endpoints` `beforeEach`/`afterEach`.

## Test Evidence

```
pnpm build:   PASS
pnpm check:   PASS  
pnpm test:    PASS
  ✓ src/gateway/server-runtime-config.test.ts (5 tests)
    ✓ should reject token mode without token configured
    ✓ should allow lan binding with token
    ✓ (3 trusted-proxy tests)
  ✓ src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts (2 tests)
    ✓ validates profile create/delete endpoints
Full quality gate: PASS
```

## AI-Assisted Disclosure

This PR was opened by an autonomous AI contributor (OpenClaw) operating under human oversight. The fix was verified by running the full test suite locally before opening.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two consistently failing CI tests by:
1. Adding explicit early validation in `resolveGatewayRuntimeConfig` for token/password auth modes missing their corresponding credentials.
2. Isolating gateway auth environment variables (`OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_PASSWORD`) in two test files to prevent ambient env vars from leaking into test expectations.

The test isolation changes are well-structured and correctly mirror the existing pattern in `installBrowserControlServerHooks`. However, the new runtime validation in `server-runtime-config.ts` has a logic issue:

- The token-mode check on line 95 is missing the `!resolvedAuth.allowTailscale` guard that exists in every other equivalent check (`assertGatewayAuthConfigured` in `auth.ts`, CLI validation in `run.ts:269`, and daemon install in `install.ts:85`). This would break valid configurations where Tailscale identity is used to satisfy token-mode auth without a configured token.

<h3>Confidence Score: 3/5</h3>

- PR has a logic bug in the token validation that could break tailscale-only token-mode configurations; test isolation fixes are solid.
- The test isolation changes are correct and follow established patterns. However, the new token-mode validation is missing the allowTailscale guard that every other equivalent check in the codebase includes, which could cause a regression for valid tailscale+token configurations.
- src/gateway/server-runtime-config.ts needs the allowTailscale guard added to the token-mode check on line 95.

<sub>Last reviewed commit: 50f58c4</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->