### PR TITLE
fix(net): enable autoSelectFamily on SSRF pinned dispatcher

### DIFF
--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -444,6 +444,8 @@ export function createPinnedDispatcher(pinned: PinnedHostname): Dispatcher {
   return new Agent({
     connect: {
       lookup: pinned.lookup,
+      autoSelectFamily: true,
+      autoSelectFamilyAttemptTimeout: 300,
     },
   });
 }


### PR DESCRIPTION
## Summary

Fixes #19147 — Telegram media downloads fail with `ETIMEDOUT` when the SSRF guard's pinned DNS dispatcher tries to connect via IPv6 in environments without IPv6 connectivity (common in Docker).

### Root cause

`createPinnedDispatcher()` in `src/infra/net/ssrf.ts` creates an `Agent` with a custom `connect.lookup` but **without `autoSelectFamily`**. When DNS resolves to both IPv4 and IPv6 addresses, Node 22's connection logic attempts IPv6 first. In Docker containers (and many other environments) where IPv6 is unreachable, this causes a silent `ETIMEDOUT`.

Note: OpenClaw already applies `net.setDefaultAutoSelectFamily(true)` globally in `src/telegram/fetch.ts` for Node 22+, but this **does not propagate** to custom `Agent` instances — each Agent uses its own `connect` options independently.

### Why previous fix attempts didn't work

- **PR #19237** (closed) switched `globalThis.fetch` to `undici.fetch`. This addresses the undici v7/v6 version mismatch but **does not fix the IPv6 timeout** — verified by testing `undici.fetch` + pinned dispatcher in a Docker container where IPv6 is unreachable. Both `globalThis.fetch` and `undici.fetch` fail identically with `ETIMEDOUT` when the dispatcher lacks `autoSelectFamily`.

### Fix

Add `autoSelectFamily: true` and `autoSelectFamilyAttemptTimeout: 300` to the `Agent` connect options in `createPinnedDispatcher()`. This mirrors Node 22's default behavior and enables the Happy Eyeballs algorithm (RFC 8305) to quickly fall back from unreachable IPv6 to IPv4.

### Changes

- `src/infra/net/ssrf.ts` — 2-line addition to `createPinnedDispatcher()`

### Verification

Tested inside Docker container (Node 22.22.0, undici 7.22.0) with `api.telegram.org` resolving to both IPv4 and IPv6:

| Configuration | Result |
|---|---|
| No `autoSelectFamily` | ❌ `ETIMEDOUT` |
| `autoSelectFamily: true` (no timeout) | ❌ `ETIMEDOUT` |
| `autoSelectFamily: true` + `timeout: 300` | ✅ HTTP 200 |
| `autoSelectFamily: true` + `timeout: 2000` | ✅ HTTP 200 |

All 36 existing tests in `src/infra/net/` pass (`ssrf.test.ts`: 31, `ssrf.pinning.test.ts`: 5).

## Test plan

- [x] Verified fix resolves Telegram photo messages in Docker (self-hosted, 3 bots)
- [x] All existing SSRF tests pass (31 + 5 = 36 tests)
- [x] Confirmed no behavior change for IPv4-only or dual-stack environments with working IPv6
- [ ] Manual: test media on other channels (Discord, WhatsApp) if they use `fetchWithSsrFGuard`

🤖 AI-assisted (Claude Code) — fully tested on self-hosted Docker instance, author understands the change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `autoSelectFamily: true` and `autoSelectFamilyAttemptTimeout: 300` to the SSRF pinned dispatcher's `Agent` connect options, enabling the Happy Eyeballs algorithm (RFC 8305) for IPv4/IPv6 fallback. This fixes `ETIMEDOUT` errors when Docker or other environments lack IPv6 connectivity but DNS returns both A and AAAA records.

- The existing global `net.setDefaultAutoSelectFamily(true)` in `src/telegram/fetch.ts` does not propagate to custom undici `Agent` instances, so this fix is necessary at the `createPinnedDispatcher` level.
- The 300ms attempt timeout is slightly above Node.js's default of 250ms, providing a reasonable balance between fast fallback and allowing slower connections.
- The change is well-scoped (2 lines) and affects all channels that use `fetchWithSsrFGuard` via `src/infra/net/fetch-guard.ts`, not just Telegram.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-understood 2-line fix to standard undici Agent connect options.
- The change adds two well-known undici connect options to enable Happy Eyeballs (RFC 8305) on the SSRF pinned dispatcher. The properties are valid, the values are reasonable (matching or slightly above Node.js defaults), and the fix correctly addresses the root cause where custom Agent instances don't inherit global autoSelectFamily settings. All 36 existing tests pass, and the fix has been verified in Docker environments.
- No files require special attention.

<sub>Last reviewed commit: 15014f0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->