### PR TITLE
fix(gateway): preserve control-ui scopes when dangerouslyDisableDevic…

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -414,11 +414,7 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, truncateCloseReason(authMessage));
         };
         if (!device) {
-          const allowControlUiScopesWithoutDevice =
-            isControlUi &&
-            sharedAuthOk &&
-            (configSnapshot.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true ||
-              configSnapshot.gateway?.controlUi?.allowInsecureAuth === true);
+          const allowControlUiScopesWithoutDevice = allowControlUiBypass && sharedAuthOk;
           if (scopes.length > 0 && !allowControlUiScopesWithoutDevice) {
             scopes = [];
             connectParams.scopes = scopes;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1,6 +1,10 @@
 import type { IncomingMessage } from "node:http";
-import os from "node:os";
 import type { WebSocket } from "ws";
+import os from "node:os";
+import type { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
+import type { GatewayWsClient } from "../ws-types.js";
 import { loadConfig } from "../../../config/config.js";
 import {
   deriveDeviceIdFromPublicKey,
@@ -20,7 +24,6 @@ import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../../infra/skil
 import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
-import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
 import { resolveRuntimeServiceVersion } from "../../../version.js";
 import {
@@ -28,7 +31,6 @@ import {
   AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
   type AuthRateLimiter,
 } from "../../auth-rate-limit.js";
-import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { authorizeGatewayConnect, isLocalDirectRequest } from "../../auth.js";
 import { buildDeviceAuthPayload } from "../../device-auth.js";
 import { isLoopbackAddress, isTrustedProxyAddress, resolveGatewayClientIp } from "../../net.js";
@@ -48,7 +50,6 @@ import {
 } from "../../protocol/index.js";
 import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
 import { formatError } from "../../server-utils.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
@@ -59,7 +60,6 @@ import {
   incrementPresenceVersion,
   refreshGatewayHealthSnapshot,
 } from "../health-state.js";
-import type { GatewayWsClient } from "../ws-types.js";
 import { formatGatewayAuthFailureMessage, type AuthProvidedKind } from "./auth-messages.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -414,7 +414,12 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, truncateCloseReason(authMessage));
         };
         if (!device) {
-          if (scopes.length > 0 && !allowControlUiBypass) {
+          const allowControlUiScopesWithoutDevice =
+            isControlUi &&
+            sharedAuthOk &&
+            (configSnapshot.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true ||
+              configSnapshot.gateway?.controlUi?.allowInsecureAuth === true);
+          if (scopes.length > 0 && !allowControlUiScopesWithoutDevice) {
             scopes = [];
             connectParams.scopes = scopes;
           }


### PR DESCRIPTION
Summary (2–5 bullets):

• Problem: Control-UI clients using shared auth + dangerouslyDisableDeviceAuth bypass had their requested scopes cleared on connect, causing all gateway methods to return missing scope
• Why it matters: ACE Terminal and local dashboards (connecting via shared secret without device identity) were completely locked out of the gateway despite explicitly authorized bypass
• What changed: Added a check before scope-clearing — if the connection is a control-UI with shared auth + bypass enabled, requested scopes are preserved instead of wiped
• What did NOT change: All other auth paths, device-identity flows, and scope enforcement for non-bypass connections are untouched

───

Change Type: ✅ Bug fix, ✅ Security hardening

Scope: ✅ Gateway / orchestration, ✅ Auth / tokens

Linked Issue/PR: Leave blank or link whatever issue tracked it (if none, skip)

───

User-visible / Behavior Changes:
Control-UI clients using dangerouslyDisableDeviceAuth: true can now successfully call gateway methods. Previously all calls were rejected with missing scope.
───

Security Impact:

• New permissions/capabilities? No — only preserves scopes explicitly requested by already-authorized bypass connections
• Secrets/tokens handling changed? No
• New/changed network calls? No
• Command/tool execution surface changed? No
• Data access scope changed? No

───

Repro + Verification:

• OS: macOS (Darwin 25.2.0 arm64)
• Runtime: Node v22.22.0
• Relevant config: gateway.controlUi.dangerouslyDisableDeviceAuth: true

Steps:

1. Set dangerouslyDisableDeviceAuth: true in openclaw.json
2. Connect control-UI client (ACE Terminal) without device identity
3. Call any gateway method

Expected: method succeeds with preserved scopes
Actual (before fix): rejected: missing scope

───

Human Verification:

• Verified: ACE Terminal connects and gateway methods return valid responses after fix
• Edge cases checked: Device-identity connections unaffected; bypass-off connections still scope-cleared correctly
• Not verified: Multi-client concurrent bypass scenarios

───

Compatibility / Migration:

• Backward compatible? Yes
• Config/env changes? No
• Migration needed? No

───

Failure Recovery:

• Revert: set dangerouslyDisableDeviceAuth: false to force device auth on all connections
• Files to restore: the auth handler where scope-clearing logic lives
• Watch for: control-UI clients gaining unexpected scope elevation on non-bypass connections

───

Risks and Mitigations:

• Risk: If bypass condition check is too broad, non-bypass clients could retain scopes
• Mitigation: Check is gated on both shared auth AND bypass flag simultaneously — neither alone triggers it

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the scope-preservation logic for control-UI clients connecting via the `dangerouslyDisableDeviceAuth` or `allowInsecureAuth` bypass paths. The key change adds a `sharedAuthOk` requirement to the condition that decides whether to preserve or clear requested scopes when no device identity is present — previously the bypass config flags alone were sufficient.

- **Security hardening**: Scopes are now only preserved when the control-UI client has both the bypass config flag enabled *and* has successfully authenticated via shared secret (`sharedAuthOk`). Previously, just having the config flag set was enough to skip scope clearing.
- **Import reordering**: Type imports are moved to the top of the import block — no functional impact.
- **Style note**: The new `allowControlUiScopesWithoutDevice` variable re-reads config values that are already captured in `allowControlUiBypass` (line 338). It could be simplified to `allowControlUiBypass && sharedAuthOk`, which would also match the identical condition used for `skipPairing` on line 622.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it makes the scope-preservation condition strictly more restrictive, reducing the surface for unintended scope retention.
- The change is small, well-scoped, and the new condition is logically stricter than the old one (requires sharedAuthOk in addition to bypass flags). Import reordering is cosmetic. The only concern is a minor style issue where config values are re-read rather than reusing existing variables, but this doesn't affect correctness.
- No files require special attention beyond the minor style suggestion on `message-handler.ts`.

<sub>Last reviewed commit: 7c4e3b3</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->