### PR TITLE
fix(diagnostics): share event bus and log transport across module bundles

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -151,6 +151,7 @@ describe("diagnostics-otel service", () => {
     logShutdown.mockClear();
     traceExporterCtor.mockClear();
     registerLogTransportMock.mockReset();
+    traceExporterCtor.mockClear();
   });
 
   test("records message-flow metrics and spans", async () => {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -35,7 +35,12 @@ export type LoggerResolvedSettings = ResolvedSettings;
 export type LogTransportRecord = Record<string, unknown>;
 export type LogTransport = (logObj: LogTransportRecord) => void;
 
-const externalTransports = new Set<LogTransport>();
+// Share transport registry via globalThis so plugin bundles (which may get a
+// separate copy of this module) can register transports that reach the logger.
+const TRANSPORTS_KEY = Symbol.for("openclaw.logExternalTransports");
+const externalTransports: Set<LogTransport> = ((globalThis as Record<symbol, unknown>)[
+  TRANSPORTS_KEY
+] ??= new Set<LogTransport>()) as Set<LogTransport>;
 
 function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTransport): void {
   logger.attachTransport((logObj: LogObj) => {


### PR DESCRIPTION
## Summary

- **Problem:** The `diagnostics-otel` extension ships with every install but has never actually worked. Three bugs stack on top of each other to prevent any telemetry from reaching a collector.
- **Why it matters:** Users configuring OTel get no errors but also no data. There are multiple open issues:  
  - #5190
  - #18794
  - #13783
- **What changed:** (1) Diagnostic event bus and log transport registry now use `globalThis[Symbol.for()]` singletons so plugin bundles share state with core. (2) `resolveOtelUrl()` uses `endsWith` against OTLP signal suffixes instead of `includes("/v1/")`.
- **What did NOT change:** No new dependencies, no config schema changes, no new diagnostic event types. The OTel plugin's metrics/spans/logs handling is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #5190
- Closes #18794
- Closes #13783
- Related #11168, #16865, #12475, #12897, #13791

## User-visible / Behavior Changes

Users who configure `diagnostics.otel.enabled: true` with an OTLP endpoint will now actually receive traces, metrics, and logs in their collector. Previously this configuration was silently non-functional.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (the OTel plugin already makes OTLP calls when enabled -- they just never fired due to the event bus bug)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime: Node v25.6.1
- Integration: diagnostics-otel extension + Jaeger OTLP collector

### Steps

1. Start Jaeger: `docker run -d -p 127.0.0.1:4318:4318 -p 127.0.0.1:16686:16686 jaegertracing/all-in-one:latest`
2. Configure OpenClaw with `diagnostics.enabled: true`, `diagnostics.otel.enabled: true`, `diagnostics.otel.endpoint: http://127.0.0.1:4318`
3. Emit diagnostic events (via gateway activity or test script)

### Expected

Traces appear in Jaeger at http://localhost:16686

### Actual

Before fix: zero traces (confirmed via `ss -tn`, matching #18794 repro).
After fix: 3 traces with 3 spans appear in Jaeger.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Unit tests: 18/18 pass (5 new tests added covering the exact bug scenarios).

Integration test output:
```
OTel service started, emitting test events...
Events emitted. Waiting for OTel batch flush...
OTel service stopped.
SUCCESS: Found 3 trace(s) with 3 span(s) in Jaeger.
```

URL resolution test covers the #13783 case directly:
```
"appends signal path when endpoint contains /v1/ in a non-terminal position"
  https://api.example.com/api/v1/private/otel -> .../api/v1/private/otel/v1/traces
```

## Human Verification (required)

- Verified scenarios: Event bus isolation fix confirmed with live Jaeger collector. URL resolution fix confirmed with Opik-style endpoint containing `/v1/` in base path.
- Edge cases checked: Endpoint already ending in `/v1/traces` (no double-append), `resetDiagnosticEventsForTest()` correctly clears shared state, unsubscribe removes only the target listener.
- What I did **not** verify: gRPC protocol (intentionally unsupported), concurrent multi-process scenarios (Vitest workers are isolated).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit. The `globalThis` singletons degrade gracefully -- if removed, behavior returns to the pre-fix state (events don't cross module boundaries, but nothing crashes).
- Files/config to restore: `src/infra/diagnostic-events.ts`, `src/logging/logger.ts`, `extensions/diagnostics-otel/src/service.ts`
- Known bad symptoms reviewers should watch for: If `globalThis` symbols collide with another library (extremely unlikely with `openclaw.` prefix), diagnostic events could leak to unintended listeners.

## Risks and Mitigations

- Risk: `globalThis` shared state could cause test interference if tests in the same Vitest worker share the bus.
  - Mitigation: `resetDiagnosticEventsForTest()` already exists for this purpose and now clears the shared bus. Existing tests already call it in `beforeEach`. New test added to verify this works.

---

**AI disclosure:** This PR was developed with AI assistance (Claude). All changes were manually reviewed, understood, and verified with live integration testing against Jaeger.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three stacked bugs that prevented the `diagnostics-otel` extension from ever delivering telemetry to a collector:

1. **Event bus isolation** (`diagnostic-events.ts`): The diagnostic event bus (listeners + sequence counter) was module-scoped, so plugin bundles that received a separate copy of the module had their own isolated bus. Events emitted by core never reached plugin listeners. Fixed by storing the bus on `globalThis` via `Symbol.for("openclaw.diagnosticEventBus")`, following the established pattern in `src/plugins/runtime.ts`.

2. **Log transport isolation** (`logger.ts`): Same module-boundary problem for the log transport registry. Fixed with the same `globalThis` + `Symbol.for()` singleton pattern.

3. **URL resolution false positive** (`service.ts`): `resolveOtelUrl()` used `includes("/v1/")` to detect fully-qualified OTLP endpoints, which incorrectly matched backends whose base URL contained `/v1/` (e.g. Opik, Fiddler). Fixed by checking `endsWith` against the three known OTLP signal suffixes (`/v1/traces`, `/v1/metrics`, `/v1/logs`).

- No new dependencies, no config schema changes, no new diagnostic event types
- 5 new tests covering the exact bug scenarios, 18/18 tests passing
- The `globalThis` singleton pattern is well-established in this codebase (used by `plugins/runtime.ts`, `warning-filter.ts`, `fetch.ts`, etc.)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — well-scoped bug fixes using established patterns with thorough test coverage.
- All three changes are minimal and targeted: two apply an existing globalThis singleton pattern (already used in plugins/runtime.ts) to fix module-boundary isolation, and one narrows a string check from includes() to endsWith(). No new dependencies, no config changes, no behavioral changes for users who don't have OTel enabled. Five new tests cover the exact bug scenarios. The patterns are well-established in the codebase.
- No files require special attention.

<sub>Last reviewed commit: 1fda875</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->