### PR TITLE
fix(tools): inject properties:{} for type:object schemas missing properties field (#20224)

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParameters } from "./pi-tools.schema.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+function makeTool(parameters: unknown): AnyAgentTool {
+  return { name: "test_tool", description: "test", parameters } as AnyAgentTool;
+}
+
+describe("normalizeToolParameters", () => {
+  describe("type:object schema without properties — OpenAI-compatible provider fix (#20224)", () => {
+    it("injects empty properties when schema has type:object but no properties field", () => {
+      const tool = makeTool({ type: "object" });
+      const result = normalizeToolParameters(tool);
+      expect((result.parameters as Record<string, unknown>).properties).toEqual({});
+    });
+
+    it("injects empty properties when schema has type:object and required but no properties", () => {
+      const tool = makeTool({ type: "object", required: ["foo"] });
+      const result = normalizeToolParameters(tool);
+      expect((result.parameters as Record<string, unknown>).properties).toEqual({});
+    });
+
+    it("preserves existing properties when present", () => {
+      const tool = makeTool({ type: "object", properties: { foo: { type: "string" } } });
+      const result = normalizeToolParameters(tool);
+      expect((result.parameters as Record<string, unknown>).properties).toEqual({
+        foo: { type: "string" },
+      });
+    });
+
+    it("does not inject properties for non-object types", () => {
+      const tool = makeTool({ type: "string" });
+      const result = normalizeToolParameters(tool);
+      expect(result.parameters).toEqual({ type: "string" });
+    });
+  });
+
+  describe("anyOf / oneOf union flattening", () => {
+    it("flattens anyOf variants into a single object schema", () => {
+      const tool = makeTool({
+        anyOf: [
+          { type: "object", properties: { action: { type: "string" } }, required: ["action"] },
+          { type: "object", properties: { action: { type: "string" }, value: { type: "number" } } },
+        ],
+      });
+      const result = normalizeToolParameters(tool);
+      const params = result.parameters as Record<string, unknown>;
+      expect(params.type).toBe("object");
+      expect(params).toHaveProperty("properties");
+    });
+  });
+
+  describe("no-op paths", () => {
+    it("returns tool unchanged when parameters is missing", () => {
+      const tool = { name: "test_tool", description: "test" } as AnyAgentTool;
+      expect(normalizeToolParameters(tool)).toBe(tool);
+    });
+
+    it("returns tool with type:object + properties unchanged (no-op for non-Gemini)", () => {
+      const original = { type: "object", properties: { x: { type: "number" } } };
+      const tool = makeTool(original);
+      const result = normalizeToolParameters(tool);
+      expect(result.parameters).toEqual(original);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug:** `normalizeToolParameters()` returns tool schemas with `type: "object"` but no `properties` field unchanged. OpenAI-compatible providers (e.g. `routellm.abacus.ai/v1`) strictly require `properties` on every object schema and return HTTP 400: *"properties field not found or is not a dictionary in tool calls."*
- **Root cause:** The `!variantKey` fallthrough path (line 124 of `pi-tools.schema.ts`) returned `tool` unchanged for any schema that wasn't a union and didn't already have `properties`. This includes valid `{ type: "object" }` schemas.
- **Fix:** In the `!variantKey` branch, inject `properties: {}` when `schema.type === "object"` and `properties` is absent. Non-object types (`type: "string"`, etc.) are unaffected.
- **Scope:** Single file change in `src/agents/pi-tools.schema.ts` + new test file. No config, API, or behavior changes for existing users.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20224

## User-visible / Behavior Changes

- Tool calls to OpenAI-compatible providers (routellm, any strict OpenAI-spec endpoint) no longer fail with HTTP 400 when tools have `type: "object"` schemas without explicit `properties`.
- No change for Anthropic, Gemini, or any provider that was already working.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Configure an OpenAI-compatible provider (e.g. `routellm.abacus.ai/v1`)
2. Trigger any tool call where the tool schema is `{ type: "object" }` (no explicit `properties`)
3. Before fix: HTTP 400 — "properties field not found or is not a dictionary"
4. After fix: tool call succeeds

### Test results

```
✓ src/agents/pi-tools.schema.test.ts (7 tests) 3ms
Test Files  1 passed (1)
Tests       7 passed (7)
```

Full suite: `pnpm build && pnpm check && pnpm test` — exit 0

## Human Verification (required)

- [x] Mark as AI-assisted — built with Claude Sonnet 4.6 via Claude Code
- [x] Degree of testing: fully tested (new unit tests cover the fixed path + all existing code paths)
- [x] I understand what the code does: `normalizeToolParameters` normalizes tool JSON Schemas for cross-provider compatibility; this fix closes a gap in the fallthrough path for bare object schemas

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to revert: single-line revert of the `if (schema.type === "object" && !("properties" in schema))` block in `pi-tools.schema.ts`
- Known bad symptoms: none expected — adding `properties: {}` is a strict superset of what providers already accept

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a compatibility issue where `normalizeToolParameters()` returned tool schemas with `type: "object"` but no `properties` field unchanged, causing HTTP 400 errors on strict OpenAI-compatible providers (e.g., `routellm.abacus.ai/v1`).

- Injects `properties: {}` in the `!variantKey` fallthrough path when `schema.type === "object"` and `properties` is absent, matching the provider-conditional pattern (Gemini/Anthropic) used throughout the function.
- Adds a new colocated test file (`pi-tools.schema.test.ts`) with 7 tests covering the fix, union flattening, and no-op paths.
- Change is minimal and well-scoped — no impact on providers that were already working (Anthropic, Gemini, standard OpenAI).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a minimal, defensive guard for a well-defined edge case with no impact on existing behavior.
- The fix is a single conditional block that only activates for bare `{ type: "object" }` schemas missing `properties`. It follows the exact same provider-conditional pattern used in adjacent code paths, making it consistent and predictable. The change is additive (injecting `properties: {}` is a strict superset), backed by 7 new unit tests, and scoped to a single function. No existing callers or providers are affected.
- No files require special attention.

<sub>Last reviewed commit: 6f096fb</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->