### PR TITLE
fix(plugins): bind logger methods to preserve this context (#19988)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins: bind logger methods in `normalizeLogger` to preserve `this` context for loggers like tslog that rely on internal state. (#19988)
 - Telegram/Cron/Heartbeat: honor explicit Telegram topic targets in cron and heartbeat delivery (`<chatId>:topic:<threadId>`) so scheduled sends land in the configured topic instead of the last active thread. (#19367) Thanks @Lukavyi.
 - Commands/Doctor: avoid rewriting invalid configs with new `gateway.auth.token` defaults during repair and only write when real config changes are detected, preventing accidental token duplication and backup churn.
 - Sandbox/Registry: serialize container and browser registry writes with shared file locks and atomic replacement to prevent lost updates and delete rollback races from desyncing `sandbox list`, `prune`, and `recreate --all`. Thanks @kexinoh.

--- a/src/plugins/logger-this-binding.test.ts
+++ b/src/plugins/logger-this-binding.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression test for #19988: normalizeLogger destroys tslog this-binding
+ *
+ * Ensures that logger methods passed to plugins preserve their `this` binding,
+ * which is required by loggers like tslog that access internal state via `this`.
+ */
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { Logger } from "tslog";
+import { loadOpenClawPlugins } from "./loader.js";
+import type { PluginLogger } from "./types.js";
+
+const fixtureRoot = path.join(os.tmpdir(), `openclaw-logger-test-${randomUUID()}`);
+let tempDirIndex = 0;
+const prevBundledDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+const EMPTY_PLUGIN_SCHEMA = { type: "object", additionalProperties: false, properties: {} };
+
+function makeTempDir() {
+  const dir = path.join(fixtureRoot, `case-${tempDirIndex++}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writePlugin(params: { id: string; body: string; dir?: string; filename?: string }) {
+  const dir = params.dir ?? makeTempDir();
+  const filename = params.filename ?? `${params.id}.js`;
+  const file = path.join(dir, filename);
+  fs.writeFileSync(file, params.body, "utf-8");
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({ id: params.id, configSchema: EMPTY_PLUGIN_SCHEMA }, null, 2),
+    "utf-8",
+  );
+  return { dir, file, id: params.id };
+}
+
+afterEach(() => {
+  if (prevBundledDir === undefined) {
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  } else {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = prevBundledDir;
+  }
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup failures
+  }
+});
+
+describe("normalizeLogger this-binding (#19988)", () => {
+  it("preserves this-binding when logger methods are called via api.logger", () => {
+    // Create a logger class that relies on `this` (like tslog)
+    class ThisDependentLogger implements PluginLogger {
+      private prefix = "[test-plugin]";
+      public callCount = 0;
+
+      info(_message: string): void {
+        // tslog and similar loggers access internal state via `this`
+        if (this === undefined || this.prefix === undefined) {
+          throw new Error("BUG CONFIRMED: `this` is undefined - binding lost");
+        }
+        this.callCount++;
+      }
+
+      warn(_message: string): void {
+        if (this === undefined || this.prefix === undefined) {
+          throw new Error("BUG CONFIRMED: `this` is undefined - binding lost");
+        }
+        this.callCount++;
+      }
+
+      error(_message: string): void {
+        if (this === undefined || this.prefix === undefined) {
+          throw new Error("BUG CONFIRMED: `this` is undefined - binding lost");
+        }
+        this.callCount++;
+      }
+
+      debug(_message: string): void {
+        if (this === undefined || this.prefix === undefined) {
+          throw new Error("BUG CONFIRMED: `this` is undefined - binding lost");
+        }
+        this.callCount++;
+      }
+    }
+
+    const thisDependentLogger = new ThisDependentLogger();
+
+    // This plugin will call api.logger methods
+    const plugin = writePlugin({
+      id: "test-logger-binding",
+      body: `
+        globalThis.__loggerBindingTestResult = { passed: true, error: null };
+
+        export default {
+          id: "test-logger-binding",
+          register(api) {
+            try {
+              api.logger.info("test info");
+              api.logger.warn("test warn");
+              api.logger.error("test error");
+              if (api.logger.debug) {
+                api.logger.debug("test debug");
+              }
+            } catch (err) {
+              globalThis.__loggerBindingTestResult = {
+                passed: false,
+                error: err.message
+              };
+            }
+          }
+        };
+      `,
+    });
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = plugin.dir;
+
+    // Pass our this-dependent logger to loadOpenClawPlugins
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      logger: thisDependentLogger,
+      config: {
+        plugins: {
+          allow: ["test-logger-binding"],
+          entries: {
+            "test-logger-binding": { enabled: true },
+          },
+        },
+      },
+    });
+
+    const loaded = registry.plugins.find((entry) => entry.id === "test-logger-binding");
+    expect(loaded?.status).toBe("loaded");
+
+    // Check if the logger calls succeeded
+    const result = (globalThis as Record<string, unknown>).__loggerBindingTestResult as {
+      passed: boolean;
+      error: string | null;
+    };
+
+    expect(result.passed).toBe(true);
+  });
+
+  it("preserves this-binding with real tslog logger", () => {
+    // Create a real tslog logger instance - this is what users actually use
+    // tslog methods rely on `this` to access internal state
+    const tslogLogger = new Logger({ type: "hidden" });
+
+    const plugin = writePlugin({
+      id: "test-tslog-binding",
+      body: `
+        globalThis.__tslogBindingTestResult = { passed: true, error: null };
+
+        export default {
+          id: "test-tslog-binding",
+          register(api) {
+            try {
+              api.logger.info("test info from tslog");
+              api.logger.warn("test warn from tslog");
+              api.logger.error("test error from tslog");
+              if (api.logger.debug) {
+                api.logger.debug("test debug from tslog");
+              }
+            } catch (err) {
+              globalThis.__tslogBindingTestResult = {
+                passed: false,
+                error: err.message
+              };
+            }
+          }
+        };
+      `,
+    });
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = plugin.dir;
+
+    // Pass the tslog logger directly - normalizeLogger should preserve the binding
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      logger: tslogLogger,
+      config: {
+        plugins: {
+          allow: ["test-tslog-binding"],
+          entries: {
+            "test-tslog-binding": { enabled: true },
+          },
+        },
+      },
+    });
+
+    const loaded = registry.plugins.find((entry) => entry.id === "test-tslog-binding");
+    expect(loaded?.status).toBe("loaded");
+
+    const result = (globalThis as Record<string, unknown>).__tslogBindingTestResult as {
+      passed: boolean;
+      error: string | null;
+    };
+
+    expect(result.passed).toBe(true);
+  });
+});

--- a/src/plugins/logger-this-binding.test.ts
+++ b/src/plugins/logger-this-binding.test.ts
@@ -8,8 +8,8 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { Logger } from "tslog";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { loadOpenClawPlugins } from "./loader.js";
 import type { PluginLogger } from "./types.js";
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -463,10 +463,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
   };
 
   const normalizeLogger = (logger: PluginLogger): PluginLogger => ({
-    info: logger.info,
-    warn: logger.warn,
-    error: logger.error,
-    debug: logger.debug,
+    info: logger.info.bind(logger),
+    warn: logger.warn.bind(logger),
+    error: logger.error.bind(logger),
+    debug: logger.debug?.bind(logger),
   });
 
   const createApi = (


### PR DESCRIPTION
## Summary

- **Bug**: Plugin SDK `normalizeLogger` destroys tslog `this`-binding
- **Root cause**: `normalizeLogger` in `src/plugins/registry.ts:465-470` destructures logger methods without `.bind()`, losing the `this` context
- **Fix**: Add `.bind(logger)` to all logger method assignments

Fixes #19988

## Problem

When `normalizeLogger` creates a new logger object by destructuring methods:

```typescript
const normalizeLogger = (logger: PluginLogger): PluginLogger => ({
  info: logger.info,    // ← loses `this`
  warn: logger.warn,
  error: logger.error,
  debug: logger.debug,
});
```

The `this` binding is lost. Loggers like tslog that rely on internal state via `this` will throw or silently fail when `api.logger.*` is called inside plugins.

**Before fix (on main branch):**
```
Input:  api.logger.info("test")  // with tslog logger
Output: TypeError: Cannot read properties of undefined
```

## Changes

- `src/plugins/registry.ts` — Add `.bind(logger)` to preserve `this` context
- `src/plugins/logger-this-binding.test.ts` — Add regression tests

**After fix:**
```
Input:  api.logger.info("test")
Output: (logs correctly)
```

## Test plan

- [x] New test: simulated `this`-dependent logger class
- [x] New test: real tslog `Logger` instance (`new Logger({ type: "hidden" })`)
- [x] Both tests fail on main, pass on fix branch
- [x] All 108 existing plugin tests pass
- [x] Lint passes

## Effect on User Experience

**Before:** Plugin authors using tslog see `api.logger.*` calls fail. They must implement workarounds (storing logger object, stderr fallback).

**After:** `api.logger.*` works correctly with any logger implementation including tslog.