### PR TITLE
fix(discord): lazy-load guilds in resolveDiscordUserAllowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/Status reactions: refresh stall timers on repeated phase updates and honor ack-reaction scope when lifecycle reactions are enabled, preventing false stall emojis and unwanted group reactions. Thanks @wolly-tundracube and @thewilloftheshadow.
 - Discord/Streaming: apply `replyToMode: first` only to the first Discord chunk so block-streamed replies do not spam mention pings. (#20726) Thanks @thewilloftheshadow for the report.
 - Discord/Components: map DM channel targets back to user-scoped component sessions so button/select interactions stay in the main DM session. Thanks @thewilloftheshadow.
+- Discord/Allowlist: lazy-load guild lists when resolving Discord user allowlists so ID-only entries resolve even if guild fetch fails. (#20208) Thanks @zhangjunmengyang.
 
 - Discord/Gateway: handle close code 4014 (missing privileged gateway intents) without crashing the gateway. Thanks @thewilloftheshadow.
 - Discord: ingest inbound stickers as media so sticker-only messages and forwarded stickers are visible to agents. Thanks @thewilloftheshadow.

--- a/src/discord/resolve-users.test.ts
+++ b/src/discord/resolve-users.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
+import { resolveDiscordUserAllowlist } from "./resolve-users.js";
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+const urlToString = (url: Request | URL | string): string => {
+  if (typeof url === "string") {
+    return url;
+  }
+  return "url" in url ? url.url : String(url);
+};
+
+describe("resolveDiscordUserAllowlist", () => {
+  it("resolves plain user ids without calling listGuilds", async () => {
+    let guildsCalled = false;
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        guildsCalled = true;
+        return jsonResponse([]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const results = await resolveDiscordUserAllowlist({
+      token: "test",
+      entries: ["123456789012345678"],
+      fetcher,
+    });
+
+    expect(results).toEqual([
+      {
+        input: "123456789012345678",
+        resolved: true,
+        id: "123456789012345678",
+      },
+    ]);
+    expect(guildsCalled).toBe(false);
+  });
+
+  it("resolves mention-format ids without calling listGuilds", async () => {
+    let guildsCalled = false;
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        guildsCalled = true;
+        return jsonResponse([]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const results = await resolveDiscordUserAllowlist({
+      token: "test",
+      entries: ["<@!123456789012345678>"],
+      fetcher,
+    });
+
+    expect(results).toEqual([
+      {
+        input: "<@!123456789012345678>",
+        resolved: true,
+        id: "123456789012345678",
+      },
+    ]);
+    expect(guildsCalled).toBe(false);
+  });
+
+  it("resolves prefixed ids (user:, discord:) without calling listGuilds", async () => {
+    let guildsCalled = false;
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        guildsCalled = true;
+        return jsonResponse([]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const results = await resolveDiscordUserAllowlist({
+      token: "test",
+      entries: ["user:111", "discord:222"],
+      fetcher,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ resolved: true, id: "111" });
+    expect(results[1]).toMatchObject({ resolved: true, id: "222" });
+    expect(guildsCalled).toBe(false);
+  });
+
+  it("resolves user ids even when listGuilds would fail", async () => {
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        throw new Error("Forbidden: Missing Access");
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    // Before the fix, this would throw because listGuilds() was called eagerly
+    const results = await resolveDiscordUserAllowlist({
+      token: "test",
+      entries: ["994979735488692324"],
+      fetcher,
+    });
+
+    expect(results).toEqual([
+      {
+        input: "994979735488692324",
+        resolved: true,
+        id: "994979735488692324",
+      },
+    ]);
+  });
+
+  it("calls listGuilds lazily when resolving usernames", async () => {
+    let guildsCalled = false;
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        guildsCalled = true;
+        return jsonResponse([{ id: "g1", name: "Test Guild" }]);
+      }
+      if (url.includes("/guilds/g1/members/search")) {
+        return jsonResponse([
+          {
+            user: { id: "u1", username: "alice", bot: false },
+            nick: null,
+          },
+        ]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const results = await resolveDiscordUserAllowlist({
+      token: "test",
+      entries: ["alice"],
+      fetcher,
+    });
+
+    expect(guildsCalled).toBe(true);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      input: "alice",
+      resolved: true,
+      id: "u1",
+      name: "alice",
+    });
+  });
+
+  it("fetches guilds only once for multiple username entries", async () => {
+    let guildsCallCount = 0;
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        guildsCallCount++;
+        return jsonResponse([{ id: "g1", name: "Test Guild" }]);
+      }
+      if (url.includes("/guilds/g1/members/search")) {
+        const params = new URL(url).searchParams;
+        const query = params.get("query") ?? "";
+        return jsonResponse([
+          {
+            user: { id: `u-${query}`, username: query, bot: false },
+            nick: null,
+          },
+        ]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const results = await resolveDiscordUserAllowlist({
+      token: "test",
+      entries: ["alice", "bob"],
+      fetcher,
+    });
+
+    expect(guildsCallCount).toBe(1);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ resolved: true, id: "u-alice" });
+    expect(results[1]).toMatchObject({ resolved: true, id: "u-bob" });
+  });
+
+  it("handles mixed ids and usernames — ids resolve even if guilds fail", async () => {
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        throw new Error("Forbidden: Missing Access");
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    // IDs should succeed, username should fail (listGuilds throws)
+    await expect(
+      resolveDiscordUserAllowlist({
+        token: "test",
+        entries: ["123456789012345678", "alice"],
+        fetcher,
+      }),
+    ).rejects.toThrow("Forbidden");
+
+    // But if we only pass IDs, it should work fine
+    const results = await resolveDiscordUserAllowlist({
+      token: "test",
+      entries: ["123456789012345678", "<@999>"],
+      fetcher,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ resolved: true, id: "123456789012345678" });
+    expect(results[1]).toMatchObject({ resolved: true, id: "999" });
+  });
+
+  it("returns unresolved for empty/blank entries", async () => {
+    const fetcher = withFetchPreconnect(async () => {
+      return new Response("not found", { status: 404 });
+    });
+
+    const results = await resolveDiscordUserAllowlist({
+      token: "test",
+      entries: ["", "  "],
+      fetcher,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ resolved: false });
+    expect(results[1]).toMatchObject({ resolved: false });
+  });
+
+  it("returns all unresolved when token is empty", async () => {
+    const results = await resolveDiscordUserAllowlist({
+      token: "",
+      entries: ["123456789012345678", "alice"],
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => !r.resolved)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** `resolveDiscordUserAllowlist()` calls `listGuilds()` eagerly before processing any entries. If the Discord API call fails (permissions, network issues, bot not in any guild), the entire function throws — even when all entries are plain user IDs that don't need guild resolution at all. This causes the onboarding flow to show "Failed to resolve usernames" for inputs like `994979735488692324`.
- **Why it matters:** New users setting up Discord `allowFrom` during onboarding hit a dead end when entering numeric user IDs. The bot may not have guild access yet (common during initial setup), but user IDs should resolve without any API calls.
- **What changed:** Deferred `listGuilds()` into a lazy getter (`getGuilds()`) that is only invoked when an entry actually requires username-based search. The guild list is cached after the first successful fetch so subsequent username entries don't trigger duplicate API calls.
- **What did NOT change (scope boundary):** No changes to `parseDiscordUserInput()`, `scoreDiscordMember()`, the guild search logic, or any other file. The lazy getter is a drop-in replacement with identical behavior when guilds are actually needed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18955

## User-visible / Behavior Changes

- `allowFrom` entries using numeric user IDs (`123456789012345678`), mention format (`<@123>`), or prefixed format (`user:123`, `discord:123`) now resolve successfully even when `listGuilds()` would fail
- Username-based entries (`alice`, `@alice`, `guild/alice`) still trigger guild lookup as before
- The guild list is fetched at most once per call (cached via lazy getter)
- No change in behavior when `listGuilds()` succeeds — the fix only affects the failure path

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (deferred, not added)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.2 (arm64)
- Runtime/container: Node.js v25.6.1
- Model/provider: N/A (onboarding wizard, no model involved)
- Integration/channel: Discord onboarding wizard
- Relevant config: `channels.discord.dmPolicy: "allowlist"`

### Steps

1. Start `openclaw setup` with a Discord bot token that has limited guild access (or no guilds yet)
2. Choose "Allowlist" for DM policy
3. Enter a numeric user ID like `994979735488692324`

### Expected

User ID resolves immediately without any guild API call.

### Actual (before fix)

"Failed to resolve usernames. Try again." because `listGuilds()` throws before the ID can be parsed.

## Evidence

- [x] Failing test added that reproduces the bug (passes after fix)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test output:
```
 ✓ src/discord/resolve-users.test.ts (9 tests) 32ms
   ✓ resolves plain user ids without calling listGuilds
   ✓ resolves mention-format ids without calling listGuilds
   ✓ resolves prefixed ids (user:, discord:) without calling listGuilds
   ✓ resolves user ids even when listGuilds would fail  ← core regression test
   ✓ calls listGuilds lazily when resolving usernames
   ✓ fetches guilds only once for multiple username entries
   ✓ handles mixed ids and usernames — ids resolve even if guilds fail
   ✓ returns unresolved for empty/blank entries
   ✓ returns all unresolved when token is empty
```

Full Discord test suite (no regressions):
```
 Test Files  26 passed (26)
      Tests  282 passed (282)
```

## Human Verification (required)

- **Verified scenarios:** All 9 unit tests covering the exact bug scenario (ID-only entries with failing `listGuilds()`), plus username resolution, caching, edge cases
- **Edge cases checked:** Empty entries, blank token, mention format `<@!id>`, prefixed `user:/discord:`, mixed ID+username batches where guilds fail
- **What I did not verify:** Live onboarding wizard end-to-end (no test Discord bot available), but the function-level behavior is fully covered

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert single commit; the change is isolated to one function in one file
- Files/config to restore: `src/discord/resolve-users.ts`
- Known bad symptoms reviewers should watch for: Username resolution failing (would mean the lazy getter has a bug — but tests cover this path)

## Risks and Mitigations

- **Risk:** Lazy getter introduces a closure-scoped mutable variable (`guilds`)
  - **Mitigation:** The variable is local to a single `resolveDiscordUserAllowlist()` call (not shared across calls), and the caching logic is trivial (null check). 9 tests verify correct behavior including the caching invariant.

## AI Disclosure

- [x] This PR is AI-assisted (Claude, via OpenClaw J.A.R.V.I.S.)
- **Degree of testing:** Fully tested — 9 new unit tests + full Discord test suite (282 tests, 0 regressions) + `pnpm check` (lint, format, typecheck) passes
- **Human understanding confirmed:** The author identified the bug from issue #18955's reproduction steps, traced it to the eager `listGuilds()` call in `resolveDiscordUserAllowlist()`, and designed the lazy-getter fix to maintain identical behavior for the success path while making the failure path resilient for ID-only entries
