### PR TITLE
Update AGENTS.md - use adequate token for staying silent in group chats

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -89,7 +89,7 @@ In group chats where you receive every message, be **smart about when to contrib
 - Correcting important misinformation
 - Summarizing when asked
 
-**Stay silent (HEARTBEAT_OK) when:**
+**Stay silent (NO_REPLY) when:**
 
 - It's just casual banter between humans
 - Someone already answered the question


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: 
agent doesnt stay silent in group chats
- Why it matters: 
its annoying
- What changed: 
adequate token is used and agent keeps silent
- What did NOT change (scope boundary): 
scoped to default AGENTS.md

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: none
- Related: none

## User-visible / Behavior Changes

default AGENTS.md

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
No
- Secrets/tokens handling changed? (`Yes/No`)
No
- New/changed network calls? (`Yes/No`)
No
- Command/tool execution surface changed? (`Yes/No`)
No
- Data access scope changed? (`Yes/No`)
No
- If any `Yes`, explain risk + mitigation:
No

## Repro + Verification

### Environment

- OS: 
any
- Runtime/container: 
any
- Model/provider: 
any
- Integration/channel (if any): 
any
- Relevant config (redacted): 
any

### Steps

1. onboard a new agent

### Expected
adequate token for staying silent is used in group chats
-

### Actual
wrong token being used when agent decides to be silent in group chats
-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: 
agent less likely to speak when it shouldnt 
- Edge cases checked: 
none
- What you did **not** verify:
none

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
Yes
- Config/env changes? (`Yes/No`)
Yes
- Migration needed? (`Yes/No`)
No
- If yes, exact upgrade steps:
none

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: not aplicable
- Files/config to restore: not aplicable
- Known bad symptoms reviewers should watch for: agent remains chatty in group chats

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the silent token referenced in the group chat section of the AGENTS.md workspace template. The previous text instructed agents to use `HEARTBEAT_OK` when staying silent in group chats, but the correct token is `NO_REPLY` — the dedicated silent reply token defined in `src/auto-reply/tokens.ts` and documented throughout the group messaging system (e.g., `docs/channels/group-messages.md`). `HEARTBEAT_OK` is reserved for heartbeat acknowledgments.

- Replaced `HEARTBEAT_OK` with `NO_REPLY` in the "Stay silent" guidance under the Group Chats section of `docs/reference/templates/AGENTS.md`
- The Chinese translation at `docs/zh-CN/reference/templates/AGENTS.md:98` still uses `HEARTBEAT_OK` in the equivalent group chat section and should be updated for consistency

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it corrects a documentation token that was causing agents to use the wrong silent reply in group chats.
- The change is a single-line documentation fix that aligns the AGENTS.md template with the actual codebase semantics. The `NO_REPLY` token is the correct one for group chat silence as confirmed by `src/auto-reply/tokens.ts` and `docs/channels/group-messages.md`. Score is 4 instead of 5 because the Chinese translation was not updated.
- The Chinese translation `docs/zh-CN/reference/templates/AGENTS.md` needs the same update at line 98 for consistency.

<sub>Last reviewed commit: f598d7a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - docs/reference/templates/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=ef691cbd-a005-4c3e-998b-6fcd72f2d312))

<!-- /greptile_comment -->