### PR TITLE
fix(model): recognize default/reset/clear keywords to clear session model override (#20137)

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -189,7 +189,9 @@ export async function maybeHandleModelDirectiveInfo(params: {
   const wantsStatus = directive === "status";
   const wantsSummary = !rawDirective;
   const wantsLegacyList = directive === "list";
-  if (!wantsSummary && !wantsStatus && !wantsLegacyList) {
+  // Reset keywords are handled by resolveModelSelectionFromDirective; skip info display.
+  const wantsReset = directive === "default" || directive === "reset" || directive === "clear";
+  if (!wantsSummary && !wantsStatus && !wantsLegacyList && !wantsReset) {
     return undefined;
   }
 
@@ -213,6 +215,12 @@ export async function maybeHandleModelDirectiveInfo(params: {
     return reply ?? { text: "No models available." };
   }
 
+  // Reset keywords (default/reset/clear) are handled by resolveModelSelectionFromDirective;
+  // return undefined here so the caller proceeds to model selection handling.
+  if (wantsReset) {
+    return undefined;
+  }
+
   if (wantsSummary) {
     const current = `${params.provider}/${params.model}`;
     const isTelegram = params.surface === "telegram";
@@ -225,6 +233,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
           "",
           "Tap below to browse models, or use:",
           "/model <provider/model> to switch",
+          "/model default (or reset/clear) to restore default",
           "/model status for details",
         ].join("\n"),
         channelData: { telegram: { buttons } },
@@ -236,6 +245,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
         `Current: ${current}`,
         "",
         "Switch: /model <provider/model>",
+        "Reset:  /model default (or reset, clear)",
         "Browse: /models (providers) or /models <provider> (models)",
         "More: /model status",
       ].join("\n"),
@@ -344,6 +354,22 @@ export function resolveModelSelectionFromDirective(params: {
         "Browse: /models or /models <provider>",
         "Switch: /model <provider/model>",
       ].join("\n"),
+    };
+  }
+
+  // Reserved reset keywords (single token, no slash) clear the session model override
+  // and fall back to the configured default. "provider/default" is still a valid model id.
+  const rawLower = raw.toLowerCase();
+  if (
+    (rawLower === "default" || rawLower === "reset" || rawLower === "clear") &&
+    !raw.includes("/")
+  ) {
+    return {
+      modelSelection: {
+        provider: params.defaultProvider,
+        model: params.defaultModel,
+        isDefault: true,
+      },
     };
   }
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -420,6 +420,22 @@ export function resolveModelDirectiveSelection(params: {
   const rawTrimmed = raw.trim();
   const rawLower = rawTrimmed.toLowerCase();
 
+  // Reserved reset keywords (single token, no slash) clear the session model override
+  // and fall back to the configured default without going through allowlist validation.
+  // "provider/default" (contains a slash) is still treated as a literal model id.
+  if (
+    (rawLower === "default" || rawLower === "reset" || rawLower === "clear") &&
+    !rawTrimmed.includes("/")
+  ) {
+    return {
+      selection: {
+        provider: defaultProvider,
+        model: defaultModel,
+        isDefault: true,
+      },
+    };
+  }
+
   const pickAliasForKey = (provider: string, model: string): string | undefined =>
     aliasIndex.byKey.get(modelKey(provider, model))?.[0];
 


### PR DESCRIPTION
## Problem

When a user types `/model default`, `/model reset`, or `/model clear`, the keyword was treated as a literal model ID. The default provider was prepended (e.g. `anthropic/default`) and the allowlist check failed with:

```
Model "anthropic/default" is not allowed. Use /models to list providers...
```

## Root Cause

`resolveModelDirectiveSelection()` and `resolveModelSelectionFromDirective()` passed the raw argument directly to `resolveModelRefFromString()` without first checking for reserved keywords. The session layer (`model-overrides.ts`) already supports `isDefault: true` to delete overrides — but no caller ever sent that flag for keyword arguments.

## Fix

- Intercept single-token keywords (`default`, `reset`, `clear`) **before** model ID resolution in both functions
- Return `isDefault: true` which triggers the existing `delete entry.modelOverride` logic in `applyModelOverrideToSessionEntry`
- `provider/default` (contains a slash) is still treated as a literal model ID
- Keywords are case-insensitive (`DEFAULT`, `Reset`, `CLEAR` all work)
- Updated `/model` help text to advertise the reset keywords

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/reply/directive-handling.model.ts` | Keyword interception in `resolveModelSelectionFromDirective`; help text update |
| `src/auto-reply/reply/model-selection.ts` | Keyword interception in `resolveModelDirectiveSelection` |
| `src/auto-reply/reply/model-selection.test.ts` | 7 new unit tests |

## Tests

7 new unit tests added covering:
- `default`, `reset`, `clear` each return `isDefault: true`
- Case-insensitivity (`DEFAULT`, `Reset`, `CLEAR`)
- `provider/default` (with slash) treated as model ID, not keyword
- Reset keyword bypasses allowlist entirely
- Trailing whitespace trimmed correctly

All 17 tests pass (10 existing + 7 new).

Closes #20137

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `/model default`, `/model reset`, and `/model clear` commands to correctly clear the session model override instead of treating these keywords as literal model IDs (which would fail allowlist validation). The fix intercepts these reserved keywords at two entry points (`resolveModelSelectionFromDirective` and `resolveModelDirectiveSelection`) before model ID resolution, returning `isDefault: true` to trigger the existing override-clearing logic in `applyModelOverrideToSessionEntry`. Help text is updated to advertise the new keywords.

- Keywords are case-insensitive and `provider/default` (with slash) is correctly treated as a literal model ID
- Reset keywords bypass the allowlist since they revert to the configured default
- 7 new unit tests cover keyword matching, case-insensitivity, slash guard, allowlist bypass, and whitespace handling
- Minor style note: `buildModelPickerCatalog` is built unnecessarily for reset keywords in `maybeHandleModelDirectiveInfo` before returning `undefined`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — changes are well-scoped and thoroughly tested.
- The fix is straightforward and correctly placed at both code paths that resolve model directives. The existing `isDefault: true` mechanism was already battle-tested, and the new keyword interception simply routes to it. All edge cases (case insensitivity, slash-containing IDs, allowlist bypass, whitespace) are covered by tests. The only minor concern is unnecessary `buildModelPickerCatalog` work for reset keywords.
- Minor optimization opportunity in `src/auto-reply/reply/directive-handling.model.ts` (unnecessary catalog build for reset keywords)

<sub>Last reviewed commit: d54b492</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->