### PR TITLE
fix: Grok web_search extracts output_text blocks at top level

### DIFF
--- a/src/agents/tools/web-search.e2e.test.ts
+++ b/src/agents/tools/web-search.e2e.test.ts
@@ -219,4 +219,26 @@ describe("web_search grok response parsing", () => {
     expect(result.text).toBeUndefined();
     expect(result.annotationCitations).toEqual([]);
   });
+
+  it("extracts output_text blocks directly in output array (no message wrapper)", () => {
+    const result = extractGrokContent({
+      output: [
+        { type: "web_search_call" },
+        {
+          type: "output_text",
+          text: "direct output text",
+          annotations: [
+            {
+              type: "url_citation",
+              url: "https://example.com/direct",
+              start_index: 0,
+              end_index: 5,
+            },
+          ],
+        },
+      ],
+    } as Parameters<typeof extractGrokContent>[0]);
+    expect(result.text).toBe("direct output text");
+    expect(result.annotationCitations).toEqual(["https://example.com/direct"]);
+  });
 });


### PR DESCRIPTION
Some xAI Responses API responses place `output_text` blocks directly in the `output` array without a `message` wrapper. This fix handles both formats.

Changes:
- Extended `GrokSearchResponse` type with top-level `text` and `annotations` fields
- `extractGrokContent` now checks for `output_text` blocks at both message-level and top-level
- Added test case for the unwrapped format

Rebased on latest main (previous PR #15340 had CI failures due to drift).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Handles a second xAI Responses API format where `output_text` blocks appear directly in the `output` array without a `message` wrapper. The `GrokSearchResponse` type is extended with top-level `text` and `annotations` fields, and `extractGrokContent` now checks for both the message-wrapped and unwrapped formats. A test case covers the new path. The change is well-scoped and correctly prioritizes the message-wrapped format when both exist.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds defensive handling for a known API response variant with no risk to existing behavior.
- The changes are minimal, well-scoped, and correctly handle both the existing message-wrapped format and the new unwrapped format. The existing tests continue to pass, and a new test covers the added code path. No security concerns, no breaking changes, and the logic is straightforward.
- No files require special attention.

<sub>Last reviewed commit: 396005c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->