### PR TITLE
Add Claude Sonnet 4.6 and 4.5 to GitHub Copilot model catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Copilot: add `claude-sonnet-4.6` and `claude-sonnet-4.5` to the default GitHub Copilot model catalog and add coverage for model-list/definition helpers. (#20270, fixes #20091) Thanks @Clawborn.
 - Config/Agents: expose Pi compaction tuning values `agents.defaults.compaction.reserveTokens` and `agents.defaults.compaction.keepRecentTokens` in config schema/types and apply them in embedded Pi runner settings overrides with floor enforcement via `reserveTokensFloor`. (#21568) Thanks @Takhoffman.
 - Auto-reply/WebChat: avoid defaulting inbound runtime channel labels to unrelated providers (for example `whatsapp`) for webchat sessions so channel-specific formatting guidance stays accurate. (#21534) Thanks @lbo728.
 - Status: include persisted `cacheRead`/`cacheWrite` in session summaries so compact `/status` output consistently shows cache hit percentages from real session data.

--- a/src/providers/github-copilot-models.test.ts
+++ b/src/providers/github-copilot-models.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildCopilotModelDefinition, getDefaultCopilotModelIds } from "./github-copilot-models.js";
+
+describe("github-copilot-models", () => {
+  describe("getDefaultCopilotModelIds", () => {
+    it("includes claude-sonnet-4.6", () => {
+      expect(getDefaultCopilotModelIds()).toContain("claude-sonnet-4.6");
+    });
+
+    it("includes claude-sonnet-4.5", () => {
+      expect(getDefaultCopilotModelIds()).toContain("claude-sonnet-4.5");
+    });
+
+    it("returns a mutable copy", () => {
+      const a = getDefaultCopilotModelIds();
+      const b = getDefaultCopilotModelIds();
+      expect(a).not.toBe(b);
+      expect(a).toEqual(b);
+    });
+  });
+
+  describe("buildCopilotModelDefinition", () => {
+    it("builds a valid definition for claude-sonnet-4.6", () => {
+      const def = buildCopilotModelDefinition("claude-sonnet-4.6");
+      expect(def.id).toBe("claude-sonnet-4.6");
+      expect(def.api).toBe("openai-responses");
+    });
+
+    it("trims whitespace from model id", () => {
+      const def = buildCopilotModelDefinition("  gpt-4o  ");
+      expect(def.id).toBe("gpt-4o");
+    });
+
+    it("throws on empty model id", () => {
+      expect(() => buildCopilotModelDefinition("")).toThrow("Model id required");
+      expect(() => buildCopilotModelDefinition("  ")).toThrow("Model id required");
+    });
+  });
+});

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -7,6 +7,8 @@ const DEFAULT_MAX_TOKENS = 8192;
 // We keep this list intentionally broad; if a model isn't available Copilot will
 // return an error and users can remove it from their config.
 const DEFAULT_MODEL_IDS = [
+  "claude-sonnet-4.6",
+  "claude-sonnet-4.5",
   "gpt-4o",
   "gpt-4.1",
   "gpt-4.1-mini",


### PR DESCRIPTION
## Problem

The `DEFAULT_MODEL_IDS` list in `github-copilot-models.ts` does not include any Claude models. Users configuring `github-copilot/claude-sonnet-4.6` experience silent failures — the model ID is unknown to the provider and requests fall through the fallback chain with no reply.

Claude Sonnet 4.6 is available and selectable in VS Code's GitHub Copilot model picker, but OpenClaw's Copilot provider catalog hasn't been updated to include it.

Fixes #20091

## Changes

- Add `claude-sonnet-4.6` and `claude-sonnet-4.5` to `DEFAULT_MODEL_IDS` in `github-copilot-models.ts`
- Add unit tests for `getDefaultCopilotModelIds` and `buildCopilotModelDefinition`

## Testing

6 new tests covering model list contents, immutability, definition building, whitespace trimming, and empty ID rejection.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `claude-sonnet-4.6` and `claude-sonnet-4.5` to the GitHub Copilot provider's `DEFAULT_MODEL_IDS` list, enabling users to configure these Claude models without silent failures. Includes a new test file covering both exported functions.

- Adds two Claude Sonnet model entries to `DEFAULT_MODEL_IDS` in `src/providers/github-copilot-models.ts`
- New test file `src/providers/github-copilot-models.test.ts` with 6 tests covering model list contents, immutability, definition building, whitespace trimming, and empty ID rejection
- Note: the separate `extensions/copilot-proxy/index.ts` has its own `DEFAULT_MODEL_IDS` that already includes `claude-sonnet-4.5` but not `claude-sonnet-4.6` — may warrant a follow-up

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds two string entries to a model ID list and introduces well-structured unit tests.
- The change is minimal (two string additions to an array) with no logic changes, no new dependencies, and no security implications. The existing code comment explicitly notes that model lists are intentionally broad and Copilot will gracefully error if a model isn't available. Tests are clean and cover the exported API.
- No files require special attention. The `extensions/copilot-proxy/index.ts` has a separate model list that may benefit from a follow-up update to include `claude-sonnet-4.6`, but that is outside this PR's scope.

<sub>Last reviewed commit: 6fd94ef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->