### PR TITLE
feat(telegram): callback direct mode with dedupe, button state, and tap intercept

### DIFF
--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -257,7 +257,6 @@ export async function resolveModelsCommandReply(params: {
     const buttons = buildModelsKeyboard({
       provider,
       models,
-      currentModel: params.currentModel,
       currentPage: safePage,
       totalPages,
       pageSize: telegramPageSize,

--- a/src/config/config.telegram-callback.test.ts
+++ b/src/config/config.telegram-callback.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("telegram callback schema", () => {
+  it("accepts callback direct mode configuration", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          callback: {
+            enabled: true,
+            tapIntercept: true,
+            forwardUnhandled: false,
+            dedupeWindowMs: 3000,
+            buttonStateMode: "mark-clicked",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+    if (!res.success) {
+      return;
+    }
+
+    expect(res.data.channels?.telegram?.callback).toEqual({
+      enabled: true,
+      tapIntercept: true,
+      forwardUnhandled: false,
+      dedupeWindowMs: 3000,
+      buttonStateMode: "mark-clicked",
+    });
+  });
+
+  it("rejects invalid callback button state mode", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          callback: {
+            buttonStateMode: "invalid",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+  });
+
+  it("accepts buttonStateMode off", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          callback: {
+            enabled: true,
+            buttonStateMode: "off",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+    if (!res.success) {
+      return;
+    }
+    expect(res.data.channels?.telegram?.callback?.buttonStateMode).toBe("off");
+  });
+
+  it("accepts buttonStateMode disable-clicked", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          callback: {
+            enabled: true,
+            buttonStateMode: "disable-clicked",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+    if (!res.success) {
+      return;
+    }
+    expect(res.data.channels?.telegram?.callback?.buttonStateMode).toBe("disable-clicked");
+  });
+
+  it("rejects forwardUnhandled=false without enabled=true", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          callback: {
+            forwardUnhandled: false,
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+    if (res.success) {
+      return;
+    }
+    const messages = res.error.issues.map((i) => i.message);
+    expect(messages).toContain(
+      "callback.forwardUnhandled=false requires callback.enabled=true to take effect",
+    );
+  });
+
+  it("accepts forwardUnhandled=false with enabled=true", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          callback: {
+            enabled: true,
+            forwardUnhandled: false,
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+});

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -29,6 +29,53 @@ export type TelegramNetworkConfig = {
 
 export type TelegramInlineButtonsScope = "off" | "dm" | "group" | "all" | "allowlist";
 
+export type TelegramCallbackButtonStateMode = "off" | "mark-clicked" | "disable-clicked";
+
+export type TelegramCallbackConfig = {
+  /**
+   * Enable callback-direct mode for inline buttons.
+   *
+   * When disabled (default), callbacks continue through the legacy processing path.
+   */
+  enabled?: boolean;
+  /**
+   * Enable top-layer callback tap intercept middleware.
+   *
+   * When enabled, raw callback_query updates are observed and immediately acknowledged
+   * before downstream textification/handlers run. Default: false.
+   */
+  tapIntercept?: boolean;
+  /**
+   * If false, unhandled callbacks are acknowledged and stopped without entering message processing.
+   * Default: true.
+   *
+   * Requires `callback.enabled=true` to take effect.
+   */
+  forwardUnhandled?: boolean;
+  /**
+   * Deduplicate repeated callback clicks within this time window (ms).
+   * Default: 8000.
+   */
+  dedupeWindowMs?: number;
+  /**
+   * Optional callback acknowledgement text shown as toast.
+   * Empty/undefined keeps Telegram default behavior.
+   */
+  ackText?: string;
+  /**
+   * Whether callback acknowledgement should be an alert popup.
+   * Default: false.
+   */
+  ackAlert?: boolean;
+  /**
+   * Optional post-click button state edit mode.
+   * - off: do not edit buttons
+   * - mark-clicked: prefix clicked button with "✅ "
+   * - disable-clicked: prefix clicked button and replace callback_data with noop marker
+   */
+  buttonStateMode?: TelegramCallbackButtonStateMode;
+};
+
 export type TelegramCapabilitiesConfig =
   | string[]
   | {
@@ -135,6 +182,8 @@ export type TelegramAccountConfig = {
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
+  /** Inline callback handling behavior (dedupe, direct mode, optional button state edits). */
+  callback?: TelegramCallbackConfig;
   /**
    * Per-channel outbound response prefix override.
    *

--- a/src/telegram/bot.create-telegram-bot.test-harness.ts
+++ b/src/telegram/bot.create-telegram-bot.test-harness.ts
@@ -111,6 +111,7 @@ export const botCtorSpy: AnyMock = vi.fn();
 export const answerCallbackQuerySpy: AnyAsyncMock = vi.fn(async () => undefined);
 export const sendChatActionSpy: AnyMock = vi.fn();
 export const editMessageTextSpy: AnyAsyncMock = vi.fn(async () => ({ message_id: 88 }));
+export const editMessageReplyMarkupSpy: AnyAsyncMock = vi.fn(async () => ({ message_id: 88 }));
 export const setMessageReactionSpy: AnyAsyncMock = vi.fn(async () => undefined);
 export const setMyCommandsSpy: AnyAsyncMock = vi.fn(async () => undefined);
 export const getMeSpy: AnyAsyncMock = vi.fn(async () => ({
@@ -126,6 +127,7 @@ type ApiStub = {
   answerCallbackQuery: typeof answerCallbackQuerySpy;
   sendChatAction: typeof sendChatActionSpy;
   editMessageText: typeof editMessageTextSpy;
+  editMessageReplyMarkup: typeof editMessageReplyMarkupSpy;
   setMessageReaction: typeof setMessageReactionSpy;
   setMyCommands: typeof setMyCommandsSpy;
   getMe: typeof getMeSpy;
@@ -139,6 +141,7 @@ const apiStub: ApiStub = {
   answerCallbackQuery: answerCallbackQuerySpy,
   sendChatAction: sendChatActionSpy,
   editMessageText: editMessageTextSpy,
+  editMessageReplyMarkup: editMessageReplyMarkupSpy,
   setMessageReaction: setMessageReactionSpy,
   setMyCommands: setMyCommandsSpy,
   getMe: getMeSpy,
@@ -306,6 +309,8 @@ beforeEach(() => {
   });
   editMessageTextSpy.mockReset();
   editMessageTextSpy.mockResolvedValue({ message_id: 88 });
+  editMessageReplyMarkupSpy.mockReset();
+  editMessageReplyMarkupSpy.mockResolvedValue({ message_id: 88 });
   enqueueSystemEventSpy.mockReset();
   wasSentByBot.mockReset();
   wasSentByBot.mockReturnValue(false);

--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -134,15 +134,14 @@ describe("buildModelsKeyboard", () => {
     expect(result[2]?.[0]?.text).toBe("<< Back");
   });
 
-  it("marks current model with checkmark", () => {
+  it("does not add checkmark to current model", () => {
     const result = buildModelsKeyboard({
       provider: "anthropic",
       models: ["claude-sonnet-4", "claude-opus-4"],
-      currentModel: "anthropic/claude-sonnet-4",
       currentPage: 1,
       totalPages: 1,
     });
-    expect(result[0]?.[0]?.text).toBe("claude-sonnet-4 ✓");
+    expect(result[0]?.[0]?.text).toBe("claude-sonnet-4");
     expect(result[1]?.[0]?.text).toBe("claude-opus-4");
   });
 

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -24,7 +24,6 @@ export type ProviderInfo = {
 export type ModelsKeyboardParams = {
   provider: string;
   models: string[];
-  currentModel?: string;
   currentPage: number;
   totalPages: number;
   pageSize?: number;
@@ -113,7 +112,7 @@ export function buildProviderKeyboard(providers: ProviderInfo[]): ButtonRow[] {
  * Build model list keyboard with pagination and back button.
  */
 export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
-  const { provider, models, currentModel, currentPage, totalPages } = params;
+  const { provider, models, currentPage, totalPages } = params;
   const pageSize = params.pageSize ?? MODELS_PAGE_SIZE;
 
   if (models.length === 0) {
@@ -128,9 +127,6 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const pageModels = models.slice(startIndex, endIndex);
 
   // Model buttons - one per row
-  const currentModelId = currentModel?.includes("/")
-    ? currentModel.split("/").slice(1).join("/")
-    : currentModel;
 
   for (const model of pageModels) {
     const callbackData = `mdl_sel_${provider}/${model}`;
@@ -139,9 +135,8 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
       continue;
     }
 
-    const isCurrentModel = model === currentModelId;
     const displayText = truncateModelId(model, 38);
-    const text = isCurrentModel ? `${displayText} ✓` : displayText;
+    const text = displayText;
 
     rows.push([
       {


### PR DESCRIPTION
## Summary

Adds a new `callback` config block under `channels.telegram` for fine-grained control over Telegram callback query handling.

### New features

- **`callback.enabled`** — enables direct callback mode (callback queries handled natively instead of being forwarded as synthetic messages)
- **`callback.tapIntercept`** — middleware-level early intercept with ack support (`ackText`, `ackAlert`)
- **`callback.forwardUnhandled`** — controls whether unmatched callbacks fall through to message processing
- **`callback.dedupeWindowMs`** — deduplicates rapid repeated clicks within a time window (capped at 60s)
- **`callback.buttonStateMode`** — visual feedback after click: `off` / `mark-clicked` (✅) / `disable-clicked` (sentinel)

### Fixes included

- **C1**: Fixed double `answerCallbackQuery` when `tapIntercept=true` + `ackText` configured — ack now happens in the middleware with the correct params, handler skips if already answered
- **M1**: `forwardUnhandled=false` now has schema validation requiring `enabled=true`; JSDoc clarified
- **N2**: Incoming clicks on `disable-clicked` buttons (sentinel prefix `ocb:clicked`) are detected and early-returned
- **R2**: `dedupeWindowMs` capped at 60,000ms to prevent memory accumulation

### Test coverage

- tap intercept + ackText: verifies single answerCallbackQuery call with correct params
- disable-sentinel detection: verifies early return without processMessage
- All `buttonStateMode` enum values tested (`off`, `mark-clicked`, `disable-clicked`)
- Regression: legacy mode (`enabled=false`) still forwards callbacks as messages

### Config example

```json5
{
  channels: {
    telegram: {
      callback: {
        enabled: true,
        tapIntercept: true,
        ackText: "Got it!",
        forwardUnhandled: false,
        dedupeWindowMs: 3000,
        buttonStateMode: "disable-clicked"
      }
    }
  }
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `callback` config block under `channels.telegram` for fine-grained control over Telegram callback query handling, including direct callback mode, tap intercept middleware, dedupe, and post-click button state editing.

- **Config & Schema**: New `TelegramCallbackConfig` type and Zod schema with validation (e.g., `forwardUnhandled=false` requires `enabled=true`). Well-structured with proper `strict()` and `superRefine`.
- **Tap Intercept**: Middleware in `bot.ts` answers callback queries early to prevent Telegram retries; the downstream handler skips its own ack when tap intercept is on. However, the middleware doesn't distinguish disabled sentinel buttons from regular callbacks, so `ackText` is shown for already-disabled buttons.
- **Dedupe**: `callbackDedupeCache` with lazy cleanup on each callback and 60s cap. Correctly gated behind `callbackDirectEnabled`.
- **Button State Mode**: `buildEditedCallbackKeyboard` treats `mark-clicked` and `disable-clicked` identically (both replace callback_data with sentinel and keep only the clicked button). The `mode` parameter is `void`-ed. The JSDoc documents different behaviors for each mode that don't match the implementation.
- **Model buttons**: Removes checkmark (✓) from current model display — `currentModel` is no longer used in `buildModelsKeyboard` but remains in the `ModelsKeyboardParams` type and is still passed at the call site (dead parameter).
- **Tests**: Comprehensive coverage for new features including tap intercept + ackText, sentinel detection, all `buttonStateMode` values, dedupe, and legacy mode regression.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge but has a UX-level logic issue with tap intercept acking disabled buttons, and a config behavior mismatch between mark-clicked and disable-clicked modes.
- The PR is well-structured with good test coverage and clear config validation. Score of 3 reflects two issues: (1) the tap intercept middleware doesn't filter out sentinel/disabled callbacks, causing ackText to show on disabled buttons when both features are combined, and (2) the mark-clicked vs disable-clicked config options are documented as distinct behaviors but implemented identically, which could confuse users.
- `src/telegram/bot.ts` (tap intercept middleware doesn't filter sentinel callbacks), `src/telegram/bot-handlers.ts` (buildEditedCallbackKeyboard ignores mode parameter)

<sub>Last reviewed commit: f980f11</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->