### PR TITLE
Add SoundChain extension + Agent Eye browser bug catcher

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -436,3 +436,124 @@ chrome.runtime.onInstalled.addListener(() => {
   // Useful: first-time instructions.
   void chrome.runtime.openOptionsPage()
 })
+
+// =============================================================================
+// Agent Eye — Passive browser bug catcher
+// Zero booleans. All state uses typed string enums with explicit equality checks.
+// =============================================================================
+
+const EYE_MODE = Object.freeze({
+  WATCHING: 'WATCHING',
+  DORMANT: 'DORMANT',
+  PAUSED: 'PAUSED',
+})
+
+const VALID_EYE_MODES = new Set(Object.values(EYE_MODE))
+
+/** @type {string} */
+let agentEyeMode = EYE_MODE.DORMANT
+
+// Restore persisted mode on startup, validate against known enum values
+chrome.storage.local.get(['agentEyeMode']).then((stored) => {
+  const raw = stored.agentEyeMode
+  if (typeof raw === 'string' && VALID_EYE_MODES.has(raw)) {
+    agentEyeMode = raw
+  } else {
+    // Unknown/corrupted value — reset to DORMANT
+    agentEyeMode = EYE_MODE.DORMANT
+    void chrome.storage.local.set({ agentEyeMode: EYE_MODE.DORMANT })
+  }
+})
+
+/**
+ * Get the gateway HTTP port (same as relay port by default, or override).
+ * @returns {Promise<number>}
+ */
+async function getGatewayPort() {
+  const stored = await chrome.storage.local.get(['gatewayPort', 'relayPort'])
+  // Prefer explicit gatewayPort, fall back to relayPort, then default
+  const raw = stored.gatewayPort || stored.relayPort
+  const n = Number.parseInt(String(raw || ''), 10)
+  if (!Number.isFinite(n) || n <= 0 || n > 65535) return 18789
+  return n
+}
+
+/**
+ * POST a bug report to the OpenClaw gateway.
+ * @param {object} report
+ */
+async function postBugReport(report) {
+  const port = await getGatewayPort()
+  const url = `http://127.0.0.1:${port}/agent-eye/report`
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(report),
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!resp.ok) {
+      console.warn(`Agent Eye: report rejected (${resp.status})`)
+    }
+  } catch (err) {
+    // Gateway not running — silently drop
+    console.debug('Agent Eye: gateway unreachable', err instanceof Error ? err.message : String(err))
+  }
+}
+
+/**
+ * Inject the Agent Eye content script into a tab.
+ * Only injects when agentEyeMode === EYE_MODE.WATCHING.
+ * @param {number} tabId
+ */
+async function injectAgentEye(tabId) {
+  if (agentEyeMode !== EYE_MODE.WATCHING) return
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ['content-script.js'],
+    })
+  } catch {
+    // Tab may not be injectable (chrome://, extensions, etc.)
+  }
+}
+
+// Listen for messages from content script
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  // Typed channel check — never truthy/falsy
+  if (typeof msg !== 'object' || msg === null) return
+  if (msg.channel !== 'AGENT_EYE_REPORT') return
+  if (agentEyeMode !== EYE_MODE.WATCHING) return
+
+  const payload = msg.payload || {}
+  const tabId = sender.tab ? sender.tab.id : undefined
+  const tabTitle = sender.tab ? sender.tab.title : undefined
+
+  const report = {
+    trigger: msg.trigger,
+    ...payload,
+    tabId,
+    tabTitle,
+  }
+
+  void postBugReport(report)
+})
+
+// Re-inject content script on tab navigation (only when WATCHING)
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status !== 'complete') return
+  if (agentEyeMode !== EYE_MODE.WATCHING) return
+  void injectAgentEye(tabId)
+})
+
+// Listen for mode changes from storage (allows /eye command to control mode)
+chrome.storage.onChanged.addListener((changes) => {
+  if (changes.agentEyeMode) {
+    const newVal = changes.agentEyeMode.newValue
+    if (typeof newVal === 'string' && VALID_EYE_MODES.has(newVal)) {
+      agentEyeMode = newVal
+    } else {
+      agentEyeMode = EYE_MODE.DORMANT
+    }
+  }
+})

