### PR TITLE
fix(sessions): allow negative IDs and colon separators in session IDs

### DIFF
--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -54,7 +54,9 @@ export function resolveSessionFilePathOptions(params: {
   return undefined;
 }
 
-export const SAFE_SESSION_ID_RE = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
+// Allow session IDs starting with `-` for negative Telegram group IDs,
+// and `:` as a separator for forum topic IDs (e.g., `-1003110470591:91088`).
+export const SAFE_SESSION_ID_RE = /^-?[a-z0-9][a-z0-9._:-]{0,127}$/i;
 
 export function validateSessionId(sessionId: string): string {
   const trimmed = sessionId.trim();

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -26,6 +26,13 @@ describe("session path safety", () => {
     expect(() => validateSessionId("/abs")).toThrow(/Invalid session ID/);
   });
 
+  it("accepts negative Telegram group IDs with topic separators", () => {
+    // Telegram supergroup/channel IDs are negative (e.g., -1003110470591)
+    expect(validateSessionId("-1003110470591")).toBe("-1003110470591");
+    // Forum topic session keys use colon as separator (e.g., -1003110470591:91088)
+    expect(validateSessionId("-1003110470591:91088")).toBe("-1003110470591:91088");
+  });
+
   it("resolves transcript path inside an explicit sessions dir", () => {
     const sessionsDir = "/tmp/openclaw/agents/main/sessions";
     const resolved = resolveSessionTranscriptPathInDir("sess-1", sessionsDir, "topic/a+b");


### PR DESCRIPTION
## Summary
Fixes #20158

Messages sent to Telegram forum topics in groups with negative chat IDs were being silently dropped because the session ID validation regex rejected them.

## Root Cause
`SAFE_SESSION_ID_RE` (`/^[a-z0-9][a-z0-9._-]{0,127}$/i`) required session IDs to start with alphanumeric characters and didn't allow colons. This rejected:
- Negative Telegram IDs: `-1003110470591` (starts with `-`)
- Topic separators: `-1003110470591:91088` (contains `:`)

## Changes
- Allow session IDs to start with `-` for negative Telegram group/channel IDs
- Allow `:` in session IDs for forum topic ID separators
- Added test coverage

---
🤖 Generated with Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes session ID validation to support Telegram forum topics in groups with negative chat IDs. The `SAFE_SESSION_ID_RE` regex is updated from `/^[a-z0-9][a-z0-9._-]{0,127}$/i` to `/^-?[a-z0-9][a-z0-9._:-]{0,127}$/i`, allowing an optional leading `-` and `:` as a separator character.

- **`src/config/sessions/paths.ts`**: Regex updated to accept negative Telegram group IDs (e.g., `-1003110470591`) and colon-separated forum topic IDs (e.g., `-1003110470591:91088`). The change is safe — neither `-` nor `:` enables path traversal, and `resolvePathWithinSessionsDir` provides an additional containment check.
- **`src/config/sessions/sessions.test.ts`**: Adds test coverage for the two new accepted formats.
- No issues found. The fix is minimal, well-scoped, and addresses a real bug where Telegram forum topic messages were silently dropped.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped regex fix with no security or path traversal risk.
- The change is a two-character addition to a regex character class plus an optional leading dash. Neither `-` nor `:` enables path traversal, and the downstream path resolution function provides additional containment. The fix addresses a real bug (Telegram forum topic messages being silently dropped) with appropriate test coverage. No issues found.
- No files require special attention.

<sub>Last reviewed commit: 4179f43</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->