### PR TITLE
fix(matrix): 2-member rooms misrouted as DMs when explicitly listed in groups config

### DIFF
--- a/extensions/matrix/src/matrix/monitor/dm-override.test.ts
+++ b/extensions/matrix/src/matrix/monitor/dm-override.test.ts
@@ -12,6 +12,12 @@ describe("resolveIsDirectMessage", () => {
     expect(resolveIsDirectMessage(true, true)).toBe(false);
   });
 
+  it("returns true when DM detected and room only matches via wildcard (not explicit)", () => {
+    // Wildcard groups config should NOT override DM detection
+    // The caller passes false for wildcardAllowed (matchSource !== "direct")
+    expect(resolveIsDirectMessage(true, false)).toBe(true);
+  });
+
   it("returns false when DM not detected regardless of groups config", () => {
     expect(resolveIsDirectMessage(false, undefined)).toBe(false);
     expect(resolveIsDirectMessage(false, true)).toBe(false);

--- a/extensions/matrix/src/matrix/monitor/dm-override.test.ts
+++ b/extensions/matrix/src/matrix/monitor/dm-override.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveIsDirectMessage } from "./handler.js";
+
+describe("resolveIsDirectMessage", () => {
+  it("returns true when DM detected and room not in groups config", () => {
+    expect(resolveIsDirectMessage(true, undefined)).toBe(true);
+    expect(resolveIsDirectMessage(true, false)).toBe(true);
+  });
+
+  it("returns false when DM detected but room is explicitly allowed in groups", () => {
+    // 2-member rooms listed in groups config should be treated as rooms, not DMs
+    expect(resolveIsDirectMessage(true, true)).toBe(false);
+  });
+
+  it("returns false when DM not detected regardless of groups config", () => {
+    expect(resolveIsDirectMessage(false, undefined)).toBe(false);
+    expect(resolveIsDirectMessage(false, true)).toBe(false);
+    expect(resolveIsDirectMessage(false, false)).toBe(false);
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -176,25 +176,25 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         }
       }
 
-      const isDirectMessage = await directTracker.isDirectMessage({
+      const isDmDetected = await directTracker.isDirectMessage({
         roomId,
         senderId,
         selfUserId,
       });
+
+      // Resolve group config early so explicit groups override DM detection (e.g. 2-member rooms)
+      const roomConfigInfo = resolveMatrixRoomConfig({
+        rooms: roomsConfig,
+        roomId,
+        aliases: roomAliases,
+        name: roomName,
+      });
+      const isDirectMessage = isDmDetected && !roomConfigInfo?.allowed;
       const isRoom = !isDirectMessage;
 
       if (isRoom && groupPolicy === "disabled") {
         return;
       }
-
-      const roomConfigInfo = isRoom
-        ? resolveMatrixRoomConfig({
-            rooms: roomsConfig,
-            roomId,
-            aliases: roomAliases,
-            name: roomName,
-          })
-        : undefined;
       const roomConfig = roomConfigInfo?.config;
       const roomMatchMeta = roomConfigInfo
         ? `matchKey=${roomConfigInfo.matchKey ?? "none"} matchSource=${

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -201,7 +201,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         aliases: roomAliases,
         name: roomName,
       });
-      const isDirectMessage = resolveIsDirectMessage(isDmDetected, roomConfigInfo?.allowed);
+      const isExplicitGroup = roomConfigInfo?.allowed && roomConfigInfo.matchSource === "direct";
+      const isDirectMessage = resolveIsDirectMessage(isDmDetected, isExplicitGroup);
       const isRoom = !isDirectMessage;
 
       if (isRoom && groupPolicy === "disabled") {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -71,6 +71,18 @@ export type MatrixMonitorHandlerParams = {
   accountId?: string | null;
 };
 
+/**
+ * Resolves whether a message should be treated as a direct message.
+ * Explicit groups config overrides DM detection (e.g. 2-member rooms
+ * that are listed in groups should be treated as rooms, not DMs).
+ */
+export function resolveIsDirectMessage(
+  isDmDetected: boolean,
+  roomConfigAllowed: boolean | undefined,
+): boolean {
+  return isDmDetected && !roomConfigAllowed;
+}
+
 export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParams) {
   const {
     client,
@@ -189,7 +201,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         aliases: roomAliases,
         name: roomName,
       });
-      const isDirectMessage = isDmDetected && !roomConfigInfo?.allowed;
+      const isDirectMessage = resolveIsDirectMessage(isDmDetected, roomConfigInfo?.allowed);
       const isRoom = !isDirectMessage;
 
       if (isRoom && groupPolicy === "disabled") {


### PR DESCRIPTION
## Problem

Rooms with exactly 2 members (bot + one user) that are explicitly configured in `channels.matrix.groups` are still classified as direct messages by `directTracker.isDirectMessage()`. This causes messages to route to the main DM session instead of getting an isolated group session.

Closes #20145

## Root Cause

`isDirectMessage()` in `direct.ts` returns `true` for any room with exactly 2 members (line 88), without considering whether the room is explicitly configured as a group.

The `resolveMatrixRoomConfig()` call that checks the groups config was only executed *after* the DM/room decision was already made (and only when `isRoom` was true), so explicitly configured groups with 2 members were never checked.

## Fix

Move `resolveMatrixRoomConfig()` before the DM decision so explicit groups config can override DM detection:

```typescript
const isDmDetected = await directTracker.isDirectMessage({ roomId, senderId, selfUserId });
const roomConfigInfo = resolveMatrixRoomConfig({ rooms: roomsConfig, roomId, aliases: roomAliases, name: roomName });
const isDirectMessage = isDmDetected && !roomConfigInfo?.allowed;
```

If a room is explicitly allowed in groups config, it's treated as a room regardless of member count.

## Changes

- `handler.ts`: Resolve room config before DM decision; use `roomConfigInfo?.allowed` to override DM detection
- No new dependencies, no config schema changes
- All existing Matrix tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes 2-member Matrix rooms that are explicitly listed in `channels.matrix.groups` config being misclassified as DMs. The fix moves `resolveMatrixRoomConfig()` before the DM decision, allowing explicit group config entries (matched by room ID or alias) to override DM detection. A `matchSource === "direct"` guard ensures wildcard (`"*"`) config entries don't suppress DM detection for genuine DM rooms.

- Extracted `resolveIsDirectMessage()` helper with clear semantics: DM detection is only overridden when the room is **explicitly** allowed in groups config (not via wildcard)
- All downstream `roomConfig` usage in the handler is properly guarded by `isRoom` checks, with one minor exception: `skillFilter: roomConfig?.skills` (line 690) is not guarded, meaning DMs that match a wildcard roomsConfig entry could now pick up skill filters where they previously didn't — a low-risk behavioral change
- New unit tests cover the key scenarios for the `resolveIsDirectMessage` helper

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk; the fix is well-scoped and correctly addresses the reported bug.
- The logic change is correct: explicit group config entries override DM detection while wildcards do not. All downstream `roomConfig` usages are properly guarded by `isRoom` checks except for `skillFilter` which is a low-risk edge case. Tests cover the core logic well.
- No files require special attention.

<sub>Last reviewed commit: 2d1930f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->