### PR TITLE
fix(doctor): skip memorySearch provider check when using QMD backend

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -104,6 +104,18 @@ describe("noteMemorySearchHealth", () => {
     });
     expect(note).not.toHaveBeenCalled();
   });
+
+  it("does not warn when memory backend is qmd (self-contained embeddings)", async () => {
+    const qmdConfig = {
+      memory: { backend: "qmd" },
+    } as OpenClawConfig;
+
+    await noteMemorySearchHealth(qmdConfig);
+
+    // QMD handles its own embeddings, so no memorySearch provider check is needed
+    expect(note).not.toHaveBeenCalled();
+    expect(resolveMemorySearchConfig).not.toHaveBeenCalled();
+  });
 });
 
 describe("detectLegacyWorkspaceDirs", () => {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -15,6 +15,13 @@ import { resolveUserPath } from "../utils.js";
 export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void> {
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
+
+  // QMD backend is self-contained — it handles its own embeddings and doesn't
+  // need the standard memorySearch provider configuration. Skip the check.
+  if (cfg.memory?.backend === "qmd") {
+    return;
+  }
+
   const resolved = resolveMemorySearchConfig(cfg, agentId);
   const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());
 

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -13,14 +13,14 @@ import { resolveUserPath } from "../utils.js";
  * Runs as part of `openclaw doctor` — config-only, no network calls.
  */
 export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void> {
-  const agentId = resolveDefaultAgentId(cfg);
-  const agentDir = resolveAgentDir(cfg, agentId);
-
   // QMD backend is self-contained — it handles its own embeddings and doesn't
   // need the standard memorySearch provider configuration. Skip the check.
   if (cfg.memory?.backend === "qmd") {
     return;
   }
+
+  const agentId = resolveDefaultAgentId(cfg);
+  const agentDir = resolveAgentDir(cfg, agentId);
 
   const resolved = resolveMemorySearchConfig(cfg, agentId);
   const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());


### PR DESCRIPTION
Fixes #19943

## What

Skip the memorySearch embedding provider check in `openclaw doctor` when the memory backend is set to `qmd`.

## Why

QMD is a self-contained memory backend that handles its own embeddings (via its own SQLite + local vector system). It doesn't use the standard `memorySearch` provider configuration at all.

Previously, `openclaw doctor` reported "Memory search is enabled but no embedding provider is configured" even when:
- `memory.backend: "qmd"` was configured
- `openclaw memory status --deep` showed QMD as ready with `Embeddings: ready` and `Vector: ready`

This made `openclaw doctor` untrustworthy — users couldn't distinguish real embedding misconfigurations from this false positive.

## How

Added an early return in `noteMemorySearchHealth()` when `cfg.memory?.backend === "qmd"` — the QMD backend is self-contained and doesn't need the standard provider check.

## Testing

- [x] Added unit test: "does not warn when memory backend is qmd (self-contained embeddings)"
- [x] `pnpm vitest run src/commands/doctor-memory-search.test.ts` passes (5 tests)
- [x] `pnpm build` succeeds
- [x] `oxlint` and `oxfmt` pass on changed files

## AI-Assisted 🤖

This PR was built with AI assistance (Claude via OpenClaw).
- [x] Code reviewed and understood
- [x] Lightly tested
- [x] Session available on request

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a false positive in `openclaw doctor` where the memory search embedding provider check incorrectly warned QMD users about missing configuration. Since QMD is a self-contained backend that manages its own embeddings, the standard `memorySearch` provider validation is not applicable.

- Adds early return in `noteMemorySearchHealth()` when `cfg.memory?.backend === "qmd"`, skipping the provider check entirely
- Adds a unit test verifying that neither `note` nor `resolveMemorySearchConfig` is called for QMD configs
- Change is consistent with the existing pattern of QMD-specific branching used elsewhere in the codebase (gateway startup, memory search manager, memory CLI)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-tested fix that prevents a false positive diagnostic warning.
- The change is a narrow, 3-line early return guarded by an explicit backend check, with a corresponding unit test. The QMD backend type is well-established in the codebase (only two backends exist: "builtin" and "qmd"), and the skip pattern is consistent with how other modules handle QMD. No risk of regression to existing behavior for non-QMD users since the new code path only activates for QMD configs.
- No files require special attention.

<sub>Last reviewed commit: 689aecf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->