### PR TITLE
Gateway/CLI: add paired-device remove and clear flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/CLI: add paired-device hygiene flows with `device.pair.remove`, plus `openclaw devices remove` and guarded `openclaw devices clear --yes [--pending]` commands for removing paired entries and optionally rejecting pending requests. (#20057) Thanks @mbelinky.
+
 ### Fixes
 
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -28,6 +28,13 @@ async function runDevicesApprove(argv: string[]) {
   await program.parseAsync(["devices", "approve", ...argv], { from: "user" });
 }
 
+async function runDevicesCommand(argv: string[]) {
+  const { registerDevicesCli } = await import("./devices-cli.js");
+  const program = new Command();
+  registerDevicesCli(program);
+  await program.parseAsync(["devices", ...argv], { from: "user" });
+}
+
 describe("devices cli approve", () => {
   afterEach(() => {
     callGateway.mockReset();
@@ -110,6 +117,78 @@ describe("devices cli approve", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(callGateway).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: "device.pair.approve" }),
+    );
+  });
+});
+
+describe("devices cli remove", () => {
+  afterEach(() => {
+    callGateway.mockReset();
+    withProgress.mockClear();
+    runtime.log.mockReset();
+    runtime.error.mockReset();
+    runtime.exit.mockReset();
+  });
+
+  it("removes a paired device by id", async () => {
+    callGateway.mockResolvedValueOnce({ deviceId: "device-1" });
+
+    await runDevicesCommand(["remove", "device-1"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "device.pair.remove",
+        params: { deviceId: "device-1" },
+      }),
+    );
+  });
+});
+
+describe("devices cli clear", () => {
+  afterEach(() => {
+    callGateway.mockReset();
+    withProgress.mockClear();
+    runtime.log.mockReset();
+    runtime.error.mockReset();
+    runtime.exit.mockReset();
+  });
+
+  it("requires --yes before clearing", async () => {
+    await runDevicesCommand(["clear"]);
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith("Refusing to clear pairing table without --yes");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("clears paired devices and optionally pending requests", async () => {
+    callGateway
+      .mockResolvedValueOnce({
+        paired: [{ deviceId: "device-1" }, { deviceId: "device-2" }],
+        pending: [{ requestId: "req-1" }],
+      })
+      .mockResolvedValueOnce({ deviceId: "device-1" })
+      .mockResolvedValueOnce({ deviceId: "device-2" })
+      .mockResolvedValueOnce({ requestId: "req-1", deviceId: "device-1" });
+
+    await runDevicesCommand(["clear", "--yes", "--pending"]);
+
+    expect(callGateway).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ method: "device.pair.list" }),
+    );
+    expect(callGateway).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: "device.pair.remove", params: { deviceId: "device-1" } }),
+    );
+    expect(callGateway).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ method: "device.pair.remove", params: { deviceId: "device-2" } }),
+    );
+    expect(callGateway).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({ method: "device.pair.reject", params: { requestId: "req-1" } }),
     );
   });
 });

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -95,6 +95,8 @@ import {
   DevicePairApproveParamsSchema,
   type DevicePairListParams,
   DevicePairListParamsSchema,
+  type DevicePairRemoveParams,
+  DevicePairRemoveParamsSchema,
   type DevicePairRejectParams,
   DevicePairRejectParamsSchema,
   type DeviceTokenRevokeParams,
@@ -332,6 +334,9 @@ export const validateDevicePairApproveParams = ajv.compile<DevicePairApprovePara
 );
 export const validateDevicePairRejectParams = ajv.compile<DevicePairRejectParams>(
   DevicePairRejectParamsSchema,
+);
+export const validateDevicePairRemoveParams = ajv.compile<DevicePairRemoveParams>(
+  DevicePairRemoveParamsSchema,
 );
 export const validateDeviceTokenRotateParams = ajv.compile<DeviceTokenRotateParams>(
   DeviceTokenRotateParamsSchema,

--- a/src/gateway/protocol/schema/devices.ts
+++ b/src/gateway/protocol/schema/devices.ts
@@ -13,6 +13,11 @@ export const DevicePairRejectParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const DevicePairRemoveParamsSchema = Type.Object(
+  { deviceId: NonEmptyString },
+  { additionalProperties: false },
+);
+
 export const DeviceTokenRotateParamsSchema = Type.Object(
   {
     deviceId: NonEmptyString,

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -68,6 +68,7 @@ import {
 import {
   DevicePairApproveParamsSchema,
   DevicePairListParamsSchema,
+  DevicePairRemoveParamsSchema,
   DevicePairRejectParamsSchema,
   DevicePairRequestedEventSchema,
   DevicePairResolvedEventSchema,
@@ -245,6 +246,7 @@ export const ProtocolSchemas: Record<string, TSchema> = {
   DevicePairListParams: DevicePairListParamsSchema,
   DevicePairApproveParams: DevicePairApproveParamsSchema,
   DevicePairRejectParams: DevicePairRejectParamsSchema,
+  DevicePairRemoveParams: DevicePairRemoveParamsSchema,
   DeviceTokenRotateParams: DeviceTokenRotateParamsSchema,
   DeviceTokenRevokeParams: DeviceTokenRevokeParamsSchema,
   DevicePairRequestedEvent: DevicePairRequestedEventSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -66,6 +66,7 @@ import type {
 import type {
   DevicePairApproveParamsSchema,
   DevicePairListParamsSchema,
+  DevicePairRemoveParamsSchema,
   DevicePairRejectParamsSchema,
   DeviceTokenRevokeParamsSchema,
   DeviceTokenRotateParamsSchema,
@@ -234,6 +235,7 @@ export type ExecApprovalResolveParams = Static<typeof ExecApprovalResolveParamsS
 export type DevicePairListParams = Static<typeof DevicePairListParamsSchema>;
 export type DevicePairApproveParams = Static<typeof DevicePairApproveParamsSchema>;
 export type DevicePairRejectParams = Static<typeof DevicePairRejectParamsSchema>;
+export type DevicePairRemoveParams = Static<typeof DevicePairRemoveParamsSchema>;
 export type DeviceTokenRotateParams = Static<typeof DeviceTokenRotateParamsSchema>;
 export type DeviceTokenRevokeParams = Static<typeof DeviceTokenRevokeParamsSchema>;
 export type ChatAbortParams = Static<typeof ChatAbortParamsSchema>;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -64,6 +64,7 @@ const BASE_METHODS = [
   "device.pair.list",
   "device.pair.approve",
   "device.pair.reject",
+  "device.pair.remove",
   "device.token.rotate",
   "device.token.revoke",
   "node.rename",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -47,6 +47,7 @@ const PAIRING_METHODS = new Set([
   "device.pair.list",
   "device.pair.approve",
   "device.pair.reject",
+  "device.pair.remove",
   "device.token.rotate",
   "device.token.revoke",
   "node.rename",

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -1,6 +1,7 @@
 import {
   approveDevicePairing,
   listDevicePairing,
+  removePairedDevice,
   type DeviceAuthToken,
   rejectDevicePairing,
   revokeDeviceToken,
@@ -13,6 +14,7 @@ import {
   formatValidationErrors,
   validateDevicePairApproveParams,
   validateDevicePairListParams,
+  validateDevicePairRemoveParams,
   validateDevicePairRejectParams,
   validateDeviceTokenRevokeParams,
   validateDeviceTokenRotateParams,
@@ -120,6 +122,29 @@ export const deviceHandlers: GatewayRequestHandlers = {
       { dropIfSlow: true },
     );
     respond(true, rejected, undefined);
+  },
+  "device.pair.remove": async ({ params, respond, context }) => {
+    if (!validateDevicePairRemoveParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid device.pair.remove params: ${formatValidationErrors(
+            validateDevicePairRemoveParams.errors,
+          )}`,
+        ),
+      );
+      return;
+    }
+    const { deviceId } = params as { deviceId: string };
+    const removed = await removePairedDevice(deviceId);
+    if (!removed) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId"));
+      return;
+    }
+    context.logGateway.info(`device pairing removed device=${removed.deviceId}`);
+    respond(true, removed, undefined);
   },
   "device.token.rotate": async ({ params, respond, context }) => {
     if (!validateDeviceTokenRotateParams(params)) {

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "vitest";
 import {
   approveDevicePairing,
   getPairedDevice,
+  removePairedDevice,
   requestDevicePairing,
   rotateDeviceToken,
   verifyDeviceToken,
@@ -108,5 +109,16 @@ describe("device pairing tokens", () => {
         baseDir,
       }),
     ).resolves.toEqual({ ok: false, reason: "token-mismatch" });
+  });
+
+  test("removes paired devices by device id", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    await setupPairedOperatorDevice(baseDir, ["operator.read"]);
+
+    const removed = await removePairedDevice("device-1", baseDir);
+    expect(removed).toEqual({ deviceId: "device-1" });
+    await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
+
+    await expect(removePairedDevice("device-1", baseDir)).resolves.toBeNull();
   });
 });

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -321,6 +321,22 @@ export async function rejectDevicePairing(
   });
 }
 
+export async function removePairedDevice(
+  deviceId: string,
+  baseDir?: string,
+): Promise<{ deviceId: string } | null> {
+  return await withLock(async () => {
+    const state = await loadState(baseDir);
+    const normalized = normalizeDeviceId(deviceId);
+    if (!normalized || !state.pairedByDeviceId[normalized]) {
+      return null;
+    }
+    delete state.pairedByDeviceId[normalized];
+    await persistState(state, baseDir);
+    return { deviceId: normalized };
+  });
+}
+
 export async function updatePairedDeviceMetadata(
   deviceId: string,
   patch: Partial<Omit<PairedDevice, "deviceId" | "createdAtMs" | "approvedAtMs">>,

--- a/src/test-utils/model-auth-mock.ts
+++ b/src/test-utils/model-auth-mock.ts
@@ -1,8 +1,13 @@
 import { vi } from "vitest";
 
-export function createModelAuthMockModule() {
+type ModelAuthMockModule = {
+  resolveApiKeyForProvider: (...args: unknown[]) => unknown;
+  requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => string;
+};
+
+export function createModelAuthMockModule(): ModelAuthMockModule {
   return {
-    resolveApiKeyForProvider: vi.fn(),
+    resolveApiKeyForProvider: vi.fn() as (...args: unknown[]) => unknown,
     requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
       if (auth?.apiKey) {
         return auth.apiKey;


### PR DESCRIPTION
## Summary
- add gateway method `device.pair.remove` to delete stale paired device rows
- add CLI commands:
  - `openclaw devices remove <deviceId>`
  - `openclaw devices clear --yes [--pending]`
- wire protocol schemas/validators/allowlists for the new method
- add infra + CLI tests for remove/clear behavior

## Testing
- pnpm vitest src/infra/device-pairing.test.ts src/cli/devices-cli.test.ts
- pnpm check
- pnpm build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `device.pair.remove` gateway method and two CLI commands (`openclaw devices remove <deviceId>` and `openclaw devices clear --yes [--pending]`) for managing paired device entries. The change spans the full vertical: Typebox schema + type, AJV validator, protocol schema registry, method allowlist, PAIRING_METHODS authorization set, server handler, infra layer (`removePairedDevice`), CLI wiring, and tests for both infra and CLI layers.

- New `removePairedDevice` infra function deletes a device from the paired-devices state file under lock, consistent with existing `rejectDevicePairing` pattern
- `device.pair.remove` server handler validates params, calls infra, returns the removed entry (or error for unknown deviceId)
- CLI `remove` subcommand sends a single RPC call; `clear` lists all entries then sequentially removes paired devices (and optionally rejects pending requests)
- Authorization is correctly gated behind `operator.pairing` scope via `PAIRING_METHODS`
- Tests cover: single remove, clear with `--yes` guard, and clear with `--pending` flag

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it follows existing patterns consistently across all layers with no logical errors.
- Score reflects that all changes are well-structured, follow existing codebase conventions (schema, validator, handler, allowlist, CLI, tests), have correct authorization gating, and include comprehensive test coverage. No bugs or security issues found.
- No files require special attention.

<sub>Last reviewed commit: df53236</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->