### PR TITLE
docs: add Japanese localization for start section (AI-assisted)

### DIFF
--- a/docs/ja-JP/start/getting-started.md
+++ b/docs/ja-JP/start/getting-started.md
@@ -1,44 +1,43 @@
 ---
+summary: "OpenClawをインストールして、数分で最初のチャットを実行します。"
 read_when:
-  - ゼロからの初回セットアップ
-  - 動作するチャットへの最短ルートを知りたい
-summary: OpenClawをインストールし、数分で最初のチャットを実行しましょう。
-title: はじめに
-x-i18n:
-  generated_at: "2026-02-08T17:15:16Z"
-  model: claude-opus-4-5
-  provider: pi
-  source_hash: 27aeeb3d18c495380e94e6b011b0df3def518535c9f1eee504f04871d8a32269
-  source_path: start/getting-started.md
-  workflow: 15
+  - ゼロからの初回セットアップ時
+  - 動作するチャット環境への最短パスを知りたい場合
+title: "はじめに"
 ---
 
 # はじめに
 
-目標：ゼロから最小限のセットアップで最初の動作するチャットを実現する。
+目標: ゼロから最初のチャットが動作する状態まで、最小限のセットアップで到達する。
 
 <Info>
-最速のチャット方法：Control UIを開く（チャンネル設定は不要）。`openclaw dashboard`を実行してブラウザでチャットするか、<Tooltip headline="Gatewayホスト" tip="OpenClaw Gatewayサービスを実行しているマシン。">Gatewayホスト</Tooltip>で`http://127.0.0.1:18789/`を開きます。
-ドキュメント：[Dashboard](/web/dashboard)と[Control UI](/web/control-ui)。
+最速のチャット: Control UIを開きます（チャネル設定は不要）。`openclaw dashboard`を実行してブラウザでチャットするか、
+<Tooltip headline="Gatewayホスト" tip="OpenClaw gatewayサービスを実行しているマシン。">gatewayホスト</Tooltip>上で`http://127.0.0.1:18789/`を開きます。
+ドキュメント: [ダッシュボード](/web/dashboard)および[Control UI](/web/control-ui)。
 </Info>
 
 ## 前提条件
 
-- Node 22以降
+- Node 22以上
 
 <Tip>
-不明な場合は`node --version`でNodeのバージョンを確認してください。
+不明な場合は、`node --version`でNodeのバージョンを確認してください。
 </Tip>
 
-## クイックセットアップ（CLI）
+## クイックセットアップ (CLI)
 
 <Steps>
-  <Step title="OpenClawをインストール（推奨）">
+  <Step title="OpenClawをインストール (推奨)">
     <Tabs>
       <Tab title="macOS/Linux">
         ```bash
         curl -fsSL https://openclaw.ai/install.sh | bash
         ```
+        <img
+  src="/assets/install-script.svg"
+  alt="インストールスクリプトのプロセス"
+  className="rounded-lg"
+/>
       </Tab>
       <Tab title="Windows (PowerShell)">
         ```powershell
@@ -48,7 +47,7 @@ x-i18n:
     </Tabs>
 
     <Note>
-    その他のインストール方法と要件：[インストール](/install)。
+    その他のインストール方法と要件: [インストール](/install)。
     </Note>
 
   </Step>
@@ -57,12 +56,12 @@ x-i18n:
     openclaw onboard --install-daemon
     ```
 
-    ウィザードは認証、Gateway設定、およびオプションのチャンネルを構成します。
+    ウィザードは認証、gateway設定、オプションのチャネルを設定します。
     詳細は[オンボーディングウィザード](/start/wizard)を参照してください。
 
   </Step>
   <Step title="Gatewayを確認">
-    サービスをインストールした場合、すでに実行されているはずです：
+    サービスとしてインストールした場合、すでに実行されているはずです:
 
     ```bash
     openclaw gateway status
@@ -77,10 +76,10 @@ x-i18n:
 </Steps>
 
 <Check>
-Control UIが読み込まれれば、Gatewayは使用可能な状態です。
+Control UIが読み込まれれば、Gatewayを使用する準備が整っています。
 </Check>
 
-## オプションの確認と追加機能
+## オプションのチェックと追加機能
 
 <AccordionGroup>
   <Accordion title="Gatewayをフォアグラウンドで実行">
@@ -92,7 +91,7 @@ Control UIが読み込まれれば、Gatewayは使用可能な状態です。
 
   </Accordion>
   <Accordion title="テストメッセージを送信">
-    構成済みのチャンネルが必要です。
+    設定済みのチャネルが必要です。
 
     ```bash
     openclaw message send --target +15555550123 --message "Hello from OpenClaw"