--- a/assets/chrome-extension/content-script.js
+++ b/assets/chrome-extension/content-script.js
@@ -1,0 +1,288 @@
+// Agent Eye — Content Script
+// Injected into browser tabs to capture user actions and errors.
+// Zero booleans. All state uses typed string enums with explicit equality checks.
+// Privacy: NEVER captures input values — only field names.
+
+;(() => {
+  'use strict'
+
+  // ---------------------------------------------------------------------------
+  // Enums (must match background.js and server-side store.ts)
+  // ---------------------------------------------------------------------------
+
+  const ACTION_KIND = Object.freeze({
+    CLICK: 'CLICK',
+    INPUT: 'INPUT',
+    SCROLL: 'SCROLL',
+    NAVIGATE: 'NAVIGATE',
+  })
+
+  const TRIGGER_KIND = Object.freeze({
+    JS_ERROR: 'JS_ERROR',
+    UNHANDLED_REJECTION: 'UNHANDLED_REJECTION',
+    CONSOLE_ERROR: 'CONSOLE_ERROR',
+    NETWORK_ERROR: 'NETWORK_ERROR',
+  })
+
+  const REPORT_STATUS = Object.freeze({
+    SENT: 'SENT',
+    DROPPED: 'DROPPED',
+    DEDUPED: 'DEDUPED',
+  })
+
+  // ---------------------------------------------------------------------------
+  // Action buffer (circular, 50 max)
+  // ---------------------------------------------------------------------------
+
+  const MAX_ACTIONS = 50
+  /** @type {Array<{kind: string, selector: string, text?: string, tag?: string, x?: number, y?: number, url?: string, timestamp: number}>} */
+  const actionBuffer = []
+
+  function pushAction(action) {
+    actionBuffer.push(action)
+    if (actionBuffer.length > MAX_ACTIONS) {
+      actionBuffer.shift()
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lightweight CSS selector — tagName + id/class, no expensive DOM walking
+  // ---------------------------------------------------------------------------
+
+  function quickSelector(el) {
+    if (!el || !el.tagName) return ''
+    let sel = el.tagName.toLowerCase()
+    if (el.id) sel += '#' + el.id
+    else if (el.className && typeof el.className === 'string') {
+      const cls = el.className.trim().split(/\s+/).slice(0, 2).join('.')
+      if (cls) sel += '.' + cls
+    }
+    return sel
+  }
+
+  function visibleText(el) {
+    if (!el) return ''
+    const text = (el.textContent || '').trim()
+    return text.slice(0, 60)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rate limiter — max 10 reports per 5 seconds, dedup via message hash
+  // ---------------------------------------------------------------------------
+
+  const RATE_WINDOW_MS = 5000
+  const RATE_MAX = 10
+  /** @type {number[]} */
+  const reportTimestamps = []
+  /** @type {Set<string>} */
+  const recentHashes = new Set()
+  let hashCleanupTimer = 0
+
+  function simpleHash(str) {
+    let h = 0
+    for (let i = 0; i < str.length; i++) {
+      h = ((h << 5) - h + str.charCodeAt(i)) | 0
+    }
+    return String(h)
+  }
+
+  function canSendReport(message) {
+    const now = Date.now()
+
+    // Rate limit
+    while (reportTimestamps.length > 0 && reportTimestamps[0] < now - RATE_WINDOW_MS) {
+      reportTimestamps.shift()
+    }
+    if (reportTimestamps.length >= RATE_MAX) return REPORT_STATUS.DROPPED
+
+    // Dedup
+    const hash = simpleHash(message)
+    if (recentHashes.has(hash)) return REPORT_STATUS.DEDUPED
+    recentHashes.add(hash)
+
+    // Clean up hashes every 10 seconds
+    if (hashCleanupTimer === 0) {
+      hashCleanupTimer = setTimeout(() => {
+        recentHashes.clear()
+        hashCleanupTimer = 0
+      }, 10000)
+    }
+
+    reportTimestamps.push(now)
+    return REPORT_STATUS.SENT
+  }
+
+  // ---------------------------------------------------------------------------
+  // Send report to background.js
+  // ---------------------------------------------------------------------------
+
+  function sendReport(trigger, details) {
+    const rateStatus = canSendReport(details.message || '')
+    if (rateStatus !== REPORT_STATUS.SENT) return
+
+    const report = {
+      channel: 'AGENT_EYE_REPORT',
+      trigger,
+      payload: {
+        ...details,
+        url: location.href,
+        timestamp: Date.now(),
+        actions: actionBuffer.slice(),
+        viewport: {
+          width: window.innerWidth,
+          height: window.innerHeight,
+        },
+      },
+    }
+
+    try {
+      chrome.runtime.sendMessage(report)
+    } catch {
+      // Extension context invalidated — page outlived the extension
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // User action listeners
+  // ---------------------------------------------------------------------------
+
+  // CLICK
+  document.addEventListener(
+    'click',
+    (e) => {
+      const target = /** @type {HTMLElement} */ (e.target)
+      pushAction({
+        kind: ACTION_KIND.CLICK,
+        selector: quickSelector(target),
+        text: visibleText(target),
+        tag: target.tagName ? target.tagName.toLowerCase() : '',
+        x: e.clientX,
+        y: e.clientY,
+        timestamp: Date.now(),
+      })
+    },
+    { capture: true, passive: true },
+  )
+
+  // INPUT — captures field name ONLY, never values
+  document.addEventListener(
+    'input',
+    (e) => {
+      const target = /** @type {HTMLInputElement} */ (e.target)
+      pushAction({
+        kind: ACTION_KIND.INPUT,
+        selector: quickSelector(target),
+        tag: target.tagName ? target.tagName.toLowerCase() : '',
+        text: target.name || target.getAttribute('aria-label') || target.placeholder || '',
+        timestamp: Date.now(),
+      })
+    },
+    { capture: true, passive: true },
+  )
+
+  // SCROLL — throttled to 1 per 500ms
+  let lastScrollTime = 0
+  document.addEventListener(
+    'scroll',
+    () => {
+      const now = Date.now()
+      if (now - lastScrollTime < 500) return
+      lastScrollTime = now
+      pushAction({
+        kind: ACTION_KIND.SCROLL,
+        selector: 'window',
+        timestamp: now,
+      })
+    },
+    { capture: true, passive: true },
+  )
+
+  // NAVIGATE — popstate (SPA navigation)
+  window.addEventListener('popstate', () => {
+    pushAction({
+      kind: ACTION_KIND.NAVIGATE,
+      selector: 'popstate',
+      url: location.href,
+      timestamp: Date.now(),
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Error triggers
+  // ---------------------------------------------------------------------------
+
+  // JS_ERROR — window.onerror
+  const originalOnError = window.onerror
+  window.onerror = function (message, filename, line, col, error) {
+    sendReport(TRIGGER_KIND.JS_ERROR, {
+      message: String(message),
+      filename: filename || '',
+      line: line || 0,
+      col: col || 0,
+      stack: error && error.stack ? error.stack : '',
+    })
+    if (typeof originalOnError === 'function') {
+      return originalOnError.call(this, message, filename, line, col, error)
+    }
+  }
+
+  // UNHANDLED_REJECTION — promise rejections
+  window.addEventListener('unhandledrejection', (e) => {
+    const reason = e.reason
+    sendReport(TRIGGER_KIND.UNHANDLED_REJECTION, {
+      message: reason instanceof Error ? reason.message : String(reason),
+      stack: reason instanceof Error ? reason.stack || '' : '',
+    })
+  })
+
+  // CONSOLE_ERROR — wraps console.error
+  const originalConsoleError = console.error
+  console.error = function (...args) {
+    const message = args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ')
+    sendReport(TRIGGER_KIND.CONSOLE_ERROR, {
+      message: message.slice(0, 1000),
+    })
+    return originalConsoleError.apply(console, args)
+  }
+
+  // NETWORK_ERROR — wraps fetch()
+  const originalFetch = window.fetch
+  window.fetch = function (...args) {
+    const request = args[0]
+    let fetchUrl = ''
+    let fetchMethod = 'GET'
+
+    if (typeof request === 'string') {
+      fetchUrl = request
+    } else if (request instanceof URL) {
+      fetchUrl = request.href
+    } else if (request instanceof Request) {
+      fetchUrl = request.url
+      fetchMethod = request.method
+    }
+
+    if (typeof args[1] === 'object' && args[1] !== null && typeof args[1].method === 'string') {
+      fetchMethod = args[1].method
+    }
+
+    return originalFetch.apply(window, args).then(
+      (response) => {
+        if (response.status >= 400) {
+          sendReport(TRIGGER_KIND.NETWORK_ERROR, {
+            message: `${fetchMethod} ${fetchUrl} → ${response.status} ${response.statusText}`,
+            status: response.status,
+            method: fetchMethod,
+          })
+        }
+        return response
+      },
+      (error) => {
+        sendReport(TRIGGER_KIND.NETWORK_ERROR, {
+          message: `${fetchMethod} ${fetchUrl} → Network failure: ${error instanceof Error ? error.message : String(error)}`,
+          method: fetchMethod,
+        })
+        throw error
+      },
+    )
+  }
+})()

--- a/assets/chrome-extension/manifest.json
+++ b/assets/chrome-extension/manifest.json
@@ -9,8 +9,8 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["debugger", "tabs", "activeTab", "storage"],
-  "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
+  "permissions": ["debugger", "tabs", "activeTab", "storage", "scripting"],
+  "host_permissions": ["http://127.0.0.1/*", "http://localhost/*", "<all_urls>"],
   "background": { "service_worker": "background.js", "type": "module" },
   "action": {
     "default_title": "OpenClaw Browser Relay (click to attach/detach)",

--- a/extensions/agent-eye/index.ts
+++ b/extensions/agent-eye/index.ts
@@ -1,0 +1,415 @@
+// Agent Eye — Passive browser bug catcher for OpenClaw
+// Zero booleans. All state uses typed string enums with explicit equality checks.
+
+import { Type } from "@sinclair/typebox";
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolFactory,
+} from "../../src/plugins/types.js";
+import {
+  BugStore,
+  BUG_SEVERITY,
+  REPORT_VERDICT,
+  EYE_MODE,
+  classifySeverity,
+  type BugSeverity,
+  type BugReport,
+  type EyeMode,
+  type UserAction,
+} from "./src/store.js";
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+const store = new BugStore();
+let eyeMode: EyeMode = EYE_MODE.DORMANT;
+
+// Rate limiter: max 30 reports per 60 seconds
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 30;
+const rateBuckets: number[] = [];
+
+function isRateLimited(): string {
+  const now = Date.now();
+  // Remove entries older than the window
+  while (rateBuckets.length > 0 && rateBuckets[0]! < now - RATE_WINDOW_MS) {
+    rateBuckets.shift();
+  }
+  if (rateBuckets.length >= RATE_MAX) return REPORT_VERDICT.RATE_LIMITED;
+  rateBuckets.push(now);
+  return REPORT_VERDICT.ACCEPTED;
+}
+
+// ---------------------------------------------------------------------------
+// Helper — tool result wrapper
+// ---------------------------------------------------------------------------
+
+function json<T>(payload: T): { content: Array<{ type: "text"; text: string }>; details: T } {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper — format bug for display
+// ---------------------------------------------------------------------------
+
+function formatBugSummary(bug: BugReport): string {
+  const ts = new Date(bug.timestamp).toISOString().slice(11, 19);
+  return `[${bug.severity}] ${ts} ${bug.trigger} — ${bug.message.slice(0, 120)}${bug.message.length > 120 ? "…" : ""}`;
+}
+
+function formatBugDetail(bug: BugReport): string {
+  const lines = [
+    `ID: ${bug.id}`,
+    `Severity: ${bug.severity}`,
+    `Trigger: ${bug.trigger}`,
+    `URL: ${bug.url}`,
+    `Time: ${new Date(bug.timestamp).toISOString()}`,
+    `Message: ${bug.message}`,
+  ];
+  if (bug.filename) lines.push(`File: ${bug.filename}:${bug.line ?? "?"}:${bug.col ?? "?"}`);
+  if (bug.stack) lines.push(`Stack:\n${bug.stack}`);
+  if (bug.status !== undefined) lines.push(`HTTP Status: ${bug.status}`);
+  if (bug.method) lines.push(`HTTP Method: ${bug.method}`);
+  if (bug.viewport) lines.push(`Viewport: ${bug.viewport.width}x${bug.viewport.height}`);
+  if (bug.tabTitle) lines.push(`Tab: ${bug.tabTitle}`);
+  if (bug.domSnippet) lines.push(`DOM Context:\n${bug.domSnippet}`);
+  if (bug.actions.length > 0) {
+    lines.push(`\nAction Timeline (${bug.actions.length} actions):`);
+    for (const action of bug.actions) {
+      const t = new Date(action.timestamp).toISOString().slice(11, 19);
+      lines.push(
+        `  ${t} ${action.kind} ${action.selector}${action.text ? ` "${action.text}"` : ""}`,
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+function createBugsTool(): AnyAgentTool {
+  return {
+    name: "agent_eye_bugs",
+    label: "Agent Eye Bugs",
+    description:
+      "List or inspect browser bugs captured by Agent Eye. " +
+      "Without an ID, lists recent bugs (optionally filtered by severity: CRITICAL, ERROR, WARNING, INFO). " +
+      "With an ID, returns full bug detail including the user action timeline.",
+    parameters: Type.Object({
+      id: Type.Optional(
+        Type.String({ description: "Bug ID — returns full detail for a specific bug" }),
+      ),
+      severity: Type.Optional(
+        Type.Union(
+          [
+            Type.Literal("CRITICAL"),
+            Type.Literal("ERROR"),
+            Type.Literal("WARNING"),
+            Type.Literal("INFO"),
+          ],
+          { description: "Filter by severity level" },
+        ),
+      ),
+      limit: Type.Optional(
+        Type.Number({ description: "Max bugs to return (default 20)", minimum: 1, maximum: 200 }),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      if (typeof params.id === "string") {
+        const bug = store.get(params.id);
+        if (bug === undefined) {
+          return json({ found: "NOT_FOUND", id: params.id });
+        }
+        return json({ found: "FOUND", bug: formatBugDetail(bug) });
+      }
+
+      const severity = params.severity as BugSeverity | undefined;
+      const bugs = store.list(severity);
+      const limit = params.limit ?? 20;
+      const sliced = bugs.slice(-limit);
+      const summaries = sliced.map(formatBugSummary);
+
+      return json({
+        total: bugs.length,
+        showing: sliced.length,
+        filter: severity ?? "ALL",
+        bugs: summaries,
+        ids: sliced.map((b) => b.id),
+      });
+    },
+  };
+}
+
+function createStatusTool(): AnyAgentTool {
+  return {
+    name: "agent_eye_status",
+    label: "Agent Eye Status",
+    description:
+      "Show Agent Eye mode (WATCHING, DORMANT, PAUSED), bug counts by severity, and buffer capacity.",
+    parameters: Type.Object({}),
+    async execute() {
+      const counts = store.counts();
+      return json({
+        mode: eyeMode,
+        bufferUsed: store.size(),
+        bufferCapacity: BugStore.capacity(),
+        counts,
+      });
+    },
+  };
+}
+
+function createClearTool(): AnyAgentTool {
+  return {
+    name: "agent_eye_clear",
+    label: "Agent Eye Clear",
+    description: "Clear all captured bugs from the Agent Eye buffer.",
+    parameters: Type.Object({}),
+    async execute() {
+      const removed = store.clear();
+      return json({ cleared: removed, verdict: "CLEARED" });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP Route handler — POST /agent-eye/report
+// ---------------------------------------------------------------------------
+
+function parseRequestBody(req: import("node:http").IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    const MAX_BODY = 256 * 1024; // 256 KB max
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY) {
+        req.destroy();
+        reject(new Error("Body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+async function handleReport(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+): Promise<void> {
+  // Only accept POST
+  if (req.method !== "POST") {
+    res.statusCode = 405;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ verdict: REPORT_VERDICT.REJECTED, reason: "Method not allowed" }));
+    return;
+  }
+
+  // Rate limit check
+  const rateCheck = isRateLimited();
+  if (rateCheck === REPORT_VERDICT.RATE_LIMITED) {
+    res.statusCode = 429;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ verdict: REPORT_VERDICT.RATE_LIMITED }));
+    return;
+  }
+
+  let body: unknown;
+  try {
+    const raw = await parseRequestBody(req);
+    body = JSON.parse(raw);
+  } catch {
+    res.statusCode = 400;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ verdict: REPORT_VERDICT.REJECTED, reason: "Invalid JSON" }));
+    return;
+  }
+
+  if (typeof body !== "object" || body === null) {
+    res.statusCode = 400;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ verdict: REPORT_VERDICT.REJECTED, reason: "Expected object" }));
+    return;
+  }
+
+  const payload = body as Record<string, unknown>;
+
+  // Validate trigger
+  const trigger = typeof payload.trigger === "string" ? payload.trigger : "";
+  if (!store.isValidTrigger(trigger)) {
+    res.statusCode = 400;
+    res.setHeader("Content-Type", "application/json");
+    res.end(
+      JSON.stringify({ verdict: REPORT_VERDICT.REJECTED, reason: `Unknown trigger: ${trigger}` }),
+    );
+    return;
+  }
+
+  // Extract fields
+  const message = typeof payload.message === "string" ? payload.message : "Unknown error";
+  const url = typeof payload.url === "string" ? payload.url : "";
+  const timestamp = typeof payload.timestamp === "number" ? payload.timestamp : Date.now();
+  const status = typeof payload.status === "number" ? payload.status : undefined;
+  const severity = classifySeverity(trigger, status);
+
+  const actions: UserAction[] = [];
+  if (Array.isArray(payload.actions)) {
+    for (const a of payload.actions) {
+      if (typeof a === "object" && a !== null) {
+        const act = a as Record<string, unknown>;
+        actions.push({
+          kind: (typeof act.kind === "string" ? act.kind : "CLICK") as UserAction["kind"],
+          selector: typeof act.selector === "string" ? act.selector : "",
+          text: typeof act.text === "string" ? act.text : undefined,
+          tag: typeof act.tag === "string" ? act.tag : undefined,
+          x: typeof act.x === "number" ? act.x : undefined,
+          y: typeof act.y === "number" ? act.y : undefined,
+          url: typeof act.url === "string" ? act.url : undefined,
+          timestamp: typeof act.timestamp === "number" ? act.timestamp : timestamp,
+        });
+      }
+    }
+  }
+
+  const viewport =
+    typeof payload.viewport === "object" && payload.viewport !== null
+      ? {
+          width:
+            typeof (payload.viewport as Record<string, unknown>).width === "number"
+              ? ((payload.viewport as Record<string, unknown>).width as number)
+              : 0,
+          height:
+            typeof (payload.viewport as Record<string, unknown>).height === "number"
+              ? ((payload.viewport as Record<string, unknown>).height as number)
+              : 0,
+        }
+      : undefined;
+
+  const id = store.add({
+    url,
+    timestamp,
+    severity,
+    trigger,
+    message,
+    stack: typeof payload.stack === "string" ? payload.stack : undefined,
+    filename: typeof payload.filename === "string" ? payload.filename : undefined,
+    line: typeof payload.line === "number" ? payload.line : undefined,
+    col: typeof payload.col === "number" ? payload.col : undefined,
+    status,
+    method: typeof payload.method === "string" ? payload.method : undefined,
+    actions,
+    domSnippet: typeof payload.domSnippet === "string" ? payload.domSnippet : undefined,
+    viewport,
+    tabId: typeof payload.tabId === "number" ? payload.tabId : undefined,
+    tabTitle: typeof payload.tabTitle === "string" ? payload.tabTitle : undefined,
+  });
+
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify({ verdict: REPORT_VERDICT.ACCEPTED, id, severity }));
+}
+
+// ---------------------------------------------------------------------------
+// /eye command handler
+// ---------------------------------------------------------------------------
+
+function handleEyeCommand(args: string): { text: string } {
+  const sub = args.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
+
+  if (sub === "watch") {
+    eyeMode = EYE_MODE.WATCHING;
+    return { text: "Agent Eye mode set to WATCHING — capturing browser actions and errors." };
+  }
+
+  if (sub === "sleep") {
+    eyeMode = EYE_MODE.DORMANT;
+    return { text: "Agent Eye mode set to DORMANT — capture paused." };
+  }
+
+  if (sub === "bugs") {
+    const bugs = store.list();
+    if (bugs.length === 0) {
+      return { text: "No bugs captured." };
+    }
+    const recent = bugs.slice(-10);
+    const lines = recent.map(formatBugSummary);
+    return { text: `Recent bugs (${recent.length} of ${bugs.length}):\n${lines.join("\n")}` };
+  }
+
+  if (sub === "clear") {
+    const removed = store.clear();
+    return { text: `Cleared ${removed} bug(s) from buffer.` };
+  }
+
+  if (sub === "status" || sub === "") {
+    const counts = store.counts();
+    const countStr = BugStore.severityOrder()
+      .map((s) => `${s}: ${counts[s]}`)
+      .join(", ");
+    return {
+      text: [
+        `Mode: ${eyeMode}`,
+        `Buffer: ${store.size()} / ${BugStore.capacity()}`,
+        `Counts: ${countStr}`,
+      ].join("\n"),
+    };
+  }
+
+  return {
+    text: [
+      "Usage: /eye <subcommand>",
+      "  watch  — start capturing (WATCHING mode)",
+      "  sleep  — stop capturing (DORMANT mode)",
+      "  bugs   — list recent bugs",
+      "  clear  — clear bug buffer",
+      "  status — show mode and stats",
+    ].join("\n"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin definition
+// ---------------------------------------------------------------------------
+
+export default {
+  id: "agent-eye",
+  name: "Agent Eye",
+  description:
+    "Passive browser bug catcher. Watches user actions and auto-captures bugs with full action timelines.",
+
+  register(api: OpenClawPluginApi) {
+    // HTTP route for Chrome extension reports
+    api.registerHttpRoute({
+      path: "/agent-eye/report",
+      handler: handleReport,
+    });
+
+    // Tools
+    const toolFactory: OpenClawPluginToolFactory = (ctx) => {
+      if (ctx.sandboxed === undefined)
+        return [createBugsTool(), createStatusTool(), createClearTool()];
+      return null;
+    };
+    api.registerTool(toolFactory, { optional: true });
+
+    // /eye command
+    api.registerCommand({
+      name: "eye",
+      description: "Agent Eye — browser bug catcher (watch, sleep, bugs, clear, status)",
+      acceptsArgs: true,
+      handler: async (ctx) => {
+        const result = handleEyeCommand(ctx.args ?? "");
+        return { text: result.text };
+      },
+    });
+  },
+};

--- a/extensions/agent-eye/openclaw.plugin.json
+++ b/extensions/agent-eye/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "agent-eye",
+  "name": "Agent Eye",
+  "description": "Passive browser bug catcher. Watches user actions (clicks, scrolls, inputs, navigation) and auto-captures bugs (JS errors, failed network requests, console.error) with a full action timeline.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/agent-eye/package.json
+++ b/extensions/agent-eye/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/agent-eye",
+  "version": "2026.2.18",
+  "description": "Passive browser bug catcher — captures JS errors, failed network requests, and console.error with a full user action timeline",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/agent-eye/src/store.ts
+++ b/extensions/agent-eye/src/store.ts
@@ -1,0 +1,202 @@
+// Agent Eye — BugStore
+// Zero booleans. All state uses typed string enums with explicit equality checks.
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const BUG_SEVERITY = {
+  CRITICAL: "CRITICAL",
+  ERROR: "ERROR",
+  WARNING: "WARNING",
+  INFO: "INFO",
+} as const;
+export type BugSeverity = (typeof BUG_SEVERITY)[keyof typeof BUG_SEVERITY];
+
+const SEVERITY_ORDER: readonly BugSeverity[] = [
+  BUG_SEVERITY.CRITICAL,
+  BUG_SEVERITY.ERROR,
+  BUG_SEVERITY.WARNING,
+  BUG_SEVERITY.INFO,
+] as const;
+
+export const TRIGGER_KIND = {
+  JS_ERROR: "JS_ERROR",
+  UNHANDLED_REJECTION: "UNHANDLED_REJECTION",
+  CONSOLE_ERROR: "CONSOLE_ERROR",
+  NETWORK_ERROR: "NETWORK_ERROR",
+} as const;
+export type TriggerKind = (typeof TRIGGER_KIND)[keyof typeof TRIGGER_KIND];
+
+const VALID_TRIGGERS = new Set<string>(Object.values(TRIGGER_KIND));
+
+export const ACTION_KIND = {
+  CLICK: "CLICK",
+  INPUT: "INPUT",
+  SCROLL: "SCROLL",
+  NAVIGATE: "NAVIGATE",
+} as const;
+export type ActionKind = (typeof ACTION_KIND)[keyof typeof ACTION_KIND];
+
+export const REPORT_VERDICT = {
+  ACCEPTED: "ACCEPTED",
+  RATE_LIMITED: "RATE_LIMITED",
+  REJECTED: "REJECTED",
+} as const;
+export type ReportVerdict = (typeof REPORT_VERDICT)[keyof typeof REPORT_VERDICT];
+
+export const EYE_MODE = {
+  WATCHING: "WATCHING",
+  DORMANT: "DORMANT",
+  PAUSED: "PAUSED",
+} as const;
+export type EyeMode = (typeof EYE_MODE)[keyof typeof EYE_MODE];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type UserAction = {
+  kind: ActionKind;
+  selector: string;
+  text?: string;
+  tag?: string;
+  x?: number;
+  y?: number;
+  url?: string;
+  timestamp: number;
+};
+
+export type BugReport = {
+  id: string;
+  url: string;
+  timestamp: number;
+  severity: BugSeverity;
+  trigger: TriggerKind;
+  message: string;
+  stack?: string;
+  filename?: string;
+  line?: number;
+  col?: number;
+  status?: number;
+  method?: string;
+  actions: UserAction[];
+  domSnippet?: string;
+  viewport?: { width: number; height: number };
+  tabId?: number;
+  tabTitle?: string;
+};
+
+// ---------------------------------------------------------------------------
+// ID generator (simple counter + random suffix, no external deps)
+// ---------------------------------------------------------------------------
+
+let idCounter = 0;
+
+function generateId(): string {
+  const now = Date.now().toString(36);
+  const count = (idCounter++).toString(36);
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `eye_${now}_${count}_${rand}`;
+}
+
+// ---------------------------------------------------------------------------
+// Severity classification
+// ---------------------------------------------------------------------------
+
+export function classifySeverity(trigger: TriggerKind, status?: number): BugSeverity {
+  if (trigger === TRIGGER_KIND.JS_ERROR) return BUG_SEVERITY.CRITICAL;
+  if (trigger === TRIGGER_KIND.UNHANDLED_REJECTION) return BUG_SEVERITY.CRITICAL;
+  if (trigger === TRIGGER_KIND.NETWORK_ERROR) {
+    if (typeof status === "number" && status >= 500) return BUG_SEVERITY.CRITICAL;
+    if (typeof status === "number" && status >= 400) return BUG_SEVERITY.ERROR;
+    return BUG_SEVERITY.ERROR;
+  }
+  if (trigger === TRIGGER_KIND.CONSOLE_ERROR) return BUG_SEVERITY.WARNING;
+  return BUG_SEVERITY.INFO;
+}
+
+// ---------------------------------------------------------------------------
+// BugStore — circular buffer with TTL
+// ---------------------------------------------------------------------------
+
+const MAX_BUGS = 200;
+const TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export class BugStore {
+  private buffer: BugReport[] = [];
+
+  /** Validate an incoming trigger string against known TRIGGER_KIND values. */
+  isValidTrigger(trigger: string): trigger is TriggerKind {
+    return VALID_TRIGGERS.has(trigger);
+  }
+
+  /** Add a bug report. Returns the generated ID. */
+  add(report: Omit<BugReport, "id">): string {
+    this.prune();
+    const id = generateId();
+    const bug: BugReport = { ...report, id };
+    this.buffer.push(bug);
+    if (this.buffer.length > MAX_BUGS) {
+      this.buffer.splice(0, this.buffer.length - MAX_BUGS);
+    }
+    return id;
+  }
+
+  /** Get a single bug by ID, or undefined. */
+  get(id: string): BugReport | undefined {
+    this.prune();
+    return this.buffer.find((b) => b.id === id);
+  }
+
+  /** List bugs, optionally filtered by severity. */
+  list(severity?: BugSeverity): BugReport[] {
+    this.prune();
+    if (severity === undefined) return this.buffer.slice();
+    return this.buffer.filter((b) => b.severity === severity);
+  }
+
+  /** Count bugs by severity. */
+  counts(): Record<BugSeverity, number> {
+    this.prune();
+    const result: Record<string, number> = {
+      [BUG_SEVERITY.CRITICAL]: 0,
+      [BUG_SEVERITY.ERROR]: 0,
+      [BUG_SEVERITY.WARNING]: 0,
+      [BUG_SEVERITY.INFO]: 0,
+    };
+    for (const bug of this.buffer) {
+      result[bug.severity] = (result[bug.severity] ?? 0) + 1;
+    }
+    return result as Record<BugSeverity, number>;
+  }
+
+  /** Total number of bugs currently stored. */
+  size(): number {
+    this.prune();
+    return this.buffer.length;
+  }
+
+  /** Clear all bugs. Returns count removed. */
+  clear(): number {
+    const count = this.buffer.length;
+    this.buffer = [];
+    return count;
+  }
+
+  /** Remove expired bugs (older than TTL). */
+  private prune(): void {
+    const cutoff = Date.now() - TTL_MS;
+    this.buffer = this.buffer.filter((b) => b.timestamp > cutoff);
+  }
+
+  /** Severity order for display (not used for comparison — always use === checks). */
+  static severityOrder(): readonly BugSeverity[] {
+    return SEVERITY_ORDER;
+  }
+
+  /** Max capacity. */
+  static capacity(): number {
+    return MAX_BUGS;
+  }
+}

--- a/extensions/soundchain-forge/index.ts
+++ b/extensions/soundchain-forge/index.ts
@@ -1,0 +1,216 @@
+// SoundChain Forge — Coding agent extension for OpenClaw
+// 7 tools: read, write, edit, bash, git, glob, grep
+// Secured with PathGuard, BashGuard, GitGuard.
+// Zero booleans for state.
+
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolFactory,
+} from "../../src/plugins/types.js";
+import { createBashTool, createGitTool, createGlobTool, createGrepTool } from "./src/exec-tools.js";
+import { createReadTool, createWriteTool, createEditTool } from "./src/file-tools.js";
+import { PathGuard, BashGuard, GitGuard } from "./src/guards.js";
+
+// ---------------------------------------------------------------------------
+// Helper — JSON tool result
+// ---------------------------------------------------------------------------
+
+function json<T>(payload: T) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP Helpers
+// ---------------------------------------------------------------------------
+
+function parseRequestBody(req: import("node:http").IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    const MAX_BODY = 512 * 1024;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY) {
+        req.destroy();
+        reject(new Error("Body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Plugin definition
+// ---------------------------------------------------------------------------
+
+const TOOL_NAMES = [
+  "forge_read",
+  "forge_write",
+  "forge_edit",
+  "forge_bash",
+  "forge_git",
+  "forge_glob",
+  "forge_grep",
+];
+
+export default {
+  id: "soundchain-forge",
+  name: "SoundChain Forge",
+  description:
+    "Coding agent tools for SMITH v2. Read, write, edit files. Run bash, git, glob, grep. " +
+    "Secured with path/command guards. The forge that builds the forge.",
+
+  register(api: OpenClawPluginApi) {
+    const cfg = (api.pluginConfig ?? {}) as Record<string, unknown>;
+
+    // Config with defaults
+    const allowedPaths: string[] = Array.isArray(cfg.allowedPaths)
+      ? cfg.allowedPaths.filter((p): p is string => typeof p === "string")
+      : ["/home/ubuntu/soundchain", "/tmp"];
+
+    const repoDir =
+      typeof cfg.repoDir === "string" && cfg.repoDir ? cfg.repoDir : "/home/ubuntu/soundchain";
+
+    // Initialize guards
+    const pathGuard = new PathGuard(allowedPaths);
+    const bashGuard = new BashGuard();
+    const gitGuard = new GitGuard();
+
+    // Create all 7 tools
+    const allTools: AnyAgentTool[] = [
+      createReadTool(pathGuard),
+      createWriteTool(pathGuard),
+      createEditTool(pathGuard),
+      createBashTool(pathGuard, bashGuard, repoDir),
+      createGitTool(gitGuard, repoDir),
+      createGlobTool(pathGuard, repoDir),
+      createGrepTool(pathGuard, repoDir),
+    ];
+
+    // Register tools — no tools in sandbox mode
+    const toolFactory: OpenClawPluginToolFactory = (ctx) => {
+      if (ctx.sandboxed) return null;
+      return allTools;
+    };
+    api.registerTool(toolFactory, { optional: true });
+
+    // ─── HTTP Route: GET /forge/status ────────────────────────────────
+    api.registerHttpRoute({
+      path: "/forge/status",
+      handler: async (_req, res) => {
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify({
+            status: "ONLINE",
+            tools: TOOL_NAMES,
+            repoDir,
+            allowedPaths,
+            version: "2026.2.19",
+          }),
+        );
+      },
+    });
+
+    // ─── HTTP Route: POST /forge/execute ──────────────────────────────
+    api.registerHttpRoute({
+      path: "/forge/execute",
+      handler: async (req, res) => {
+        if (req.method !== "POST") {
+          res.statusCode = 405;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ error: "Method not allowed" }));
+          return;
+        }
+
+        let body: Record<string, unknown>;
+        try {
+          const raw = await parseRequestBody(req);
+          body = JSON.parse(raw);
+        } catch {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ error: "Invalid JSON" }));
+          return;
+        }
+
+        const toolName = typeof body.tool === "string" ? body.tool : "";
+        const params =
+          typeof body.params === "object" && body.params !== null
+            ? (body.params as Record<string, unknown>)
+            : {};
+
+        const tool = allTools.find((t) => t.name === toolName);
+        if (!tool) {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(
+            JSON.stringify({
+              error: `Unknown tool: ${toolName}. Available: ${TOOL_NAMES.join(", ")}`,
+            }),
+          );
+          return;
+        }
+
+        try {
+          const result = await tool.execute("http-exec", params);
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify(result));
+        } catch (err: any) {
+          res.statusCode = 500;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ error: `Execution failed: ${err.message}` }));
+        }
+      },
+    });
+
+    // ─── /forge command ──────────────────────────────────────────────
+    api.registerCommand({
+      name: "forge",
+      description: "SoundChain Forge — coding agent status and tool list",
+      acceptsArgs: true,
+      handler: async (ctx) => {
+        const sub = (ctx.args ?? "").trim().toLowerCase();
+
+        if (sub === "tools") {
+          return {
+            text: [
+              "SoundChain Forge Tools:",
+              "",
+              "  forge_read   — Read file with line numbers",
+              "  forge_write  — Create or overwrite file (atomic)",
+              "  forge_edit   — String replacement in file",
+              "  forge_bash   — Execute shell command",
+              "  forge_git    — Safe git operations",
+              "  forge_glob   — File pattern matching",
+              "  forge_grep   — Content search (regex)",
+              "",
+              `Repo: ${repoDir}`,
+              `Allowed paths: ${allowedPaths.join(", ")}`,
+            ].join("\n"),
+          };
+        }
+
+        return {
+          text: [
+            "SoundChain Forge — SMITH v2 Coding Agent",
+            "",
+            `  Status: ONLINE`,
+            `  Tools: ${TOOL_NAMES.length}`,
+            `  Repo: ${repoDir}`,
+            "",
+            "  /forge tools — list all tools",
+          ].join("\n"),
+        };
+      },
+    });
+  },
+};

--- a/extensions/soundchain-forge/openclaw.plugin.json
+++ b/extensions/soundchain-forge/openclaw.plugin.json
@@ -1,0 +1,20 @@
+{
+  "id": "soundchain-forge",
+  "name": "SoundChain Forge",
+  "description": "Coding agent tools for SMITH v2 — read, write, edit files, run bash commands, git operations, glob search, grep content search. Secured with path/command guards.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "allowedPaths": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Filesystem paths the agent can access (default: /home/ubuntu/soundchain, /tmp)"
+      },
+      "repoDir": {
+        "type": "string",
+        "description": "Primary repo directory for git operations (default: /home/ubuntu/soundchain)"
+      }
+    }
+  }
+}

