### PR TITLE
fix(commands): handle /model default|reset|clear to reset model override

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -86,6 +86,60 @@ describe("/model chat UX", () => {
     });
     expect(resolved.errorText).toBeUndefined();
   });
+
+  it.each(["default", "reset", "clear"])("resets to default with /model %s", (keyword) => {
+    const directives = parseInlineDirectives(`/model ${keyword}`);
+    const cfg = baseConfig();
+
+    const resolved = resolveModelSelectionFromDirective({
+      directives,
+      cfg,
+      agentDir: "/tmp/agent",
+      defaultProvider: "anthropic",
+      defaultModel: "claude-sonnet-4-5-20250514",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys: new Set([
+        "anthropic/claude-sonnet-4-5-20250514",
+        "anthropic/claude-opus-4-5",
+      ]),
+      allowedModelCatalog: [
+        { provider: "anthropic", id: "claude-sonnet-4-5-20250514" },
+        { provider: "anthropic", id: "claude-opus-4-5" },
+      ],
+      provider: "anthropic",
+    });
+
+    expect(resolved.modelSelection).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5-20250514",
+      isDefault: true,
+    });
+    expect(resolved.errorText).toBeUndefined();
+  });
+
+  it("resets to default with /model DEFAULT (case insensitive)", () => {
+    const directives = parseInlineDirectives("/model DEFAULT");
+    const cfg = baseConfig();
+
+    const resolved = resolveModelSelectionFromDirective({
+      directives,
+      cfg,
+      agentDir: "/tmp/agent",
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys: new Set(["openai/gpt-4o"]),
+      allowedModelCatalog: [{ provider: "openai", id: "gpt-4o" }],
+      provider: "openai",
+    });
+
+    expect(resolved.modelSelection).toEqual({
+      provider: "openai",
+      model: "gpt-4o",
+      isDefault: true,
+    });
+    expect(resolved.errorText).toBeUndefined();
+  });
 });
 
 describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -336,6 +336,19 @@ export function resolveModelSelectionFromDirective(params: {
   const raw = params.directives.rawModelDirective.trim();
   let modelSelection: ModelDirectiveSelection | undefined;
 
+  // Handle reset keywords: `/model default`, `/model reset`, `/model clear`
+  // should clear the session modelOverride and fall back to the configured default.
+  const rawLower = raw.toLowerCase();
+  if (rawLower === "default" || rawLower === "reset" || rawLower === "clear") {
+    return {
+      modelSelection: {
+        provider: params.defaultProvider,
+        model: params.defaultModel,
+        isDefault: true,
+      },
+    };
+  }
+
   if (/^[0-9]+$/.test(raw)) {
     return {
       errorText: [


### PR DESCRIPTION
## Summary

- **Problem:** `/model default`, `/model reset`, and `/model clear` fail with `Model "anthropic/default" is not allowed` instead of resetting to the configured default model.
- **Why it matters:** Users who switch models via `/model` have no way to return to their configured default without manually editing session JSON files. This affects all channels (Discord, Telegram, Webchat, etc.).
- **What changed:** Added an early return in `resolveModelSelectionFromDirective()` that recognizes reset keywords (`default`, `reset`, `clear`, case-insensitive) and returns a selection with `isDefault: true`, which causes `applyModelOverrideToSessionEntry()` to clear the session `modelOverride`.
- **What did NOT change (scope boundary):** No changes to model resolution, allowlist logic, session persistence, or any other directive handlers. The `session_status` tool's existing `"default"` handling is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20137

## User-visible / Behavior Changes

- `/model default` now resets to the configured default model instead of showing "Model not allowed"
- `/model reset` and `/model clear` behave identically
- All three keywords are case-insensitive (e.g., `/model DEFAULT` works)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.2 (arm64)
- Runtime/container: Node.js v25.6.1
- Model/provider: anthropic/claude-opus-4-6
- Integration/channel: Webchat + Discord
- Relevant config: `agents.defaults.model.primary: "anthropic/claude-sonnet-4-5-20250514"`

### Steps

1. Set `agents.defaults.model.primary` to `anthropic/claude-sonnet-4-5-20250514`
2. Use `/model anthropic/claude-opus-4-6` to switch models
3. Try `/model default` to return to Sonnet

### Expected

Model resets to `anthropic/claude-sonnet-4-5-20250514` with confirmation message.

### Actual (before fix)

Error: `Model "anthropic/default" is not allowed`

## Evidence

- [x] Failing test/log before + passing after

All 455 tests in `src/auto-reply/reply/` pass, including 4 new test cases:

```
✓ src/auto-reply/reply/directive-handling.model.test.ts (9 tests)
  ✓ resets to default with /model default
  ✓ resets to default with /model reset
  ✓ resets to default with /model clear
  ✓ resets to default with /model DEFAULT (case insensitive)
```

`pnpm check` (format + typecheck + lint) passes with zero warnings/errors.

## Human Verification (required)

- Verified scenarios: `/model default`, `/model reset`, `/model clear`, `/model DEFAULT` all produce `{ isDefault: true }` selection with correct provider/model
- Edge cases checked: Case insensitivity, different default providers (anthropic, openai), empty allowlist vs populated allowlist
- What I did **not** verify: End-to-end gateway integration (verified via unit tests only); Telegram model-picker button interaction with reset

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; the early-return guard is isolated
- Files/config to restore: `src/auto-reply/reply/directive-handling.model.ts`
- Known bad symptoms reviewers should watch for: If a model named literally "default", "reset", or "clear" existed in a provider catalog, it would no longer be selectable via `/model default` (extremely unlikely edge case)

## Risks and Mitigations

- Risk: A provider could theoretically have a model named "default"
  - Mitigation: No known provider uses these as model names; the keywords align with established conventions (`session_status` tool, `/queue reset`, etc.)

## AI Disclosure

- [x] This PR is AI-assisted (Claude, via OpenClaw J.A.R.V.I.S.)
- **Degree of testing:** Fully tested — 4 new unit tests + full `pnpm check` + 455 existing tests pass
- **Human understanding confirmed:** The author identified the bug through daily usage of OpenClaw, traced the root cause in `resolveModelSelectionFromDirective()` where reset keywords were passed to `resolveModelRefFromString()` instead of being intercepted, and reviewed the fix logic (early return with `isDefault: true`) against the downstream `applyModelOverrideToSessionEntry()` behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds early-return handling in `resolveModelSelectionFromDirective()` for the keywords `default`, `reset`, and `clear` (case-insensitive), returning a selection with `isDefault: true` that causes `applyModelOverrideToSessionEntry()` to delete session model/provider overrides. This mirrors the existing behavior in the `session_status` tool and fixes the bug where `/model default` was treated as a literal model name.

- **`directive-handling.model.ts`**: 13 lines added — detects reset keywords before the raw value reaches `resolveModelRefFromString()`, returning the configured default with `isDefault: true`.
- **`directive-handling.model.test.ts`**: 51 lines added — parametrized tests for all three keywords plus case-insensitivity, using a different provider (`openai`) in the case-insensitive test to confirm provider/model are correctly sourced from params.
- No issues found — the change is minimal, well-scoped, and consistent with the existing `session_status` tool's reset handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — minimal, well-scoped bug fix with correct logic and thorough test coverage.
- The change is a straightforward 13-line early return that correctly intercepts reset keywords before they reach model name resolution. The `isDefault: true` flag is already well-tested downstream in `applyModelOverrideToSessionEntry()`. The fix is consistent with the existing `session_status` tool's handling of the "default" keyword. All four new tests cover the expected behavior including case insensitivity and different providers.
- No files require special attention.

<sub>Last reviewed commit: 453a621</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->
