### PR TITLE
fix: register poll action gate for Telegram adapter (#17528)

### DIFF
--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -12,6 +12,7 @@ import {
   listEnabledTelegramAccounts,
 } from "../../../telegram/accounts.js";
 import { isTelegramInlineButtonsEnabled } from "../../../telegram/inline-buttons.js";
+import { sendPollTelegram } from "../../../telegram/send.js";
 import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 
 const providerId = "telegram";
@@ -68,6 +69,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (gate("sticker", false)) {
       actions.add("sticker");
       actions.add("sticker-search");
+    }
+    if (gate("polls")) {
+      actions.add("poll");
     }
     if (gate("createForumTopic")) {
       actions.add("topic-create");
@@ -221,6 +225,31 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
         },
         cfg,
       );
+    }
+
+    if (action === "poll") {
+      const to = readStringParam(params, "to", { required: true });
+      const question = readStringParam(params, "pollQuestion", { required: true });
+      const options = readStringArrayParam(params, "pollOption", { required: true }) ?? [];
+      const allowMultiselect = typeof params.pollMulti === "boolean" ? params.pollMulti : undefined;
+      const durationSeconds = readNumberParam(params, "pollDurationSeconds", {
+        integer: true,
+      });
+      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
+      const result = await sendPollTelegram(
+        to,
+        {
+          question,
+          options,
+          maxSelections: allowMultiselect ? Math.max(2, options.length) : 1,
+          durationSeconds: durationSeconds ?? undefined,
+        },
+        {
+          accountId: accountId ?? undefined,
+          messageThreadId: messageThreadId ?? undefined,
+        },
+      );
+      return { ok: true, ...result };
     }
 
     throw new Error(`Action ${action} is not supported for provider ${providerId}.`);

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -3,6 +3,7 @@ import {
   readStringArrayParam,
   readStringOrNumberParam,
   readStringParam,
+  jsonResult,
 } from "../../../agents/tools/common.js";
 import { handleTelegramAction } from "../../../agents/tools/telegram-actions.js";
 import type { TelegramActionConfig } from "../../../config/types.telegram.js";
@@ -249,7 +250,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           messageThreadId: messageThreadId ?? undefined,
         },
       );
-      return { ok: true, ...result };
+      return jsonResult({ ok: true, ...result });
     }
 
     throw new Error(`Action ${action} is not supported for provider ${providerId}.`);

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -20,6 +20,8 @@ export type TelegramActionConfig = {
   sticker?: boolean;
   /** Enable forum topic creation. */
   createForumTopic?: boolean;
+  /** Enable poll actions. */
+  polls?: boolean;
 };
 
 export type TelegramNetworkConfig = {


### PR DESCRIPTION
Registers the `poll` action in the Telegram adapter's `listActions` gate and adds the corresponding handler in `handleAction`.

Closes #17528

Rebased on latest main (previous PR #17649 had CI failures due to drift).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `poll` action to the Telegram adapter by registering it in `listActions` (gated behind `"polls"`) and adding a `handleAction` handler that reads poll parameters and delegates to `sendPollTelegram`. The handler logic follows the same pattern as the Discord poll adapter and correctly maps parameters to `PollInput`.

- The `handleAction` implementation for `"poll"` is well-structured and consistent with other adapters (Discord, WhatsApp).
- **Missing type/schema updates**: `gate("polls")` will fail TypeScript type-checking because `"polls"` is not a key of `TelegramActionConfig` (`src/config/types.telegram.ts`). The Telegram Zod schema (`src/config/zod-schema.providers-core.ts`) also lacks a `polls` field and uses `.strict()`, so users cannot configure `actions.polls` in their Telegram config. Both `DiscordActionConfig` and `WhatsAppActionConfig` already include `polls?: boolean` — the same needs to be added for Telegram.

<h3>Confidence Score: 2/5</h3>

- This PR will cause a TypeScript compilation error due to a missing type definition and cannot be merged as-is.
- The handler logic is correct and follows established patterns, but the PR is incomplete: `TelegramActionConfig` and the Telegram Zod schema both need a `polls` field for this to compile and for users to be able to configure the gate. Without these changes, `gate("polls")` is a type error and the poll action can never be toggled via config.
- `src/config/types.telegram.ts` needs `polls?: boolean` added to `TelegramActionConfig`. `src/config/zod-schema.providers-core.ts` needs `polls: z.boolean().optional()` added to the Telegram actions schema.

<sub>Last reviewed commit: cd800b4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->