### PR TITLE
Add Claude Sonnet 4.6 to OpenCode Zen model catalog

### DIFF
--- a/src/agents/opencode-zen-models.ts
+++ b/src/agents/opencode-zen-models.ts
@@ -124,6 +124,7 @@ const MODEL_COSTS: Record<
     cacheWrite: 0,
   },
   "claude-opus-4-6": { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  "claude-sonnet-4-6": { input: 1.5, output: 7.5, cacheRead: 0.15, cacheWrite: 1.875 },
   "claude-opus-4-5": { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   "gemini-3-pro": { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0 },
   "gpt-5.1-codex-mini": {
@@ -149,6 +150,7 @@ const DEFAULT_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "gpt-5.1-codex": 400000,
   "claude-opus-4-6": 1000000,
+  "claude-sonnet-4-6": 200000,
   "claude-opus-4-5": 200000,
   "gemini-3-pro": 1048576,
   "gpt-5.1-codex-mini": 400000,
@@ -166,6 +168,7 @@ function getDefaultContextWindow(modelId: string): number {
 const MODEL_MAX_TOKENS: Record<string, number> = {
   "gpt-5.1-codex": 128000,
   "claude-opus-4-6": 128000,
+  "claude-sonnet-4-6": 64000,
   "claude-opus-4-5": 64000,
   "gemini-3-pro": 65536,
   "gpt-5.1-codex-mini": 128000,
@@ -203,6 +206,7 @@ function buildModelDefinition(modelId: string): ModelDefinitionConfig {
 const MODEL_NAMES: Record<string, string> = {
   "gpt-5.1-codex": "GPT-5.1 Codex",
   "claude-opus-4-6": "Claude Opus 4.6",
+  "claude-sonnet-4-6": "Claude Sonnet 4.6",
   "claude-opus-4-5": "Claude Opus 4.5",
   "gemini-3-pro": "Gemini 3 Pro",
   "gpt-5.1-codex-mini": "GPT-5.1 Codex Mini",
@@ -231,6 +235,7 @@ export function getOpencodeZenStaticFallbackModels(): ModelDefinitionConfig[] {
   const modelIds = [
     "gpt-5.1-codex",
     "claude-opus-4-6",
+    "claude-sonnet-4-6",
     "claude-opus-4-5",
     "gemini-3-pro",
     "gpt-5.1-codex-mini",


### PR DESCRIPTION
## Problem

`claude-sonnet-4-6` is missing from the OpenCode Zen static model data tables. When the model is resolved (e.g. via alias), it falls back to default values — zero costs, 128k context window, 8k max tokens — all incorrect.

## Fix

Add `claude-sonnet-4-6` to:
- `MODEL_COSTS`: $1.50/$7.50 per million tokens (input/output)
- `MODEL_CONTEXT_WINDOWS`: 200k
- `MODEL_MAX_TOKENS`: 64k
- `MODEL_NAMES`: "Claude Sonnet 4.6"
- `getOpencodeZenStaticFallbackModels()`: included in static fallback list

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `claude-sonnet-4-6` to all five OpenCode Zen static model data tables (costs, context window, max tokens, display name, and fallback list). The cost ratios (cacheRead at 10% of input, cacheWrite at 125% of input) are consistent with the existing Claude model entries, and the 200k context window / 64k max tokens match `claude-opus-4-5`.

- The existing test in `opencode-zen-models.e2e.test.ts` hardcodes `expect(models.length).toBe(10)` and will fail since the fallback list now contains 11 models.

<h3>Confidence Score: 3/5</h3>

- The data changes are correct, but the PR will break an existing test.
- The model data entries are consistent with existing patterns and the PR description is accurate. However, the test in `opencode-zen-models.e2e.test.ts` hardcodes `models.length` as 10 and will fail since the fallback list now has 11 models. This needs to be fixed before merging.
- `src/agents/opencode-zen-models.e2e.test.ts` needs its model count assertion updated from 10 to 11.

<sub>Last reviewed commit: 9818622</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->