### PR TITLE
fix(schema): ensure normalizeToolParameters always includes properties field

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool } from "./pi-tools.schema.js";
+import { normalizeToolParameters } from "./pi-tools.schema.js";
+
+describe("normalizeToolParameters", () => {
+  it("adds empty properties when schema has type but no properties/anyOf/oneOf (#20224)", () => {
+    const tool = {
+      name: "my_tool",
+      description: "A tool",
+      parameters: { type: "object" },
+    } as unknown as AnyAgentTool;
+
+    const result = normalizeToolParameters(tool);
+    const params = result.parameters as Record<string, unknown>;
+    expect(params.type).toBe("object");
+    expect(params.properties).toEqual({});
+  });
+
+  it("preserves existing properties when present", () => {
+    const tool = {
+      name: "my_tool",
+      description: "A tool",
+      parameters: { type: "object", properties: { foo: { type: "string" } } },
+    } as unknown as AnyAgentTool;
+
+    const result = normalizeToolParameters(tool);
+    const params = result.parameters as Record<string, unknown>;
+    expect(params.properties).toEqual({ foo: { type: "string" } });
+  });
+
+  it("returns tool unchanged when no parameters", () => {
+    const tool = { name: "my_tool", description: "A tool" } as unknown as AnyAgentTool;
+    const result = normalizeToolParameters(tool);
+    expect(result).toBe(tool);
+  });
+});

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -122,6 +122,11 @@ export function normalizeToolParameters(
       ? "oneOf"
       : null;
   if (!variantKey) {
+    // Ensure `properties` exists — OpenAI-compatible providers require it even
+    // when the schema only has `type` and no object fields (#20224).
+    if (!("properties" in schema)) {
+      return { ...tool, parameters: { ...schema, properties: {} } };
+    }
     return tool;
   }
   const variants = schema[variantKey] as unknown[];


### PR DESCRIPTION
Fixes #20224

## Problem
`normalizeToolParameters()` has a fallthrough path that returns the tool unchanged when the schema has `type` but no `properties`, `anyOf`, or `oneOf`. OpenAI-compatible providers (e.g. Abacus RouteLLM) strictly require `properties` on every tool schema, causing HTTP 400 errors.

## Fix
Add an empty `properties: {}` fallback in the no-variant-key path before returning.

## Testing
- Added unit tests in `pi-tools.schema.test.ts` (3 tests, all passing)
- AI-assisted (Claude), lightly tested

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a compatibility issue where `normalizeToolParameters()` could return tool schemas without a `properties` field, causing HTTP 400 errors on OpenAI-compatible providers (e.g., Abacus RouteLLM) that strictly require `properties` on every tool schema.

- Adds a `properties: {}` fallback in the `!variantKey` path of `normalizeToolParameters()` when the schema has `type` but no `properties`, `anyOf`, or `oneOf`
- The implementation fix in `pi-tools.schema.ts` is minimal and correct — it only affects the specific fallthrough path that was missing the `properties` field
- The new test file (`pi-tools.schema.test.ts`) has an **incorrect import**: `AnyAgentTool` is imported from `./pi-tools.schema.js`, but that module does not export this type. It should be imported from `./pi-tools.types.js`

<h3>Confidence Score: 4/5</h3>

- The core fix is safe to merge, but the test file has a compilation error that needs a one-line fix before merging.
- The logic change in pi-tools.schema.ts is minimal, correct, and well-targeted to the reported issue. However, the test file has an incorrect import (AnyAgentTool from the wrong module) that will fail TypeScript compilation, preventing the tests from actually running. This is a straightforward fix but should be addressed before merge.
- src/agents/pi-tools.schema.test.ts — incorrect import source for AnyAgentTool type

<sub>Last reviewed commit: cff1b5b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->