### PR TITLE
Use expandHomePrefix for consistent tilde expansion

### DIFF
--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -9,6 +9,7 @@ import {
 } from "../../config/sessions/paths.js";
 import { loadSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import { expandHomePrefix } from "../../infra/home-dir.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveCommandsSystemPromptBundle } from "./commands-system-prompt.js";
 import type { HandleCommandsParams } from "./commands-types.js";
@@ -169,11 +170,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
   const defaultFileName = `openclaw-session-${entry.sessionId.slice(0, 8)}-${timestamp}.html`;
   const outputPath = args.outputPath
-    ? path.resolve(
-        args.outputPath.startsWith("~")
-          ? args.outputPath.replace("~", process.env.HOME ?? "")
-          : args.outputPath,
-      )
+    ? path.resolve(expandHomePrefix(args.outputPath))
     : path.join(params.workspaceDir, defaultFileName);
 
   // Ensure directory exists

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -18,6 +18,7 @@ import { recordInboundSession } from "../../channels/session.js";
 import { loadConfig } from "../../config/config.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
+import { expandHomePrefix } from "../../infra/home-dir.js";
 import { waitForTransportReady } from "../../infra/transport-ready.js";
 import { mediaKindFromMime } from "../../media/constants.js";
 import { buildPairingReply } from "../../pairing/pairing-messages.js";
@@ -50,9 +51,7 @@ import type { IMessagePayload, MonitorIMessageOpts } from "./types.js";
 async function detectRemoteHostFromCliPath(cliPath: string): Promise<string | undefined> {
   try {
     // Expand ~ to home directory
-    const expanded = cliPath.startsWith("~")
-      ? cliPath.replace(/^~/, process.env.HOME ?? "")
-      : cliPath;
+    const expanded = expandHomePrefix(cliPath);
     const content = await fs.readFile(expanded, "utf8");
 
     // Match user@host pattern first (e.g., openclaw@192.168.64.3)


### PR DESCRIPTION
Two files manually expand `~` using `process.env.HOME` with ad-hoc string replacements:

- `commands-export-session.ts`: `args.outputPath.replace("~", process.env.HOME ?? "")`
- `monitor-provider.ts`: `cliPath.replace(/^~/, process.env.HOME ?? "")`

When `HOME` is unset, the replacement produces root-relative paths (e.g. `/foo` instead of `~/foo`). These also ignore `OPENCLAW_HOME` overrides and Windows `USERPROFILE` fallbacks.

Replace with the existing `expandHomePrefix` helper from `infra/home-dir.ts` which handles all edge cases.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces two ad-hoc `~` expansion patterns (`process.env.HOME` string replacement) with the existing `expandHomePrefix` helper from `infra/home-dir.ts`. This fixes edge cases where `HOME` is unset (previously produced root-relative paths), respects `OPENCLAW_HOME` overrides and Windows `USERPROFILE` fallbacks, and ensures consistency with the rest of the codebase which already uses this utility.

- `commands-export-session.ts`: Replaced inline tilde expansion with `expandHomePrefix` for output path resolution
- `monitor-provider.ts`: Replaced inline tilde expansion with `expandHomePrefix` for CLI path detection

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it replaces ad-hoc logic with an existing, well-tested utility function.
- Minimal, focused refactor that replaces two instances of ad-hoc tilde expansion with the existing `expandHomePrefix` helper. The helper is already used in 5+ other places in the codebase and is well-tested. No new behavior is introduced, and the change strictly improves edge-case handling.
- No files require special attention.

<sub>Last reviewed commit: 8116b47</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->