### PR TITLE
feat(memory): support path-based weights for QMD search (Fixes #20139)

### DIFF
--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -20,6 +20,7 @@ export type MemoryQmdConfig = {
   update?: MemoryQmdUpdateConfig;
   limits?: MemoryQmdLimitsConfig;
   scope?: SessionSendPolicyConfig;
+  weights?: Record<string, number>;
 };
 
 export type MemoryQmdMcporterConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -103,6 +103,7 @@ const MemoryQmdSchema = z
     update: MemoryQmdUpdateSchema.optional(),
     limits: MemoryQmdLimitsSchema.optional(),
     scope: SessionSendPolicySchema.optional(),
+    weights: z.record(z.string(), z.number().positive()).optional(),
   })
   .strict();
 

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -67,6 +67,7 @@ export type ResolvedQmdConfig = {
   limits: ResolvedQmdLimitsConfig;
   includeDefaultMemory: boolean;
   scope?: SessionSendPolicyConfig;
+  weights?: Record<string, number>;
 };
 
 const DEFAULT_BACKEND: MemoryBackend = "builtin";
@@ -344,6 +345,7 @@ export function resolveMemoryBackendConfig(params: {
     },
     limits: resolveLimits(qmdCfg?.limits),
     scope: qmdCfg?.scope ?? DEFAULT_QMD_SCOPE,
+    weights: qmdCfg?.weights,
   };
 
   return {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -623,7 +623,8 @@ export class QmdMemoryManager implements MemorySearchManager {
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
     // Fetch more results to allow for client-side re-ranking (weighting)
-    const fetchLimit = this.qmd.weights ? limit * 5 : limit;
+    const hasWeights = this.qmd.weights && Object.keys(this.qmd.weights).length > 0;
+    const fetchLimit = hasWeights ? limit * 5 : limit;
 
     const collectionNames = this.listManagedCollectionNames();
     if (collectionNames.length === 0) {
@@ -721,7 +722,6 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const results: MemorySearchResult[] = [];
     const weights = this.qmd.weights || {};
-    const hasWeights = Object.keys(weights).length > 0;
 
     for (const entry of parsed) {
       const doc = await this.resolveDocLocation(entry.docid, {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -692,7 +692,12 @@ export class QmdMemoryManager implements MemorySearchManager {
           );
           try {
             if (collectionNames.length > 1) {
-              return await this.runQueryAcrossCollections(trimmed, fetchLimit, collectionNames, "query");
+              return await this.runQueryAcrossCollections(
+                trimmed,
+                fetchLimit,
+                collectionNames,
+                "query",
+              );
             }
             const fallbackArgs = this.buildSearchArgs("query", trimmed, fetchLimit);
             fallbackArgs.push(...this.buildCollectionFilterArgs(collectionNames));
@@ -768,11 +773,25 @@ export class QmdMemoryManager implements MemorySearchManager {
 
   private matchesPath(target: string, pattern: string): boolean {
     // Simple glob matching
+    if (pattern === "**") {
+      return true;
+    }
+
     // Handle "dir/**"
     if (pattern.endsWith("/**")) {
       const prefix = pattern.slice(0, -3);
       return target.startsWith(prefix + "/") || target === prefix;
     }
+
+    // Handle "**/*.md" or "**/foo"
+    if (pattern.startsWith("**/")) {
+      const rest = pattern.slice(3);
+      if (rest.startsWith("*")) {
+        return target.endsWith(rest.slice(1));
+      }
+      return target.endsWith("/" + rest) || target === rest;
+    }
+
     // Handle "*.md"
     if (pattern.startsWith("*")) {
       return target.endsWith(pattern.slice(1));

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -622,6 +622,9 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
+    // Fetch more results to allow for client-side re-ranking (weighting)
+    const fetchLimit = this.qmd.weights ? limit * 5 : limit;
+
     const collectionNames = this.listManagedCollectionNames();
     if (collectionNames.length === 0) {
       log.warn("qmd query skipped: no managed collections configured");
@@ -645,7 +648,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             return await this.runMcporterAcrossCollections({
               tool,
               query: trimmed,
-              limit,
+              limit: fetchLimit,
               minScore,
               collectionNames,
             });
@@ -654,7 +657,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             mcporter: this.qmd.mcporter,
             tool,
             query: trimmed,
-            limit,
+            limit: fetchLimit,
             minScore,
             collection: collectionNames[0],
             timeoutMs: this.qmd.limits.timeoutMs,
@@ -663,12 +666,12 @@ export class QmdMemoryManager implements MemorySearchManager {
         if (collectionNames.length > 1) {
           return await this.runQueryAcrossCollections(
             trimmed,
-            limit,
+            fetchLimit,
             collectionNames,
             qmdSearchCommand,
           );
         }
-        const args = this.buildSearchArgs(qmdSearchCommand, trimmed, limit);
+        const args = this.buildSearchArgs(qmdSearchCommand, trimmed, fetchLimit);
         args.push(...this.buildCollectionFilterArgs(collectionNames));
         // Always scope to managed collections (default + custom). Even for `search`/`vsearch`,
         // pass collection filters; if a given QMD build rejects these flags, we fall back to `query`.
@@ -688,9 +691,9 @@ export class QmdMemoryManager implements MemorySearchManager {
           );
           try {
             if (collectionNames.length > 1) {
-              return await this.runQueryAcrossCollections(trimmed, limit, collectionNames, "query");
+              return await this.runQueryAcrossCollections(trimmed, fetchLimit, collectionNames, "query");
             }
-            const fallbackArgs = this.buildSearchArgs("query", trimmed, limit);
+            const fallbackArgs = this.buildSearchArgs("query", trimmed, fetchLimit);
             fallbackArgs.push(...this.buildCollectionFilterArgs(collectionNames));
             const fallback = await this.runQmd(fallbackArgs, {
               timeoutMs: this.qmd.limits.timeoutMs,
@@ -717,6 +720,9 @@ export class QmdMemoryManager implements MemorySearchManager {
       parsed = await runSearchAttempt(false);
     }
     const results: MemorySearchResult[] = [];
+    const weights = this.qmd.weights || {};
+    const hasWeights = Object.keys(weights).length > 0;
+
     for (const entry of parsed) {
       const doc = await this.resolveDocLocation(entry.docid, {
         preferredCollection: entry.collection,
@@ -727,7 +733,17 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       const snippet = entry.snippet?.slice(0, this.qmd.limits.maxSnippetChars) ?? "";
       const lines = this.extractSnippetLines(snippet);
-      const score = typeof entry.score === "number" ? entry.score : 0;
+      let score = typeof entry.score === "number" ? entry.score : 0;
+
+      // Apply weights
+      if (hasWeights) {
+        for (const [pattern, weight] of Object.entries(weights)) {
+          if (this.matchesPath(doc.rel, pattern)) {
+            score *= weight;
+          }
+        }
+      }
+
       const minScore = opts?.minScore ?? 0;
       if (score < minScore) {
         continue;
@@ -741,7 +757,28 @@ export class QmdMemoryManager implements MemorySearchManager {
         source: doc.source,
       });
     }
+
+    // Re-sort if weights were applied
+    if (hasWeights) {
+      results.sort((a, b) => b.score - a.score);
+    }
+
     return this.clampResultsByInjectedChars(this.diversifyResultsBySource(results, limit));
+  }
+
+  private matchesPath(target: string, pattern: string): boolean {
+    // Simple glob matching
+    // Handle "dir/**"
+    if (pattern.endsWith("/**")) {
+      const prefix = pattern.slice(0, -3);
+      return target.startsWith(prefix + "/") || target === prefix;
+    }
+    // Handle "*.md"
+    if (pattern.startsWith("*")) {
+      return target.endsWith(pattern.slice(1));
+    }
+    // Exact match
+    return target === pattern;
   }
 
   async sync(params?: {


### PR DESCRIPTION
### Description

This PR implements the requested feature from #20139 to allow configuring path-based weights for QMD memory search.

This enables users to deprioritize archived logs (e.g. `memory/archive/**`) while boosting core memory files (e.g. `MEMORY.md`), implementing a static time decay / relevance weighting system.

### Changes

- **Config**: Added `weights` field to `memory.qmd` config.
  - Type: `Record<string, number>`
  - Example: `{ "memory/archive/**": 0.5, "MEMORY.md": 2.0 }`
- **QMD Manager**:
  - Implemented client-side re-ranking logic.
  - Fetches 5x `limit` results from QMD to ensure sufficient candidates for re-ranking.
  - Multiplies score by weight if path matches pattern.
  - Re-sorts results by new score.
  - Implemented basic glob matching (`**` prefix/suffix) to avoid new dependencies.

### Example Configuration

```json
"memory": {
  "qmd": {
    "weights": {
      "MEMORY.md": 2.0,
      "memory/archive/**": 0.5
    }
  }
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds path-based weight configuration for QMD memory search, allowing users to boost or deprioritize results from specific file paths (e.g., boosting `MEMORY.md` with weight 2.0, deprioritizing `memory/archive/**` with 0.5). The implementation over-fetches 5x results from QMD, applies weight multipliers based on simple glob matching, and re-sorts before returning.

- Config plumbing in `types.memory.ts` and `backend-config.ts` is clean — adds `weights?: Record<string, number>` and passes it through without transformation.
- The `fetchLimit` check (`this.qmd.weights`) is inconsistent with the later `hasWeights` check (`Object.keys(weights).length > 0`), causing unnecessary 5x over-fetching when `weights: {}` is configured.
- The `matchesPath` glob implementation handles `dir/**`, `*.ext`, and exact matches, but silently fails on common patterns like `**/*.md` — worth documenting the supported syntax or handling this case.

<h3>Confidence Score: 3/5</h3>

- Functional but has a logic inconsistency in over-fetching and limited glob matching that could cause unexpected behavior.
- The core re-ranking logic works for the documented patterns, but the mismatch between fetchLimit truthiness check and hasWeights check is a real logic bug (wasted work with empty weights config). The matchesPath glob limitations aren't immediately breaking but could silently surprise users with common patterns like **/*.md.
- `src/memory/qmd-manager.ts` — the `fetchLimit` inconsistency and `matchesPath` glob handling need attention.

<sub>Last reviewed commit: 503486d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->