### PR TITLE
fix(discord): recognize numeric channel IDs in guildId/channelId input

### DIFF
--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -122,4 +122,64 @@ describe("resolveDiscordChannelAllowlist", () => {
     expect(res2[0]?.guildId).toBe("999");
     expect(res2[0]?.channelId).toBeUndefined();
   });
+
+  it("resolves guildId/channelId with numeric channel ID (fixes #12185)", async () => {
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111111111111111111", name: "My Server" }]);
+      }
+      if (url.endsWith("/channels/222222222222222222")) {
+        return jsonResponse({
+          id: "222222222222222222",
+          name: "general",
+          guild_id: "111111111111111111",
+          type: 0,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    // Before the fix, "111111111111111111/222222222222222222" would treat the
+    // channel part as a slug name, try to match it via normalizeDiscordSlug(),
+    // and fail with "channel not found in guild". This is the exact format
+    // produced by the onboarding wizard and used in config files.
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111111111111111111/222222222222222222"],
+      fetcher,
+    });
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.guildId).toBe("111111111111111111");
+    expect(res[0]?.channelId).toBe("222222222222222222");
+    expect(res[0]?.channelName).toBe("general");
+  });
+
+  it("guildId/channel-name still resolves by slug matching", async () => {
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111111111111111111", name: "My Guild" }]);
+      }
+      if (url.endsWith("/guilds/111111111111111111/channels")) {
+        return jsonResponse([
+          { id: "c1", name: "general", guild_id: "111111111111111111", type: 0 },
+        ]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    // Numeric guildId + non-numeric channel name should still go through slug matching
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111111111111111111/general"],
+      fetcher,
+    });
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.guildId).toBe("111111111111111111");
+    expect(res[0]?.channelId).toBe("c1");
+    expect(res[0]?.channelName).toBe("general");
+  });
 });

--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -61,6 +61,9 @@ function parseDiscordChannelInput(raw: string): {
       return guild ? { guild: guild.trim(), guildOnly: true } : {};
     }
     if (guild && /^\d+$/.test(guild)) {
+      if (/^\d+$/.test(channel)) {
+        return { guildId: guild, channelId: channel };
+      }
       return { guildId: guild, channel };
     }
     return { guild, channel };


### PR DESCRIPTION
## Summary

- **Problem:** `parseDiscordChannelInput()` treats numeric channel IDs as slug names when paired with a numeric guild ID in `guildId/channelId` format (e.g. `111111111111111111/222222222222222222`). The channel part is matched via `normalizeDiscordSlug()`, which never matches a numeric string, causing all such channels to be reported as "unresolved" at startup.
- **Why it matters:** This is a **regression that silently drops all inbound Discord messages** for users whose config was generated by the onboarding wizard (which stores channels with numeric ID keys). The only clue is a subtle startup log: `[discord] channels unresolved: <guildId>/<channelId>`. This took the original reporter 8+ hours to diagnose.
- **What changed:** Added a 3-line early return in `parseDiscordChannelInput()` that checks if the channel part is also numeric and returns it as `channelId` (routed to the direct `/channels/<id>` API path) instead of a slug name.
- **What did NOT change (scope boundary):** No changes to `resolveDiscordChannelAllowlist()`, guild resolution, slug matching logic, or any other file. Non-numeric channel names (`guildId/general`) continue through the existing slug matching path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #12185

## User-visible / Behavior Changes

- `guildId/channelId` format (both numeric) now correctly resolves the channel ID instead of treating it as a slug name
- Configs generated by the onboarding wizard (which use numeric channel ID keys) now work correctly
- `[discord] channels unresolved` startup warnings disappear for correctly configured channels
- All inbound Discord messages are no longer silently dropped

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same `/channels/<id>` API path, just now correctly reached)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.2 (arm64)
- Runtime/container: Node.js v25.6.1
- Model/provider: N/A (channel resolution, no model involved)
- Integration/channel: Discord
- Relevant config:
```json
{
  "channels": {
    "discord": {
      "guilds": {
        "111111111111111111": {
          "channels": {
            "222222222222222222": { "allow": true }
          }
        }
      }
    }
  }
}
```

### Steps

