### PR TITLE
macOS: harden cron editor updates and compatibility

### DIFF
--- a/apps/macos/Sources/OpenClaw/CronJobsStore.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobsStore.swift
@@ -133,6 +133,9 @@ final class CronJobsStore {
         payload: [String: AnyCodable]) async throws
     {
         if let id {
+            if payload.isEmpty {
+                return
+            }
             try await GatewayConnection.shared.cronUpdate(jobId: id, patch: payload)
         } else {
             try await GatewayConnection.shared.cronAdd(payload: payload)

--- a/apps/macos/Tests/OpenClawIPCTests/CronModelsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronModelsTests.swift
@@ -138,4 +138,52 @@ struct CronModelsTests {
         #expect(job.nextRunDate == Date(timeIntervalSince1970: 1_700_000_000))
         #expect(job.lastRunDate == Date(timeIntervalSince1970: 1_700_000_050))
     }
+
+    @Test func enumsDecodeUnknownRawValues() throws {
+        let json = """
+        {
+          "id":"job-unknown",
+          "agentId":null,
+          "name":"Unknown job",
+          "description":null,
+          "enabled":true,
+          "deleteAfterRun":null,
+          "createdAtMs":0,
+          "updatedAtMs":0,
+          "schedule":{"kind":"at","at":"2026-02-03T18:00:00Z"},
+          "sessionTarget":"session:abc123",
+          "wakeMode":"trigger-heartbeat",
+          "payload":{"kind":"systemEvent","text":"ping"},
+          "delivery":{"mode":"custom-mode","to":"dest"},
+          "state":{}
+        }
+        """
+        let job = try JSONDecoder().decode(CronJob.self, from: Data(json.utf8))
+        #expect(job.sessionTarget.rawValue == "session:abc123")
+        #expect(job.wakeMode.rawValue == "trigger-heartbeat")
+        #expect(job.delivery?.mode.rawValue == "custom-mode")
+    }
+
+    @Test func cronJobDecodesPostRunFallbackAsWakeMode() throws {
+        let json = """
+        {
+          "id":"job-post-run",
+          "agentId":null,
+          "name":"Post run job",
+          "description":null,
+          "enabled":true,
+          "deleteAfterRun":null,
+          "createdAtMs":0,
+          "updatedAtMs":0,
+          "schedule":{"kind":"at","at":"2026-02-03T18:00:00Z"},
+          "sessionTarget":"isolated",
+          "postRun":"trigger-heartbeat",
+          "payload":{"kind":"agentTurn","message":"ping"},
+          "delivery":{"mode":"none"},
+          "state":{}
+        }
+        """
+        let job = try JSONDecoder().decode(CronJob.self, from: Data(json.utf8))
+        #expect(job.wakeMode == .nextHeartbeat)
+    }
 }


### PR DESCRIPTION
## Summary
- harden macOS cron model decoding to preserve unknown/future enum values for `sessionTarget`, `wakeMode`, and `delivery.mode`
- make cron editor updates non-lossy by sending diff-only `cron.update` patches instead of full overwrites
- add compatibility fallback for `postRun`-only jobs so wake behavior still decodes safely
- extend editor UI to handle webhook delivery and preserve unknown/raw delivery modes
- add tests covering non-clobbering edit behavior and unknown/postRun decode compatibility

## Why
Current edit flow can unintentionally clobber fields introduced by other cron PRs (for example webhook/raw delivery, custom session targets, or postRun-based jobs). This change makes edit operations resilient and merge-friendly.

## Testing
- `swift test --filter Cron` (from `apps/macos`) was attempted
- blocked in this environment by upstream dependency macro plugin resolution in `swiftui-math` (`SwiftUIMacros` / `PreviewsMacros` not found)
- added targeted unit coverage in:
  - `apps/macos/Tests/OpenClawIPCTests/CronJobEditorSmokeTests.swift`
  - `apps/macos/Tests/OpenClawIPCTests/CronModelsTests.swift`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens macOS cron job editing to be non-lossy and forward-compatible. The three main changes are:

- **Enum hardening**: `CronSessionTarget`, `CronWakeMode`, and `CronDeliveryMode` are refactored from raw-value enums to manual `Codable` types with `.unknown(String)` catch-all cases, preserving unrecognized values during decode/re-encode round-trips.
- **Diff-only patches**: The editor now computes a JSON diff between the current job state and the edited state, sending only changed fields via `cron.update` instead of full overwrites. This prevents clobbering fields set by other cron PRs (e.g., webhook delivery, custom session targets).
- **Backward compatibility**: A `postRun` fallback in the `CronJob` decoder maps legacy `"trigger-heartbeat"` values to `.nextHeartbeat`, and the UI gracefully handles webhook, raw, and unknown delivery modes.

The implementation is well-structured with targeted test coverage. One concern: delivery settings are visible in the UI for non-isolated session targets (e.g., `current`) but silently excluded from the payload — this could confuse users who configure delivery for a `current`-target job.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor UI/UX concern around delivery visibility for non-isolated session targets.
- The code changes are well-structured, the diff-only patching logic is correct, and backward-compatibility is properly handled. The enum hardening pattern is clean and idiomatic. The only concern is a UI/logic mismatch where delivery settings are editable but silently dropped for non-isolated targets. Tests cover the key scenarios but could not be run in CI due to dependency issues.
- `apps/macos/Sources/OpenClaw/CronJobEditor+Helpers.swift` — delivery gating logic in `shouldIncludeDeliveryInRoot()` may silently discard user-configured delivery for non-isolated session targets.

<sub>Last reviewed commit: 109f947</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->