### PR TITLE
feat(telegram): configurable SSRF policy for media fetch

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -723,6 +723,8 @@ Primary reference:
 - `channels.telegram.linkPreview`: toggle link previews for outbound messages (default: true).
 - `channels.telegram.streamMode`: `off | partial | block` (live stream preview).
 - `channels.telegram.mediaMaxMb`: inbound/outbound media cap (MB).
+- `channels.telegram.mediaFetch.allowPrivateNetwork`: allow Telegram media fetch URLs that resolve to private/internal IPs (default: false).
+- `channels.telegram.mediaFetch.urlAllowlist`: optional hostname allowlist for Telegram media fetch URLs (exact host or wildcard subdomains).
 - `channels.telegram.retry`: retry policy for outbound Telegram API calls (attempts, minDelayMs, maxDelayMs, jitter).
 - `channels.telegram.network.autoSelectFamily`: override Node autoSelectFamily (true=enable, false=disable). Defaults to disabled on Node 22 to avoid Happy Eyeballs timeouts.
 - `channels.telegram.proxy`: proxy URL for Bot API calls (SOCKS/HTTP).
@@ -747,7 +749,7 @@ Telegram-specific high-signal fields:
 - threading/replies: `replyToMode`
 - streaming: `streamMode` (preview), `draftChunk`, `blockStreaming`
 - formatting/delivery: `textChunkLimit`, `chunkMode`, `linkPreview`, `responsePrefix`
-- media/network: `mediaMaxMb`, `timeoutSeconds`, `retry`, `network.autoSelectFamily`, `proxy`
+- media/network: `mediaMaxMb`, `mediaFetch.allowPrivateNetwork`, `mediaFetch.urlAllowlist`, `timeoutSeconds`, `retry`, `network.autoSelectFamily`, `proxy`
 - webhook: `webhookUrl`, `webhookSecret`, `webhookPath`, `webhookHost`
 - actions/capabilities: `capabilities.inlineButtons`, `actions.sendMessage|editMessage|deleteMessage|reactions|sticker`
 - reactions: `reactionNotifications`, `reactionLevel`

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -376,6 +376,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Override Node autoSelectFamily for Telegram (true=enable, false=disable).",
   "channels.telegram.timeoutSeconds":
     "Max seconds before Telegram API requests are aborted (default: 500 per grammY).",
+  "channels.telegram.mediaFetch.allowPrivateNetwork":
+    "Allow Telegram media fetch URLs that resolve to private/internal IPs (default: false).",
+  "channels.telegram.mediaFetch.urlAllowlist":
+    "Optional hostname allowlist for Telegram media fetch URLs (exact or wildcard like *.example.com).",
   "channels.whatsapp.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.whatsapp.allowFrom=["*"].',
   "channels.whatsapp.selfChatMode": "Same-phone setup (bot uses your personal WhatsApp number).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -257,6 +257,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.telegram.retry.jitter": "Telegram Retry Jitter",
   "channels.telegram.network.autoSelectFamily": "Telegram autoSelectFamily",
   "channels.telegram.timeoutSeconds": "Telegram API Timeout (seconds)",
+  "channels.telegram.mediaFetch.allowPrivateNetwork": "Telegram Media Fetch Allow Private Network",
+  "channels.telegram.mediaFetch.urlAllowlist": "Telegram Media Fetch URL Allowlist",
   "channels.telegram.capabilities.inlineButtons": "Telegram Inline Buttons",
   "channels.whatsapp.dmPolicy": "WhatsApp DM Policy",
   "channels.whatsapp.selfChatMode": "WhatsApp Self-Phone Mode",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -27,6 +27,19 @@ export type TelegramNetworkConfig = {
   autoSelectFamily?: boolean;
 };
 
+export type TelegramMediaFetchConfig = {
+  /**
+   * Allow Telegram media download URLs that resolve to private/internal IPs.
+   * Default: false (safer).
+   */
+  allowPrivateNetwork?: boolean;
+  /**
+   * Optional hostname allowlist for Telegram media fetches.
+   * Supports exact hostnames and wildcard subdomains (e.g. "*.example.com").
+   */
+  urlAllowlist?: string[];
+};
+
 export type TelegramInlineButtonsScope = "off" | "dm" | "group" | "all" | "allowlist";
 
 export type TelegramCapabilitiesConfig =
