### PR TITLE
fix(nodes): use formatExecCommand for approval request command text

### DIFF
--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -17,6 +17,7 @@ import {
 } from "../../cli/nodes-screen.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { formatExecCommand } from "../../infra/system-run-command.js";
 import { imageMimeFromFormat } from "../../media/mime.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { resolveImageSanitizationLimits } from "../image-sanitization.js";
@@ -464,7 +465,7 @@ export function createNodesTool(options?: {
             // Node requires approval – create a pending approval request on
             // the gateway and wait for the user to approve/deny via the UI.
             const APPROVAL_TIMEOUT_MS = 120_000;
-            const cmdText = command.join(" ");
+            const cmdText = formatExecCommand(command);
             const approvalId = crypto.randomUUID();
             const approvalResult = await callGatewayTool(
               "exec.approval.request",

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -13,6 +13,7 @@ import {
 } from "../../infra/exec-approvals.js";
 import { buildNodeShellCommand } from "../../infra/node-shell.js";
 import { applyPathPrepend } from "../../infra/path-prepend.js";
+import { formatExecCommand } from "../../infra/system-run-command.js";
 import { defaultRuntime } from "../../runtime.js";
 import { parseEnvPairs, parseTimeoutMs } from "../nodes-run.js";
 import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
@@ -251,7 +252,7 @@ export function registerNodesInvokeCommands(nodes: Command) {
               opts,
               {
                 id: approvalId,
-                command: rawCommand ?? argv.join(" "),
+                command: rawCommand ?? formatExecCommand(argv),
                 cwd: opts.cwd,
                 host: "node",
                 security: hostSecurity,


### PR DESCRIPTION
## Summary

This PR fixes a bug where `nodes.run` would consistently fail with an `approval id does not match request` error when the command contained arguments with spaces. The root cause was a command string mismatch between the approval request creation and the gateway-side validation.

- The gateway normalizes the command text using `formatExecCommand` to handle shell quoting correctly.
- However, the `nodes.run` tool and `nodes invoke` CLI were creating the approval request command text using a simple `command.join(" ")`, which does not preserve quoting for arguments with spaces (e.g., `bash -lc "echo ..."`).

This change updates both `nodes-tool.ts` and `register.invoke.ts` to use the canonical `formatExecCommand` helper, ensuring that the command text is consistent across both the request creation and validation paths. This resolves the approval ID correlation failure.

## Test Plan

The `formatExecCommand` helper is already covered by unit tests in `system-run-command.test.ts`. 
For commands without spaces, `formatExecCommand` produces identical output to `join(" ")`, 
so there is no regression risk for the common case. The fix aligns the approval request 
creation path with the existing gateway validation path (`getCmdText` in 
`node-invoke-system-run-approval.ts`), which already uses `formatExecCommand`.

Fixes #19862

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where `nodes.run` failed with `approval id does not match request` when the command contained arguments with spaces. The root cause was that the approval request was created using `command.join(" ")`, which loses quoting information, while the gateway-side validation uses `formatExecCommand()` which correctly quotes arguments containing spaces. The fix updates both `nodes-tool.ts` (agent tool path) and `register.invoke.ts` (CLI path) to use `formatExecCommand()`, ensuring the command text is consistent between approval request creation and gateway validation.

- Both callsites now use the canonical `formatExecCommand` helper from `system-run-command.ts`
- The fix is minimal, targeted, and consistent with how the gateway normalizes command text in `getCmdText()` (`node-invoke-system-run-approval.ts:47-59`)
- No remaining `command.join(" ")` patterns for approval command text were found in the codebase
- Existing tests in `system-run-command.test.ts` cover the behavior of `formatExecCommand`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix with no behavioral side effects for commands without spaces.
- The change is two one-line fixes that align the approval request creation with the existing gateway validation logic. The `formatExecCommand` function is well-tested and already used by the gateway. For commands without spaces, `formatExecCommand` produces the same output as `join(" ")`, so there are no regressions for the common case.
- No files require special attention.

<sub>Last reviewed commit: ed334fb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->