### PR TITLE
fix(plugins): strip workspace:* dev-deps before npm install

### DIFF
--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -1,6 +1,46 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { fileExists } from "./archive.js";
+
+/**
+ * Remove `devDependencies` entries that use the pnpm `workspace:` protocol.
+ *
+ * Published npm packages from this monorepo may contain
+ * `"openclaw": "workspace:*"` in their `devDependencies`.  The specifier is
+ * only meaningful inside the pnpm workspace – plain `npm install` (even with
+ * `--omit=dev`) fails to *parse* it, which causes every extension / hook
+ * install from the npm registry to error out.
+ *
+ * Stripping these entries before `npm install` is safe because:
+ *   1. We already pass `--omit=dev`, so dev-deps are never installed.
+ *   2. The entries are only used for in-repo development builds.
+ */
+async function stripWorkspaceDevDeps(dir: string): Promise<void> {
+  const pkgPath = path.join(dir, "package.json");
+  const raw = await fs.readFile(pkgPath, "utf-8");
+  const pkg = JSON.parse(raw);
+
+  const devDeps: Record<string, string> | undefined = pkg.devDependencies;
+  if (!devDeps) {
+    return;
+  }
+
+  let changed = false;
+  for (const [name, spec] of Object.entries(devDeps)) {
+    if (typeof spec === "string" && spec.startsWith("workspace:")) {
+      delete devDeps[name];
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    if (Object.keys(devDeps).length === 0) {
+      delete pkg.devDependencies;
+    }
+    await fs.writeFile(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+  }
+}
 
 export async function installPackageDir(params: {
   sourceDir: string;
@@ -44,6 +84,7 @@ export async function installPackageDir(params: {
 
   if (params.hasDeps) {
     params.logger?.info?.(params.depsLogMessage);
+    await stripWorkspaceDevDeps(params.targetDir);
     const npmRes = await runCommandWithTimeout(
       ["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"],
       {


### PR DESCRIPTION
## Summary

This PR fixes a long-standing issue where installing any OpenClaw extension or hook from the official NPM registry fails. The failure is caused by `devDependencies` in the published `package.json` files containing `pnpm`'s `workspace:*` protocol, which `npm` cannot parse.

Even though `npm install` is run with `--omit=dev`, `npm` still parses the entire `package.json` before handling that flag, leading to a fatal `EUNSUPPORTEDPROTOCOL` error.

This fix introduces a helper function, `stripWorkspaceDevDeps`, which is called right before `npm install` inside the generic `installPackageDir` utility. This function reads the `package.json` of the package being installed, removes any `devDependencies` that use the `workspace:` protocol, and writes the cleaned `package.json` back to disk. The subsequent `npm install` can then proceed without parsing errors.

## Test Plan

This change was manually verified:

1.  Created a test package with a `workspace:*` devDependency.
2.  Confirmed that `npm install --omit=dev` fails with `EUNSUPPORTEDPROTOCOL`.
3.  Programmatically removed the `workspace:*` dependency from `package.json`.
4.  Confirmed that `npm install --omit=dev` then succeeds.

The fix is safe as it only modifies `devDependencies`, which are never installed anyway due to the `--omit=dev` flag. It correctly handles packages with no `devDependencies` or no `workspace:` specifiers.

Fixes  #5780, #5292, #1839, #6879, #8145, #8492

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where installing OpenClaw extensions/hooks from the npm registry fails with `EUNSUPPORTEDPROTOCOL` because published `package.json` files contain pnpm `workspace:*` specifiers in `devDependencies` that `npm` cannot parse.

- Adds a `stripWorkspaceDevDeps` helper in `src/infra/install-package-dir.ts` that removes `workspace:` protocol entries from `devDependencies` before running `npm install`
- The fix is minimal and safe: it only modifies `devDependencies` (never installed due to `--omit=dev`), and only touches the target directory copy — not the source
- Confirmed that all 31 extension `package.json` files in the repo contain `"openclaw": "workspace:*"` in `devDependencies`, validating the real-world need for this fix
- The function correctly handles packages with no `devDependencies`, no `workspace:` specifiers, and mixed devDeps (only strips `workspace:` entries, keeps the rest)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it makes a targeted, well-scoped fix that only modifies dev dependencies in a copied package directory before npm install.
- The change is small, well-documented, and addresses a real issue affecting all 31 extensions in the repo. The logic is straightforward with proper early-returns and guards. The only minor observation is that `stripWorkspaceDevDeps` is not wrapped in a try-catch (unlike the adjacent `afterCopy` call), but since the file was already validated by callers and just copied, failure is extremely unlikely in practice.
- No files require special attention

<sub>Last reviewed commit: fdb4a38</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->