### PR TITLE
feat(sessions_spawn): add sessionKey param to reuse sub-agent sessions

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn-reuses-session-key.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-reuses-session-key.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender",
+  },
+};
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+import "./test-helpers/fast-core-tools.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+describe("openclaw-tools: subagents sessionKey", () => {
+  beforeEach(() => {
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    };
+  });
+
+  it("sessions_spawn uses provided sessionKey instead of random UUID", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    let childSessionKey: string | undefined;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      if (request.method === "agent") {
+        const params = request.params as { sessionKey?: string } | undefined;
+        childSessionKey = params?.sessionKey;
+        return { runId: "run-1", status: "accepted", acceptedAt: 5000 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-sk1", {
+      task: "do thing",
+      sessionKey: "chiyan",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+    });
+    expect(childSessionKey).toBe("agent:main:subagent:chiyan");
+  });
+
+  it("sessions_spawn falls back to random UUID when sessionKey is not provided", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    let childSessionKey: string | undefined;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      if (request.method === "agent") {
+        const params = request.params as { sessionKey?: string } | undefined;
+        childSessionKey = params?.sessionKey;
+        return { runId: "run-2", status: "accepted", acceptedAt: 5100 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-sk2", {
+      task: "do thing",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-2",
+    });
+    // Without sessionKey, should use a random UUID pattern
+    expect(childSessionKey?.startsWith("agent:main:subagent:")).toBe(true);
+    expect(childSessionKey).not.toBe("agent:main:subagent:chiyan");
+  });
+
+  it("sessions_spawn preserves fully-qualified sessionKey containing :subagent:", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    let childSessionKey: string | undefined;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      if (request.method === "agent") {
+        const params = request.params as { sessionKey?: string } | undefined;
+        childSessionKey = params?.sessionKey;
+        return { runId: "run-3", status: "accepted", acceptedAt: 5200 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-sk3", {
+      task: "do thing",
+      sessionKey: "agent:main:subagent:xuanwu",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-3",
+    });
+    // Fully-qualified key should be used as-is
+    expect(childSessionKey).toBe("agent:main:subagent:xuanwu");
+  });
+
+  it("sessions_spawn rejects fully-qualified sessionKey targeting a different agent", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      if (request.method === "agent") {
+        return { runId: "run-4", status: "accepted", acceptedAt: 5300 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    // Passing a fully-qualified key that targets a different agent ("other") should throw
+    await expect(
+      tool.execute("call-sk4", {
+        task: "do thing",
+        sessionKey: "agent:other:subagent:foo",
+      })
+    ).rejects.toThrow(/sessionKey agentId mismatch/);
+  });
+});


### PR DESCRIPTION
Add an optional `sessionKey` parameter to `sessions_spawn`. When provided, the sub-agent runs in a deterministic session instead of a new random-UUID session each time, preserving conversation history across spawns.

- If `sessionKey` is a short key, maps to `agent:{agentId}:subagent:{sessionKey}`
- If `sessionKey` is fully-qualified (contains ":subagent:"), validates that the embedded agentId matches targetAgentId to prevent cross-agent session injection
- Falls back to `crypto.randomUUID()` when omitted — no behavior change

Fixes: session key bypasses allowlist (Greptile review finding)

Tests: 4 cases covering deterministic key, UUID fallback, fully-qualified passthrough, and cross-agent mismatch rejection.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `sessionKey` parameter to `sessions_spawn` to allow sub-agents to reuse deterministic sessions instead of always creating a new random-UUID session. Short keys are namespaced to `agent:{agentId}:subagent:{key}`, fully-qualified keys are validated against the target agent to prevent cross-agent session injection, and omitting the parameter preserves the existing random-UUID behavior.

- **Blocking: test file will not compile** — the test imports `createOpenClawTools` from `./openclaw-tools.js`, which does not exist. All other subagent spawn tests import `createClawdbotTools` from `./clawdbot-tools.js`. This needs to be corrected for the tests to run.
- **Case-sensitivity bug in cross-agent validation** — the embedded agentId extracted from a fully-qualified key is not normalized/lowercased, but `targetAgentId` is always lowercase via `normalizeAgentId()`. This causes false mismatch rejections for mixed-case keys.
- **Inconsistent error handling** — the cross-agent mismatch check uses `throw new Error(...)` while the other security checks in the same function use `return jsonResult({ status: "forbidden", ... })`. This may produce different error surfaces depending on caller handling.

<h3>Confidence Score: 2/5</h3>

- This PR has a blocking test compilation issue and a logic bug in the security validation that need to be fixed before merging.
- Score of 2 reflects: (1) the test file imports a non-existent module (`openclaw-tools.js` instead of `clawdbot-tools.js`), meaning tests will fail at compile time and provide no coverage; (2) the cross-agent mismatch validation has a case-sensitivity bug where mixed-case fully-qualified keys are incorrectly rejected; and (3) inconsistent error handling (`throw` vs `jsonResult`) for the security check. The core feature logic in the production code is sound, but the issues prevent confident merging.
- Both files need attention: `src/agents/openclaw-tools.subagents.sessions-spawn-reuses-session-key.test.ts` (broken import), `src/agents/tools/sessions-spawn-tool.ts` (case-sensitivity bug and error handling inconsistency)

<sub>Last reviewed commit: 4a4be48</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->