### PR TITLE
fix(protocol): preserve AnyCodable booleans from JSON bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- OpenClawKit/Protocol: preserve JSON boolean literals (`true`/`false`) when bridging through `AnyCodable` so Apple client RPC params no longer re-encode booleans as `1`/`0`. Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.
 - Browser/Relay: reuse an already-running extension relay when the relay port is occupied by another OpenClaw process, while still failing on non-relay port collisions to avoid masking unrelated listeners. (#20035) Thanks @mbelinky.
 - Telegram/Cron/Heartbeat: honor explicit Telegram topic targets in cron and heartbeat delivery (`<chatId>:topic:<threadId>`) so scheduled sends land in the configured topic instead of the last active thread. (#19367) Thanks @Lukavyi.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift
@@ -6,13 +6,13 @@ import Foundation
 public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
     public let value: Any
 
-    public init(_ value: Any) { self.value = value }
+    public init(_ value: Any) { self.value = Self.normalize(value) }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
+        if let boolVal = try? container.decode(Bool.self) { self.value = boolVal; return }
         if let intVal = try? container.decode(Int.self) { self.value = intVal; return }
         if let doubleVal = try? container.decode(Double.self) { self.value = doubleVal; return }
-        if let boolVal = try? container.decode(Bool.self) { self.value = boolVal; return }
         if let stringVal = try? container.decode(String.self) { self.value = stringVal; return }
         if container.decodeNil() { self.value = NSNull(); return }
         if let dict = try? container.decode([String: AnyCodable].self) { self.value = dict; return }
@@ -23,10 +23,12 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self.value {
+        case let boolVal as Bool: try container.encode(boolVal)
         case let intVal as Int: try container.encode(intVal)
         case let doubleVal as Double: try container.encode(doubleVal)
-        case let boolVal as Bool: try container.encode(boolVal)
         case let stringVal as String: try container.encode(stringVal)
+        case let number as NSNumber where CFGetTypeID(number) == CFBooleanGetTypeID():
+            try container.encode(number.boolValue)
         case is NSNull: try container.encodeNil()
         case let dict as [String: AnyCodable]: try container.encode(dict)
         case let array as [AnyCodable]: try container.encode(array)
@@ -49,6 +51,13 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
                 debugDescription: "Unsupported type")
             throw EncodingError.invalidValue(self.value, context)
         }
+    }
+
+    private static func normalize(_ value: Any) -> Any {
+        if let number = value as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return number.boolValue
+        }
+        return value
     }
 
     public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/AnyCodableTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/AnyCodableTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+import OpenClawProtocol
+
+struct AnyCodableTests {
+    @Test
+    func encodesNSNumberBooleansAsJSONBooleans() throws {
+        let trueData = try JSONEncoder().encode(AnyCodable(NSNumber(value: true)))
+        let falseData = try JSONEncoder().encode(AnyCodable(NSNumber(value: false)))
+
+        #expect(String(data: trueData, encoding: .utf8) == "true")
+        #expect(String(data: falseData, encoding: .utf8) == "false")
+    }
+
+    @Test
+    func preservesBooleanLiteralsFromJSONSerializationBridge() throws {
+        let raw = try #require(
+            JSONSerialization.jsonObject(with: Data(#"{"enabled":true,"nested":{"active":false}}"#.utf8))
+                as? [String: Any]
+        )
+        let enabled = try #require(raw["enabled"])
+        let nested = try #require(raw["nested"])
+
+        struct RequestEnvelope: Codable {
+            let params: [String: AnyCodable]
+        }
+
+        let envelope = RequestEnvelope(
+            params: [
+                "enabled": AnyCodable(enabled),
+                "nested": AnyCodable(nested),
+            ]
+        )
+        let data = try JSONEncoder().encode(envelope)
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        #expect(json.contains(#""enabled":true"#))
+        #expect(json.contains(#""active":false"#))
+    }
+}


### PR DESCRIPTION
## Summary
- normalize `NSNumber` booleans to native `Bool` in `OpenClawProtocol.AnyCodable`
- ensure bool matching occurs before int matching during encode/decode
- add regression tests that assert `NSNumber(true/false)` and `JSONSerialization`-bridged values encode as JSON `true/false` (not `1/0`)
- add changelog entry under `2026.2.18 (Unreleased)` fixes

## Problem
Some Apple-client RPC payloads pass through `JSONSerialization`, which bridges booleans to `NSNumber`. In `AnyCodable`, type matching checked `Int` before `Bool`, so bridged booleans could be encoded as `1`/`0`, causing gateway schema validation errors (`must be boolean`).

## Root Cause
Type matching order in `AnyCodable` favored integers ahead of booleans, and bridged `NSNumber` booleans satisfy both `is Int` and `is Bool` in Swift.

## Validation
- `swift test --package-path apps/shared/OpenClawKit --filter AnyCodableTests`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where `AnyCodable` would encode `NSNumber`-bridged booleans (from `JSONSerialization`) as integers (`1`/`0`) instead of JSON booleans (`true`/`false`), causing gateway schema validation failures on Apple client RPC payloads.

- Reorders type matching in `encode(to:)` and `init(from:)` to check `Bool` before `Int`, since `NSNumber` booleans satisfy both `is Int` and `is Bool` in Swift
- Adds a `normalize()` function called at `init` time that converts `NSNumber` booleans (detected via `CFBooleanGetTypeID()`) to native `Bool`
- Adds an `NSNumber` CFBoolean safety-net case in the encode switch for defense in depth
- Includes regression tests covering both direct `NSNumber` boolean encoding and `JSONSerialization`-bridged nested boolean encoding
- The real-world trigger is `GatewayNodeSession.decodeParamsJSON` which uses `JSONSerialization.jsonObject` then wraps results in `AnyCodable`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a clear encoding bug with a well-layered defensive approach and targeted regression tests.
- The fix correctly addresses a real-world issue where NSNumber-bridged booleans were misencoded as integers. The approach is thorough with three defense layers: normalize at init, Bool-first ordering in encode/decode, and a CFBoolean safety-net case. Tests cover the two key scenarios. One minor style inconsistency: the == and hash functions still check Int before Bool, though normalize() prevents this from causing issues. Deducting one point for that inconsistency.
- Minor attention on `apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift` — the `==` and `hash(into:)` functions have `Int`-before-`Bool` ordering that is inconsistent with the fix, though `normalize()` prevents practical issues.

<sub>Last reviewed commit: 0eefe8d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->