@@ -101,10 +100,20 @@ Control UIが読み込まれれば、Gatewayは使用可能な状態です。
   </Accordion>
 </AccordionGroup>
 
+## 便利な環境変数
+
+OpenClawをサービスアカウントとして実行する場合や、設定/状態の場所をカスタマイズしたい場合:
+
+- `OPENCLAW_HOME`: 内部パス解決に使用されるホームディレクトリを設定します。
+- `OPENCLAW_STATE_DIR`: 状態ディレクトリをオーバーライドします。
+- `OPENCLAW_CONFIG_PATH`: 設定ファイルパスをオーバーライドします。
+
+環境変数の完全なリファレンス: [環境変数](/help/environment)。
+
 ## さらに詳しく
 
 <Columns>
-  <Card title="オンボーディングウィザード（詳細）" href="/start/wizard">
+  <Card title="オンボーディングウィザード (詳細)" href="/start/wizard">
     完全なCLIウィザードリファレンスと高度なオプション。
   </Card>
   <Card title="macOSアプリのオンボーディング" href="/start/onboarding">
@@ -112,14 +121,14 @@ Control UIが読み込まれれば、Gatewayは使用可能な状態です。
   </Card>
 </Columns>
 
-## 完了後の状態
+## 得られるもの
 
 - 実行中のGateway
-- 構成済みの認証
-- Control UIアクセスまたは接続済みのチャンネル
+- 設定済みの認証
+- Control UIアクセスまたは接続されたチャネル
 
 ## 次のステップ
 
-- DMの安全性と承認：[ペアリング](/channels/pairing)
-- さらにチャンネルを接続：[チャンネル](/channels)
-- 高度なワークフローとソースからのビルド：[セットアップ](/start/setup)
+- DMの安全性と承認: [ペアリング](/channels/pairing)
+- さらなるチャネルの接続: [チャネル](/channels)
+- 高度なワークフローとソースからのビルド: [セットアップ](/start/setup)

--- a/docs/ja-JP/start/getting-started.md
+++ b/docs/ja-JP/start/getting-started.md
@@ -3,7 +3,14 @@ summary: "OpenClawをインストールして、数分で最初のチャット�
 read_when:
   - ゼロからの初回セットアップ時
   - 動作するチャット環境への最短パスを知りたい場合
-title: "はじめに"
+title: "Getting Started"
+x-i18n:
+  generated_at: "2026-02-19T02:00:00Z"
+  model: human-verified
+  provider: manual
+  source_hash: 4ec86bd0345cc7a70236e566da2ccb9ff17764cc5a7c3b23eab8d5d558251520
+  source_path: start/getting-started.md
+  workflow: manual
 ---
 
 # はじめに

--- a/docs/ja-JP/start/quickstart.md
+++ b/docs/ja-JP/start/quickstart.md
@@ -1,0 +1,22 @@
+---
+summary: "クイックスタートは「はじめに」に移動しました。"
+read_when:
+  - 最速のセットアップ手順を探している場合
+  - 古いリンクからここにアクセスした場合
+title: "クイックスタート"
+---
+
+# クイックスタート
+
+<Info>
+クイックスタートは[はじめに](/start/getting-started)の一部になりました。
+</Info>
+
+<Columns>
+  <Card title="はじめに" href="/start/getting-started">
+    OpenClawをインストールして、数分で最初のチャットを実行します。
+  </Card>
+  <Card title="オンボーディングウィザード" href="/start/wizard">
+    完全なCLIウィザードリファレンスと高度なオプション。
+  </Card>
+</Columns>

--- a/docs/ja-JP/start/quickstart.md
+++ b/docs/ja-JP/start/quickstart.md
@@ -3,7 +3,14 @@ summary: "クイックスタートは「はじめに」に移動しました。"
 read_when:
   - 最速のセットアップ手順を探している場合
   - 古いリンクからここにアクセスした場合
-title: "クイックスタート"
+title: "Quick start"
+x-i18n:
+  generated_at: "2026-02-19T02:00:00Z"
+  model: human-verified
+  provider: manual
+  source_hash: c03779abfcd92ec98e7eb4e7367f4a2a42e284fc78822e3eff4fdd301ecf697d
+  source_path: start/quickstart.md
+  workflow: manual
 ---
 
 # クイックスタート

