### PR TITLE
Add Mistral embedding provider

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -2,9 +2,9 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig, MemorySearchConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import { DEFAULT_MISTRAL_EMBEDDING_MODEL } from "../memory/embeddings-mistral.js";
 import { clampInt, clampNumber, resolveUserPath } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
-import { DEFAULT_MISTRAL_EMBEDDING_MODEL } from "../memory/embeddings-mistral.js";
 
 export type ResolvedMemorySearchConfig = {
   enabled: boolean;

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -4,12 +4,13 @@ import type { OpenClawConfig, MemorySearchConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { clampInt, clampNumber, resolveUserPath } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
+import { DEFAULT_MISTRAL_EMBEDDING_MODEL } from "../memory/embeddings-mistral.js";
 
 export type ResolvedMemorySearchConfig = {
   enabled: boolean;
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
-  provider: "openai" | "local" | "gemini" | "voyage" | "auto";
+  provider: "openai" | "local" | "gemini" | "voyage" | "mistral" | "auto";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -25,7 +26,7 @@ export type ResolvedMemorySearchConfig = {
   experimental: {
     sessionMemory: boolean;
   };
-  fallback: "openai" | "gemini" | "local" | "voyage" | "none";
+  fallback: "openai" | "gemini" | "local" | "voyage" | "mistral" | "none";
   model: string;
   local: {
     modelPath?: string;
@@ -153,6 +154,7 @@ function mergeConfig(
     provider === "openai" ||
     provider === "gemini" ||
     provider === "voyage" ||
+    provider === "mistral" ||
     provider === "auto";
   const batch = {
     enabled: overrideRemote?.batch?.enabled ?? defaultRemote?.batch?.enabled ?? false,
@@ -182,7 +184,9 @@ function mergeConfig(
         ? DEFAULT_OPENAI_MODEL
         : provider === "voyage"
           ? DEFAULT_VOYAGE_MODEL
-          : undefined;
+          : provider === "mistral"
+            ? DEFAULT_MISTRAL_EMBEDDING_MODEL
+            : undefined;
   const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -111,7 +111,7 @@ function hasLocalEmbeddings(local: { modelPath?: string }): boolean {
 }
 
 async function hasApiKeyForProvider(
-  provider: "openai" | "gemini" | "voyage",
+  provider: "openai" | "gemini" | "voyage" | "mistral",
   cfg: OpenClawConfig,
   agentDir: string,
 ): Promise<boolean> {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -68,7 +68,7 @@ export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void>
   if (hasLocalEmbeddings(resolved.local)) {
     return;
   }
-  for (const provider of ["openai", "gemini", "voyage"] as const) {
+  for (const provider of ["openai", "gemini", "voyage", "mistral"] as const) {
     if (hasRemoteApiKey || (await hasApiKeyForProvider(provider, cfg, agentDir))) {
       return;
     }

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -282,13 +282,13 @@ export type MemorySearchConfig = {
     sessionMemory?: boolean;
   };
   /** Embedding provider mode. */
-  provider?: "openai" | "gemini" | "local" | "voyage";
+  provider?: "openai" | "gemini" | "local" | "voyage" | "mistral";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
     headers?: Record<string, string>;
     batch?: {
-      /** Enable batch API for embedding indexing (OpenAI/Gemini; default: true). */
+      /** Enable batch API for embedding indexing (OpenAI/Gemini/Mistral; default: true). */
       enabled?: boolean;
       /** Wait for batch completion (default: true). */
       wait?: boolean;
@@ -301,7 +301,7 @@ export type MemorySearchConfig = {
     };
   };
   /** Fallback behavior when embeddings fail. */
-  fallback?: "openai" | "gemini" | "local" | "voyage" | "none";
+  fallback?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "none";
   /** Embedding model id (remote) or alias (local). */
   model?: string;
   /** Local embedding settings (node-llama-cpp). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -464,7 +464,13 @@ export const MemorySearchSchema = z
       .strict()
       .optional(),
     provider: z
-      .union([z.literal("openai"), z.literal("local"), z.literal("gemini"), z.literal("voyage"), z.literal("mistral")])
+      .union([
+        z.literal("openai"),
+        z.literal("local"),
+        z.literal("gemini"),
+        z.literal("voyage"),
+        z.literal("mistral"),
+      ])
       .optional(),
     remote: z
       .object({

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -464,7 +464,7 @@ export const MemorySearchSchema = z
       .strict()
       .optional(),
     provider: z
-      .union([z.literal("openai"), z.literal("local"), z.literal("gemini"), z.literal("voyage")])
+      .union([z.literal("openai"), z.literal("local"), z.literal("gemini"), z.literal("voyage"), z.literal("mistral")])
       .optional(),
     remote: z
       .object({
@@ -488,6 +488,7 @@ export const MemorySearchSchema = z
       .union([
         z.literal("openai"),
         z.literal("gemini"),
+        z.literal("mistral"),
         z.literal("local"),
         z.literal("voyage"),
         z.literal("none"),

--- a/src/memory/batch-mistral.ts
+++ b/src/memory/batch-mistral.ts
@@ -1,0 +1,173 @@
+import type { MistralEmbeddingClient } from "./embeddings-mistral.js";
+import { hashText } from "./internal.js";
+
+export type MistralBatchRequest = {
+  custom_id: string;
+  text: string;
+};
+
+export type MistralBatchStatus = {
+  id?: string;
+  status?: string;
+  output?: Map<string, number[]>;
+  error?: string;
+};
+
+const MISTRAL_BATCH_MAX_REQUESTS = 100;
+
+function getMistralBaseUrl(mistral: MistralEmbeddingClient): string {
+  return mistral.baseUrl?.replace(/\/$/, "") ?? "";
+}
+
+function getMistralHeaders(mistral: MistralEmbeddingClient): Record<string, string> {
+  const headers = mistral.headers ? { ...mistral.headers } : {};
+  if (!headers["Content-Type"] && !headers["content-type"]) {
+    headers["Content-Type"] = "application/json";
+  }
+  return headers;
+}
+
+function splitMistralBatchRequests(requests: MistralBatchRequest[]): MistralBatchRequest[][] {
+  if (requests.length <= MISTRAL_BATCH_MAX_REQUESTS) return [requests];
+  const groups: MistralBatchRequest[][] = [];
+  for (let i = 0; i < requests.length; i += MISTRAL_BATCH_MAX_REQUESTS) {
+    groups.push(requests.slice(i, i + MISTRAL_BATCH_MAX_REQUESTS));
+  }
+  return groups;
+}
+
+async function submitMistralBatch(params: {
+  mistral: MistralEmbeddingClient;
+  requests: MistralBatchRequest[];
+}): Promise<Map<string, number[]>> {
+  if (params.requests.length === 0) return new Map();
+
+  const baseUrl = getMistralBaseUrl(params.mistral);
+  const url = `${baseUrl}/embeddings`;
+
+  const byCustomId = new Map<string, number[]>();
+
+  // Process all requests in one batch API call
+  const inputTexts = params.requests.map((req) => req.text);
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: getMistralHeaders(params.mistral),
+    body: JSON.stringify({
+      model: params.mistral.model,
+      input: inputTexts,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`mistral batch failed: ${res.status} ${text}`);
+  }
+
+  const payload = (await res.json()) as {
+    data?: Array<{ embedding?: number[]; index?: number }>;
+    error?: { message?: string };
+  };
+
+  if (payload.error?.message) {
+    throw new Error(`mistral batch failed: ${payload.error.message}`);
+  }
+
+  const data = payload.data ?? [];
+  if (data.length !== params.requests.length) {
+    throw new Error(
+      `mistral batch failed: expected ${params.requests.length} results, got ${data.length}`,
+    );
+  }
+
+  // Map results back to custom IDs
+  for (let i = 0; i < data.length; i++) {
+    const result = data[i];
+    const customId = params.requests[i].custom_id;
+    const embedding = result.embedding ?? [];
+    if (embedding.length === 0) {
+      throw new Error(`mistral batch failed: empty embedding for ${customId}`);
+    }
+    byCustomId.set(customId, embedding);
+  }
+
+  return byCustomId;
+}
+
+async function runWithConcurrency<T>(tasks: Array<() => Promise<T>>, limit: number): Promise<T[]> {
+  if (tasks.length === 0) return [];
+  const resolvedLimit = Math.max(1, Math.min(limit, tasks.length));
+  const results: T[] = Array.from({ length: tasks.length });
+  let next = 0;
+  let firstError: unknown = null;
+
+  const workers = Array.from({ length: resolvedLimit }, async () => {
+    while (true) {
+      if (firstError) return;
+      const index = next;
+      next += 1;
+      if (index >= tasks.length) return;
+      try {
+        results[index] = await tasks[index]();
+      } catch (err) {
+        firstError = err;
+        return;
+      }
+    }
+  });
+
+  await Promise.allSettled(workers);
+  if (firstError) throw firstError;
+  return results;
+}
+
+export async function runMistralEmbeddingBatches(params: {
+  mistral: MistralEmbeddingClient;
+  agentId: string;
+  requests: MistralBatchRequest[];
+  wait: boolean;
+  pollIntervalMs: number;
+  timeoutMs: number;
+  concurrency: number;
+  debug?: (message: string, data?: Record<string, unknown>) => void;
+}): Promise<Map<string, number[]>> {
+  if (params.requests.length === 0) return new Map();
+
+  const groups = splitMistralBatchRequests(params.requests);
+  const byCustomId = new Map<string, number[]>();
+
+  const tasks = groups.map((group, groupIndex) => async () => {
+    params.debug?.("memory embeddings: mistral batch start", {
+      group: groupIndex + 1,
+      groups: groups.length,
+      requests: group.length,
+    });
+
+    const results = await submitMistralBatch({
+      mistral: params.mistral,
+      requests: group,
+    });
+
+    params.debug?.("memory embeddings: mistral batch complete", {
+      group: groupIndex + 1,
+      results: results.size,
+    });
+
+    // Merge results into main map
+    for (const [customId, embedding] of results.entries()) {
+      byCustomId.set(customId, embedding);
+    }
+  });
+
+  params.debug?.("memory embeddings: mistral batch submit", {
+    requests: params.requests.length,
+    groups: groups.length,
+    wait: params.wait,
+    concurrency: params.concurrency,
+    pollIntervalMs: params.pollIntervalMs,
+    timeoutMs: params.timeoutMs,
+  });
+
+  await runWithConcurrency(tasks, params.concurrency);
+  return byCustomId;
+}

--- a/src/memory/batch-mistral.ts
+++ b/src/memory/batch-mistral.ts
@@ -1,5 +1,4 @@
 import type { MistralEmbeddingClient } from "./embeddings-mistral.js";
-import { hashText } from "./internal.js";
 
 export type MistralBatchRequest = {
   custom_id: string;

--- a/src/memory/embeddings-mistral.ts
+++ b/src/memory/embeddings-mistral.ts
@@ -1,0 +1,90 @@
+import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
+import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
+
+export type MistralEmbeddingClient = {
+  baseUrl: string;
+  headers: Record<string, string>;
+  model: string;
+};
+
+export const DEFAULT_MISTRAL_EMBEDDING_MODEL = "mistral-embed";
+const DEFAULT_MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
+
+export function normalizeMistralModel(model: string): string {
+  const trimmed = model.trim();
+  if (!trimmed) return DEFAULT_MISTRAL_EMBEDDING_MODEL;
+  if (trimmed.startsWith("mistral/")) return trimmed.slice("mistral/".length);
+  return trimmed;
+}
+
+export async function createMistralEmbeddingProvider(
+  options: EmbeddingProviderOptions,
+): Promise<{ provider: EmbeddingProvider; client: MistralEmbeddingClient }> {
+  const client = await resolveMistralEmbeddingClient(options);
+  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+
+  const embed = async (input: string[]): Promise<number[][]> => {
+    if (input.length === 0) return [];
+    const res = await fetch(url, {
+      method: "POST",
+      headers: client.headers,
+      body: JSON.stringify({ model: client.model, input }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`mistral embeddings failed: ${res.status} ${text}`);
+    }
+    const payload = (await res.json()) as {
+      data?: Array<{ embedding?: number[] }>;
+      error?: { message?: string };
+    };
+    if (payload.error?.message) {
+      throw new Error(`mistral embeddings failed: ${payload.error.message}`);
+    }
+    const data = payload.data ?? [];
+    return data.map((entry) => entry.embedding ?? []);
+  };
+
+  return {
+    provider: {
+      id: "mistral",
+      model: client.model,
+      embedQuery: async (text) => {
+        const [vec] = await embed([text]);
+        return vec ?? [];
+      },
+      embedBatch: embed,
+    },
+    client,
+  };
+}
+
+export async function resolveMistralEmbeddingClient(
+  options: EmbeddingProviderOptions,
+): Promise<MistralEmbeddingClient> {
+  const remote = options.remote;
+  const remoteApiKey = remote?.apiKey?.trim();
+  const remoteBaseUrl = remote?.baseUrl?.trim();
+
+  const apiKey = remoteApiKey
+    ? remoteApiKey
+    : requireApiKey(
+        await resolveApiKeyForProvider({
+          provider: "mistral",
+          cfg: options.config,
+          agentDir: options.agentDir,
+        }),
+        "mistral",
+      );
+
+  const providerConfig = options.config.models?.providers?.mistral;
+  const baseUrl = remoteBaseUrl || providerConfig?.baseUrl?.trim() || DEFAULT_MISTRAL_BASE_URL;
+  const headerOverrides = Object.assign({}, providerConfig?.headers, remote?.headers);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+    ...headerOverrides,
+  };
+  const model = normalizeMistralModel(options.model);
+  return { baseUrl, headers, model };
+}

--- a/src/memory/embeddings-remote-client.ts
+++ b/src/memory/embeddings-remote-client.ts
@@ -1,7 +1,7 @@
 import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import type { EmbeddingProviderOptions } from "./embeddings.js";
 
-type RemoteEmbeddingProviderId = "openai" | "voyage";
+type RemoteEmbeddingProviderId = "openai" | "voyage" | "mistral";
 
 export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -4,6 +4,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveUserPath } from "../utils.js";
 import { createGeminiEmbeddingProvider, type GeminiEmbeddingClient } from "./embeddings-gemini.js";
+import {
+  createMistralEmbeddingProvider,
+  type MistralEmbeddingClient,
+} from "./embeddings-mistral.js";
 import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./embeddings-openai.js";
 import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embeddings-voyage.js";
 import { importNodeLlamaCpp } from "./node-llama.js";
@@ -18,6 +22,7 @@ function sanitizeAndNormalizeEmbedding(vec: number[]): number[] {
 }
 
 export type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
+export type { MistralEmbeddingClient } from "./embeddings-mistral.js";
 export type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
 export type { VoyageEmbeddingClient } from "./embeddings-voyage.js";
 
@@ -29,11 +34,11 @@ export type EmbeddingProvider = {
   embedBatch: (texts: string[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage";
+export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "mistral";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 
-const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage"] as const;
+const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "mistral"] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -44,6 +49,7 @@ export type EmbeddingProviderResult = {
   openAi?: OpenAiEmbeddingClient;
   gemini?: GeminiEmbeddingClient;
   voyage?: VoyageEmbeddingClient;
+  mistral?: MistralEmbeddingClient;
 };
 
 export type EmbeddingProviderOptions = {
@@ -153,6 +159,10 @@ export async function createEmbeddingProvider(
     if (id === "voyage") {
       const { provider, client } = await createVoyageEmbeddingProvider(options);
       return { provider, voyage: client };
+    }
+    if (id === "mistral") {
+      const { provider, client } = await createMistralEmbeddingProvider(options);
+      return { provider, mistral: client };
     }
     const { provider, client } = await createOpenAiEmbeddingProvider(options);
     return { provider, openAi: client };
@@ -278,3 +288,5 @@ function formatLocalSetupError(err: unknown): string {
     .filter(Boolean)
     .join("\n");
 }
+
+export { createMistralEmbeddingProvider } from "./embeddings-mistral.js";

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs/promises";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runGeminiEmbeddingBatches, type GeminiBatchRequest } from "./batch-gemini.js";
+import { type MistralBatchRequest, runMistralEmbeddingBatches } from "./batch-mistral.js";
 import {
   OPENAI_BATCH_ENDPOINT,
   type OpenAiBatchRequest,
   runOpenAiEmbeddingBatches,
 } from "./batch-openai.js";
-import { type MistralBatchRequest, runMistralEmbeddingBatches } from "./batch-mistral.js";
 import { type VoyageBatchRequest, runVoyageEmbeddingBatches } from "./batch-voyage.js";
 import { enforceEmbeddingMaxInputTokens } from "./embedding-chunk-limits.js";
 import { estimateUtf8Bytes } from "./embedding-input-limits.js";
@@ -388,7 +388,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     chunks: MemoryChunk[];
     entry: MemoryFileEntry | SessionFileEntry;
     source: MemorySource;
-    provider: "voyage" | "openai" | "gemini";
+    provider: "voyage" | "openai" | "gemini" | "mistral";
     enabled: boolean;
     buildRequest: (chunk: MemoryChunk) => Omit<TRequest, "custom_id">;
     runBatch: (runnerOptions: {

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -471,7 +471,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       provider: "mistral",
       enabled: Boolean(mistral),
       buildRequest: (chunk) => ({
-        custom_id: hashText(chunk.text),
         text: chunk.text,
       }),
       runBatch: async (runnerOptions) =>

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -12,6 +12,7 @@ import {
   type EmbeddingProvider,
   type EmbeddingProviderResult,
   type GeminiEmbeddingClient,
+  type MistralEmbeddingClient,
   type OpenAiEmbeddingClient,
   type VoyageEmbeddingClient,
 } from "./embeddings.js";
@@ -45,13 +46,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected readonly workspaceDir: string;
   protected readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null;
-  private readonly requestedProvider: "openai" | "local" | "gemini" | "voyage" | "auto";
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage";
+  private readonly requestedProvider: "openai" | "local" | "gemini" | "voyage" | "mistral" | "auto";
+  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "mistral";
   protected fallbackReason?: string;
   private readonly providerUnavailableReason?: string;
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;
+  protected mistral?: MistralEmbeddingClient;
   protected batch: {
     enabled: boolean;
     wait: boolean;
@@ -158,6 +160,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.openAi = params.providerResult.openAi;
     this.gemini = params.providerResult.gemini;
     this.voyage = params.providerResult.voyage;
+    this.mistral = params.providerResult.mistral;
     this.sources = new Set(params.settings.sources);
     this.db = this.openDatabase();
     this.providerKey = this.computeProviderKey();


### PR DESCRIPTION
## Summary

- **Problem:** Mistral's `mistral-embed` model is not available as a memory search embedding provider.
- **Why it matters:** Users with Mistral API keys have no way to use them for memory embeddings, forcing them to rely on OpenAI/Gemini/Voyage.
- **What changed:** Added `mistral` as a new embedding provider, following the same pattern as the existing Voyage provider — provider factory, batch pipeline, config schema, type definitions, fallback chain, doctor checks, and tests.
- **What did NOT change:** No changes to existing providers. No config migration needed — `mistral` is purely additive.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None.

## User-visible / Behavior Changes

- `memorySearch.provider` now accepts `"mistral"` as a valid value.
- `memorySearch.fallbackFrom` now accepts `"mistral"`.
- Auto-selection will pick Mistral when a Mistral API key is available and no explicit provider is configured.
- Default model: `mistral-embed`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — reuses existing `resolveApiKeyForProvider` flow.
- New/changed network calls? `Yes` — calls Mistral's `/v1/embeddings` endpoint when configured.
  - **Risk + mitigation:** Same pattern as Voyage/OpenAI/Gemini providers. Only activated when user explicitly configures `"mistral"` or has a Mistral API key. All requests go through the existing auth resolution and header-merge pipeline.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Linux 6.18)
- Runtime: Node 22 via volta
- Model/provider: Mistral (`mistral-embed`)
- Relevant config (redacted):
  ```json
  {
    "memorySearch": {
      "provider": "mistral",
      "remote": { "apiKey": "***", "batch": { "enabled": true } },
      "model": "mistral-embed"
    }
  }
  ```

### Steps

1. Set `memorySearch.provider` to `"mistral"` with a valid API key.
2. Run `openclaw` and trigger memory indexing.
3. Verify embeddings are generated via Mistral's API.

### Expected

- Memory search uses Mistral embeddings, batch pipeline splits requests into groups of 100.

### Actual

- Works as expected.

## Evidence

- [x] Failing test/log before + passing after
- All 752 test files pass (6,404 tests), including new Mistral-specific tests in `embeddings.test.ts`.
- `pnpm build`, `pnpm tsgo`, and `pnpm test:macmini` all pass clean.

## Human Verification (required)

- Verified scenarios: Configured `mistral-embed` as provider, confirmed memory indexing and search work end-to-end on a local instance.
- Edge cases checked: Missing API key (falls back correctly), batch splitting at 100-request boundary.
- What I did **not** verify: Mistral batch API with extremely large corpora (>10k chunks).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` — new optional values only.
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Change `memorySearch.provider` to any other provider (e.g. `"openai"`).
- Files/config to restore: None.
- Known bad symptoms: If Mistral API is unreachable, embedding indexing would fail — same behavior as other remote providers.

## Risks and Mitigations

- Risk: Mistral API rate limits differ from other providers.
  - Mitigation: Batch pipeline uses configurable concurrency (default 2) and splits at 100 requests per batch, same pattern as Voyage.

---

> AI-assisted: Rebase conflict resolution was done with Claude Code. All code was reviewed and tested manually.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Mistral as a new memory search embedding provider, following the existing pattern for Voyage/OpenAI/Gemini — provider factory, batch pipeline, config schema, type definitions, fallback chain, doctor checks, and tests.

- **Critical: Batch embeddings silently dropped** — In `manager-embedding-ops.ts`, the Mistral `buildRequest` callback returns `custom_id` which overwrites the framework-assigned composite ID via JS spread semantics. This causes the `applyBatchEmbeddings` mapping lookup to fail silently, dropping all batch-produced embeddings. The fix is to remove `custom_id` from the `buildRequest` return (matching how Voyage, OpenAI, and Gemini do it).
- **Doctor auto-detection incomplete** — `doctor-memory-search.ts` doesn't include `"mistral"` in the auto-detection provider loop, causing false "no provider configured" warnings for users with only a Mistral API key.
- **Code duplication** — `embeddings-mistral.ts` reimplements the auth/headers/baseUrl resolution logic instead of reusing the shared `resolveRemoteEmbeddingBearerClient` helper. Similarly, `batch-mistral.ts` reimplements concurrency control instead of using the shared `runEmbeddingBatchGroups` helper.

<h3>Confidence Score: 2/5</h3>

- This PR has a critical logic bug where batch embeddings are silently dropped due to a custom_id overwrite, which will cause the Mistral batch pipeline to produce no usable embeddings.
- Score of 2 reflects a confirmed logic bug in the batch pipeline (custom_id overwrite) that would cause all batch-produced Mistral embeddings to be silently lost, plus a missing doctor check for auto-detection. The non-batch embedding path (embedQuery/embedBatch directly) works correctly, so basic functionality is not completely broken, but the batch pipeline — which is the primary indexing path — is.
- Pay close attention to `src/memory/manager-embedding-ops.ts` (custom_id overwrite bug in buildRequest) and `src/commands/doctor-memory-search.ts` (missing mistral in auto-detection loop).

<sub>Last reviewed commit: 581b7f1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->