### PR TITLE
Fix surrogate pair splitting in channel metadata truncation

### DIFF
--- a/src/security/channel-metadata.test.ts
+++ b/src/security/channel-metadata.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { buildUntrustedChannelMetadata } from "./channel-metadata.js";
+
+describe("buildUntrustedChannelMetadata", () => {
+  it("returns undefined for empty entries", () => {
+    const result = buildUntrustedChannelMetadata({
+      source: "test",
+      label: "Test",
+      entries: [],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when all entries are null or empty", () => {
+    const result = buildUntrustedChannelMetadata({
+      source: "test",
+      label: "Test",
+      entries: [null, undefined, "", "   "],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("wraps valid entries with external content markers", () => {
+    const result = buildUntrustedChannelMetadata({
+      source: "telegram",
+      label: "Group info",
+      entries: ["My Group"],
+    });
+    expect(result).toBeDefined();
+    expect(result).toContain("My Group");
+    expect(result).toContain("EXTERNAL_UNTRUSTED_CONTENT");
+  });
+
+  it("deduplicates identical entries", () => {
+    const result = buildUntrustedChannelMetadata({
+      source: "test",
+      label: "Label",
+      entries: ["foo", "foo", "bar"],
+    });
+    expect(result).toBeDefined();
+    // Should appear only once
+    const fooCount = (result!.match(/foo/g) ?? []).length;
+    expect(fooCount).toBe(1);
+  });
+
+  it("normalizes whitespace in entries", () => {
+    const result = buildUntrustedChannelMetadata({
+      source: "test",
+      label: "Label",
+      entries: ["  hello   world  "],
+    });
+    expect(result).toBeDefined();
+    expect(result).toContain("hello world");
+  });
+
+  it("truncates without splitting surrogate pairs", () => {
+    // Create an entry that would cause truncation at a surrogate pair boundary.
+    // 😀 is 2 UTF-16 code units (\uD83D\uDE00).
+    const emoji = "😀";
+    const filler = "x".repeat(395);
+    // Entry: 395 x's + 😀 = 397 chars (UTF-16 length). Max entry is 400.
+    // But the overall truncation at 800 chars with header can still cause issues.
+    const result = buildUntrustedChannelMetadata({
+      source: "test",
+      label: "L",
+      entries: [`${filler}${emoji}`],
+    });
+    expect(result).toBeDefined();
+    // The result should not contain a lone surrogate (would show as \uFFFD or cause issues).
+    // Verify no lone high surrogates exist in the output.
+    for (let i = 0; i < result!.length; i++) {
+      const code = result!.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        // High surrogate must be followed by a low surrogate
+        const next = result!.charCodeAt(i + 1);
+        expect(next >= 0xdc00 && next <= 0xdfff).toBe(true);
+      }
+    }
+  });
+
+  it("respects custom maxChars", () => {
+    const result = buildUntrustedChannelMetadata({
+      source: "test",
+      label: "Label",
+      entries: ["a".repeat(200)],
+      maxChars: 100,
+    });
+    expect(result).toBeDefined();
+    // The output includes wrapper overhead, but the inner content should be truncated
+    expect(result!.length).toBeLessThan(300);
+  });
+});

--- a/src/security/channel-metadata.ts
+++ b/src/security/channel-metadata.ts
@@ -14,7 +14,15 @@ function truncateText(value: string, maxChars: number): string {
   if (value.length <= maxChars) {
     return value;
   }
-  const trimmed = value.slice(0, Math.max(0, maxChars - 3)).trimEnd();
+  let end = Math.max(0, maxChars - 3);
+  // Avoid splitting a UTF-16 surrogate pair at the cut boundary.
+  if (end > 0 && end < value.length) {
+    const code = value.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  const trimmed = value.slice(0, end).trimEnd();
   return `${trimmed}...`;
 }
 


### PR DESCRIPTION
`truncateText` in `channel-metadata.ts` uses `.slice()` which can cut between a UTF-16 high and low surrogate, producing invalid strings. This affects channel metadata for groups/topics with emoji in their names.

Check for a high surrogate at the cut boundary and step back one position. Also adds unit tests for `buildUntrustedChannelMetadata`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where `truncateText` in `channel-metadata.ts` could split UTF-16 surrogate pairs when truncating channel metadata strings (e.g., emoji in group/topic names). The fix checks for a high surrogate at the cut boundary and steps back one position to keep the pair intact. Also adds a comprehensive test suite for `buildUntrustedChannelMetadata`.

- **Bug fix**: Prevents invalid strings from being produced when channel metadata with emoji is truncated at a surrogate pair boundary.
- **Tests**: New `channel-metadata.test.ts` covers empty entries, null/undefined handling, deduplication, whitespace normalization, surrogate pair safety, and custom `maxChars`.
- **Style note**: The codebase already has `sliceUtf16Safe`/`truncateUtf16Safe` in `src/utils.ts` that handle surrogate-pair-safe slicing. The inline fix duplicates that logic — consider reusing the existing utility for consistency.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the fix is correct and well-tested, with only a minor style suggestion about reusing existing utilities.
- The surrogate pair fix is logically sound and addresses a real bug. New tests provide good coverage. The only note is a style concern about duplicating existing utility logic from `src/utils.ts`.
- No files require special attention.

<sub>Last reviewed commit: 13733db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->