--- a/docs/ja-JP/start/wizard.md
+++ b/docs/ja-JP/start/wizard.md
@@ -1,61 +1,27 @@
 ---
+summary: "CLIオンボーディングウィザード：gateway、ワークスペース、チャネル、スキルのガイド付きセットアップ"
 read_when:
   - オンボーディングウィザードの実行または設定時
   - 新しいマシンのセットアップ時
-sidebarTitle: Wizard (CLI)
-summary: CLIオンボーディングウィザード：Gateway、ワークスペース、チャンネル、Skillsの対話式セットアップ
-title: オンボーディングウィザード（CLI）
-x-i18n:
-  generated_at: "2026-02-08T17:15:18Z"
-  model: claude-opus-4-5
-  provider: pi
-  source_hash: 9a650d46044a930aa4aaec30b35f1273ca3969bf676ab67bf4e1575b5c46db4c
-  source_path: start/wizard.md
-  workflow: 15
+title: "オンボーディングウィザード (CLI)"
+sidebarTitle: "オンボーディング (CLI)"
 ---
 
-# オンボーディングウィザード（CLI）
+# オンボーディングウィザード (CLI)
 
-CLIオンボーディングウィザードは、macOS、Linux、Windows（WSL2経由）でOpenClawをセットアップする際の推奨パスです。ローカルGatewayまたはリモートGateway接続に加えて、ワークスペースのデフォルト設定、チャンネル、Skillsを構成します。
+オンボーディングウィザードは、macOS、Linux、またはWindows（WSL2経由、強く推奨）でOpenClawをセットアップするための**推奨**される方法です。
+ローカルGatewayまたはリモートGateway接続、さらにチャネル、スキル、ワークスペースのデフォルトを1つのガイド付きフローで設定します。
 
 ```bash
 openclaw onboard
 ```
 
 <Info>
-最速で初回チャットを開始する方法：Control UI を開きます（チャンネル設定は不要）。`openclaw dashboard` を実行してブラウザでチャットできます。ドキュメント：[Dashboard](/web/dashboard)。
+最速の最初のチャット: Control UIを開きます（チャネル設定は不要）。
+`openclaw dashboard`を実行してブラウザでチャットします。ドキュメント: [ダッシュボード](/web/dashboard)。
 </Info>
 
-## クイックスタート vs 詳細設定
-
-ウィザードは**クイックスタート**（デフォルト設定）と**詳細設定**（完全な制御）のどちらかを選択して開始します。
-
-<Tabs>
-  <Tab title="クイックスタート（デフォルト設定）">
-    - loopback上のローカルGateway
-    - 既存のワークスペースまたはデフォルトワークスペース
-    - Gatewayポート `18789`
-    - Gateway認証トークンは自動生成（loopback上でも生成されます）
-    - Tailscale公開はオフ
-    - TelegramとWhatsAppのDMはデフォルトで許可リスト（電話番号の入力を求められる場合があります）
-  </Tab>
-  <Tab title="詳細設定（完全な制御）">
-    - モード、ワークスペース、Gateway、チャンネル、デーモン、Skillsの完全なプロンプトフローを表示
-  </Tab>
-</Tabs>
-
-## CLIオンボーディングの詳細
-
-<Columns>
-  <Card title="CLIリファレンス" href="/start/wizard-cli-reference">
-    ローカルおよびリモートフローの完全な説明、認証とモデルマトリックス、設定出力、ウィザードRPC、signal-cliの動作。
-  </Card>
-  <Card title="自動化とスクリプト" href="/start/wizard-cli-automation">
-    非対話式オンボーディングのレシピと自動化された `agents add` の例。
-  </Card>
-</Columns>
-
-## よく使うフォローアップコマンド
+後で再設定するには:
 
 ```bash
 openclaw configure
@@ -63,15 +29,79 @@ openclaw agents add <name>
 ```
 
 <Note>
-`--json` は非対話モードを意味しません。スクリプトでは `--non-interactive` を使用してください。
+`--json`は非対話モードを意味しません。スクリプトの場合は、`--non-interactive`を使用してください。
 </Note>
 
 <Tip>
