### PR TITLE
Telegram: fix cross-provider model checkmark in /models keyboard

### DIFF
--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -146,6 +146,18 @@ describe("buildModelsKeyboard", () => {
     expect(result[1]?.[0]?.text).toBe("claude-opus-4");
   });
 
+  it("does not mark model from a different provider", () => {
+    const result = buildModelsKeyboard({
+      provider: "github-copilot",
+      models: ["gpt-5.3-codex", "claude-sonnet-4"],
+      currentModel: "openai-codex/gpt-5.3-codex",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(result[0]?.[0]?.text).toBe("gpt-5.3-codex");
+    expect(result[1]?.[0]?.text).toBe("claude-sonnet-4");
+  });
+
   it("shows pagination when multiple pages", () => {
     const result = buildModelsKeyboard({
       provider: "anthropic",

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -127,10 +127,20 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const endIndex = Math.min(startIndex + pageSize, models.length);
   const pageModels = models.slice(startIndex, endIndex);
 
-  // Model buttons - one per row
-  const currentModelId = currentModel?.includes("/")
-    ? currentModel.split("/").slice(1).join("/")
-    : currentModel;
+  // Parse current selection. When provider is present, require provider+model
+  // match to avoid cross-provider false positives for same model IDs.
+  let currentModelProvider: string | undefined;
+  let currentModelId: string | undefined;
+  if (typeof currentModel === "string" && currentModel.trim().length > 0) {
+    const trimmed = currentModel.trim();
+    const slashIndex = trimmed.indexOf("/");
+    if (slashIndex > 0 && slashIndex < trimmed.length - 1) {
+      currentModelProvider = trimmed.slice(0, slashIndex).trim().toLowerCase();
+      currentModelId = trimmed.slice(slashIndex + 1);
+    } else {
+      currentModelId = trimmed;
+    }
+  }
 
   for (const model of pageModels) {
     const callbackData = `mdl_sel_${provider}/${model}`;
@@ -139,7 +149,9 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
       continue;
     }
 
-    const isCurrentModel = model === currentModelId;
+    const isCurrentModel =
+      model === currentModelId &&
+      (currentModelProvider == null || provider.toLowerCase() === currentModelProvider);
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 


### PR DESCRIPTION
## Summary

- Problem: In Telegram model keyboard (`/models`), active checkmark used only model id and ignored provider.
- Why it matters: Same model id under different providers (for example `openai-codex/gpt-5.3-codex` and `github-copilot/gpt-5.3-codex`) showed a false active `✓`.
- What changed: `buildModelsKeyboard` now parses `currentModel` as `provider/model` and marks active only when both provider and model match; added regression test for cross-provider duplicate model ids.
- What did NOT change (scope boundary): Model selection flow, callback handling, and session override persistence logic were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

- In Telegram model picker, `✓` is now shown only for the exact active `provider/model` pair.
- No behavior change in actual model switching command execution.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node `v22.19.0` + pnpm `10.23.0` (no container)
- Model/provider: `openai-codex/gpt-5.3-codex`, `github-copilot/gpt-5.3-codex`
- Integration/channel (if any): Telegram
- Relevant config (redacted): allowlist includes both providers with overlapping model id

### Steps

1. Set current session model to `openai-codex/gpt-5.3-codex`.
2. Open Telegram `/models github-copilot`.
3. Observe model row `gpt-5.3-codex`.

### Expected

- No `✓` on `github-copilot/gpt-5.3-codex` when active model is `openai-codex/gpt-5.3-codex`.

### Actual

- Before fix: `✓` was shown incorrectly.
- After fix: `✓` is shown only on exact provider/model match.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run src/telegram/model-buttons.test.ts`  
Result: `✓ src/telegram/model-buttons.test.ts (29 tests)`

## Human Verification (required)

- Verified scenarios: Added and ran regression test for duplicate model id across different providers; confirmed no checkmark on wrong provider page.
- Edge cases checked: Existing test for same-provider active checkmark still passes; pagination/callback-size tests still pass.
- What you did **not** verify: Manual live Telegram interaction against a running bot instance.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit.
- Files/config to restore: `src/telegram/model-buttons.ts`, `src/telegram/model-buttons.test.ts`
- Known bad symptoms reviewers should watch for: Missing `✓` for active model when provider aliases differ unexpectedly.

## Risks and Mitigations

- Risk: If provider alias forms differ (`z.ai` vs `zai`) in `currentModel` vs keyboard provider id, `✓` may be absent.
  - Mitigation: Selection/switch logic is unaffected (still uses full `/model provider/model` path); this change affects only visual active marker.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug in the Telegram `/models` keyboard where the active model checkmark (`✓`) was shown based solely on model ID, ignoring the provider. This caused false-positive checkmarks when different providers offered models with the same ID (e.g., `openai-codex/gpt-5.3-codex` vs `github-copilot/gpt-5.3-codex`).

- `buildModelsKeyboard` now parses `currentModel` into both provider and model ID, and requires both to match before showing the `✓` marker
- Backward-compatible: when `currentModel` has no provider prefix, the function falls back to model-ID-only matching
- Added a regression test for the cross-provider duplicate model ID scenario

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a focused, well-tested bug fix with no behavioral side effects outside the visual checkmark logic.
- The change is small, targeted, and correct. It fixes a clear bug (cross-provider false-positive checkmark) with proper backward compatibility for provider-less model strings. The parsing logic correctly handles edge cases (nested model paths, empty/whitespace strings). Both callers in bot-handlers.ts and commands-models.ts pass the same provider/currentModel shape. A regression test is included.
- No files require special attention.

<sub>Last reviewed commit: 0e10d63</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->