### PR TITLE
fix: update Venice provider model catalog with latest models

### DIFF
--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -1,3 +1,5 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { ModelApi } from "../config/types.models.js";
 import {
   buildHuggingfaceModelDefinition,
   HUGGINGFACE_BASE_URL,
@@ -26,8 +28,6 @@ import {
   VENICE_DEFAULT_MODEL_REF,
   VENICE_MODEL_CATALOG,
 } from "../agents/venice-models.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type { ModelApi } from "../config/types.models.js";
 import {
   HUGGINGFACE_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
@@ -296,7 +296,7 @@ export function applyVeniceProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
   models[VENICE_DEFAULT_MODEL_REF] = {
     ...models[VENICE_DEFAULT_MODEL_REF],
-    alias: models[VENICE_DEFAULT_MODEL_REF]?.alias ?? "Llama 3.3 70B",
+    alias: models[VENICE_DEFAULT_MODEL_REF]?.alias ?? "Kimi K2.5",
   };
 
   const veniceModels = VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);


### PR DESCRIPTION
Fixes #20156

## What changed
- Updated Venice AI provider static catalog with Kimi K2.5, Claude Opus 4.6, Claude Sonnet 4.6, GLM 4.7 Flash, GLM 5, and MiniMax M2.5.
- Changed default model to Kimi K2.5 for reasoning + vision capabilities.
- Updated privacy modes for kimi-k2-thinking and minimax-m21.
- Improved discovery reliability with increased timeout and offline model filtering.

## AI-assisted contribution
- This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build && pnpm check && pnpm test
- The fix addresses the root cause by adding missing models to the static catalog and updating the default model to a more capable option

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Venice AI provider static model catalog with 8 new model entries (Kimi K2.5, Kimi K2 Thinking, MiniMax M2.5/M2.1, GLM 4.7 Flash/GLM 5, Claude Opus 4.6, Claude Sonnet 4.6), changes the default model from `llama-3.3-70b` to `kimi-k2.5`, reclassifies `kimi-k2-thinking` and `minimax-m21` from "anonymized" to "private" privacy mode, increases API discovery timeout from 5s to 10s, and filters out offline models during discovery.

- The default model change introduces a **stale alias bug** in `src/commands/onboard-auth.config-core.ts:299` where `VENICE_DEFAULT_MODEL_REF` (now `venice/kimi-k2.5`) will still display the alias "Llama 3.3 70B" to new users during onboarding. This file needs to be updated as part of this PR.
- The privacy mode reclassification of `kimi-k2-thinking` and `minimax-m21` from "anonymized" to "private" is a documentation-only change (the `privacy` field is not propagated to `ModelDefinitionConfig`), but it should be verified against Venice's actual current model metadata.

<h3>Confidence Score: 3/5</h3>

- PR introduces a stale alias bug in the onboarding flow that will show the wrong model name to new Venice users
- The catalog additions and discovery improvements are straightforward, but changing the default model ID without updating the hardcoded alias in onboard-auth.config-core.ts will cause new users to see 'Llama 3.3 70B' as the name for Kimi K2.5 during Venice onboarding.
- src/commands/onboard-auth.config-core.ts needs its hardcoded Venice alias updated from 'Llama 3.3 70B' to 'Kimi K2.5' to match the new default model

<sub>Last reviewed commit: ef4eada</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->