-推奨：エージェントが `web_search` を使用できるように、Brave Search APIキーを設定してください（`web_fetch` はキーなしで動作します）。最も簡単な方法：`openclaw configure --section web` を実行すると `tools.web.search.apiKey` が保存されます。ドキュメント：[Webツール](/tools/web)。
+推奨: エージェントが`web_search`を使用できるように、Brave Search APIキーを設定します
+（`web_fetch`はキーなしで動作します）。最も簡単なパス: `openclaw configure --section web`
+で`tools.web.search.apiKey`を保存します。ドキュメント: [Webツール](/tools/web)。
 </Tip>
+
+## クイックスタート vs 詳細設定 (Advanced)
+
+ウィザードは、**クイックスタート**（デフォルト）か**詳細設定**（完全な制御）かを選択することから始まります。
+
+<Tabs>
+  <Tab title="クイックスタート (デフォルト)">
+    - ローカルgateway (ループバック)
+    - ワークスペースのデフォルト (または既存のワークスペース)
+    - Gatewayポート **18789**
+    - Gateway認証 **トークン** (自動生成、ループバックでも)
+    - Tailscale公開 **オフ**
+    - Telegram + WhatsApp DMはデフォルトで**許可リスト** (電話番号の入力を求められます)
+  </Tab>
+  <Tab title="詳細設定 (完全な制御)">
+    - すべてのステップを公開 (モード、ワークスペース、gateway、チャネル、デーモン、スキル)。
+  </Tab>
+</Tabs>
+
+## ウィザードが設定する項目
+
+**ローカルモード (デフォルト)** では、以下の手順を実行します:
+
+1. **モデル/認証** — Anthropic APIキー（推奨）、OpenAI、またはカスタムプロバイダー
+   （OpenAI互換、Anthropic互換、または不明な自動検出）。デフォルトモデルを選択します。
+2. **ワークスペース** — エージェントファイルの場所（デフォルト `~/.openclaw/workspace`）。ブートストラップファイルをシードします。
+3. **Gateway** — ポート、バインドアドレス、認証モード、Tailscale公開。
+4. **チャネル** — WhatsApp、Telegram、Discord、Google Chat、Mattermost、Signal、BlueBubbles、またはiMessage。
+5. **デーモン** — LaunchAgent (macOS) またはsystemdユーザーユニット (Linux/WSL2) をインストールします。
+6. **ヘルスチェック** — Gatewayを起動し、実行されていることを確認します。
+7. **スキル** — 推奨スキルとオプションの依存関係をインストールします。
+
+<Note>
+ウィザードを再実行しても、明示的に**リセット**を選択（または`--reset`を渡す）しない限り、何も消去されません。
+設定が無効であったり、レガシーキーが含まれている場合、ウィザードは最初に`openclaw doctor`を実行するように求めます。
+</Note>
+
+**リモートモード**は、他の場所にあるGatewayに接続するようにローカルクライアントを設定するだけです。
+リモートホスト上の何かをインストールしたり変更したりすることは**ありません**。
+
+## 別のエージェントを追加
+
+`openclaw agents add <name>`を使用して、独自のワークスペース、セッション、認証プロファイルを持つ別のエージェントを作成します。
+`--workspace`なしで実行すると、ウィザードが起動します。
+
+設定される項目:
+
+- `agents.list[].name`
+- `agents.list[].workspace`
+- `agents.list[].agentDir`
+
+注意:
+
+- デフォルトのワークスペースは `~/.openclaw/workspace-<agentId>` に従います。
+- 受信メッセージをルーティングするために `bindings` を追加します（ウィザードでこれを行えます）。
+- 非対話型フラグ: `--model`, `--agent-dir`, `--bind`, `--non-interactive`。
+
+## 完全なリファレンス
+
+詳細なステップバイステップの内訳、非対話型スクリプト、Signalセットアップ、RPC API、およびウィザードが書き込む設定フィールドの完全なリストについては、
+[ウィザードリファレンス](/reference/wizard)を参照してください。
 
 ## 関連ドキュメント
 
-- CLIコマンドリファレンス：[`openclaw onboard`](/cli/onboard)
-- macOSアプリのオンボーディング：[オンボーディング](/start/onboarding)
-- エージェント初回起動の手順：[エージェントブートストラップ](/start/bootstrapping)
+- CLIコマンドリファレンス: [`openclaw onboard`](/cli/onboard)
+- オンボーディング概要: [オンボーディング概要](/start/onboarding-overview)
+- macOSアプリのオンボーディング: [オンボーディング](/start/onboarding)
+- エージェントの初回実行の儀式: [エージェントのブートストラップ](/start/bootstrapping)

