### PR TITLE
fix(irc): add configurable commandPrefix to avoid IRC reserved / prefix (#20127)

### DIFF
--- a/extensions/irc/src/config-schema.ts
+++ b/extensions/irc/src/config-schema.ts
@@ -69,6 +69,7 @@ export const IrcAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    commandPrefix: z.string().min(1).max(3).optional(),
     responsePrefix: z.string().optional(),
     mediaMaxMb: z.number().positive().optional(),
   })

--- a/extensions/irc/src/types.ts
+++ b/extensions/irc/src/types.ts
@@ -56,6 +56,7 @@ export type IrcAccountConfig = {
   chunkMode?: "length" | "newline";
   blockStreaming?: boolean;
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  commandPrefix?: string;
   responsePrefix?: string;
   mediaMaxMb?: number;
 };

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -514,4 +514,16 @@ describe("control command parsing", () => {
       }),
     ).toBe(true);
   });
+
+  it("detects commands with custom commandPrefix", () => {
+    expect(hasControlCommand("!status", undefined, { commandPrefix: "!" })).toBe(true);
+    expect(hasControlCommand("!help", undefined, { commandPrefix: "!" })).toBe(true);
+    expect(hasControlCommand("!send on", undefined, { commandPrefix: "!" })).toBe(true);
+    expect(hasControlCommand("~status", undefined, { commandPrefix: "~" })).toBe(true);
+    expect(hasControlCommand(">>status", undefined, { commandPrefix: ">>" })).toBe(true);
+    // Does not match when prefix is different
+    expect(hasControlCommand("!status", undefined, { commandPrefix: "~" })).toBe(false);
+    // Plain text never matches
+    expect(hasControlCommand("hello", undefined, { commandPrefix: "!" })).toBe(false);
+  });
 });

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -364,12 +364,21 @@ export function resolveCommandArgMenu(params: {
 
 export function normalizeCommandBody(raw: string, options?: CommandNormalizeOptions): string {
   const trimmed = raw.trim();
-  if (!trimmed.startsWith("/")) {
-    return trimmed;
+
+  // When a transport-specific prefix is configured (e.g. "!" for IRC),
+  // normalize it to the canonical "/" so the rest of the pipeline is unchanged.
+  const prefix = options?.commandPrefix;
+  const prefixed =
+    prefix && prefix !== "/" && trimmed.startsWith(prefix)
+      ? "/" + trimmed.slice(prefix.length)
+      : trimmed;
+
+  if (!prefixed.startsWith("/")) {
+    return prefixed;
   }
 
-  const newline = trimmed.indexOf("\n");
-  const singleLine = newline === -1 ? trimmed : trimmed.slice(0, newline).trim();
+  const newline = prefixed.indexOf("\n");
+  const singleLine = newline === -1 ? prefixed : prefixed.slice(0, newline).trim();
 
   const colonMatch = singleLine.match(/^\/([^\s:]+)\s*:(.*)$/);
   const normalized = colonMatch

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -72,6 +72,9 @@ export type NativeCommandSpec = {
 
 export type CommandNormalizeOptions = {
   botUsername?: string;
+  /** Transport-specific command prefix (e.g. "!" for IRC). When set,
+   *  messages starting with this prefix are normalized to canonical "/" form. */
+  commandPrefix?: string;
 };
 
 export type CommandDetection = {

--- a/src/config/schema.irc.ts
+++ b/src/config/schema.irc.ts
@@ -1,5 +1,6 @@
 export const IRC_FIELD_LABELS: Record<string, string> = {
   "channels.irc": "IRC",
+  "channels.irc.commandPrefix": "IRC Command Prefix",
   "channels.irc.dmPolicy": "IRC DM Policy",
   "channels.irc.nickserv.enabled": "IRC NickServ Enabled",
   "channels.irc.nickserv.service": "IRC NickServ Service",
@@ -10,6 +11,8 @@ export const IRC_FIELD_LABELS: Record<string, string> = {
 };
 
 export const IRC_FIELD_HELP: Record<string, string> = {
+  "channels.irc.commandPrefix":
+    'Character(s) used to trigger bot commands in IRC (default: "!"). Set to any 1-3 character string (e.g. "!", "~", ">>").',
   "channels.irc.configWrites":
     "Allow IRC to write config in response to channel events/commands (default: true).",
   "channels.irc.dmPolicy":


### PR DESCRIPTION
## Problem

IRC servers reserve the `/` prefix for native commands (e.g. `/join`, `/nick`). OpenClaw's command parser hardcoded `/` as the only valid prefix, so commands like `/status` were intercepted by the IRC client and never reached the bot.

Fixes #20127

## Solution

Added a configurable `commandPrefix` option to the IRC extension, defaulting to `!` (the standard IRC bot convention). Messages starting with the configured prefix are normalized to canonical `/` form before entering the existing command pipeline — no changes to command definitions needed.

## Changes

- **`extensions/irc/src/config-schema.ts`** — Add `commandPrefix` field (1–3 chars, optional) to Zod schema
- **`extensions/irc/src/types.ts`** — Add `commandPrefix` to `IrcAccountConfig` type
- **`src/auto-reply/commands-registry.types.ts`** — Add `commandPrefix` to `CommandNormalizeOptions`
- **`src/auto-reply/commands-registry.ts`** — `normalizeCommandBody()` normalizes custom prefix → `/` before further processing
- **`extensions/irc/src/inbound.ts`** — Read `commandPrefix` from account config (default `!`), pass to `hasControlCommand()` and pre-normalize `CommandBody` for the reply pipeline
- **`src/config/schema.irc.ts`** — Add field label and help text for `commandPrefix`

## Configuration

```yaml
channels:
  irc:
    commandPrefix: "!"   # default; configurable 1-3 chars (e.g. "!", "~", ">>")
```

## Tests

- 9 new tests in `commands-registry.test.ts` for prefix-aware `normalizeCommandBody()`
- 1 new test in `command-control.test.ts` for `hasControlCommand()` with `commandPrefix`
- All 47 tests pass ✅

## Notes

Model persistence across transports (the second part of #20127) is deferred — it requires a separate design discussion around session identity management.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a configurable `commandPrefix` option to the IRC extension so bot commands can use `!` (or any 1–3 character prefix) instead of `/`, which is reserved by IRC clients for native commands. The implementation normalizes custom-prefixed messages to canonical `/` form early in the inbound pipeline, allowing the entire downstream command processing (detection, resolution, abort handling) to work unchanged.

- `normalizeCommandBody()` in `commands-registry.ts` gains `commandPrefix` support, converting transport-specific prefixes to `/` before existing alias/colon/mention normalization
- IRC `inbound.ts` reads `commandPrefix` from account config (default `!`), passes it to `hasControlCommand()`, and pre-normalizes `CommandBody` for the reply pipeline
- Zod schema, TypeScript type, and config UI labels/help text updated for the new field
- 10 new tests covering prefix-aware normalization and command detection with custom prefixes

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — changes are well-scoped and backward compatible.
- The implementation is clean and follows existing patterns (similar to Telegram's botUsername normalization). The prefix normalization is applied early in the pipeline, the downstream command processing works unchanged, and there are comprehensive tests. The Zod schema properly validates the input. No breaking changes to existing behavior (default prefix for IRC changes from `/` to `!`, but this is the fix — `/` was broken on IRC).
- No files require special attention. `extensions/irc/src/inbound.ts` has a minor style concern with duplicated normalization logic, but it's intentional and correct.

<sub>Last reviewed commit: 15640a3</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->