### PR TITLE
Agents: fix Cloud Code Assist tool schema compatibility

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -101,7 +101,18 @@ const APPROVAL_SLUG_LENGTH = 8;
 export const execSchema = Type.Object({
   command: Type.String({ description: "Shell command to execute" }),
   workdir: Type.Optional(Type.String({ description: "Working directory (defaults to cwd)" })),
-  env: Type.Optional(Type.Record(Type.String(), Type.String())),
+  env: Type.Optional(
+    Type.Array(
+      Type.Object({
+        key: Type.String({ description: "Environment variable name" }),
+        value: Type.String({ description: "Environment variable value" }),
+      }),
+      {
+        description:
+          "Environment variables as key/value pairs. Example: [{ key: 'LANG', value: 'C.UTF-8' }].",
+      },
+    ),
+  ),
   yieldMs: Type.Optional(
     Type.Number({
       description: "Milliseconds to wait before backgrounding (default 10000)",

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -66,7 +66,6 @@ const processSchema = Type.Object({
   timeout: Type.Optional(
     Type.Number({
       description: "For poll: wait up to this many milliseconds before returning",
-      minimum: 0,
     }),
   ),
 });

--- a/src/agents/pi-embedded-runner/google.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/google.e2e.test.ts
@@ -33,4 +33,37 @@ describe("sanitizeToolsForGoogle", () => {
     expect(params.additionalProperties).toBeUndefined();
     expect(params.properties?.foo?.format).toBeUndefined();
   });
+
+  it("also strips unsupported schema keywords for google-antigravity", () => {
+    const tool = {
+      name: "test",
+      description: "test",
+      parameters: {
+        type: "object",
+        patternProperties: {
+          "^x-": { type: "string" },
+        },
+        properties: {
+          foo: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      },
+      execute: async () => ({ ok: true, content: [] }),
+    } as unknown as AgentTool;
+
+    const [sanitized] = sanitizeToolsForGoogle({
+      tools: [tool],
+      provider: "google-antigravity",
+    });
+
+    const params = sanitized.parameters as {
+      patternProperties?: unknown;
+      properties?: Record<string, { format?: unknown }>;
+    };
+
+    expect(params.patternProperties).toBeUndefined();
+    expect(params.properties?.foo?.format).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -247,11 +247,10 @@ export function sanitizeToolsForGoogle<
   tools: AgentTool<TSchemaType, TResult>[];
   provider: string;
 }): AgentTool<TSchemaType, TResult>[] {
-  // google-antigravity serves Anthropic models (e.g. claude-opus-4-6-thinking),
-  // NOT Gemini. Applying Gemini schema cleaning strips JSON Schema keywords
-  // (minimum, maximum, format, etc.) that Anthropic's API requires for
-  // draft 2020-12 compliance. Only clean for actual Gemini providers.
-  if (params.provider !== "google-gemini-cli") {
+  // Cloud Code Assist-style Google providers (including antigravity) reject
+  // several JSON Schema keywords in function declarations.
+  // Apply the same schema scrubber for both to avoid 400 invalid payload errors.
+  if (params.provider !== "google-gemini-cli" && params.provider !== "google-antigravity") {
     return params.tools;
   }
   return params.tools.map((tool) => {

--- a/src/agents/tools/browser-tool.schema.ts
+++ b/src/agents/tools/browser-tool.schema.ts
@@ -42,6 +42,13 @@ const BROWSER_SNAPSHOT_REFS = ["role", "aria"] as const;
 
 const BROWSER_IMAGE_TYPES = ["png", "jpeg"] as const;
 
+const BrowserFormFieldSchema = Type.Object({
+  ref: Type.String(),
+  type: Type.String(),
+  // Keep value scalar-only for tool-call portability across providers.
+  value: Type.Optional(Type.String()),
+});
+
 // NOTE: Using a flattened object schema instead of Type.Union([Type.Object(...), ...])
 // because Claude API on Vertex AI rejects nested anyOf schemas as invalid JSON Schema.
 // The discriminator (kind) determines which properties are relevant; runtime validates.
@@ -65,8 +72,8 @@ const BrowserActSchema = Type.Object({
   endRef: Type.Optional(Type.String()),
   // select
   values: Type.Optional(Type.Array(Type.String())),
-  // fill - use permissive array of objects
-  fields: Type.Optional(Type.Array(Type.Object({}, { additionalProperties: true }))),
+  // fill
+  fields: Type.Optional(Type.Array(BrowserFormFieldSchema)),
   // resize
   width: Type.Optional(Type.Number()),
   height: Type.Optional(Type.Number()),


### PR DESCRIPTION
## Summary

- Problem: Cloud Code Assist rejected tool declarations with `Unknown name "patternProperties"` (HTTP 400), blocking tool use on `google-antigravity`.
- Why it matters: Claude models via Cloud Code Assist became unusable for any tool-bearing request.
- What changed:
  - Reworked `exec` tool schema env input to avoid `Type.Record(...)` (`patternProperties`) and added runtime normalization for backward compatibility.
  - Extended Google tool-schema sanitization to include `google-antigravity` (not only `google-gemini-cli`).
  - Removed one remaining schema constraint keyword from `process` tool (`minimum`) and tightened browser fill-field schema to avoid `additionalProperties`.
  - Added regression tests for schema sanitization and `exec` schema compatibility.
- What did NOT change (scope boundary):
  - No changes to tool business logic semantics beyond schema/input-shape compatibility.
  - No provider auth or transport protocol changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #19860
- Related #19860

## User-visible / Behavior Changes

- Claude via `google-antigravity` no longer fails with Cloud Code Assist 400 due to unsupported tool-schema keywords.
- `exec.env` accepts key/value array schema for tool declaration compatibility while preserving object-form runtime compatibility.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local verification)
- Runtime/container: Node 22+, pnpm
- Model/provider: `google-antigravity` (Cloud Code Assist path)
- Integration/channel (if any): N/A
- Relevant config (redacted): default local dev config

### Steps

1. Use `google-antigravity/claude-*` and trigger a tool-bearing request.
2. Observe 400 error mentioning `patternProperties` before fix.
3. Apply patch, rebuild, restart gateway, retry same request.

### Expected

- Tool declarations accepted by Cloud Code Assist; request continues normally.

### Actual

- After fix: no `patternProperties`-related 400 in tool-bearing requests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test:e2e src/agents/pi-embedded-runner/google.e2e.test.ts src/agents/bash-tools.exec.path.e2e.test.ts`
  - Reproduced issue symptom and confirmed behavior resolved after rebuild/restart.
- Edge cases checked:
  - `exec` host env validation still blocks dangerous keys with both object-form and key/value env entries.
- What you did **not** verify:
  - Full live integration matrix across all channels/providers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/bash-tools.exec-runtime.ts`
  - `src/agents/bash-tools.exec.ts`
  - `src/agents/pi-embedded-runner/google.ts`
- Known bad symptoms reviewers should watch for:
  - Any regression in `exec.env` parsing or unexpected provider-side schema rejections.

## Risks and Mitigations

- Risk:
  - Over-sanitization could remove constraints expected by some providers.
  - Mitigation:
    - Scope sanitization to Google Cloud Code Assist paths and cover with provider-specific tests.
- Risk:
  - `exec.env` schema shape change could break strict callers.
  - Mitigation:
    - Runtime keeps backward compatibility for object-form env input.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Cloud Code Assist (`google-antigravity`) rejecting tool declarations containing unsupported JSON Schema keywords (notably `patternProperties` from `Type.Record()`), which caused HTTP 400 errors blocking all tool-bearing requests.

**Key changes:**
- Replaced `Type.Record(Type.String(), Type.String())` for `exec.env` with a `Type.Array(Type.Object({ key, value }))` schema to eliminate `patternProperties`, and added `parseExecEnvInput()` to normalize both array-form and legacy object-form inputs at runtime
- Extended `sanitizeToolsForGoogle()` to include `google-antigravity` alongside `google-gemini-cli`, reversing a prior decision that antigravity didn't need schema sanitization
- Removed `minimum` from `process` tool's `timeout` schema and tightened browser `fill.fields` schema to use explicit properties instead of `additionalProperties: true`
- Added regression tests for schema compatibility and env validation with the new array-form input

The changes are scoped to schema declarations and input normalization — no tool business logic semantics were altered. Backward compatibility is maintained for existing callers passing object-form env values.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it addresses a clear compatibility bug with well-scoped, backward-compatible schema changes and runtime normalization.
- All changes are narrowly scoped to JSON Schema declarations and input normalization. No tool business logic was altered. Backward compatibility for object-form env input is maintained via `parseExecEnvInput()`. The Google schema sanitization extension aligns with an already-existing pattern. Tests cover the new behavior. Security validation (dangerous env var blocking) works correctly with both input formats.
- No files require special attention.

<sub>Last reviewed commit: 8a72643</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->