### PR TITLE
iOS: stabilize pairing/reconnect loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.
 - Browser/Relay: reuse an already-running extension relay when the relay port is occupied by another OpenClaw process, while still failing on non-relay port collisions to avoid masking unrelated listeners. (#20035) Thanks @mbelinky.
 - Telegram/Cron/Heartbeat: honor explicit Telegram topic targets in cron and heartbeat delivery (`<chatId>:topic:<threadId>`) so scheduled sends land in the configured topic instead of the last active thread. (#19367) Thanks @Lukavyi.
 - iOS/Signing: restore local auto-selected signing-team overrides during iOS project generation by wiring `.local-signing.xcconfig` into the active signing config and emitting `OPENCLAW_DEVELOPMENT_TEAM` in local signing setup. (#19993) Thanks @ngutman.

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -584,8 +584,11 @@ final class NodeAppModel {
             onFailure: { [weak self] _ in
                 guard let self else { return }
                 await self.operatorGateway.disconnect()
+                await self.nodeGateway.disconnect()
                 await MainActor.run {
                     self.operatorConnected = false
+                    self.gatewayConnected = false
+                    self.gatewayStatusText = "Reconnecting…"
                     self.talkMode.updateGatewayConnected(false)
                 }
             })
@@ -1928,7 +1931,9 @@ private extension NodeAppModel {
             clientId: clientId,
             clientMode: "ui",
             clientDisplayName: displayName,
-            includeDeviceIdentity: true)
+            // Operator traffic should authenticate via shared gateway auth only.
+            // Including device identity here can trigger duplicate pairing flows.
+            includeDeviceIdentity: false)
     }
 
     func legacyClientIdFallback(currentClientId: String, error: Error) -> String? {

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -675,6 +675,11 @@ struct OnboardingWizardView: View {
         // We intentionally stop reconnect churn while unpaired to avoid generating multiple pending requests.
         self.appModel.gatewayAutoReconnectEnabled = true
         self.appModel.gatewayPairingPaused = false
+        self.appModel.gatewayPairingRequestId = nil
+        // Pairing state is sticky to prevent UI flip-flop during reconnect churn.
+        // Once the user explicitly resumes after approving, clear the sticky issue
+        // so new status/auth errors can surface instead of being masked as pairing.
+        self.issue = .none
         self.connectMessage = "Retrying after approval…"
         self.statusLine = "Retrying after approval…"
         Task { await self.retryLastAttempt() }


### PR DESCRIPTION
## Summary
- stop sticky pairing dead-end by fully pausing reconnect churn until explicit resume
- ensure operator session does not include device identity (prevents duplicate pairing pressure)
- on repeated health-check failures, reset both operator + node sessions to force clean reconnect

## Testing
- pnpm check
- manual iOS pairing flow validation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three related iOS pairing/reconnect stability issues:

- **Health monitor now resets both gateways on failure**: Previously, repeated health-check failures only disconnected the operator gateway. Now it also disconnects the node gateway and resets `gatewayConnected`/`gatewayStatusText`, ensuring both sessions reconnect cleanly rather than leaving the node session in a stale state.
- **Operator session no longer includes device identity**: Changing `includeDeviceIdentity` from `true` to `false` for the operator connect options prevents the gateway from treating the operator session as a separate device, which was triggering duplicate pairing requests.
- **Sticky pairing state cleared on resume**: `resumeAfterPairingApproval()` now clears `gatewayPairingRequestId` and the sticky `issue` enum, so that after the user approves pairing and taps "Resume", new errors can surface instead of being masked by the stale pairing state.

All three changes are consistent with existing patterns in the codebase (e.g., the foreground-resume handler at `NodeAppModel.swift:326` already disconnects both gateways). The reconnect loops correctly pick up the disconnected state and retry.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the changes are targeted, well-commented, and consistent with existing patterns in the iOS codebase.
- The PR makes three small, focused changes to fix pairing/reconnect stability issues. All changes follow existing patterns (e.g., the foreground-resume handler already disconnects both gateways). The includeDeviceIdentity change addresses a clear architectural issue. The sticky-state clearing in the onboarding view is a straightforward fix. No new logic paths or edge cases are introduced. Score is 4 rather than 5 because the testing is described as manual only (no automated tests for these specific scenarios).
- No files require special attention — both files have straightforward, low-risk changes.

<sub>Last reviewed commit: d40fad0</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->