### PR TITLE
feat: memory plugin compaction control

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -84,8 +84,9 @@ These run inside the agent loop or gateway pipeline:
 - **`before_model_resolve`**: runs pre-session (no `messages`) to deterministically override provider/model before model resolution.
 - **`before_prompt_build`**: runs after session load (with `messages`) to inject `prependContext`/`systemPrompt` before prompt submission.
 - **`before_agent_start`**: legacy compatibility hook that may run in either phase; prefer the explicit hooks above.
-- **`agent_end`**: inspect the final message list and run metadata after completion.
+- **`agent_end`**: inspect the final message list and run metadata after completion. The hook context includes `requestCompaction()` to schedule a compaction after the agent turn completes.
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.
+- **`provide_compaction_summary`**: a modifying hook that lets a plugin return a custom compaction summary, bypassing the default LLM call. Useful for memory plugins that maintain their own context. Also supports `skipCompaction` to defer compaction (max 3 consecutive skips).
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
 - **`tool_result_persist`**: synchronously transform tool results before they are written to the session transcript.
 - **`message_received` / `message_sending` / `message_sent`**: inbound + outbound message hooks.

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -67,6 +67,16 @@ compaction and can run alongside it.
 
 See [OpenAI provider](/providers/openai) for model params and overrides.
 
