### PR TITLE
fix(nostr): move openclaw from devDependencies to peerDependencies

### DIFF
--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -7,8 +7,8 @@
     "nostr-tools": "^2.23.1",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.1.0"
   },
   "openclaw": {
     "extensions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,13 +455,12 @@ importers:
       nostr-tools:
         specifier: ^2.23.1
         version: 2.23.1(typescript@5.9.3)
+      openclaw:
+        specifier: '>=2026.1.0'
+        version: 2026.2.17(@napi-rs/canvas@0.1.93)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.9)(node-llama-cpp@3.15.1(typescript@5.9.3))(signal-polyfill@0.2.2)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-    devDependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
 
   extensions/open-prose:
     devDependencies:
@@ -4797,6 +4796,14 @@ packages:
       zod:
         optional: true
 
+  openclaw@2026.2.17:
+    resolution: {integrity: sha512-OgblBbjR9aRxlRUa5DS9K02IxnMY+1GDDznKEcm8/N2FhakAItKEg5uv9ulI6Lr/rtIbublRhuk4a7ntYDxqIw==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.89
+      node-llama-cpp: 3.15.1
+
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
 
@@ -6912,7 +6919,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6928,7 +6935,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7132,7 +7139,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7241,7 +7248,6 @@ snapshots:
       '@napi-rs/canvas-linux-x64-musl': 0.1.93
       '@napi-rs/canvas-win32-arm64-msvc': 0.1.93
       '@napi-rs/canvas-win32-x64-msvc': 0.1.93
-    optional: true
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -8079,7 +8085,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8125,7 +8131,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -9013,14 +9019,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9599,8 +9597,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
@@ -10550,6 +10546,82 @@ snapshots:
     optionalDependencies:
       ws: 8.19.0
       zod: 4.3.6
+
+  openclaw@2026.2.17(@napi-rs/canvas@0.1.93)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.9)(node-llama-cpp@3.15.1(typescript@5.9.3))(signal-polyfill@0.2.2):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock': 3.992.0
+      '@buape/carbon': 0.14.0(hono@4.11.9)
+      '@clack/prompts': 1.0.1
+      '@grammyjs/runner': 2.0.3(grammy@1.40.0)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.40.0)
+      '@homebridge/ciao': 1.3.5
+      '@larksuiteoapi/node-sdk': 1.59.0
+      '@line/bot-sdk': 10.6.0
+      '@lydell/node-pty': 1.2.0-beta.3
+      '@mariozechner/pi-agent-core': 0.53.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.53.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.53.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.53.0
+      '@mozilla/readability': 0.6.0
+      '@napi-rs/canvas': 0.1.93
+      '@sinclair/typebox': 0.34.48
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/web-api': 7.14.1
+      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      ajv: 8.18.0
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      cli-highlight: 2.1.11
+      commander: 14.0.3
+      croner: 10.0.1
+      discord-api-types: 0.38.39
+      dotenv: 17.3.1
+      express: 5.2.1
+      file-type: 21.3.0
+      grammy: 1.40.0
+      https-proxy-agent: 7.0.6
+      jiti: 2.6.1
+      json5: 2.2.3
+      jszip: 3.10.1
+      linkedom: 0.18.12
+      long: 5.3.2
+      markdown-it: 14.1.1
+      node-edge-tts: 1.2.10
+      node-llama-cpp: 3.15.1(typescript@5.9.3)
+      osc-progress: 0.3.0
+      pdfjs-dist: 5.4.624
+      playwright-core: 1.58.2
+      proper-lockfile: 4.1.2
+      qrcode-terminal: 0.12.0
+      sharp: 0.34.5
+      signal-utils: 0.21.1(signal-polyfill@0.2.2)
+      sqlite-vec: 0.1.7-alpha.2
+      tar: 7.5.9
+      tslog: 4.10.2
+      undici: 7.22.0
+      ws: 8.19.0
+      yaml: 2.8.2
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - '@modelcontextprotocol/sdk'
+      - '@types/express'
+      - audio-decode
+      - aws-crt
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - ffmpeg-static
+      - hono
+      - jimp
+      - link-preview-js
+      - node-opus
+      - opusscript
+      - signal-polyfill
+      - supports-color
+      - utf-8-validate
 
   opus-decoder@0.7.11:
     dependencies:


### PR DESCRIPTION
## Summary

`openclaw plugins install @openclaw/nostr` fails because `npm install` inside the extracted plugin directory chokes on `workspace:*` in `devDependencies`:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

This happens because npm validates **all** dependency specifiers (including devDependencies) even when using `--omit=dev`. The `workspace:*` protocol is only valid inside a pnpm workspace context.

## Fix

Move `openclaw` from `devDependencies` to `peerDependencies` with a concrete semver range (`>=2026.1.0`). This:
- Avoids the `EUNSUPPORTEDPROTOCOL` error during plugin install
- Matches guidance in AGENTS.md: *"put openclaw in devDependencies or peerDependencies instead (runtime resolves openclaw/plugin-sdk via jiti alias)"*
- Aligns with how third-party plugins (e.g. openclaw-agent-reach) declare the dependency

## Reproduction

```bash
# This fails:
openclaw plugins install @openclaw/nostr

# Underlying cause - npm install inside the plugin dir:
cd ~/.openclaw/extensions/nostr
npm install --omit=dev
# Error: Unsupported URL Type "workspace:": workspace:*
```

## Note

This same issue affects **all extensions** that have `workspace:*` in devDependencies — not just nostr. A broader fix across all extensions would fully resolve #6879.

Fixes #6879

---

🤖 AI-assisted (Claude via OpenClaw). Fully understood and verified — tested npm install behavior with and without the workspace:* specifier.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves `openclaw` from `devDependencies` (with `workspace:*`) to `peerDependencies` (with `>=2026.1.0`) in the nostr extension's `package.json`, fixing `EUNSUPPORTEDPROTOCOL` errors when installing the plugin via `openclaw plugins install @openclaw/nostr`.

- The root cause is confirmed: `npm install --omit=dev` (used in `src/infra/install-package-dir.ts:48`) validates all dependency specifiers including `devDependencies`, and `workspace:*` is only valid inside a pnpm workspace context.
- This aligns with the guidance in `AGENTS.md` line 12: *"put `openclaw` in `devDependencies` or `peerDependencies` instead"*.
- Note: ~30 other extensions under `extensions/` still have `"openclaw": "workspace:*"` in `devDependencies` and will exhibit the same failure. Even `googlechat` and `memory-core`, which already added `peerDependencies`, still retain the problematic `devDependencies` entry. A broader fix is needed to fully resolve the linked issue #6879.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it makes a minimal, well-understood change to a single package.json file that fixes a confirmed installation bug.
- The change is a one-file metadata-only edit (package.json dependency section) with clear rationale, confirmed by the plugin install logic in src/infra/install-package-dir.ts. The semver range is reasonable, peerDependencies will resolve correctly in both workspace (development) and standalone (npm install) contexts, and the pattern is already established by googlechat and memory-core extensions.
- No files require special attention.

<sub>Last reviewed commit: 38eda62</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->