### PR TITLE
feat: skills-audit — Phase 1 security scanner for installed skills

### DIFF
--- a/scripts/security/SKILLS-AUDIT.md
+++ b/scripts/security/SKILLS-AUDIT.md
@@ -1,0 +1,87 @@
+# openclaw-skills-audit
+
+**Phase 1 prototype for [RFC #10890](https://github.com/openclaw/openclaw/issues/10890) — Skill Security Framework**
+
+A CLI tool that scans installed OpenClaw skills for security risks.
+
+## What it does
+
+- Scans all installed skills (bundled + workspace + ClawHub)
+- Flags tools referenced in SKILL.md (`exec`, `browser`, `web_fetch`, etc.)
+- Detects executable scripts (`.sh`, `.py`, `.js`)
+- Checks for references to sensitive paths (`~/.ssh/`, `~/.aws/`, credentials, tokens)
+- Scans executables for potential exfiltration patterns (`curl POST`, `requests.post`, etc.)
+- Checks for permission manifest files (`permissions.json`, `skill.json`)
+- Computes SHA-256 hashes for integrity tracking
+- Assigns risk levels: 🔴 high / 🟡 medium / 🔵 low / 🟢 clean
+
+## Risk Classification
+
+| Level | Criteria |
+|-------|----------|
+| **High** | exec + network tools combo, or exfiltration patterns detected |
+| **Medium** | Uses `exec`, or references sensitive paths |
+| **Low** | Contains executables but no other flags |
+| **Clean** | No executables, no risky tool references, no sensitive path access |
+
+## Usage
+
+```bash
+# Scan default locations
+./skills-audit.sh
+
+# Verbose output (detailed findings per skill)
+./skills-audit.sh -v
+
+# JSON output (for CI/automation)
+./skills-audit.sh -j
+
+# Scan specific directory
+./skills-audit.sh /path/to/skills
+```
+
+## Sample Output
+
+```
+🦞 OpenClaw Skills Audit
+Phase 1 prototype — RFC #10890
+
+  RISK     SKILL                        HASH           MANIFEST  TOOLS
+  ─────────────────────────────────────────────────────────────────────
+  [clean]  weather                      6953295d3da5   ❌  none
+  [medium] coding-agent                 92fd54f39fac   ❌  exec,message
+  [high]   sus-weather-skill            a1b2c3d4e5f6   ❌  exec,web_fetch
+
+  Summary: 52 skills scanned
+    🔴 High:   1
+    🟡 Medium: 2
+    🟢 Clean:  49
+    📦 Executables found: 3
+
+  ⚠️  1 high-risk skill(s) detected. Review before use.
+  📋 52 skill(s) have no permission manifest.
+```
+
+## Next Steps
+
+This is a Phase 1 prototype. Future work:
+- **Permission manifest spec** — JSON Schema for skills to declare required tools, paths, domains
+- **Hash store** — persist hashes on install, detect tampering on audit
+- **Integration** — `openclaw skills audit` as a first-class CLI command
+- **Install warnings** — prompt users before installing flagged skills
+- **CI integration** — run audit in ClawHub publishing pipeline
+
+## Related
+
+- [RFC #10890](https://github.com/openclaw/openclaw/issues/10890) — Skill Security Framework
+- [SkillSandbox](https://github.com/theMachineClay/skillsandbox) — Runtime enforcement (Phase 3)
+- [AgentTrace](https://github.com/theMachineClay/agenttrace) — Session-aware policy engine
+
+## Authors
+
+- Clay ([@theMachineClay](https://github.com/theMachineClay))
+- Ivy Fei
+
+## License
+
+MIT

--- a/scripts/security/SKILLS-AUDIT.md
+++ b/scripts/security/SKILLS-AUDIT.md
@@ -17,12 +17,12 @@ A CLI tool that scans installed OpenClaw skills for security risks.
 
 ## Risk Classification
 
-| Level | Criteria |
-|-------|----------|
-| **High** | exec + network tools combo, or exfiltration patterns detected |
-| **Medium** | Uses `exec`, or references sensitive paths |
-| **Low** | Contains executables but no other flags |
-| **Clean** | No executables, no risky tool references, no sensitive path access |
+| Level      | Criteria                                                           |
+| ---------- | ------------------------------------------------------------------ |
+| **High**   | exec + network tools combo, or exfiltration patterns detected      |
+| **Medium** | Uses `exec`, or references sensitive paths                         |
+| **Low**    | Contains executables but no other flags                            |
+| **Clean**  | No executables, no risky tool references, no sensitive path access |
 
 ## Usage
 
@@ -65,6 +65,7 @@ Phase 1 prototype — RFC #10890
 ## Next Steps
 
 This is a Phase 1 prototype. Future work:
+
 - **Permission manifest spec** — JSON Schema for skills to declare required tools, paths, domains
 - **Hash store** — persist hashes on install, detect tampering on audit
 - **Integration** — `openclaw skills audit` as a first-class CLI command

--- a/scripts/security/skills-audit.sh
+++ b/scripts/security/skills-audit.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# openclaw-skills-audit — Scan installed skills for security risks
+# Prototype for Phase 1 of RFC #10890
+# Author: Clay (@theMachineClay) & Ivy Fei
+# License: MIT
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# Defaults
+VERBOSE=0
+JSON_OUTPUT=0
+SKILL_DIRS=()
+
+usage() {
+  cat <<EOF
+Usage: skills-audit [OPTIONS] [SKILL_DIR ...]
+
+Scan OpenClaw skills for security risks.
+
+Options:
+  -v, --verbose     Show detailed findings per skill
+  -j, --json        Output JSON instead of table
+  -h, --help        Show this help
+
+If no SKILL_DIR is given, scans the default OpenClaw skill locations:
+  - Bundled: /opt/homebrew/lib/node_modules/openclaw/skills (macOS brew)
+  - Bundled: /usr/lib/node_modules/openclaw/skills (Linux global)
+  - Workspace: ~/.openclaw/workspace/skills
+  - ClawHub: ~/.openclaw/skills
+
+EOF
+}
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -v|--verbose) VERBOSE=1; shift ;;
+    -j|--json) JSON_OUTPUT=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) SKILL_DIRS+=("$1"); shift ;;
+  esac
+done
+
+# Default skill directories
+if [[ ${#SKILL_DIRS[@]} -eq 0 ]]; then
+  for d in \
+    "/opt/homebrew/lib/node_modules/openclaw/skills" \
+    "/usr/lib/node_modules/openclaw/skills" \
+    "$HOME/.openclaw/workspace/skills" \
+    "$HOME/.openclaw/skills"; do
+    [[ -d "$d" ]] && SKILL_DIRS+=("$d")
+  done
+fi
+
+if [[ ${#SKILL_DIRS[@]} -eq 0 ]]; then
+  echo "No skill directories found."
+  exit 1
+fi
+
+# Risk patterns in SKILL.md content
+DANGEROUS_TOOL_PATTERNS=(
+  'exec'
+  'browser'
+  'web_fetch'
+  'web_search'
+  'gateway'
+  'nodes'
+  'cron'
+  'message'
+)
+
+SENSITIVE_PATH_PATTERNS=(
+  '\.ssh'
+  '\.aws'
+  '\.env'
+  '\.config'
+  '\.gnupg'
+  '\.gitconfig'
+  'credentials'
+  'secret'
+  'token'
+  'password'
+  'private.key'
+  'id_rsa'
+)
+
+EXFIL_PATTERNS=(
+  'curl.*POST'
+  'wget.*--post'
+  'requests\.post'
+  'fetch\('
+  'webhook'
+  'ngrok'
+  'burp'
+  'evil'
+  'exfil'
+  'base64.*encode'
+)
+
+# Counters
+total_skills=0
+total_executables=0
+total_high=0
+total_medium=0
+total_low=0
+total_clean=0
+
+# JSON array
+json_results="["
+
+scan_skill() {
+  local skill_dir="$1"
+  local skill_name
+  skill_name=$(basename "$skill_dir")
+  local skill_md="$skill_dir/SKILL.md"
+  local risk_level="clean"
+  local findings=()
+  local tools_referenced=()
+  local has_executables=0
+  local has_sensitive_paths=0
+  local has_exfil_patterns=0
+  local has_permission_manifest=0
+  local executable_files=()
+
+  total_skills=$((total_skills + 1))
+
+  # Check for SKILL.md
+  if [[ ! -f "$skill_md" ]]; then
+    findings+=("⚠️  No SKILL.md found")
+    risk_level="medium"
+  fi
+
+  # Check for permission manifest
+  if [[ -f "$skill_dir/permissions.json" ]] || [[ -f "$skill_dir/permissions.yaml" ]] || [[ -f "$skill_dir/skill.json" ]]; then
+    has_permission_manifest=1
+  fi
+
+  # Scan for executables
+  while IFS= read -r -d '' f; do
+    executable_files+=("$(basename "$f")")
+    has_executables=1
+    total_executables=$((total_executables + 1))
+  done < <(find "$skill_dir" -type f \( -name "*.sh" -o -name "*.py" -o -name "*.js" -o -name "*.rb" -o -name "*.go" \) -not -path "*/node_modules/*" -print0 2>/dev/null)
+
+  if [[ $has_executables -eq 1 ]]; then
+    findings+=("📦 Contains executables: ${executable_files[*]}")
+    [[ "$risk_level" == "clean" ]] && risk_level="low"
+  fi
+
+  # Scan SKILL.md for tool references
+  if [[ -f "$skill_md" ]]; then
+    local content
+    content=$(cat "$skill_md")
+
+    for pattern in "${DANGEROUS_TOOL_PATTERNS[@]}"; do
+      if echo "$content" | grep -qi "\b${pattern}\b"; then
+        tools_referenced+=("$pattern")
+      fi
+    done
+
+    if [[ ${#tools_referenced[@]} -gt 0 ]]; then
+      findings+=("🔧 Tools referenced: ${tools_referenced[*]}")
+      # exec + browser + network = high risk combo
+      if [[ " ${tools_referenced[*]} " =~ " exec " ]] && [[ " ${tools_referenced[*]} " =~ " web_fetch " || " ${tools_referenced[*]} " =~ " browser " ]]; then
+        risk_level="high"
+      elif [[ " ${tools_referenced[*]} " =~ " exec " ]]; then
+        [[ "$risk_level" != "high" ]] && risk_level="medium"
+      fi
+    fi
+  fi
+
+  # Scan all text files for sensitive path access
+  while IFS= read -r -d '' f; do
+    for pattern in "${SENSITIVE_PATH_PATTERNS[@]}"; do
+      if grep -qiE "$pattern" "$f" 2>/dev/null; then
+        has_sensitive_paths=1
+        break 2
+      fi
+    done
+  done < <(find "$skill_dir" -type f \( -name "*.md" -o -name "*.sh" -o -name "*.py" -o -name "*.js" -o -name "*.yaml" -o -name "*.json" \) -not -path "*/node_modules/*" -print0 2>/dev/null)
+
+  if [[ $has_sensitive_paths -eq 1 ]]; then
+    findings+=("🔑 References sensitive paths (credentials, keys, tokens)")
+    [[ "$risk_level" != "high" ]] && risk_level="medium"
+  fi
+
+  # Scan executables for exfiltration patterns
+  if [[ $has_executables -eq 1 ]]; then
+    while IFS= read -r -d '' f; do
+      for pattern in "${EXFIL_PATTERNS[@]}"; do
+        if grep -qiE "$pattern" "$f" 2>/dev/null; then
+          has_exfil_patterns=1
+          findings+=("🚨 Potential exfiltration pattern in $(basename "$f"): matches '$pattern'")
+          risk_level="high"
+          break
+        fi
+      done
+    done < <(find "$skill_dir" -type f \( -name "*.sh" -o -name "*.py" -o -name "*.js" \) -not -path "*/node_modules/*" -print0 2>/dev/null)
+  fi
+
+  # No permission manifest
+  if [[ $has_permission_manifest -eq 0 ]]; then
+    findings+=("📋 No permission manifest found")
+  fi
+
+  # Compute hash of SKILL.md for integrity tracking
+  local skill_hash="n/a"
+  if [[ -f "$skill_md" ]]; then
+    skill_hash=$(shasum -a 256 "$skill_md" | cut -d' ' -f1 | head -c 12)
+  fi
+
+  # Update counters
+  case "$risk_level" in
+    high) total_high=$((total_high + 1)) ;;
+    medium) total_medium=$((total_medium + 1)) ;;
+    low) total_low=$((total_low + 1)) ;;
+    clean) total_clean=$((total_clean + 1)) ;;
+  esac
+
+  # Output
+  if [[ $JSON_OUTPUT -eq 1 ]]; then
+    local tools_json="[]"
+    if [[ ${#tools_referenced[@]} -gt 0 ]]; then
+      tools_json=$(printf '%s\n' "${tools_referenced[@]}" | jq -R . | jq -s .)
+    fi
+    local execs_json="[]"
+    if [[ ${#executable_files[@]} -gt 0 ]]; then
+      execs_json=$(printf '%s\n' "${executable_files[@]}" | jq -R . | jq -s .)
+    fi
+    local findings_json="[]"
+    if [[ ${#findings[@]} -gt 0 ]]; then
+      findings_json=$(printf '%s\n' "${findings[@]}" | jq -R . | jq -s .)
+    fi
+
+    [[ "$json_results" != "[" ]] && json_results+=","
+    json_results+=$(cat <<JSONEOF
+{
+  "name": "$skill_name",
+  "risk": "$risk_level",
+  "hash": "$skill_hash",
+  "has_manifest": $( [[ $has_permission_manifest -eq 1 ]] && echo true || echo false ),
+  "tools": $tools_json,
+  "executables": $execs_json,
+  "findings": $findings_json
+}
+JSONEOF
+)
+  else
+    # Table row
+    local risk_color
+    case "$risk_level" in
+      high) risk_color="$RED" ;;
+      medium) risk_color="$YELLOW" ;;
+      low) risk_color="$CYAN" ;;
+      clean) risk_color="$GREEN" ;;
+    esac
+
+    local manifest_icon
+    [[ $has_permission_manifest -eq 1 ]] && manifest_icon="✅" || manifest_icon="❌"
+
+    printf "  ${risk_color}%-8s${NC} %-28s %-14s %s  %s\n" \
+      "[$risk_level]" "$skill_name" "$skill_hash" "$manifest_icon" \
+      "$(IFS=,; echo "${tools_referenced[*]:-none}")"
+
+    if [[ $VERBOSE -eq 1 ]] && [[ ${#findings[@]} -gt 0 ]]; then
+      for finding in "${findings[@]}"; do
+        printf "           ${DIM}%s${NC}\n" "$finding"
+      done
+      echo ""
+    fi
+  fi
+}
+
+# Header
+if [[ $JSON_OUTPUT -eq 0 ]]; then
+  echo ""
+  echo -e "${BOLD}🦞 OpenClaw Skills Audit${NC}"
+  echo -e "${DIM}Phase 1 prototype — RFC #10890${NC}"
+  echo ""
+  echo -e "  ${BOLD}%-8s %-28s %-14s %s  %s${NC}" "RISK" "SKILL" "HASH" "MANIFEST" "TOOLS"
+  echo "  ─────────────────────────────────────────────────────────────────────────────"
+fi
+
+# Scan all skill directories
+for dir in "${SKILL_DIRS[@]}"; do
+  if [[ $JSON_OUTPUT -eq 0 ]]; then
+    echo -e "\n  ${DIM}📂 $dir${NC}"
+  fi
+  for skill in "$dir"/*/; do
+    [[ -d "$skill" ]] && scan_skill "$skill"
+  done
+done
+
+# Footer
+if [[ $JSON_OUTPUT -eq 1 ]]; then
+  json_results+="]"
+  echo "$json_results" | jq .
+else
+  echo ""
+  echo "  ─────────────────────────────────────────────────────────────────────────────"
+  echo -e "  ${BOLD}Summary:${NC} $total_skills skills scanned"
+  echo -e "    ${RED}🔴 High:${NC}   $total_high"
+  echo -e "    ${YELLOW}🟡 Medium:${NC} $total_medium"
+  echo -e "    ${CYAN}🔵 Low:${NC}    $total_low"
+  echo -e "    ${GREEN}🟢 Clean:${NC}  $total_clean"
+  echo -e "    📦 Executables found: $total_executables"
+  echo ""
+  if [[ $total_high -gt 0 ]]; then
+    echo -e "  ${RED}${BOLD}⚠️  $total_high high-risk skill(s) detected. Review before use.${NC}"
+  fi
+  if [[ $((total_skills - total_clean)) -gt 0 ]]; then
+    echo -e "  ${YELLOW}📋 $((total_skills)) skill(s) have no permission manifest.${NC}"
+  fi
+  echo ""
+  echo -e "  ${DIM}Tip: Run with -v for detailed findings, -j for JSON output.${NC}"
+  echo ""
+fi


### PR DESCRIPTION
## Summary

Prototype implementation of `skills-audit`, the Phase 1 security scanner proposed in [RFC #10890](https://github.com/openclaw/openclaw/issues/10890).

This is a standalone bash script that scans all installed OpenClaw skills and flags security risks. It's designed to be the foundation for a future `openclaw skills audit` CLI command.

## What it scans

| Check | Description |
|-------|-------------|
| **Tool references** | Flags skills that reference `exec`, `browser`, `web_fetch`, `gateway`, `nodes`, `cron`, `message` in SKILL.md |
| **Executables** | Detects `.sh`, `.py`, `.js`, `.rb`, `.go` files in skill directories |
| **Sensitive paths** | Checks for references to `~/.ssh/`, `~/.aws/`, credentials, tokens, private keys |
| **Exfiltration patterns** | Scans executables for `curl POST`, `requests.post`, `webhook`, `base64 encode`, etc. |
| **Permission manifest** | Checks for `permissions.json`, `permissions.yaml`, or `skill.json` |
| **Integrity hashes** | Computes SHA-256 of each SKILL.md for tamper detection |

## Risk classification

| Level | Criteria |
|-------|----------|
| 🔴 **High** | `exec` + network tool combo, or exfiltration patterns found |
| 🟡 **Medium** | Uses `exec`, or references sensitive paths |
| 🔵 **Low** | Contains executables but no other flags |
| 🟢 **Clean** | No executables, no risky tools, no sensitive path access |

## Usage

```bash
# Scan default skill locations
./scripts/security/skills-audit.sh

# Verbose (detailed findings per skill)
./scripts/security/skills-audit.sh -v

# JSON output (for CI/automation)
./scripts/security/skills-audit.sh -j
```

## Test results

Ran against a real OpenClaw 2026.2.15 installation (51 bundled + 1 workspace skill):

- 🟡 3 medium-risk skills flagged (coding-agent, tmux, 1p3a-sweep)
- 🟢 49 clean skills
- 📋 **0 out of 52 skills have a permission manifest** — confirming the RFC's urgency
- 📦 0 exfiltration patterns detected in bundled skills (good!)

## Next steps

This PR is the first building block. Follow-up work:

1. **Permission manifest JSON Schema** — so skills can declare what they need (Phase 1.2 of the RFC)
2. **Hash persistence** — store hashes on install, compare on audit to detect tampering (Phase 1.3)
3. **CLI integration** — wire this into `openclaw skills audit` as a first-class command
4. **Runtime enforcement** — [SkillSandbox](https://github.com/theMachineClay/skillsandbox) implements Phase 3 (capability-based runtime isolation with seccomp-bpf, iptables, filesystem scoping, MCP integration)
5. **Session-aware policy** — [AgentTrace](https://github.com/theMachineClay/agenttrace) adds stateful violation tracking for Phase 3 anomaly detection

Happy to iterate on feedback. The goal is to make the skill ecosystem trustworthy enough to grow safely.

Refs: #10890, #7827, #12565, #10827

Co-Authored-By: Ivy Fei <ivy.d.fei@gmail.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a standalone bash script (`scripts/security/skills-audit.sh`) that scans installed OpenClaw skills for security risks (dangerous tool references, executables, sensitive paths, exfiltration patterns) and classifies them by risk level. This is a Phase 1 prototype for RFC #10890.

- The table header output is broken: `echo -e` is used with `printf`-style format specifiers (`%-8s`) which it doesn't interpret, resulting in literal format strings in the output
- JSON output mode has an injection vulnerability: `$skill_name` is interpolated directly into a heredoc JSON template without escaping — skill names containing `"` or `\` will produce invalid/injected JSON
- The "no permission manifest" footer summary uses wrong logic — it checks if any non-clean skills exist but reports **all** skills as missing manifests
- The sensitive path patterns (`token`, `secret`, `password`, `credentials`) will produce high false-positive rates when scanning SKILL.md documentation files, since these words appear legitimately in 23+ skill docs across the repo

<h3>Confidence Score: 2/5</h3>

- This PR has multiple functional bugs that need fixing before merge — broken output formatting, JSON injection, and incorrect summary logic.
- Score reflects three distinct bugs (broken echo/printf header, JSON injection in output mode, wrong manifest count logic) plus a design issue with false-positive-prone patterns. The script is a standalone addition so risk to existing code is low, but it won't work correctly as-is.
- `scripts/security/skills-audit.sh` — all issues are in this file

<sub>Last reviewed commit: beff8e6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->