### PR TITLE
feat: workspace-aware post-compaction context

### DIFF
--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -1,7 +1,76 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { readPostCompactionContext } from "./post-compaction-context.js";
+import { detectBootstrapFiles, readPostCompactionContext } from "./post-compaction-context.js";
+
+describe("detectBootstrapFiles", () => {
+  const tmpDir = path.join("/tmp", "test-detect-bootstrap-" + Date.now());
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when no files exist", async () => {
+    const result = await detectBootstrapFiles(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it("detects AGENTS.md", async () => {
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# Agent");
+    const result = await detectBootstrapFiles(tmpDir);
+    expect(result).toContain("AGENTS.md");
+  });
+
+  it("detects multiple bootstrap files", async () => {
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# Agent");
+    fs.writeFileSync(path.join(tmpDir, "SOUL.md"), "# Soul");
+    fs.writeFileSync(path.join(tmpDir, "MEMORY.md"), "# Memory");
+    fs.writeFileSync(path.join(tmpDir, "IDENTITY.md"), "# Identity");
+    const result = await detectBootstrapFiles(tmpDir);
+    expect(result).toContain("AGENTS.md");
+    expect(result).toContain("SOUL.md");
+    expect(result).toContain("MEMORY.md");
+    expect(result).toContain("IDENTITY.md");
+  });
+
+  it("detects daily memory files", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.writeFileSync(path.join(memDir, "2026-02-17.md"), "notes");
+    fs.writeFileSync(path.join(memDir, "2026-02-18.md"), "notes");
+    const result = await detectBootstrapFiles(tmpDir);
+    expect(result).toContain("memory/2026-02-18.md");
+    expect(result).toContain("memory/2026-02-17.md");
+  });
+
+  it("limits daily memory files to most recent 2", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.writeFileSync(path.join(memDir, "2026-02-15.md"), "old");
+    fs.writeFileSync(path.join(memDir, "2026-02-16.md"), "older");
+    fs.writeFileSync(path.join(memDir, "2026-02-17.md"), "recent");
+    fs.writeFileSync(path.join(memDir, "2026-02-18.md"), "today");
+    const result = await detectBootstrapFiles(tmpDir);
+    expect(result).toContain("memory/2026-02-18.md");
+    expect(result).toContain("memory/2026-02-17.md");
+    expect(result).not.toContain("memory/2026-02-15.md");
+    expect(result).not.toContain("memory/2026-02-16.md");
+  });
+
+  it("ignores non-date files in memory directory", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.writeFileSync(path.join(memDir, "heartbeat-state.json"), "{}");
+    fs.writeFileSync(path.join(memDir, "2026-02-18.md"), "today");
+    const result = await detectBootstrapFiles(tmpDir);
+    expect(result).toContain("memory/2026-02-18.md");
+    expect(result).not.toContain("memory/heartbeat-state.json");
+  });
+});
 
 describe("readPostCompactionContext", () => {
   const tmpDir = path.join("/tmp", "test-post-compaction-" + Date.now());
@@ -14,18 +83,22 @@ describe("readPostCompactionContext", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("returns null when no AGENTS.md exists", async () => {
+  it("returns null when no workspace files exist", async () => {
     const result = await readPostCompactionContext(tmpDir);
     expect(result).toBeNull();
   });
 
-  it("returns null when AGENTS.md has no relevant sections", async () => {
-    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# My Agent\n\nSome content.\n");
+  it("lists detected bootstrap files in output", async () => {
+    fs.writeFileSync(path.join(tmpDir, "SOUL.md"), "# Soul");
+    fs.writeFileSync(path.join(tmpDir, "MEMORY.md"), "# Memory");
     const result = await readPostCompactionContext(tmpDir);
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result).toContain("SOUL.md");
+    expect(result).toContain("MEMORY.md");
+    expect(result).toContain("re-read them now");
   });
 
-  it("extracts Session Startup section", async () => {
+  it("includes AGENTS.md sections when present", async () => {
     const content = `# Agent Rules
 
 ## Session Startup
@@ -66,30 +139,58 @@ Stuff.
     expect(result).toContain("Never do X");
   });
 
-  it("extracts both sections", async () => {
+  it("extracts Every Session section", async () => {
     const content = `# Rules
 
-## Session Startup
+## Every Session
 
-Do startup things.
-
-## Red Lines
-
-Never break things.
+Before doing anything else:
+1. Read SOUL.md
+2. Read USER.md
 
 ## Other
 
-Ignore this.
+Stuff.
 `;
     fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
     const result = await readPostCompactionContext(tmpDir);
     expect(result).not.toBeNull();
-    expect(result).toContain("Session Startup");
-    expect(result).toContain("Red Lines");
-    expect(result).not.toContain("Other");
+    expect(result).toContain("Every Session");
+    expect(result).toContain("Read SOUL.md");
   });
 
-  it("truncates when content exceeds limit", async () => {
+  it("combines file inventory with AGENTS.md sections", async () => {
+    fs.writeFileSync(path.join(tmpDir, "SOUL.md"), "# Soul");
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# Rules\n\n## Red Lines\n\nNever break.\n");
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("SOUL.md");
+    expect(result).toContain("AGENTS.md");
+    expect(result).toContain("Red Lines");
+    expect(result).toContain("Never break");
+  });
+
+  it("works with only bootstrap files and no AGENTS.md sections", async () => {
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# My Agent\n\nSome content.\n");
+    fs.writeFileSync(path.join(tmpDir, "SOUL.md"), "# Soul");
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("AGENTS.md");
+    expect(result).toContain("SOUL.md");
+    expect(result).toContain("re-read them now");
+  });
+
+  it("includes daily memory files in inventory", async () => {
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# Agent");
+    const memDir = path.join(tmpDir, "memory");
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.writeFileSync(path.join(memDir, "2026-02-18.md"), "today");
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("memory/2026-02-18.md");
+  });
+
+  it("truncates when AGENTS.md sections exceed limit", async () => {
     const longContent = "## Session Startup\n\n" + "A".repeat(4000) + "\n\n## Other\n\nStuff.";
     fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), longContent);
     const result = await readPostCompactionContext(tmpDir);

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -4,39 +4,106 @@ import path from "node:path";
 const MAX_CONTEXT_CHARS = 3000;
 
 /**
- * Read critical sections from workspace AGENTS.md for post-compaction injection.
- * Returns formatted system event text, or null if no AGENTS.md or no relevant sections.
+ * Well-known workspace bootstrap files that agents may rely on.
+ * Order matters — higher-priority files are listed first.
+ */
+const BOOTSTRAP_FILENAMES = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  "CLAUDE.local.md",
+  "SOUL.md",
+  "IDENTITY.md",
+  "USER.md",
+  "MEMORY.md",
+  "memory.md",
+  "HEARTBEAT.md",
+  "TOOLS.md",
+];
+
+/**
+ * Scan workspace for existing bootstrap files.
+ * Returns the list of filenames that exist on disk.
+ */
+export async function detectBootstrapFiles(workspaceDir: string): Promise<string[]> {
+  const found: string[] = [];
+  for (const name of BOOTSTRAP_FILENAMES) {
+    const filePath = path.join(workspaceDir, name);
+    try {
+      await fs.promises.access(filePath);
+      found.push(name);
+    } catch {
+      // File doesn't exist — skip
+    }
+  }
+
+  // Also check for recent daily memory files (memory/YYYY-MM-DD.md)
+  const memoryDir = path.join(workspaceDir, "memory");
+  try {
+    const entries = await fs.promises.readdir(memoryDir);
+    const dailyFiles = entries
+      .filter((e) => /^\d{4}-\d{2}-\d{2}\.md$/.test(e))
+      .toSorted()
+      .toReversed()
+      .slice(0, 2); // Most recent 2 days
+    for (const daily of dailyFiles) {
+      found.push(`memory/${daily}`);
+    }
+  } catch {
+    // No memory directory — skip
+  }
+
+  return found;
+}
+
+/**
+ * Build post-compaction context for injection as a system event.
+ *
+ * Two layers:
+ * 1. Workspace-aware file inventory — tells the agent which bootstrap files
+ *    exist so it can re-read them after compaction.
+ * 2. Critical AGENTS.md sections — inlines "Session Startup" and "Red Lines"
+ *    sections directly (preserving the original behaviour).
  */
 export async function readPostCompactionContext(workspaceDir: string): Promise<string | null> {
-  const agentsPath = path.join(workspaceDir, "AGENTS.md");
-
   try {
-    if (!fs.existsSync(agentsPath)) {
-      return null;
+    const parts: string[] = [];
+
+    // Layer 1: Detect and list all bootstrap files in the workspace
+    const bootstrapFiles = await detectBootstrapFiles(workspaceDir);
+
+    if (bootstrapFiles.length > 0) {
+      parts.push(
+        "Your workspace contains these bootstrap files — re-read them now before responding:\n" +
+          bootstrapFiles.map((f) => `  - ${f}`).join("\n"),
+      );
     }
 
-    const content = await fs.promises.readFile(agentsPath, "utf-8");
+    // Layer 2: Inline critical AGENTS.md sections (if they exist)
+    const agentsPath = path.join(workspaceDir, "AGENTS.md");
+    if (fs.existsSync(agentsPath)) {
+      const content = await fs.promises.readFile(agentsPath, "utf-8");
+      const sections = extractSections(content, ["Session Startup", "Red Lines", "Every Session"]);
 
-    // Extract "## Session Startup" and "## Red Lines" sections
-    // Each section ends at the next "## " heading or end of file
-    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
-
-    if (sections.length === 0) {
-      return null;
+      if (sections.length > 0) {
+        const combined = sections.join("\n\n");
+        const safeContent =
+          combined.length > MAX_CONTEXT_CHARS
+            ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
+            : combined;
+        parts.push("Critical rules from AGENTS.md:\n\n" + safeContent);
+      }
     }
 
-    const combined = sections.join("\n\n");
-    const safeContent =
-      combined.length > MAX_CONTEXT_CHARS
-        ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
-        : combined;
+    if (parts.length === 0) {
+      return null;
+    }
 
     return (
       "[Post-compaction context refresh]\n\n" +
-      "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
-      "Execute your Session Startup sequence now — read the required files before responding to the user.\n\n" +
-      "Critical rules from AGENTS.md:\n\n" +
-      safeContent
+      "Session was just compacted. The conversation summary above is a condensed hint, " +
+      "NOT a substitute for your workspace files. " +
+      "Re-read your bootstrap files before responding to the user.\n\n" +
+      parts.join("\n\n")
     );
   } catch {
     return null;


### PR DESCRIPTION
## Problem

Fixes #20225

After auto-compaction, agents frequently forget to re-read their workspace bootstrap files. The existing post-compaction context injection only extracts `## Session Startup` and `## Red Lines` sections from AGENTS.md — but most users don't have those exact section names, so the injection returns `null` and agents lose their identity mid-session.

This is the single most common cause of "my agent forgot who it is" reports.

## Fix

Make the post-compaction context injection **workspace-aware**:

1. **Scan the workspace** for well-known bootstrap files: AGENTS.md, CLAUDE.md, CLAUDE.local.md, SOUL.md, IDENTITY.md, USER.md, MEMORY.md, HEARTBEAT.md, TOOLS.md
2. **Detect recent daily memory files** (`memory/YYYY-MM-DD.md`, most recent 2 days)
3. **Generate a file inventory** telling the agent exactly which files to re-read
4. **Also extract `## Every Session` sections** from AGENTS.md (a common pattern alongside Session Startup and Red Lines)

The file inventory and AGENTS.md sections are combined into a single system event, so agents get both a concrete list of files to re-read and any critical inline rules.

## Changes

- `src/auto-reply/reply/post-compaction-context.ts`: Add `detectBootstrapFiles()` function, enhance `readPostCompactionContext()` with two-layer approach (file inventory + AGENTS.md sections)
- `src/auto-reply/reply/post-compaction-context.test.ts`: 19 tests covering file detection, daily memory files, section extraction, and combined output

## Before / After

**Before:** Agent compacts → gets summary → has no idea what files exist → responds without identity/context.

**After:** Agent compacts → gets summary + `[Post-compaction context refresh]` listing all bootstrap files → re-reads them → responds with full context.

## Example output

```
[Post-compaction context refresh]

Session was just compacted. The conversation summary above is a condensed hint, NOT a substitute for your workspace files. Re-read your bootstrap files before responding to the user.

Your workspace contains these bootstrap files — re-read them now before responding:
  - AGENTS.md
  - SOUL.md
  - IDENTITY.md
  - USER.md
  - MEMORY.md
  - HEARTBEAT.md
  - TOOLS.md
  - memory/2026-02-18.md
  - memory/2026-02-17.md

Critical rules from AGENTS.md:

## Every Session

Before doing anything else:
1. Read SOUL.md — this is who you are
2. Read USER.md — this is who you're helping
...
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the post-compaction context injection to be workspace-aware, addressing the common issue of agents losing their identity after auto-compaction. Instead of only extracting specific AGENTS.md sections (which many users don't have), the system now scans for well-known bootstrap files (AGENTS.md, CLAUDE.md, SOUL.md, etc.) and recent daily memory files, then generates a file inventory instructing the agent to re-read them. It also adds extraction of `## Every Session` sections from AGENTS.md.

- Adds `detectBootstrapFiles()` to scan for well-known workspace files and recent daily memory entries (`memory/YYYY-MM-DD.md`, limited to 2 most recent)
- Enhances `readPostCompactionContext()` with a two-layer approach: file inventory listing + inlined critical AGENTS.md sections
- Returns `null` only when zero workspace files exist (previously returned `null` when AGENTS.md lacked specific section names)
- Adds "Every Session" to the list of extracted section names alongside "Session Startup" and "Red Lines"
- 19 comprehensive tests covering detection, filtering, section extraction, truncation, and combined output
- **Issue**: `MEMORY.md` and `memory.md` are both in the bootstrap file list — on case-insensitive filesystems (macOS), both will resolve to the same file, producing duplicate entries in the inventory

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor filesystem edge case to consider on macOS.
- The changes are well-structured with a clean two-layer design, comprehensive test coverage (19 tests), and graceful error handling (try/catch with null fallback). The only issue found is a duplicate detection bug on case-insensitive filesystems where both MEMORY.md and memory.md entries would resolve to the same file. The feature is best-effort (silent failure on errors) and doesn't affect core agent execution paths.
- `src/auto-reply/reply/post-compaction-context.ts` — the `BOOTSTRAP_FILENAMES` array contains both `MEMORY.md` and `memory.md`, which will produce duplicate entries on case-insensitive filesystems (macOS).

<sub>Last reviewed commit: ba0af93</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->