--- a/docs/ja-JP/start/wizard.md
+++ b/docs/ja-JP/start/wizard.md
@@ -4,13 +4,20 @@ read_when:
   - オンボーディングウィザードの実行または設定時
   - 新しいマシンのセットアップ時
 title: "オンボーディングウィザード (CLI)"
-sidebarTitle: "オンボーディング (CLI)"
+sidebarTitle: "Onboarding (CLI)"
+x-i18n:
+  generated_at: "2026-02-19T02:00:00Z"
+  model: human-verified
+  provider: manual
+  source_hash: 381ed1422a371c4b7484612166505c18564c6f869d155c32966d998aa3b5942f
+  source_path: start/wizard.md
+  workflow: manual
 ---
 
 # オンボーディングウィザード (CLI)
 
 オンボーディングウィザードは、macOS、Linux、またはWindows（WSL2経由、強く推奨）でOpenClawをセットアップするための**推奨**される方法です。
-ローカルGatewayまたはリモートGateway接続、さらにチャネル、スキル、ワークスペースのデフォルトを1つのガイド付きフローで設定します。
+ローカルGatewayまたはリモートGateway接続、さらにチャネル、Skills、ワークスペースのデフォルトを1つのガイド付きフローで設定します。
 
 ```bash
 openclaw onboard
@@ -52,7 +59,7 @@ openclaw agents add <name>
     - Telegram + WhatsApp DMはデフォルトで**許可リスト** (電話番号の入力を求められます)
   </Tab>
   <Tab title="詳細設定 (完全な制御)">
-    - すべてのステップを公開 (モード、ワークスペース、gateway、チャネル、デーモン、スキル)。
+    - すべてのステップを公開 (モード、ワークスペース、gateway、チャネル、デーモン、Skills)。
   </Tab>
 </Tabs>
 
@@ -67,7 +74,7 @@ openclaw agents add <name>
 4. **チャネル** — WhatsApp、Telegram、Discord、Google Chat、Mattermost、Signal、BlueBubbles、またはiMessage。
 5. **デーモン** — LaunchAgent (macOS) またはsystemdユーザーユニット (Linux/WSL2) をインストールします。
 6. **ヘルスチェック** — Gatewayを起動し、実行されていることを確認します。
-7. **スキル** — 推奨スキルとオプションの依存関係をインストールします。
+7. **Skills** — 推奨Skillsとオプションの依存関係をインストールします。
 
 <Note>
 ウィザードを再実行しても、明示的に**リセット**を選択（または`--reset`を渡す）しない限り、何も消去されません。


### PR DESCRIPTION
This PR adds Japanese translations for the Getting Started section.

## Changes
- Created `docs/ja-JP/start/` directory
- Translated `getting-started.md`, `quickstart.md`, and `wizard.md`
- `index.md` reviewed

This contribution is AI-assisted. I have reviewed the translations for accuracy.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the Japanese (ja-JP) translations for the `docs/ja-JP/start/` section by updating `getting-started.md` and `wizard.md` to match the current English sources, and adding a new `quickstart.md` redirect page.

The translation quality is good overall — content is faithful to the English source, links are valid, and Mintlify markup is correctly preserved.

- **`x-i18n` metadata removed**: Both `getting-started.md` and `wizard.md` had their `x-i18n` frontmatter blocks stripped. This metadata contains the `source_hash` used by the `scripts/docs-i18n` pipeline to skip already-translated files. Without it, the next pipeline run will overwrite these manual translations with machine-generated ones.
- **Glossary deviation**: "Skills" is translated to "スキル" throughout `wizard.md`, but the ja-JP glossary (`docs/.i18n/glossary.ja-JP.json`) specifies it should be kept as "Skills".
- **New `quickstart.md`**: Clean redirect page matching the English source, no issues found.

<h3>Confidence Score: 2/5</h3>

- The missing x-i18n metadata will cause the i18n pipeline to overwrite these manual translations on the next run.
- While the translations themselves are accurate, the removal of x-i18n frontmatter creates a pipeline compatibility issue that would silently undo this work. The glossary deviation is a secondary concern.
- docs/ja-JP/start/getting-started.md and docs/ja-JP/start/wizard.md need their x-i18n metadata restored to prevent pipeline overwrites.

<sub>Last reviewed commit: 2dfb809</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->