### PR TITLE
fix(protocol): align bool-first AnyCodable equality/hash dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- OpenClawKit/Protocol: preserve JSON boolean literals (`true`/`false`) when bridging through `AnyCodable` so Apple client RPC params no longer re-encode booleans as `1`/`0`. Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.
 - Browser/Relay: reuse an already-running extension relay when the relay port is occupied by another OpenClaw process, while still failing on non-relay port collisions to avoid masking unrelated listeners. (#20035) Thanks @mbelinky.
 - Telegram/Cron/Heartbeat: honor explicit Telegram topic targets in cron and heartbeat delivery (`<chatId>:topic:<threadId>`) so scheduled sends land in the configured topic instead of the last active thread. (#19367) Thanks @Lukavyi.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift
@@ -6,13 +6,13 @@ import Foundation
 public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
     public let value: Any
 
-    public init(_ value: Any) { self.value = value }
+    public init(_ value: Any) { self.value = Self.normalize(value) }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
+        if let boolVal = try? container.decode(Bool.self) { self.value = boolVal; return }
         if let intVal = try? container.decode(Int.self) { self.value = intVal; return }
         if let doubleVal = try? container.decode(Double.self) { self.value = doubleVal; return }
-        if let boolVal = try? container.decode(Bool.self) { self.value = boolVal; return }
         if let stringVal = try? container.decode(String.self) { self.value = stringVal; return }
         if container.decodeNil() { self.value = NSNull(); return }
         if let dict = try? container.decode([String: AnyCodable].self) { self.value = dict; return }
@@ -23,10 +23,12 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self.value {
+        case let boolVal as Bool: try container.encode(boolVal)
         case let intVal as Int: try container.encode(intVal)
         case let doubleVal as Double: try container.encode(doubleVal)
-        case let boolVal as Bool: try container.encode(boolVal)
         case let stringVal as String: try container.encode(stringVal)
+        case let number as NSNumber where CFGetTypeID(number) == CFBooleanGetTypeID():
+            try container.encode(number.boolValue)
         case is NSNull: try container.encodeNil()
         case let dict as [String: AnyCodable]: try container.encode(dict)
         case let array as [AnyCodable]: try container.encode(array)
@@ -49,6 +51,13 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
                 debugDescription: "Unsupported type")
             throw EncodingError.invalidValue(self.value, context)
         }
+    }
+
+    private static func normalize(_ value: Any) -> Any {
+        if let number = value as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return number.boolValue
+        }
+        return value
     }
 
     public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift
@@ -62,9 +62,9 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
 
     public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
         switch (lhs.value, rhs.value) {
+        case let (l as Bool, r as Bool): l == r
         case let (l as Int, r as Int): l == r
         case let (l as Double, r as Double): l == r
-        case let (l as Bool, r as Bool): l == r
         case let (l as String, r as String): l == r
         case (_ as NSNull, _ as NSNull): true
         case let (l as [String: AnyCodable], r as [String: AnyCodable]): l == r
@@ -76,12 +76,12 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
 
     public func hash(into hasher: inout Hasher) {
         switch self.value {
+        case let v as Bool:
+            hasher.combine(2); hasher.combine(v)
         case let v as Int:
             hasher.combine(0); hasher.combine(v)
         case let v as Double:
             hasher.combine(1); hasher.combine(v)
-        case let v as Bool:
-            hasher.combine(2); hasher.combine(v)
         case let v as String:
             hasher.combine(3); hasher.combine(v)
         case _ as NSNull:

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/AnyCodableTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/AnyCodableTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+import OpenClawProtocol
+
+struct AnyCodableTests {
+    @Test
+    func encodesNSNumberBooleansAsJSONBooleans() throws {
+        let trueData = try JSONEncoder().encode(AnyCodable(NSNumber(value: true)))
+        let falseData = try JSONEncoder().encode(AnyCodable(NSNumber(value: false)))
+
+        #expect(String(data: trueData, encoding: .utf8) == "true")
+        #expect(String(data: falseData, encoding: .utf8) == "false")
+    }
+
+    @Test
+    func preservesBooleanLiteralsFromJSONSerializationBridge() throws {
+        let raw = try #require(
+            JSONSerialization.jsonObject(with: Data(#"{"enabled":true,"nested":{"active":false}}"#.utf8))
+                as? [String: Any]
+        )
+        let enabled = try #require(raw["enabled"])
+        let nested = try #require(raw["nested"])
+
+        struct RequestEnvelope: Codable {
+            let params: [String: AnyCodable]
+        }
+
+        let envelope = RequestEnvelope(
+            params: [
+                "enabled": AnyCodable(enabled),
+                "nested": AnyCodable(nested),
+            ]
+        )
+        let data = try JSONEncoder().encode(envelope)
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        #expect(json.contains(#""enabled":true"#))
+        #expect(json.contains(#""active":false"#))
+    }
+}


### PR DESCRIPTION
## Summary
- reorder `AnyCodable` type dispatch so `Bool` is checked before numeric types in `==`
- reorder `AnyCodable` type dispatch so `Bool` is checked before numeric types in `hash(into:)`

## Why
Follow-up to #20220 so all AnyCodable dispatch sites use consistent bool-first ordering.

## Testing
- `swift test` (in `apps/shared/OpenClawKit`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the bool-first type dispatch alignment in `AnyCodable` that was started in #20220. The previous commit reordered `init(from:)` and `encode(to:)` to check `Bool` before `Int`/`Double`, added a `normalize()` helper to convert `NSNumber` booleans to Swift `Bool` at init time, and added an `NSNumber` boolean guard in encoding. This follow-up PR applies the same bool-first reordering to the two remaining dispatch sites: `==` (Equatable) and `hash(into:)` (Hashable).

- Reorders `Bool` case before `Int`/`Double` in `==` operator to prevent Swift's `NSNumber` bridging from matching booleans as integers during equality checks
- Reorders `Bool` case before `Int`/`Double` in `hash(into:)` for consistent dispatch ordering across all code paths
- Adds a changelog entry documenting the full boolean-preservation fix
- Includes new tests verifying `NSNumber` booleans encode as JSON `true`/`false` and that `JSONSerialization`-bridged booleans round-trip correctly through nested structures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it consists entirely of switch-case reordering for consistency with no behavioral changes beyond what was already established by the parent commit.
- The changes are minimal and mechanical: reordering Bool before Int/Double in two switch statements (== and hash(into:)) to match the ordering already applied in init(from:) and encode(to:) by the parent commit. The normalize() function ensures NSNumber booleans are converted to Swift Bool at init time, so the ordering change in == and hash(into:) is a consistency improvement rather than a behavioral fix. The new tests are well-targeted and validate the core use case. No new logic, no API changes, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 4ebaa7f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->