### PR TITLE
security: MAESTRO threat mitigations (LM-001, SC-003, AF-005, DI-006, EO-004, AE-001)

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,5 +1,9 @@
 FROM debian:bookworm-slim
 
+# AF-005: Document that containers must be run with --security-opt no-new-privileges
+# and --cap-drop ALL (enforced via docker-compose.yml security_opt / cap_drop settings).
+LABEL security.no-new-privileges="true"
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,12 @@ services:
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
     init: true
     restart: unless-stopped
+    # Security hardening (DI-006 / AF-005): prevent privilege escalation and
+    # reduce attack surface by dropping all Linux capabilities.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     command:
       [
         "node",
@@ -43,4 +49,10 @@ services:
     stdin_open: true
     tty: true
     init: true
+    # Security hardening (DI-006 / AF-005): prevent privilege escalation and
+    # reduce attack surface by dropping all Linux capabilities.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     entrypoint: ["node", "dist/index.js"]

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -13,6 +13,47 @@ const PAIRING_CODE_LENGTH = 8;
 const PAIRING_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const PAIRING_PENDING_TTL_MS = 60 * 60 * 1000;
 const PAIRING_PENDING_MAX = 3;
+
+// Rate-limiting constants for pairing code approval attempts
+const MAX_PAIRING_ATTEMPTS = 5;
+const PAIRING_LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Simple in-process rate limiter for pairing code approval attempts.
+ *
+ * Tracks failures per (channel, code) key and locks out after MAX_PAIRING_ATTEMPTS
+ * failed attempts for PAIRING_LOCKOUT_MS milliseconds, mitigating brute-force attacks.
+ */
+class PairingRateLimiter {
+  private readonly failures = new Map<string, { count: number; lockedUntil?: number }>();
+
+  /** Check whether a given key is currently allowed to attempt approval. */
+  check(key: string): { allowed: boolean; retryAfterMs?: number } {
+    const entry = this.failures.get(key);
+    if (!entry) return { allowed: true };
+    if (entry.lockedUntil !== undefined && Date.now() < entry.lockedUntil) {
+      return { allowed: false, retryAfterMs: entry.lockedUntil - Date.now() };
+    }
+    return { allowed: true };
+  }
+
+  /** Record a failed attempt for a key, locking out if threshold is reached. */
+  recordFailure(key: string): void {
+    const entry = this.failures.get(key) ?? { count: 0 };
+    entry.count += 1;
+    if (entry.count >= MAX_PAIRING_ATTEMPTS) {
+      entry.lockedUntil = Date.now() + PAIRING_LOCKOUT_MS;
+    }
+    this.failures.set(key, entry);
+  }
+
+  /** Reset failure tracking after a successful approval. */
+  reset(key: string): void {
+    this.failures.delete(key);
+  }
+}
+
+const pairingRateLimiter = new PairingRateLimiter();
 const PAIRING_STORE_LOCK_OPTIONS = {
   retries: {
     retries: 10,
@@ -545,6 +586,13 @@ export async function approveChannelPairingCode(params: {
     return null;
   }
 
+  // SC-003: Brute-force rate limiting per (channel, code) key
+  const rateLimitKey = `${params.channel}:${code}`;
+  const rlCheck = pairingRateLimiter.check(rateLimitKey);
+  if (!rlCheck.allowed) {
+    return null; // too many failed attempts — locked out
+  }
+
   const filePath = resolvePairingPath(params.channel, env);
   return await withFileLock(
     filePath,
@@ -565,6 +613,7 @@ export async function approveChannelPairingCode(params: {
             requests: pruned,
           } satisfies PairingStore);
         }
+        pairingRateLimiter.recordFailure(rateLimitKey);
         return null;
       }
       const entry = pruned[idx];
@@ -583,6 +632,7 @@ export async function approveChannelPairingCode(params: {
         accountId: params.accountId?.trim() || entryAccountId,
         env,
       });
+      pairingRateLimiter.reset(rateLimitKey);
       return { id: entry.id, entry };
     },
   );

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -41,6 +41,45 @@ export function detectSuspiciousPatterns(content: string): string[] {
 }
 
 /**
+ * Result of a suspicious-content check that may block processing.
+ */
+export type SuspiciousContentResult = {
+  /** Whether the content was blocked due to detected patterns */
+  blocked: boolean;
+  /** Human-readable reason for blocking (empty string if not blocked) */
+  reason: string;
+  /** All matched suspicious pattern sources */
+  matches: string[];
+};
+
+/**
+ * Checks content for prompt injection patterns and returns a blocking result.
+ *
+ * Unlike `detectSuspiciousPatterns` (which is log-only), this function returns
+ * a structured result that callers MUST act on to enforce hard blocking.
+ *
+ * @example
+ * ```ts
+ * const result = checkAndBlockSuspiciousContent(userContent);
+ * if (result.blocked) {
+ *   logger.warn("Blocked prompt injection attempt", { reason: result.reason });
+ *   return; // do not pass content to the LLM
+ * }
+ * ```
+ */
+export function checkAndBlockSuspiciousContent(content: string): SuspiciousContentResult {
+  const matches = detectSuspiciousPatterns(content);
+  if (matches.length === 0) {
+    return { blocked: false, reason: "", matches: [] };
+  }
+  return {
+    blocked: true,
+    reason: `Prompt injection detected: ${matches[0]}`,
+    matches,
+  };
+}
+
+/**
  * Unique boundary markers for external content.
  * Using XML-style tags that are unlikely to appear in legitimate content.
  */

--- a/src/security/log-integrity.ts
+++ b/src/security/log-integrity.ts
@@ -1,0 +1,104 @@
+/**
+ * EO-004: Audit Log Integrity — HMAC-SHA256 chaining
+ *
+ * Provides tamper-evident log chaining: each entry includes an HMAC-SHA256
+ * computed over (previousChainHash + serialized entry payload), using a
+ * caller-supplied secret key.  An attacker who modifies any past log entry
+ * must re-forge every subsequent HMAC, which is infeasible without the key.
+ *
+ * Usage:
+ *   const chain = new LogIntegrityChain(secretKey);
+ *   const sealed = chain.seal({ level: "info", message: "user logged in", ts: Date.now() });
+ *   // store `sealed` (which includes sealed.chain for the running hash)
+ *
+ *   // Verify a sequence of sealed entries:
+ *   const ok = LogIntegrityChain.verify(sealedEntries, secretKey);
+ */
+
+import crypto from "node:crypto";
+
+/** Raw log entry payload before sealing. */
+export type LogEntry = {
+  level: string;
+  message: string;
+  ts: number;
+  [key: string]: unknown;
+};
+
+/** A log entry with its HMAC chain hash appended. */
+export type SealedLogEntry = LogEntry & {
+  /** HMAC-SHA256(key, previousChain || JSON(payload)) over the immutable fields. */
+  chain: string;
+};
+
+/** Genesis hash used when there is no previous entry. */
+const GENESIS_HASH = "0000000000000000000000000000000000000000000000000000000000000000";
+
+/**
+ * Stateful chain builder.  Create one instance per log stream (e.g., per file
+ * or per session).  Call `seal()` in order for each entry.
+ */
+export class LogIntegrityChain {
+  private previousHash: string;
+
+  constructor(
+    private readonly secretKey: string,
+    /** Optionally seed from the last stored chain hash to resume an existing log. */
+    lastChainHash?: string,
+  ) {
+    this.previousHash = lastChainHash ?? GENESIS_HASH;
+  }
+
+  /**
+   * Seal a log entry by appending an HMAC chain hash.
+   * The original `entry` object is not mutated; a new object is returned.
+   */
+  seal(entry: LogEntry): SealedLogEntry {
+    const payload = JSON.stringify(entry);
+    const hmac = crypto.createHmac("sha256", this.secretKey);
+    hmac.update(this.previousHash);
+    hmac.update(payload);
+    const chain = hmac.digest("hex");
+    this.previousHash = chain;
+    return { ...entry, chain };
+  }
+
+  /** Return the current chain tip (hash of the last sealed entry). */
+  get currentHash(): string {
+    return this.previousHash;
+  }
+
+  /**
+   * Verify the integrity of an ordered sequence of sealed entries.
+   *
+   * Returns `{ valid: true }` if the chain is unbroken, or
+   * `{ valid: false; firstBadIndex: number; expected: string; actual: string }`
+   * if any entry has been tampered with.
+   */
+  static verify(
+    entries: SealedLogEntry[],
+    secretKey: string,
+    seedHash?: string,
+  ):
+    | { valid: true }
+    | { valid: false; firstBadIndex: number; expected: string; actual: string } {
+    let previousHash = seedHash ?? GENESIS_HASH;
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]!;
+      // Reconstruct payload without the chain field
+      const { chain: storedChain, ...payload } = entry;
+      const payloadStr = JSON.stringify(payload);
+      const hmac = crypto.createHmac("sha256", secretKey);
+      hmac.update(previousHash);
+      hmac.update(payloadStr);
+      const expected = hmac.digest("hex");
+
+      if (storedChain !== expected) {
+        return { valid: false, firstBadIndex: i, expected, actual: storedChain };
+      }
+      previousHash = expected;
+    }
+    return { valid: true };
+  }
+}


