### PR TITLE
fix: LaunchAgent KeepAlive causes restart loop (fixes #20257)

### DIFF
--- a/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
@@ -42,7 +42,10 @@ enum LaunchAgentManager {
           <key>RunAtLoad</key>
           <true/>
           <key>KeepAlive</key>
-          <true/>
+          <dict>
+            <key>SuccessfulExit</key>
+            <false/>
+          </dict>
           <key>EnvironmentVariables</key>
           <dict>
             <key>PATH</key>

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -106,5 +106,31 @@ export function buildLaunchAgentPlist({
     ? `\n    <key>Comment</key>\n    <string>${plistEscape(comment.trim())}</string>`
     : "";
   const envXml = renderEnvDict(environment);
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>${plistEscape(label)}</string>
+    ${commentXml}
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+    <key>ProgramArguments</key>
+    <array>${argsXml}
+    </array>
+    ${workingDirXml}
+    <key>StandardOutPath</key>
+    <string>${plistEscape(stdoutPath)}</string>
+    <key>StandardErrorPath</key>
+    <string>${plistEscape(stderrPath)}</string>${envXml}
+  </dict>
+</plist>
+`;
 }

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -170,7 +170,10 @@ async function auditLaunchdPlist(
   }
 
   const hasRunAtLoad = /<key>RunAtLoad<\/key>\s*<true\s*\/>/i.test(content);
-  const hasKeepAlive = /<key>KeepAlive<\/key>\s*<true\s*\/>/i.test(content);
+  // Accept both <true/> format and <dict> format (e.g., with SuccessfulExit)
+  const hasKeepAlive =
+    /<key>KeepAlive<\/key>\s*<true\s*\/>/i.test(content) ||
+    /<key>KeepAlive<\/key>\s*<dict>/i.test(content);
   if (!hasRunAtLoad) {
     issues.push({
       code: SERVICE_AUDIT_CODES.launchdRunAtLoad,


### PR DESCRIPTION
## Bug Summary
When both LaunchAgent (KeepAlive: true) and the App's GatewayLaunchAgentManager manage the gateway lifecycle, they conflict — causing a restart loop, duplicate processes, and 100% CPU.

This is because KeepAlive: true tells launchd to restart the gateway whenever it exits (for any reason). Combined with the App's periodic SIGUSR1 signals (issue #10600), this creates a continuous restart loop.

## Root Cause
- `KeepAlive: true` in the LaunchAgent plist causes launchd to restart gateway on every exit
- App sends periodic SIGUSR1 signals every 8-11 minutes (issue #10600)
- Each SIGUSR1 triggers gateway restart, which launchd immediately restarts due to KeepAlive: true
- Results in continuous restart loop, duplicate processes, 100% CPU

## Fix
1. Changed `KeepAlive: true` to `KeepAlive: { SuccessfulExit: false }` — only restart on crash (non-zero exit), not on intentional stop
2. Added `ThrottleInterval: 5` to prevent exponential backoff on crash loops (related to issue #4632)

## Testing
- [x] pnpm install
- [x] pnpm build  
- [x] pnpm check (format + lint + typecheck)
- [x] pnpm test (launchd tests pass)

---
**AI-assisted code** - This fix was generated by an automated bug-fix agent.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes the LaunchAgent `KeepAlive` setting from `true` to `{ SuccessfulExit: false }` and adds `ThrottleInterval: 5` to prevent restart loops caused by launchd restarting the gateway on every exit (including intentional SIGUSR1-triggered restarts). The template is also reformatted from a single-line string to a multi-line template literal for readability.

- **Service audit regression**: `src/daemon/service-audit.ts:173` uses a regex that only matches `KeepAlive` followed by `<true/>`. After this change, the plist uses a dict-based `KeepAlive`, so the audit will emit false-positive `"LaunchAgent is missing KeepAlive=true"` warnings for every correctly-configured installation. The audit check needs to be updated to accept the new format.
- **macOS app divergence**: `apps/macos/Sources/OpenClaw/LaunchAgentManager.swift:44` still generates `KeepAlive: true` in its own plist. If the macOS app's LaunchAgent has the same restart-loop issue, it should be updated as well for consistency.

<h3>Confidence Score: 2/5</h3>

- This PR introduces a regression in the service audit system that will produce false-positive warnings for all installations
- The core KeepAlive and ThrottleInterval changes are correct and well-motivated, but the PR does not update the service-audit.ts regex that validates plist contents. After this change, every correctly-configured installation will be flagged with a spurious 'LaunchAgent is missing KeepAlive=true' warning. This is a functional regression that needs to be addressed before merging.
- `src/daemon/service-audit.ts` needs its KeepAlive regex updated to accept the new dict-based format. `apps/macos/Sources/OpenClaw/LaunchAgentManager.swift` may also need the same KeepAlive change for consistency.

<sub>Last reviewed commit: 34d8426</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->