@@ -109,6 +122,8 @@ export type TelegramAccountConfig = {
   /** Network transport overrides for Telegram. */
   network?: TelegramNetworkConfig;
   proxy?: string;
+  /** Telegram media fetch SSRF policy overrides. */
+  mediaFetch?: TelegramMediaFetchConfig;
   webhookUrl?: string;
   webhookSecret?: string;
   webhookPath?: string;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -132,6 +132,13 @@ export const TelegramAccountSchemaBase = z
       .strict()
       .optional(),
     proxy: z.string().optional(),
+    mediaFetch: z
+      .object({
+        allowPrivateNetwork: z.boolean().optional(),
+        urlAllowlist: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
     webhookUrl: z.string().optional(),
     webhookSecret: z.string().optional().register(sensitive),
     webhookPath: z.string().optional(),

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -16,6 +16,7 @@ import { writeConfigFile } from "../config/io.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
+import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
@@ -85,6 +86,13 @@ export const registerTelegramHandlers = ({
     Number.isFinite(opts.testTimings.mediaGroupFlushMs)
       ? Math.max(10, Math.floor(opts.testTimings.mediaGroupFlushMs))
       : MEDIA_GROUP_TIMEOUT_MS;
+
+  const mediaFetchSsrFPolicy: SsrFPolicy | undefined = telegramCfg.mediaFetch
+    ? {
+        allowPrivateNetwork: telegramCfg.mediaFetch.allowPrivateNetwork,
+        hostnameAllowlist: telegramCfg.mediaFetch.urlAllowlist,
+      }
+    : undefined;
 
   const mediaGroupBuffer = new Map<string, MediaGroupEntry>();
   let mediaGroupProcessing: Promise<void> = Promise.resolve();
@@ -248,7 +256,13 @@ export const registerTelegramHandlers = ({
 
       const allMedia: TelegramMediaRef[] = [];
       for (const { ctx } of entry.messages) {
-        const media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+        const media = await resolveMedia(
+          ctx,
+          mediaMaxBytes,
+          opts.token,
+          opts.proxyFetch,
+          mediaFetchSsrFPolicy,
+        );
         if (media) {
           allMedia.push({
             path: media.path,
@@ -639,7 +653,13 @@ export const registerTelegramHandlers = ({
 
     let media: Awaited<ReturnType<typeof resolveMedia>> = null;
     try {
-      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+      media = await resolveMedia(
+        ctx,
+        mediaMaxBytes,
+        opts.token,
+        opts.proxyFetch,
+        mediaFetchSsrFPolicy,
+      );
     } catch (mediaErr) {
       const errMsg = String(mediaErr);
       if (errMsg.includes("exceeds") && errMsg.includes("MB limit")) {

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -195,4 +195,37 @@ describe("resolveMedia getFile retry", () => {
     expect(getFile).toHaveBeenCalledTimes(2);
     expect(result).not.toBeNull();
   });
+
+  it("forwards SSRF policy to media fetch", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "photo/file_1.jpg" });
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("img"),
+      contentType: "image/jpeg",
+      fileName: "file_1.jpg",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_1.jpg",
+      contentType: "image/jpeg",
+    });
+
+    const ssrfPolicy = {
+      allowPrivateNetwork: true,
+      hostnameAllowlist: ["api.telegram.org"],
+    };
+
+    const result = await resolveMedia(
+      makeCtx("photo", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      undefined,
+      ssrfPolicy,
+    );
+
+    expect(result).toEqual(expect.objectContaining({ path: "/tmp/file_1.jpg" }));
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ssrfPolicy,
+      }),
+    );
+  });
 });

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -5,6 +5,7 @@ import type { ReplyToMode } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import { danger, logVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { retryAsync } from "../../infra/retry.js";
 import { mediaKindFromMime } from "../../media/constants.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
@@ -306,6 +307,7 @@ export async function resolveMedia(
   maxBytes: number,
   token: string,
   proxyFetch?: typeof fetch,
+  ssrfPolicy?: SsrFPolicy,
 ): Promise<{
   path: string;
   contentType?: string;
@@ -319,6 +321,7 @@ export async function resolveMedia(
       url,
       fetchImpl,
       filePathHint: filePath,
+      ssrfPolicy,
     });
     const originalName = fetched.fileName ?? filePath;
     return saveMediaBuffer(fetched.buffer, fetched.contentType, "inbound", maxBytes, originalName);


### PR DESCRIPTION
Closes #19934

## What
Adds config knobs for Telegram media download SSRF behavior (without source patching):

- `channels.telegram.mediaFetch.allowPrivateNetwork`
- `channels.telegram.mediaFetch.urlAllowlist`

These options are applied only to Telegram media fetch path (`resolveMedia -> fetchRemoteMedia`), so operators can allow proxied/internal routing for `api.telegram.org` while keeping default SSRF protections elsewhere.

## Why
Some deployments intentionally resolve `api.telegram.org` via internal proxy/private IP. Previously media fetch failed with `SsrFBlockedError` and there was no config-level override for this channel path.

## Changes
- Config types/schema:
  - `src/config/types.telegram.ts`
  - `src/config/zod-schema.providers-core.ts`
  - `src/config/schema.help.ts`
  - `src/config/schema.labels.ts`
- Telegram media path:
  - `src/telegram/bot-handlers.ts` (build SSRF policy from config)
  - `src/telegram/bot/delivery.ts` (forward policy to `fetchRemoteMedia`)
- Tests:
  - `src/telegram/bot/delivery.resolve-media-retry.test.ts` (assert SSRF policy forwarding)
- Docs:
  - `docs/channels/telegram.md`

## Validation
Ran:
- `pnpm test:fast src/telegram/bot/delivery.resolve-media-retry.test.ts src/media/fetch.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new config knobs under `channels.telegram.mediaFetch` to control SSRF behavior for Telegram media downloads: `allowPrivateNetwork` (permits media URLs resolving to private/internal IPs) and `urlAllowlist` (restricts media fetches to specific hostnames with wildcard support). These options are scoped exclusively to the Telegram media fetch path, leaving default SSRF protections intact for all other operations.

- Config plumbing: new `TelegramMediaFetchConfig` type, matching zod schema with `.strict()`, labels, and help text
- Runtime wiring: `bot-handlers.ts` builds an `SsrFPolicy` from the config and passes it through `resolveMedia()` → `fetchRemoteMedia()` → `fetchWithSsrFGuard()` → `resolvePinnedHostnameWithPolicy()`
- Test: verifies SSRF policy is correctly forwarded from `resolveMedia` to `fetchRemoteMedia`
- Docs: updated Telegram channel docs with new config keys

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds well-scoped, opt-in config knobs with correct plumbing and test coverage.
- All changes are additive and opt-in. The new config fields default to the existing strict SSRF behavior (allowPrivateNetwork defaults to false, empty urlAllowlist means no restriction). The implementation correctly maps config values to the existing SsrFPolicy type and threads the policy through the established fetch guard infrastructure. Type definitions, zod schema, labels, help text, and docs are all consistent. The new test verifies the parameter forwarding.
- No files require special attention.

<sub>Last reviewed commit: 48a0f90</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->