### PR TITLE
docs(discord): replace quick setup and add recommended guild setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Docs: https://docs.openclaw.ai
 - Tools/web_search: support `freshness` for the Perplexity provider by mapping `pd`/`pw`/`pm`/`py` to Perplexity `search_recency_filter` values and including freshness in the Perplexity cache key. (#15343) Thanks @echoVic.
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Memory: switch default local embedding model to the QAT `embeddinggemma-300m-qat-Q8_0` variant for better quality at the same footprint. (#15429) Thanks @azade-c.
+- Docs/Discord: expand quick setup and clarify guild workspace guidance. (#20088) Thanks @pejmanjohn, @thewilloftheshadow.
 - Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.
 
 ## 2026.2.12

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -98,9 +98,9 @@ You will need to create a new application with a bot, add the bot to your server
       <Tab title="Ask your agent">
         Chat with your OpenClaw agent on any existing channel (e.g. Telegram) and tell it:
 
-        > "I want to set up Discord as a channel in OpenClaw. Here is my Bot Token: `<token>`, User ID: `<user_id>`, and Server ID: `<server_id>`"
+        > "I set my Discord bot token in config. Please finish Discord setup with User ID `<user_id>` and Server ID `<server_id>`."
 
-        Your agent will update the config and restart the gateway.
+        Keep secrets out of chat history: set the Bot Token in config/CLI, then ask your agent to complete the non-secret setup.
       </Tab>
       <Tab title="CLI / config">
         Add the token to your config:
@@ -122,10 +122,10 @@ You will need to create a new application with a bot, add the bot to your server
 DISCORD_BOT_TOKEN=...
 ```
 
-        Then restart the gateway:
+        Then start the gateway:
 
 ```bash
-openclaw gateway restart
+openclaw gateway
 ```
 
       </Tab>

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -88,7 +88,7 @@ You will need to create a new application with a bot, add the bot to your server
   <Step title="Allow DMs from server members">
     For pairing to work, Discord needs to allow your bot to DM you. Right-click your **server icon** → **Privacy Settings** → toggle on **Direct Messages**.
 
-    This lets server members (including bots) send you DMs. You can turn it off after pairing if you prefer.
+    This lets server members (including bots) send you DMs. Keep this enabled if you want to use Discord DMs with OpenClaw. If you only plan to use guild channels, you can disable DMs after pairing.
 
   </Step>
 
@@ -109,7 +109,7 @@ openclaw gateway
 
     <Tabs>
       <Tab title="Ask your agent">
-        Chat with your OpenClaw agent on any existing channel (e.g. Telegram) and tell it:
+        Chat with your OpenClaw agent on any existing channel (e.g. Telegram) and tell it. If Discord is your first channel, use the CLI / config tab instead.
 
         > "I already set my Discord bot token in config. Please finish Discord setup with User ID `<user_id>` and Server ID `<server_id>`."
       </Tab>
@@ -232,23 +232,15 @@ Once DMs are working, you can set up your Discord server as a full workspace whe
 
   </Step>
 
-  <Step title="Enable memory access for guild channels">
-    By default, long-term memory (MEMORY.md) only loads in DM sessions. If this is a private server, you probably want your agent to have full memory in every channel.
+  <Step title="Plan for memory in guild channels">
+    By default, long-term memory (MEMORY.md) only loads in DM sessions. Guild channels do not auto-load MEMORY.md.
 
     <Tabs>
       <Tab title="Ask your agent">
-        > "Update AGENTS.md to load MEMORY.md for my Discord server in all channels"
+        > "When I ask questions in Discord channels, use memory_search or memory_get if you need long-term context from MEMORY.md."
       </Tab>
       <Tab title="Manual">
-        Add your guild ID to a trusted contexts list in your `AGENTS.md` file. For example:
-
-```markdown
-### Trusted Contexts (treat like main session for memory access)
-
-- Direct chats (DMs) on any channel
-- Discord guild `YOUR_SERVER_ID`
-```
-
+        If you need shared context in every channel, put the stable instructions in `AGENTS.md` or `USER.md` (they are injected for every session). Keep long-term notes in `MEMORY.md` and access them on demand with memory tools.
       </Tab>
     </Tabs>
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -92,18 +92,29 @@ You will need to create a new application with a bot, add the bot to your server
 
   </Step>
 
+  <Step title="Step 0: Set your bot token securely (do not send it in chat)">
+    Your Discord bot token is a secret (like a password). Set it on the machine running OpenClaw before messaging your agent.
+
+```bash
+openclaw config set channels.discord.token '"YOUR_BOT_TOKEN"' --json
+openclaw config set channels.discord.enabled true --json
+openclaw gateway
+```
+
+    If OpenClaw is already running as a background service, use `openclaw gateway restart` instead.
+
+  </Step>
+
   <Step title="Configure OpenClaw and pair">
 
     <Tabs>
       <Tab title="Ask your agent">
         Chat with your OpenClaw agent on any existing channel (e.g. Telegram) and tell it:
 
-        > "I set my Discord bot token in config. Please finish Discord setup with User ID `<user_id>` and Server ID `<server_id>`."
-
-        Keep secrets out of chat history: set the Bot Token in config/CLI, then ask your agent to complete the non-secret setup.
+        > "I already set my Discord bot token in config. Please finish Discord setup with User ID `<user_id>` and Server ID `<server_id>`."
       </Tab>
       <Tab title="CLI / config">
-        Add the token to your config:
+        If you prefer file-based config, set:
 
 ```json5
 {
@@ -122,19 +133,13 @@ You will need to create a new application with a bot, add the bot to your server
 DISCORD_BOT_TOKEN=...
 ```
 
-        Then start the gateway:
-
-```bash
-openclaw gateway
-```
-
       </Tab>
     </Tabs>
 
   </Step>
 
   <Step title="Approve first DM pairing">
-    Wait until the gateway restarts, then DM your bot in Discord. It will respond with a pairing code.
+    Wait until the gateway is running, then DM your bot in Discord. It will respond with a pairing code.
 
     <Tabs>
       <Tab title="Ask your agent">


### PR DESCRIPTION
## Summary
- replace the Quick setup section in docs/channels/discord.md with the new draft from scratch/discord-docs-draft.md
- add a new Recommended: Set up a guild workspace section
- keep the rest of the Discord doc unchanged

## Testing
- docs-only change

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the minimal Quick Setup section in `docs/channels/discord.md` with a comprehensive step-by-step guide covering application creation, intent configuration, token generation, OAuth2 URL generation, Developer Mode setup, DM privacy settings, and OpenClaw pairing. Adds a new "Recommended: Set up a guild workspace" section guiding users through guild allowlisting, disabling `requireMention`, and enabling memory access for guild channels.

- The expanded Quick Setup breaks the original 4-step process into 8 granular steps with clear instructions, reducing friction for first-time Discord integrations.
- Each configuration step offers dual tabs ("Ask your agent" and "CLI / config"), giving users flexibility to configure via chat or manual config.
- The guild workspace section is a net-new addition that covers a common post-setup flow (private server as workspace) with config examples that are consistent with the existing configuration reference and schema.
- No code changes — docs-only PR.

<h3>Confidence Score: 4/5</h3>

- This is a docs-only PR with no code changes; safe to merge.
- Documentation-only change with well-structured content. Config examples match the actual Discord schema validated against source code. No broken links, no logic errors, and previously flagged issues from prior threads have been addressed or acknowledged. Score is 4 rather than 5 because the two concerns from prior review threads (gateway restart command choice and token-in-chat guidance) remain areas the author may want to revisit.
- No files require special attention.

<sub>Last reviewed commit: d4c44e4</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->