### PR TITLE
feat(compaction): improve merge summary instructions for better nuance preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/Compaction: improve merge-summary context preservation with structured guidance for decisions, TODOs, constraints, files/commands, errors, preferences, and key tool outcomes. (#20075) thanks @jlwestsr.
+
 ### Fixes
 
 - LINE/auth boundary hardening synthesis: enforce strict LINE webhook authn/z boundary semantics across pairing-store account scoping, DM/group allowlist separation, fail-closed webhook auth/runtime behavior, and replay/duplication controls (including in-flight replay reservation and post-success dedupe marking). (from #26701, #26683, #25978, #17593, #16619, #31990, #26047, #30584, #18777) Thanks @bmendonca3, @davidahmann, @harshang03, @haosenwang1018, @liuxiaopai-ai, @coygeek, and @Takhoffman.

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -15,8 +15,19 @@ export const SAFETY_MARGIN = 1.2; // 20% buffer for estimateTokens() inaccuracy
 const DEFAULT_SUMMARY_FALLBACK = "No prior history.";
 const DEFAULT_PARTS = 2;
 const MERGE_SUMMARIES_INSTRUCTIONS =
-  "Merge these partial summaries into a single cohesive summary. Preserve decisions," +
-  " TODOs, open questions, and any constraints.";
+  "Merge these partial summaries into a single cohesive summary.\n\n" +
+  "You MUST preserve all of the following if present:\n" +
+  "- **Decisions made** - what was decided and why\n" +
+  "- **TODOs and open tasks** - incomplete work, next steps\n" +
+  "- **Open questions** - unresolved issues awaiting answers\n" +
+  "- **Constraints and requirements** - technical or user-imposed limits\n" +
+  "- **File paths and commands** - specific files edited, commands run, branches used\n" +
+  "- **Errors encountered** - what failed and whether it was resolved\n" +
+  "- **User preferences expressed** - any stated preferences or corrections\n" +
+  "- **Key tool interactions** - important tool calls and their outcomes (not routine reads)\n\n" +
+  "Structure the summary with clear sections when content warrants it. " +
+  "Prefer concrete details (file names, error messages, specific values) over vague descriptions.";
+
 const IDENTIFIER_PRESERVATION_INSTRUCTIONS =
   "Preserve all opaque identifiers exactly as written (no shortening or reconstruction), " +
   "including UUIDs, hashes, IDs, tokens, API keys, hostnames, IPs, ports, URLs, and file names.";


### PR DESCRIPTION
## Problem

When sessions compact, the merge summary prompt is a vague one-liner:

> *Merge these partial summaries into a single cohesive summary. Preserve decisions, TODOs, open questions, and any constraints.*

This leads to summaries that lose critical context — file paths, error messages, user preferences, and specific tool interactions get flattened into vague descriptions. For long-running sessions (agents, personal assistants), this causes the model to "forget" important details after compaction.

## Solution

Expanded the merge summary instructions with structured guidance:

- **Decisions made** — what was decided and why
- **TODOs and open tasks** — incomplete work, next steps
- **Open questions** — unresolved issues
- **Constraints and requirements** — technical or user-imposed limits
- **File paths and commands** — specific files, commands, branches
- **Errors encountered** — what failed and resolution status
- **User preferences** — stated preferences or corrections
- **Key tool interactions** — important tool calls and outcomes

Also instructs the model to prefer concrete details over vague descriptions, and use sections when content warrants it.

## Impact

- No behavior change for short sessions (summaries that fit in one pass)
- Meaningfully better context preservation for multi-hour sessions that trigger compaction
- Zero performance impact (prompt text only)

## Testing

This modifies a prompt constant — no logic changes. Verified that the existing compaction e2e tests pass without modification.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Expands the `MERGE_SUMMARIES_INSTRUCTIONS` prompt constant in `src/agents/compaction.ts` from a brief one-liner to structured guidance with 8 specific categories (decisions, TODOs, open questions, constraints, file paths, errors, user preferences, tool interactions). This improves context preservation during multi-pass compaction merges for long-running sessions.

- Prompt-only change with no logic, API, or control flow modifications
- The constant is module-private and used only in `summarizeInStages()` for the merge pass
- Existing tests pass without modification since they mock the underlying `generateSummary` call
- No issues found during review

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only modifies a prompt text constant with no logic changes.
- The change is limited to a single module-private string constant used as LLM prompt instructions. No logic, control flow, API surface, or exported interfaces are modified. The constant is correctly integrated at its single usage site (lines 322-324). Existing tests pass without modification.
- No files require special attention.

<sub>Last reviewed commit: 671e255</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->