### PR TITLE
Fix Matrix messages silently dropped due to zero startup grace

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -130,6 +130,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const eventTs = event.origin_server_ts;
       const eventAge = event.unsigned?.age;
       if (typeof eventTs === "number" && eventTs < startupMs - startupGraceMs) {
+        logger.debug(
+          `Skipping pre-startup event in ${roomId} (ts=${eventTs}, startup=${startupMs}, grace=${startupGraceMs})`,
+        );
         return;
       }
       if (
@@ -137,6 +140,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         typeof eventAge === "number" &&
         eventAge > startupGraceMs
       ) {
+        logger.debug(
+          `Skipping stale event in ${roomId} (age=${eventAge}ms, grace=${startupGraceMs}ms)`,
+        );
         return;
       }
 

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -255,7 +255,10 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const mediaMaxMb = opts.mediaMaxMb ?? accountConfig.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
   const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const startupMs = Date.now();
-  const startupGraceMs = 0;
+  // Grace period to tolerate clock skew between the homeserver and the local
+  // host.  A value of 0 silently drops every message when the homeserver clock
+  // is even slightly behind (see #19843).
+  const startupGraceMs = 5_000;
   const directTracker = createDirectRoomTracker(client, { log: logVerboseMessage });
   registerMatrixAutoJoin({ client, cfg, runtime });
   const warnedEncryptedRooms = new Set<string>();


### PR DESCRIPTION
Fixes #19843

`startupGraceMs` was hardcoded to 0, causing every incoming message to be dropped when the Matrix homeserver clock is even slightly behind the OpenClaw host. This is common in multi-machine setups (e.g. Pi running OpenClaw + separate Synapse server).

Changes:
- Bump grace period from 0 to 5 seconds to tolerate typical NTP skew
- Add debug-level logging when events are filtered, so operators can diagnose message delivery issues without patching the source

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes silent message dropping in the Matrix extension caused by a hardcoded `startupGraceMs = 0`. When the Matrix homeserver clock is even slightly behind the OpenClaw host (common in multi-machine setups like Pi + separate Synapse), every incoming message was filtered out. The grace period is now 5 seconds, and debug-level logging is added to the two event-filtering branches for easier diagnosis.

- `startupGraceMs` bumped from `0` to `5_000` in `extensions/matrix/src/matrix/monitor/index.ts`
- Debug log statements added to both pre-startup and stale-event filters in `extensions/matrix/src/matrix/monitor/handler.ts`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, targeted fix with no risk of regression.
- The change is extremely small and well-scoped: a single constant change from 0 to 5000 and two debug log additions. The fix addresses a clear bug (zero grace period causing silent message drops). The 5-second grace period is a reasonable default for NTP skew. The debug logging is non-intrusive and aids future troubleshooting. No behavioral changes beyond the intended fix.
- No files require special attention.

<sub>Last reviewed commit: b4ada1c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->