### PR TITLE
fix(reply): prevent duplicate final payloads in block pipeline

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -289,16 +289,16 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads).toHaveLength(0);
   });
 
+  it("suppresses mutating tool errors when messages.suppressToolErrors is enabled", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "write", error: "connection timeout" },
+      config: { messages: { suppressToolErrors: true } },
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
   it.each([
-    {
-      name: "still shows mutating tool errors when messages.suppressToolErrors is enabled",
-      payload: {
-        lastToolError: { toolName: "write", error: "connection timeout" },
-        config: { messages: { suppressToolErrors: true } },
-      },
-      title: "Write",
-      absentDetail: "connection timeout",
-    },
     {
       name: "shows recoverable tool errors for mutating tools",
       payload: {
@@ -324,14 +324,25 @@ describe("buildEmbeddedRunPayloads", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Done."],
       lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
-      lastToolError: { toolName: "write", error: "file missing" },
+      lastToolError: { toolName: "write", error: "path required" },
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Done.");
+  });
+
+  it("shows non-recoverable mutating tool errors when assistant output exists", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Done."],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: { toolName: "write", error: "disk full" },
     });
 
     expect(payloads).toHaveLength(2);
     expect(payloads[0]?.text).toBe("Done.");
     expect(payloads[1]?.isError).toBe(true);
     expect(payloads[1]?.text).toContain("Write");
-    expect(payloads[1]?.text).not.toContain("missing");
+    expect(payloads[1]?.text).not.toContain("disk full");
   });
 
   it("does not treat session_status read failures as mutating when explicitly flagged", () => {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -115,11 +115,10 @@ export function buildReplyPayloads(params: {
   const filteredPayloads = shouldDropFinalPayloads
     ? []
     : params.blockStreamingEnabled
-      ? mediaFilteredPayloads.filter(
-          (payload) =>
-            params.blockReplyPipeline?.isAborted()
-              ? !params.blockReplyPipeline.hasEnqueuedPayload(payload)
-              : !params.blockReplyPipeline?.hasSentPayload(payload),
+      ? mediaFilteredPayloads.filter((payload) =>
+          params.blockReplyPipeline?.isAborted()
+            ? !params.blockReplyPipeline.hasEnqueuedPayload(payload)
+            : !params.blockReplyPipeline?.hasSentPayload(payload),
         )
       : params.directlySentBlockKeys?.size
         ? mediaFilteredPayloads.filter(

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -111,13 +111,13 @@ export function buildReplyPayloads(params: {
     : dedupedPayloads;
   // Filter out payloads already sent via pipeline or directly during tool flush.
   // When the pipeline aborted (for example due to delivery timeout), suppress payloads that
-  // were already enqueued even if ack never confirmed.
+  // already started delivery attempts to avoid duplicate final fallbacks.
   const filteredPayloads = shouldDropFinalPayloads
     ? []
     : params.blockStreamingEnabled
       ? mediaFilteredPayloads.filter((payload) =>
           params.blockReplyPipeline?.isAborted()
-            ? !params.blockReplyPipeline.hasEnqueuedPayload(payload)
+            ? !params.blockReplyPipeline.hasAttemptedPayload(payload)
             : !params.blockReplyPipeline?.hasSentPayload(payload),
         )
       : params.directlySentBlockKeys?.size

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -110,11 +110,16 @@ export function buildReplyPayloads(params: {
       })
     : dedupedPayloads;
   // Filter out payloads already sent via pipeline or directly during tool flush.
+  // When the pipeline aborted (for example due to delivery timeout), suppress payloads that
+  // were already enqueued even if ack never confirmed.
   const filteredPayloads = shouldDropFinalPayloads
     ? []
     : params.blockStreamingEnabled
       ? mediaFilteredPayloads.filter(
-          (payload) => !params.blockReplyPipeline?.hasSentPayload(payload),
+          (payload) =>
+            params.blockReplyPipeline?.isAborted()
+              ? !params.blockReplyPipeline.hasEnqueuedPayload(payload)
+              : !params.blockReplyPipeline?.hasSentPayload(payload),
         )
       : params.directlySentBlockKeys?.size
         ? mediaFilteredPayloads.filter(

--- a/src/auto-reply/reply/block-reply-pipeline.has-enqueued-payload.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.has-enqueued-payload.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
+
+describe("BlockReplyPipeline.hasEnqueuedPayload", () => {
+  it("returns true for payloads enqueued before pipeline abort", async () => {
+    const onBlockReply = vi.fn().mockImplementation(
+      () => new Promise((resolve) => setTimeout(resolve, 5_000)),
+    );
+
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply,
+      timeoutMs: 50,
+    });
+
+    pipeline.enqueue({ text: "hello" });
+
+    // Wait for the timeout to trigger abort
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.isAborted()).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "hello" })).toBe(false);
+    expect(pipeline.hasEnqueuedPayload({ text: "hello" })).toBe(true);
+  });
+
+  it("returns false for payloads never enqueued", () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: vi.fn(),
+      timeoutMs: 15_000,
+    });
+
+    expect(pipeline.hasEnqueuedPayload({ text: "never seen" })).toBe(false);
+  });
+
+  it("returns true for successfully sent payloads", async () => {
+    const onBlockReply = vi.fn().mockResolvedValue(undefined);
+
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply,
+      timeoutMs: 15_000,
+    });
+
+    pipeline.enqueue({ text: "sent ok" });
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.isAborted()).toBe(false);
+    expect(pipeline.hasSentPayload({ text: "sent ok" })).toBe(true);
+    expect(pipeline.hasEnqueuedPayload({ text: "sent ok" })).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/block-reply-pipeline.has-enqueued-payload.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.has-enqueued-payload.test.ts
@@ -3,9 +3,9 @@ import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
 
 describe("BlockReplyPipeline.hasEnqueuedPayload", () => {
   it("returns true for payloads enqueued before pipeline abort", async () => {
-    const onBlockReply = vi.fn().mockImplementation(
-      () => new Promise((resolve) => setTimeout(resolve, 5_000)),
-    );
+    const onBlockReply = vi
+      .fn()
+      .mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 5_000)));
 
     const pipeline = createBlockReplyPipeline({
       onBlockReply,

--- a/src/auto-reply/reply/block-reply-pipeline.has-enqueued-payload.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.has-enqueued-payload.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
+import { createBlockReplyPayloadKey, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 
-describe("BlockReplyPipeline.hasEnqueuedPayload", () => {
-  it("returns true for payloads enqueued before pipeline abort", async () => {
+describe("BlockReplyPipeline.hasAttemptedPayload", () => {
+  it("returns true for payloads attempted before pipeline abort", async () => {
     const onBlockReply = vi
       .fn()
       .mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 5_000)));
@@ -19,16 +19,37 @@ describe("BlockReplyPipeline.hasEnqueuedPayload", () => {
 
     expect(pipeline.isAborted()).toBe(true);
     expect(pipeline.hasSentPayload({ text: "hello" })).toBe(false);
-    expect(pipeline.hasEnqueuedPayload({ text: "hello" })).toBe(true);
+    expect(pipeline.hasAttemptedPayload({ text: "hello" })).toBe(true);
   });
 
-  it("returns false for payloads never enqueued", () => {
+  it("returns false for payloads never attempted", () => {
     const pipeline = createBlockReplyPipeline({
       onBlockReply: vi.fn(),
       timeoutMs: 15_000,
     });
 
-    expect(pipeline.hasEnqueuedPayload({ text: "never seen" })).toBe(false);
+    expect(pipeline.hasAttemptedPayload({ text: "never seen" })).toBe(false);
+  });
+
+  it("keeps queued tail payloads eligible for final fallback after abort", async () => {
+    const onBlockReply = vi
+      .fn()
+      .mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 5_000)));
+
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply,
+      timeoutMs: 50,
+    });
+
+    pipeline.enqueue({ text: "first" });
+    pipeline.enqueue({ text: "second" });
+
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.isAborted()).toBe(true);
+    expect(pipeline.hasAttemptedPayload({ text: "first" })).toBe(true);
+    expect(pipeline.hasAttemptedPayload({ text: "second" })).toBe(false);
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
   });
 
   it("returns true for successfully sent payloads", async () => {
@@ -44,6 +65,13 @@ describe("BlockReplyPipeline.hasEnqueuedPayload", () => {
 
     expect(pipeline.isAborted()).toBe(false);
     expect(pipeline.hasSentPayload({ text: "sent ok" })).toBe(true);
-    expect(pipeline.hasEnqueuedPayload({ text: "sent ok" })).toBe(true);
+    expect(pipeline.hasAttemptedPayload({ text: "sent ok" })).toBe(true);
+  });
+
+  it("keeps reply targets distinct in payload key deduplication", () => {
+    const keyA = createBlockReplyPayloadKey({ text: "same", replyToId: "111" });
+    const keyB = createBlockReplyPayloadKey({ text: "same", replyToId: "222" });
+
+    expect(keyA).not.toBe(keyB);
   });
 });

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -11,6 +11,7 @@ export type BlockReplyPipeline = {
   didStream: () => boolean;
   isAborted: () => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
+  hasEnqueuedPayload: (payload: ReplyPayload) => boolean;
 };
 
 export type BlockReplyBuffer = {
@@ -44,7 +45,6 @@ export function createBlockReplyPayloadKey(payload: ReplyPayload): string {
   return JSON.stringify({
     text,
     mediaList,
-    replyToId: payload.replyToId ?? null,
   });
 }
 
@@ -84,6 +84,8 @@ export function createBlockReplyPipeline(params: {
   const seenKeys = new Set<string>();
   const bufferedKeys = new Set<string>();
   const bufferedPayloadKeys = new Set<string>();
+  /** Persistent record of every individual payload key ever enqueued (never cleared). */
+  const allEnqueuedKeys = new Set<string>();
   const bufferedPayloads: ReplyPayload[] = [];
   let sendChain: Promise<void> = Promise.resolve();
   let aborted = false;
@@ -196,6 +198,7 @@ export function createBlockReplyPipeline(params: {
     if (aborted) {
       return;
     }
+    allEnqueuedKeys.add(createBlockReplyPayloadKey(payload));
     if (bufferPayload(payload)) {
       return;
     }
@@ -237,6 +240,10 @@ export function createBlockReplyPipeline(params: {
     hasSentPayload: (payload) => {
       const payloadKey = createBlockReplyPayloadKey(payload);
       return sentKeys.has(payloadKey);
+    },
+    hasEnqueuedPayload: (payload) => {
+      const payloadKey = createBlockReplyPayloadKey(payload);
+      return allEnqueuedKeys.has(payloadKey);
     },
   };
 }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1281,7 +1281,7 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.telegram.customCommands":
     "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
   "messages.suppressToolErrors":
-    "When true, suppress ⚠️ tool-error warnings from being shown to the user. The agent already sees errors in context and can retry. Default: false.",
+    "When true, suppress all ⚠️ tool-error warnings from being shown to the user (including mutating-tool warnings). The agent already sees errors in context and can retry. Default: false.",
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -117,7 +117,10 @@ export type MessagesConfig = {
   removeAckAfterReply?: boolean;
   /** Lifecycle status reactions configuration. */
   statusReactions?: StatusReactionsConfig;
-  /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
+  /**
+   * When true, suppress all ⚠️ tool-error warnings from being shown to the user,
+   * including mutating tool warnings. Default: false.
+   */
   suppressToolErrors?: boolean;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;


### PR DESCRIPTION
## Summary
This PR now includes two focused fixes:
1. Prevent duplicate final reply emission in block reply pipeline abort/dedup paths.
2. Suppress misleading user-facing tool warning bubbles when errors are recoverable and a normal assistant reply already exists.

## Problem
- In certain abort-edge timing paths, final payloads can be emitted more than once, causing duplicate user-visible final replies.
- Tool retries that recover can still leave a visible `⚠️ ... failed` warning, which can mislead users into thinking the task failed.

## Changes
### Reply pipeline dedupe
- Suppress duplicate final payload emission during block pipeline abort handling.
- Tighten block-streaming dedup path checks.
- Add regression coverage for has-enqueued/final-payload behavior.

### Tool warning policy
- Update embedded run payload warning policy in `src/agents/pi-embedded-runner/run/payloads.ts`.
- `messages.suppressToolErrors=true` now suppresses all tool warning bubbles (including mutating tools).
- Default behavior now suppresses mutating warnings only when:
  - the error is recoverable (`required`/`missing`/`invalid`-style), and
  - a user-facing assistant reply was already produced.
- Preserve existing `exec`/`bash` verbose-level gating.
- Align config wording in:
  - `src/config/types.messages.ts`
  - `src/config/schema.help.ts`

## Validation
- `pnpm -s vitest run src/agents/pi-embedded-runner/run/payloads.errors.test.ts src/agents/pi-embedded-runner/run/payloads.test.ts src/auto-reply/reply/block-reply-pipeline.has-enqueued-payload.test.ts`

## Risk
Low to medium.
- Dedupe changes are scoped to reply finalization paths.
- Tool warning changes affect user-visible warning policy, but are covered by targeted tests.