### PR DESCRIPTION
Implements 6 MAESTRO security mitigations: LM-001 prompt injection detection, SC-003 pairing rate limiting, AF-005/DI-006 Docker hardening, EO-004 HMAC log integrity, AE-001 skill scanner. See threat-assessment.md for details.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds six MAESTRO security mitigations across Docker hardening, pairing rate-limiting, prompt injection detection, HMAC log integrity, and a skill content scanner.

- **Docker hardening (AF-005/DI-006)**: Adds `security_opt: no-new-privileges` and `cap_drop: ALL` to both services in `docker-compose.yml`, and a metadata label to `Dockerfile.sandbox`. Straightforward and correct.
- **Pairing rate limiter (SC-003)**: Introduces an in-process `PairingRateLimiter` in `pairing-store.ts`, but the rate-limit key is per (channel, code) — a brute-force attacker trying different codes would never trigger the lockout. Should key on channel alone or channel + source.
- **Prompt injection blocking (LM-001)**: Adds `checkAndBlockSuspiciousContent()` in `external-content.ts`, but it is only called from the new `skills scan` CLI command — it is not yet wired into any actual LLM content pipeline.
- **Log integrity (EO-004)**: New `log-integrity.ts` provides HMAC-SHA256 chaining for tamper-evident logs. Clean implementation, but has a correctness edge case (entries with a pre-existing "chain" property cause seal/verify mismatch) and no callers or tests yet.
- **Skill scanner (AE-001)**: Adds `openclaw skills scan` subcommand that reads skill files and checks them against prompt injection patterns. Uses unnecessary type assertions that weaken type safety.

<h3>Confidence Score: 3/5</h3>

- PR is mostly additive with low regression risk, but the rate limiter has a design flaw that undermines its stated security goal.
- Docker hardening changes are safe. The rate limiter's per-(channel, code) keying doesn't prevent brute-force enumeration across codes, defeating its purpose. Log integrity has a correctness edge case. New modules lack tests and callers.
- src/pairing/pairing-store.ts (rate limiter design flaw), src/security/log-integrity.ts (seal/verify mismatch edge case, no tests)

<sub>Last reviewed commit: 7595180</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->