### PR TITLE
fix: detect Venice 402 insufficient USD/Diem balance as billing failover [AI-assisted]

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -49,6 +49,7 @@ describe("isBillingErrorMessage", () => {
       "Payment Required",
       "HTTP 402 Payment Required",
       "plans & billing",
+      '402 "Insufficient USD or Diem balance to complete request"',
     ];
     for (const sample of samples) {
       expect(isBillingErrorMessage(sample)).toBe(true);
@@ -91,6 +92,7 @@ describe("isBillingErrorMessage", () => {
       '{"status":402,"type":"error"}',
       '{"code":402,"message":"payment required"}',
       '{"error":{"code":402,"message":"billing hard limit reached"}}',
+      '402 "Insufficient USD or Diem balance to complete request"',
     ];
     for (const sample of realErrors) {
       expect(isBillingErrorMessage(sample)).toBe(true);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -600,12 +600,13 @@ const ERROR_PATTERNS = {
     /\bunhandled stop reason:\s*abort\b/i,
   ],
   billing: [
-    /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,
+    /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment|^\s*402\s*["'{[]/i,
     "payment required",
     "insufficient credits",
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    "insufficient usd or diem balance",
   ],
   auth: [
     /invalid[_ ]?api[_ ]?key/,


### PR DESCRIPTION
## Summary\nThis fixes a failover gap where Venice returns errors like:\n\n`402 "Insufficient USD or Diem balance to complete request"`\n\nThose messages were not classified as billing/failover errors, so model fallback cascades could stop early.\n\n### Changes\n- Expand billing regex to recognize generic quoted/bracketed leading 402 payloads.\n- Add explicit billing phrase match for `insufficient usd or diem balance`.\n- Add regression test coverage for the Venice 402 string.\n\n## Why\nOpenClaw fallback logic depends on failover classification. If this 402 shape is missed, fallback does not advance and users see raw provider errors.\n\n## Testing\nAI-assisted PR: yes (Codex/OpenClaw).\n\nDegree of testing: **lightly tested + targeted**\n\nRan locally:\n- `pnpm vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts` ✅ (32/32 passed)\n- `pnpm lint` ✅\n- `pnpm tsgo` ✅\n- `pnpm build` ✅\n\n## Prompt / Session context\nIssue was identified from a real main-session transcript where fallback stalled after Venice returned the 402 string above. This patch is the minimal classification fix + regression test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a failover classification gap where Venice returns `402 "Insufficient USD or Diem balance to complete request"` errors that were not recognized as billing errors. Without this fix, the model fallback cascade stalls and users see raw provider error messages.

- Adds a new regex alternation `^\s*402\s*["'{[]` to the billing pattern to match 402 responses prefixed with quoted/bracketed payloads (e.g., Venice's format). The `^` anchor and structured-delimiter character class avoid false positives.
- Adds an explicit `"insufficient usd or diem balance"` string pattern, which is needed because the existing `"insufficient balance"` pattern requires a contiguous substring match and does not match the Venice phrasing.
- Adds the Venice 402 string to two test sections for regression coverage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-targeted pattern expansion with regression tests and no risk of false positives.
- The changes are small and focused: two additions to pattern-matching logic (one regex alternation, one string literal) plus corresponding test coverage. The regex uses a `^` anchor and structured-delimiter character class that prevent false positives, verified against the existing false-positive test suite. No control flow, API, or architectural changes are introduced.
- No files require special attention.

<sub>Last reviewed commit: ea39070</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->