### PR TITLE
feat(tool-truncation): use head+tail strategy to preserve errors during truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Docs/Web search: remove outdated Brave free-tier wording and replace prescriptive AI ToS guidance with neutral compliance language in Brave setup docs. (#26860) Thanks @HenryLoenwind.
 - Tools/Diffs guidance loading: move diffs usage guidance from unconditional prompt-hook injection to the plugin companion skill path, reducing unrelated-turn prompt noise while keeping diffs tool behavior unchanged. (#32630) thanks @sircrumpet.
+- Agents/tool-result truncation: preserve important tail diagnostics by using head+tail truncation for oversized tool results while keeping configurable truncation options. (#20076) thanks @jlwestsr.
 
 ### Fixes
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -289,3 +289,25 @@ describe("sessionLikelyHasOversizedToolResults", () => {
     ).toBe(false);
   });
 });
+
+describe("truncateToolResultText head+tail strategy", () => {
+  it("preserves error content at the tail when present", () => {
+    const head = "Line 1\n".repeat(500);
+    const middle = "data data data\n".repeat(500);
+    const tail = "\nError: something failed\nStack trace: at foo.ts:42\n";
+    const text = head + middle + tail;
+    const result = truncateToolResultText(text, 5000);
+    // Should contain both the beginning and the error at the end
+    expect(result).toContain("Line 1");
+    expect(result).toContain("Error: something failed");
+    expect(result).toContain("middle content omitted");
+  });
+
+  it("uses simple head truncation when tail has no important content", () => {
+    const text = "normal line\n".repeat(1000);
+    const result = truncateToolResultText(text, 5000);
+    expect(result).toContain("normal line");
+    expect(result).not.toContain("middle content omitted");
+    expect(result).toContain("truncated");
+  });
+});

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -39,7 +39,34 @@ type ToolResultTruncationOptions = {
 };
 
 /**
- * Truncate a single text string to fit within maxChars, preserving the beginning.
+ * Marker inserted between head and tail when using head+tail truncation.
+ */
+const MIDDLE_OMISSION_MARKER =
+  "\n\n⚠️ [... middle content omitted — showing head and tail ...]\n\n";
+
+/**
+ * Detect whether text likely contains error/diagnostic content near the end,
+ * which should be preserved during truncation.
+ */
+function hasImportantTail(text: string): boolean {
+  // Check last ~2000 chars for error-like patterns
+  const tail = text.slice(-2000).toLowerCase();
+  return (
+    /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)\b/.test(tail) ||
+    // JSON closing — if the output is JSON, the tail has closing structure
+    /\}\s*$/.test(tail.trim()) ||
+    // Summary/result lines often appear at the end
+    /\b(total|summary|result|complete|finished|done)\b/.test(tail)
+  );
+}
+
+/**
+ * Truncate a single text string to fit within maxChars.
+ *
+ * Uses a head+tail strategy when the tail contains important content
+ * (errors, results, JSON structure), otherwise preserves the beginning.
+ * This ensures error messages and summaries at the end of tool output
+ * aren't lost during truncation.
  */
 export function truncateToolResultText(
   text: string,
@@ -51,11 +78,35 @@ export function truncateToolResultText(
   if (text.length <= maxChars) {
     return text;
   }
-  const keepChars = Math.max(minKeepChars, maxChars - suffix.length);
-  // Try to break at a newline boundary to avoid cutting mid-line
-  let cutPoint = keepChars;
-  const lastNewline = text.lastIndexOf("\n", keepChars);
-  if (lastNewline > keepChars * 0.8) {
+  const budget = Math.max(minKeepChars, maxChars - suffix.length);
+
+  // If tail looks important, split budget between head and tail
+  if (hasImportantTail(text) && budget > minKeepChars * 2) {
+    const tailBudget = Math.min(Math.floor(budget * 0.3), 4_000);
+    const headBudget = budget - tailBudget - MIDDLE_OMISSION_MARKER.length;
+
+    if (headBudget > minKeepChars) {
+      // Find clean cut points at newline boundaries
+      let headCut = headBudget;
+      const headNewline = text.lastIndexOf("\n", headBudget);
+      if (headNewline > headBudget * 0.8) {
+        headCut = headNewline;
+      }
+
+      let tailStart = text.length - tailBudget;
+      const tailNewline = text.indexOf("\n", tailStart);
+      if (tailNewline !== -1 && tailNewline < tailStart + tailBudget * 0.2) {
+        tailStart = tailNewline + 1;
+      }
+
+      return text.slice(0, headCut) + MIDDLE_OMISSION_MARKER + text.slice(tailStart) + suffix;
+    }
+  }
+
+  // Default: keep the beginning
+  let cutPoint = budget;
+  const lastNewline = text.lastIndexOf("\n", budget);
+  if (lastNewline > budget * 0.8) {
     cutPoint = lastNewline;
   }
   return text.slice(0, cutPoint) + suffix;


### PR DESCRIPTION
## Problem

When tool results exceed the character limit, `truncateToolResultText` keeps the head and discards everything after the cutoff. Error messages, stack traces, and result summaries typically appear at the **end** of tool output — exactly what gets truncated.

This means the model loses the most actionable part of the output (the error) and is left with only the preamble.

## Solution

Introduced a head+tail truncation strategy:

1. **Detect important tails** — checks the last ~2000 chars for error-like patterns (`error`, `exception`, `traceback`, `panic`, etc.), JSON closing structure, or summary keywords
2. **Split the budget** — when important tail content is detected, allocates 70% to head and 30% to tail (capped at 4000 chars)
3. **Clean boundaries** — cuts at newline boundaries to avoid mid-line breaks
4. **Clear marker** — inserts a visible `⚠️ [... middle content omitted ...]` marker between head and tail

Falls back to the existing head-only strategy when the tail doesn't contain important content.

## Example

Before (head-only):
```
$ npm test
PASS src/foo.test.ts
PASS src/bar.test.ts
... [truncated — 50000 chars]
```

After (head+tail):
```
$ npm test
PASS src/foo.test.ts
PASS src/bar.test.ts
...
⚠️ [... middle content omitted — showing head and tail ...]

FAIL src/baz.test.ts
  Error: expected 42 but got undefined
    at Object.<anonymous> (src/baz.test.ts:15:5)
Tests: 47 passed, 1 failed
```

## Testing

Added two test cases:
- Verifies error content at tail is preserved with the head+tail split
- Verifies normal content without errors uses simple head truncation

Existing e2e tests pass without modification.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a head+tail truncation strategy to `truncateToolResultText` so that error messages, stack traces, and result summaries at the end of tool output are preserved during truncation instead of being discarded.

- Introduces `hasImportantTail()` to detect error-like patterns, JSON structure, or summary keywords in the last ~2000 chars of text
- When important tail content is detected, allocates 70% of the budget to head and 30% to tail (capped at 4000 chars), with newline-boundary cuts and a visible omission marker
- Falls back to the existing head-only truncation when the tail doesn't contain important content
- The size arithmetic is correct — output stays within `maxChars` through proper budget accounting of both the middle omission marker and the truncation suffix
- Two new test cases cover the head+tail and head-only paths; existing tests pass unchanged
- The `hasImportantTail` detection heuristic is fairly broad (words like "done", "result", "complete" and any trailing `}` will trigger it), which means the head+tail strategy may fire more often than intended, reducing head content by 30% for false positives — this is a non-critical trade-off worth considering tightening over time

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the size arithmetic is correct, edge cases are guarded, and it falls back gracefully to the existing behavior.
- Score of 4 reflects that the implementation is logically sound with correct budget math, proper fallback to head-only truncation, and adequate test coverage. The only concerns are non-critical: the tail-detection heuristic may produce false positives due to broad keyword patterns, which could unnecessarily reduce head content.
- No files require special attention — both changed files are straightforward and self-contained.

<sub>Last reviewed commit: 75f8e0f</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->