### PR TITLE
fix(agents): suppress narration text when assistant message has tool calls (#20005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Subscribe: suppress narration text (e.g., "Let me search for that...") from user-facing replies when assistant messages contain tool calls, preventing internal reasoning from leaking to chat. (#20005)
+
 - Telegram/Cron/Heartbeat: honor explicit Telegram topic targets in cron and heartbeat delivery (`<chatId>:topic:<threadId>`) so scheduled sends land in the configured topic instead of the last active thread. (#19367) Thanks @Lukavyi.
 - Commands/Doctor: avoid rewriting invalid configs with new `gateway.auth.token` defaults during repair and only write when real config changes are detected, preventing accidental token duplication and backup churn.
 - Sandbox/Registry: serialize container and browser registry writes with shared file locks and atomic replacement to prevent lost updates and delete rollback races from desyncing `sandbox list`, `prune`, and `recreate --all`. Thanks @kexinoh.

--- a/src/agents/pi-embedded-subscribe.narration-leak.test.ts
+++ b/src/agents/pi-embedded-subscribe.narration-leak.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression test for #20005: Narration leak - text between tool calls delivered to user
+ *
+ * When an assistant message contains interleaved text and tool_use blocks,
+ * the text blocks (narration) should NOT be delivered to the user as messages.
+ * Only the final answer (after all tool calls complete) should be delivered.
+ */
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+type StubSession = {
+  subscribe: (fn: (evt: unknown) => void) => () => void;
+};
+
+describe("narration leak (#20005)", () => {
+  it("does NOT include narration text in assistantTexts when message has tool calls", () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run",
+      onBlockReply: () => {},
+    });
+
+    // Simulate streaming: assistant starts with narration text
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Let me search for that information.",
+      },
+    });
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_end",
+      },
+    });
+
+    // The final message contains both text (narration) and tool_use blocks
+    const assistantMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Let me search for that information." },
+        {
+          type: "tool_use",
+          id: "tool_1",
+          name: "web_search",
+          input: { query: "test" },
+        },
+      ],
+    } as AssistantMessage;
+
+    handler?.({ type: "message_end", message: assistantMessage });
+
+    // The narration text should NOT be in assistantTexts when tool calls are present
+    expect(subscription.assistantTexts).toEqual([]);
+  });
+
+  it("preserves assistantTexts when message has NO tool calls (normal reply)", () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run",
+      onBlockReply: () => {},
+    });
+
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Here is your answer.",
+      },
+    });
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_end",
+      },
+    });
+
+    // Normal message with only text, no tool calls
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "Here is your answer." }],
+    } as AssistantMessage;
+
+    handler?.({ type: "message_end", message: assistantMessage });
+
+    // This should be preserved - it's a real user-facing reply
+    expect(subscription.assistantTexts).toEqual(["Here is your answer."]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: Text between tool calls (narration) leaks to user as messages
- **Root cause**: `emitBlockChunk` pushes text to `assistantTexts` during streaming, but when the message contains tool calls, this text should be suppressed
- **Fix**: Clear text added during current message when tool calls are detected in `handleMessageEnd`

Fixes #20005

## Problem

When an assistant message contains interleaved text and `tool_use` blocks, the text blocks are "narration" (e.g., "Let me search for that information.") and should NOT be delivered to the user. However, `emitBlockChunk` pushes this text to `assistantTexts` during streaming, and `finalizeAssistantTexts` only updates the baseline without clearing the already-pushed text.

**Before fix:**
```
Input:  Assistant streams "Let me search for that..." then calls web_search tool
Output: User receives "Let me search for that..." as a message (BUG)
```

## Changes

- `src/agents/pi-embedded-subscribe.handlers.messages.ts` — Import `hasToolCall` and splice out text added during current message when tool calls are detected

**After fix:**
```
Input:  Assistant streams "Let me search for that..." then calls web_search tool
Output: User receives nothing (narration suppressed, tool executes silently)
```

## Test plan

- [x] New test: `pi-embedded-subscribe.narration-leak.test.ts` - verifies narration is suppressed when tool calls present
- [x] New test: verifies normal replies (no tool calls) are preserved
- [x] All 45 existing pi-embedded-subscribe tests pass
- [x] Lint passes

## Effect on User Experience

**Before:** Users see internal reasoning like "Let me search for that..." as separate messages before tool results
**After:** Only the final answer (after tool execution) is delivered to users

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a narration leak bug (#20005) where internal assistant reasoning text (e.g., "Let me search for that...") was being delivered to users when the assistant message also contained tool calls. The fix detects tool calls in `handleMessageEnd` using `hasToolCall()` and splices narration entries from `assistantTexts` before finalization, ensuring the final reply payload only contains the actual answer.

- The core approach is sound: splicing `assistantTexts` at `handleMessageEnd` correctly removes narration from the final user-facing payload
- Tests cover both the narration-suppression case and the normal-reply-preservation case
- There is a subtle edge case where `finalizeAssistantTexts` may re-add the narration text via its `!addedDuringMessage` fallback path — currently guarded by dedup logic, but worth hardening

<h3>Confidence Score: 3/5</h3>

- The fix addresses the reported bug but has a subtle edge case where narration could re-leak through the finalizeAssistantTexts fallback path
- The fix correctly splices narration from assistantTexts when tool calls are detected. However, the splice causes addedDuringMessage to become false, which triggers finalizeAssistantTexts's fallback pushAssistantText(text) call. This is currently prevented by dedup logic (shouldSkipAssistantText), but relies on the streamed text matching the final extracted text exactly — a fragile assumption. A one-line hardening change (passing empty text to finalizeAssistantTexts when tool calls are present) would make this robust.
- Pay close attention to `src/agents/pi-embedded-subscribe.handlers.messages.ts` — the interaction between the splice and `finalizeAssistantTexts` fallback path

<sub>Last reviewed commit: c9238cf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->