### PR TITLE
UI: keep agents primary model dropdown in sync with overview

### DIFF
--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -367,19 +367,27 @@ function resolveConfiguredModels(
 
 export function buildModelOptions(
   configForm: Record<string, unknown> | null,
-  current?: string | null,
+  selected: string,
 ) {
   const options = resolveConfiguredModels(configForm);
-  const hasCurrent = current ? options.some((option) => option.value === current) : false;
-  if (current && !hasCurrent) {
-    options.unshift({ value: current, label: `Current (${current})` });
+  const selectedModel = selected.trim();
+  const hasCurrent = selectedModel
+    ? options.some((option) => option.value === selectedModel)
+    : false;
+  if (selectedModel && !hasCurrent) {
+    options.unshift({ value: selectedModel, label: `Current (${selectedModel})` });
   }
   if (options.length === 0) {
     return html`
-      <option value="" disabled>No configured models</option>
+      <option value="" disabled ?selected=${selectedModel === ""}>No configured models</option>
     `;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) =>
+      html`<option value=${option.value} ?selected=${option.value === selectedModel}
+        >${option.label}</option
+      >`,
+  );
 }
 
 type CompiledPattern =

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -1,0 +1,142 @@
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import type { AgentsProps } from "./agents.ts";
+import { renderAgents } from "./agents.ts";
+
+function createProps(overrides: Partial<AgentsProps> = {}): AgentsProps {
+  return {
+    loading: false,
+    error: null,
+    agentsList: {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [{ id: "main", name: "Hop", identity: { name: "Hop", emoji: "🗝️" } }],
+    },
+    selectedAgentId: "main",
+    activePanel: "overview",
+    configForm: null,
+    configLoading: false,
+    configSaving: false,
+    configDirty: false,
+    channelsLoading: false,
+    channelsError: null,
+    channelsSnapshot: null,
+    channelsLastSuccess: null,
+    cronLoading: false,
+    cronStatus: null,
+    cronJobs: [],
+    cronError: null,
+    agentFilesLoading: false,
+    agentFilesError: null,
+    agentFilesList: { agentId: "main", workspace: "/tmp/workspace", files: [] },
+    agentFileActive: null,
+    agentFileContents: {},
+    agentFileDrafts: {},
+    agentFileSaving: false,
+    agentIdentityLoading: false,
+    agentIdentityError: null,
+    agentIdentityById: {},
+    agentSkillsLoading: false,
+    agentSkillsReport: null,
+    agentSkillsError: null,
+    agentSkillsAgentId: null,
+    skillsFilter: "",
+    onRefresh: () => undefined,
+    onSelectAgent: () => undefined,
+    onSelectPanel: () => undefined,
+    onLoadFiles: () => undefined,
+    onSelectFile: () => undefined,
+    onFileDraftChange: () => undefined,
+    onFileReset: () => undefined,
+    onFileSave: () => undefined,
+    onToolsProfileChange: () => undefined,
+    onToolsOverridesChange: () => undefined,
+    onConfigReload: () => undefined,
+    onConfigSave: () => undefined,
+    onModelChange: () => undefined,
+    onModelFallbacksChange: () => undefined,
+    onChannelsRefresh: () => undefined,
+    onCronRefresh: () => undefined,
+    onSkillsFilterChange: () => undefined,
+    onSkillsRefresh: () => undefined,
+    onAgentSkillToggle: () => undefined,
+    onAgentSkillsClear: () => undefined,
+    onAgentSkillsDisableAll: () => undefined,
+    ...overrides,
+  };
+}
+
+function queryPrimaryModelSelect(container: HTMLElement): HTMLSelectElement {
+  const select = container.querySelector(".agent-model-select select");
+  expect(select).not.toBeNull();
+  return select as HTMLSelectElement;
+}
+
+describe("agents view", () => {
+  it("keeps model selection aligned with overview primary model", () => {
+    const container = document.createElement("div");
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.3-codex",
+            fallbacks: ["openai-codex/gpt-5.2"],
+          },
+          models: {
+            "openai-codex/gpt-5.2": {},
+            "openai-codex/gpt-5.3": {},
+            "openai-codex/gpt-5.3-codex": {},
+            "openai-codex/gpt-5.3-codex-spark": {},
+          },
+        },
+        list: [
+          {
+            id: "main",
+            model: {
+              primary: "openai-codex/gpt-5.3-codex-spark",
+              fallbacks: ["openai-codex/gpt-5.2"],
+            },
+          },
+        ],
+      },
+    } as Record<string, unknown>;
+    render(renderAgents(createProps({ configForm: config })), container);
+
+    expect(container.textContent).toContain("openai-codex/gpt-5.3-codex-spark (+1 fallback)");
+    const select = queryPrimaryModelSelect(container);
+    expect(select.value).toBe("openai-codex/gpt-5.3-codex-spark");
+  });
+
+  it("keeps an unlisted current model selected using a Current option", () => {
+    const container = document.createElement("div");
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.2",
+          },
+          models: {
+            "openai-codex/gpt-5.2": {},
+          },
+        },
+        list: [
+          {
+            id: "main",
+            model: {
+              primary: "openai-codex/gpt-5.3-codex-spark",
+              fallbacks: ["openai-codex/gpt-5.2"],
+            },
+          },
+        ],
+      },
+    } as Record<string, unknown>;
+    render(renderAgents(createProps({ configForm: config })), container);
+
+    const select = queryPrimaryModelSelect(container);
+    expect(select.value).toBe("openai-codex/gpt-5.3-codex-spark");
+    expect(select.selectedOptions[0]?.textContent).toContain(
+      "Current (openai-codex/gpt-5.3-codex-spark)",
+    );
+  });
+});

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -383,6 +383,7 @@ function renderAgentOverview(params: {
     resolveModelPrimary(config.defaults?.model) ||
     (defaultModel !== "-" ? normalizeModelValue(defaultModel) : null);
   const effectivePrimary = modelPrimary ?? defaultPrimary ?? null;
+  const selectedPrimaryValue = effectivePrimary ?? "";
   const modelFallbacks = resolveModelFallbacks(config.entry?.model);
   const fallbackText = modelFallbacks ? modelFallbacks.join(", ") : "";
   const identityName =
@@ -440,7 +441,6 @@ function renderAgentOverview(params: {
           <label class="field" style="min-width: 260px; flex: 1;">
             <span>Primary model${isDefault ? " (default)" : ""}</span>
             <select
-              .value=${effectivePrimary ?? ""}
               ?disabled=${!configForm || configLoading || configSaving}
               @change=${(e: Event) =>
                 onModelChange(agent.id, (e.target as HTMLSelectElement).value || null)}
@@ -449,12 +449,14 @@ function renderAgentOverview(params: {
                 isDefault
                   ? nothing
                   : html`
-                      <option value="">
-                        ${defaultPrimary ? `Inherit default (${defaultPrimary})` : "Inherit default"}
+                      <option value="" ?selected=${selectedPrimaryValue === ""}>
+                        ${
+                          defaultPrimary ? `Inherit default (${defaultPrimary})` : "Inherit default"
+                        }
                       </option>
                     `
               }
-              ${buildModelOptions(configForm, effectivePrimary ?? undefined)}
+              ${buildModelOptions(configForm, selectedPrimaryValue)}
             </select>
           </label>
           <label class="field" style="min-width: 260px; flex: 1;">


### PR DESCRIPTION
## Summary
Fixes a dashboard mismatch where the Agents Overview `Primary Model` value could differ from the selected value in the `Primary model` dropdown.

## Root Cause
The model `<select>` relied on `.value` while options were generated in the same render pass. In this flow, the browser could fall back to the first option, so the visible selection drifted from the resolved primary model shown in Overview.

## Changes
- Updated `ui/src/ui/views/agents.ts` to drive selection via explicit `?selected` on options.
- Preserved handling for inherited/default model selection (`value=""`) for non-default agents.
- Added `ui/src/ui/views/agents.test.ts` regression coverage for:
  - explicit agent primary model alignment with Overview text
  - unlisted current models rendered as `Current (...)` and selected

## Verification
- `pnpm --dir ui test src/ui/views/agents.test.ts`

Closes #20109

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR contains two related but distinct fixes:

1. **UI model dropdown sync fix** (`agents.ts`): Switches the agents primary model `<select>` from `.value` binding to explicit `?selected` attributes on each `<option>`, preventing the browser from falling back to the first option when options are generated in the same render pass. A new `selectedPrimaryValue` variable cleanly drives selection. Regression tests are added in a new `agents.test.ts` file.

2. **Config `$include` resolution fix** (`setup.ts`, `io.ts`): Replaces the local `readConfigFileRaw()` in `setup.ts` with the shared `readConfigFileSnapshot()` to properly resolve `$include` directives before writing. A defensive `resolveConfigIncludes` call is also added to `writeConfigFile` in `io.ts` to catch any callers that pass unresolved configs.

- The UI fix in `agents.ts` is straightforward and well-tested.
- The config fix in `setup.ts` has a behavioral side-effect: `snapshot.config` includes applied runtime defaults (agent concurrency, sessions, logging, messages) that were not present in the raw parse used by the old code. Running `openclaw setup` may now persist these injected defaults to disk, bloating the config file.

<h3>Confidence Score: 3/5</h3>

- The UI fix is safe, but the config setup change may unintentionally persist runtime defaults to user config files.
- The UI changes in agents.ts are clean, well-tested, and correctly fix the dropdown sync issue. However, the setup.ts change from readConfigFileRaw() to readConfigFileSnapshot().config introduces a behavioral change: snapshot.config has runtime defaults (maxConcurrent, session, logging, message defaults) baked in, which will now be written to the user's config file on disk — bloating minimal configs with values the user never set.
- src/commands/setup.ts — uses snapshot.config (with applied defaults) instead of raw parsed config, which may cause config file bloat

<sub>Last reviewed commit: 62cd11b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->