### PR TITLE
fix(agents): use label and model in subagent completion announce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Docs: https://docs.openclaw.ai
 
+- Onboarding/headless Linux daemon probe hardening: treat `systemctl --user is-enabled` probe failures as non-fatal during daemon install flow so onboarding no longer crashes on SSH/headless VPS environments before showing install guidance. (#37297) Thanks @acarbajal-web.
 ## Unreleased
 
 ### Changes

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1163,6 +1163,7 @@ export async function runSubagentAnnounceFlow(params: {
   startedAt?: number;
   endedAt?: number;
   label?: string;
+  model?: string;
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
   expectsCompletionMessage?: boolean;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -561,6 +561,7 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     startedAt: entry.startedAt,
     endedAt: entry.endedAt,
     label: entry.label,
+    model: entry.model,
     outcome: entry.outcome,
     spawnMode: entry.spawnMode,
     expectsCompletionMessage: entry.expectsCompletionMessage,


### PR DESCRIPTION
## Summary

Prefer `params.label` over agent id in subagent completion announce header.
Append child session model name when available (e.g. `claude-sonnet-4-6`).
Strip provider prefix from model name (e.g. `anthropic/claude-sonnet-4-6` → `claude-sonnet-4-6`).

**Before:** `✅ Subagent main finished` (always "main", no way to tell which task or model)
**After:** `✅ Subagent lint-fix (claude-sonnet-4-6) finished`

Graceful degradation: no label → agent id, no model → omit parenthetical.

## Changes

- `subagent-announce.ts`: Use `params.label || resolveAgentIdFromSessionKey()` for baseName; add `model` param; strip provider prefix from model
- `subagent-registry.ts`: Pass `model: entry.model` to announce flow
- Tests updated to match new format