### PR TITLE
fix: include provider and model name in billing error message

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -4,10 +4,13 @@ import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
 import { stableStringify } from "../stable-stringify.js";
 import type { FailoverReason } from "./types.js";
 
-export function formatBillingErrorMessage(provider?: string): string {
+export function formatBillingErrorMessage(provider?: string, model?: string): string {
   const providerName = provider?.trim();
-  if (providerName) {
-    return `⚠️ ${providerName} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your ${providerName} billing dashboard and top up or switch to a different API key.`;
+  const modelName = model?.trim();
+  const providerLabel =
+    providerName && modelName ? `${providerName} (${modelName})` : providerName || undefined;
+  if (providerLabel) {
+    return `⚠️ ${providerLabel} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your ${providerName} billing dashboard and top up or switch to a different API key.`;
   }
   return "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
 }
@@ -420,7 +423,7 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
 
 export function formatAssistantErrorText(
   msg: AssistantMessage,
-  opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string },
+  opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string; model?: string },
 ): string | undefined {
   // Also format errors if errorMessage is present, even if stopReason isn't "error"
   const raw = (msg.errorMessage ?? "").trim();
@@ -487,7 +490,7 @@ export function formatAssistantErrorText(
   }
 
   if (isBillingErrorMessage(raw)) {
-    return formatBillingErrorMessage(opts?.provider);
+    return formatBillingErrorMessage(opts?.provider, opts?.model);
   }
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -554,6 +554,7 @@ export async function runEmbeddedPiAgent(
                 cfg: params.config,
                 sessionKey: params.sessionKey ?? params.sessionId,
                 provider,
+                model: modelId,
               })
             : undefined;
           const assistantErrorText =
@@ -920,6 +921,7 @@ export async function runEmbeddedPiAgent(
                       cfg: params.config,
                       sessionKey: params.sessionKey ?? params.sessionId,
                       provider,
+                      model: modelId,
                     })
                   : undefined) ||
                 lastAssistant?.errorMessage?.trim() ||
@@ -928,7 +930,7 @@ export async function runEmbeddedPiAgent(
                   : rateLimitFailure
                     ? "LLM request rate limited."
                     : billingFailure
-                      ? formatBillingErrorMessage(provider)
+                      ? formatBillingErrorMessage(provider, modelId)
                       : authFailure
                         ? "LLM request unauthorized."
                         : "LLM request failed.");


### PR DESCRIPTION
Adds the model name alongside the provider in billing error messages so users can identify which specific model/key ran out of credits.

Changes:
- `formatBillingErrorMessage` now accepts optional `model` parameter
- `formatAssistantErrorText` opts type extended with `model`
- All 3 call sites in `run.ts` pass `modelId`

Rebased on latest main (previous PR #15897 had CI failures due to drift).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances billing error messages by including the model name (e.g., `claude-3-opus`) alongside the provider name, helping users identify which specific model/key ran out of credits.

- `formatBillingErrorMessage` now accepts an optional `model` parameter; when both provider and model are present, the label becomes `"Provider (model)"` (e.g., `"Anthropic (claude-3-opus)"`)
- `formatAssistantErrorText` opts type extended with `model` field, wired through at the single call site
- All 3 call sites in `run.ts` now pass `modelId` to the billing error formatter
- Backward-compatible: existing callers without `model` produce identical output to before

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds an optional parameter with backward-compatible behavior and no logic changes.
- The change is minimal and well-scoped: an optional parameter added to a formatting function, with all edge cases handled correctly. No existing behavior is altered when the new parameter is omitted. All 3 call sites in run.ts correctly pass modelId which is always defined. The existing test suite covers the provider-only case and remains valid.
- No files require special attention.

<sub>Last reviewed commit: bf7229b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->