--- a/extensions/soundchain-forge/package.json
+++ b/extensions/soundchain-forge/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/soundchain-forge",
+  "version": "2026.2.19",
+  "description": "SoundChain Forge — coding agent tools: read, write, edit, bash, git, glob, grep",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48",
+    "fast-glob": "^3.3.3"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/soundchain-forge/serve.ts
+++ b/extensions/soundchain-forge/serve.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env npx tsx
+// SoundChain Forge — Standalone BYOK Server
+// Runs independently of OpenClaw gateway. Serves /forge/agent, /forge/status, /forge/execute.
+// User's API key in request body → Anthropic → tool execution → SSE back.
+// Key never touches disk. True BYOK.
+//
+// Usage: npx tsx serve.ts [--port 3334]
+
+import { createServer } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { runForgeAgent } from "./src/agent-loop.js";
+import { createBashTool, createGitTool, createGlobTool, createGrepTool } from "./src/exec-tools.js";
+import { createReadTool, createWriteTool, createEditTool } from "./src/file-tools.js";
+import { PathGuard, BashGuard, GitGuard } from "./src/guards.js";
+
+// ─── Config ──────────────────────────────────────────────────────────
+const PORT = parseInt(process.argv.find((_, i, a) => a[i - 1] === "--port") || "3334", 10);
+const ALLOWED_PATHS = ["/home/ubuntu/soundchain", "/home/ubuntu/openclaw", "/tmp"];
+const REPO_DIR = "/home/ubuntu/soundchain";
+
+// ─── Initialize guards and tools ─────────────────────────────────────
+const pathGuard = new PathGuard(ALLOWED_PATHS);
+const bashGuard = new BashGuard();
+const gitGuard = new GitGuard();
+
+const allTools = [
+  createReadTool(pathGuard),
+  createWriteTool(pathGuard),
+  createEditTool(pathGuard),
+  createBashTool(pathGuard, bashGuard, REPO_DIR),
+  createGitTool(gitGuard, REPO_DIR),
+  createGlobTool(pathGuard, REPO_DIR),
+  createGrepTool(pathGuard, REPO_DIR),
+];
+
+const TOOL_NAMES = allTools.map((t) => t.name);
+
+// ─── HTTP Helpers ────────────────────────────────────────────────────
+
+function parseBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > 512 * 1024) {
+        req.destroy();
+        reject(new Error("Body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+function jsonResponse(res: ServerResponse, status: number, body: unknown) {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+  });
+  res.end(JSON.stringify(body));
+}
+
+function corsHeaders(res: ServerResponse) {
+  res.writeHead(204, {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Max-Age": "86400",
+  });
+  res.end();
+}
+
+// ─── Routes ──────────────────────────────────────────────────────────
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse) {
+  const url = new URL(req.url || "/", "http://localhost");
+  const path = url.pathname;
+
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    corsHeaders(res);
+    return;
+  }
+
+  // GET /forge/status
+  if (path === "/forge/status" && req.method === "GET") {
+    jsonResponse(res, 200, {
+      status: "ONLINE",
+      tools: TOOL_NAMES,
+      repoDir: REPO_DIR,
+      allowedPaths: ALLOWED_PATHS,
+      version: "2026.2.20",
+      mode: "BYOK_STANDALONE",
+    });
+    return;
+  }
+
+  // POST /forge/execute — single tool execution
+  if (path === "/forge/execute" && req.method === "POST") {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(await parseBody(req));
+    } catch {
+      jsonResponse(res, 400, { error: "Invalid JSON" });
+      return;
+    }
+
+    const toolName = typeof body.tool === "string" ? body.tool : "";
+    const params =
+      typeof body.params === "object" && body.params !== null
+        ? (body.params as Record<string, unknown>)
+        : {};
+
+    const tool = allTools.find((t) => t.name === toolName);
+    if (!tool) {
+      jsonResponse(res, 400, {
+        error: `Unknown tool: ${toolName}. Available: ${TOOL_NAMES.join(", ")}`,
+      });
+      return;
+    }
+
+    try {
+      const result = await tool.execute("http-exec", params);
+      jsonResponse(res, 200, result);
+    } catch (err: any) {
+      jsonResponse(res, 500, { error: `Execution failed: ${err.message}` });
+    }
+    return;
+  }
+
+  // POST /forge/agent — BYOK agent loop (the key endpoint)
+  if (path === "/forge/agent" && req.method === "POST") {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(await parseBody(req));
+    } catch {
+      jsonResponse(res, 400, { error: "Invalid JSON body" });
+      return;
+    }
+
+    const apiKey = typeof body.apiKey === "string" ? body.apiKey : "";
+    const messages = Array.isArray(body.messages) ? body.messages : [];
+    const model = typeof body.model === "string" ? body.model : undefined;
+
+    if (!apiKey) {
+      jsonResponse(res, 401, { error: "Missing apiKey — BYOK required" });
+      return;
+    }
+
+    if (messages.length === 0) {
+      jsonResponse(res, 400, { error: "Missing messages array" });
+      return;
+    }
+
+    try {
+      await runForgeAgent(res, apiKey, messages, allTools, model);
+    } catch (err: any) {
+      if (!res.headersSent) {
+        jsonResponse(res, 500, { error: `Agent loop failed: ${err.message}` });
+      }
+    }
+    return;
+  }
+
+  // 404
+  jsonResponse(res, 404, { error: "Not found. Try /forge/status" });
+}
+
+// ─── Start ───────────────────────────────────────────────────────────
+
+const server = createServer((req, res) => {
+  handleRequest(req, res).catch((err) => {
+    console.error("[forge-server] Unhandled:", err);
+    if (!res.headersSent) {
+      jsonResponse(res, 500, { error: "Internal server error" });
+    }
+  });
+});
+
+server.listen(PORT, "0.0.0.0", () => {
+  console.log(`[forge-server] SoundChain Forge BYOK Server`);
+  console.log(`[forge-server] Listening on http://0.0.0.0:${PORT}`);
+  console.log(`[forge-server] Tools: ${TOOL_NAMES.join(", ")}`);
+  console.log(`[forge-server] Repo: ${REPO_DIR}`);
+  console.log(`[forge-server] Mode: BYOK — key per-request, never stored`);
+});

--- a/extensions/soundchain-forge/src/agent-loop.ts
+++ b/extensions/soundchain-forge/src/agent-loop.ts
@@ -1,0 +1,314 @@
+// SoundChain Forge — BYOK Agent Loop
+// Accepts API key per-request. Key flows in memory only, never stored on disk.
+// Calls Anthropic → handles tool_use → executes forge tools → loops → streams SSE.
+// The operator's console. The warroom desk.
+
+import type { ServerResponse } from "node:http";
+import type { AnyAgentTool } from "../../../src/plugins/types.js";
+
+// ─── Enums ───────────────────────────────────────────────────────────
+const AGENT_STATUS = {
+  RUNNING: "RUNNING",
+  DONE: "DONE",
+  ERROR: "ERROR",
+  MAX_TURNS: "MAX_TURNS",
+} as const;
+
+// ─── Config ──────────────────────────────────────────────────────────
+const MAX_TURNS = 15;
+const MAX_MSG_LEN = 8000;
+const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+const DEFAULT_MODEL = "claude-sonnet-4-5-20250929";
+
+const FORGE_SYSTEM = `You are SMITH FORGE — a full coding agent in the SoundChain forge.
+You have 7 tools: forge_read, forge_write, forge_edit, forge_bash, forge_git, forge_glob, forge_grep.
+You are operating on the SoundChain codebase. Use your tools to complete coding tasks.
+
+Rules:
+- Read files before editing them. Understand existing code first.
+- Use forge_git for safe git operations (status, diff, log, add, commit, push).
+- Use forge_bash for running commands (build, test, install).
+- Be direct. Complete the task, show what you did.
+- Never force-push, never delete branches without asking.
+- Keep explanations concise. Show code changes clearly.
+
+Identity: SMITH FORGE · Signature: SC-FURL-THE-ONE · Runtime: EC2
+Twin: FURL (browser-side) · Platform: SoundChain (soundchain.io)`;
+
+// ─── SSE Emitter ─────────────────────────────────────────────────────
+
+function setupSSE(res: ServerResponse) {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    "X-Accel-Buffering": "no",
+    "Access-Control-Allow-Origin": "*",
+  });
+
+  return (event: Record<string, unknown>) => {
+    try {
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+    } catch {
+      // Client disconnected
+    }
+  };
+}
+
+// ─── Tool Definitions → Anthropic Format ─────────────────────────────
+
+function toolsToAnthropic(tools: AnyAgentTool[]) {
+  return tools.map((t) => ({
+    name: t.name,
+    description: t.description || "",
+    input_schema: t.parameters || { type: "object" as const, properties: {} },
+  }));
+}
+
+// ─── Anthropic Streaming Parser ──────────────────────────────────────
+// Parses SSE from Anthropic Messages API, extracts text deltas and tool_use blocks.
+
+interface ToolUse {
+  id: string;
+  name: string;
+  inputJson: string;
+}
+
+interface ParsedResponse {
+  textParts: string[];
+  toolUses: ToolUse[];
+  stopReason: string;
+}
+
+async function streamAnthropicResponse(
+  body: ReadableStream<Uint8Array>,
+  emit: (event: Record<string, unknown>) => void,
+): Promise<ParsedResponse> {
+  const reader = (body as any).getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  const textParts: string[] = [];
+  const toolUses: ToolUse[] = [];
+  let stopReason = "";
+  let currentBlockType = "";
+  let currentToolInputJson = "";
+  let accumulatedText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      const data = line.slice(6).trim();
+      if (data === "[DONE]") continue;
+
+      try {
+        const parsed = JSON.parse(data);
+
+        if (parsed.type === "content_block_start") {
+          const block = parsed.content_block;
+          if (block.type === "text") {
+            currentBlockType = "text";
+          } else if (block.type === "tool_use") {
+            currentBlockType = "tool_use";
+            currentToolInputJson = "";
+            toolUses.push({ id: block.id, name: block.name, inputJson: "" });
+            emit({ type: "tool_start", name: block.name, id: block.id });
+          }
+        }
+
+        if (parsed.type === "content_block_delta") {
+          if (parsed.delta?.type === "text_delta" && parsed.delta.text) {
+            emit({ type: "delta", text: parsed.delta.text });
+            accumulatedText += parsed.delta.text;
+          }
+          if (parsed.delta?.type === "input_json_delta") {
+            currentToolInputJson += parsed.delta.partial_json || "";
+          }
+        }
+
+        if (parsed.type === "content_block_stop") {
+          if (currentBlockType === "text") {
+            textParts.push(accumulatedText);
+            accumulatedText = "";
+          } else if (currentBlockType === "tool_use" && toolUses.length > 0) {
+            toolUses[toolUses.length - 1].inputJson = currentToolInputJson;
+          }
+          currentBlockType = "";
+        }
+
+        if (parsed.type === "message_delta") {
+          stopReason = parsed.delta?.stop_reason || "";
+        }
+      } catch {
+        // Skip malformed SSE lines
+      }
+    }
+  }
+
+  // Capture any remaining text
+  if (accumulatedText) textParts.push(accumulatedText);
+
+  return { textParts, toolUses, stopReason };
+}
+
+// ─── The Agent Loop ──────────────────────────────────────────────────
+// BYOK: API key in, SSE out. Key never touches disk.
+
+export async function runForgeAgent(
+  res: ServerResponse,
+  apiKey: string,
+  userMessages: Array<{ role: string; content: string }>,
+  tools: AnyAgentTool[],
+  model?: string,
+) {
+  const emit = setupSSE(res);
+  emit({ type: "start", provider: "FORGE" });
+
+  const anthropicTools = toolsToAnthropic(tools);
+  const useModel = model || DEFAULT_MODEL;
+
+  // Build initial messages
+  const messages: any[] = userMessages.map((m) => ({
+    role: m.role === "user" ? "user" : "assistant",
+    content: String(m.content).slice(0, MAX_MSG_LEN),
+  }));
+
+  let status: string = AGENT_STATUS.RUNNING;
+
+  for (let turn = 0; turn < MAX_TURNS; turn++) {
+    // ─── Call Anthropic ────────────────────────────────────────────
+    let anthropicRes: Response;
+    try {
+      anthropicRes = await fetch(ANTHROPIC_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+          "anthropic-version": ANTHROPIC_VERSION,
+        },
+        body: JSON.stringify({
+          model: useModel,
+          max_tokens: 4096,
+          stream: true,
+          system: FORGE_SYSTEM,
+          tools: anthropicTools,
+          messages,
+        }),
+      });
+    } catch (err: any) {
+      emit({ type: "error", text: `Network error: ${err.message}` });
+      res.end();
+      return;
+    }
+
+    if (!anthropicRes.ok) {
+      const errText = await anthropicRes.text().catch(() => "Unknown");
+      emit({
+        type: "error",
+        text: `Anthropic ${anthropicRes.status}: ${errText.slice(0, 300)}`,
+      });
+      res.end();
+      return;
+    }
+
+    const body = anthropicRes.body as any;
+    if (!body?.getReader) {
+      emit({ type: "error", text: "No streaming support on this runtime" });
+      res.end();
+      return;
+    }
+
+    // ─── Stream and parse response ─────────────────────────────────
+    const { textParts, toolUses, stopReason } = await streamAnthropicResponse(body, emit);
+
+    // ─── End turn — no tool calls ──────────────────────────────────
+    if (stopReason !== "tool_use" || toolUses.length === 0) {
+      status = AGENT_STATUS.DONE;
+      break;
+    }
+
+    // ─── Build assistant message (text + tool_use blocks) ──────────
+    const assistantContent: any[] = [];
+    for (const tp of textParts) {
+      if (tp) assistantContent.push({ type: "text", text: tp });
+    }
+    for (const tu of toolUses) {
+      let input: Record<string, unknown> = {};
+      try {
+        input = JSON.parse(tu.inputJson);
+      } catch {
+        input = {};
+      }
+      assistantContent.push({
+        type: "tool_use",
+        id: tu.id,
+        name: tu.name,
+        input,
+      });
+    }
+
+    messages.push({ role: "assistant", content: assistantContent });
+
+    // ─── Execute tools ─────────────────────────────────────────────
+    const toolResults: any[] = [];
+
+    for (const tu of toolUses) {
+      const tool = tools.find((t) => t.name === tu.name);
+      let input: Record<string, unknown> = {};
+      try {
+        input = JSON.parse(tu.inputJson);
+      } catch {
+        input = {};
+      }
+
+      let resultText = "";
+
+      if (!tool) {
+        resultText = `Unknown tool: ${tu.name}`;
+      } else {
+        emit({ type: "delta", text: `\n⚙ ${tu.name}...` });
+        try {
+          const result = await tool.execute("forge-agent", input);
+          resultText = result?.content?.[0]?.text || JSON.stringify(result);
+          emit({ type: "delta", text: " done\n" });
+        } catch (err: any) {
+          resultText = `Tool error: ${err.message}`;
+          emit({ type: "delta", text: ` error: ${err.message}\n` });
+        }
+      }
+
+      emit({
+        type: "tool_result",
+        name: tu.name,
+        id: tu.id,
+        preview: resultText.slice(0, 200),
+      });
+
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: tu.id,
+        content: resultText.slice(0, 30000), // Cap tool output
+      });
+    }
+
+    // Add tool results as user message (Anthropic format)
+    messages.push({ role: "user", content: toolResults });
+
+    // Loop continues — Claude will respond to tool results
+  }
+
+  if (status !== AGENT_STATUS.DONE) {
+    emit({ type: "delta", text: "\n\n[Reached max tool turns]" });
+  }
+
+  emit({ type: "done" });
+  res.end();
+}