+## Plugin-provided summaries
+
+Plugins can override the default compaction summary via the `provide_compaction_summary` hook. When a plugin returns a `summary` string, the LLM compaction call is skipped entirely and the plugin's summary is stored as the compaction entry.
+
+This is useful for memory plugins that already extract structured knowledge from conversations — they can produce a compact summary at a fraction of the token cost.
+
+A plugin can also request `skipCompaction` to defer compaction entirely. A safety gate forces standard compaction after 3 consecutive plugin skips to prevent unbounded context growth.
+
+See [Plugins](/tools/plugin#plugin-hooks) for hook registration and [Agent Loop](/concepts/agent-loop#hook-points) for all available hooks.
+
 ## Tips
 
 - Use `/compact` when sessions feel stale or context is bloated.

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -308,8 +308,38 @@ Notes:
 - The flush is skipped when the session workspace is read-only (`workspaceAccess: "ro"` or `"none"`).
 - See [Memory](/concepts/memory) for the workspace file layout and write patterns.
 
-Pi also exposes a `session_before_compact` hook in the extension API, but OpenClaw’s
+Pi also exposes a `session_before_compact` hook in the extension API, but OpenClaw's
 flush logic lives on the Gateway side today.
+
+---
+
+## Plugin-provided compaction summary
+
+Plugins can intercept the compaction pipeline via two mechanisms:
+
+### `provide_compaction_summary` hook
+
+A **modifying hook** (sequential, awaited) that fires after `before_compaction` but before the LLM compaction call. The plugin receives:
+
+- `messageCount` — total messages in the session
+- `tokensBefore` — estimated tokens being compacted
+- `sessionFile` — path to the session JSONL (all pre-compaction messages are preserved on disk)
+- `previousSummary` — summary from the last compaction cycle, if any (for iterative compaction)
+
+The plugin can return:
+
+- `summary` (string) — a custom summary. When provided, OpenClaw writes this directly via `sessionManager.appendCompaction()` with `fromHook: true`, **skipping the LLM call entirely**.
+- `skipCompaction` (boolean) — skip compaction this cycle. A safety gate tracks consecutive skips per session and forces standard compaction after 3 consecutive plugin skips.
+
+Multiple plugins are merged sequentially: last non-undefined `summary` wins; `skipCompaction` uses OR-logic (any plugin requesting skip wins).
+
+Timeout: the hook races against `EMBEDDED_COMPACTION_TIMEOUT_MS` (300 seconds). If the plugin doesn't respond in time, standard compaction proceeds.
+
+### `requestCompaction()` on agent context
+
+The `agent_end` hook context includes a `requestCompaction(customInstructions?)` method. Calling it schedules a compaction after the current agent turn completes. This is useful for memory plugins that detect when extraction is complete and want to trigger compaction programmatically.
+
+The compaction runs as a separate lane task (deferred execution) to avoid deadlocking the current session lane.
 
 ---
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -373,6 +373,39 @@ Notes:
 - Plugin-managed hooks show up in `openclaw hooks list` with `plugin:<id>`.
 - You cannot enable/disable plugin-managed hooks via `openclaw hooks`; enable/disable the plugin instead.
 
+### Typed hooks (agent lifecycle)
+
+Plugins can also register typed hooks directly via the plugin API. These integrate deeply into the agent loop:
+
+```typescript
+export default function register(api) {
+  // Provide a custom compaction summary (bypasses the LLM compaction call)
+  api.on("provide_compaction_summary", async (event, ctx) => {
+    const summary = await myMemoryPlugin.buildSummary(event.sessionFile);
+    return { summary };
+  });
+
+  // Request compaction after agent turn completes
+  api.on("agent_end", async (event, ctx) => {
+    if (shouldCompact(event)) {
+      await ctx.requestCompaction?.("Focus on key decisions");
+    }
+  });
+}
+```
+
+Available typed hooks and their categories:
+
+- **Model/prompt phase**: `before_model_resolve`, `before_prompt_build`
+- **Agent lifecycle**: `before_agent_start`, `agent_end`
+- **Compaction**: `before_compaction`, `after_compaction`, `provide_compaction_summary`
+- **Tool lifecycle**: `before_tool_call`, `after_tool_call`, `tool_result_persist`
+- **Messages**: `message_received`, `message_sending`, `message_sent`, `before_message_write`
+- **Session**: `session_start`, `session_end`, `before_reset`
+- **Gateway**: `gateway_start`, `gateway_stop`
+
+See [Agent Loop](/concepts/agent-loop#hook-points) for when each hook fires in the pipeline.
+
 ## Provider plugins (model auth)
 
 Plugins can register **model provider auth** flows so users can run OAuth or

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -23,6 +23,7 @@ import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
+import { withTimeout } from "../../utils/with-timeout.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
@@ -706,7 +707,7 @@ export async function compactEmbeddedPiSessionDirect(
         let pluginSummary: string | undefined;
         if (hookRunner?.hasHooks("provide_compaction_summary")) {
           try {
-            const summaryResult = await Promise.race([
+            const summaryResult = await withTimeout(
               hookRunner.runProvideCompactionSummary(
                 {
                   messageCount: preCompactionMessages.length,
@@ -716,10 +717,13 @@ export async function compactEmbeddedPiSessionDirect(
                 },
                 hookCtx,
               ),
-              new Promise<undefined>((resolve) =>
-                setTimeout(() => resolve(undefined), EMBEDDED_COMPACTION_TIMEOUT_MS),
-              ),
-            ]);
+              EMBEDDED_COMPACTION_TIMEOUT_MS,
+            ).catch((err: unknown): Promise<undefined> | undefined => {
+              if ((err as Error)?.message === "timeout") {
+                return undefined;
+              }
+              throw err;
+            });
             if (summaryResult?.skipCompaction) {
               pluginSkipped = true;
             }

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -85,6 +85,32 @@ import type { EmbeddedPiCompactResult } from "./types.js";
 import { describeUnknownError, mapThinkingLevel } from "./utils.js";
 import { flushPendingToolResultsAfterIdle } from "./wait-for-idle-before-flush.js";
 
+// ---------------------------------------------------------------------------
+// Plugin skip-compaction safety gate
+// ---------------------------------------------------------------------------
+const MAX_PLUGIN_SKIP_COUNT = 3;
+/** Bounded map: evicts oldest entry when exceeding MAX_SKIP_MAP_SIZE to prevent
+ *  unbounded growth from abandoned sessions. */
+const MAX_SKIP_MAP_SIZE = 1000;
+const pluginSkipCounts = new Map<string, number>();
+
+function incrementPluginSkipCount(sessionId: string): number {
+  const count = (pluginSkipCounts.get(sessionId) ?? 0) + 1;
+  pluginSkipCounts.set(sessionId, count);
+  // Evict oldest entry if map grows too large (abandoned sessions).
+  if (pluginSkipCounts.size > MAX_SKIP_MAP_SIZE) {
+    const oldest = pluginSkipCounts.keys().next().value;
+    if (oldest !== undefined) {
+      pluginSkipCounts.delete(oldest);
+    }
+  }
+  return count;
+}
+
+function resetPluginSkipCount(sessionId: string): void {
+  pluginSkipCounts.delete(sessionId);
+}
+
 export type CompactEmbeddedPiSessionParams = {
   sessionId: string;
   runId?: string;
@@ -647,6 +673,97 @@ export async function compactEmbeddedPiSessionDirect(
             });
         }
 
+        // Estimate tokens before compaction (used by plugin hook and diagnostics).
+        let estTokensBefore: number | undefined;
+        try {
+          estTokensBefore = 0;
+          for (const msg of preCompactionMessages) {
+            estTokensBefore += estimateTokens(msg);
+          }
+        } catch {
+          estTokensBefore = undefined;
+        }
+
+        // Extract previous compaction summary for iterative compaction support.
+        let previousSummary: string | undefined;
+        try {
+          const entries = sessionManager.getEntries();
+          for (let i = entries.length - 1; i >= 0; i--) {
+            const entry = entries[i];
+            if (entry && entry.type === "compaction" && typeof entry.summary === "string") {
+              previousSummary = entry.summary;
+              break;
+            }
+          }
+        } catch {
+          // Non-critical — leave undefined if entries can't be read.
+        }
+
+        // Ask memory plugin for a custom compaction summary (sequential, awaited).
+        // If the plugin returns a summary, we write it directly via appendCompaction()
+        // and skip the default LLM compaction call entirely.
+        let pluginSkipped = false;
+        let pluginSummary: string | undefined;
+        if (hookRunner?.hasHooks("provide_compaction_summary")) {
+          try {
+            const summaryResult = await Promise.race([
+              hookRunner.runProvideCompactionSummary(
+                {
+                  messageCount: preCompactionMessages.length,
+                  tokensBefore: estTokensBefore,
+                  sessionFile: params.sessionFile,
+                  previousSummary,
+                },
+                hookCtx,
+              ),
+              new Promise<undefined>((resolve) =>
+                setTimeout(() => resolve(undefined), EMBEDDED_COMPACTION_TIMEOUT_MS),
+              ),
+            ]);
+            if (summaryResult?.skipCompaction) {
+              pluginSkipped = true;
+            }
+            if (summaryResult?.summary) {
+              pluginSummary = summaryResult.summary;
+            }
+          } catch (hookErr) {
+            log.warn(`provide_compaction_summary hook failed: ${String(hookErr)}`);
+          }
+        }
+
+        // If plugin requested skip (without providing a summary), honor it
+        // with a safety gate: max 3 consecutive skips per session.
+        if (pluginSkipped && !pluginSummary) {
+          const skipCount = incrementPluginSkipCount(params.sessionId);
+          if (skipCount <= MAX_PLUGIN_SKIP_COUNT) {
+            // Fire after_compaction for consistency (matched pair with before_compaction).
+            if (hookRunner?.hasHooks("after_compaction")) {
+              hookRunner
+                .runAfterCompaction(
+                  {
+                    messageCount: session.messages.length,
+                    tokenCount: undefined,
+                    compactedCount: 0,
+                    sessionFile: params.sessionFile,
+                  },
+                  hookCtx,
+                )
+                .catch((hookErr) => {
+                  log.warn(`after_compaction hook failed: ${hookErr}`);
+                });
+            }
+            return {
+              ok: true,
+              compacted: false,
+              reason: "plugin_skipped",
+            };
+          }
+          log.warn(
+            `[compaction] Plugin skipped compaction ${skipCount} consecutive times — ` +
+              `forcing standard compaction (safety gate: max ${MAX_PLUGIN_SKIP_COUNT})`,
+          );
+        }
+
         const diagEnabled = log.isEnabled("debug");
         const preMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
         if (diagEnabled && preMetrics) {
@@ -663,23 +780,60 @@ export async function compactEmbeddedPiSessionDirect(
         }
 
         const compactStartedAt = Date.now();
-        const result = await compactWithSafetyTimeout(() =>
-          session.compact(params.customInstructions),
-        );
-        // Estimate tokens after compaction by summing token estimates for remaining messages
+        let result;
+        if (pluginSummary) {
+          // Plugin provided a summary — write it directly as a compaction entry,
+          // bypassing the LLM call entirely. Uses sessionManager.appendCompaction()
+          // with fromHook=true to mark this as a plugin-provided compaction.
+          log.info(
+            `[compaction] Using plugin-provided summary (${pluginSummary.length} chars), skipping LLM compaction`,
+          );
+          const entries = sessionManager.getEntries();
+          const lastEntryId = entries.length > 0 ? (entries[entries.length - 1]?.id ?? "") : "";
+          sessionManager.appendCompaction(
+            pluginSummary,
+            lastEntryId,
+            estTokensBefore ?? 0,
+            undefined,
+            true, // fromHook
+          );
+          resetPluginSkipCount(params.sessionId);
+          // Build a result object compatible with the standard compaction path.
+          result = {
+            summary: pluginSummary,
+            firstKeptEntryId: lastEntryId,
+            tokensBefore: estTokensBefore ?? 0,
+            details: undefined,
+          };
+        } else {
+          result = await compactWithSafetyTimeout(() => session.compact(params.customInstructions));
+          resetPluginSkipCount(params.sessionId);
+        }
+        // Estimate tokens after compaction.
+        // For plugin-provided summaries, session.messages is NOT pruned in memory
+        // (pruning happens on next session load), so we estimate from the summary
+        // length instead of iterating the unpruned message set.
         let tokensAfter: number | undefined;
-        try {
-          tokensAfter = 0;
-          for (const message of session.messages) {
-            tokensAfter += estimateTokens(message);
+        let compactedCount: number;
+        if (pluginSummary) {
+          // Plugin path: estimate from summary length (~4 chars per token)
+          tokensAfter = Math.ceil(pluginSummary.length / 4);
+          compactedCount = preCompactionMessages.length;
+        } else {
+          // Standard LLM path: estimate from remaining messages
+          try {
+            tokensAfter = 0;
+            for (const message of session.messages) {
+              tokensAfter += estimateTokens(message);
+            }
+            // Sanity check: tokensAfter should be less than tokensBefore
+            if (tokensAfter > result.tokensBefore) {
+              tokensAfter = undefined; // Don't trust the estimate
+            }
+          } catch {
+            tokensAfter = undefined;
           }
-          // Sanity check: tokensAfter should be less than tokensBefore
-          if (tokensAfter > result.tokensBefore) {
-            tokensAfter = undefined; // Don't trust the estimate
-          }
-        } catch {
-          // If estimation fails, leave tokensAfter undefined
-          tokensAfter = undefined;
+          compactedCount = limited.length - session.messages.length;
         }
         // Run after_compaction hooks (fire-and-forget).
         // Also includes sessionFile for plugins that only need to act after
@@ -688,9 +842,9 @@ export async function compactEmbeddedPiSessionDirect(
           hookRunner
             .runAfterCompaction(
               {
-                messageCount: session.messages.length,
+                messageCount: pluginSummary ? 1 : session.messages.length,
                 tokenCount: tokensAfter,
-                compactedCount: limited.length - session.messages.length,
+                compactedCount,
                 sessionFile: params.sessionFile,
               },
               hookCtx,
@@ -720,7 +874,7 @@ export async function compactEmbeddedPiSessionDirect(
           compacted: true,
           result: {
             summary: result.summary,
-            firstKeptEntryId: result.firstKeptEntryId,
+            firstKeptEntryId: result.firstKeptEntryId ?? "",
             tokensBefore: result.tokensBefore,
             tokensAfter,
             details: result.details,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -140,7 +140,7 @@ export type CompactEmbeddedPiSessionParams = {
   reasoningLevel?: ReasoningLevel;
   bashElevated?: ExecElevatedDefaults;
   customInstructions?: string;
-  trigger?: "overflow" | "manual";
+  trigger?: "overflow" | "manual" | "plugin";
   diagId?: string;
   attempt?: number;
   maxAttempts?: number;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -842,6 +842,8 @@ export async function compactEmbeddedPiSessionDirect(
           hookRunner
             .runAfterCompaction(
               {
+                // Plugin-provided summary uses appendCompaction() without pruning
+                // in-memory messages; report a summary placeholder count until reload.
                 messageCount: pluginSummary ? 1 : session.messages.length,
                 tokenCount: tokensAfter,
                 compactedCount,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1593,6 +1593,11 @@ export async function runEmbeddedAttempt(
         // This is fire-and-forget, so we don't await
         // Run even on compaction timeout so plugins can log/cleanup
         if (hookRunner?.hasHooks("agent_end")) {
+          // requestCompaction: deferred flag checked after agent_end completes.
+          // We cannot call compactEmbeddedPiSession inline here because we are
+          // already inside the session lane — re-entering would deadlock.
+          let compactionRequested = false;
+          let compactionCustomInstructions: string | undefined;
           hookRunner
             .runAgentEnd(
               {
@@ -1607,8 +1612,33 @@ export async function runEmbeddedAttempt(
                 sessionId: params.sessionId,
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,
+                requestCompaction: async (customInstructions?: string) => {
+                  if (compactionRequested) {
+                    return false;
+                  }
+                  compactionRequested = true;
+                  compactionCustomInstructions = customInstructions;
+                  return true;
+                },
               },
             )
+            .then(async () => {
+              // Deferred compaction: schedule outside the current lane after agent_end completes.
+              if (compactionRequested && params.sessionFile && params.sessionKey) {
+                const { compactEmbeddedPiSession: deferredCompact } = await import("../compact.js");
+                void deferredCompact({
+                  sessionId: params.sessionId,
+                  sessionKey: params.sessionKey,
+                  sessionFile: params.sessionFile,
+                  workspaceDir: params.workspaceDir,
+                  config: params.config,
+                  provider: params.provider,
+                  model: params.modelId,
+                  customInstructions: compactionCustomInstructions,
+                  trigger: "manual" as const, // TODO: add "plugin" trigger variant
+                });
+              }
+            })
             .catch((err) => {
               log.warn(`agent_end hook failed: ${err}`);
             });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1636,6 +1636,8 @@ export async function runEmbeddedAttempt(
                   model: params.modelId,
                   customInstructions: compactionCustomInstructions,
                   trigger: "plugin" as const,
+                }).catch((deferredErr) => {
+                  log.warn(`deferred plugin compaction failed: ${String(deferredErr)}`);
                 });
               }
             })

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1635,7 +1635,7 @@ export async function runEmbeddedAttempt(
                   provider: params.provider,
                   model: params.modelId,
                   customInstructions: compactionCustomInstructions,
-                  trigger: "manual" as const, // TODO: add "plugin" trigger variant
+                  trigger: "plugin" as const,
                 });
               }
             })

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1613,6 +1613,14 @@ export async function runEmbeddedAttempt(
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,
                 requestCompaction: async (customInstructions?: string) => {
+                  if (!params.sessionKey || !params.sessionFile) {
+                    // requestCompaction needs session identity + transcript path;
+                    // fail fast instead of returning true and silently skipping later.
+                    log.warn(
+                      `requestCompaction ignored: missing session context (sessionKey=${String(params.sessionKey)}, sessionFile=${String(params.sessionFile)})`,
+                    );
+                    return false;
+                  }
                   if (compactionRequested) {
                     return false;
                   }

--- a/src/plugins/hooks.provide-compaction-summary-wiring.test.ts
+++ b/src/plugins/hooks.provide-compaction-summary-wiring.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Test: provide_compaction_summary wiring
+ *
+ * Validates that the hook runner correctly recognizes and dispatches
+ * provide_compaction_summary hooks, and that hasHooks() returns true
+ * when a handler is registered.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import type { PluginHookRegistration } from "./types.js";
+
+describe("provide_compaction_summary wiring", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  it("hasHooks returns false when no provide_compaction_summary handlers registered", () => {
+    const runner = createHookRunner(registry);
+    expect(runner.hasHooks("provide_compaction_summary")).toBe(false);
+  });
+
+  it("hasHooks returns true when a provide_compaction_summary handler is registered", () => {
+    registry.typedHooks.push({
+      pluginId: "quaid",
+      hookName: "provide_compaction_summary",
+      handler: () => ({ summary: "test" }),
+      source: "test",
+    } as PluginHookRegistration);
+
+    const runner = createHookRunner(registry);
+    expect(runner.hasHooks("provide_compaction_summary")).toBe(true);
+  });
+
+  it("runProvideCompactionSummary passes event data to handler", async () => {
+    let receivedEvent: unknown;
+    let receivedCtx: unknown;
+
+    registry.typedHooks.push({
+      pluginId: "quaid",
+      hookName: "provide_compaction_summary",
+      handler: (event: unknown, ctx: unknown) => {
+        receivedEvent = event;
+        receivedCtx = ctx;
+        return { summary: "Plugin summary" };
+      },
+      source: "test",
+    } as PluginHookRegistration);
+
+    const runner = createHookRunner(registry);
+
+    const event = {
+      messageCount: 42,
+      tokensBefore: 8000,
+      sessionFile: "/tmp/session.jsonl",
+      previousSummary: "Previous summary text",
+    };
+    const ctx = {
+      agentId: "main",
+      sessionKey: "telegram:12345",
+      sessionId: "sess-1",
+    };
+
+    const result = await runner.runProvideCompactionSummary(event as never, ctx as never);
+
+    expect(result?.summary).toBe("Plugin summary");
+    expect(receivedEvent).toMatchObject({
+      messageCount: 42,
+      tokensBefore: 8000,
+      sessionFile: "/tmp/session.jsonl",
+      previousSummary: "Previous summary text",
+    });
+    expect(receivedCtx).toMatchObject({
+      agentId: "main",
+      sessionKey: "telegram:12345",
+    });
+  });
+
+  it("handles handler that throws without crashing", async () => {
+    registry.typedHooks.push({
+      pluginId: "broken-plugin",
+      hookName: "provide_compaction_summary",
+      handler: () => {
+        throw new Error("Plugin crashed");
+      },
+      source: "test",
+    } as PluginHookRegistration);
+
+    // createHookRunner with default catchErrors=true should swallow the error
+    const runner = createHookRunner(registry);
+    const result = await runner.runProvideCompactionSummary(
+      { messageCount: 10 } as never,
+      {} as never,
+    );
+
+    // Error is caught — returns undefined (no result)
+    expect(result).toBeUndefined();
+  });
+
+  it("requestCompaction is exposed in PluginHookAgentContext type shape", () => {
+    // This is a compile-time check — if types.ts correctly includes requestCompaction,
+    // this test compiles. We verify the runtime shape matches.
+    const mockCtx = {
+      agentId: "main",
+      sessionKey: "test:1",
+      sessionId: "s1",
+      workspaceDir: "/tmp",
+      requestCompaction: async (_instructions?: string) => true,
+    };
+
+    expect(typeof mockCtx.requestCompaction).toBe("function");
+  });
+});

--- a/src/plugins/hooks.provide-compaction-summary.test.ts
+++ b/src/plugins/hooks.provide-compaction-summary.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Test: provide_compaction_summary hook merge logic
+ *
+ * Exercises the sequential modifying-hook pattern:
+ * - Single plugin returning summary
+ * - Multiple plugins — last summary wins, skipCompaction OR-logic
+ * - Plugin returning void (no-op)
+ * - Error in one plugin doesn't block others
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import type { PluginHookProvideCompactionSummaryResult, PluginHookRegistration } from "./types.js";
+
+function addCompactionSummaryHook(
+  registry: PluginRegistry,
+  pluginId: string,
+  handler: () =>
+    | PluginHookProvideCompactionSummaryResult
+    | Promise<PluginHookProvideCompactionSummaryResult>
+    | void,
+  priority?: number,
+) {
+  registry.typedHooks.push({
+    pluginId,
+    hookName: "provide_compaction_summary",
+    handler,
+    priority,
+    source: "test",
+  } as PluginHookRegistration);
+}
+
+const dummyCtx = {} as never;
+const dummyEvent = { messageCount: 10, tokensBefore: 5000 } as never;
+
+describe("provide_compaction_summary merge logic", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  it("returns undefined when no hooks are registered", async () => {
+    const runner = createHookRunner(registry);
+    const result = await runner.runProvideCompactionSummary(dummyEvent, dummyCtx);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns summary from a single plugin", async () => {
+    addCompactionSummaryHook(registry, "memory-plugin", () => ({
+      summary: "User discussed recipe ideas.",
+    }));
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runProvideCompactionSummary(dummyEvent, dummyCtx);
+
+    expect(result?.summary).toBe("User discussed recipe ideas.");
+    expect(result?.skipCompaction).toBeFalsy();
+  });
+
+  it("returns skipCompaction from a single plugin", async () => {
+    addCompactionSummaryHook(registry, "memory-plugin", () => ({
+      skipCompaction: true,
+    }));
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runProvideCompactionSummary(dummyEvent, dummyCtx);
+
+    expect(result?.skipCompaction).toBe(true);
+    expect(result?.summary).toBeUndefined();
+  });
+
+  it("last summary wins when multiple plugins provide summaries", async () => {
+    addCompactionSummaryHook(registry, "plugin-a", () => ({ summary: "Summary from A" }), 1);
+    addCompactionSummaryHook(registry, "plugin-b", () => ({ summary: "Summary from B" }), 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runProvideCompactionSummary(dummyEvent, dummyCtx);
+
+    // Higher priority runs first in modifying hooks, then lower priority.
+    // The merge function uses next.summary ?? acc.summary, so the last
+    // non-undefined summary wins.
+    expect(result?.summary).toBe("Summary from A");
+  });
+
+  it("skipCompaction uses OR-logic across plugins", async () => {
+    addCompactionSummaryHook(
+      registry,
+      "plugin-a",
+      () => ({ skipCompaction: false, summary: "A summary" }),
+      10,
+    );
+    addCompactionSummaryHook(registry, "plugin-b", () => ({ skipCompaction: true }), 1);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runProvideCompactionSummary(dummyEvent, dummyCtx);
+
+    // OR-logic: any plugin requesting skip wins
+    expect(result?.skipCompaction).toBe(true);
+  });
+
+  it("preserves summary when later plugin returns only skipCompaction", async () => {
+    addCompactionSummaryHook(
+      registry,
+      "memory-plugin",
+      () => ({ summary: "Important context" }),
+      10,
+    );
+    addCompactionSummaryHook(registry, "rate-limiter", () => ({ skipCompaction: false }), 1);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runProvideCompactionSummary(dummyEvent, dummyCtx);
+
+    // summary should be preserved from first plugin since second returns undefined summary
+    expect(result?.summary).toBe("Important context");
+  });
+
+  it("ignores plugins that return void", async () => {
+    addCompactionSummaryHook(registry, "no-op-plugin", () => {
+      // returns void
+    });
+    addCompactionSummaryHook(registry, "memory-plugin", () => ({
+      summary: "Real summary",
+    }));
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runProvideCompactionSummary(dummyEvent, dummyCtx);
+
+    expect(result?.summary).toBe("Real summary");
+  });
+
+  it("handles async handlers", async () => {
+    addCompactionSummaryHook(registry, "async-plugin", async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      return { summary: "Async summary" };
+    });
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runProvideCompactionSummary(dummyEvent, dummyCtx);
+
+    expect(result?.summary).toBe("Async summary");
+  });
+});

--- a/src/plugins/hooks.provide-compaction-summary.test.ts
+++ b/src/plugins/hooks.provide-compaction-summary.test.ts
@@ -3,7 +3,7 @@
  *
  * Exercises the sequential modifying-hook pattern:
  * - Single plugin returning summary
- * - Multiple plugins — last summary wins, skipCompaction OR-logic
+ * - Multiple plugins — highest-priority summary wins, skipCompaction OR-logic
  * - Plugin returning void (no-op)
  * - Error in one plugin doesn't block others
  */
@@ -70,17 +70,17 @@ describe("provide_compaction_summary merge logic", () => {
     expect(result?.summary).toBeUndefined();
   });
 
-  it("last summary wins when multiple plugins provide summaries", async () => {
+  it("highest-priority summary wins when multiple plugins provide summaries", async () => {
     addCompactionSummaryHook(registry, "plugin-a", () => ({ summary: "Summary from A" }), 1);
     addCompactionSummaryHook(registry, "plugin-b", () => ({ summary: "Summary from B" }), 10);
 
     const runner = createHookRunner(registry);
     const result = await runner.runProvideCompactionSummary(dummyEvent, dummyCtx);
 
-    // Higher priority runs first in modifying hooks, then lower priority.
-    // The merge function uses next.summary ?? acc.summary, so the last
-    // non-undefined summary wins.
-    expect(result?.summary).toBe("Summary from A");
+    // Higher priority runs first in modifying hooks.
+    // The merge function uses acc.summary ?? next.summary, so the first
+    // non-undefined summary (highest priority) wins.
+    expect(result?.summary).toBe("Summary from B");
   });
 
   it("skipCompaction uses OR-logic across plugins", async () => {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -49,6 +49,8 @@ import type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookProvideCompactionSummaryEvent,
+  PluginHookProvideCompactionSummaryResult,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -80,6 +82,8 @@ export type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookProvideCompactionSummaryEvent,
+  PluginHookProvideCompactionSummaryResult,
   PluginHookSessionContext,
   PluginHookSessionStartEvent,
   PluginHookSessionEndEvent,
@@ -369,6 +373,27 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     ctx: PluginHookAgentContext,
   ): Promise<void> {
     return runVoidHook("before_reset", event, ctx);
+  }
+
+  /**
+   * Run provide_compaction_summary hook.
+   * Allows a memory plugin to return a custom compaction summary, bypassing the
+   * default LLM call. Runs sequentially (modifying hook).
+   */
+  async function runProvideCompactionSummary(
+    event: PluginHookProvideCompactionSummaryEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookProvideCompactionSummaryResult | undefined> {
+    return runModifyingHook<"provide_compaction_summary", PluginHookProvideCompactionSummaryResult>(
+      "provide_compaction_summary",
+      event,
+      ctx,
+      (acc, next) => ({
+        summary: next.summary ?? acc?.summary,
+        // OR-logic: any plugin requesting skip wins
+        skipCompaction: next.skipCompaction || acc?.skipCompaction,
+      }),
+    );
   }
 
   // =========================================================================
@@ -724,6 +749,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runBeforeCompaction,
     runAfterCompaction,
     runBeforeReset,
+    runProvideCompactionSummary,
     // Message hooks
     runMessageReceived,
     runMessageSending,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -389,7 +389,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       event,
       ctx,
       (acc, next) => ({
-        summary: next.summary ?? acc?.summary,
+        // Match modifying-hook precedence: earlier (higher-priority) summary wins.
+        summary: acc?.summary ?? next.summary,
         // OR-logic: any plugin requesting skip wins
         skipCompaction: next.skipCompaction || acc?.skipCompaction,
       }),

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -326,6 +326,7 @@ export type PluginHookName =
   | "before_message_write"
   | "session_start"
   | "session_end"
+  | "provide_compaction_summary"
   | "subagent_spawning"
   | "subagent_delivery_target"
   | "subagent_spawned"
@@ -344,6 +345,11 @@ export type PluginHookAgentContext = {
   trigger?: string;
   /** Channel identifier (e.g. "telegram", "discord", "whatsapp"). */
   channelId?: string;
+  /** Request compaction of the current session. The compaction is deferred and
+   *  runs after the current agent run completes (to avoid lane deadlocks).
+   *  Returns false if compaction was already requested or is in progress.
+   *  Only available on agent-scoped hooks (agent_end, after_tool_call). */
+  requestCompaction?: (customInstructions?: string) => Promise<boolean>;
 };
 
 // before_model_resolve hook
@@ -447,6 +453,38 @@ export type PluginHookAfterCompactionEvent = {
    *  preserved on disk, so plugins can read and process them asynchronously
    *  without blocking the compaction pipeline. */
   sessionFile?: string;
+};
+
+// provide_compaction_summary hook
+/** Fired after before_compaction handlers have been dispatched, before the
+ *  compaction LLM call. A plugin can return a custom summary to bypass the
+ *  LLM entirely.
+ *
+ *  IMPORTANT: before_compaction is fire-and-forget. Async work started there
+ *  (e.g., memory extraction) may still be running. Plugins that need extraction
+ *  results must coordinate through their own shared state (e.g., a module-level
+ *  promise keyed by ctx.sessionId). */
+export type PluginHookProvideCompactionSummaryEvent = {
+  /** Total messages in the session */
+  messageCount: number;
+  /** Estimated tokens being compacted */
+  tokensBefore?: number;
+  /** Path to the session JSONL transcript (all messages on disk) */
+  sessionFile?: string;
+  /** Summary from the previous compaction cycle, if any (for iterative
+   *  compaction — plugin can incorporate or supersede it) */
+  previousSummary?: string;
+};
+
+export type PluginHookProvideCompactionSummaryResult = {
+  /** Custom compaction summary. If provided, the gateway writes this as the
+   *  compaction entry instead of calling the compaction LLM. The plugin is
+   *  responsible for producing a useful summary. */
+  summary?: string;
+  /** If true, skip compaction entirely this cycle. The gateway tracks consecutive
+   *  skips per session and forces a standard compaction after 3 consecutive
+   *  plugin skips to prevent unbounded context growth. */
+  skipCompaction?: boolean;
 };
 
 // Message context
@@ -712,6 +750,13 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeResetEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<void> | void;
+  provide_compaction_summary: (
+    event: PluginHookProvideCompactionSummaryEvent,
+    ctx: PluginHookAgentContext,
+  ) =>
+    | Promise<PluginHookProvideCompactionSummaryResult | void>
+    | PluginHookProvideCompactionSummaryResult
+    | void;
   message_received: (
     event: PluginHookMessageReceivedEvent,
     ctx: PluginHookMessageContext,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -348,7 +348,7 @@ export type PluginHookAgentContext = {
   /** Request compaction of the current session. The compaction is deferred and
    *  runs after the current agent run completes (to avoid lane deadlocks).
    *  Returns false if compaction was already requested or is in progress.
-   *  Only available on agent-scoped hooks (agent_end, after_tool_call). */
+   *  Only available on the agent_end hook context. */
   requestCompaction?: (customInstructions?: string) => Promise<boolean>;
 };
 
@@ -446,6 +446,9 @@ export type PluginHookBeforeResetEvent = {
 };
 
 export type PluginHookAfterCompactionEvent = {
+  /** Remaining in-memory message count after compaction.
+   *  Note: for plugin-provided summaries, in-memory pruning does not happen
+   *  until next session load, so this is reported as 1 (summary placeholder). */
   messageCount: number;
   tokenCount?: number;
   compactedCount: number;


### PR DESCRIPTION
## Summary

Two plugin API additions that give memory plugins control over compaction — custom summaries and programmatic compaction triggers. Each change is isolated and backward-compatible. Builds on #13287 (`before_compaction`, `before_reset`, `extraBootstrapFiles`).

- **`provide_compaction_summary` hook** — new modifying hook that lets a plugin return a custom compaction summary, bypassing the default LLM compaction call entirely. Uses `sessionManager.appendCompaction()` with `fromHook: true`. Includes a skip-counter safety gate (max 3 consecutive skips).
- **`requestCompaction()` on hook context** — lets plugins trigger compaction programmatically (e.g., after idle-timeout extraction in `agent_end`). Deferred execution to avoid lane deadlocks.

Both are purely additive — `before_compaction` remains fire-and-forget, new hooks only activate when registered, zero overhead for plugins that don't use them.

---

## Context

Today, every compaction runs an LLM call to summarize the conversation. A memory plugin that has already extracted structured facts and relationships from the conversation can represent the same information in far fewer tokens — but has no way to tell the gateway "I've got this."

Internal benchmarks with [Quaid](https://github.com/Steadman-Labs/quaid) (a local SQLite knowledge graph using sqlite-vec + FTS5 + Haiku reranker) show **~90% recall accuracy at ~12% of the input tokens** compared to full-context replay. But without these hooks, those token savings can't be captured — the gateway will still run the LLM compaction regardless of what the plugin knows.

These hooks enable a pattern where memory plugins provide their own compaction summaries from their knowledge graph, saving the cost and latency of the default LLM compaction call.

| Hook | Phase | Type | What It Controls |
|------|-------|------|-----------------|
| `before_compaction` | Compaction | void (unchanged) | Observe/extract — fire-and-forget |
| `provide_compaction_summary` | Compaction | modifying (new) | Replace LLM summary with plugin summary |
| `requestCompaction()` | Agent hooks | method (new) | Trigger compaction programmatically |

---

## 1. `provide_compaction_summary` — Plugin-provided compaction summary

**Problem:** The `before_compaction` hook is fire-and-forget (`runVoidHook`). Plugins can observe and extract, but cannot provide a compaction summary. The gateway always runs the default LLM summarization, even when a memory plugin has already processed every message.

**Solution:** Add a new modifying hook `provide_compaction_summary` that fires after `before_compaction` handlers have been dispatched. The plugin can return a custom summary string; the gateway writes it directly via `sessionManager.appendCompaction()` with `fromHook: true`, skipping the LLM call entirely.

**Key implementation details:**

- `tokensBefore` populated by `estimateTokens()` loop over `preCompactionMessages`
- `previousSummary` extracted from last compaction entry in `sessionManager.getEntries()`
- Plugin summary path uses `sessionManager.appendCompaction(pluginSummary, lastEntryId, estTokensBefore, undefined, true)` — `fromHook: true` marks it as plugin-provided
- Skip-counter safety gate: `MAX_PLUGIN_SKIP_COUNT = 3` consecutive skips before forced standard compaction
- Same timeout as default compaction (`EMBEDDED_COMPACTION_TIMEOUT_MS` = 300s)

**Files:** `types.ts`, `hooks.ts`, `compact.ts`

---

## 2. Plugin-triggered compaction via hook context

**Problem:** Plugins cannot trigger compaction programmatically. Use case: a memory plugin's idle-timeout handler (in `agent_end`) extracts facts after inactivity and wants to compact the session for the next turn.

**Solution:** Add `requestCompaction(customInstructions?)` to `PluginHookAgentContext`. The method sets a deferred flag; after `agent_end` completes, the compaction is scheduled as a new lane task via dynamic import to avoid deadlocking the current session lane.

**Files:** `types.ts`, `run/attempt.ts`

---

## Backward Compatibility

- `before_compaction` remains fire-and-forget — existing plugins unaffected
- New hooks only activate when registered — zero overhead otherwise
- `requestCompaction()` is optional on the context object
- `skipCompaction` has a 3-consecutive-skip safety gate to prevent unbounded context growth
- `after_compaction` fires regardless of which path was taken (plugin summary or default LLM)

## Tests

- 13 new vitest tests covering hook merge logic (OR-logic for `skipCompaction`, last-summary-wins), wiring (`hasHooks` detection, event passthrough, error handling), and type shapes
- 5 existing compaction hook tests still pass
- 119 total plugin tests pass

## Docs Updated

- `docs/concepts/agent-loop.md` — added `provide_compaction_summary` to hook list, noted `requestCompaction()` on `agent_end`
- `docs/concepts/compaction.md` — added "Plugin-provided summaries" section
- `docs/reference/session-management-compaction.md` — added detailed section on plugin-provided compaction summary and `requestCompaction()`
- `docs/tools/plugin.md` — added "Typed hooks" section with registration examples and hook category list

## Changes since initial submission

- Removed `provide_session_context` (deferred to future PR — not needed yet)
- Fixed: `session.compact(pluginSummary)` → `sessionManager.appendCompaction()` for true LLM bypass
- Fixed: added skip-counter safety gate (`MAX_PLUGIN_SKIP_COUNT = 3`)
- Fixed: populated `tokensBefore` and `previousSummary` (were hardcoded `undefined`)
- Fixed: trigger label `"overflow"` → `"manual"`
- Added 13 new tests and 4 doc updates

Happy to answer questions or hop on Discord.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two plugin API hooks for memory plugins to control compaction: `provide_compaction_summary` allows plugins to provide custom summaries (bypassing LLM calls), and `requestCompaction()` enables programmatic compaction triggers. Implementation is backward-compatible with proper safety gates (3-skip limit, bounded map with 1000-entry cap, timeout protection). Previous review issues have been addressed: skip counter is implemented, `tokensBefore`/`previousSummary` are populated, `sessionManager.appendCompaction()` correctly bypasses LLM, and trigger label is `"manual"`. Tests cover hook merge logic, wiring, and error handling. Documentation updated across 4 files.

- Implements plugin-provided compaction summaries with proper LLM bypass via `sessionManager.appendCompaction()`
- Adds `requestCompaction()` method to agent hook context with deferred execution to avoid lane deadlocks
- Safety gate prevents unbounded context growth (max 3 consecutive plugin skips before forced compaction)
- Skip counter map uses bounded eviction (FIFO at 1000 entries) to prevent memory leaks from abandoned sessions
- 13 new tests validate hook merge logic (OR-logic for `skipCompaction`, last-summary-wins), wiring, and error handling

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations - well-tested backward-compatible feature addition with proper safety gates
- All previous review issues have been addressed (skip counter implemented, `tokensBefore`/`previousSummary` populated, correct LLM bypass via `sessionManager.appendCompaction()`, trigger label fixed to `"manual"`). Implementation includes comprehensive safety mechanisms (3-skip limit, bounded map, timeout protection), extensive test coverage (13 new tests), and clear documentation updates. The bounded map uses FIFO eviction (not true LRU) which is acceptable for preventing unbounded growth. The deferred compaction pattern correctly avoids lane deadlocks. Minor point: the TODO comment about adding a `"plugin"` trigger variant could be addressed but is acceptable as-is.
- No files require special attention - implementation is clean and previous review concerns have been resolved

<sub>Last reviewed commit: f98c1f6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

## AI Assistance & Testing Disclosure

- AI-assisted: yes (development, analysis, and conflict resolution support).
- Testing status: previously documented test coverage remains applicable for feature changes; this latest update is a merge-conflict resolution commit on `src/plugins/types.ts` to include both new hook names.
- CI is expected to validate the merged head commit.


---

## Contributor Checklist Update (2026-02-24)

Feature process / pre-discussion:
- Discussion opened for feature review and API-shape feedback: https://github.com/openclaw/openclaw/discussions/25398

Testing rerun status:
- Local checks rerun:
  - `pnpm build` ✅
  - `pnpm check` ✅
- Full `pnpm test` rerun attempted in isolated Spark lane with throttling:
  - `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_WORKERS=2 OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB=8192 pnpm test`
  - environment: isolated Spark container `openclaw-pr20184-gw`, state/workspace `/home/solomon/.openclaw-pr20184`, ports `19089/19090`
  - shard summaries completed green:
    - `Test Files 21 passed (21)`
    - `Test Files 88 passed (88)`
    - `Test Files 134 passed (134)`
  - note: test wrapper did not exit cleanly in this container after shard completion and required termination.

Live isolated gateway proof for this PR:
- `requestCompaction()` from hook context returned true (`hasReq=true`, `requested=true` in probe log).
- `provide_compaction_summary` takeover confirmed by compaction entry containing marker and `fromHook:true`.
- command checks in live run:
  - `/compact` works
  - `/new` resets conversation context while retaining memory files
  - `/reset` prompts for scope confirmation before reset

Code-path understanding confirmation:
- `provide_compaction_summary` bypasses default LLM compaction path by writing compaction entry directly.
- `requestCompaction()` is deferred post-`agent_end` to avoid lane deadlock.
- existing compaction safeguards remain in place.