1. Configure Discord with numeric guild ID and numeric channel ID keys (default format from onboarding wizard)
2. Start the gateway
3. Send a message in a configured Discord channel

### Expected

Message is received and processed by the bot.

### Actual (before fix)

Startup log shows `[discord] channels unresolved: 111.../222...`. All inbound messages are silently dropped. No error in logs. `openclaw channels status` and `openclaw doctor` report no issues.

## Evidence

- [x] Failing test added that reproduces the bug (passes after fix)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test output:
```
 ✓ src/discord/resolve-channels.test.ts (6 tests) 30ms
   ✓ resolves guild/channel by name
   ✓ resolves channel id to guild
   ✓ resolves guild: prefixed id as guild (not channel)
   ✓ bare numeric guild id is misrouted as channel id (regression)
   ✓ resolves guildId/channelId with numeric channel ID (fixes #12185)  ← new
   ✓ guildId/channel-name still resolves by slug matching  ← new
```

Full Discord test suite (no regressions):
```
 Test Files  26 passed (26)
      Tests  284 passed (284)
```

Lint and format:
```
 pnpm lint: 0 warnings, 0 errors ✅
 pnpm format:check: All matched files use the correct format ✅
```

## Human Verification (required)

- **Verified scenarios:** Numeric `guildId/channelId` now returns `{ guildId, channelId }` and routes to the `/channels/<id>` API path; numeric `guildId/channel-name` still goes through slug matching
- **Edge cases checked:** Non-numeric channel names with numeric guild IDs, pure numeric channel IDs (bare), mention format (`<#id>`), guild-only entries
- **What I did not verify:** Live Discord gateway end-to-end (verified via unit tests covering the exact parsing and resolution paths)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- Note: This **restores** the expected behavior for configs generated by the onboarding wizard

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert single commit; workaround is replacing numeric channel keys with slug names in config
- Files/config to restore: `src/discord/resolve-channels.ts`
- Known bad symptoms reviewers should watch for: Channel resolution failing for slug-name entries (would mean the numeric check is too greedy — but tests cover this path)

## Risks and Mitigations

- **Risk:** A channel name that is purely numeric (e.g., a channel literally named "123456") would now be treated as a channel ID instead of a slug
  - **Mitigation:** Discord channel names cannot be purely numeric (Discord enforces this). Even if they could, the downstream `fetchChannel()` would resolve the correct channel by ID, which is more reliable than slug matching.

## AI Disclosure

- [x] This PR is AI-assisted (Claude, via OpenClaw J.A.R.V.I.S.)
- **Degree of testing:** Fully tested — 2 new unit tests + full Discord test suite (284 tests, 0 regressions) + `pnpm lint` + `pnpm format:check` pass
- **Human understanding confirmed:** The author identified the bug from their own daily gateway logs (`[discord] channels unresolved`), traced it to the `parseDiscordChannelInput()` function where numeric channel parts in `guildId/channelId` format were routed to slug matching instead of direct ID resolution, and verified the fix preserves the slug matching path for non-numeric channel names

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a regression where `parseDiscordChannelInput()` treated numeric channel IDs in `guildId/channelId` format as slug names, causing them to fail slug matching and be reported as "unresolved" — silently dropping all inbound Discord messages for configs generated by the onboarding wizard.

- Adds a 3-line early return in `parseDiscordChannelInput()` that detects when both guild and channel parts are numeric, returning `{ guildId, channelId }` instead of `{ guildId, channel }` (which would route to slug matching)
- Two new tests cover the numeric `guildId/channelId` case and verify that mixed `guildId/channel-name` still routes through slug matching
- The fix is minimal and correctly scoped — it only changes parsing behavior for fully-numeric `guild/channel` pairs, and downstream resolution via `fetchChannel()` (the `/channels/<id>` API path) is already well-tested

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-tested 3-line fix for a clear regression in input parsing.
- The change is small (3 lines of logic), correctly scoped to the exact parsing branch that caused the regression, backed by 2 new targeted tests, and the full Discord test suite (284 tests) passes with no regressions. The fix restores expected behavior without altering any other code paths.
- No files require special attention.

<sub>Last reviewed commit: 73ca2b1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->