### PR TITLE
fix: allow loopback binding with trusted-proxy auth mode

### DIFF
--- a/src/commands/configure.gateway.e2e.test.ts
+++ b/src/commands/configure.gateway.e2e.test.ts
@@ -127,7 +127,7 @@ describe("promptGatewayConfig", () => {
       requiredHeaders: ["x-forwarded-proto", "x-forwarded-host"],
       allowUsers: ["nick@example.com"],
     });
-    expect(result.config.gateway?.bind).toBe("lan");
+    expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.trustedProxies).toEqual(["10.0.1.10", "192.168.1.5"]);
   });
 
@@ -141,7 +141,7 @@ describe("promptGatewayConfig", () => {
       userHeader: "x-remote-user",
       // requiredHeaders and allowUsers should be undefined when empty
     });
-    expect(result.config.gateway?.bind).toBe("lan");
+    expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.trustedProxies).toEqual(["10.0.0.1"]);
   });
 
@@ -150,7 +150,7 @@ describe("promptGatewayConfig", () => {
       tailscaleMode: "serve",
       textQueue: ["18789", "x-forwarded-user", "", "", "10.0.0.1"],
     });
-    expect(result.config.gateway?.bind).toBe("lan");
+    expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.tailscale?.mode).toBe("off");
     expect(result.config.gateway?.tailscale?.resetOnExit).toBe(false);
   });

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -142,10 +142,6 @@ export async function promptGatewayConfig(
     authMode = "password";
   }
 
-  if (authMode === "trusted-proxy" && bind === "loopback") {
-    note("Trusted proxy auth requires network bind. Adjusting bind to lan.", "Note");
-    bind = "lan";
-  }
   if (authMode === "trusted-proxy" && tailscaleMode !== "off") {
     note(
       "Trusted proxy auth is incompatible with Tailscale serve/funnel. Disabling Tailscale.",

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -30,7 +30,7 @@ describe("resolveGatewayRuntimeConfig", () => {
       expect(result.bindHost).toBe("0.0.0.0");
     });
 
-    it("should reject loopback binding with trusted-proxy auth mode", async () => {
+    it("should allow loopback binding with trusted-proxy auth mode when trustedProxies is configured", async () => {
       const cfg = {
         gateway: {
           bind: "loopback" as const,
@@ -44,12 +44,13 @@ describe("resolveGatewayRuntimeConfig", () => {
         },
       };
 
-      await expect(
-        resolveGatewayRuntimeConfig({
-          cfg,
-          port: 18789,
-        }),
-      ).rejects.toThrow("gateway auth mode=trusted-proxy makes no sense with bind=loopback");
+      const result = await resolveGatewayRuntimeConfig({
+        cfg,
+        port: 18789,
+      });
+
+      expect(result.authMode).toBe("trusted-proxy");
+      expect(result.bindHost).toBe("127.0.0.1");
     });
 
     it("should reject trusted-proxy without trustedProxies configured", async () => {

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -103,11 +103,6 @@ export async function resolveGatewayRuntimeConfig(params: {
   }
 
   if (authMode === "trusted-proxy") {
-    if (isLoopbackHost(bindHost)) {
-      throw new Error(
-        "gateway auth mode=trusted-proxy makes no sense with bind=loopback; use bind=lan or bind=custom with gateway.trustedProxies configured",
-      );
-    }
     if (trustedProxies.length === 0) {
       throw new Error(
         "gateway auth mode=trusted-proxy requires gateway.trustedProxies to be configured with at least one proxy IP",


### PR DESCRIPTION
Fixes #20073

## What changed
Removed the validation that prevented using  with . This allows users with tunnels like cloudflared that add authentication headers to use the more secure loopback binding while still designating the tunnel as a trusted proxy.

## AI-assisted contribution
This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)

Testing depth: validated with pnpm build && pnpm check && pnpm test

The fix addresses the root cause described in the issue by removing the overly restrictive check that assumed loopback binding and trusted-proxy mode could never be used together. This is a valid configuration when using tunnels that add authentication headers.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the validation in `server-runtime-config.ts` that prevented using `bind=loopback` with `auth mode=trusted-proxy`, enabling tunnel setups like cloudflared that add authentication headers while connecting via loopback. The test is updated to validate the new allowed combination.

- The runtime config change is sound: the remaining `trustedProxies.length === 0` check ensures trusted-proxy mode still requires proxy IPs to be configured.
- **Incomplete fix**: `src/commands/configure.gateway.ts` (line 145-148) still forcibly overrides `bind` from `loopback` to `lan` when `trusted-proxy` is selected in the interactive wizard, contradicting this PR's intent. The corresponding e2e tests in `configure.gateway.e2e.test.ts` also assert the old behavior.

<h3>Confidence Score: 3/5</h3>

- The runtime config change is safe, but the fix is incomplete — the interactive configuration wizard still overrides loopback to lan for trusted-proxy.
- The two changed files are correct and well-tested, but the PR misses updating `src/commands/configure.gateway.ts` which still enforces the old restriction by forcibly changing bind from loopback to lan when trusted-proxy is selected. This means users configuring via the wizard cannot achieve the combination this PR enables.
- src/commands/configure.gateway.ts and src/commands/configure.gateway.e2e.test.ts need matching updates to fully support the loopback + trusted-proxy combination.

<sub>Last reviewed commit: 85600f3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->