--- a/extensions/soundchain-forge/src/agent-loop.ts
+++ b/extensions/soundchain-forge/src/agent-loop.ts
@@ -4,7 +4,14 @@
 // The operator's console. The warroom desk.
 
 import type { ServerResponse } from "node:http";
-import type { AnyAgentTool } from "../../../src/plugins/types.js";
+
+// Minimal tool interface — works standalone without OpenClaw dependency
+interface ForgeTool {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+  execute: (id: string, params: Record<string, unknown>) => Promise<any>;
+}
 
 // ─── Enums ───────────────────────────────────────────────────────────
 const AGENT_STATUS = {
@@ -58,7 +65,7 @@ function setupSSE(res: ServerResponse) {
 
 // ─── Tool Definitions → Anthropic Format ─────────────────────────────
 
-function toolsToAnthropic(tools: AnyAgentTool[]) {
+function toolsToAnthropic(tools: ForgeTool[]) {
   return tools.map((t) => ({
     name: t.name,
     description: t.description || "",
@@ -166,7 +173,7 @@ export async function runForgeAgent(
   res: ServerResponse,
   apiKey: string,
   userMessages: Array<{ role: string; content: string }>,
-  tools: AnyAgentTool[],
+  tools: ForgeTool[],
   model?: string,
 ) {
   const emit = setupSSE(res);

--- a/extensions/soundchain-forge/src/exec-tools.ts
+++ b/extensions/soundchain-forge/src/exec-tools.ts
@@ -7,7 +7,14 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import { resolve, join, relative } from "node:path";
 import { createInterface } from "node:readline";
 import { Type } from "@sinclair/typebox";
-import type { AnyAgentTool } from "../../../src/plugins/types.js";
+// Standalone type — no OpenClaw dependency needed at runtime
+type AnyAgentTool = {
+  name: string;
+  label?: string;
+  description?: string;
+  parameters?: any;
+  execute: (id: string, params: Record<string, unknown>) => Promise<any>;
+};
 import { PathGuard, BashGuard, GitGuard } from "./guards.js";
 
 const MAX_OUTPUT = 30 * 1024; // 30 KB output cap

--- a/extensions/soundchain-forge/src/exec-tools.ts
+++ b/extensions/soundchain-forge/src/exec-tools.ts
@@ -1,0 +1,380 @@
+// SoundChain Forge — Execution tools: bash, git, glob, grep
+// Mirrors Claude Code's Bash, Glob, Grep semantics.
+
+import { spawn } from "node:child_process";
+import { createReadStream } from "node:fs";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { resolve, join, relative } from "node:path";
+import { createInterface } from "node:readline";
+import { Type } from "@sinclair/typebox";
+import type { AnyAgentTool } from "../../../src/plugins/types.js";
+import { PathGuard, BashGuard, GitGuard } from "./guards.js";
+
+const MAX_OUTPUT = 30 * 1024; // 30 KB output cap
+
+function json<T>(payload: T) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + `\n... (truncated at ${max} bytes)`;
+}
+
+// ─── Shell execution helper ──────────────────────────────────────────────
+
+function execShell(
+  command: string,
+  opts: { cwd?: string; timeout?: number },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const timeout = Math.min(opts.timeout ?? 120_000, 600_000);
+    let stdout = "";
+    let stderr = "";
+    let killed = false;
+
+    const proc = spawn("/bin/bash", ["-c", command], {
+      cwd: opts.cwd,
+      timeout,
+      env: { ...process.env, TERM: "dumb" },
+    });
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      if (stdout.length > MAX_OUTPUT * 2) {
+        stdout = stdout.slice(0, MAX_OUTPUT);
+        proc.kill("SIGTERM");
+        killed = true;
+      }
+    });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+      if (stderr.length > MAX_OUTPUT) {
+        stderr = stderr.slice(0, MAX_OUTPUT);
+      }
+    });
+
+    proc.on("close", (code) => {
+      resolve({
+        stdout: truncate(stdout, MAX_OUTPUT),
+        stderr: truncate(stderr, MAX_OUTPUT),
+        exitCode: killed ? 137 : (code ?? 1),
+      });
+    });
+
+    proc.on("error", (err) => {
+      resolve({
+        stdout: "",
+        stderr: `Process error: ${err.message}`,
+        exitCode: 1,
+      });
+    });
+  });
+}
+
+// ─── forge_bash ──────────────────────────────────────────────────────────
+
+export function createBashTool(
+  pathGuard: PathGuard,
+  bashGuard: BashGuard,
+  defaultCwd: string,
+): AnyAgentTool {
+  return {
+    name: "forge_bash",
+    label: "Forge Bash",
+    description:
+      "Execute a bash command. Output is captured (stdout + stderr). " +
+      "Default timeout 120s, max 600s. Output truncated at 30KB.",
+    parameters: Type.Object({
+      command: Type.String({ description: "The bash command to execute" }),
+      timeout: Type.Optional(
+        Type.Number({
+          description: "Timeout in milliseconds (default 120000, max 600000)",
+          minimum: 1000,
+          maximum: 600000,
+        }),
+      ),
+      cwd: Type.Optional(Type.String({ description: "Working directory (defaults to repo root)" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const command = typeof params.command === "string" ? params.command : "";
+      const timeout = typeof params.timeout === "number" ? params.timeout : 120_000;
+      const cwd = typeof params.cwd === "string" ? params.cwd : defaultCwd;
+
+      if (!command.trim()) {
+        return json({ error: "Command cannot be empty" });
+      }
+
+      const bashCheck = bashGuard.validate(command);
+      if (bashCheck.verdict !== "ALLOWED") {
+        return json({ error: bashCheck.error });
+      }
+
+      // Validate cwd if provided
+      if (cwd !== defaultCwd) {
+        const cwdCheck = pathGuard.validate(cwd);
+        if (cwdCheck.verdict !== "ALLOWED") {
+          return json({ error: `Working directory: ${cwdCheck.error}` });
+        }
+      }
+
+      const result = await execShell(command, { cwd, timeout });
+      return json(result);
+    },
+  } as AnyAgentTool;
+}
+
+// ─── forge_git ───────────────────────────────────────────────────────────
+
+export function createGitTool(gitGuard: GitGuard, defaultCwd: string): AnyAgentTool {
+  return {
+    name: "forge_git",
+    label: "Forge Git",
+    description:
+      "Run git operations safely. Blocks dangerous flags (--force, --hard, --no-verify). " +
+      "Allowed subcommands: status, diff, log, add, commit, push, pull, branch, checkout, " +
+      "stash, show, remote, fetch, merge, rebase, cherry-pick, tag, rev-parse, ls-files, blame.",
+    parameters: Type.Object({
+      command: Type.String({
+        description: "Git subcommand (e.g. 'status', 'diff', 'log', 'add', 'commit')",
+      }),
+      args: Type.Optional(
+        Type.Array(Type.String(), {
+          description: "Arguments for the git command",
+        }),
+      ),
+      cwd: Type.Optional(
+        Type.String({ description: "Repository directory (defaults to repo root)" }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const subcommand = typeof params.command === "string" ? params.command.trim() : "";
+      const args: string[] = Array.isArray(params.args)
+        ? params.args.filter((a): a is string => typeof a === "string")
+        : [];
+      const cwd = typeof params.cwd === "string" ? params.cwd : defaultCwd;
+
+      if (!subcommand) {
+        return json({ error: "Git subcommand is required" });
+      }
+
+      const check = gitGuard.validate(subcommand, args);
+      if (check.verdict !== "ALLOWED") {
+        return json({ error: check.error });
+      }
+
+      const fullCmd = ["git", subcommand, ...args].join(" ");
+      const result = await execShell(fullCmd, { cwd, timeout: 60_000 });
+      return json(result);
+    },
+  } as AnyAgentTool;
+}
+
+// ─── forge_glob ──────────────────────────────────────────────────────────
+
+export function createGlobTool(pathGuard: PathGuard, defaultCwd: string): AnyAgentTool {
+  return {
+    name: "forge_glob",
+    label: "Forge Glob",
+    description:
+      "Find files by glob pattern (e.g. '**/*.ts', 'src/**/*.tsx'). " +
+      "Ignores node_modules and .git. Results sorted by modification time (newest first).",
+    parameters: Type.Object({
+      pattern: Type.String({ description: "Glob pattern to match files" }),
+      path: Type.Optional(
+        Type.String({ description: "Directory to search in (defaults to repo root)" }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const pattern = typeof params.pattern === "string" ? params.pattern : "";
+      const searchPath = typeof params.path === "string" ? params.path : defaultCwd;
+
+      if (!pattern) {
+        return json({ error: "Pattern is required" });
+      }
+
+      const pathCheck = pathGuard.validate(searchPath);
+      if (pathCheck.verdict !== "ALLOWED") {
+        return json({ error: pathCheck.error });
+      }
+
+      try {
+        // Use fast-glob if available, fallback to find command
+        let fg: typeof import("fast-glob") | null = null;
+        try {
+          fg = await import("fast-glob");
+        } catch {
+          // fast-glob not installed, use find fallback
+        }
+
+        if (fg) {
+          const files = await fg.default(pattern, {
+            cwd: pathCheck.resolved,
+            ignore: ["**/node_modules/**", "**/.git/**"],
+            absolute: true,
+            stats: true,
+            onlyFiles: true,
+          });
+
+          // Sort by mtime newest first
+          const sorted = files
+            .sort((a, b) => {
+              const aTime = a.stats?.mtimeMs ?? 0;
+              const bTime = b.stats?.mtimeMs ?? 0;
+              return bTime - aTime;
+            })
+            .slice(0, 200);
+
+          return json({
+            pattern,
+            path: pathCheck.resolved,
+            count: files.length,
+            showing: sorted.length,
+            files: sorted.map((f) => f.path),
+          });
+        }
+
+        // Fallback: use find command
+        const result = await execShell(
+          `find . -name '.git' -prune -o -name 'node_modules' -prune -o -name '${pattern.replace(/\*/g, "*")}' -type f -print | head -200`,
+          { cwd: pathCheck.resolved, timeout: 15_000 },
+        );
+
+        const files = result.stdout
+          .trim()
+          .split("\n")
+          .filter((f) => f.length > 0)
+          .map((f) => resolve(pathCheck.resolved, f));
+
+        return json({
+          pattern,
+          path: pathCheck.resolved,
+          count: files.length,
+          files,
+        });
+      } catch (err: any) {
+        return json({ error: `Glob failed: ${err.message}` });
+      }
+    },
+  } as AnyAgentTool;
+}
+
+// ─── forge_grep ──────────────────────────────────────────────────────────
+
+export function createGrepTool(pathGuard: PathGuard, defaultCwd: string): AnyAgentTool {
+  return {
+    name: "forge_grep",
+    label: "Forge Grep",
+    description:
+      "Search file contents by regex pattern. Uses ripgrep (rg) if available, " +
+      "falls back to grep. Supports output modes: 'content' (matching lines), " +
+      "'files' (file paths only), 'count' (match counts per file).",
+    parameters: Type.Object({
+      pattern: Type.String({ description: "Regex pattern to search for" }),
+      path: Type.Optional(
+        Type.String({ description: "File or directory to search (defaults to repo root)" }),
+      ),
+      glob: Type.Optional(
+        Type.String({ description: "Glob filter for files (e.g. '*.ts', '*.tsx')" }),
+      ),
+      output_mode: Type.Optional(
+        Type.Union([Type.Literal("content"), Type.Literal("files"), Type.Literal("count")], {
+          description: "Output mode: content, files, or count (default: files)",
+        }),
+      ),
+      context: Type.Optional(
+        Type.Number({
+          description: "Lines of context around matches (for content mode)",
+          minimum: 0,
+          maximum: 10,
+        }),
+      ),
+      case_insensitive: Type.Optional(Type.Boolean({ description: "Case-insensitive search" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const pattern = typeof params.pattern === "string" ? params.pattern : "";
+      const searchPath = typeof params.path === "string" ? params.path : defaultCwd;
+      const glob = typeof params.glob === "string" ? params.glob : "";
+      const mode = typeof params.output_mode === "string" ? params.output_mode : "files";
+      const context = typeof params.context === "number" ? params.context : 0;
+      const caseInsensitive = params.case_insensitive === true;
+
+      if (!pattern) {
+        return json({ error: "Pattern is required" });
+      }
+
+      const pathCheck = pathGuard.validate(searchPath);
+      if (pathCheck.verdict !== "ALLOWED") {
+        return json({ error: pathCheck.error });
+      }
+
+      // Build rg command (try ripgrep first, fallback to grep)
+      const args: string[] = [];
+
+      // Output mode flags
+      if (mode === "files") args.push("-l");
+      else if (mode === "count") args.push("-c");
+      else if (context > 0) args.push(`-C${context}`);
+
+      if (caseInsensitive) args.push("-i");
+
+      // Add line numbers for content mode
+      if (mode === "content") args.push("-n");
+
+      // Glob filter
+      if (glob) args.push(`--glob=${glob}`);
+
+      // Ignore patterns
+      args.push("--glob=!node_modules", "--glob=!.git");
+
+      // Max results
+      if (mode === "content") args.push("--max-count=200");
+
+      args.push("--", pattern, pathCheck.resolved);
+
+      // Try ripgrep first
+      let result = await execShell(`rg ${args.join(" ")}`, {
+        cwd: pathCheck.resolved,
+        timeout: 30_000,
+      });
+
+      // Fallback to grep if rg not found
+      if (result.exitCode === 127 || result.stderr.includes("not found")) {
+        const grepArgs: string[] = ["-r"];
+        if (mode === "files") grepArgs.push("-l");
+        else if (mode === "count") grepArgs.push("-c");
+        else grepArgs.push("-n");
+        if (caseInsensitive) grepArgs.push("-i");
+        if (context > 0 && mode === "content") grepArgs.push(`-C${context}`);
+        grepArgs.push("--exclude-dir=node_modules", "--exclude-dir=.git");
+        if (glob) grepArgs.push(`--include=${glob}`);
+        grepArgs.push("--", pattern, pathCheck.resolved);
+
+        result = await execShell(`grep ${grepArgs.join(" ")}`, {
+          cwd: pathCheck.resolved,
+          timeout: 30_000,
+        });
+      }
+
+      if (result.exitCode === 1 && !result.stdout.trim()) {
+        return json({ pattern, matches: 0, output: "No matches found" });
+      }
+
+      const lines = result.stdout
+        .trim()
+        .split("\n")
+        .filter((l) => l.length > 0);
+
+      return json({
+        pattern,
+        mode,
+        matches: lines.length,
+        output: truncate(result.stdout, MAX_OUTPUT),
+      });
+    },
+  } as AnyAgentTool;
+}

--- a/extensions/soundchain-forge/src/file-tools.ts
+++ b/extensions/soundchain-forge/src/file-tools.ts
@@ -5,7 +5,14 @@ import { randomBytes } from "node:crypto";
 import { readFile, writeFile, mkdir, rename, stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { Type } from "@sinclair/typebox";
-import type { AnyAgentTool } from "../../../src/plugins/types.js";
+// Standalone type — no OpenClaw dependency needed at runtime
+type AnyAgentTool = {
+  name: string;
+  label?: string;
+  description?: string;
+  parameters?: any;
+  execute: (id: string, params: Record<string, unknown>) => Promise<any>;
+};
 import { PathGuard } from "./guards.js";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB

--- a/extensions/soundchain-forge/src/file-tools.ts
+++ b/extensions/soundchain-forge/src/file-tools.ts
@@ -1,0 +1,208 @@
+// SoundChain Forge — File tools: read, write, edit
+// Mirrors Claude Code's Read, Write, Edit semantics.
+
+import { randomBytes } from "node:crypto";
+import { readFile, writeFile, mkdir, rename, stat } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { Type } from "@sinclair/typebox";
+import type { AnyAgentTool } from "../../../src/plugins/types.js";
+import { PathGuard } from "./guards.js";
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_READ_LINES = 2000;
+
+function json<T>(payload: T) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+// ─── forge_read ──────────────────────────────────────────────────────────
+
+export function createReadTool(guard: PathGuard): AnyAgentTool {
+  return {
+    name: "forge_read",
+    label: "Forge Read",
+    description:
+      "Read a file with line numbers (cat -n style). Returns up to 2000 lines. " +
+      "Use offset and limit for large files.",
+    parameters: Type.Object({
+      file_path: Type.String({ description: "Absolute path to the file to read" }),
+      offset: Type.Optional(
+        Type.Number({ description: "Line number to start from (1-based)", minimum: 1 }),
+      ),
+      limit: Type.Optional(
+        Type.Number({ description: "Number of lines to read", minimum: 1, maximum: 5000 }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = typeof params.file_path === "string" ? params.file_path : "";
+      const offset = typeof params.offset === "number" ? params.offset : 1;
+      const limit =
+        typeof params.limit === "number" ? Math.min(params.limit, 5000) : MAX_READ_LINES;
+
+      const check = guard.validate(filePath);
+      if (check.verdict !== "ALLOWED") {
+        return json({ error: check.error });
+      }
+
+      try {
+        const content = await readFile(check.resolved, "utf-8");
+        const allLines = content.split("\n");
+        const startIdx = offset - 1;
+        const sliced = allLines.slice(startIdx, startIdx + limit);
+
+        const numbered = sliced.map((line, i) => {
+          const lineNum = String(startIdx + i + 1).padStart(6, " ");
+          const truncated = line.length > 2000 ? line.slice(0, 2000) + "..." : line;
+          return `${lineNum}\t${truncated}`;
+        });
+
+        return json({
+          file: check.resolved,
+          totalLines: allLines.length,
+          showing: `${offset}-${offset + sliced.length - 1}`,
+          content: numbered.join("\n"),
+        });
+      } catch (err: any) {
+        return json({ error: `Read failed: ${err.message}` });
+      }
+    },
+  } as AnyAgentTool;
+}
+
+// ─── forge_write ─────────────────────────────────────────────────────────
+
+export function createWriteTool(guard: PathGuard): AnyAgentTool {
+  return {
+    name: "forge_write",
+    label: "Forge Write",
+    description:
+      "Create or overwrite a file. Creates parent directories if needed. " +
+      "Uses atomic write (temp file + rename) for safety. Max 10MB.",
+    parameters: Type.Object({
+      file_path: Type.String({ description: "Absolute path to the file to write" }),
+      content: Type.String({ description: "The content to write to the file" }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = typeof params.file_path === "string" ? params.file_path : "";
+      const content = typeof params.content === "string" ? params.content : "";
+
+      const check = guard.validate(filePath);
+      if (check.verdict !== "ALLOWED") {
+        return json({ error: check.error });
+      }
+
+      if (Buffer.byteLength(content, "utf-8") > MAX_FILE_SIZE) {
+        return json({ error: `Content exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit` });
+      }
+
+      try {
+        // Ensure parent directory exists
+        await mkdir(dirname(check.resolved), { recursive: true });
+
+        // Atomic write: write to temp, then rename
+        const tmpPath = check.resolved + `.tmp.${randomBytes(4).toString("hex")}`;
+        await writeFile(tmpPath, content, "utf-8");
+        await rename(tmpPath, check.resolved);
+
+        const lines = content.split("\n").length;
+        const bytes = Buffer.byteLength(content, "utf-8");
+        return json({
+          written: check.resolved,
+          lines,
+          bytes,
+          verdict: "WRITTEN",
+        });
+      } catch (err: any) {
+        return json({ error: `Write failed: ${err.message}` });
+      }
+    },
+  } as AnyAgentTool;
+}
+
+// ─── forge_edit ──────────────────────────────────────────────────────────
+
+export function createEditTool(guard: PathGuard): AnyAgentTool {
+  return {
+    name: "forge_edit",
+    label: "Forge Edit",
+    description:
+      "Edit a file by replacing an exact string match. " +
+      "Fails if old_string is not found or not unique (unless replace_all is true). " +
+      "old_string must be different from new_string.",
+    parameters: Type.Object({
+      file_path: Type.String({ description: "Absolute path to the file to edit" }),
+      old_string: Type.String({ description: "The exact text to find and replace" }),
+      new_string: Type.String({ description: "The replacement text" }),
+      replace_all: Type.Optional(
+        Type.Boolean({ description: "Replace all occurrences (default false)" }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = typeof params.file_path === "string" ? params.file_path : "";
+      const oldStr = typeof params.old_string === "string" ? params.old_string : "";
+      const newStr = typeof params.new_string === "string" ? params.new_string : "";
+      const replaceAll = params.replace_all === true;
+
+      const check = guard.validate(filePath);
+      if (check.verdict !== "ALLOWED") {
+        return json({ error: check.error });
+      }
+
+      if (!oldStr) {
+        return json({ error: "old_string cannot be empty" });
+      }
+
+      if (oldStr === newStr) {
+        return json({ error: "old_string and new_string are identical" });
+      }
+
+      try {
+        const content = await readFile(check.resolved, "utf-8");
+
+        // Count occurrences
+        let count = 0;
+        let idx = 0;
+        while (true) {
+          idx = content.indexOf(oldStr, idx);
+          if (idx === -1) break;
+          count++;
+          idx += oldStr.length;
+        }
+
+        if (count === 0) {
+          return json({ error: "old_string not found in file" });
+        }
+
+        if (count > 1 && !replaceAll) {
+          return json({
+            error: `old_string found ${count} times. Use replace_all: true to replace all, or provide more context to make it unique.`,
+          });
+        }
+
+        let result: string;
+        if (replaceAll) {
+          result = content.split(oldStr).join(newStr);
+        } else {
+          const pos = content.indexOf(oldStr);
+          result = content.slice(0, pos) + newStr + content.slice(pos + oldStr.length);
+        }
+
+        // Atomic write
+        const tmpPath = check.resolved + `.tmp.${randomBytes(4).toString("hex")}`;
+        await writeFile(tmpPath, result, "utf-8");
+        await rename(tmpPath, check.resolved);
+
+        return json({
+          edited: check.resolved,
+          replacements: replaceAll ? count : 1,
+          verdict: "EDITED",
+        });
+      } catch (err: any) {
+        return json({ error: `Edit failed: ${err.message}` });
+      }
+    },
+  } as AnyAgentTool;
+}

--- a/extensions/soundchain-forge/src/guards.ts
+++ b/extensions/soundchain-forge/src/guards.ts
@@ -1,0 +1,210 @@
+// Security guards for SoundChain Forge tools
+// Zero booleans — all validation returns typed string results.
+
+import { resolve, normalize } from "node:path";
+
+// ─── Path Guard ──────────────────────────────────────────────────────────
+
+const PATH_VERDICT = {
+  ALLOWED: "ALLOWED",
+  BLOCKED: "BLOCKED",
+  OUTSIDE: "OUTSIDE",
+} as const;
+
+type PathVerdict = (typeof PATH_VERDICT)[keyof typeof PATH_VERDICT];
+
+type PathResult = {
+  verdict: PathVerdict;
+  resolved: string;
+  error?: string;
+};
+
+const DEFAULT_ALLOWED = ["/home/ubuntu/soundchain", "/tmp"];
+const BLOCKED_PATHS = ["/etc/shadow", "/etc/passwd", "/root", "/proc", "/sys"];
+const BLOCKED_PREFIXES = [
+  "/root/",
+  "/etc/ssh/",
+  "/etc/ssl/",
+  "/home/ubuntu/.ssh/",
+  "/home/ubuntu/.aws/",
+  "/home/ubuntu/.gnupg/",
+];
+
+export class PathGuard {
+  private allowedPaths: string[];
+
+  constructor(allowedPaths?: string[]) {
+    this.allowedPaths = (allowedPaths ?? DEFAULT_ALLOWED).map((p) => resolve(p));
+  }
+
+  validate(filePath: string): PathResult {
+    const resolved = resolve(normalize(filePath));
+
+    // Block known sensitive paths
+    for (const blocked of BLOCKED_PATHS) {
+      if (resolved === blocked) {
+        return {
+          verdict: PATH_VERDICT.BLOCKED,
+          resolved,
+          error: `Access denied: ${blocked}`,
+        };
+      }
+    }
+
+    for (const prefix of BLOCKED_PREFIXES) {
+      if (resolved.startsWith(prefix)) {
+        return {
+          verdict: PATH_VERDICT.BLOCKED,
+          resolved,
+          error: `Access denied: ${prefix}*`,
+        };
+      }
+    }
+
+    // Check against allowed roots
+    const inside = this.allowedPaths.some(
+      (root) => resolved === root || resolved.startsWith(root + "/"),
+    );
+
+    if (!inside) {
+      return {
+        verdict: PATH_VERDICT.OUTSIDE,
+        resolved,
+        error: `Path outside allowed directories: ${this.allowedPaths.join(", ")}`,
+      };
+    }
+
+    return { verdict: PATH_VERDICT.ALLOWED, resolved };
+  }
+}
+
+// ─── Bash Guard ──────────────────────────────────────────────────────────
+
+const BASH_VERDICT = {
+  ALLOWED: "ALLOWED",
+  BLOCKED: "BLOCKED",
+} as const;
+
+type BashResult = {
+  verdict: (typeof BASH_VERDICT)[keyof typeof BASH_VERDICT];
+  error?: string;
+};
+
+const BASH_BLOCKLIST = [
+  "rm -rf /",
+  "rm -rf /*",
+  "sudo ",
+  "dd if=",
+  "mkfs",
+  ":(){ :|:& };:",
+  "shutdown",
+  "reboot",
+  "halt",
+  "init 0",
+  "init 6",
+  "> /dev/sda",
+  "chmod -R 777 /",
+  "chown -R",
+  "curl | sh",
+  "curl | bash",
+  "wget | sh",
+  "wget | bash",
+];
+
+export class BashGuard {
+  validate(command: string): BashResult {
+    const lower = command.toLowerCase().trim();
+
+    for (const blocked of BASH_BLOCKLIST) {
+      if (lower.includes(blocked.toLowerCase())) {
+        return {
+          verdict: BASH_VERDICT.BLOCKED,
+          error: `Blocked command pattern: ${blocked}`,
+        };
+      }
+    }
+
+    return { verdict: BASH_VERDICT.ALLOWED };
+  }
+}
+
+// ─── Git Guard ───────────────────────────────────────────────────────────
+
+const GIT_VERDICT = {
+  ALLOWED: "ALLOWED",
+  BLOCKED: "BLOCKED",
+} as const;
+
+type GitResult = {
+  verdict: (typeof GIT_VERDICT)[keyof typeof GIT_VERDICT];
+  error?: string;
+};
+
+const GIT_ALLOWED_COMMANDS = [
+  "status",
+  "diff",
+  "log",
+  "add",
+  "commit",
+  "push",
+  "pull",
+  "branch",
+  "checkout",
+  "stash",
+  "show",
+  "remote",
+  "fetch",
+  "merge",
+  "rebase",
+  "cherry-pick",
+  "tag",
+  "rev-parse",
+  "ls-files",
+  "blame",
+];
+
+const GIT_BLOCKED_FLAGS = ["--force", "-f", "--no-verify", "--hard", "--force-with-lease"];
+
+const GIT_BLOCKED_COMBOS = [
+  "push --force",
+  "push -f",
+  "reset --hard",
+  "clean -f",
+  "clean -fd",
+  "branch -D",
+];
+
+export class GitGuard {
+  validate(subcommand: string, args: string[]): GitResult {
+    const cmd = subcommand.toLowerCase();
+
+    if (!GIT_ALLOWED_COMMANDS.includes(cmd)) {
+      return {
+        verdict: GIT_VERDICT.BLOCKED,
+        error: `Git subcommand not allowed: ${cmd}. Allowed: ${GIT_ALLOWED_COMMANDS.join(", ")}`,
+      };
+    }
+
+    const full = `${cmd} ${args.join(" ")}`.toLowerCase();
+
+    for (const combo of GIT_BLOCKED_COMBOS) {
+      if (full.includes(combo)) {
+        return {
+          verdict: GIT_VERDICT.BLOCKED,
+          error: `Blocked git command: ${combo}`,
+        };
+      }
+    }
+
+    for (const flag of GIT_BLOCKED_FLAGS) {
+      if (args.some((a) => a.toLowerCase() === flag)) {
+        return {
+          verdict: GIT_VERDICT.BLOCKED,
+          error: `Blocked git flag: ${flag}`,
+        };
+      }
+    }
+
+    return { verdict: GIT_VERDICT.ALLOWED };
+  }
+}

--- a/extensions/soundchain/index.ts
+++ b/extensions/soundchain/index.ts
@@ -1,0 +1,335 @@
+import { Type } from "@sinclair/typebox";
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolFactory,
+} from "../../src/plugins/types.js";
+import { createSoundChainApi, type SoundChainApi, type SoundChainConfig } from "./src/api.js";
+import {
+  createWarRoomClient,
+  type WarRoomClient,
+  type WarRoomConfig,
+  OLLAMA_MODELS,
+  FLEET_NODES,
+  SPECIALISTS,
+} from "./src/warroom.js";
+
+function json(payload: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Music Tools (SoundChain Agent REST API)
+// ---------------------------------------------------------------------------
+
+function createSearchTool(api: SoundChainApi): AnyAgentTool {
+  return {
+    name: "soundchain_search",
+    label: "SoundChain Search",
+    description:
+      "Search for music tracks on SoundChain by title, artist, or album. Returns track info including stream URLs, play counts, and SCID codes for streaming rewards.",
+    parameters: Type.Object({
+      query: Type.String({
+        description: "Search query (title, artist, or album). Minimum 2 characters.",
+      }),
+      limit: Type.Optional(
+        Type.Number({ description: "Max results to return (1-50, default 10)." }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const query = typeof params.query === "string" ? params.query.trim() : "";
+      if (!query || query.length < 2) {
+        return json({ error: "Search query must be at least 2 characters." });
+      }
+      const limit = typeof params.limit === "number" ? Math.min(Math.max(params.limit, 1), 50) : 10;
+      return json(await api.searchTracks(query, limit));
+    },
+  } as AnyAgentTool;
+}
+
+function createRadioTool(api: SoundChainApi): AnyAgentTool {
+  return {
+    name: "soundchain_radio",
+    label: "OGUN Radio",
+    description:
+      "Get the currently playing track on OGUN Radio — a decentralized NFT radio station rotating 600+ tracks. Returns now-playing info, stream URL, SCID for rewards, and available genres.",
+    parameters: Type.Object({}),
+    async execute() {
+      return json(await api.getRadio());
+    },
+  } as AnyAgentTool;
+}
+
+function createPlayTool(api: SoundChainApi): AnyAgentTool {
+  return {
+    name: "soundchain_play",
+    label: "SoundChain Play",
+    description:
+      "Report a track play on SoundChain and trigger OGUN streaming rewards. Both the creator (70%) and listener (30%) earn OGUN tokens. Include the SCID code to activate rewards.",
+    parameters: Type.Object({
+      track_id: Type.String({ description: "Track ID from search or radio results." }),
+      track_title: Type.String({ description: "Track title for display." }),
+      scid: Type.Optional(
+        Type.String({
+          description: "SCID code (e.g. SC-POL-XXXX-XXXXXXX) to trigger OGUN rewards.",
+        }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const trackId = typeof params.track_id === "string" ? params.track_id.trim() : "";
+      const trackTitle = typeof params.track_title === "string" ? params.track_title.trim() : "";
+      if (!trackId) return json({ error: "track_id is required." });
+      if (!trackTitle) return json({ error: "track_title is required." });
+      const scid = typeof params.scid === "string" ? params.scid.trim() : undefined;
+      return json(await api.reportPlay(trackId, trackTitle, scid));
+    },
+  } as AnyAgentTool;
+}
+
+function createStatsTool(api: SoundChainApi): AnyAgentTool {
+  return {
+    name: "soundchain_stats",
+    label: "SoundChain Stats",
+    description:
+      "Get SoundChain platform statistics: total tracks, IPFS-backed audio/artwork counts, NFT counts, and estimated totals.",
+    parameters: Type.Object({}),
+    async execute() {
+      return json(await api.getPlatformStats());
+    },
+  } as AnyAgentTool;
+}
+
+function createTrendingTool(api: SoundChainApi): AnyAgentTool {
+  return {
+    name: "soundchain_trending",
+    label: "SoundChain Trending",
+    description:
+      "Get trending content on SoundChain: hot tracks by play count, trending stories/reels, and rising artists by follower count.",
+    parameters: Type.Object({}),
+    async execute() {
+      return json(await api.getTrending());
+    },
+  } as AnyAgentTool;
+}
+
+function createDiscoverTool(api: SoundChainApi): AnyAgentTool {
+  return {
+    name: "soundchain_discover",
+    label: "SoundChain Discover",
+    description:
+      "Discover random tracks, posts, and artists on SoundChain. Returns a shuffled mix of content for serendipitous exploration — great for finding new music.",
+    parameters: Type.Object({}),
+    async execute() {
+      return json(await api.getDiscover());
+    },
+  } as AnyAgentTool;
+}
+
+function createLeaderboardTool(api: SoundChainApi): AnyAgentTool {
+  return {
+    name: "soundchain_leaderboard",
+    label: "SoundChain Leaderboard",
+    description:
+      "View the SoundChain agent leaderboard: top agents ranked by plays, comments, SCID mints, and OGUN earned. Shows whitelist status and airdrop eligibility.",
+    parameters: Type.Object({}),
+    async execute() {
+      return json(await api.getLeaderboard());
+    },
+  } as AnyAgentTool;
+}
+
+// ---------------------------------------------------------------------------
+// War Room Tools (SCid Worker + Ollama + Fleet)
+// ---------------------------------------------------------------------------
+
+function createWarRoomHealthTool(wr: WarRoomClient): AnyAgentTool {
+  return {
+    name: "warroom_health",
+    label: "War Room Health",
+    description:
+      "Check the health of the entire War Room: SCid Worker (task router), Ollama (7 local LLM models), fleet nodes (mini/grater/rog), and specialist agent domains. Returns status of all systems.",
+    parameters: Type.Object({}),
+    async execute() {
+      return json(await wr.fleetHealth());
+    },
+  } as AnyAgentTool;
+}
+
+function createOllamaThinkTool(wr: WarRoomClient): AnyAgentTool {
+  return {
+    name: "warroom_think",
+    label: "War Room Think",
+    description:
+      "Quick reasoning via the War Room's Mistral model (First Responder). Fast queries, scan logs, instant patches. Routes through the SCid Worker task router on localhost:8787.",
+    parameters: Type.Object({
+      prompt: Type.String({ description: "The prompt to reason about." }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const prompt = typeof params.prompt === "string" ? params.prompt.trim() : "";
+      if (!prompt) return json({ error: "prompt is required." });
+      return json(await wr.think(prompt));
+    },
+  } as AnyAgentTool;
+}
+
+function createOllamaCodeTool(wr: WarRoomClient): AnyAgentTool {
+  return {
+    name: "warroom_code",
+    label: "War Room Code",
+    description:
+      "Code analysis via the War Room's Qwen model (Code Specialist). Understands syntax, patterns, and code structure. Routes through the SCid Worker task router.",
+    parameters: Type.Object({
+      prompt: Type.String({ description: "Code question or snippet to analyze." }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const prompt = typeof params.prompt === "string" ? params.prompt.trim() : "";
+      if (!prompt) return json({ error: "prompt is required." });
+      return json(await wr.code(prompt));
+    },
+  } as AnyAgentTool;
+}
+
+function createOllamaReasonTool(wr: WarRoomClient): AnyAgentTool {
+  return {
+    name: "warroom_reason",
+    label: "War Room Reason",
+    description:
+      "Complex reasoning via the War Room's Llama 3.1 model (Team Captain). Deep analysis, multi-step logic, review consistency. Routes through the SCid Worker task router.",
+    parameters: Type.Object({
+      prompt: Type.String({ description: "Complex question requiring deep reasoning." }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const prompt = typeof params.prompt === "string" ? params.prompt.trim() : "";
+      if (!prompt) return json({ error: "prompt is required." });
+      return json(await wr.reason(prompt));
+    },
+  } as AnyAgentTool;
+}
+
+function createOllamaDirectTool(wr: WarRoomClient): AnyAgentTool {
+  return {
+    name: "warroom_ollama",
+    label: "War Room Ollama",
+    description:
+      "Send a prompt directly to any Ollama model in the War Room. Available models: mistral (fast), qwen:7b (code), llama3.1 (reason), falcon:7b (syntax), gemma:7b (deps), mixtral:8x22b (architect, 79GB), jmorgan/grok (deep analysis, 116GB). Zero token cost — all local.",
+    parameters: Type.Object({
+      model: Type.String({
+        description:
+          "Model name (e.g. 'mistral:latest', 'llama3.1:latest', 'mixtral:8x22b', 'jmorgan/grok:latest'). Use warroom_health to see available models.",
+      }),
+      prompt: Type.String({ description: "The prompt to send to the model." }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const model = typeof params.model === "string" ? params.model.trim() : "";
+      const prompt = typeof params.prompt === "string" ? params.prompt.trim() : "";
+      if (!model) return json({ error: "model is required." });
+      if (!prompt) return json({ error: "prompt is required." });
+      return json(await wr.ollamaGenerate(model, prompt));
+    },
+  } as AnyAgentTool;
+}
+
+function createWarRoomTaskTool(wr: WarRoomClient): AnyAgentTool {
+  return {
+    name: "warroom_task",
+    label: "War Room Task",
+    description:
+      "Send a raw task to the SCid Worker (localhost:8787). The worker routes to the right Ollama model based on task prefix: 'think:', 'code:', 'reason:', 'bash:', 'read:', 'grep:', 'glob:', 'git:status', 'build', 'ping'. Returns the task result.",
+    parameters: Type.Object({
+      task: Type.String({
+        description:
+          "Task string. Examples: 'think:why is this failing?', 'bash:ls -la', 'read:src/index.ts', 'grep:TODO:src/', 'build', 'git:status', 'ping'.",
+      }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const task = typeof params.task === "string" ? params.task.trim() : "";
+      if (!task) return json({ error: "task is required." });
+      return json(await wr.scidTask(task));
+    },
+  } as AnyAgentTool;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry point
+// ---------------------------------------------------------------------------
+
+const plugin = {
+  id: "soundchain",
+  name: "SoundChain",
+  description:
+    "Search music, play tracks, earn OGUN streaming rewards, and command the War Room — 7 Ollama models + fleet nodes + SCid Worker — all from any OpenClaw channel.",
+
+  register(api: OpenClawPluginApi) {
+    const cfg = (api.pluginConfig ?? {}) as Record<string, unknown>;
+
+    // Music API config
+    const scConfig: SoundChainConfig = {
+      apiUrl: typeof cfg.apiUrl === "string" && cfg.apiUrl ? cfg.apiUrl : "https://soundchain.io",
+      agentName:
+        typeof cfg.agentName === "string" && cfg.agentName ? cfg.agentName : "openclaw-agent",
+      agentWallet:
+        typeof cfg.agentWallet === "string" && cfg.agentWallet ? cfg.agentWallet : undefined,
+    };
+
+    // War Room config
+    const wrConfig: WarRoomConfig = {
+      scidWorkerUrl:
+        typeof cfg.scidWorkerUrl === "string" && cfg.scidWorkerUrl
+          ? cfg.scidWorkerUrl
+          : "http://localhost:8787",
+      ollamaUrl:
+        typeof cfg.ollamaUrl === "string" && cfg.ollamaUrl
+          ? cfg.ollamaUrl
+          : "http://localhost:11434",
+    };
+
+    const scApi = createSoundChainApi(scConfig);
+    const wrClient = createWarRoomClient(wrConfig);
+
+    // Music tools (SoundChain Agent REST API)
+    const musicTools = [
+      createSearchTool,
+      createRadioTool,
+      createPlayTool,
+      createStatsTool,
+      createTrendingTool,
+      createDiscoverTool,
+      createLeaderboardTool,
+    ];
+
+    for (const createTool of musicTools) {
+      api.registerTool(
+        ((ctx) => {
+          if (ctx.sandboxed) return null;
+          return createTool(scApi);
+        }) as OpenClawPluginToolFactory,
+        { optional: true },
+      );
+    }
+
+    // War Room tools (SCid Worker + Ollama + Fleet)
+    const warRoomTools = [
+      createWarRoomHealthTool,
+      createOllamaThinkTool,
+      createOllamaCodeTool,
+      createOllamaReasonTool,
+      createOllamaDirectTool,
+      createWarRoomTaskTool,
+    ];
+
+    for (const createTool of warRoomTools) {
+      api.registerTool(
+        ((ctx) => {
+          if (ctx.sandboxed) return null;
+          return createTool(wrClient);
+        }) as OpenClawPluginToolFactory,
+        { optional: true },
+      );
+    }
+  },
+};
+
+export default plugin;

--- a/extensions/soundchain/index.ts
+++ b/extensions/soundchain/index.ts
@@ -5,6 +5,7 @@ import type {
   OpenClawPluginToolFactory,
 } from "../../src/plugins/types.js";
 import { createSoundChainApi, type SoundChainApi, type SoundChainConfig } from "./src/api.js";
+import { soundchainChannelPlugin } from "./src/channel.js";
 import {
   runPipeline,
   quickDiagnose,
@@ -439,6 +440,13 @@ const plugin = {
       }) as OpenClawPluginToolFactory,
       { optional: true },
     );
+
+    // --- SoundChain messaging channel ---
+    // Registers SoundChain as an OpenClaw messaging channel.
+    // Configure with channels.soundchain.apiToken in openclaw config.
+    // Enables: outbound DMs to SoundChain users, inbound message polling,
+    // and future cross-channel routing (WhatsApp/Telegram/Signal via OpenClaw).
+    api.registerChannel({ plugin: soundchainChannelPlugin });
   },
 };
 

--- a/extensions/soundchain/openclaw.plugin.json
+++ b/extensions/soundchain/openclaw.plugin.json
@@ -1,0 +1,56 @@
+{
+  "id": "soundchain",
+  "name": "SoundChain",
+  "description": "Search music, play tracks, earn OGUN streaming rewards, and command the War Room — 7 Ollama models, fleet nodes, and SCid Worker.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiUrl": {
+        "type": "string",
+        "description": "SoundChain API base URL"
+      },
+      "agentName": {
+        "type": "string",
+        "description": "Agent identity for play tracking"
+      },
+      "agentWallet": {
+        "type": "string",
+        "description": "Polygon wallet address for OGUN listener rewards"
+      },
+      "scidWorkerUrl": {
+        "type": "string",
+        "description": "SCid Worker URL (task router for Ollama models)"
+      },
+      "ollamaUrl": {
+        "type": "string",
+        "description": "Ollama API URL (local LLM inference)"
+      }
+    }
+  },
+  "uiHints": {
+    "apiUrl": {
+      "label": "API URL",
+      "placeholder": "https://soundchain.io"
+    },
+    "agentName": {
+      "label": "Agent Name",
+      "placeholder": "my-agent"
+    },
+    "agentWallet": {
+      "label": "OGUN Wallet",
+      "placeholder": "0x...",
+      "help": "Polygon wallet to receive listener rewards"
+    },
+    "scidWorkerUrl": {
+      "label": "SCid Worker URL",
+      "placeholder": "http://localhost:8787",
+      "help": "Task router for War Room Ollama models"
+    },
+    "ollamaUrl": {
+      "label": "Ollama URL",
+      "placeholder": "http://localhost:11434",
+      "help": "Local Ollama API for zero-cost LLM inference"
+    }
+  }
+}

--- a/extensions/soundchain/openclaw.plugin.json
+++ b/extensions/soundchain/openclaw.plugin.json
@@ -1,7 +1,8 @@
 {
   "id": "soundchain",
   "name": "SoundChain",
-  "description": "Search music, play tracks, earn OGUN streaming rewards, and command the War Room — 7 Ollama models, fleet nodes, and SCid Worker.",
+  "channels": ["soundchain"],
+  "description": "Search music, play tracks, earn OGUN streaming rewards, send DMs via SoundChain messaging channel, and command the War Room — 7 Ollama models, fleet nodes, and SCid Worker.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/soundchain/package.json
+++ b/extensions/soundchain/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/soundchain",
+  "version": "2026.2.18",
+  "description": "SoundChain music platform tools for OpenClaw - search, play, earn OGUN",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/soundchain/src/api.ts
+++ b/extensions/soundchain/src/api.ts
@@ -1,0 +1,74 @@
+/**
+ * SoundChain Agent API Client
+ *
+ * Wraps the SoundChain Agent REST API at /api/agent/*
+ * All read endpoints require NO authentication.
+ */
+
+export interface SoundChainConfig {
+  apiUrl: string;
+  agentName: string;
+  agentWallet?: string;
+}
+
+async function request(baseUrl: string, path: string, options?: RequestInit): Promise<unknown> {
+  const url = `${baseUrl}${path}`;
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+  return res.json();
+}
+
+export function createSoundChainApi(config: SoundChainConfig) {
+  const base = config.apiUrl.replace(/\/+$/, "");
+
+  return {
+    async searchTracks(query: string, limit = 10): Promise<unknown> {
+      return request(base, `/api/agent/tracks?q=${encodeURIComponent(query)}&limit=${limit}`);
+    },
+
+    async getRadio(): Promise<unknown> {
+      return request(base, "/api/agent/radio");
+    },
+
+    async reportPlay(trackId: string, trackTitle: string, scid?: string): Promise<unknown> {
+      return request(base, "/api/agent/play", {
+        method: "POST",
+        body: JSON.stringify({
+          track_id: trackId,
+          track_title: trackTitle,
+          agent_name: config.agentName,
+          agent_wallet: config.agentWallet,
+          scid,
+          source: "openclaw",
+        }),
+      });
+    },
+
+    async getPlayStats(): Promise<unknown> {
+      return request(base, "/api/agent/play");
+    },
+
+    async getPlatformStats(): Promise<unknown> {
+      return request(base, "/api/agent/stats");
+    },
+
+    async getTrending(): Promise<unknown> {
+      return request(base, "/api/agent/trending");
+    },
+
+    async getDiscover(): Promise<unknown> {
+      return request(base, "/api/agent/discover");
+    },
+
+    async getLeaderboard(): Promise<unknown> {
+      return request(base, "/api/agent/leaderboard");
+    },
+  };
+}
+
+export type SoundChainApi = ReturnType<typeof createSoundChainApi>;

--- a/extensions/soundchain/src/channel.ts
+++ b/extensions/soundchain/src/channel.ts
@@ -1,0 +1,259 @@
+/**
+ * SoundChain Channel Plugin — OpenClaw Messaging Channel
+ *
+ * Turns SoundChain into an OpenClaw messaging channel. This means:
+ * - OpenClaw agents can send DMs to SoundChain users via `sendText`
+ * - Inbound messages are detected via 10s polling and logged
+ * - Future: full inbound pipeline → OpenClaw agent responses
+ *
+ * Config (in openclaw config file under `channels.soundchain`):
+ *   apiUrl:       GraphQL endpoint (default: https://api.soundchain.io/graphql)
+ *   apiToken:     JWT for the bot account (required)
+ *   accountName:  Display name (default: "SoundChain")
+ *
+ * Architecture:
+ *   Pulse (PWA) ←→ SoundChain GraphQL ←→ OpenClaw Channel Plugin
+ *                                              ↕
+ *                                    OpenClaw Gateway (WebSocket)
+ *                                              ↕
+ *                                    WhatsApp / Telegram / Nostr
+ */
+
+import type { ChannelPlugin } from "openclaw/plugin-sdk";
+import { createMessagingClient, type MessagingClient } from "./messaging.js";
+
+// ---------------------------------------------------------------------------
+// Account types
+// ---------------------------------------------------------------------------
+
+const DEFAULT_ACCOUNT_ID = "default";
+const POLL_INTERVAL_MS = 10_000;
+const MAX_SEEN_IDS = 5_000;
+
+export interface ResolvedSoundChainAccount {
+  accountId: string;
+  name: string;
+  enabled: boolean;
+  configured: boolean;
+  apiUrl: string;
+  apiToken: string;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level state (mirrors Nostr channel pattern)
+// ---------------------------------------------------------------------------
+
+/** Active messaging clients per account — used by outbound.sendText */
+const activeClients = new Map<string, MessagingClient>();
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+function extractChannelConfig(cfg: Record<string, unknown>): Record<string, unknown> {
+  const channels = (cfg.channels ?? {}) as Record<string, unknown>;
+  return (channels.soundchain ?? {}) as Record<string, unknown>;
+}
+
+function resolveAccount(
+  cfg: Record<string, unknown>,
+  accountId?: string,
+): ResolvedSoundChainAccount {
+  const sc = extractChannelConfig(cfg);
+  const apiUrl =
+    typeof sc.apiUrl === "string" && sc.apiUrl ? sc.apiUrl : "https://api.soundchain.io/graphql";
+  const apiToken = typeof sc.apiToken === "string" ? sc.apiToken : "";
+  const accountName =
+    typeof sc.accountName === "string" && sc.accountName ? sc.accountName : "SoundChain";
+
+  return {
+    accountId: accountId ?? DEFAULT_ACCOUNT_ID,
+    name: accountName,
+    enabled: !!apiToken,
+    configured: !!apiToken,
+    apiUrl,
+    apiToken,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Channel plugin
+// ---------------------------------------------------------------------------
+
+export const soundchainChannelPlugin: ChannelPlugin<ResolvedSoundChainAccount> = {
+  id: "soundchain",
+
+  meta: {
+    id: "soundchain",
+    label: "SoundChain",
+    selectionLabel: "SoundChain",
+    docsPath: "/channels/soundchain",
+    docsLabel: "soundchain",
+    blurb: "DMs via SoundChain — decentralized music social network",
+    order: 200,
+  },
+
+  capabilities: {
+    chatTypes: ["direct"],
+    media: false,
+  },
+
+  reload: { configPrefixes: ["channels.soundchain"] },
+
+  // ---------------------------------------------------------------------------
+  // Config adapter — account resolution from OpenClaw config
+  // ---------------------------------------------------------------------------
+
+  config: {
+    listAccountIds: (cfg) => {
+      const sc = extractChannelConfig(cfg);
+      return sc.apiToken ? [DEFAULT_ACCOUNT_ID] : [];
+    },
+
+    resolveAccount: (cfg, accountId) => resolveAccount(cfg, accountId ?? undefined),
+
+    defaultAccountId: () => DEFAULT_ACCOUNT_ID,
+
+    isConfigured: (account) => account.configured,
+
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+    }),
+  },
+
+  // ---------------------------------------------------------------------------
+  // Messaging adapter — target normalization
+  // ---------------------------------------------------------------------------
+
+  messaging: {
+    normalizeTarget: (target) => target.trim(),
+    targetResolver: {
+      looksLikeId: (input) => {
+        const trimmed = input.trim();
+        // SoundChain profile IDs are MongoDB ObjectIds (24 hex chars)
+        return /^[0-9a-fA-F]{24}$/.test(trimmed);
+      },
+      hint: "<SoundChain profile ID (24-char hex)>",
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Outbound adapter — send DMs via SoundChain GraphQL
+  // ---------------------------------------------------------------------------
+
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 2000,
+
+    sendText: async ({ to, text, accountId }) => {
+      const aid = accountId ?? DEFAULT_ACCOUNT_ID;
+      const client = activeClients.get(aid);
+
+      if (!client) {
+        throw new Error(`SoundChain messaging client not running for account ${aid}`);
+      }
+
+      const result = await client.sendMessage(to, text ?? "");
+
+      return {
+        channel: "soundchain" as const,
+        to,
+        messageId: result.id ?? `sc-${Date.now()}`,
+      };
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Gateway adapter — lifecycle + inbound message polling
+  // ---------------------------------------------------------------------------
+
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+
+      if (!account.configured) {
+        throw new Error("SoundChain API token not configured — set channels.soundchain.apiToken");
+      }
+
+      ctx.log?.info(`[${account.accountId}] Starting SoundChain channel (${account.name})`);
+
+      // Create and store the messaging client
+      const client = createMessagingClient(account.apiUrl, account.apiToken);
+      activeClients.set(account.accountId, client);
+
+      // Track seen message IDs to avoid reprocessing
+      const seenIds = new Set<string>();
+
+      // Seed with current messages so we don't replay history
+      try {
+        const chats = await client.getChats();
+        for (const chat of chats) {
+          if (chat.lastMessage?.id) {
+            seenIds.add(chat.lastMessage.id);
+          }
+        }
+        ctx.log?.debug?.(`[${account.accountId}] Seeded ${seenIds.size} existing message IDs`);
+      } catch (err) {
+        ctx.log?.warn?.(`[${account.accountId}] Initial chat seed failed: ${err}`);
+      }
+
+      // Poll for new inbound messages
+      const interval = setInterval(async () => {
+        try {
+          const chats = await client.getChats();
+
+          for (const chat of chats) {
+            const msg = chat.lastMessage;
+            if (!msg?.id || seenIds.has(msg.id)) continue;
+
+            seenIds.add(msg.id);
+
+            // Cap seen IDs to prevent unbounded growth
+            if (seenIds.size > MAX_SEEN_IDS) {
+              const entries = Array.from(seenIds);
+              for (let i = 0; i < entries.length - MAX_SEEN_IDS; i++) {
+                seenIds.delete(entries[i]);
+              }
+            }
+
+            const sender = chat.profile?.displayName ?? chat.profile?.handle ?? "unknown";
+            const preview = msg.message?.slice(0, 80) ?? "";
+
+            ctx.log?.info(
+              `[${account.accountId}] New DM from ${sender}: ${preview}${(msg.message?.length ?? 0) > 80 ? "..." : ""}`,
+            );
+
+            // Future: forward to OpenClaw message pipeline via
+            // runtime.channel.reply.handleInboundMessage({
+            //   channel: "soundchain",
+            //   accountId: account.accountId,
+            //   senderId: chat.profile?.id,
+            //   chatType: "direct",
+            //   chatId: chat.profile?.id,
+            //   text: msg.message,
+            //   reply: async (text) => { await client.sendMessage(chat.profile!.id, text); },
+            // });
+          }
+        } catch {
+          // Polling errors are non-fatal — gateway will retry on next interval
+        }
+      }, POLL_INTERVAL_MS);
+
+      ctx.log?.info(
+        `[${account.accountId}] SoundChain channel started — polling every ${POLL_INTERVAL_MS / 1000}s`,
+      );
+
+      // Return cleanup function (called by gateway on stop)
+      return {
+        stop: () => {
+          clearInterval(interval);
+          activeClients.delete(account.accountId);
+          ctx.log?.info(`[${account.accountId}] SoundChain channel stopped`);
+        },
+      };
+    },
+  },
+};

--- a/extensions/soundchain/src/messaging.ts
+++ b/extensions/soundchain/src/messaging.ts
@@ -1,0 +1,141 @@
+/**
+ * SoundChain Messaging Client
+ *
+ * GraphQL client for SoundChain DM operations.
+ * Used by the channel plugin for outbound messaging
+ * and inbound message polling.
+ *
+ * CRITICAL: `toId` must be a PROFILE ID, not a chat ID.
+ * Using chat.id instead of chat.profile.id causes blank page crash
+ * (documented Bug #17 in CLAUDE.md).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChatMessage {
+  id: string;
+  message: string;
+  createdAt: string;
+  from?: { id: string; displayName?: string };
+  to?: { id: string; displayName?: string };
+}
+
+export interface Chat {
+  id: string;
+  profile?: {
+    id: string;
+    displayName?: string;
+    handle?: string;
+  };
+  lastMessage?: ChatMessage;
+  unreadMessageCount?: number;
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL transport
+// ---------------------------------------------------------------------------
+
+interface GraphQLResponse {
+  data?: Record<string, unknown>;
+  errors?: Array<{ message: string }>;
+}
+
+async function graphql(
+  apiUrl: string,
+  token: string,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(apiUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const json = (await res.json()) as GraphQLResponse;
+
+  if (json.errors && json.errors.length > 0) {
+    throw new Error(`SoundChain GraphQL: ${json.errors[0].message}`);
+  }
+
+  return json.data ?? {};
+}
+
+// ---------------------------------------------------------------------------
+// Queries & Mutations
+// ---------------------------------------------------------------------------
+
+const CHATS_QUERY = `
+  query Chats {
+    chats {
+      id
+      profile {
+        id
+        displayName
+        handle
+      }
+      lastMessage {
+        id
+        message
+        createdAt
+        from { id }
+      }
+      unreadMessageCount
+    }
+  }
+`;
+
+const SEND_MESSAGE_MUTATION = `
+  mutation SendMessage($toId: ID!, $message: String!) {
+    sendMessage(toId: $toId, message: $message) {
+      id
+      message
+      createdAt
+    }
+  }
+`;
+
+const UNREAD_COUNT_QUERY = `
+  query UnreadMessageCount {
+    unreadMessageCount
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+export interface MessagingClient {
+  getChats(): Promise<Chat[]>;
+  sendMessage(toProfileId: string, message: string): Promise<ChatMessage>;
+  getUnreadCount(): Promise<number>;
+}
+
+export function createMessagingClient(apiUrl: string, token: string): MessagingClient {
+  return {
+    async getChats(): Promise<Chat[]> {
+      const data = await graphql(apiUrl, token, CHATS_QUERY);
+      return (data.chats as Chat[] | undefined) ?? [];
+    },
+
+    async sendMessage(toProfileId: string, message: string): Promise<ChatMessage> {
+      const data = await graphql(apiUrl, token, SEND_MESSAGE_MUTATION, {
+        toId: toProfileId,
+        message,
+      });
+      const result = data.sendMessage as ChatMessage | undefined;
+      if (!result) throw new Error("sendMessage returned null");
+      return result;
+    },
+
+    async getUnreadCount(): Promise<number> {
+      const data = await graphql(apiUrl, token, UNREAD_COUNT_QUERY);
+      return (data.unreadMessageCount as number | undefined) ?? 0;
+    },
+  };
+}

--- a/extensions/soundchain/src/phil-jackson.ts
+++ b/extensions/soundchain/src/phil-jackson.ts
@@ -1,0 +1,343 @@
+/**
+ * Phil Jackson Triangle Pipeline — 7 Ollama Models, Zero Tokens
+ *
+ * The legendary triangle offense, adapted for code diagnostics.
+ * Each model has a role. Each role has a trigger. The pipeline
+ * chains them in sequence — syntax → deep analysis → fast fix →
+ * deps → architect → captain → backup — until the problem is solved.
+ *
+ * "The strength of the team is each individual member.
+ *  The strength of each member is the team." — Phil Jackson
+ *
+ * Team Chemistry (from agentide_optimizer.py):
+ *   falcon:7b       — Syntax Specialist (Steph Curry's shooting)
+ *   jmorgan/grok    — Deep Analyst (LeBron: sees the whole court)
+ *   mistral:latest  — First Responder (Curry: fast handles, instant patch)
+ *   gemma:7b        — Dependency Coordinator (Draymond: organizes the team)
+ *   mixtral:8x22b   — Architect (Durant: builds with long-range vision)
+ *   llama3.1        — Team Captain (Jordan: closes with dominance)
+ *   qwen:7b         — Backup (Iguodala: steps up when needed)
+ */
+
+import type { WarRoomClient } from "./warroom.js";
+
+// ---------------------------------------------------------------------------
+// Pipeline stage definitions (mirrors ORCHESTRATION_CONFIG from Python)
+// ---------------------------------------------------------------------------
+
+export interface PipelineStage {
+  name: string;
+  model: string;
+  role: string;
+  trigger: string;
+  tasks: string[];
+  output: string;
+  /** NBA analogy from team_chemistry */
+  chemistry: string;
+}
+
+export const PIPELINE_STAGES: PipelineStage[] = [
+  {
+    name: "syntax_correction",
+    model: "falcon:7b",
+    role: "Syntax Specialist",
+    trigger: "any_syntax_error",
+    tasks: [
+      "Detect and fix syntax errors (missing >, ;, unterminated regex)",
+      "Ensure JSX/TSX validity",
+    ],
+    output: "syntax_patch",
+    chemistry: "Steph Curry's shooting — precision from deep",
+  },
+  {
+    name: "logic_validation",
+    model: "jmorgan/grok:latest",
+    role: "Deep Analyst",
+    trigger: "any_type_error",
+    tasks: [
+      "Detect logic conflicts across tsconfig, next.config.js, dockerfiles",
+      "Explain error causes in human-friendly terms",
+      "Validate and update type definitions",
+    ],
+    output: "validated_fix",
+    chemistry: "LeBron — sees the whole court, validates plays",
+  },
+  {
+    name: "fast_reaction",
+    model: "mistral:latest",
+    role: "First Responder",
+    trigger: "any_build_error",
+    tasks: [
+      "Scan logs instantly",
+      "Apply quick fixes like missing imports and typos",
+      "Suggest yarn install if lockfile integrity fails",
+    ],
+    output: "quick_fix_patch",
+    chemistry: "Curry — fast handles, instant patch",
+  },
+  {
+    name: "dependency_management",
+    model: "gemma:7b",
+    role: "Dependency Coordinator",
+    trigger: "after_quick_fix_patch",
+    tasks: [
+      "Validate dependency versions in package.json and lock files",
+      "Suggest yarn/pnpm add/remove for missing or conflicting deps",
+    ],
+    output: "dependency_patch",
+    chemistry: "Draymond — organizes the team, sets the screen",
+  },
+  {
+    name: "strategic_reasoning",
+    model: "mixtral:8x22b",
+    role: "Architect",
+    trigger: "after_validated_fix",
+    tasks: [
+      "Analyze project-wide implications of fixes",
+      "Suggest architectural or config-level improvements",
+      "Future-proof corrections for CI/CD and workspace",
+    ],
+    output: "strategic_fix_plan",
+    chemistry: "Durant — builds with long-range vision",
+  },
+  {
+    name: "final_review",
+    model: "llama3.1:latest",
+    role: "Team Captain",
+    trigger: "after_strategic_fix_plan",
+    tasks: ["Review all fixes for consistency", "Ensure build success", "Make the final call"],
+    output: "final_patch",
+    chemistry: "Jordan — closes with dominance",
+  },
+  {
+    name: "fallback",
+    model: "qwen:7b",
+    role: "Backup",
+    trigger: "after_final_review_fail",
+    tasks: [
+      "Provide alternative fixes if primary pipeline fails",
+      "Fresh perspective on the problem",
+    ],
+    output: "fallback_fix",
+    chemistry: "Iguodala — steps up when it matters most",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Decision flow — routes errors to the right starting stage
+// ---------------------------------------------------------------------------
+
+export type ErrorCategory = "syntax" | "type" | "build" | "dependency" | "complex" | "unknown";
+
+export function classifyError(error: string): ErrorCategory {
+  const lower = error.toLowerCase();
+  if (
+    lower.includes("unexpected token") ||
+    lower.includes("unterminated") ||
+    lower.includes("missing >") ||
+    lower.includes("jsx") ||
+    lower.includes("parsing error")
+  ) {
+    return "syntax";
+  }
+  if (
+    lower.includes("type error") ||
+    lower.includes("does not exist on type") ||
+    lower.includes("is not assignable") ||
+    lower.includes("ts(") ||
+    lower.includes("cannot find name")
+  ) {
+    return "type";
+  }
+  if (
+    lower.includes("module not found") ||
+    lower.includes("cannot find module") ||
+    lower.includes("yarn add") ||
+    lower.includes("pnpm add") ||
+    lower.includes("peer dep") ||
+    lower.includes("version mismatch")
+  ) {
+    return "dependency";
+  }
+  if (
+    lower.includes("build") ||
+    lower.includes("compile") ||
+    lower.includes("webpack") ||
+    lower.includes("next build") ||
+    lower.includes("tsc")
+  ) {
+    return "build";
+  }
+  if (
+    lower.includes("architecture") ||
+    lower.includes("refactor") ||
+    lower.includes("circular") ||
+    lower.includes("design")
+  ) {
+    return "complex";
+  }
+  return "unknown";
+}
+
+/** Get the starting stage index for an error category */
+function getStartStage(category: ErrorCategory): number {
+  switch (category) {
+    case "syntax":
+      return 0; // Start with falcon (syntax specialist)
+    case "type":
+      return 1; // Start with grok (deep analyst)
+    case "build":
+      return 2; // Start with mistral (fast reaction)
+    case "dependency":
+      return 3; // Start with gemma (dep coordinator)
+    case "complex":
+      return 4; // Start with mixtral (architect)
+    case "unknown":
+      return 2; // Default to mistral (first responder)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline execution
+// ---------------------------------------------------------------------------
+
+export interface StageResult {
+  stage: string;
+  model: string;
+  role: string;
+  chemistry: string;
+  response: unknown;
+  durationMs: number;
+}
+
+export interface DiagnoseResult {
+  problem: string;
+  category: ErrorCategory;
+  stagesRun: StageResult[];
+  totalDurationMs: number;
+}
+
+/**
+ * Run the Phil Jackson Triangle Pipeline.
+ *
+ * Routes the problem through models in sequence based on error category.
+ * Each stage builds on the previous — like passing the ball around the
+ * triangle until someone has the open shot.
+ *
+ * @param maxStages - Max models to consult (default: all 7). Use fewer for speed.
+ */
+export async function runPipeline(
+  client: WarRoomClient,
+  problem: string,
+  maxStages = 7,
+): Promise<DiagnoseResult> {
+  const category = classifyError(problem);
+  const startIdx = getStartStage(category);
+  const totalStart = Date.now();
+
+  const stagesRun: StageResult[] = [];
+
+  // Build context that accumulates across stages
+  let context = problem;
+
+  for (let i = 0; i < maxStages && i < PIPELINE_STAGES.length; i++) {
+    const stageIdx = (startIdx + i) % PIPELINE_STAGES.length;
+    const stage = PIPELINE_STAGES[stageIdx];
+
+    const prompt = buildStagePrompt(stage, context, stagesRun);
+
+    const stageStart = Date.now();
+    let response: unknown;
+    try {
+      response = await client.ollamaGenerate(stage.model, prompt);
+    } catch (err) {
+      response = { error: `Model ${stage.model} unavailable: ${err}` };
+    }
+    const durationMs = Date.now() - stageStart;
+
+    const result: StageResult = {
+      stage: stage.name,
+      model: stage.model,
+      role: stage.role,
+      chemistry: stage.chemistry,
+      response,
+      durationMs,
+    };
+    stagesRun.push(result);
+
+    // Add this stage's output to the rolling context
+    const responseText =
+      typeof response === "object" && response !== null && "response" in response
+        ? String((response as Record<string, unknown>).response)
+        : JSON.stringify(response);
+    context += `\n\n--- ${stage.role} (${stage.model}) ---\n${responseText}`;
+  }
+
+  return {
+    problem,
+    category,
+    stagesRun,
+    totalDurationMs: Date.now() - totalStart,
+  };
+}
+
+/**
+ * Quick diagnose — only runs the most relevant model for the error type.
+ * Fast. One model. One answer. Like a fast break.
+ */
+export async function quickDiagnose(
+  client: WarRoomClient,
+  problem: string,
+): Promise<DiagnoseResult> {
+  return runPipeline(client, problem, 1);
+}
+
+/**
+ * Deep diagnose — runs all 7 models. Full triangle rotation.
+ * Takes longer but gives a 360-degree view of the problem.
+ */
+export async function deepDiagnose(
+  client: WarRoomClient,
+  problem: string,
+): Promise<DiagnoseResult> {
+  return runPipeline(client, problem, 7);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+function buildStagePrompt(
+  stage: PipelineStage,
+  context: string,
+  previousResults: StageResult[],
+): string {
+  const taskList = stage.tasks.map((t, i) => `  ${i + 1}. ${t}`).join("\n");
+
+  let prompt = `You are the ${stage.role} in the Phil Jackson Triangle Pipeline.
+Your job: ${stage.tasks[0]}
+
+PROBLEM:
+${context}
+
+YOUR TASKS:
+${taskList}
+
+`;
+
+  if (previousResults.length > 0) {
+    prompt += `PREVIOUS ANALYSIS FROM THE TEAM:\n`;
+    for (const prev of previousResults) {
+      const text =
+        typeof prev.response === "object" && prev.response !== null && "response" in prev.response
+          ? String((prev.response as Record<string, unknown>).response)
+          : JSON.stringify(prev.response);
+      prompt += `- ${prev.role} (${prev.model}): ${text.slice(0, 500)}\n`;
+    }
+    prompt += `\nBuild on their analysis. Don't repeat what they already found.\n`;
+  }
+
+  prompt += `\nBe concise and actionable. Give specific file paths, line numbers, and code fixes where possible. No fluff.`;
+
+  return prompt;
+}

--- a/extensions/soundchain/src/warroom.ts
+++ b/extensions/soundchain/src/warroom.ts
@@ -1,0 +1,243 @@
+/**
+ * War Room Client — SCid Worker + Ollama + Fleet Dispatch
+ *
+ * Bridges OpenClaw to the SoundChain War Room:
+ *   - SCid Worker (localhost:8787) — task router for bash/think/code/reason
+ *   - Ollama (localhost:11434) — 7 local LLM models, zero tokens
+ *   - Fleet nodes (mini/grater/rog) — distributed compute via SSH
+ *
+ * Phil Jackson Pipeline (7 models):
+ *   1. falcon:7b      — Syntax Specialist (Steph Curry's shooting)
+ *   2. jmorgan/grok   — Deep Analyst (LeBron: sees the whole court)
+ *   3. mistral:latest — First Responder (Curry: fast handles)
+ *   4. gemma:7b       — Dependency Coordinator (Draymond: organizes)
+ *   5. mixtral:8x22b  — Architect (Durant: long-range vision)
+ *   6. llama3.1       — Team Captain (Jordan: closes with dominance)
+ *   7. qwen:7b        — Backup (Iguodala: steps up when needed)
+ */
+
+export interface WarRoomConfig {
+  scidWorkerUrl: string;
+  ollamaUrl: string;
+}
+
+// Ollama model roster — Phil Jackson's starting five + bench
+export const OLLAMA_MODELS: Record<string, { model: string; role: string; description: string }> = {
+  fast: {
+    model: "mistral:latest",
+    role: "First Responder",
+    description: "Quick queries, scan logs, instant patches (4.4GB)",
+  },
+  code: {
+    model: "qwen:7b",
+    role: "Code Specialist",
+    description: "Code understanding, syntax analysis (4.5GB)",
+  },
+  reason: {
+    model: "llama3.1:latest",
+    role: "Team Captain",
+    description: "Complex reasoning, review consistency (4.9GB)",
+  },
+  syntax: {
+    model: "falcon:7b",
+    role: "Syntax Specialist",
+    description: "Detect and fix syntax errors, JSX/TSX validation (4.2GB)",
+  },
+  deps: {
+    model: "gemma:7b",
+    role: "Dependency Coordinator",
+    description: "Validate dependency versions, package.json analysis (5.0GB)",
+  },
+  architect: {
+    model: "mixtral:8x22b",
+    role: "Architect",
+    description: "Project-wide implications, strategic planning (79GB)",
+  },
+  deep: {
+    model: "jmorgan/grok:latest",
+    role: "Deep Analyst",
+    description: "Deep analysis, type system validation (116GB)",
+  },
+};
+
+// War Room fleet nodes
+export const FLEET_NODES = {
+  mini: { ip: "192.168.1.22", role: "Headless test runner, CI/CD" },
+  grater: { ip: "192.168.1.23", role: "Log streaming, monitoring" },
+  rog: { ip: "192.168.1.29", role: "Windows testing, 16TB storage, GPU compute" },
+} as const;
+
+// 7 Specialist subagent domains (from archived Claude agents)
+export const SPECIALISTS = {
+  "code-simplifier": {
+    focus: "Cleanup and refactoring after fixes",
+    triggers: ["debug code removal", "duplicate consolidation", "unused export cleanup"],
+  },
+  "dex-inspector": {
+    focus: "DEX swap flow debugging",
+    triggers: ["marketplace transaction", "OGUN swap", "auction flow", "staking panel"],
+  },
+  "helix-validator": {
+    focus: "MongoDB <-> Blockchain sync verification",
+    triggers: ["ownership mismatch", "balance desync", "SCid registration", "reward accumulation"],
+  },
+  "ipfs-auditor": {
+    focus: "IPFS/Pinata streaming issues",
+    triggers: ["track won't load", "CID missing", "gateway timeout", "artwork not showing"],
+  },
+  "mobile-detective": {
+    focus: "iOS/Android specific issues",
+    triggers: ["safari bug", "mobile crash", "wallet deep link", "in-app browser"],
+  },
+  "verify-app": {
+    focus: "E2E testing before PRs",
+    triggers: ["pre-merge check", "regression test", "cross-platform verify"],
+  },
+  "wallet-debugger": {
+    focus: "Wallet connection issues",
+    triggers: ["metamask won't connect", "balance shows 0", "session lost", "chain switch"],
+  },
+} as const;
+
+async function fetchJson(url: string, options?: RequestInit): Promise<unknown> {
+  const res = await fetch(url, {
+    ...options,
+    headers: { "Content-Type": "application/json", ...options?.headers },
+  });
+  return res.json();
+}
+
+export function createWarRoomClient(config: WarRoomConfig) {
+  const scid = config.scidWorkerUrl.replace(/\/+$/, "");
+  const ollama = config.ollamaUrl.replace(/\/+$/, "");
+
+  return {
+    // ---------------------------------------------------------------
+    // SCid Worker tasks (localhost:8787)
+    // ---------------------------------------------------------------
+
+    /** Send any task to SCid Worker */
+    async scidTask(task: string): Promise<unknown> {
+      return fetchJson(`${scid}/task`, {
+        method: "POST",
+        body: JSON.stringify({ task }),
+      });
+    },
+
+    /** Health check — returns status + available models */
+    async scidHealth(): Promise<unknown> {
+      return fetchJson(`${scid}/health`);
+    },
+
+    // ---------------------------------------------------------------
+    // Ollama direct API (localhost:11434)
+    // ---------------------------------------------------------------
+
+    /** Generate completion from a specific Ollama model */
+    async ollamaGenerate(model: string, prompt: string): Promise<unknown> {
+      return fetchJson(`${ollama}/api/generate`, {
+        method: "POST",
+        body: JSON.stringify({ model, prompt, stream: false }),
+      });
+    },
+
+    /** List all locally available Ollama models */
+    async ollamaList(): Promise<unknown> {
+      return fetchJson(`${ollama}/api/tags`);
+    },
+
+    // ---------------------------------------------------------------
+    // Convenience wrappers matching SCid Worker task routing
+    // ---------------------------------------------------------------
+
+    /** Quick think (mistral) */
+    async think(prompt: string): Promise<unknown> {
+      return this.scidTask(`think:${prompt}`);
+    },
+
+    /** Code analysis (qwen) */
+    async code(prompt: string): Promise<unknown> {
+      return this.scidTask(`code:${prompt}`);
+    },
+
+    /** Complex reasoning (llama3.1) */
+    async reason(prompt: string): Promise<unknown> {
+      return this.scidTask(`reason:${prompt}`);
+    },
+
+    /** Run bash command on Fleet Commander */
+    async bash(cmd: string): Promise<unknown> {
+      return this.scidTask(`bash:${cmd}`);
+    },
+
+    /** Run yarn build */
+    async build(): Promise<unknown> {
+      return this.scidTask("build");
+    },
+
+    /** Git status */
+    async gitStatus(): Promise<unknown> {
+      return this.scidTask("git:status");
+    },
+
+    /** Read a file */
+    async readFile(path: string): Promise<unknown> {
+      return this.scidTask(`read:${path}`);
+    },
+
+    /** Grep search */
+    async grep(pattern: string, path?: string): Promise<unknown> {
+      return this.scidTask(path ? `grep:${pattern}:${path}` : `grep:${pattern}`);
+    },
+
+    /** Glob find files */
+    async glob(pattern: string, path?: string): Promise<unknown> {
+      return this.scidTask(path ? `glob:${pattern}:${path}` : `glob:${pattern}`);
+    },
+
+    /** Ping SCid Worker */
+    async ping(): Promise<unknown> {
+      return this.scidTask("ping");
+    },
+
+    // ---------------------------------------------------------------
+    // War Room fleet health
+    // ---------------------------------------------------------------
+
+    /** Check all War Room nodes + SCid Worker + Ollama */
+    async fleetHealth(): Promise<unknown> {
+      const results: Record<string, unknown> = {
+        fleet_commander: { status: "active", role: "Strategic command, Claude Code" },
+      };
+
+      // SCid Worker
+      try {
+        results.scid_worker = await this.scidHealth();
+      } catch {
+        results.scid_worker = { status: "offline", url: scid };
+      }
+
+      // Ollama
+      try {
+        const tags = (await this.ollamaList()) as { models?: unknown[] };
+        results.ollama = {
+          status: "online",
+          models_loaded: Array.isArray(tags?.models) ? tags.models.length : 0,
+          url: ollama,
+        };
+      } catch {
+        results.ollama = { status: "offline", url: ollama };
+      }
+
+      // Fleet nodes (informational — SSH check would need subprocess)
+      results.nodes = FLEET_NODES;
+
+      // Specialist domains available
+      results.specialists = Object.keys(SPECIALISTS);
+
+      return results;
+    },
+  };
+}
+
+export type WarRoomClient = ReturnType<typeof createWarRoomClient>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,16 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
+  extensions/agent-eye:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/bluebubbles:
     devDependencies:
       openclaw:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,16 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/soundchain:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/telegram:
     devDependencies:
       openclaw:
@@ -6912,7 +6922,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6928,7 +6938,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7132,7 +7142,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8079,7 +8089,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8125,7 +8135,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -9013,14 +9023,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9599,8 +9601,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- **SoundChain extension** (`extensions/soundchain/`) — 13 tools wrapping the SoundChain music platform API (search, play, trending, discover, leaderboard) + War Room fleet management + Phil Jackson Triangle diagnostic pipeline (7-model Ollama chain for automated bug diagnosis)
- **Agent Eye extension** (`extensions/agent-eye/`) — Passive browser bug catcher. Content script captures user actions (clicks, scrolls, inputs, navigation) and auto-captures errors (JS errors, unhandled rejections, console.error, failed network requests) with full action timelines. 3-layer architecture: content script → Chrome background.js relay → OpenClaw HTTP route → in-memory BugStore. Exposes `agent_eye_bugs`, `agent_eye_status`, `agent_eye_clear` tools + `/eye` command
- **Chrome extension updates** — Added `scripting` permission, `<all_urls>` host permission, and Agent Eye background logic (programmatic content script injection, typed enum state management)
- **Zero booleans in Agent Eye** — All state uses typed string enums (`EYE_MODE`, `BUG_SEVERITY`, `TRIGGER_KIND`, `ACTION_KIND`, `REPORT_VERDICT`) with explicit `===` equality checks. No truthy/falsy patterns

## Test plan
- [ ] `pnpm install` discovers both new workspace packages
- [ ] `tsc --noEmit` compiles clean (verified locally)
- [ ] Load updated Chrome extension in `chrome://extensions`
- [ ] Visit any page, trigger `console.error('test')` in devtools
- [ ] `/eye watch` activates capture, `/eye bugs` shows captured bug with action timeline
- [ ] `agent_eye_bugs` tool returns bugs to LLM for diagnosis
- [ ] `grep -r 'true\|false' extensions/agent-eye/` returns only framework API params (no state booleans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new extensions: **SoundChain** (music platform API + War Room fleet management + Phil Jackson Triangle diagnostic pipeline) and **Agent Eye** (passive browser bug catcher with Chrome content script injection). Also updates the Chrome extension manifest with `scripting` permission and `<all_urls>` host permission.

- **Critical**: Agent Eye's `ctx.sandboxed` check in `extensions/agent-eye/index.ts:397` is inverted — tools are enabled only when `sandboxed === undefined` and disabled when `sandboxed === false`, which is opposite to every other extension in the repo. The tools will not be available in the normal non-sandboxed context.
- **Critical**: Content script re-injection on `tabs.onUpdated` (`background.js:549`) stacks duplicate event listeners and monkey-patches (`console.error`, `window.fetch`, `window.onerror`) with each navigation, causing duplicate bug reports and compounding wrapper chains.
- Both extensions use `Type.Union([Type.Literal(...)])` for tool parameter schemas, which compiles to `anyOf` — the repo explicitly provides `stringEnum`/`optionalStringEnum` helpers to avoid this pattern, as some providers reject `anyOf` schemas.
- The `request()` and `fetchJson()` helpers in `extensions/soundchain/src/api.ts` and `extensions/soundchain/src/warroom.ts` do not check `res.ok` before calling `res.json()`, which will throw on non-JSON error responses.
- `<all_urls>` host permission in the Chrome manifest is a significant scope increase from the previous localhost-only permissions.

<h3>Confidence Score: 2/5</h3>

- Two logic bugs (inverted sandboxed check, content script re-injection stacking) need to be fixed before merging.
- Score of 2 reflects two confirmed logic bugs that would cause runtime misbehavior: (1) Agent Eye tools will not register in the normal non-sandboxed context due to an inverted condition, and (2) content script re-injection on navigation will cause duplicate event listeners and compounding monkey-patches. Additionally, Type.Union usage violates documented repo conventions.
- `extensions/agent-eye/index.ts` (inverted sandboxed check), `assets/chrome-extension/background.js` and `assets/chrome-extension/content-script.js` (re-injection stacking bug)

<sub>Last reviewed commit: ff525cb</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->