### PR TITLE
fix: strip unsupported JSON Schema keywords for Claude via Cloud Code Assist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Google: clean tool JSON Schemas for `google-antigravity` the same as `google-gemini-cli` before Cloud Code Assist requests, preventing Claude tool calls from failing with `patternProperties` 400 errors. (#19860)
 - Tests/Telegram: add regression coverage for command-menu sync that asserts all `setMyCommands` entries are Telegram-safe and hyphen-normalized across native/custom/plugin command sources. (#19703) Thanks @obviyus.
 - Agents/Image: collapse resize diagnostics to one line per image and include visible pixel/byte size details in the log message for faster triage.
 - Auth/Cooldowns: clear all usage stats fields (`disabledUntil`, `disabledReason`, `failureCounts`) in `clearAuthProfileCooldown` so manual cooldown resets fully recover billing-disabled profiles without requiring direct file edits. (#19211) Thanks @nabbilkhan.

--- a/src/agents/pi-embedded-runner/google.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/google.e2e.test.ts
@@ -33,4 +33,37 @@ describe("sanitizeToolsForGoogle", () => {
     expect(params.additionalProperties).toBeUndefined();
     expect(params.properties?.foo?.format).toBeUndefined();
   });
+
+  it("strips unsupported schema keywords for google-antigravity", () => {
+    const tool = {
+      name: "test",
+      description: "test",
+      parameters: {
+        type: "object",
+        patternProperties: {
+          "^x-": { type: "string" },
+        },
+        properties: {
+          foo: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      },
+      execute: async () => ({ ok: true, content: [] }),
+    } as unknown as AgentTool;
+
+    const [sanitized] = sanitizeToolsForGoogle({
+      tools: [tool],
+      provider: "google-antigravity",
+    });
+
+    const params = sanitized.parameters as {
+      patternProperties?: unknown;
+      properties?: Record<string, { format?: unknown }>;
+    };
+
+    expect(params.patternProperties).toBeUndefined();
+    expect(params.properties?.foo?.format).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -247,11 +247,11 @@ export function sanitizeToolsForGoogle<
   tools: AgentTool<TSchemaType, TResult>[];
   provider: string;
 }): AgentTool<TSchemaType, TResult>[] {
-  // google-antigravity serves Anthropic models (e.g. claude-opus-4-6-thinking),
-  // NOT Gemini. Applying Gemini schema cleaning strips JSON Schema keywords
-  // (minimum, maximum, format, etc.) that Anthropic's API requires for
-  // draft 2020-12 compliance. Only clean for actual Gemini providers.
-  if (params.provider !== "google-gemini-cli") {
+  // Cloud Code Assist uses the OpenAPI 3.03 `parameters` field for both Gemini
+  // AND Claude models.  This field does not support JSON Schema keywords such as
+  // patternProperties, additionalProperties, $ref, etc.  We must clean schemas
+  // for every provider that routes through this path.
+  if (params.provider !== "google-gemini-cli" && params.provider !== "google-antigravity") {
     return params.tools;
   }
   return params.tools.map((tool) => {


### PR DESCRIPTION
## Problem

Claude models via Cloud Code Assist (`google-antigravity` provider) fail with HTTP 400 on every tool-bearing request:

```
Cloud Code Assist API error (400): Invalid JSON payload received.
Unknown name "patternProperties" at 'request.tools[0].function_declarations[3].parameters.properties[2].value': Cannot find field.
```

## Root Cause

Cloud Code Assist uses the OpenAPI 3.03 `parameters` field for **both** Gemini AND Claude models. This field does not support JSON Schema keywords such as `patternProperties`, `additionalProperties`, `$ref`, etc.

`sanitizeToolsForGoogle` only cleaned schemas for `google-gemini-cli`, skipping `google-antigravity` (Claude via CCA). The guard assumed Anthropic models need full JSON Schema (draft 2020-12), but Cloud Code Assist routes Claude through the same restricted `parameters` path as Gemini.

## Fix

Include `google-antigravity` in the provider check so `cleanToolSchemaForGemini` also applies when the provider is `google-antigravity`:

```diff
-  if (params.provider !== "google-gemini-cli") {
+  if (params.provider !== "google-gemini-cli" && params.provider !== "google-antigravity") {
```

## Testing

- All 9 existing tests in `google-shared.preserves-parameters-type-is-missing.test.ts` pass
- Verified locally by patching the installed binary and restarting the daemon

Fixes #19860

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Targeted one-line fix that includes `google-antigravity` in the provider check for `sanitizeToolsForGoogle`, so Claude models routed through Cloud Code Assist also get their tool schemas cleaned of unsupported JSON Schema keywords (`patternProperties`, `additionalProperties`, `$ref`, etc.). This resolves the HTTP 400 errors when tool-bearing requests are sent to Claude via CCA.

- The fix itself is correct and minimal — adding `google-antigravity` to the existing guard condition alongside `google-gemini-cli`
- The updated comment accurately explains why both providers need cleaning (CCA uses the same restricted OpenAPI 3.03 `parameters` field for both Gemini and Claude)
- A now-stale comment in `normalizeToolParameters` (`pi-tools.schema.ts:81`) still claims `google-antigravity` expects full JSON Schema draft 2020-12 — this should be updated to avoid confusion
- No new test was added for the `google-antigravity` provider path, though the existing test only covers `google-gemini-cli`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the fix is minimal and correctly extends existing schema sanitization logic to an additional provider.
- Single-line change extending an existing, well-tested code path to a new provider. The logic is straightforward and consistent with how `logToolSchemasForGoogle` already handles both providers. Deducted one point because no test was added for the new provider path and a stale comment in a related file could cause future confusion.
- src/agents/pi-tools.schema.ts has a stale comment (line 81) that contradicts the new behavior

<sub>Last reviewed commit: ab172ff</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->