### PR TITLE
fix(gateway): trusted-proxy auth rejected when bind=loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Auth: allow trusted-proxy mode with loopback bind for same-host reverse-proxy deployments, while still requiring configured `gateway.trustedProxies`. (#20097) thanks @xinhuagu.
 - Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.
 - Gateway/Hooks: include transform export name in hook-transform cache keys so distinct exports from the same module do not reuse the wrong cached transform function. (#13855) thanks @mcaxtr.
 - Gateway/Control UI: return 404 for missing static-asset paths instead of serving SPA fallback HTML, while preserving client-route fallback behavior for extensionless and non-asset dotted paths. (#12060) thanks @mcaxtr.

--- a/src/commands/configure.gateway.e2e.test.ts
+++ b/src/commands/configure.gateway.e2e.test.ts
@@ -127,7 +127,7 @@ describe("promptGatewayConfig", () => {
       requiredHeaders: ["x-forwarded-proto", "x-forwarded-host"],
       allowUsers: ["nick@example.com"],
     });
-    expect(result.config.gateway?.bind).toBe("lan");
+    expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.trustedProxies).toEqual(["10.0.1.10", "192.168.1.5"]);
   });
 
@@ -141,7 +141,7 @@ describe("promptGatewayConfig", () => {
       userHeader: "x-remote-user",
       // requiredHeaders and allowUsers should be undefined when empty
     });
-    expect(result.config.gateway?.bind).toBe("lan");
+    expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.trustedProxies).toEqual(["10.0.0.1"]);
   });
 
@@ -150,7 +150,7 @@ describe("promptGatewayConfig", () => {
       tailscaleMode: "serve",
       textQueue: ["18789", "x-forwarded-user", "", "", "10.0.0.1"],
     });
-    expect(result.config.gateway?.bind).toBe("lan");
+    expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.tailscale?.mode).toBe("off");
     expect(result.config.gateway?.tailscale?.resetOnExit).toBe(false);
   });

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -142,10 +142,8 @@ export async function promptGatewayConfig(
     authMode = "password";
   }
 
-  if (authMode === "trusted-proxy" && bind === "loopback") {
-    note("Trusted proxy auth requires network bind. Adjusting bind to lan.", "Note");
-    bind = "lan";
-  }
+  // trusted-proxy + loopback is valid when the reverse proxy runs on the same
+  // host (e.g. cloudflared, nginx, Caddy). trustedProxies must include 127.0.0.1.
   if (authMode === "trusted-proxy" && tailscaleMode !== "off") {
     note(
       "Trusted proxy auth is incompatible with Tailscale serve/funnel. Disabling Tailscale.",

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -117,11 +117,6 @@ export async function resolveGatewayRuntimeConfig(params: {
   }
 
   if (authMode === "trusted-proxy") {
-    if (isLoopbackHost(bindHost)) {
-      throw new Error(
-        "gateway auth mode=trusted-proxy makes no sense with bind=loopback; use bind=lan or bind=custom with gateway.trustedProxies configured",
-      );
-    }
     if (trustedProxies.length === 0) {
       throw new Error(
         "gateway auth mode=trusted-proxy requires gateway.trustedProxies to be configured with at least one proxy IP",


### PR DESCRIPTION
## Problem

Gateway refuses to start with `bind=loopback` + `auth.mode=trusted-proxy`, throwing:

```
gateway auth mode=trusted-proxy makes no sense with bind=loopback
```

This blocks a valid deployment pattern: reverse proxy (cloudflared, nginx, Caddy) running on the **same host**, connecting to the gateway via loopback while adding authentication headers.

Users are forced to use `bind=lan`, unnecessarily exposing the gateway port to the local network.

## Root Cause

Two hardcoded restrictions:

1. `server-runtime-config.ts`: throws on loopback + trusted-proxy
2. `configure.gateway.ts`: silently overrides bind from loopback to lan

## Why This Is Safe

The trusted-proxy auth mode validates identity via **HTTP headers** (not IP origin) and checks `req.socket.remoteAddress` against `gateway.trustedProxies`. On loopback, the remote address is `127.0.0.1` — users configure `trustedProxies: ["127.0.0.1"]` to allow it. The existing `trustedProxies.length === 0` check is preserved, so misconfiguration is still caught.

## Fix

Remove the loopback restriction. Keep the trustedProxies-must-be-configured check.

Closes #20073

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes two hardcoded restrictions that blocked `trusted-proxy` auth when `bind=loopback`: a hard error in `server-runtime-config.ts` and a silent `bind` override to `"lan"` in `configure.gateway.ts`. This unblocks a valid deployment pattern where a reverse proxy (e.g. cloudflared, nginx, Caddy) runs on the same host and connects to the gateway via loopback while adding authentication headers.

- The existing safety check requiring `trustedProxies` to be non-empty is preserved, preventing misconfiguration.
- On loopback, `req.socket.remoteAddress` is `127.0.0.1`, so users must configure `trustedProxies: ["127.0.0.1"]` for the auth to work — this is validated at both config time and runtime.
- Tests are updated to reflect the new behavior and a new test case covers loopback + trusted-proxy with empty `trustedProxies`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it removes an unnecessary restriction while preserving all security validations.
- The change is minimal and well-scoped: two restriction blocks removed, safety checks (trustedProxies must be configured) preserved. The auth flow in auth.ts validates remoteAddress against trustedProxies at request time, so security is not degraded. Tests are comprehensive and cover both the happy path and misconfiguration case. No other code paths depend on the removed restrictions.
- No files require special attention

<sub>Last reviewed commit: 3cfb225</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->