### PR TITLE
Fix sonnet alias resolving to opus in OpenCode Zen model aliases

### DIFF
--- a/src/agents/opencode-zen-models.test.ts
+++ b/src/agents/opencode-zen-models.test.ts
@@ -11,9 +11,14 @@ describe("resolveOpencodeZenAlias", () => {
     expect(resolveOpencodeZenAlias("opus")).toBe("claude-opus-4-6");
   });
 
+  it("resolves sonnet alias to claude-sonnet-4-6", () => {
+    expect(resolveOpencodeZenAlias("sonnet")).toBe("claude-sonnet-4-6");
+    expect(resolveOpencodeZenAlias("sonnet-4")).toBe("claude-sonnet-4-6");
+    expect(resolveOpencodeZenAlias("sonnet-4.6")).toBe("claude-sonnet-4-6");
+  });
+
   it("keeps legacy aliases working", () => {
-    expect(resolveOpencodeZenAlias("sonnet")).toBe("claude-opus-4-6");
-    expect(resolveOpencodeZenAlias("haiku")).toBe("claude-opus-4-6");
+    expect(resolveOpencodeZenAlias("haiku")).toBe("claude-sonnet-4-6");
     expect(resolveOpencodeZenAlias("gpt4")).toBe("gpt-5.1");
     expect(resolveOpencodeZenAlias("o1")).toBe("gpt-5.2");
     expect(resolveOpencodeZenAlias("gemini-2.5")).toBe("gemini-3-pro");
@@ -91,9 +96,10 @@ describe("OPENCODE_ZEN_MODEL_ALIASES", () => {
     expect(OPENCODE_ZEN_MODEL_ALIASES.glm).toBe("glm-4.7");
     expect(OPENCODE_ZEN_MODEL_ALIASES["opus-4.5"]).toBe("claude-opus-4-5");
 
+    // Sonnet aliases (first-class, not legacy).
+    expect(OPENCODE_ZEN_MODEL_ALIASES.sonnet).toBe("claude-sonnet-4-6");
     // Legacy aliases (kept for backward compatibility).
-    expect(OPENCODE_ZEN_MODEL_ALIASES.sonnet).toBe("claude-opus-4-6");
-    expect(OPENCODE_ZEN_MODEL_ALIASES.haiku).toBe("claude-opus-4-6");
+    expect(OPENCODE_ZEN_MODEL_ALIASES.haiku).toBe("claude-sonnet-4-6");
     expect(OPENCODE_ZEN_MODEL_ALIASES.gpt4).toBe("gpt-5.1");
     expect(OPENCODE_ZEN_MODEL_ALIASES.o1).toBe("gpt-5.2");
     expect(OPENCODE_ZEN_MODEL_ALIASES["gemini-2.5"]).toBe("gemini-3-pro");

--- a/src/agents/opencode-zen-models.ts
+++ b/src/agents/opencode-zen-models.ts
@@ -36,11 +36,14 @@ export const OPENCODE_ZEN_MODEL_ALIASES: Record<string, string> = {
   "opus-4.5": "claude-opus-4-5",
   "opus-4": "claude-opus-4-6",
 
+  // Claude Sonnet
+  sonnet: "claude-sonnet-4-6",
+  "sonnet-4.6": "claude-sonnet-4-6",
+  "sonnet-4": "claude-sonnet-4-6",
+
   // Legacy Claude aliases (OpenCode Zen rotates model catalogs; keep old keys working).
-  sonnet: "claude-opus-4-6",
-  "sonnet-4": "claude-opus-4-6",
-  haiku: "claude-opus-4-6",
-  "haiku-3.5": "claude-opus-4-6",
+  haiku: "claude-sonnet-4-6",
+  "haiku-3.5": "claude-sonnet-4-6",
 
   // GPT-5.x family
   gpt5: "gpt-5.2",


### PR DESCRIPTION
## Problem

The `sonnet` and `sonnet-4` aliases in `OPENCODE_ZEN_MODEL_ALIASES` incorrectly resolve to `claude-opus-4-6` instead of `claude-sonnet-4-6`.

Users typing `sonnet` expecting the cheaper/faster Sonnet model silently get Opus instead — wrong model, higher cost, no warning.

## Fix

- `sonnet` → `claude-sonnet-4-6`
- `sonnet-4` → `claude-sonnet-4-6`
- Added `sonnet-4.6` alias
- `haiku`/`haiku-3.5` legacy aliases now point to Sonnet (closer match than Opus)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the `sonnet` and `sonnet-4` aliases in `OPENCODE_ZEN_MODEL_ALIASES` to correctly resolve to `claude-sonnet-4-6` instead of `claude-opus-4-6`, preventing users from being silently billed at Opus rates when requesting Sonnet. Also adds a `sonnet-4.6` alias and updates legacy `haiku`/`haiku-3.5` aliases to point to Sonnet instead of Opus.

- **Bug found**: The `OPENCODE_ZEN_MODEL_ALIASES` test block (lines 99-101) was not updated — it still asserts `sonnet` and `haiku` map to `claude-opus-4-6`, which will cause test failures.
- The source code changes in `opencode-zen-models.ts` are correct and consistent with the rest of the codebase (e.g., `model-selection.ts` and `live-model-filter.ts` already reference `claude-sonnet-4-6`).

<h3>Confidence Score: 2/5</h3>

- The source code fix is correct, but the test file has stale assertions that will fail — this PR should not be merged until the test is updated.
- The alias corrections in the source file are valid and address a real billing/correctness issue. However, the test file contains two assertions (lines 100-101) that contradict the source changes and will fail, indicating the PR was not fully validated before submission.
- `src/agents/opencode-zen-models.e2e.test.ts` — lines 99-101 have stale assertions that need updating to match the new alias mappings.

<sub>Last reviewed commit: 2c2e2e4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

🤖 **AI-assisted PR** (Claude, via OpenClaw agent)
- Testing: Fully tested locally with vitest; all relevant test suites pass
- The contributor understands what this code does