### PR TITLE
Trigger model failover on connection-refused and DNS errors

### DIFF
--- a/src/agents/failover-error.e2e.test.ts
+++ b/src/agents/failover-error.e2e.test.ts
@@ -28,6 +28,13 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ code: "ECONNRESET" })).toBe("timeout");
   });
 
+  it("infers timeout from connection-refused and DNS errors", () => {
+    expect(resolveFailoverReasonFromError({ code: "ECONNREFUSED" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "ENOTFOUND" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "EHOSTUNREACH" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "ENETUNREACH" })).toBe("timeout");
+  });
+
   it("infers timeout from abort stop-reason messages", () => {
     expect(resolveFailoverReasonFromError({ message: "Unhandled stop reason: abort" })).toBe(
       "timeout",

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -169,6 +169,9 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
     return "timeout";
   }
+  if (["ECONNREFUSED", "ENOTFOUND", "EHOSTUNREACH", "ENETUNREACH"].includes(code)) {
+    return "timeout";
+  }
   if (isTimeoutError(err)) {
     return "timeout";
   }


### PR DESCRIPTION
ECONNREFUSED, ENOTFOUND, EHOSTUNREACH, and ENETUNREACH were not classified as failover-eligible errors. When a local LLM provider (llama-server, LM Studio, Ollama, etc.) goes down or DNS fails, OpenClaw errors out instead of falling over to the next configured model.

These are connection-level failures equivalent to the already-handled ETIMEDOUT and ECONNRESET codes. Classify them as `timeout` to trigger the same failover behavior.

Common scenario: user has `llama-server` as primary + `anthropic` as fallback. Server crashes → should failover, not error.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds four new Node.js error codes (`ECONNREFUSED`, `ENOTFOUND`, `EHOSTUNREACH`, `ENETUNREACH`) to the failover-eligible set in `resolveFailoverReasonFromError`, classifying them as `"timeout"` to trigger model failover. This ensures that when a local LLM provider goes down or DNS resolution fails, OpenClaw falls over to the next configured model instead of erroring out.

- The new error codes are kept in a separate `includes()` check from the existing timeout/reset codes, which improves readability by grouping connection-refused/DNS errors apart from socket timeout/reset errors
- Corresponding test coverage is added for all four new error codes
- The change is consistent with the existing failover architecture in `model-fallback.ts`, which triggers failover on any recognized `FailoverError` regardless of specific reason type

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, well-scoped addition that extends existing error classification logic with appropriate test coverage.
- The change is minimal (3 lines of logic, 6 lines of tests), follows the existing pattern exactly, and the new error codes are clearly connection-level failures that should trigger failover. No behavioral changes to existing code paths.
- No files require special attention.

<sub>Last reviewed commit: 5cb4b0f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->