### PR TITLE
fix(hooks): skip main-session summary when hook agent already delivered

### DIFF
--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from "node:crypto";
 import type { CliDeps } from "../../cli/deps.js";
-import type { CronJob } from "../../cron/types.js";
-import type { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { HookMessageChannel, HooksConfigResolved } from "../hooks.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
 import { runCronIsolatedAgentTurn } from "../../cron/isolated-agent.js";
+import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { HookMessageChannel, HooksConfigResolved } from "../hooks.js";
 import { createHooksRequestHandler } from "../server-http.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;


### PR DESCRIPTION
## Summary

Fixes #20196

- Problem: When a hook triggers an isolated agent run via `/hooks/agent` with `deliver: true`, the announce flow already sends the output to the target channel. The hooks handler was unconditionally posting a summary to the main session and waking the heartbeat afterward, causing the main agent to generate a duplicate response.
- Why it matters: Users receive what appears to be duplicate messages on every hook-triggered delivery.
- What changed: Added a `result.delivered` guard in `dispatchAgentHook` — the same pattern applied to the cron timer path in ea95e88dd (#15692).
- What did NOT change (scope boundary): The error path still always posts to main session (errors should always be reported). The `dispatchWakeHook` path is unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20196
- Related #15692 (same fix pattern applied to cron timer)

## User-visible / Behavior Changes

Hook-triggered agent runs with `deliver: true` no longer produce duplicate messages in the target channel.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel: Telegram (multi-agent with bindings)
- Relevant config: hooks.enabled=true, two agents with Telegram bindings

### Steps

1. Configure two agents (`main` and `familyoffice`) with Telegram bindings
2. POST to `/hooks/agent` with `{ "message": "Hello", "agentId": "familyoffice", "deliver": true, "channel": "telegram", "to": "<group-id>", "wakeMode": "now" }`
3. Before fix: two messages appear (announce + main agent summary). After fix: one message appears.

### Expected

Single message delivered to target channel.

### Actual (before fix)

Two messages: one from announce flow, one from main agent processing the system event.

## Evidence

- Existing cron timer fix (ea95e88dd) applies the identical `!result.delivered` guard and has been stable since #15692.
- The `RunCronAgentTurnResult.delivered` flag's JSDoc explicitly documents: "Callers should skip posting a summary to the main session to avoid duplicate messages."
- All 47 gateway tests pass (456 tests), all 31 cron tests pass (173 tests).

## Human Verification (required)

- Verified scenarios: Code review confirms the guard matches the established pattern in `timer.ts:541`.
- Edge cases checked: Error path still unconditionally posts (errors should always be reported). Non-delivered results still get summaries.
- What you did **not** verify: Live multi-agent Telegram setup (no access).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit.
- Files/config to restore: `src/gateway/server/hooks.ts`
- Known bad symptoms reviewers should watch for: Hook agent responses not appearing at all (would indicate `delivered` is incorrectly set to `true` when it shouldn't be).

## Risks and Mitigations

- Risk: If `runCronIsolatedAgentTurn` returns `delivered: true` but delivery actually failed silently, the summary would be suppressed and the user would see no output.
  - Mitigation: The `delivered` flag is set by the announce flow only on confirmed delivery. The same risk exists for the cron timer path (ea95e88dd) and has been stable.

---
🤖 Generated with Claude Code (issue-hunter-pro)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Applies a `!result.delivered` guard in the hook-agent dispatch path (`dispatchAgentHook`) to prevent posting a duplicate summary to the main session when the isolated agent run has already delivered its output to the target channel via the announce flow.

- Wraps the `enqueueSystemEvent` + `requestHeartbeatNow` calls inside `if (!result.delivered)` so they are skipped when delivery already occurred
- Follows the same pattern established in `src/cron/service/timer.ts:541` (PR #15692) for the cron timer path
- Error path (catch block) remains unconditional — errors are always reported to the main session
- Import reordering is cosmetic (type imports grouped before value imports)
- The `delivered` field on `RunCronAgentTurnResult` is well-documented and only set to `true` on confirmed delivery

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it applies a well-established guard pattern to a single code path with no behavioral risk to existing flows.
- The change is minimal (one conditional guard wrapping existing code), follows an identical pattern already proven stable in the cron timer path since PR #15692, preserves the error-reporting path, and the `delivered` flag semantics are well-documented in the type definition. No new dependencies, no API changes, no edge cases introduced.
- No files require special attention.

<sub>Last reviewed commit: 7050a30</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->