### PR TITLE
Fix Anthropic 1M model ID: strip -1m suffix before API call

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.anthropic-1m.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.anthropic-1m.test.ts
@@ -1,0 +1,90 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+function createModel(id: string): Model<"anthropic-messages"> {
+  return {
+    id,
+    name: id,
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 8192,
+  };
+}
+
+function captureStreamCall(
+  provider: string,
+  modelId: string,
+  extraParams?: Record<string, unknown>,
+) {
+  let capturedModel: Model<"anthropic-messages"> | undefined;
+  let capturedHeaders: Record<string, string> | undefined;
+
+  const baseStreamFn: StreamFn = (model, _context, options) => {
+    capturedModel = model as Model<"anthropic-messages">;
+    capturedHeaders = options?.headers;
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, undefined, provider, modelId, extraParams);
+
+  const model = createModel(modelId);
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(model, context, {});
+
+  return { capturedModel, capturedHeaders };
+}
+
+describe("extra-params: Anthropic 1M model ID handling", () => {
+  it("strips -1m suffix from model ID before sending to API", () => {
+    const { capturedModel } = captureStreamCall("anthropic", "claude-opus-4-6-1m", {
+      context1m: true,
+    });
+    expect(capturedModel?.id).toBe("claude-opus-4-6");
+  });
+
+  it("strips -1m suffix case-insensitively", () => {
+    const { capturedModel } = captureStreamCall("anthropic", "claude-sonnet-4-6-1M", {
+      context1m: true,
+    });
+    expect(capturedModel?.id).toBe("claude-sonnet-4-6");
+  });
+
+  it("auto-injects context-1m beta header when model ID ends with -1m", () => {
+    const { capturedHeaders } = captureStreamCall("anthropic", "claude-opus-4-6-1m");
+    expect(capturedHeaders?.["anthropic-beta"]).toContain("context-1m-2025-08-07");
+  });
+
+  it("does not strip suffix for non-anthropic providers", () => {
+    const { capturedModel } = captureStreamCall("openrouter", "claude-opus-4-6-1m");
+    expect(capturedModel?.id).toBe("claude-opus-4-6-1m");
+  });
+
+  it("preserves model ID when no -1m suffix", () => {
+    const { capturedModel } = captureStreamCall("anthropic", "claude-opus-4-6", {
+      context1m: true,
+    });
+    expect(capturedModel?.id).toBe("claude-opus-4-6");
+  });
+
+  it("injects beta header with explicit context1m param (no suffix)", () => {
+    const { capturedHeaders } = captureStreamCall("anthropic", "claude-opus-4-6", {
+      context1m: true,
+    });
+    expect(capturedHeaders?.["anthropic-beta"]).toContain("context-1m-2025-08-07");
+  });
+});


### PR DESCRIPTION
## Problem

When using the `-1m` model ID convention (e.g. `claude-opus-4-6-1m`), the suffix is sent directly to the Anthropic API, resulting in a 404 error. The API doesn't recognize `claude-opus-4-6-1m` as a valid model name.

The codebase already has partial 1M support (`isAnthropic1MModel()`, beta header injection), but the model ID wasn't being normalized before the API call.

## Fix

- Strip `-1m` suffix from the model ID in `createAnthropicBetaHeadersWrapper` before forwarding to the Anthropic API
- Auto-detect `-1m` suffix to inject the `context-1m-2025-08-07` beta header without requiring an explicit `context1m` param
- `isAnthropic1MModel()` now recognizes `-1m` suffixed model IDs (strips suffix before prefix check)

## Testing

6 new tests covering:
- Suffix stripping for Opus and Sonnet models
- Case-insensitive suffix handling
- Auto-injection of beta header from suffix
- Non-anthropic providers are not affected
- Explicit `context1m` param still works without suffix

Fixes #20079

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 404 error when using the `-1m` model ID convention (e.g., `claude-opus-4-6-1m`) by stripping the `-1m` suffix before sending the model ID to the Anthropic API, and auto-detecting the suffix to inject the `context-1m-2025-08-07` beta header. The change completes the existing partial 1M support in the codebase.

- Two new helper functions (`stripAnthropic1MSuffix`, `hasAnthropic1MSuffix`) centralize suffix detection and removal logic
- `isAnthropic1MModel()` updated to strip the suffix before checking model prefixes
- `resolveAnthropicBetas()` now auto-detects `-1m` suffix in addition to the explicit `context1m` param
- `createAnthropicBetaHeadersWrapper()` strips the `-1m` suffix from the model object before forwarding to the underlying stream function
- 6 well-structured tests covering suffix stripping, case-insensitive handling, auto-injection, and provider isolation
- **Issue**: `stripAnthropic1MSuffix` doesn't `.trim()` while `hasAnthropic1MSuffix` does, creating an inconsistency that could cause the suffix to not be stripped when it's detected
- **Issue**: Non-opus/sonnet models with `-1m` suffix (e.g., `claude-haiku-3-5-1m`) will still 404 since the suffix is only stripped inside the beta headers wrapper, which isn't created when 1M is unsupported

<h3>Confidence Score: 3/5</h3>

- This PR solves the main problem but has minor correctness issues worth addressing before merge.
- The core fix is sound and well-tested for the primary use case (opus/sonnet with -1m suffix). However, the trim inconsistency between stripAnthropic1MSuffix and hasAnthropic1MSuffix could cause the suffix to remain unstripped in edge cases, and unsupported model types with -1m suffix will still 404 without clear user feedback beyond a warning log.
- src/agents/pi-embedded-runner/extra-params.ts - review the trim inconsistency and unsupported model edge case

<sub>Last reviewed commit: 03048c4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

🤖 **AI-assisted PR** (Claude, via OpenClaw agent)
- Testing: Fully tested locally with vitest; all relevant test suites pass
- The contributor understands what this code does