### PR TITLE
fix(node): respect tools.exec.notifyOnExit for node exec events

### DIFF
--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -471,6 +471,15 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!sessionKey) {
         return;
       }
+
+      // Respect tools.exec.notifyOnExit setting (default: true)
+      // When false, skip system event notifications for node exec events.
+      const cfg = loadConfig();
+      const notifyOnExit = cfg.tools?.exec?.notifyOnExit !== false;
+      if (!notifyOnExit) {
+        return;
+      }
+
       const runId = typeof obj.runId === "string" ? obj.runId.trim() : "";
       const command = typeof obj.command === "string" ? obj.command.trim() : "";
       const exitCode =


### PR DESCRIPTION
## Summary
Fixes #20193

Node exec events (`exec.started`, `exec.finished`, `exec.denied`) were generating system event notifications regardless of the `tools.exec.notifyOnExit` setting. This caused duplicate messages: the inline tool result AND the system event notification.

## Changes
- Check `tools.exec.notifyOnExit` config before generating node exec event notifications
- When `notifyOnExit: false`, skip all node exec event notifications

This makes node exec behavior consistent with gateway exec, which already respects this setting.

---
🤖 Generated with Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes #20193 by checking the `tools.exec.notifyOnExit` config setting before generating system event notifications for node exec events (`exec.started`, `exec.finished`, `exec.denied`). Previously, node exec events always emitted system notifications regardless of this setting, causing duplicate messages when the inline tool result was already sufficient.

- The implementation correctly defaults to `true` (via `!== false`), matching the documented default and the existing gateway exec behavior in `bash-tools.exec-runtime.ts`
- `loadConfig()` is cached with a 200ms TTL, so the added call has negligible performance impact
- The change is minimal and well-scoped — a single guard clause in the right location
- No test coverage was added for the `notifyOnExit: false` code path

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a simple, well-placed config guard that matches existing patterns in the codebase.
- The change is minimal (one guard clause), uses the same config-reading pattern found elsewhere in the codebase, and defaults to existing behavior when the setting is unset. The only gap is missing test coverage for the new code path, which is a minor concern for a straightforward boolean check.
- No files require special attention — the change in server-node-events.ts is straightforward and consistent with existing patterns.

<sub>Last reviewed commit: e339071</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->