### PR TITLE
Cron: add simple direct-command scheduled jobs (runtime, CLI, dashboard)

### DIFF
--- a/.agents/skills/PR_WORKFLOW.md
+++ b/.agents/skills/PR_WORKFLOW.md
@@ -110,7 +110,7 @@ Before any substantive review or prep work, **always rebase the PR branch onto c
 - During `prepare-pr`, use concise, action-oriented subjects **without** PR numbers or thanks; reserve `(#<PR>) thanks @<pr-author>` for the final merge/squash commit.
 - Group related changes; avoid bundling unrelated refactors.
 - Changelog workflow: keep the latest released version at the top (no `Unreleased`); after publishing, bump the version and start a new top section.
-- When working on a PR: add a changelog entry with the PR number and thank the contributor (mandatory in this workflow).
+- When working on a PR: add a changelog entry line with the PR number `(#<PR>)` and `thanks @<pr-author>` when author metadata is available (mandatory in this workflow).
 - When working on an issue: reference the issue in the changelog entry.
 - In this workflow, changelog is always required even for internal/test-only changes.
 

--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -41,11 +41,12 @@ scripts/pr-merge <PR>
 scripts/pr-merge run <PR>
 ```
 
-3. Ensure output reports:
+3. Capture and report these values in a human-readable summary (not raw `key=value` lines):
 
-- `merge_sha=<sha>`
-- `merge_author_email=<email>`
-- `comment_url=<url>`
+- Merge commit SHA
+- Merge author email
+- Merge completion comment URL
+- PR URL
 
 ## Steps
 
@@ -97,3 +98,4 @@ Cleanup is handled by `run` after merge success.
 
 - End in `MERGED`, never `CLOSED`.
 - Cleanup only after confirmed merge.
+- In final chat output, use labeled lines or bullets; do not paste raw wrapper diagnostics unless debugging.

--- a/.agents/skills/prepare-pr/SKILL.md
+++ b/.agents/skills/prepare-pr/SKILL.md
@@ -74,6 +74,11 @@ jq -r '.changelog' .local/review.json
 jq -r '.docs' .local/review.json
 ```
 
+Changelog gate requirement:
+
+- `CHANGELOG.md` must include a newly added changelog entry line.
+- When PR author metadata is available, that same changelog entry line must include `(#<PR>) thanks @<pr-author>`.
+
 4. Commit scoped changes
 
 Use concise, action-oriented subject lines without PR numbers/thanks. The final merge/squash commit is the only place we include PR numbers and contributor thanks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: unify message-like inbound handling so `message` and `channel_post` share the same dedupe/access/media pipeline and remain behaviorally consistent. (#20591) Thanks @obviyus.
 - Telegram/Agents: gate exec/bash tool-failure warnings behind verbose mode so default Telegram replies stay clean while verbose sessions still surface diagnostics. (#20560) Thanks @obviyus.
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
 - Agents/Billing: include the active model that produced a billing error in user-facing billing messages (for example, `OpenAI (gpt-5.3)`) across payload, failover, and lifecycle error paths, so users can identify exactly which key needs credits. (#20510) Thanks @echoVic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/Agents: gate exec/bash tool-failure warnings behind verbose mode so default Telegram replies stay clean while verbose sessions still surface diagnostics. (#20560) Thanks @obviyus.
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
 - Agents/Billing: include the active model that produced a billing error in user-facing billing messages (for example, `OpenAI (gpt-5.3)`) across payload, failover, and lifecycle error paths, so users can identify exactly which key needs credits. (#20510) Thanks @echoVic.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Canvas/A2UI: improve bundled-asset resolution and empty-state handling so UI fallbacks render reliably. (#20312) Thanks @mbelinky.
 - UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - OpenClawKit/Protocol: preserve JSON boolean literals (`true`/`false`) when bridging through `AnyCodable` so Apple client RPC params no longer re-encode booleans as `1`/`0`. Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/APNs: add a push-test pipeline for APNs delivery validation in gateway flows. (#20307) Thanks @mbelinky.
 - iOS/Watch: add an Apple Watch companion MVP with watch inbox UI, watch notification relay handling, and gateway command surfaces for watch status/send flows. (#20054) Thanks @mbelinky.
 - Gateway/CLI: add paired-device hygiene flows with `device.pair.remove`, plus `openclaw devices remove` and guarded `openclaw devices clear --yes [--pending]` commands for removing paired entries and optionally rejecting pending requests. (#20057) Thanks @mbelinky.
 - Skills: harden coding-agent skill guidance by removing shell-command examples that interpolate untrusted issue text directly into command strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
+- Agents/Billing: include the active model that produced a billing error in user-facing billing messages (for example, `OpenAI (gpt-5.3)`) across payload, failover, and lifecycle error paths, so users can identify exactly which key needs credits. (#20510) Thanks @echoVic.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - Gateway/TUI: honor `agents.defaults.blockStreamingDefault` for `chat.send` by removing the hardcoded block-streaming disable override, so replies can use configured block-mode delivery. (#19693) Thanks @neipor.
 - Protocol/Apple: regenerate Swift gateway models for `push.test` so `pnpm protocol:check` stays green on main. Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- iOS/APNs: add push registration and notification-signing configuration for node delivery. (#20308) Thanks @mbelinky.
 - Gateway/APNs: add a push-test pipeline for APNs delivery validation in gateway flows. (#20307) Thanks @mbelinky.
 - iOS/Watch: add an Apple Watch companion MVP with watch inbox UI, watch notification relay handling, and gateway command surfaces for watch status/send flows. (#20054) Thanks @mbelinky.
 - Gateway/CLI: add paired-device hygiene flows with `device.pair.remove`, plus `openclaw devices remove` and guarded `openclaw devices clear --yes [--pending]` commands for removing paired entries and optionally rejecting pending requests. (#20057) Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - Gateway/TUI: honor `agents.defaults.blockStreamingDefault` for `chat.send` by removing the hardcoded block-streaming disable override, so replies can use configured block-mode delivery. (#19693) Thanks @neipor.
 - Protocol/Apple: regenerate Swift gateway models for `push.test` so `pnpm protocol:check` stays green on main. Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - OpenClawKit/Protocol: preserve JSON boolean literals (`true`/`false`) when bridging through `AnyCodable` so Apple client RPC params no longer re-encode booleans as `1`/`0`. Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.
 - Browser/Relay: reuse an already-running extension relay when the relay port is occupied by another OpenClaw process, while still failing on non-relay port collisions to avoid masking unrelated listeners. (#20035) Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - Protocol/Apple: regenerate Swift gateway models for `push.test` so `pnpm protocol:check` stays green on main. Thanks @mbelinky.
 - Canvas/A2UI: improve bundled-asset resolution and empty-state handling so UI fallbacks render reliably. (#20312) Thanks @mbelinky.
 - UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Protocol/Apple: regenerate Swift gateway models for `push.test` so `pnpm protocol:check` stays green on main. Thanks @mbelinky.
 - Canvas/A2UI: improve bundled-asset resolution and empty-state handling so UI fallbacks render reliably. (#20312) Thanks @mbelinky.
 - UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
+- Gateway/TUI: honor `agents.defaults.blockStreamingDefault` for `chat.send` by removing the hardcoded block-streaming disable override, so replies can use configured block-mode delivery. (#19693) Thanks @neipor.
 - Protocol/Apple: regenerate Swift gateway models for `push.test` so `pnpm protocol:check` stays green on main. Thanks @mbelinky.
 - Canvas/A2UI: improve bundled-asset resolution and empty-state handling so UI fallbacks render reliably. (#20312) Thanks @mbelinky.
 - UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- iOS/Gateway: wake disconnected iOS nodes via APNs before `nodes.invoke` and auto-reconnect gateway sessions on silent push wake to reduce invoke failures while the app is backgrounded. (#20332) Thanks @mbelinky.
 - iOS/APNs: add push registration and notification-signing configuration for node delivery. (#20308) Thanks @mbelinky.
 - Gateway/APNs: add a push-test pipeline for APNs delivery validation in gateway flows. (#20307) Thanks @mbelinky.
 - iOS/Watch: add an Apple Watch companion MVP with watch inbox UI, watch notification relay handling, and gateway command surfaces for watch status/send flows. (#20054) Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - OpenClawKit/Protocol: preserve JSON boolean literals (`true`/`false`) when bridging through `AnyCodable` so Apple client RPC params no longer re-encode booleans as `1`/`0`. Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.

--- a/apps/ios/.swiftlint.yml
+++ b/apps/ios/.swiftlint.yml
@@ -3,3 +3,7 @@ parent_config: ../../.swiftlint.yml
 included:
   - Sources
   - ../shared/ClawdisNodeKit/Sources
+
+type_body_length:
+  warning: 900
+  error: 1300

--- a/apps/ios/Config/Signing.xcconfig
+++ b/apps/ios/Config/Signing.xcconfig
@@ -1,10 +1,14 @@
 // Shared iOS signing defaults for local development + CI.
 OPENCLAW_IOS_DEFAULT_TEAM = Y5PE65HELJ
 OPENCLAW_IOS_SELECTED_TEAM = $(OPENCLAW_IOS_DEFAULT_TEAM)
+OPENCLAW_APP_BUNDLE_ID = ai.openclaw.ios
+OPENCLAW_WATCH_APP_BUNDLE_ID = ai.openclaw.ios.watchkitapp
+OPENCLAW_WATCH_EXTENSION_BUNDLE_ID = ai.openclaw.ios.watchkitapp.extension
 
 // Local contributors can override this by running scripts/ios-configure-signing.sh.
 // Keep include after defaults: xcconfig is evaluated top-to-bottom.
 #include? "../.local-signing.xcconfig"
+#include? "../LocalSigning.xcconfig"
 
 CODE_SIGN_STYLE = Automatic
 CODE_SIGN_IDENTITY = Apple Development

--- a/apps/ios/LocalSigning.xcconfig.example
+++ b/apps/ios/LocalSigning.xcconfig.example
@@ -6,6 +6,8 @@ OPENCLAW_DEVELOPMENT_TEAM = P5Z8X89DJL
 
 OPENCLAW_APP_BUNDLE_ID = ai.openclaw.ios.test.mariano
 OPENCLAW_SHARE_BUNDLE_ID = ai.openclaw.ios.test.mariano.share
+OPENCLAW_WATCH_APP_BUNDLE_ID = ai.openclaw.ios.test.mariano.watchkitapp
+OPENCLAW_WATCH_EXTENSION_BUNDLE_ID = ai.openclaw.ios.test.mariano.watchkitapp.extension
 
 // Leave empty with automatic signing.
 OPENCLAW_APP_PROFILE =

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -1,73 +1,110 @@
-# OpenClaw (iOS)
+# OpenClaw iOS (Super Alpha)
 
-This is an **alpha** iOS app that connects to an OpenClaw Gateway as a `role: node`.
+NO TEST FLIGHT AVAILABLE AT THIS POINT
 
-Expect rough edges:
+This iPhone app is super-alpha and internal-use only. It connects to an OpenClaw Gateway as a `role: node`.
 
-- UI and onboarding are changing quickly.
-- Background behavior is not stable yet (foreground app is the supported mode right now).
-- Permissions are opt-in and the app should be treated as sensitive while we harden it.
+## Distribution Status
 
-## What It Does
+NO TEST FLIGHT AVAILABLE AT THIS POINT
 
-- Connects to a Gateway over `ws://` / `wss://`
-- Pairs a new device (approved from your bot)
-- Exposes phone services as node commands (camera, location, photos, calendar, reminders, etc; gated by iOS permissions)
-- Provides Talk + Chat surfaces (alpha)
+- Current distribution: local/manual deploy from source via Xcode.
+- App Store flow is not part of the current internal development path.
 
-## Pairing (Recommended Flow)
+## Super-Alpha Disclaimer
 
-If your Gateway has the `device-pair` plugin installed:
+- Breaking changes are expected.
+- UI and onboarding flows can change without migration guarantees.
+- Foreground use is the only reliable mode right now.
+- Treat this build as sensitive while permissions and background behavior are still being hardened.
 
-1. In Telegram, message your bot: `/pair`
-2. Copy the **setup code** message
-3. On iOS: OpenClaw → Settings → Gateway → paste setup code → Connect
-4. Back in Telegram: `/pair approve`
+## Exact Xcode Manual Deploy Flow
 
-## Build And Run
-
-Prereqs:
-
-- Xcode (current stable)
-- `pnpm`
-- `xcodegen`
-
-From the repo root:
+1. Prereqs:
+   - Xcode 16+
+   - `pnpm`
+   - `xcodegen`
+   - Apple Development signing set up in Xcode
+2. From repo root:
 
 ```bash
 pnpm install
+./scripts/ios-configure-signing.sh
+cd apps/ios
+xcodegen generate
+open OpenClaw.xcodeproj
+```
+
+3. In Xcode:
+   - Scheme: `OpenClaw`
+   - Destination: connected iPhone (recommended for real behavior)
+   - Build configuration: `Debug`
+   - Run (`Product` -> `Run`)
+4. If signing fails on a personal team:
+   - Use unique local bundle IDs via `apps/ios/LocalSigning.xcconfig`.
+   - Start from `apps/ios/LocalSigning.xcconfig.example`.
+
+Shortcut command (same flow + open project):
+
+```bash
 pnpm ios:open
 ```
 
-`pnpm ios:open` now runs `scripts/ios-configure-signing.sh` before `xcodegen`:
+## APNs Expectations For Local/Manual Builds
 
-- If `IOS_DEVELOPMENT_TEAM` is set, it uses that team.
-- Otherwise it prefers the canonical OpenClaw team (`Y5PE65HELJ`) when that team exists locally.
-- If not present, it picks the first non-personal team from your Xcode account (falls back to personal team if needed).
-- It writes the selected team to `apps/ios/.local-signing.xcconfig` (local-only, gitignored).
+- The app calls `registerForRemoteNotifications()` at launch.
+- `apps/ios/Sources/OpenClaw.entitlements` sets `aps-environment` to `development`.
+- APNs token registration to gateway happens only after gateway connection (`push.apns.register`).
+- Your selected team/profile must support Push Notifications for the app bundle ID you are signing.
+- If push capability or provisioning is wrong, APNs registration fails at runtime (check Xcode logs for `APNs registration failed`).
+- Debug builds register as APNs sandbox; Release builds use production.
 
-Then in Xcode:
+## What Works Now (Concrete)
 
-1. Select the `OpenClaw` scheme
-2. Select a simulator or a connected device
-3. Run
+- Pairing via setup code flow (`/pair` then `/pair approve` in Telegram).
+- Gateway connection via discovery or manual host/port with TLS fingerprint trust prompt.
+- Chat + Talk surfaces through the operator gateway session.
+- iPhone node commands in foreground: camera snap/clip, canvas present/navigate/eval/snapshot, screen record, location, contacts, calendar, reminders, photos, motion, local notifications.
+- Share extension deep-link forwarding into the connected gateway session.
 
-If you're using a personal Apple Development team, you may still need to change the bundle identifier in Xcode to a unique value so signing succeeds.
+## Known Issues / Limitations / Problems
 
-## Build From CLI
+- Foreground-first: iOS can suspend sockets in background; reconnect recovery is still being tuned.
+- Background command limits are strict: `canvas.*`, `camera.*`, `screen.*`, and `talk.*` are blocked when backgrounded.
+- Background location requires `Always` location permission.
+- Pairing/auth errors intentionally pause reconnect loops until a human fixes auth/pairing state.
+- Voice Wake and Talk contend for the same microphone; Talk suppresses wake capture while active.
+- APNs reliability depends on local signing/provisioning/topic alignment.
+- Expect rough UX edges and occasional reconnect churn during active development.
 
-```bash
-pnpm ios:build
-```
+## Current In-Progress Workstream
 
-## Tests
+Automatic wake/reconnect hardening:
 
-```bash
-cd apps/ios
-xcodegen generate
-xcodebuild test -project OpenClaw.xcodeproj -scheme OpenClaw -destination "platform=iOS Simulator,name=iPhone 17"
-```
+- improve wake/resume behavior across scene transitions
+- reduce dead-socket states after background -> foreground
+- tighten node/operator session reconnect coordination
+- reduce manual recovery steps after transient network failures
 
-## Shared Code
+## Debugging Checklist
 
-- `apps/shared/OpenClawKit` contains the shared transport/types used by the iOS app.
+1. Confirm build/signing baseline:
+   - regenerate project (`xcodegen generate`)
+   - verify selected team + bundle IDs
+2. In app `Settings -> Gateway`:
+   - confirm status text, server, and remote address
+   - verify whether status shows pairing/auth gating
+3. If pairing is required:
+   - run `/pair approve` from Telegram, then reconnect
+4. If discovery is flaky:
+   - enable `Discovery Debug Logs`
+   - inspect `Settings -> Gateway -> Discovery Logs`
+5. If network path is unclear:
+   - switch to manual host/port + TLS in Gateway Advanced settings
+6. In Xcode console, filter for subsystem/category signals:
+   - `ai.openclaw.ios`
+   - `GatewayDiag`
+   - `APNs registration failed`
+7. Validate background expectations:
+   - repro in foreground first
+   - then test background transitions and confirm reconnect on return

--- a/apps/ios/ShareExtension/Info.plist
+++ b/apps/ios/ShareExtension/Info.plist
@@ -4,14 +4,14 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>OpenClaw Share</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleDisplayName</key>
-	<string>OpenClaw Share</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
@@ -28,6 +28,8 @@
 			<dict>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
 				<integer>10</integer>
+				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
+				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -62,6 +62,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -73,26 +73,6 @@ final class NodeAppModel {
     var lastShareEventText: String = "No share events yet."
     var openChatRequestID: Int = 0
 
-    var mainSessionKey: String {
-        let base = SessionKey.normalizeMainKey(self.mainSessionBaseKey)
-        let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if agentId.isEmpty || (!defaultId.isEmpty && agentId == defaultId) { return base }
-        return SessionKey.makeAgentSessionKey(agentId: agentId, baseKey: base)
-    }
-
-    var activeAgentName: String {
-        let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedId = agentId.isEmpty ? defaultId : agentId
-        if resolvedId.isEmpty { return "Main" }
-        if let match = self.gatewayAgents.first(where: { $0.id == resolvedId }) {
-            let name = (match.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-            return name.isEmpty ? match.id : name
-        }
-        return resolvedId
-    }
-
     // Primary "node" connection: used for device capabilities and node.invoke requests.
     private let nodeGateway = GatewayNodeSession()
     // Secondary "operator" connection: used for chat/talk/config/voicewake requests.
@@ -1615,6 +1595,26 @@ private extension NodeAppModel {
 }
 
 extension NodeAppModel {
+    var mainSessionKey: String {
+        let base = SessionKey.normalizeMainKey(self.mainSessionBaseKey)
+        let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if agentId.isEmpty || (!defaultId.isEmpty && agentId == defaultId) { return base }
+        return SessionKey.makeAgentSessionKey(agentId: agentId, baseKey: base)
+    }
+
+    var activeAgentName: String {
+        let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedId = agentId.isEmpty ? defaultId : agentId
+        if resolvedId.isEmpty { return "Main" }
+        if let match = self.gatewayAgents.first(where: { $0.id == resolvedId }) {
+            let name = (match.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            return name.isEmpty ? match.id : name
+        }
+        return resolvedId
+    }
+
     func connectToGateway(
         url: URL,
         gatewayStableID: String,

--- a/apps/ios/Sources/OpenClaw.entitlements
+++ b/apps/ios/Sources/OpenClaw.entitlements
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>
+

--- a/apps/ios/Sources/OpenClawApp.swift
+++ b/apps/ios/Sources/OpenClawApp.swift
@@ -1,10 +1,51 @@
 import SwiftUI
 import Foundation
+import os
+import UIKit
+
+final class OpenClawAppDelegate: NSObject, UIApplicationDelegate {
+    private let logger = Logger(subsystem: "ai.openclaw.ios", category: "Push")
+    private var pendingAPNsDeviceToken: Data?
+    weak var appModel: NodeAppModel? {
+        didSet {
+            guard let model = self.appModel, let token = self.pendingAPNsDeviceToken else { return }
+            self.pendingAPNsDeviceToken = nil
+            Task { @MainActor in
+                model.updateAPNsDeviceToken(token)
+            }
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool
+    {
+        application.registerForRemoteNotifications()
+        return true
+    }
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        if let appModel = self.appModel {
+            Task { @MainActor in
+                appModel.updateAPNsDeviceToken(deviceToken)
+            }
+            return
+        }
+
+        self.pendingAPNsDeviceToken = deviceToken
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: any Error) {
+        self.logger.error("APNs registration failed: \(error.localizedDescription, privacy: .public)")
+    }
+}
 
 @main
 struct OpenClawApp: App {
     @State private var appModel: NodeAppModel
     @State private var gatewayController: GatewayConnectionController
+    @UIApplicationDelegateAdaptor(OpenClawAppDelegate.self) private var appDelegate
     @Environment(\.scenePhase) private var scenePhase
 
     init() {
@@ -21,6 +62,9 @@ struct OpenClawApp: App {
                 .environment(self.appModel)
                 .environment(self.appModel.voiceWake)
                 .environment(self.gatewayController)
+                .task {
+                    self.appDelegate.appModel = self.appModel
+                }
                 .onOpenURL { url in
                     Task { await self.appModel.handleDeepLink(url: url) }
                 }

--- a/apps/ios/Sources/Screen/ScreenWebView.swift
+++ b/apps/ios/Sources/Screen/ScreenWebView.swift
@@ -5,11 +5,189 @@ import WebKit
 struct ScreenWebView: UIViewRepresentable {
     var controller: ScreenController
 
-    func makeUIView(context: Context) -> WKWebView {
-        self.controller.webView
+    func makeCoordinator() -> ScreenWebViewCoordinator {
+        ScreenWebViewCoordinator(controller: self.controller)
     }
 
-    func updateUIView(_ webView: WKWebView, context: Context) {
-        // State changes are driven by ScreenController.
+    func makeUIView(context: Context) -> UIView {
+        context.coordinator.makeContainerView()
+    }
+
+    func updateUIView(_: UIView, context: Context) {
+        context.coordinator.updateController(self.controller)
+    }
+
+    static func dismantleUIView(_: UIView, coordinator: ScreenWebViewCoordinator) {
+        coordinator.teardown()
+    }
+}
+
+@MainActor
+final class ScreenWebViewCoordinator: NSObject {
+    private weak var controller: ScreenController?
+    private let navigationDelegate = ScreenNavigationDelegate()
+    private let a2uiActionHandler = CanvasA2UIActionMessageHandler()
+    private let userContentController = WKUserContentController()
+
+    private(set) var managedWebView: WKWebView?
+    private weak var containerView: UIView?
+
+    init(controller: ScreenController) {
+        self.controller = controller
+        super.init()
+        self.navigationDelegate.controller = controller
+        self.a2uiActionHandler.controller = controller
+    }
+
+    func makeContainerView() -> UIView {
+        if let containerView {
+            return containerView
+        }
+
+        let container = UIView(frame: .zero)
+        container.backgroundColor = .black
+
+        let webView = Self.makeWebView(userContentController: self.userContentController)
+        webView.navigationDelegate = self.navigationDelegate
+        self.installA2UIHandlers()
+
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: container.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        self.managedWebView = webView
+        self.containerView = container
+        self.controller?.attachWebView(webView)
+        return container
+    }
+
+    func updateController(_ controller: ScreenController) {
+        let previousController = self.controller
+        let controllerChanged = self.controller !== controller
+        self.controller = controller
+        self.navigationDelegate.controller = controller
+        self.a2uiActionHandler.controller = controller
+        if controllerChanged, let managedWebView {
+            previousController?.detachWebView(managedWebView)
+            controller.attachWebView(managedWebView)
+        }
+    }
+
+    func teardown() {
+        if let managedWebView {
+            self.controller?.detachWebView(managedWebView)
+            managedWebView.navigationDelegate = nil
+        }
+        self.removeA2UIHandlers()
+        self.navigationDelegate.controller = nil
+        self.a2uiActionHandler.controller = nil
+        self.managedWebView = nil
+        self.containerView = nil
+    }
+
+    private static func makeWebView(userContentController: WKUserContentController) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+        config.userContentController = userContentController
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        // Canvas scaffold is a fully self-contained HTML page; avoid relying on transparency underlays.
+        webView.isOpaque = true
+        webView.backgroundColor = .black
+
+        let scrollView = webView.scrollView
+        scrollView.backgroundColor = .black
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.contentInset = .zero
+        scrollView.scrollIndicatorInsets = .zero
+        scrollView.automaticallyAdjustsScrollIndicatorInsets = false
+
+        return webView
+    }
+
+    private func installA2UIHandlers() {
+        for name in CanvasA2UIActionMessageHandler.handlerNames {
+            self.userContentController.add(self.a2uiActionHandler, name: name)
+        }
+    }
+
+    private func removeA2UIHandlers() {
+        for name in CanvasA2UIActionMessageHandler.handlerNames {
+            self.userContentController.removeScriptMessageHandler(forName: name)
+        }
+    }
+}
+
+// MARK: - Navigation Delegate
+
+/// Handles navigation policy to intercept openclaw:// deep links from canvas
+@MainActor
+private final class ScreenNavigationDelegate: NSObject, WKNavigationDelegate {
+    weak var controller: ScreenController?
+
+    func webView(
+        _: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void)
+    {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        // Intercept openclaw:// deep links.
+        if url.scheme?.lowercased() == "openclaw" {
+            decisionHandler(.cancel)
+            self.controller?.onDeepLink?(url)
+            return
+        }
+
+        decisionHandler(.allow)
+    }
+
+    func webView(
+        _: WKWebView,
+        didFailProvisionalNavigation _: WKNavigation?,
+        withError error: any Error)
+    {
+        self.controller?.errorText = error.localizedDescription
+    }
+
+    func webView(_: WKWebView, didFinish _: WKNavigation?) {
+        self.controller?.errorText = nil
+        self.controller?.applyDebugStatusIfNeeded()
+    }
+
+    func webView(_: WKWebView, didFail _: WKNavigation?, withError error: any Error) {
+        self.controller?.errorText = error.localizedDescription
+    }
+}
+
+private final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {
+    static let messageName = "openclawCanvasA2UIAction"
+    static let handlerNames = [messageName]
+
+    weak var controller: ScreenController?
+
+    func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard Self.handlerNames.contains(message.name) else { return }
+        guard let controller else { return }
+
+        guard let url = message.webView?.url else { return }
+        if url.isFileURL {
+            guard controller.isTrustedCanvasUIURL(url) else { return }
+        } else {
+            // For security, only accept actions from local-network pages (e.g. the canvas host).
+            guard controller.isLocalNetworkCanvasURL(url) else { return }
+        }
+
+        guard let body = ScreenController.parseA2UIActionBody(message.body) else { return }
+
+        controller.onA2UIAction?(body)
     }
 }

--- a/apps/ios/Tests/ScreenControllerTests.swift
+++ b/apps/ios/Tests/ScreenControllerTests.swift
@@ -2,25 +2,38 @@ import Testing
 import WebKit
 @testable import OpenClaw
 
+@MainActor
+private func mountScreen(_ screen: ScreenController) throws -> (ScreenWebViewCoordinator, WKWebView) {
+    let coordinator = ScreenWebViewCoordinator(controller: screen)
+    _ = coordinator.makeContainerView()
+    let webView = try #require(coordinator.managedWebView)
+    return (coordinator, webView)
+}
+
 @Suite struct ScreenControllerTests {
-    @Test @MainActor func canvasModeConfiguresWebViewForTouch() {
+    @Test @MainActor func canvasModeConfiguresWebViewForTouch() throws {
         let screen = ScreenController()
+        let (coordinator, webView) = try mountScreen(screen)
+        defer { coordinator.teardown() }
 
-        #expect(screen.webView.isOpaque == true)
-        #expect(screen.webView.backgroundColor == .black)
+        #expect(webView.isOpaque == true)
+        #expect(webView.backgroundColor == .black)
 
-        let scrollView = screen.webView.scrollView
+        let scrollView = webView.scrollView
         #expect(scrollView.backgroundColor == .black)
         #expect(scrollView.contentInsetAdjustmentBehavior == .never)
         #expect(scrollView.isScrollEnabled == false)
         #expect(scrollView.bounces == false)
     }
 
-    @Test @MainActor func navigateEnablesScrollForWebPages() {
+    @Test @MainActor func navigateEnablesScrollForWebPages() throws {
         let screen = ScreenController()
+        let (coordinator, webView) = try mountScreen(screen)
+        defer { coordinator.teardown() }
+
         screen.navigate(to: "https://example.com")
 
-        let scrollView = screen.webView.scrollView
+        let scrollView = webView.scrollView
         #expect(scrollView.isScrollEnabled == true)
         #expect(scrollView.bounces == true)
     }
@@ -34,6 +47,9 @@ import WebKit
 
     @Test @MainActor func evalExecutesJavaScript() async throws {
         let screen = ScreenController()
+        let (coordinator, _) = try mountScreen(screen)
+        defer { coordinator.teardown() }
+
         let deadline = ContinuousClock().now.advanced(by: .seconds(3))
 
         while true {

--- a/apps/ios/WatchApp/Info.plist
+++ b/apps/ios/WatchApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.16</string>
+	<string>2026.2.18</string>
 	<key>CFBundleVersion</key>
-	<string>20260216</string>
+	<string>20260218</string>
 	<key>WKCompanionAppBundleIdentifier</key>
-	<string>ai.openclaw.ios</string>
+	<string>$(OPENCLAW_APP_BUNDLE_ID)</string>
 	<key>WKWatchKitApp</key>
 	<true/>
 </dict>

--- a/apps/ios/WatchExtension/Info.plist
+++ b/apps/ios/WatchExtension/Info.plist
@@ -15,15 +15,15 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.16</string>
+	<string>2026.2.18</string>
 	<key>CFBundleVersion</key>
-	<string>20260216</string>
+	<string>20260218</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>WKAppBundleIdentifier</key>
-			<string>ai.openclaw.ios.watchkitapp</string>
+			<string>$(OPENCLAW_WATCH_APP_BUNDLE_ID)</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>

--- a/apps/ios/WatchExtension/Sources/WatchConnectivityReceiver.swift
+++ b/apps/ios/WatchExtension/Sources/WatchConnectivityReceiver.swift
@@ -70,9 +70,9 @@ extension WatchConnectivityReceiver: WCSessionDelegate {
             replyHandler(["ok": false])
             return
         }
+        replyHandler(["ok": true])
         Task { @MainActor in
             self.store.consume(message: incoming, transport: "sendMessage")
-            replyHandler(["ok": true])
         }
     }
 

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -75,6 +75,7 @@ targets:
     settings:
       base:
         CODE_SIGN_IDENTITY: "Apple Development"
+        CODE_SIGN_ENTITLEMENTS: Sources/OpenClaw.entitlements
         CODE_SIGN_STYLE: "$(OPENCLAW_CODE_SIGN_STYLE)"
         DEVELOPMENT_TEAM: "$(OPENCLAW_DEVELOPMENT_TEAM)"
         PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_APP_BUNDLE_ID)"
@@ -98,6 +99,7 @@ targets:
           UIApplicationSupportsMultipleScenes: false
         UIBackgroundModes:
           - audio
+          - remote-notification
         NSLocalNetworkUsageDescription: OpenClaw discovers and connects to your OpenClaw gateway on the local network.
         NSAppTransportSecurity:
           NSAllowsArbitraryLoadsInWebContent: true
@@ -140,6 +142,19 @@ targets:
         SWIFT_STRICT_CONCURRENCY: complete
     info:
       path: ShareExtension/Info.plist
+      properties:
+        CFBundleDisplayName: OpenClaw Share
+        CFBundleShortVersionString: "2026.2.18"
+        CFBundleVersion: "20260218"
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.share-services
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).ShareViewController"
+          NSExtensionAttributes:
+            NSExtensionActivationRule:
+              NSExtensionActivationSupportsText: true
+              NSExtensionActivationSupportsWebURLWithMaxCount: 1
+              NSExtensionActivationSupportsImageWithMaxCount: 10
+              NSExtensionActivationSupportsMovieWithMaxCount: 1
 
   OpenClawWatchApp:
     type: application.watchapp2
@@ -154,14 +169,14 @@ targets:
       Release: Config/Signing.xcconfig
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: ai.openclaw.ios.watchkitapp
+        PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_WATCH_APP_BUNDLE_ID)"
     info:
       path: WatchApp/Info.plist
       properties:
         CFBundleDisplayName: OpenClaw
-        CFBundleShortVersionString: "2026.2.16"
-        CFBundleVersion: "20260216"
-        WKCompanionAppBundleIdentifier: ai.openclaw.ios
+        CFBundleShortVersionString: "2026.2.18"
+        CFBundleVersion: "20260218"
+        WKCompanionAppBundleIdentifier: "$(OPENCLAW_APP_BUNDLE_ID)"
         WKWatchKitApp: true
 
   OpenClawWatchExtension:
@@ -178,16 +193,16 @@ targets:
       Release: Config/Signing.xcconfig
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: ai.openclaw.ios.watchkitapp.extension
+        PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_WATCH_EXTENSION_BUNDLE_ID)"
     info:
       path: WatchExtension/Info.plist
       properties:
         CFBundleDisplayName: OpenClaw
-        CFBundleShortVersionString: "2026.2.16"
-        CFBundleVersion: "20260216"
+        CFBundleShortVersionString: "2026.2.18"
+        CFBundleVersion: "20260218"
         NSExtension:
           NSExtensionAttributes:
-            WKAppBundleIdentifier: ai.openclaw.ios.watchkitapp
+            WKAppBundleIdentifier: "$(OPENCLAW_WATCH_APP_BUNDLE_ID)"
           NSExtensionPointIdentifier: com.apple.watchkit
 
   OpenClawTests:

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -925,6 +925,68 @@ public struct NodeInvokeRequestEvent: Codable, Sendable {
     }
 }
 
+public struct PushTestParams: Codable, Sendable {
+    public let nodeid: String
+    public let title: String?
+    public let body: String?
+    public let environment: String?
+
+    public init(
+        nodeid: String,
+        title: String?,
+        body: String?,
+        environment: String?
+    ) {
+        self.nodeid = nodeid
+        self.title = title
+        self.body = body
+        self.environment = environment
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case title
+        case body
+        case environment
+    }
+}
+
+public struct PushTestResult: Codable, Sendable {
+    public let ok: Bool
+    public let status: Int
+    public let apnsid: String?
+    public let reason: String?
+    public let tokensuffix: String
+    public let topic: String
+    public let environment: String
+
+    public init(
+        ok: Bool,
+        status: Int,
+        apnsid: String?,
+        reason: String?,
+        tokensuffix: String,
+        topic: String,
+        environment: String
+    ) {
+        self.ok = ok
+        self.status = status
+        self.apnsid = apnsid
+        self.reason = reason
+        self.tokensuffix = tokensuffix
+        self.topic = topic
+        self.environment = environment
+    }
+    private enum CodingKeys: String, CodingKey {
+        case ok
+        case status
+        case apnsid = "apnsId"
+        case reason
+        case tokensuffix = "tokenSuffix"
+        case topic
+        case environment
+    }
+}
+
 public struct SessionsListParams: Codable, Sendable {
     public let limit: Int?
     public let activeminutes: Int?

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -447,7 +447,10 @@ public final class OpenClawChatViewModel {
         // even when this view currently uses an alias key (for example "main").
         // Never drop events for our own pending run on key mismatch, or the UI can stay
         // stuck at "thinking" until the user reopens and forces a history reload.
-        if let sessionKey = chat.sessionKey, sessionKey != self.sessionKey, !isOurRun {
+        if let sessionKey = chat.sessionKey,
+           !Self.matchesCurrentSessionKey(incoming: sessionKey, current: self.sessionKey),
+           !isOurRun
+        {
             return
         }
         if !isOurRun {
@@ -479,6 +482,21 @@ public final class OpenClawChatViewModel {
         default:
             break
         }
+    }
+
+    private static func matchesCurrentSessionKey(incoming: String, current: String) -> Bool {
+        let incomingNormalized = incoming.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let currentNormalized = current.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if incomingNormalized == currentNormalized {
+            return true
+        }
+        // Common alias pair in operator clients: UI uses "main" while gateway emits canonical.
+        if (incomingNormalized == "agent:main:main" && currentNormalized == "main") ||
+            (incomingNormalized == "main" && currentNormalized == "agent:main:main")
+        {
+            return true
+        }
+        return false
     }
 
     private func handleAgentEvent(_ evt: OpenClawAgentEventPayload) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -925,6 +925,68 @@ public struct NodeInvokeRequestEvent: Codable, Sendable {
     }
 }
 
+public struct PushTestParams: Codable, Sendable {
+    public let nodeid: String
+    public let title: String?
+    public let body: String?
+    public let environment: String?
+
+    public init(
+        nodeid: String,
+        title: String?,
+        body: String?,
+        environment: String?
+    ) {
+        self.nodeid = nodeid
+        self.title = title
+        self.body = body
+        self.environment = environment
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case title
+        case body
+        case environment
+    }
+}
+
+public struct PushTestResult: Codable, Sendable {
+    public let ok: Bool
+    public let status: Int
+    public let apnsid: String?
+    public let reason: String?
+    public let tokensuffix: String
+    public let topic: String
+    public let environment: String
+
+    public init(
+        ok: Bool,
+        status: Int,
+        apnsid: String?,
+        reason: String?,
+        tokensuffix: String,
+        topic: String,
+        environment: String
+    ) {
+        self.ok = ok
+        self.status = status
+        self.apnsid = apnsid
+        self.reason = reason
+        self.tokensuffix = tokensuffix
+        self.topic = topic
+        self.environment = environment
+    }
+    private enum CodingKeys: String, CodingKey {
+        case ok
+        case status
+        case apnsid = "apnsId"
+        case reason
+        case tokensuffix = "tokenSuffix"
+        case topic
+        case environment
+    }
+}
+
 public struct SessionsListParams: Codable, Sendable {
     public let limit: Int?
     public let activeminutes: Int?

--- a/apps/shared/OpenClawKit/Tools/CanvasA2UI/bootstrap.js
+++ b/apps/shared/OpenClawKit/Tools/CanvasA2UI/bootstrap.js
@@ -451,7 +451,6 @@ class OpenClawA2UIHost extends LitElement {
     if (this.surfaces.length === 0) {
       return html`<div class="empty">
         <div class="empty-title">Canvas (A2UI)</div>
-        <div>Waiting for A2UI messages…</div>
       </div>`;
     }
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -166,16 +166,28 @@ your main chat history.
 
 ### Payload shapes (what runs)
 
-Two payload kinds are supported:
+Three payload kinds are supported:
 
 - `systemEvent`: main-session only, routed through the heartbeat prompt.
 - `agentTurn`: isolated-session only, runs a dedicated agent turn.
+- `directCommand`: isolated-session only, runs a direct process command without an LLM turn.
 
 Common `agentTurn` fields:
 
 - `message`: required text prompt.
 - `model` / `thinking`: optional overrides (see below).
 - `timeoutSeconds`: optional timeout override.
+
+Common `directCommand` fields:
+
+- `command`: required executable path or command name.
+- `args`: optional argv list.
+- `cwd`: optional working directory override.
+- `env`: optional environment map (`{ "NAME": "value" }`).
+- `timeoutSeconds`: optional timeout override.
+- `maxOutputBytes`: optional output cap for captured stdout/stderr.
+
+`directCommand` still uses `sessionTarget: "isolated"`; no separate session target is required.
 
 Delivery config:
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -193,6 +193,14 @@ Execution details:
 - Commands are executed with `shell: false` (argv only), so shell interpolation is not used unless your command explicitly invokes a shell.
 - These jobs bypass heartbeat and LLM turn execution flows entirely.
 
+`directCommand` runs produce a deterministic result object with:
+
+- `status`: `ok` / `error` / `skipped`
+- `summary`: compact merged output text
+- `captured.stdout` / `captured.stderr`: bounded captured streams
+
+The finished cron event summary stores this result object as JSON, so webhook consumers and run logs can parse a stable shape.
+
 `directCommand` still uses `sessionTarget: "isolated"`; no separate session target is required.
 
 Delivery config:
@@ -204,6 +212,9 @@ Delivery config:
 
 Announce delivery suppresses messaging tool sends for the run; use `delivery.channel`/`delivery.to`
 to target the chat instead. When `delivery.mode = "none"`, no summary is posted to the main session.
+
+For `directCommand` jobs, `delivery.mode = "announce"` sends a compact command-result message directly with
+`delivery.channel` + `delivery.to` (respecting `delivery.bestEffort`) without running an isolated LLM turn.
 
 If `delivery` is omitted for isolated jobs, OpenClaw defaults to `announce`.
 
@@ -233,6 +244,7 @@ Behavior details:
 - The endpoint must be a valid HTTP(S) URL.
 - No channel delivery is attempted in webhook mode.
 - No main-session summary is posted in webhook mode.
+- For `directCommand` jobs, the webhook summary is the deterministic command result object JSON.
 - If `cron.webhookToken` is set, auth header is `Authorization: Bearer <cron.webhookToken>`.
 - Deprecated fallback: stored legacy jobs with `notify: true` still post to `cron.webhook` (if configured), with a warning so you can migrate to `delivery.mode = "webhook"`.
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -192,6 +192,8 @@ Execution details:
 - Direct command jobs run through a dedicated spawn-based executor.
 - Commands are executed with `shell: false` (argv only), so shell interpolation is not used unless your command explicitly invokes a shell.
 - These jobs bypass heartbeat and LLM turn execution flows entirely.
+- By default, commands must satisfy exec allowlist checks before execution (`cron.directCommand.enforceAllowlist: true`).
+- You can opt out in trusted setups with `cron.directCommand.enforceAllowlist: false`.
 
 `directCommand` runs produce a deterministic result object with:
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -187,6 +187,12 @@ Common `directCommand` fields:
 - `timeoutSeconds`: optional timeout override.
 - `maxOutputBytes`: optional output cap for captured stdout/stderr.
 
+Execution details:
+
+- Direct command jobs run through a dedicated spawn-based executor.
+- Commands are executed with `shell: false` (argv only), so shell interpolation is not used unless your command explicitly invokes a shell.
+- These jobs bypass heartbeat and LLM turn execution flows entirely.
+
 `directCommand` still uses `sessionTarget: "isolated"`; no separate session target is required.
 
 Delivery config:

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -192,8 +192,6 @@ Execution details:
 - Direct command jobs run through a dedicated spawn-based executor.
 - Commands are executed with `shell: false` (argv only), so shell interpolation is not used unless your command explicitly invokes a shell.
 - These jobs bypass heartbeat and LLM turn execution flows entirely.
-- By default, commands must satisfy exec allowlist checks before execution (`cron.directCommand.enforceAllowlist: true`).
-- You can opt out in trusted setups with `cron.directCommand.enforceAllowlist: false`.
 
 `directCommand` runs produce a deterministic result object with:
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2370,6 +2370,9 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
   cron: {
     enabled: true,
     maxConcurrentRuns: 2,
+    directCommand: {
+      enforceAllowlist: true, // default true; set false only for trusted environments
+    },
     webhook: "https://example.invalid/legacy", // deprecated fallback for stored notify:true jobs
     webhookToken: "replace-with-dedicated-token", // optional bearer token for outbound webhook auth
     sessionRetention: "24h", // duration string or false
@@ -2378,6 +2381,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 ```
 
 - `sessionRetention`: how long to keep completed cron sessions before pruning. Default: `24h`.
+- `directCommand.enforceAllowlist`: when true (default), `payload.kind = "directCommand"` must pass exec allowlist checks before running.
 - `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
 - `webhook`: deprecated legacy fallback webhook URL (http/https) used only for stored jobs that still have `notify: true`.
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2370,9 +2370,6 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
   cron: {
     enabled: true,
     maxConcurrentRuns: 2,
-    directCommand: {
-      enforceAllowlist: true, // default true; set false only for trusted environments
-    },
     webhook: "https://example.invalid/legacy", // deprecated fallback for stored notify:true jobs
     webhookToken: "replace-with-dedicated-token", // optional bearer token for outbound webhook auth
     sessionRetention: "24h", // duration string or false
@@ -2381,7 +2378,6 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 ```
 
 - `sessionRetention`: how long to keep completed cron sessions before pruning. Default: `24h`.
-- `directCommand.enforceAllowlist`: when true (default), `payload.kind = "directCommand"` must pass exec allowlist checks before running.
 - `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
 - `webhook`: deprecated legacy fallback webhook URL (http/https) used only for stored jobs that still have `notify: true`.
 

--- a/scripts/pr
+++ b/scripts/pr
@@ -625,12 +625,54 @@ prepare_validate_commit() {
   echo "commit subject validated: $subject"
 }
 
+validate_changelog_entry_for_pr() {
+  local pr="$1"
+  local contrib="$2"
+
+  local added_lines
+  added_lines=$(git diff --unified=0 origin/main...HEAD -- CHANGELOG.md | awk '
+    /^\+\+\+/ { next }
+    /^\+/ { print substr($0, 2) }
+  ')
+
+  if [ -z "$added_lines" ]; then
+    echo "CHANGELOG.md is in diff but no added lines were detected."
+    exit 1
+  fi
+
+  local pr_pattern
+  pr_pattern="(#$pr|openclaw#$pr)"
+
+  local with_pr
+  with_pr=$(printf '%s\n' "$added_lines" | rg -in "$pr_pattern" || true)
+  if [ -z "$with_pr" ]; then
+    echo "CHANGELOG.md update must reference PR #$pr (for example, (#$pr))."
+    exit 1
+  fi
+
+  if [ -n "$contrib" ] && [ "$contrib" != "null" ]; then
+    local with_pr_and_thanks
+    with_pr_and_thanks=$(printf '%s\n' "$added_lines" | rg -in "$pr_pattern" | rg -i "thanks @$contrib" || true)
+    if [ -z "$with_pr_and_thanks" ]; then
+      echo "CHANGELOG.md update must include both PR #$pr and thanks @$contrib on the changelog entry line."
+      exit 1
+    fi
+    echo "changelog validated: found PR #$pr + thanks @$contrib"
+    return 0
+  fi
+
+  echo "changelog validated: found PR #$pr (contributor handle unavailable, skipping thanks check)"
+}
+
 prepare_gates() {
   local pr="$1"
   enter_worktree "$pr" false
 
   checkout_prep_branch "$pr"
   bootstrap_deps_if_needed
+  require_artifact .local/pr-meta.env
+  # shellcheck disable=SC1091
+  source .local/pr-meta.env
 
   local changed_files
   changed_files=$(git diff --name-only origin/main...HEAD)
@@ -647,6 +689,8 @@ prepare_gates() {
     echo "Missing CHANGELOG.md update in PR diff. This workflow requires a changelog entry."
     exit 1
   fi
+  local contrib="${PR_AUTHOR:-}"
+  validate_changelog_entry_for_pr "$pr" "$contrib"
 
   run_quiet_logged "pnpm build" ".local/gates-build.log" pnpm build
   run_quiet_logged "pnpm check" ".local/gates-check.log" pnpm check
@@ -1043,10 +1087,14 @@ EOF_COMMENT
   git branch -D "pr-$pr" 2>/dev/null || true
   git branch -D "pr-$pr-prep" 2>/dev/null || true
 
+  local pr_url
+  pr_url=$(gh pr view "$pr" --json url --jq .url)
+
   echo "merge-run complete for PR #$pr"
-  echo "merge_sha=$merge_sha"
-  echo "merge_author_email=$selected_merge_author_email"
-  echo "comment_url=$comment_url"
+  echo "merge commit: $merge_sha"
+  echo "merge author email: $selected_merge_author_email"
+  echo "completion comment: $comment_url"
+  echo "$pr_url"
 }
 
 main() {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -32,7 +32,7 @@ type ResolvedAgentConfig = {
 
 let defaultAgentWarned = false;
 
-function listAgents(cfg: OpenClawConfig): AgentEntry[] {
+export function listAgentEntries(cfg: OpenClawConfig): AgentEntry[] {
   const list = cfg.agents?.list;
   if (!Array.isArray(list)) {
     return [];
@@ -41,7 +41,7 @@ function listAgents(cfg: OpenClawConfig): AgentEntry[] {
 }
 
 export function listAgentIds(cfg: OpenClawConfig): string[] {
-  const agents = listAgents(cfg);
+  const agents = listAgentEntries(cfg);
   if (agents.length === 0) {
     return [DEFAULT_AGENT_ID];
   }
@@ -59,7 +59,7 @@ export function listAgentIds(cfg: OpenClawConfig): string[] {
 }
 
 export function resolveDefaultAgentId(cfg: OpenClawConfig): string {
-  const agents = listAgents(cfg);
+  const agents = listAgentEntries(cfg);
   if (agents.length === 0) {
     return DEFAULT_AGENT_ID;
   }
@@ -93,7 +93,7 @@ export function resolveSessionAgentId(params: {
 
 function resolveAgentEntry(cfg: OpenClawConfig, agentId: string): AgentEntry | undefined {
   const id = normalizeAgentId(agentId);
-  return listAgents(cfg).find((entry) => normalizeAgentId(entry.id) === id);
+  return listAgentEntries(cfg).find((entry) => normalizeAgentId(entry.id) === id);
 }
 
 export function resolveAgentConfig(

--- a/src/agents/auth-health.e2e.test.ts
+++ b/src/agents/auth-health.e2e.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildAuthHealthSummary, DEFAULT_OAUTH_WARN_MS } from "./auth-health.js";
+import {
+  buildAuthHealthSummary,
+  DEFAULT_OAUTH_WARN_MS,
+  formatRemainingShort,
+} from "./auth-health.js";
 
 describe("buildAuthHealthSummary", () => {
   const now = 1_700_000_000_000;
@@ -85,5 +89,12 @@ describe("buildAuthHealthSummary", () => {
     );
 
     expect(statuses["google:no-refresh"]).toBe("expired");
+  });
+});
+
+describe("formatRemainingShort", () => {
+  it("supports an explicit under-minute label override", () => {
+    expect(formatRemainingShort(20_000)).toBe("1m");
+    expect(formatRemainingShort(20_000, { underMinuteLabel: "soon" })).toBe("soon");
   });
 });

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -43,14 +43,23 @@ export function resolveAuthProfileSource(_profileId: string): AuthProfileSource 
   return "store";
 }
 
-export function formatRemainingShort(remainingMs?: number): string {
+export function formatRemainingShort(
+  remainingMs?: number,
+  opts?: {
+    underMinuteLabel?: string;
+  },
+): string {
   if (remainingMs === undefined || Number.isNaN(remainingMs)) {
     return "unknown";
   }
   if (remainingMs <= 0) {
     return "0m";
   }
-  const minutes = Math.max(1, Math.round(remainingMs / 60_000));
+  const roundedMinutes = Math.round(remainingMs / 60_000);
+  if (roundedMinutes < 1) {
+    return opts?.underMinuteLabel ?? "1m";
+  }
+  const minutes = roundedMinutes;
   if (minutes < 60) {
     return `${minutes}m`;
   }

--- a/src/agents/auth-profiles/oauth.test.ts
+++ b/src/agents/auth-profiles/oauth.test.ts
@@ -104,3 +104,53 @@ describe("resolveApiKeyForProfile config compatibility", () => {
     expect(result).toBeNull();
   });
 });
+
+describe("resolveApiKeyForProfile token expiry handling", () => {
+  it("returns null for expired token credentials", async () => {
+    const profileId = "anthropic:token-expired";
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "token",
+          provider: "anthropic",
+          token: "tok-expired",
+          expires: Date.now() - 1_000,
+        },
+      },
+    };
+
+    const result = await resolveApiKeyForProfile({
+      cfg: cfgFor(profileId, "anthropic", "token"),
+      store,
+      profileId,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts token credentials when expires is 0", async () => {
+    const profileId = "anthropic:token-no-expiry";
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "token",
+          provider: "anthropic",
+          token: "tok-123",
+          expires: 0,
+        },
+      },
+    };
+
+    const result = await resolveApiKeyForProfile({
+      cfg: cfgFor(profileId, "anthropic", "token"),
+      store,
+      profileId,
+    });
+    expect(result).toEqual({
+      apiKey: "tok-123",
+      provider: "anthropic",
+      email: undefined,
+    });
+  });
+});

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -66,6 +66,24 @@ function buildApiKeyProfileResult(params: { apiKey: string; provider: string; em
   };
 }
 
+function buildOAuthProfileResult(params: {
+  provider: string;
+  credentials: OAuthCredentials;
+  email?: string;
+}) {
+  return buildApiKeyProfileResult({
+    apiKey: buildOAuthApiKey(params.provider, params.credentials),
+    provider: params.provider,
+    email: params.email,
+  });
+}
+
+function isExpiredCredential(expires: number | undefined): boolean {
+  return (
+    typeof expires === "number" && Number.isFinite(expires) && expires > 0 && Date.now() >= expires
+  );
+}
+
 async function refreshOAuthTokenWithLock(params: {
   profileId: string;
   agentDir?: string;
@@ -148,9 +166,9 @@ async function tryResolveOAuthProfile(params: {
   }
 
   if (Date.now() < cred.expires) {
-    return buildApiKeyProfileResult({
-      apiKey: buildOAuthApiKey(cred.provider, cred),
+    return buildOAuthProfileResult({
       provider: cred.provider,
+      credentials: cred,
       email: cred.email,
     });
   }
@@ -205,20 +223,15 @@ export async function resolveApiKeyForProfile(params: {
     if (!token) {
       return null;
     }
-    if (
-      typeof cred.expires === "number" &&
-      Number.isFinite(cred.expires) &&
-      cred.expires > 0 &&
-      Date.now() >= cred.expires
-    ) {
+    if (isExpiredCredential(cred.expires)) {
       return null;
     }
     return buildApiKeyProfileResult({ apiKey: token, provider: cred.provider, email: cred.email });
   }
   if (Date.now() < cred.expires) {
-    return buildApiKeyProfileResult({
-      apiKey: buildOAuthApiKey(cred.provider, cred),
+    return buildOAuthProfileResult({
       provider: cred.provider,
+      credentials: cred,
       email: cred.email,
     });
   }
@@ -240,9 +253,9 @@ export async function resolveApiKeyForProfile(params: {
     const refreshedStore = ensureAuthProfileStore(params.agentDir);
     const refreshed = refreshedStore.profiles[profileId];
     if (refreshed?.type === "oauth" && Date.now() < refreshed.expires) {
-      return buildApiKeyProfileResult({
-        apiKey: buildOAuthApiKey(refreshed.provider, refreshed),
+      return buildOAuthProfileResult({
         provider: refreshed.provider,
+        credentials: refreshed,
         email: refreshed.email ?? cred.email,
       });
     }
@@ -282,9 +295,9 @@ export async function resolveApiKeyForProfile(params: {
             agentDir: params.agentDir,
             expires: new Date(mainCred.expires).toISOString(),
           });
-          return buildApiKeyProfileResult({
-            apiKey: buildOAuthApiKey(mainCred.provider, mainCred),
+          return buildOAuthProfileResult({
             provider: mainCred.provider,
+            credentials: mainCred,
             email: mainCred.email,
           });
         }

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -84,6 +84,13 @@ function isExpiredCredential(expires: number | undefined): boolean {
   );
 }
 
+type ResolveApiKeyForProfileParams = {
+  cfg?: OpenClawConfig;
+  store: AuthProfileStore;
+  profileId: string;
+  agentDir?: string;
+};
+
 async function refreshOAuthTokenWithLock(params: {
   profileId: string;
   agentDir?: string;
@@ -143,12 +150,9 @@ async function refreshOAuthTokenWithLock(params: {
   });
 }
 
-async function tryResolveOAuthProfile(params: {
-  cfg?: OpenClawConfig;
-  store: AuthProfileStore;
-  profileId: string;
-  agentDir?: string;
-}): Promise<{ apiKey: string; provider: string; email?: string } | null> {
+async function tryResolveOAuthProfile(
+  params: ResolveApiKeyForProfileParams,
+): Promise<{ apiKey: string; provider: string; email?: string } | null> {
   const { cfg, store, profileId } = params;
   const cred = store.profiles[profileId];
   if (!cred || cred.type !== "oauth") {
@@ -187,12 +191,9 @@ async function tryResolveOAuthProfile(params: {
   });
 }
 
-export async function resolveApiKeyForProfile(params: {
-  cfg?: OpenClawConfig;
-  store: AuthProfileStore;
-  profileId: string;
-  agentDir?: string;
-}): Promise<{ apiKey: string; provider: string; email?: string } | null> {
+export async function resolveApiKeyForProfile(
+  params: ResolveApiKeyForProfileParams,
+): Promise<{ apiKey: string; provider: string; email?: string } | null> {
   const { cfg, store, profileId } = params;
   const cred = store.profiles[profileId];
   if (!cred) {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -96,6 +96,26 @@ type ModelFallbackRunResult<T> = {
   attempts: FallbackAttempt[];
 };
 
+function throwFallbackFailureSummary(params: {
+  attempts: FallbackAttempt[];
+  candidates: ModelCandidate[];
+  lastError: unknown;
+  label: string;
+  formatAttempt: (attempt: FallbackAttempt) => string;
+}): never {
+  if (params.attempts.length <= 1 && params.lastError) {
+    throw params.lastError;
+  }
+  const summary =
+    params.attempts.length > 0 ? params.attempts.map(params.formatAttempt).join(" | ") : "unknown";
+  throw new Error(
+    `All ${params.label} failed (${params.attempts.length || params.candidates.length}): ${summary}`,
+    {
+      cause: params.lastError instanceof Error ? params.lastError : undefined,
+    },
+  );
+}
+
 function resolveImageFallbackCandidates(params: {
   cfg: OpenClawConfig | undefined;
   defaultProvider: string;
@@ -376,22 +396,15 @@ export async function runWithModelFallback<T>(params: {
     }
   }
 
-  if (attempts.length <= 1 && lastError) {
-    throw lastError;
-  }
-  const summary =
-    attempts.length > 0
-      ? attempts
-          .map(
-            (attempt) =>
-              `${attempt.provider}/${attempt.model}: ${attempt.error}${
-                attempt.reason ? ` (${attempt.reason})` : ""
-              }`,
-          )
-          .join(" | ")
-      : "unknown";
-  throw new Error(`All models failed (${attempts.length || candidates.length}): ${summary}`, {
-    cause: lastError instanceof Error ? lastError : undefined,
+  throwFallbackFailureSummary({
+    attempts,
+    candidates,
+    lastError,
+    label: "models",
+    formatAttempt: (attempt) =>
+      `${attempt.provider}/${attempt.model}: ${attempt.error}${
+        attempt.reason ? ` (${attempt.reason})` : ""
+      }`,
   });
 }
 
@@ -445,16 +458,11 @@ export async function runWithImageModelFallback<T>(params: {
     }
   }
 
-  if (attempts.length <= 1 && lastError) {
-    throw lastError;
-  }
-  const summary =
-    attempts.length > 0
-      ? attempts
-          .map((attempt) => `${attempt.provider}/${attempt.model}: ${attempt.error}`)
-          .join(" | ")
-      : "unknown";
-  throw new Error(`All image models failed (${attempts.length || candidates.length}): ${summary}`, {
-    cause: lastError instanceof Error ? lastError : undefined,
+  throwFallbackFailureSummary({
+    attempts,
+    candidates,
+    lastError,
+    label: "image models",
+    formatAttempt: (attempt) => `${attempt.provider}/${attempt.model}: ${attempt.error}`,
   });
 }

--- a/src/agents/model-forward-compat.test.ts
+++ b/src/agents/model-forward-compat.test.ts
@@ -1,0 +1,59 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { resolveForwardCompatModel } from "./model-forward-compat.js";
+import type { ModelRegistry } from "./pi-model-discovery.js";
+
+function createTemplateModel(provider: string, id: string): Model<Api> {
+  return {
+    id,
+    name: id,
+    provider,
+    api: "anthropic-messages",
+    input: ["text"],
+    reasoning: true,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  } as Model<Api>;
+}
+
+function createRegistry(models: Record<string, Model<Api>>): ModelRegistry {
+  return {
+    find(provider: string, modelId: string) {
+      return models[`${provider}/${modelId}`] ?? null;
+    },
+  } as ModelRegistry;
+}
+
+describe("agents/model-forward-compat", () => {
+  it("resolves anthropic opus 4.6 via 4.5 template", () => {
+    const registry = createRegistry({
+      "anthropic/claude-opus-4-5": createTemplateModel("anthropic", "claude-opus-4-5"),
+    });
+    const model = resolveForwardCompatModel("anthropic", "claude-opus-4-6", registry);
+    expect(model?.id).toBe("claude-opus-4-6");
+    expect(model?.name).toBe("claude-opus-4-6");
+    expect(model?.provider).toBe("anthropic");
+  });
+
+  it("resolves anthropic sonnet 4.6 dot variant with suffix", () => {
+    const registry = createRegistry({
+      "anthropic/claude-sonnet-4.5-20260219": createTemplateModel(
+        "anthropic",
+        "claude-sonnet-4.5-20260219",
+      ),
+    });
+    const model = resolveForwardCompatModel("anthropic", "claude-sonnet-4.6-20260219", registry);
+    expect(model?.id).toBe("claude-sonnet-4.6-20260219");
+    expect(model?.name).toBe("claude-sonnet-4.6-20260219");
+    expect(model?.provider).toBe("anthropic");
+  });
+
+  it("does not resolve anthropic 4.6 fallback for other providers", () => {
+    const registry = createRegistry({
+      "anthropic/claude-opus-4-5": createTemplateModel("anthropic", "claude-opus-4-5"),
+    });
+    const model = resolveForwardCompatModel("openai", "claude-opus-4-6", registry);
+    expect(model).toBeUndefined();
+  });
+});

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -104,11 +104,17 @@ function resolveOpenAICodexGpt53FallbackModel(
   } as Model<Api>);
 }
 
-function resolveAnthropicOpus46ForwardCompatModel(
-  provider: string,
-  modelId: string,
-  modelRegistry: ModelRegistry,
-): Model<Api> | undefined {
+function resolveAnthropic46ForwardCompatModel(params: {
+  provider: string;
+  modelId: string;
+  modelRegistry: ModelRegistry;
+  dashModelId: string;
+  dotModelId: string;
+  dashTemplateId: string;
+  dotTemplateId: string;
+  fallbackTemplateIds: readonly string[];
+}): Model<Api> | undefined {
+  const { provider, modelId, modelRegistry, dashModelId, dotModelId } = params;
   const normalizedProvider = normalizeProviderId(provider);
   if (normalizedProvider !== "anthropic") {
     return undefined;
@@ -116,23 +122,23 @@ function resolveAnthropicOpus46ForwardCompatModel(
 
   const trimmedModelId = modelId.trim();
   const lower = trimmedModelId.toLowerCase();
-  const isOpus46 =
-    lower === ANTHROPIC_OPUS_46_MODEL_ID ||
-    lower === ANTHROPIC_OPUS_46_DOT_MODEL_ID ||
-    lower.startsWith(`${ANTHROPIC_OPUS_46_MODEL_ID}-`) ||
-    lower.startsWith(`${ANTHROPIC_OPUS_46_DOT_MODEL_ID}-`);
-  if (!isOpus46) {
+  const is46Model =
+    lower === dashModelId ||
+    lower === dotModelId ||
+    lower.startsWith(`${dashModelId}-`) ||
+    lower.startsWith(`${dotModelId}-`);
+  if (!is46Model) {
     return undefined;
   }
 
   const templateIds: string[] = [];
-  if (lower.startsWith(ANTHROPIC_OPUS_46_MODEL_ID)) {
-    templateIds.push(lower.replace(ANTHROPIC_OPUS_46_MODEL_ID, "claude-opus-4-5"));
+  if (lower.startsWith(dashModelId)) {
+    templateIds.push(lower.replace(dashModelId, params.dashTemplateId));
   }
-  if (lower.startsWith(ANTHROPIC_OPUS_46_DOT_MODEL_ID)) {
-    templateIds.push(lower.replace(ANTHROPIC_OPUS_46_DOT_MODEL_ID, "claude-opus-4.5"));
+  if (lower.startsWith(dotModelId)) {
+    templateIds.push(lower.replace(dotModelId, params.dotTemplateId));
   }
-  templateIds.push(...ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS);
+  templateIds.push(...params.fallbackTemplateIds);
 
   return cloneFirstTemplateModel({
     normalizedProvider,
@@ -142,41 +148,37 @@ function resolveAnthropicOpus46ForwardCompatModel(
   });
 }
 
+function resolveAnthropicOpus46ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  return resolveAnthropic46ForwardCompatModel({
+    provider,
+    modelId,
+    modelRegistry,
+    dashModelId: ANTHROPIC_OPUS_46_MODEL_ID,
+    dotModelId: ANTHROPIC_OPUS_46_DOT_MODEL_ID,
+    dashTemplateId: "claude-opus-4-5",
+    dotTemplateId: "claude-opus-4.5",
+    fallbackTemplateIds: ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS,
+  });
+}
+
 function resolveAnthropicSonnet46ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  const normalizedProvider = normalizeProviderId(provider);
-  if (normalizedProvider !== "anthropic") {
-    return undefined;
-  }
-
-  const trimmedModelId = modelId.trim();
-  const lower = trimmedModelId.toLowerCase();
-  const isSonnet46 =
-    lower === ANTHROPIC_SONNET_46_MODEL_ID ||
-    lower === ANTHROPIC_SONNET_46_DOT_MODEL_ID ||
-    lower.startsWith(`${ANTHROPIC_SONNET_46_MODEL_ID}-`) ||
-    lower.startsWith(`${ANTHROPIC_SONNET_46_DOT_MODEL_ID}-`);
-  if (!isSonnet46) {
-    return undefined;
-  }
-
-  const templateIds: string[] = [];
-  if (lower.startsWith(ANTHROPIC_SONNET_46_MODEL_ID)) {
-    templateIds.push(lower.replace(ANTHROPIC_SONNET_46_MODEL_ID, "claude-sonnet-4-5"));
-  }
-  if (lower.startsWith(ANTHROPIC_SONNET_46_DOT_MODEL_ID)) {
-    templateIds.push(lower.replace(ANTHROPIC_SONNET_46_DOT_MODEL_ID, "claude-sonnet-4.5"));
-  }
-  templateIds.push(...ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS);
-
-  return cloneFirstTemplateModel({
-    normalizedProvider,
-    trimmedModelId,
-    templateIds,
+  return resolveAnthropic46ForwardCompatModel({
+    provider,
+    modelId,
     modelRegistry,
+    dashModelId: ANTHROPIC_SONNET_46_MODEL_ID,
+    dotModelId: ANTHROPIC_SONNET_46_DOT_MODEL_ID,
+    dashTemplateId: "claude-sonnet-4-5",
+    dotTemplateId: "claude-sonnet-4.5",
+    fallbackTemplateIds: ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS,
   });
 }
 

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
@@ -92,12 +92,18 @@ describe("formatAssistantErrorText", () => {
     const result = formatAssistantErrorText(msg);
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
-  it("includes provider name in billing message when provider is given", () => {
+  it("includes provider and assistant model in billing message when provider is given", () => {
     const msg = makeAssistantError("insufficient credits");
     const result = formatAssistantErrorText(msg, { provider: "Anthropic" });
-    expect(result).toBe(formatBillingErrorMessage("Anthropic"));
+    expect(result).toBe(formatBillingErrorMessage("Anthropic", "test-model"));
     expect(result).toContain("Anthropic");
     expect(result).not.toContain("API provider");
+  });
+  it("uses the active assistant model for billing message context", () => {
+    const msg = makeAssistantError("insufficient credits");
+    msg.model = "claude-3-5-sonnet";
+    const result = formatAssistantErrorText(msg, { provider: "Anthropic" });
+    expect(result).toBe(formatBillingErrorMessage("Anthropic", "claude-3-5-sonnet"));
   });
   it("returns generic billing message when provider is not given", () => {
     const msg = makeAssistantError("insufficient credits");

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -181,19 +181,10 @@ describe("isContextOverflowError", () => {
     }
   });
 
-  it("matches Anthropic 'Request size exceeds model context window' error", () => {
-    // Anthropic returns this error format when the prompt exceeds the context window.
-    // Without this fix, auto-compaction is NOT triggered because neither
-    // isContextOverflowError nor pi-ai's isContextOverflow recognizes this pattern.
-    // The user sees: "LLM request rejected: Request size exceeds model context window"
-    // instead of automatic compaction + retry.
-    const anthropicRawError =
-      '{"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}';
-    expect(isContextOverflowError(anthropicRawError)).toBe(true);
-  });
-
   it("matches 'exceeds model context window' in various formats", () => {
     const samples = [
+      // Anthropic returns this JSON payload when prompt exceeds model context window.
+      '{"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',
       "Request size exceeds model context window",
       "request size exceeds model context window",
       '400 {"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
@@ -191,9 +191,6 @@ describe("sanitizeToolCallId", () => {
     it("strips invalid characters", () => {
       expect(sanitizeToolCallId("call_abc|item:456")).toBe("callabcitem456");
     });
-    it("returns default for empty IDs", () => {
-      expect(sanitizeToolCallId("")).toBe("defaulttoolid");
-    });
   });
 
   describe("strict mode (alphanumeric only)", () => {
@@ -204,9 +201,6 @@ describe("sanitizeToolCallId", () => {
         "whatsapplogin17687998415271",
       );
     });
-    it("returns default for empty IDs", () => {
-      expect(sanitizeToolCallId("", "strict")).toBe("defaulttoolid");
-    });
   });
 
   describe("strict9 mode (Mistral tool call IDs)", () => {
@@ -214,9 +208,26 @@ describe("sanitizeToolCallId", () => {
       const out = sanitizeToolCallId("call_abc|item:456", "strict9");
       expect(out).toMatch(/^[a-zA-Z0-9]{9}$/);
     });
-    it("returns default for empty IDs", () => {
-      expect(sanitizeToolCallId("", "strict9")).toMatch(/^[a-zA-Z0-9]{9}$/);
-    });
+  });
+
+  it.each([
+    {
+      modeLabel: "default",
+      run: () => sanitizeToolCallId(""),
+      assert: (value: string) => expect(value).toBe("defaulttoolid"),
+    },
+    {
+      modeLabel: "strict",
+      run: () => sanitizeToolCallId("", "strict"),
+      assert: (value: string) => expect(value).toBe("defaulttoolid"),
+    },
+    {
+      modeLabel: "strict9",
+      run: () => sanitizeToolCallId("", "strict9"),
+      assert: (value: string) => expect(value).toMatch(/^[a-zA-Z0-9]{9}$/),
+    },
+  ])("returns default for empty IDs in $modeLabel mode", ({ run, assert }) => {
+    assert(run());
   });
 });
 

--- a/src/agents/pi-embedded-helpers.validate-turns.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.e2e.test.ts
@@ -10,23 +10,31 @@ function asMessages(messages: unknown[]): AgentMessage[] {
   return messages as AgentMessage[];
 }
 
-describe("validateGeminiTurns", () => {
-  it("should return empty array unchanged", () => {
-    const result = validateGeminiTurns([]);
-    expect(result).toEqual([]);
+describe("validate turn edge cases", () => {
+  it("returns empty array unchanged", () => {
+    expect(validateGeminiTurns([])).toEqual([]);
+    expect(validateAnthropicTurns([])).toEqual([]);
   });
 
-  it("should return single message unchanged", () => {
-    const msgs = asMessages([
+  it("returns single message unchanged", () => {
+    const geminiMsgs = asMessages([
       {
         role: "user",
         content: "Hello",
       },
     ]);
-    const result = validateGeminiTurns(msgs);
-    expect(result).toEqual(msgs);
+    const anthropicMsgs = asMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    ]);
+    expect(validateGeminiTurns(geminiMsgs)).toEqual(geminiMsgs);
+    expect(validateAnthropicTurns(anthropicMsgs)).toEqual(anthropicMsgs);
   });
+});
 
+describe("validateGeminiTurns", () => {
   it("should leave alternating user/assistant unchanged", () => {
     const msgs = asMessages([
       { role: "user", content: "Hello" },
@@ -123,22 +131,6 @@ describe("validateGeminiTurns", () => {
 });
 
 describe("validateAnthropicTurns", () => {
-  it("should return empty array unchanged", () => {
-    const result = validateAnthropicTurns([]);
-    expect(result).toEqual([]);
-  });
-
-  it("should return single message unchanged", () => {
-    const msgs = asMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "Hello" }],
-      },
-    ]);
-    const result = validateAnthropicTurns(msgs);
-    expect(result).toEqual(msgs);
-  });
-
   it("should return alternating user/assistant unchanged", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Question" }] },

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -4,10 +4,13 @@ import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
 import { stableStringify } from "../stable-stringify.js";
 import type { FailoverReason } from "./types.js";
 
-export function formatBillingErrorMessage(provider?: string): string {
+export function formatBillingErrorMessage(provider?: string, model?: string): string {
   const providerName = provider?.trim();
-  if (providerName) {
-    return `⚠️ ${providerName} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your ${providerName} billing dashboard and top up or switch to a different API key.`;
+  const modelName = model?.trim();
+  const providerLabel =
+    providerName && modelName ? `${providerName} (${modelName})` : providerName || undefined;
+  if (providerLabel) {
+    return `⚠️ ${providerLabel} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your ${providerName} billing dashboard and top up or switch to a different API key.`;
   }
   return "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
 }
@@ -420,7 +423,7 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
 
 export function formatAssistantErrorText(
   msg: AssistantMessage,
-  opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string },
+  opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string; model?: string },
 ): string | undefined {
   // Also format errors if errorMessage is present, even if stopReason isn't "error"
   const raw = (msg.errorMessage ?? "").trim();
@@ -487,7 +490,7 @@ export function formatAssistantErrorText(
   }
 
   if (isBillingErrorMessage(raw)) {
-    return formatBillingErrorMessage(opts?.provider);
+    return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {

--- a/src/agents/pi-embedded-payloads.ts
+++ b/src/agents/pi-embedded-payloads.ts
@@ -1,0 +1,8 @@
+export type BlockReplyPayload = {
+  text?: string;
+  mediaUrls?: string[];
+  audioAsVoice?: boolean;
+  replyToId?: string;
+  replyToTag?: boolean;
+  replyToCurrent?: boolean;
+};

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -160,6 +160,17 @@ const toNormalizedUsage = (usage: UsageAccumulator) => {
   };
 };
 
+function resolveActiveErrorContext(params: {
+  lastAssistant: { provider?: string; model?: string } | undefined;
+  provider: string;
+  model: string;
+}): { provider: string; model: string } {
+  return {
+    provider: params.lastAssistant?.provider ?? params.provider,
+    model: params.lastAssistant?.model ?? params.model,
+  };
+}
+
 export async function runEmbeddedPiAgent(
   params: RunEmbeddedPiAgentParams,
 ): Promise<EmbeddedPiRunResult> {
@@ -549,11 +560,17 @@ export async function runEmbeddedPiAgent(
           const lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
           const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
           autoCompactionCount += attemptCompactionCount;
+          const activeErrorContext = resolveActiveErrorContext({
+            lastAssistant,
+            provider,
+            model: modelId,
+          });
           const formattedAssistantErrorText = lastAssistant
             ? formatAssistantErrorText(lastAssistant, {
                 cfg: params.config,
                 sessionKey: params.sessionKey ?? params.sessionId,
-                provider,
+                provider: activeErrorContext.provider,
+                model: activeErrorContext.model,
               })
             : undefined;
           const assistantErrorText =
@@ -919,7 +936,8 @@ export async function runEmbeddedPiAgent(
                   ? formatAssistantErrorText(lastAssistant, {
                       cfg: params.config,
                       sessionKey: params.sessionKey ?? params.sessionId,
-                      provider,
+                      provider: activeErrorContext.provider,
+                      model: activeErrorContext.model,
                     })
                   : undefined) ||
                 lastAssistant?.errorMessage?.trim() ||
@@ -928,7 +946,10 @@ export async function runEmbeddedPiAgent(
                   : rateLimitFailure
                     ? "LLM request rate limited."
                     : billingFailure
-                      ? formatBillingErrorMessage(provider)
+                      ? formatBillingErrorMessage(
+                          activeErrorContext.provider,
+                          activeErrorContext.model,
+                        )
                       : authFailure
                         ? "LLM request unauthorized."
                         : "LLM request failed.");
@@ -937,8 +958,8 @@ export async function runEmbeddedPiAgent(
                 (isTimeoutErrorMessage(message) ? 408 : undefined);
               throw new FailoverError(message, {
                 reason: assistantFailoverReason ?? "unknown",
-                provider,
-                model: modelId,
+                provider: activeErrorContext.provider,
+                model: activeErrorContext.model,
                 profileId: lastProfileId,
                 status,
               });
@@ -973,7 +994,8 @@ export async function runEmbeddedPiAgent(
             lastToolError: attempt.lastToolError,
             config: params.config,
             sessionKey: params.sessionKey ?? params.sessionId,
-            provider,
+            provider: activeErrorContext.provider,
+            model: activeErrorContext.model,
             verboseLevel: params.verboseLevel,
             reasoningLevel: params.reasoningLevel,
             toolResultFormat: resolvedToolResultFormat,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import type { enqueueCommand } from "../../../process/command-queue.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
 import type { ExecElevatedDefaults, ExecToolDefaults } from "../../bash-tools.js";
+import type { BlockReplyPayload } from "../../pi-embedded-payloads.js";
 import type { BlockReplyChunking, ToolResultFormat } from "../../pi-embedded-subscribe.js";
 import type { SkillSnapshot } from "../../skills.js";
 
@@ -85,14 +86,7 @@ export type RunEmbeddedPiAgentParams = {
   shouldEmitToolOutput?: () => boolean;
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
-  onBlockReply?: (payload: {
-    text?: string;
-    mediaUrls?: string[];
-    audioAsVoice?: boolean;
-    replyToId?: string;
-    replyToTag?: boolean;
-    replyToCurrent?: boolean;
-  }) => void | Promise<void>;
+  onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
   onBlockReplyFlush?: () => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;

--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -163,7 +163,7 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toBe("All good");
   });
 
-  it("adds tool error fallback when the assistant only invoked tools", () => {
+  it("adds tool error fallback when the assistant only invoked tools and verbose mode is on", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({
         stopReason: "toolUse",
@@ -178,6 +178,7 @@ describe("buildEmbeddedRunPayloads", () => {
         ],
       }),
       lastToolError: { toolName: "exec", error: "Command exited with code 1" },
+      verboseLevel: "on",
     });
 
     expect(payloads).toHaveLength(1);

--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -96,17 +96,19 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads.some((payload) => payload.text?.includes("request_id"))).toBe(false);
   });
 
-  it("includes provider context for billing errors", () => {
+  it("includes provider and model context for billing errors", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({
+        model: "claude-3-5-sonnet",
         errorMessage: "insufficient credits",
         content: [{ type: "text", text: "insufficient credits" }],
       }),
       provider: "Anthropic",
+      model: "claude-3-5-sonnet",
     });
 
     expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.text).toBe(formatBillingErrorMessage("Anthropic"));
+    expect(payloads[0]?.text).toBe(formatBillingErrorMessage("Anthropic", "claude-3-5-sonnet"));
     expect(payloads[0]?.isError).toBe(true);
   });
 

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildEmbeddedRunPayloads } from "./payloads.js";
+
+type BuildPayloadParams = Parameters<typeof buildEmbeddedRunPayloads>[0];
+
+function buildPayloads(overrides: Partial<BuildPayloadParams> = {}) {
+  return buildEmbeddedRunPayloads({
+    assistantTexts: [],
+    toolMetas: [],
+    lastAssistant: undefined,
+    sessionKey: "session:telegram",
+    inlineToolResultsAllowed: false,
+    verboseLevel: "off",
+    reasoningLevel: "off",
+    toolResultFormat: "plain",
+    ...overrides,
+  });
+}
+
+describe("buildEmbeddedRunPayloads tool-error warnings", () => {
+  it("suppresses exec tool errors when verbose mode is off", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "exec", error: "command failed" },
+      verboseLevel: "off",
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("shows exec tool errors when verbose mode is on", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "exec", error: "command failed" },
+      verboseLevel: "on",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("Exec");
+    expect(payloads[0]?.text).toContain("command failed");
+  });
+
+  it("keeps non-exec mutating tool failures visible", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "write", error: "permission denied" },
+      verboseLevel: "off",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("Write");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -49,8 +49,14 @@ function shouldShowToolErrorWarning(params: {
   hasUserFacingReply: boolean;
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean;
+  verboseLevel?: VerboseLevel;
 }): boolean {
   if (params.suppressToolErrorWarnings) {
+    return false;
+  }
+  const normalizedToolName = params.lastToolError.toolName.trim().toLowerCase();
+  const verboseEnabled = params.verboseLevel === "on" || params.verboseLevel === "full";
+  if ((normalizedToolName === "exec" || normalizedToolName === "bash") && !verboseEnabled) {
     return false;
   }
   const isMutatingToolError =
@@ -255,6 +261,7 @@ export function buildEmbeddedRunPayloads(params: {
       hasUserFacingReply: hasUserFacingAssistantReply,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+      verboseLevel: params.verboseLevel,
     });
 
     // Always surface mutating tool failures so we do not silently confirm actions that did not happen.

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -72,6 +72,7 @@ export function buildEmbeddedRunPayloads(params: {
   config?: OpenClawConfig;
   sessionKey: string;
   provider?: string;
+  model?: string;
   verboseLevel?: VerboseLevel;
   reasoningLevel?: ReasoningLevel;
   toolResultFormat?: ToolResultFormat;
@@ -104,6 +105,7 @@ export function buildEmbeddedRunPayloads(params: {
         cfg: params.config,
         sessionKey: params.sessionKey,
         provider: params.provider,
+        model: params.model,
       })
     : undefined;
   const rawErrorMessage = lastAssistantErrored

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -35,6 +35,8 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     const friendlyError = formatAssistantErrorText(lastAssistant, {
       cfg: ctx.params.config,
       sessionKey: ctx.params.sessionKey,
+      provider: lastAssistant.provider,
+      model: lastAssistant.model,
     });
     emitAgentEvent({
       runId: ctx.params.runId,

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -67,15 +67,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     });
   }
 
-  if (ctx.params.onBlockReply) {
-    if (ctx.blockChunker?.hasBuffered()) {
-      ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
-      ctx.blockChunker.reset();
-    } else if (ctx.state.blockBuffer.length > 0) {
-      ctx.emitBlockChunk(ctx.state.blockBuffer);
-      ctx.state.blockBuffer = "";
-    }
-  }
+  ctx.flushBlockReplyBuffer();
 
   ctx.state.blockState.thinking = false;
   ctx.state.blockState.final = false;

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -201,13 +201,7 @@ export function handleMessageUpdate(
   }
 
   if (evtType === "text_end" && ctx.state.blockReplyBreak === "text_end") {
-    if (ctx.blockChunker?.hasBuffered()) {
-      ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
-      ctx.blockChunker.reset();
-    } else if (ctx.state.blockBuffer.length > 0) {
-      ctx.emitBlockChunk(ctx.state.blockBuffer);
-      ctx.state.blockBuffer = "";
-    }
+    ctx.flushBlockReplyBuffer();
   }
 }
 

--- a/src/agents/pi-embedded-subscribe.lifecycle-billing-error.e2e.test.ts
+++ b/src/agents/pi-embedded-subscribe.lifecycle-billing-error.e2e.test.ts
@@ -1,0 +1,35 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { createStubSessionHarness } from "./pi-embedded-subscribe.e2e-harness.js";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+describe("subscribeEmbeddedPiSession lifecycle billing errors", () => {
+  it("includes provider and model context in lifecycle billing errors", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run-billing-error",
+      onAgentEvent,
+      sessionKey: "test-session",
+    });
+
+    const assistantMessage = {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "insufficient credits",
+      provider: "Anthropic",
+      model: "claude-3-5-sonnet",
+    } as AssistantMessage;
+
+    emit({ type: "message_update", message: assistantMessage });
+    emit({ type: "agent_end" });
+
+    const lifecycleError = onAgentEvent.mock.calls.find(
+      (call) => call[0]?.stream === "lifecycle" && call[0]?.data?.phase === "error",
+    );
+    expect(lifecycleError).toBeDefined();
+    expect(lifecycleError?.[0]?.data?.error).toContain("Anthropic (claude-3-5-sonnet)");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { extractToolErrorMessage } from "./pi-embedded-subscribe.tools.js";
+
+describe("extractToolErrorMessage", () => {
+  it("ignores non-error status values", () => {
+    expect(extractToolErrorMessage({ details: { status: "0" } })).toBeUndefined();
+    expect(extractToolErrorMessage({ details: { status: "completed" } })).toBeUndefined();
+    expect(extractToolErrorMessage({ details: { status: "ok" } })).toBeUndefined();
+  });
+
+  it("keeps error-like status values", () => {
+    expect(extractToolErrorMessage({ details: { status: "failed" } })).toBe("failed");
+    expect(extractToolErrorMessage({ details: { status: "timeout" } })).toBe("timeout");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -29,6 +29,23 @@ function normalizeToolErrorText(text: string): string | undefined {
     : firstLine;
 }
 
+function isErrorLikeStatus(status: string): boolean {
+  const normalized = status.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (
+    normalized === "0" ||
+    normalized === "ok" ||
+    normalized === "success" ||
+    normalized === "completed" ||
+    normalized === "running"
+  ) {
+    return false;
+  }
+  return /error|fail|timeout|timed[_\s-]?out|denied|cancel|invalid|forbidden/.test(normalized);
+}
+
 function readErrorCandidate(value: unknown): string | undefined {
   if (typeof value === "string") {
     return normalizeToolErrorText(value);
@@ -59,7 +76,10 @@ function extractErrorField(value: unknown): string | undefined {
     return direct;
   }
   const status = typeof record.status === "string" ? record.status.trim() : "";
-  return status ? normalizeToolErrorText(status) : undefined;
+  if (!status || !isErrorLikeStatus(status)) {
+    return undefined;
+  }
+  return normalizeToolErrorText(status);
 }
 
 export function sanitizeToolResult(result: unknown): unknown {

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -3,6 +3,7 @@ import type { ReasoningLevel, VerboseLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";
+import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
 
 export type ToolResultFormat = "markdown" | "plain";
 
@@ -19,14 +20,7 @@ export type SubscribeEmbeddedPiSessionParams = {
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */
   onReasoningEnd?: () => void | Promise<void>;
-  onBlockReply?: (payload: {
-    text?: string;
-    mediaUrls?: string[];
-    audioAsVoice?: boolean;
-    replyToId?: string;
-    replyToTag?: boolean;
-    replyToCurrent?: boolean;
-  }) => void | Promise<void>;
+  onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
   /** Flush pending block replies (e.g., before tool execution to preserve message boundaries). */
   onBlockReplyFlush?: () => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -118,6 +118,19 @@ function extractToolResultText(content: unknown): string {
   return joined?.trim() ?? "";
 }
 
+function extractInlineTextContent(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return (
+    extractTextFromChatContent(content, {
+      sanitizeText: sanitizeTextContent,
+      normalizeText: (text) => text.trim(),
+      joinWith: "",
+    }) ?? ""
+  );
+}
+
 function extractSubagentOutputText(message: unknown): string {
   if (!message || typeof message !== "object") {
     return "";
@@ -133,13 +146,7 @@ function extractSubagentOutputText(message: unknown): string {
       return sanitizeTextContent(content);
     }
     if (Array.isArray(content)) {
-      return (
-        extractTextFromChatContent(content, {
-          sanitizeText: sanitizeTextContent,
-          normalizeText: (text) => text.trim(),
-          joinWith: "",
-        }) ?? ""
-      );
+      return extractInlineTextContent(content);
     }
     return "";
   }
@@ -150,13 +157,7 @@ function extractSubagentOutputText(message: unknown): string {
     return sanitizeTextContent(content);
   }
   if (Array.isArray(content)) {
-    return (
-      extractTextFromChatContent(content, {
-        sanitizeText: sanitizeTextContent,
-        normalizeText: (text) => text.trim(),
-        joinWith: "",
-      }) ?? ""
-    );
+    return extractInlineTextContent(content);
   }
   return "";
 }

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -290,7 +290,7 @@ describe("subagent registry steer restarts", () => {
       expect(announceSpy).toHaveBeenCalledTimes(3);
       expect(mod.listSubagentRunsForRequester("agent:main:main")[0]?.announceRetryCount).toBe(3);
 
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(4_001);
       expect(announceSpy).toHaveBeenCalledTimes(3);
       expect(mod.listSubagentRunsForRequester("agent:main:main")[0]?.cleanupCompletedAt).toBeTypeOf(
         "number",

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -41,7 +41,7 @@ export type SpawnSubagentContext = {
 };
 
 export const SUBAGENT_SPAWN_ACCEPTED_NOTE =
-  "auto-announces on completion, do not poll/sleep. The response will be sent back as an agent message.";
+  "auto-announces on completion, do not poll/sleep. The response will be sent back as an user message.";
 
 export type SpawnSubagentResult = {
   status: "accepted" | "forbidden" | "error";

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -6,6 +6,7 @@ import {
   cameraTempPath,
   parseCameraClipPayload,
   parseCameraSnapPayload,
+  writeCameraClipPayloadToFile,
   writeBase64ToFile,
   writeUrlToFile,
 } from "../../cli/nodes-camera.js";
@@ -300,16 +301,10 @@ export function createNodesTool(options?: {
               idempotencyKey: crypto.randomUUID(),
             });
             const payload = parseCameraClipPayload(raw?.payload);
-            const filePath = cameraTempPath({
-              kind: "clip",
+            const filePath = await writeCameraClipPayloadToFile({
+              payload,
               facing,
-              ext: payload.format,
             });
-            if (payload.url) {
-              await writeUrlToFile(filePath, payload.url);
-            } else if (payload.base64) {
-              await writeBase64ToFile(filePath, payload.base64);
-            }
             return {
               content: [{ type: "text", text: `FILE:${filePath}` }],
               details: {

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -1,25 +1,9 @@
-import type {
-  NodeListNode,
-  PairedNode,
-  PairingList,
-  PendingRequest,
-} from "../../shared/node-list-types.js";
+import { parseNodeList, parsePairingList } from "../../shared/node-list-parse.js";
+import type { NodeListNode } from "../../shared/node-list-types.js";
 import { resolveNodeIdFromCandidates } from "../../shared/node-match.js";
 import { callGatewayTool, type GatewayCallOptions } from "./gateway.js";
 
 export type { NodeListNode };
-
-function parseNodeList(value: unknown): NodeListNode[] {
-  const obj = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-  return Array.isArray(obj.nodes) ? (obj.nodes as NodeListNode[]) : [];
-}
-
-function parsePairingList(value: unknown): PairingList {
-  const obj = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-  const pending = Array.isArray(obj.pending) ? (obj.pending as PendingRequest[]) : [];
-  const paired = Array.isArray(obj.paired) ? (obj.paired as PairedNode[]) : [];
-  return { pending, paired };
-}
 
 async function loadNodes(opts: GatewayCallOptions): Promise<NodeListNode[]> {
   try {

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -10,6 +10,7 @@ import {
   isAbortRequestText,
   isAbortTrigger,
   resetAbortMemoryForTest,
+  resolveSessionEntryForKey,
   setAbortMemory,
   tryFastAbortFromMessage,
 } from "./abort.js";
@@ -126,6 +127,18 @@ describe("abort detection", () => {
     expect(getAbortMemorySizeForTest()).toBe(2000);
     expect(getAbortMemory("session-0")).toBeUndefined();
     expect(getAbortMemory("session-2104")).toBe(true);
+  });
+
+  it("resolves session entry when key exists in store", () => {
+    const store = {
+      "session-1": { sessionId: "abc", updatedAt: 0 },
+    } as const;
+    expect(resolveSessionEntryForKey(store, "session-1")).toEqual({
+      entry: store["session-1"],
+      key: "session-1",
+    });
+    expect(resolveSessionEntryForKey(store, "session-2")).toEqual({});
+    expect(resolveSessionEntryForKey(undefined, "session-1")).toEqual({});
   });
 
   it("fast-aborts even when text commands are disabled", async () => {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -102,7 +102,7 @@ export function formatAbortReplyText(stoppedSubagents?: number): string {
   return `⚙️ Agent was aborted. Stopped ${stoppedSubagents} ${label}.`;
 }
 
-function resolveSessionEntryForKey(
+export function resolveSessionEntryForKey(
   store: Record<string, SessionEntry> | undefined,
   sessionKey: string | undefined,
 ) {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import { resolveAgentModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -14,7 +13,6 @@ import {
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import {
-  resolveAgentIdFromSessionKey,
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
   type SessionEntry,
@@ -33,11 +31,10 @@ import type { VerboseLevel } from "../thinking.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
-  buildEmbeddedContextFromTemplate,
-  buildTemplateSenderContext,
-  resolveRunAuthProfile,
+  buildEmbeddedRunBaseParams,
+  buildEmbeddedRunContexts,
+  resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
-import { resolveEnforceFinalTag } from "./agent-runner-utils.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
 import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
@@ -157,14 +154,7 @@ export async function runAgentTurnWithFallback(params: {
       const blockReplyPipeline = params.blockReplyPipeline;
       const onToolResult = params.opts?.onToolResult;
       const fallbackResult = await runWithModelFallback({
-        cfg: params.followupRun.run.config,
-        provider: params.followupRun.run.provider,
-        model: params.followupRun.run.model,
-        agentDir: params.followupRun.run.agentDir,
-        fallbacksOverride: resolveAgentModelFallbacksOverride(
-          params.followupRun.run.config,
-          resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
-        ),
+        ...resolveModelFallbackOptions(params.followupRun.run),
         run: (provider, model) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.
@@ -262,13 +252,19 @@ export async function runAgentTurnWithFallback(params: {
               }
             })();
           }
-          const authProfile = resolveRunAuthProfile(params.followupRun.run, provider);
-          const embeddedContext = buildEmbeddedContextFromTemplate({
+          const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts({
             run: params.followupRun.run,
             sessionCtx: params.sessionCtx,
             hasRepliedRef: params.opts?.hasRepliedRef,
+            provider,
           });
-          const senderContext = buildTemplateSenderContext(params.sessionCtx);
+          const runBaseParams = buildEmbeddedRunBaseParams({
+            run: params.followupRun.run,
+            provider,
+            model,
+            runId,
+            authProfile,
+          });
           return runEmbeddedPiAgent({
             ...embeddedContext,
             groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
@@ -276,22 +272,9 @@ export async function runAgentTurnWithFallback(params: {
               params.sessionCtx.GroupChannel?.trim() ?? params.sessionCtx.GroupSubject?.trim(),
             groupSpace: params.sessionCtx.GroupSpace?.trim() ?? undefined,
             ...senderContext,
-            sessionFile: params.followupRun.run.sessionFile,
-            workspaceDir: params.followupRun.run.workspaceDir,
-            agentDir: params.followupRun.run.agentDir,
-            config: params.followupRun.run.config,
-            skillsSnapshot: params.followupRun.run.skillsSnapshot,
+            ...runBaseParams,
             prompt: params.commandBody,
             extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-            ownerNumbers: params.followupRun.run.ownerNumbers,
-            enforceFinalTag: resolveEnforceFinalTag(params.followupRun.run, provider),
-            provider,
-            model,
-            ...authProfile,
-            thinkLevel: params.followupRun.run.thinkLevel,
-            verboseLevel: params.followupRun.run.verboseLevel,
-            reasoningLevel: params.followupRun.run.reasoningLevel,
-            execOverrides: params.followupRun.run.execOverrides,
             toolResultFormat: (() => {
               const channel = resolveMessageChannel(
                 params.sessionCtx.Surface,
@@ -303,9 +286,6 @@ export async function runAgentTurnWithFallback(params: {
               return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
             })(),
             suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
-            bashElevated: params.followupRun.run.bashElevated,
-            timeoutMs: params.followupRun.run.timeoutMs,
-            runId,
             images: params.opts?.images,
             abortSignal: params.opts?.abortSignal,
             blockReplyBreak: params.resolvedBlockStreamingBreak,

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FollowupRun } from "./queue.js";
+
+const hoisted = vi.hoisted(() => {
+  const resolveAgentModelFallbacksOverrideMock = vi.fn();
+  const resolveAgentIdFromSessionKeyMock = vi.fn();
+  return { resolveAgentModelFallbacksOverrideMock, resolveAgentIdFromSessionKeyMock };
+});
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentModelFallbacksOverride: (...args: unknown[]) =>
+    hoisted.resolveAgentModelFallbacksOverrideMock(...args),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveAgentIdFromSessionKey: (...args: unknown[]) =>
+    hoisted.resolveAgentIdFromSessionKeyMock(...args),
+}));
+
+const {
+  buildEmbeddedRunBaseParams,
+  buildEmbeddedRunContexts,
+  resolveModelFallbackOptions,
+  resolveProviderScopedAuthProfile,
+} = await import("./agent-runner-utils.js");
+
+function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"] {
+  return {
+    sessionId: "session-1",
+    agentId: "agent-1",
+    config: { models: { providers: {} } },
+    provider: "openai",
+    model: "gpt-4.1",
+    agentDir: "/tmp/agent",
+    sessionKey: "agent:test:session",
+    sessionFile: "/tmp/session.json",
+    workspaceDir: "/tmp/workspace",
+    skillsSnapshot: [],
+    ownerNumbers: ["+15550001"],
+    enforceFinalTag: false,
+    thinkLevel: "medium",
+    verboseLevel: "off",
+    reasoningLevel: "none",
+    execOverrides: {},
+    bashElevated: false,
+    timeoutMs: 60_000,
+    ...overrides,
+  } as unknown as FollowupRun["run"];
+}
+
+describe("agent-runner-utils", () => {
+  beforeEach(() => {
+    hoisted.resolveAgentModelFallbacksOverrideMock.mockReset();
+    hoisted.resolveAgentIdFromSessionKeyMock.mockReset();
+  });
+
+  it("resolves model fallback options from run context", () => {
+    hoisted.resolveAgentIdFromSessionKeyMock.mockReturnValue("agent-id");
+    hoisted.resolveAgentModelFallbacksOverrideMock.mockReturnValue(["fallback-model"]);
+    const run = makeRun();
+
+    const resolved = resolveModelFallbackOptions(run);
+
+    expect(hoisted.resolveAgentIdFromSessionKeyMock).toHaveBeenCalledWith(run.sessionKey);
+    expect(hoisted.resolveAgentModelFallbacksOverrideMock).toHaveBeenCalledWith(
+      run.config,
+      "agent-id",
+    );
+    expect(resolved).toEqual({
+      cfg: run.config,
+      provider: run.provider,
+      model: run.model,
+      agentDir: run.agentDir,
+      fallbacksOverride: ["fallback-model"],
+    });
+  });
+
+  it("builds embedded run base params with auth profile and run metadata", () => {
+    const run = makeRun({ enforceFinalTag: true });
+    const authProfile = resolveProviderScopedAuthProfile({
+      provider: "openai",
+      primaryProvider: "openai",
+      authProfileId: "profile-openai",
+      authProfileIdSource: "user",
+    });
+
+    const resolved = buildEmbeddedRunBaseParams({
+      run,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      runId: "run-1",
+      authProfile,
+    });
+
+    expect(resolved).toMatchObject({
+      sessionFile: run.sessionFile,
+      workspaceDir: run.workspaceDir,
+      agentDir: run.agentDir,
+      config: run.config,
+      skillsSnapshot: run.skillsSnapshot,
+      ownerNumbers: run.ownerNumbers,
+      enforceFinalTag: true,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      authProfileId: "profile-openai",
+      authProfileIdSource: "user",
+      thinkLevel: run.thinkLevel,
+      verboseLevel: run.verboseLevel,
+      reasoningLevel: run.reasoningLevel,
+      execOverrides: run.execOverrides,
+      bashElevated: run.bashElevated,
+      timeoutMs: run.timeoutMs,
+      runId: "run-1",
+    });
+  });
+
+  it("builds embedded contexts and scopes auth profile by provider", () => {
+    const run = makeRun({
+      authProfileId: "profile-openai",
+      authProfileIdSource: "auto",
+    });
+
+    const resolved = buildEmbeddedRunContexts({
+      run,
+      sessionCtx: {
+        Provider: "OpenAI",
+        To: "channel-1",
+        SenderId: "sender-1",
+      },
+      hasRepliedRef: undefined,
+      provider: "anthropic",
+    });
+
+    expect(resolved.authProfile).toEqual({
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    });
+    expect(resolved.embeddedContext).toMatchObject({
+      sessionId: run.sessionId,
+      sessionKey: run.sessionKey,
+      agentId: run.agentId,
+      messageProvider: "openai",
+      messageTo: "channel-1",
+    });
+    expect(resolved.senderContext).toEqual({
+      senderId: "sender-1",
+      senderName: undefined,
+      senderUsername: undefined,
+      senderE164: undefined,
+    });
+  });
+});

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -12,25 +12,12 @@ import { normalizeUsageDisplay, resolveResponseUsageMode } from "../thinking.js"
 import {
   formatAbortReplyText,
   isAbortTrigger,
+  resolveSessionEntryForKey,
   setAbortMemory,
   stopSubagentsForRequester,
 } from "./abort.js";
 import type { CommandHandler } from "./commands-types.js";
 import { clearSessionQueues } from "./queue.js";
-
-function resolveSessionEntryForKey(
-  store: Record<string, SessionEntry> | undefined,
-  sessionKey: string | undefined,
-) {
-  if (!store || !sessionKey) {
-    return {};
-  }
-  const direct = store[sessionKey];
-  if (direct) {
-    return { entry: direct, key: sessionKey };
-  }
-  return {};
-}
 
 function resolveAbortTarget(params: {
   ctx: { CommandTargetSessionKey?: string | null };

--- a/src/auto-reply/reply/commands-setunset-standard.ts
+++ b/src/auto-reply/reply/commands-setunset-standard.ts
@@ -1,0 +1,23 @@
+import { parseSlashCommandWithSetUnset } from "./commands-setunset.js";
+
+export function parseStandardSetUnsetSlashCommand<T>(params: {
+  raw: string;
+  slash: string;
+  invalidMessage: string;
+  usageMessage: string;
+  onKnownAction: (action: string, args: string) => T | undefined;
+  onSet?: (path: string, value: unknown) => T;
+  onUnset?: (path: string) => T;
+  onError?: (message: string) => T;
+}): T | null {
+  return parseSlashCommandWithSetUnset<T>({
+    raw: params.raw,
+    slash: params.slash,
+    invalidMessage: params.invalidMessage,
+    usageMessage: params.usageMessage,
+    onKnownAction: params.onKnownAction,
+    onSet: params.onSet ?? ((path, value) => ({ action: "set", path, value }) as T),
+    onUnset: params.onUnset ?? ((path) => ({ action: "unset", path }) as T),
+    onError: params.onError ?? ((message) => ({ action: "error", message }) as T),
+  });
+}

--- a/src/auto-reply/reply/commands-setunset.test.ts
+++ b/src/auto-reply/reply/commands-setunset.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { parseStandardSetUnsetSlashCommand } from "./commands-setunset-standard.js";
 import {
   parseSetUnsetCommand,
   parseSetUnsetCommandAction,
@@ -112,5 +113,30 @@ describe("parseSlashCommandWithSetUnset", () => {
       onError: (message) => ({ action: "error", message }),
     });
     expect(unknownAction).toEqual({ action: "error", message: "Usage: /config show|set|unset" });
+  });
+});
+
+describe("parseStandardSetUnsetSlashCommand", () => {
+  it("uses default set/unset/error mappings", () => {
+    const result = parseStandardSetUnsetSlashCommand<ParsedSetUnsetAction>({
+      raw: '/config set a.b={"ok":true}',
+      slash: "/config",
+      invalidMessage: "Invalid /config syntax.",
+      usageMessage: "Usage: /config show|set|unset",
+      onKnownAction: () => undefined,
+    });
+    expect(result).toEqual({ action: "set", path: "a.b", value: { ok: true } });
+  });
+
+  it("supports caller-provided mappings", () => {
+    const result = parseStandardSetUnsetSlashCommand<ParsedSetUnsetAction>({
+      raw: "/config unset a.b",
+      slash: "/config",
+      invalidMessage: "Invalid /config syntax.",
+      usageMessage: "Usage: /config show|set|unset",
+      onKnownAction: () => undefined,
+      onUnset: (path) => ({ action: "unset", path: `wrapped:${path}` }),
+    });
+    expect(result).toEqual({ action: "unset", path: "wrapped:a.b" });
   });
 });

--- a/src/auto-reply/reply/config-commands.ts
+++ b/src/auto-reply/reply/config-commands.ts
@@ -1,4 +1,4 @@
-import { parseSlashCommandWithSetUnset } from "./commands-setunset.js";
+import { parseStandardSetUnsetSlashCommand } from "./commands-setunset-standard.js";
 
 export type ConfigCommand =
   | { action: "show"; path?: string }
@@ -7,7 +7,7 @@ export type ConfigCommand =
   | { action: "error"; message: string };
 
 export function parseConfigCommand(raw: string): ConfigCommand | null {
-  return parseSlashCommandWithSetUnset<ConfigCommand>({
+  return parseStandardSetUnsetSlashCommand<ConfigCommand>({
     raw,
     slash: "/config",
     invalidMessage: "Invalid /config syntax.",
@@ -18,8 +18,5 @@ export function parseConfigCommand(raw: string): ConfigCommand | null {
       }
       return undefined;
     },
-    onSet: (path, value) => ({ action: "set", path, value }),
-    onUnset: (path) => ({ action: "unset", path }),
-    onError: (message) => ({ action: "error", message }),
   });
 }

--- a/src/auto-reply/reply/debug-commands.ts
+++ b/src/auto-reply/reply/debug-commands.ts
@@ -1,4 +1,4 @@
-import { parseSlashCommandWithSetUnset } from "./commands-setunset.js";
+import { parseStandardSetUnsetSlashCommand } from "./commands-setunset-standard.js";
 
 export type DebugCommand =
   | { action: "show" }
@@ -8,7 +8,7 @@ export type DebugCommand =
   | { action: "error"; message: string };
 
 export function parseDebugCommand(raw: string): DebugCommand | null {
-  return parseSlashCommandWithSetUnset<DebugCommand>({
+  return parseStandardSetUnsetSlashCommand<DebugCommand>({
     raw,
     slash: "/debug",
     invalidMessage: "Invalid /debug syntax.",
@@ -22,8 +22,5 @@ export function parseDebugCommand(raw: string): DebugCommand | null {
       }
       return undefined;
     },
-    onSet: (path, value) => ({ action: "set", path, value }),
-    onUnset: (path) => ({ action: "unset", path }),
-    onError: (message) => ({ action: "error", message }),
   });
 }

--- a/src/auto-reply/reply/directive-handling.auth.ts
+++ b/src/auto-reply/reply/directive-handling.auth.ts
@@ -1,3 +1,4 @@
+import { formatRemainingShort } from "../../agents/auth-health.js";
 import {
   isProfileInCooldown,
   resolveAuthProfileDisplayLabel,
@@ -32,23 +33,8 @@ export const resolveAuthLabel = async (
   const lastGood = findNormalizedProviderValue(store.lastGood, providerKey);
   const nextProfileId = order[0];
   const now = Date.now();
-
-  const formatUntil = (timestampMs: number) => {
-    const remainingMs = Math.max(0, timestampMs - now);
-    const minutes = Math.round(remainingMs / 60_000);
-    if (minutes < 1) {
-      return "soon";
-    }
-    if (minutes < 60) {
-      return `${minutes}m`;
-    }
-    const hours = Math.round(minutes / 60);
-    if (hours < 48) {
-      return `${hours}h`;
-    }
-    const days = Math.round(hours / 24);
-    return `${days}d`;
-  };
+  const formatUntil = (timestampMs: number) =>
+    formatRemainingShort(timestampMs - now, { underMinuteLabel: "soon" });
 
   if (order.length > 0) {
     if (mode === "compact") {

--- a/src/auto-reply/reply/reply-elevated.ts
+++ b/src/auto-reply/reply/reply-elevated.ts
@@ -3,6 +3,7 @@ import { getChannelDock } from "../../channels/dock.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { CHAT_CHANNEL_ORDER } from "../../channels/registry.js";
 import type { AgentElevatedAllowFromConfig, OpenClawConfig } from "../../config/config.js";
+import { normalizeAtHashSlug } from "../../shared/string-normalization.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import type { MsgContext } from "../templating.js";
 export { formatElevatedUnavailableMessage } from "./elevated-unavailable.js";
@@ -15,17 +16,7 @@ function normalizeAllowToken(value?: string) {
 }
 
 function slugAllowToken(value?: string) {
-  if (!value) {
-    return "";
-  }
-  let text = value.trim().toLowerCase();
-  if (!text) {
-    return "";
-  }
-  text = text.replace(/^[@#]+/, "");
-  text = text.replace(/[\s_]+/g, "-");
-  text = text.replace(/[^a-z0-9-]+/g, "-");
-  return text.replace(/-{2,}/g, "-").replace(/^-+|-+$/g, "");
+  return normalizeAtHashSlug(value);
 }
 
 const SENDER_PREFIXES = [

--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -113,6 +113,11 @@ function createCdpSender(ws: WebSocket) {
 }
 
 export async function fetchJson<T>(url: string, timeoutMs = 1500, init?: RequestInit): Promise<T> {
+  const res = await fetchChecked(url, timeoutMs, init);
+  return (await res.json()) as T;
+}
+
+async function fetchChecked(url: string, timeoutMs = 1500, init?: RequestInit): Promise<Response> {
   const ctrl = new AbortController();
   const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
@@ -121,24 +126,14 @@ export async function fetchJson<T>(url: string, timeoutMs = 1500, init?: Request
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }
-    return (await res.json()) as T;
+    return res;
   } finally {
     clearTimeout(t);
   }
 }
 
 export async function fetchOk(url: string, timeoutMs = 1500, init?: RequestInit): Promise<void> {
-  const ctrl = new AbortController();
-  const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
-  try {
-    const headers = getHeadersWithAuth(url, (init?.headers as Record<string, string>) || {});
-    const res = await fetch(url, { ...init, headers, signal: ctrl.signal });
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}`);
-    }
-  } finally {
-    clearTimeout(t);
-  }
+  await fetchChecked(url, timeoutMs, init);
 }
 
 export async function withCdpSocket<T>(

--- a/src/browser/client-actions-core.ts
+++ b/src/browser/client-actions-core.ts
@@ -88,6 +88,23 @@ export type BrowserDownloadPayload = {
   path: string;
 };
 
+type BrowserDownloadResult = { ok: true; targetId: string; download: BrowserDownloadPayload };
+
+async function postDownloadRequest(
+  baseUrl: string | undefined,
+  route: "/wait/download" | "/download",
+  body: Record<string, unknown>,
+  profile?: string,
+): Promise<BrowserDownloadResult> {
+  const q = buildProfileQuery(profile);
+  return await fetchBrowserJson<BrowserDownloadResult>(withBaseUrl(baseUrl, `${route}${q}`), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    timeoutMs: 20000,
+  });
+}
+
 export async function browserNavigate(
   baseUrl: string | undefined,
   opts: {
@@ -165,22 +182,17 @@ export async function browserWaitForDownload(
     timeoutMs?: number;
     profile?: string;
   },
-): Promise<{ ok: true; targetId: string; download: BrowserDownloadPayload }> {
-  const q = buildProfileQuery(opts.profile);
-  return await fetchBrowserJson<{
-    ok: true;
-    targetId: string;
-    download: BrowserDownloadPayload;
-  }>(withBaseUrl(baseUrl, `/wait/download${q}`), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
+): Promise<BrowserDownloadResult> {
+  return await postDownloadRequest(
+    baseUrl,
+    "/wait/download",
+    {
       targetId: opts.targetId,
       path: opts.path,
       timeoutMs: opts.timeoutMs,
-    }),
-    timeoutMs: 20000,
-  });
+    },
+    opts.profile,
+  );
 }
 
 export async function browserDownload(
@@ -192,23 +204,18 @@ export async function browserDownload(
     timeoutMs?: number;
     profile?: string;
   },
-): Promise<{ ok: true; targetId: string; download: BrowserDownloadPayload }> {
-  const q = buildProfileQuery(opts.profile);
-  return await fetchBrowserJson<{
-    ok: true;
-    targetId: string;
-    download: BrowserDownloadPayload;
-  }>(withBaseUrl(baseUrl, `/download${q}`), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
+): Promise<BrowserDownloadResult> {
+  return await postDownloadRequest(
+    baseUrl,
+    "/download",
+    {
       targetId: opts.targetId,
       ref: opts.ref,
       path: opts.path,
       timeoutMs: opts.timeoutMs,
-    }),
-    timeoutMs: 20000,
-  });
+    },
+    opts.profile,
+  );
 }
 
 export async function browserAct(

--- a/src/browser/pw-session.browserless.live.test.ts
+++ b/src/browser/pw-session.browserless.live.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { isTruthyEnvValue } from "../infra/env.js";
 
 const LIVE = isTruthyEnvValue(process.env.LIVE) || isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST);
@@ -9,14 +9,7 @@ async function waitFor(
   fn: () => Promise<boolean>,
   opts: { timeoutMs: number; intervalMs: number },
 ): Promise<void> {
-  const deadline = Date.now() + opts.timeoutMs;
-  while (Date.now() < deadline) {
-    if (await fn()) {
-      return;
-    }
-    await new Promise((r) => setTimeout(r, opts.intervalMs));
-  }
-  throw new Error("timed out");
+  await expect.poll(fn, { timeout: opts.timeoutMs, interval: opts.intervalMs }).toBe(true);
 }
 
 describeLive("browser (live): remote CDP tab persistence", () => {

--- a/src/browser/routes/agent.act.ts
+++ b/src/browser/routes/agent.act.ts
@@ -7,10 +7,9 @@ import {
   parseClickModifiers,
 } from "./agent.act.shared.js";
 import {
-  handleRouteError,
   readBody,
-  requirePwAi,
-  resolveProfileContext,
+  resolveTargetIdFromBody,
+  withPlaywrightRouteContext,
   SELECTOR_UNSUPPORTED_MESSAGE,
 } from "./agent.shared.js";
 import {
@@ -27,330 +26,321 @@ export function registerBrowserAgentActRoutes(
   ctx: BrowserRouteContext,
 ) {
   app.post("/act", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
     const kindRaw = toStringOrEmpty(body.kind);
     if (!isActKind(kindRaw)) {
       return jsonError(res, 400, "kind is required");
     }
     const kind: ActKind = kindRaw;
-    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const targetId = resolveTargetIdFromBody(body);
     if (Object.hasOwn(body, "selector") && kind !== "wait") {
       return jsonError(res, 400, SELECTOR_UNSUPPORTED_MESSAGE);
     }
 
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const cdpUrl = profileCtx.profile.cdpUrl;
-      const pw = await requirePwAi(res, `act:${kind}`);
-      if (!pw) {
-        return;
-      }
-      const evaluateEnabled = ctx.state().resolved.evaluateEnabled;
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: `act:${kind}`,
+      run: async ({ cdpUrl, tab, pw }) => {
+        const evaluateEnabled = ctx.state().resolved.evaluateEnabled;
 
-      switch (kind) {
-        case "click": {
-          const ref = toStringOrEmpty(body.ref);
-          if (!ref) {
-            return jsonError(res, 400, "ref is required");
-          }
-          const doubleClick = toBoolean(body.doubleClick) ?? false;
-          const timeoutMs = toNumber(body.timeoutMs);
-          const buttonRaw = toStringOrEmpty(body.button) || "";
-          const button = buttonRaw ? parseClickButton(buttonRaw) : undefined;
-          if (buttonRaw && !button) {
-            return jsonError(res, 400, "button must be left|right|middle");
-          }
+        switch (kind) {
+          case "click": {
+            const ref = toStringOrEmpty(body.ref);
+            if (!ref) {
+              return jsonError(res, 400, "ref is required");
+            }
+            const doubleClick = toBoolean(body.doubleClick) ?? false;
+            const timeoutMs = toNumber(body.timeoutMs);
+            const buttonRaw = toStringOrEmpty(body.button) || "";
+            const button = buttonRaw ? parseClickButton(buttonRaw) : undefined;
+            if (buttonRaw && !button) {
+              return jsonError(res, 400, "button must be left|right|middle");
+            }
 
-          const modifiersRaw = toStringArray(body.modifiers) ?? [];
-          const parsedModifiers = parseClickModifiers(modifiersRaw);
-          if (parsedModifiers.error) {
-            return jsonError(res, 400, parsedModifiers.error);
+            const modifiersRaw = toStringArray(body.modifiers) ?? [];
+            const parsedModifiers = parseClickModifiers(modifiersRaw);
+            if (parsedModifiers.error) {
+              return jsonError(res, 400, parsedModifiers.error);
+            }
+            const modifiers = parsedModifiers.modifiers;
+            const clickRequest: Parameters<typeof pw.clickViaPlaywright>[0] = {
+              cdpUrl,
+              targetId: tab.targetId,
+              ref,
+              doubleClick,
+            };
+            if (button) {
+              clickRequest.button = button;
+            }
+            if (modifiers) {
+              clickRequest.modifiers = modifiers;
+            }
+            if (timeoutMs) {
+              clickRequest.timeoutMs = timeoutMs;
+            }
+            await pw.clickViaPlaywright(clickRequest);
+            return res.json({ ok: true, targetId: tab.targetId, url: tab.url });
           }
-          const modifiers = parsedModifiers.modifiers;
-          const clickRequest: Parameters<typeof pw.clickViaPlaywright>[0] = {
-            cdpUrl,
-            targetId: tab.targetId,
-            ref,
-            doubleClick,
-          };
-          if (button) {
-            clickRequest.button = button;
+          case "type": {
+            const ref = toStringOrEmpty(body.ref);
+            if (!ref) {
+              return jsonError(res, 400, "ref is required");
+            }
+            if (typeof body.text !== "string") {
+              return jsonError(res, 400, "text is required");
+            }
+            const text = body.text;
+            const submit = toBoolean(body.submit) ?? false;
+            const slowly = toBoolean(body.slowly) ?? false;
+            const timeoutMs = toNumber(body.timeoutMs);
+            const typeRequest: Parameters<typeof pw.typeViaPlaywright>[0] = {
+              cdpUrl,
+              targetId: tab.targetId,
+              ref,
+              text,
+              submit,
+              slowly,
+            };
+            if (timeoutMs) {
+              typeRequest.timeoutMs = timeoutMs;
+            }
+            await pw.typeViaPlaywright(typeRequest);
+            return res.json({ ok: true, targetId: tab.targetId });
           }
-          if (modifiers) {
-            clickRequest.modifiers = modifiers;
+          case "press": {
+            const key = toStringOrEmpty(body.key);
+            if (!key) {
+              return jsonError(res, 400, "key is required");
+            }
+            const delayMs = toNumber(body.delayMs);
+            await pw.pressKeyViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              key,
+              delayMs: delayMs ?? undefined,
+            });
+            return res.json({ ok: true, targetId: tab.targetId });
           }
-          if (timeoutMs) {
-            clickRequest.timeoutMs = timeoutMs;
+          case "hover": {
+            const ref = toStringOrEmpty(body.ref);
+            if (!ref) {
+              return jsonError(res, 400, "ref is required");
+            }
+            const timeoutMs = toNumber(body.timeoutMs);
+            await pw.hoverViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              ref,
+              timeoutMs: timeoutMs ?? undefined,
+            });
+            return res.json({ ok: true, targetId: tab.targetId });
           }
-          await pw.clickViaPlaywright(clickRequest);
-          return res.json({ ok: true, targetId: tab.targetId, url: tab.url });
+          case "scrollIntoView": {
+            const ref = toStringOrEmpty(body.ref);
+            if (!ref) {
+              return jsonError(res, 400, "ref is required");
+            }
+            const timeoutMs = toNumber(body.timeoutMs);
+            const scrollRequest: Parameters<typeof pw.scrollIntoViewViaPlaywright>[0] = {
+              cdpUrl,
+              targetId: tab.targetId,
+              ref,
+            };
+            if (timeoutMs) {
+              scrollRequest.timeoutMs = timeoutMs;
+            }
+            await pw.scrollIntoViewViaPlaywright(scrollRequest);
+            return res.json({ ok: true, targetId: tab.targetId });
+          }
+          case "drag": {
+            const startRef = toStringOrEmpty(body.startRef);
+            const endRef = toStringOrEmpty(body.endRef);
+            if (!startRef || !endRef) {
+              return jsonError(res, 400, "startRef and endRef are required");
+            }
+            const timeoutMs = toNumber(body.timeoutMs);
+            await pw.dragViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              startRef,
+              endRef,
+              timeoutMs: timeoutMs ?? undefined,
+            });
+            return res.json({ ok: true, targetId: tab.targetId });
+          }
+          case "select": {
+            const ref = toStringOrEmpty(body.ref);
+            const values = toStringArray(body.values);
+            if (!ref || !values?.length) {
+              return jsonError(res, 400, "ref and values are required");
+            }
+            const timeoutMs = toNumber(body.timeoutMs);
+            await pw.selectOptionViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              ref,
+              values,
+              timeoutMs: timeoutMs ?? undefined,
+            });
+            return res.json({ ok: true, targetId: tab.targetId });
+          }
+          case "fill": {
+            const rawFields = Array.isArray(body.fields) ? body.fields : [];
+            const fields = rawFields
+              .map((field) => {
+                if (!field || typeof field !== "object") {
+                  return null;
+                }
+                const rec = field as Record<string, unknown>;
+                const ref = toStringOrEmpty(rec.ref);
+                const type = toStringOrEmpty(rec.type);
+                if (!ref || !type) {
+                  return null;
+                }
+                const value =
+                  typeof rec.value === "string" ||
+                  typeof rec.value === "number" ||
+                  typeof rec.value === "boolean"
+                    ? rec.value
+                    : undefined;
+                const parsed: BrowserFormField =
+                  value === undefined ? { ref, type } : { ref, type, value };
+                return parsed;
+              })
+              .filter((field): field is BrowserFormField => field !== null);
+            if (!fields.length) {
+              return jsonError(res, 400, "fields are required");
+            }
+            const timeoutMs = toNumber(body.timeoutMs);
+            await pw.fillFormViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              fields,
+              timeoutMs: timeoutMs ?? undefined,
+            });
+            return res.json({ ok: true, targetId: tab.targetId });
+          }
+          case "resize": {
+            const width = toNumber(body.width);
+            const height = toNumber(body.height);
+            if (!width || !height) {
+              return jsonError(res, 400, "width and height are required");
+            }
+            await pw.resizeViewportViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              width,
+              height,
+            });
+            return res.json({ ok: true, targetId: tab.targetId, url: tab.url });
+          }
+          case "wait": {
+            const timeMs = toNumber(body.timeMs);
+            const text = toStringOrEmpty(body.text) || undefined;
+            const textGone = toStringOrEmpty(body.textGone) || undefined;
+            const selector = toStringOrEmpty(body.selector) || undefined;
+            const url = toStringOrEmpty(body.url) || undefined;
+            const loadStateRaw = toStringOrEmpty(body.loadState);
+            const loadState =
+              loadStateRaw === "load" ||
+              loadStateRaw === "domcontentloaded" ||
+              loadStateRaw === "networkidle"
+                ? loadStateRaw
+                : undefined;
+            const fn = toStringOrEmpty(body.fn) || undefined;
+            const timeoutMs = toNumber(body.timeoutMs) ?? undefined;
+            if (fn && !evaluateEnabled) {
+              return jsonError(
+                res,
+                403,
+                [
+                  "wait --fn is disabled by config (browser.evaluateEnabled=false).",
+                  "Docs: /gateway/configuration#browser-openclaw-managed-browser",
+                ].join("\n"),
+              );
+            }
+            if (
+              timeMs === undefined &&
+              !text &&
+              !textGone &&
+              !selector &&
+              !url &&
+              !loadState &&
+              !fn
+            ) {
+              return jsonError(
+                res,
+                400,
+                "wait requires at least one of: timeMs, text, textGone, selector, url, loadState, fn",
+              );
+            }
+            await pw.waitForViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              timeMs,
+              text,
+              textGone,
+              selector,
+              url,
+              loadState,
+              fn,
+              timeoutMs,
+            });
+            return res.json({ ok: true, targetId: tab.targetId });
+          }
+          case "evaluate": {
+            if (!evaluateEnabled) {
+              return jsonError(
+                res,
+                403,
+                [
+                  "act:evaluate is disabled by config (browser.evaluateEnabled=false).",
+                  "Docs: /gateway/configuration#browser-openclaw-managed-browser",
+                ].join("\n"),
+              );
+            }
+            const fn = toStringOrEmpty(body.fn);
+            if (!fn) {
+              return jsonError(res, 400, "fn is required");
+            }
+            const ref = toStringOrEmpty(body.ref) || undefined;
+            const evalTimeoutMs = toNumber(body.timeoutMs);
+            const evalRequest: Parameters<typeof pw.evaluateViaPlaywright>[0] = {
+              cdpUrl,
+              targetId: tab.targetId,
+              fn,
+              ref,
+              signal: req.signal,
+            };
+            if (evalTimeoutMs !== undefined) {
+              evalRequest.timeoutMs = evalTimeoutMs;
+            }
+            const result = await pw.evaluateViaPlaywright(evalRequest);
+            return res.json({
+              ok: true,
+              targetId: tab.targetId,
+              url: tab.url,
+              result,
+            });
+          }
+          case "close": {
+            await pw.closePageViaPlaywright({ cdpUrl, targetId: tab.targetId });
+            return res.json({ ok: true, targetId: tab.targetId });
+          }
+          default: {
+            return jsonError(res, 400, "unsupported kind");
+          }
         }
-        case "type": {
-          const ref = toStringOrEmpty(body.ref);
-          if (!ref) {
-            return jsonError(res, 400, "ref is required");
-          }
-          if (typeof body.text !== "string") {
-            return jsonError(res, 400, "text is required");
-          }
-          const text = body.text;
-          const submit = toBoolean(body.submit) ?? false;
-          const slowly = toBoolean(body.slowly) ?? false;
-          const timeoutMs = toNumber(body.timeoutMs);
-          const typeRequest: Parameters<typeof pw.typeViaPlaywright>[0] = {
-            cdpUrl,
-            targetId: tab.targetId,
-            ref,
-            text,
-            submit,
-            slowly,
-          };
-          if (timeoutMs) {
-            typeRequest.timeoutMs = timeoutMs;
-          }
-          await pw.typeViaPlaywright(typeRequest);
-          return res.json({ ok: true, targetId: tab.targetId });
-        }
-        case "press": {
-          const key = toStringOrEmpty(body.key);
-          if (!key) {
-            return jsonError(res, 400, "key is required");
-          }
-          const delayMs = toNumber(body.delayMs);
-          await pw.pressKeyViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            key,
-            delayMs: delayMs ?? undefined,
-          });
-          return res.json({ ok: true, targetId: tab.targetId });
-        }
-        case "hover": {
-          const ref = toStringOrEmpty(body.ref);
-          if (!ref) {
-            return jsonError(res, 400, "ref is required");
-          }
-          const timeoutMs = toNumber(body.timeoutMs);
-          await pw.hoverViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            ref,
-            timeoutMs: timeoutMs ?? undefined,
-          });
-          return res.json({ ok: true, targetId: tab.targetId });
-        }
-        case "scrollIntoView": {
-          const ref = toStringOrEmpty(body.ref);
-          if (!ref) {
-            return jsonError(res, 400, "ref is required");
-          }
-          const timeoutMs = toNumber(body.timeoutMs);
-          const scrollRequest: Parameters<typeof pw.scrollIntoViewViaPlaywright>[0] = {
-            cdpUrl,
-            targetId: tab.targetId,
-            ref,
-          };
-          if (timeoutMs) {
-            scrollRequest.timeoutMs = timeoutMs;
-          }
-          await pw.scrollIntoViewViaPlaywright(scrollRequest);
-          return res.json({ ok: true, targetId: tab.targetId });
-        }
-        case "drag": {
-          const startRef = toStringOrEmpty(body.startRef);
-          const endRef = toStringOrEmpty(body.endRef);
-          if (!startRef || !endRef) {
-            return jsonError(res, 400, "startRef and endRef are required");
-          }
-          const timeoutMs = toNumber(body.timeoutMs);
-          await pw.dragViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            startRef,
-            endRef,
-            timeoutMs: timeoutMs ?? undefined,
-          });
-          return res.json({ ok: true, targetId: tab.targetId });
-        }
-        case "select": {
-          const ref = toStringOrEmpty(body.ref);
-          const values = toStringArray(body.values);
-          if (!ref || !values?.length) {
-            return jsonError(res, 400, "ref and values are required");
-          }
-          const timeoutMs = toNumber(body.timeoutMs);
-          await pw.selectOptionViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            ref,
-            values,
-            timeoutMs: timeoutMs ?? undefined,
-          });
-          return res.json({ ok: true, targetId: tab.targetId });
-        }
-        case "fill": {
-          const rawFields = Array.isArray(body.fields) ? body.fields : [];
-          const fields = rawFields
-            .map((field) => {
-              if (!field || typeof field !== "object") {
-                return null;
-              }
-              const rec = field as Record<string, unknown>;
-              const ref = toStringOrEmpty(rec.ref);
-              const type = toStringOrEmpty(rec.type);
-              if (!ref || !type) {
-                return null;
-              }
-              const value =
-                typeof rec.value === "string" ||
-                typeof rec.value === "number" ||
-                typeof rec.value === "boolean"
-                  ? rec.value
-                  : undefined;
-              const parsed: BrowserFormField =
-                value === undefined ? { ref, type } : { ref, type, value };
-              return parsed;
-            })
-            .filter((field): field is BrowserFormField => field !== null);
-          if (!fields.length) {
-            return jsonError(res, 400, "fields are required");
-          }
-          const timeoutMs = toNumber(body.timeoutMs);
-          await pw.fillFormViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            fields,
-            timeoutMs: timeoutMs ?? undefined,
-          });
-          return res.json({ ok: true, targetId: tab.targetId });
-        }
-        case "resize": {
-          const width = toNumber(body.width);
-          const height = toNumber(body.height);
-          if (!width || !height) {
-            return jsonError(res, 400, "width and height are required");
-          }
-          await pw.resizeViewportViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            width,
-            height,
-          });
-          return res.json({ ok: true, targetId: tab.targetId, url: tab.url });
-        }
-        case "wait": {
-          const timeMs = toNumber(body.timeMs);
-          const text = toStringOrEmpty(body.text) || undefined;
-          const textGone = toStringOrEmpty(body.textGone) || undefined;
-          const selector = toStringOrEmpty(body.selector) || undefined;
-          const url = toStringOrEmpty(body.url) || undefined;
-          const loadStateRaw = toStringOrEmpty(body.loadState);
-          const loadState =
-            loadStateRaw === "load" ||
-            loadStateRaw === "domcontentloaded" ||
-            loadStateRaw === "networkidle"
-              ? loadStateRaw
-              : undefined;
-          const fn = toStringOrEmpty(body.fn) || undefined;
-          const timeoutMs = toNumber(body.timeoutMs) ?? undefined;
-          if (fn && !evaluateEnabled) {
-            return jsonError(
-              res,
-              403,
-              [
-                "wait --fn is disabled by config (browser.evaluateEnabled=false).",
-                "Docs: /gateway/configuration#browser-openclaw-managed-browser",
-              ].join("\n"),
-            );
-          }
-          if (
-            timeMs === undefined &&
-            !text &&
-            !textGone &&
-            !selector &&
-            !url &&
-            !loadState &&
-            !fn
-          ) {
-            return jsonError(
-              res,
-              400,
-              "wait requires at least one of: timeMs, text, textGone, selector, url, loadState, fn",
-            );
-          }
-          await pw.waitForViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            timeMs,
-            text,
-            textGone,
-            selector,
-            url,
-            loadState,
-            fn,
-            timeoutMs,
-          });
-          return res.json({ ok: true, targetId: tab.targetId });
-        }
-        case "evaluate": {
-          if (!evaluateEnabled) {
-            return jsonError(
-              res,
-              403,
-              [
-                "act:evaluate is disabled by config (browser.evaluateEnabled=false).",
-                "Docs: /gateway/configuration#browser-openclaw-managed-browser",
-              ].join("\n"),
-            );
-          }
-          const fn = toStringOrEmpty(body.fn);
-          if (!fn) {
-            return jsonError(res, 400, "fn is required");
-          }
-          const ref = toStringOrEmpty(body.ref) || undefined;
-          const evalTimeoutMs = toNumber(body.timeoutMs);
-          const evalRequest: Parameters<typeof pw.evaluateViaPlaywright>[0] = {
-            cdpUrl,
-            targetId: tab.targetId,
-            fn,
-            ref,
-            signal: req.signal,
-          };
-          if (evalTimeoutMs !== undefined) {
-            evalRequest.timeoutMs = evalTimeoutMs;
-          }
-          const result = await pw.evaluateViaPlaywright(evalRequest);
-          return res.json({
-            ok: true,
-            targetId: tab.targetId,
-            url: tab.url,
-            result,
-          });
-        }
-        case "close": {
-          await pw.closePageViaPlaywright({ cdpUrl, targetId: tab.targetId });
-          return res.json({ ok: true, targetId: tab.targetId });
-        }
-        default: {
-          return jsonError(res, 400, "unsupported kind");
-        }
-      }
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+      },
+    });
   });
 
   app.post("/hooks/file-chooser", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const targetId = resolveTargetIdFromBody(body);
     const ref = toStringOrEmpty(body.ref) || undefined;
     const inputRef = toStringOrEmpty(body.inputRef) || undefined;
     const element = toStringOrEmpty(body.element) || undefined;
@@ -359,134 +349,125 @@ export function registerBrowserAgentActRoutes(
     if (!paths.length) {
       return jsonError(res, 400, "paths are required");
     }
-    try {
-      const uploadPathsResult = resolvePathsWithinRoot({
-        rootDir: DEFAULT_UPLOAD_DIR,
-        requestedPaths: paths,
-        scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,
-      });
-      if (!uploadPathsResult.ok) {
-        res.status(400).json({ error: uploadPathsResult.error });
-        return;
-      }
-      const resolvedPaths = uploadPathsResult.paths;
 
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "file chooser hook");
-      if (!pw) {
-        return;
-      }
-      if (inputRef || element) {
-        if (ref) {
-          return jsonError(res, 400, "ref cannot be combined with inputRef/element");
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "file chooser hook",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const uploadPathsResult = resolvePathsWithinRoot({
+          rootDir: DEFAULT_UPLOAD_DIR,
+          requestedPaths: paths,
+          scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,
+        });
+        if (!uploadPathsResult.ok) {
+          res.status(400).json({ error: uploadPathsResult.error });
+          return;
         }
-        await pw.setInputFilesViaPlaywright({
-          cdpUrl: profileCtx.profile.cdpUrl,
-          targetId: tab.targetId,
-          inputRef,
-          element,
-          paths: resolvedPaths,
-        });
-      } else {
-        await pw.armFileUploadViaPlaywright({
-          cdpUrl: profileCtx.profile.cdpUrl,
-          targetId: tab.targetId,
-          paths: resolvedPaths,
-          timeoutMs: timeoutMs ?? undefined,
-        });
-        if (ref) {
-          await pw.clickViaPlaywright({
-            cdpUrl: profileCtx.profile.cdpUrl,
+        const resolvedPaths = uploadPathsResult.paths;
+
+        if (inputRef || element) {
+          if (ref) {
+            return jsonError(res, 400, "ref cannot be combined with inputRef/element");
+          }
+          await pw.setInputFilesViaPlaywright({
+            cdpUrl,
             targetId: tab.targetId,
-            ref,
+            inputRef,
+            element,
+            paths: resolvedPaths,
           });
+        } else {
+          await pw.armFileUploadViaPlaywright({
+            cdpUrl,
+            targetId: tab.targetId,
+            paths: resolvedPaths,
+            timeoutMs: timeoutMs ?? undefined,
+          });
+          if (ref) {
+            await pw.clickViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              ref,
+            });
+          }
         }
-      }
-      res.json({ ok: true });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+        res.json({ ok: true });
+      },
+    });
   });
 
   app.post("/hooks/dialog", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const targetId = resolveTargetIdFromBody(body);
     const accept = toBoolean(body.accept);
     const promptText = toStringOrEmpty(body.promptText) || undefined;
     const timeoutMs = toNumber(body.timeoutMs);
     if (accept === undefined) {
       return jsonError(res, 400, "accept is required");
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "dialog hook");
-      if (!pw) {
-        return;
-      }
-      await pw.armDialogViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        accept,
-        promptText,
-        timeoutMs: timeoutMs ?? undefined,
-      });
-      res.json({ ok: true });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "dialog hook",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.armDialogViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          accept,
+          promptText,
+          timeoutMs: timeoutMs ?? undefined,
+        });
+        res.json({ ok: true });
+      },
+    });
   });
 
   app.post("/wait/download", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const targetId = resolveTargetIdFromBody(body);
     const out = toStringOrEmpty(body.path) || "";
     const timeoutMs = toNumber(body.timeoutMs);
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "wait for download");
-      if (!pw) {
-        return;
-      }
-      let downloadPath: string | undefined;
-      if (out.trim()) {
-        const downloadPathResult = resolvePathWithinRoot({
-          rootDir: DEFAULT_DOWNLOAD_DIR,
-          requestedPath: out,
-          scopeLabel: "downloads directory",
-        });
-        if (!downloadPathResult.ok) {
-          res.status(400).json({ error: downloadPathResult.error });
-          return;
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "wait for download",
+      run: async ({ cdpUrl, tab, pw }) => {
+        let downloadPath: string | undefined;
+        if (out.trim()) {
+          const downloadPathResult = resolvePathWithinRoot({
+            rootDir: DEFAULT_DOWNLOAD_DIR,
+            requestedPath: out,
+            scopeLabel: "downloads directory",
+          });
+          if (!downloadPathResult.ok) {
+            res.status(400).json({ error: downloadPathResult.error });
+            return;
+          }
+          downloadPath = downloadPathResult.path;
         }
-        downloadPath = downloadPathResult.path;
-      }
-      const result = await pw.waitForDownloadViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        path: downloadPath,
-        timeoutMs: timeoutMs ?? undefined,
-      });
-      res.json({ ok: true, targetId: tab.targetId, download: result });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+        const result = await pw.waitForDownloadViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          path: downloadPath,
+          timeoutMs: timeoutMs ?? undefined,
+        });
+        res.json({ ok: true, targetId: tab.targetId, download: result });
+      },
+    });
   });
 
   app.post("/download", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const targetId = resolveTargetIdFromBody(body);
     const ref = toStringOrEmpty(body.ref);
     const out = toStringOrEmpty(body.path);
     const timeoutMs = toNumber(body.timeoutMs);
@@ -496,91 +477,86 @@ export function registerBrowserAgentActRoutes(
     if (!out) {
       return jsonError(res, 400, "path is required");
     }
-    try {
-      const downloadPathResult = resolvePathWithinRoot({
-        rootDir: DEFAULT_DOWNLOAD_DIR,
-        requestedPath: out,
-        scopeLabel: "downloads directory",
-      });
-      if (!downloadPathResult.ok) {
-        res.status(400).json({ error: downloadPathResult.error });
-        return;
-      }
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "download");
-      if (!pw) {
-        return;
-      }
-      const result = await pw.downloadViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        ref,
-        path: downloadPathResult.path,
-        timeoutMs: timeoutMs ?? undefined,
-      });
-      res.json({ ok: true, targetId: tab.targetId, download: result });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "download",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const downloadPathResult = resolvePathWithinRoot({
+          rootDir: DEFAULT_DOWNLOAD_DIR,
+          requestedPath: out,
+          scopeLabel: "downloads directory",
+        });
+        if (!downloadPathResult.ok) {
+          res.status(400).json({ error: downloadPathResult.error });
+          return;
+        }
+        const result = await pw.downloadViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          ref,
+          path: downloadPathResult.path,
+          timeoutMs: timeoutMs ?? undefined,
+        });
+        res.json({ ok: true, targetId: tab.targetId, download: result });
+      },
+    });
   });
 
   app.post("/response/body", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const targetId = resolveTargetIdFromBody(body);
     const url = toStringOrEmpty(body.url);
     const timeoutMs = toNumber(body.timeoutMs);
     const maxChars = toNumber(body.maxChars);
     if (!url) {
       return jsonError(res, 400, "url is required");
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "response body");
-      if (!pw) {
-        return;
-      }
-      const result = await pw.responseBodyViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        url,
-        timeoutMs: timeoutMs ?? undefined,
-        maxChars: maxChars ?? undefined,
-      });
-      res.json({ ok: true, targetId: tab.targetId, response: result });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "response body",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const result = await pw.responseBodyViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          url,
+          timeoutMs: timeoutMs ?? undefined,
+          maxChars: maxChars ?? undefined,
+        });
+        res.json({ ok: true, targetId: tab.targetId, response: result });
+      },
+    });
   });
 
   app.post("/highlight", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const targetId = resolveTargetIdFromBody(body);
     const ref = toStringOrEmpty(body.ref);
     if (!ref) {
       return jsonError(res, 400, "ref is required");
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "highlight");
-      if (!pw) {
-        return;
-      }
-      await pw.highlightViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        ref,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "highlight",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.highlightViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          ref,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 }

--- a/src/browser/routes/agent.debug.ts
+++ b/src/browser/routes/agent.debug.ts
@@ -2,7 +2,12 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { BrowserRouteContext } from "../server-context.js";
-import { handleRouteError, readBody, requirePwAi, resolveProfileContext } from "./agent.shared.js";
+import {
+  readBody,
+  resolveTargetIdFromBody,
+  resolveTargetIdFromQuery,
+  withPlaywrightRouteContext,
+} from "./agent.shared.js";
 import { DEFAULT_TRACE_DIR, resolvePathWithinRoot } from "./path-output.js";
 import type { BrowserRouteRegistrar } from "./types.js";
 import { toBoolean, toStringOrEmpty } from "./utils.js";
@@ -12,151 +17,133 @@ export function registerBrowserAgentDebugRoutes(
   ctx: BrowserRouteContext,
 ) {
   app.get("/console", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
-    const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
+    const targetId = resolveTargetIdFromQuery(req.query);
     const level = typeof req.query.level === "string" ? req.query.level : "";
 
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
-      const pw = await requirePwAi(res, "console messages");
-      if (!pw) {
-        return;
-      }
-      const messages = await pw.getConsoleMessagesViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        level: level.trim() || undefined,
-      });
-      res.json({ ok: true, messages, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "console messages",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const messages = await pw.getConsoleMessagesViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          level: level.trim() || undefined,
+        });
+        res.json({ ok: true, messages, targetId: tab.targetId });
+      },
+    });
   });
 
   app.get("/errors", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
-    const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
+    const targetId = resolveTargetIdFromQuery(req.query);
     const clear = toBoolean(req.query.clear) ?? false;
 
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
-      const pw = await requirePwAi(res, "page errors");
-      if (!pw) {
-        return;
-      }
-      const result = await pw.getPageErrorsViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        clear,
-      });
-      res.json({ ok: true, targetId: tab.targetId, ...result });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "page errors",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const result = await pw.getPageErrorsViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          clear,
+        });
+        res.json({ ok: true, targetId: tab.targetId, ...result });
+      },
+    });
   });
 
   app.get("/requests", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
-    const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
+    const targetId = resolveTargetIdFromQuery(req.query);
     const filter = typeof req.query.filter === "string" ? req.query.filter : "";
     const clear = toBoolean(req.query.clear) ?? false;
 
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
-      const pw = await requirePwAi(res, "network requests");
-      if (!pw) {
-        return;
-      }
-      const result = await pw.getNetworkRequestsViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        filter: filter.trim() || undefined,
-        clear,
-      });
-      res.json({ ok: true, targetId: tab.targetId, ...result });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "network requests",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const result = await pw.getNetworkRequestsViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          filter: filter.trim() || undefined,
+          clear,
+        });
+        res.json({ ok: true, targetId: tab.targetId, ...result });
+      },
+    });
   });
 
   app.post("/trace/start", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const targetId = resolveTargetIdFromBody(body);
     const screenshots = toBoolean(body.screenshots) ?? undefined;
     const snapshots = toBoolean(body.snapshots) ?? undefined;
     const sources = toBoolean(body.sources) ?? undefined;
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "trace start");
-      if (!pw) {
-        return;
-      }
-      await pw.traceStartViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        screenshots,
-        snapshots,
-        sources,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "trace start",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.traceStartViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          screenshots,
+          snapshots,
+          sources,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/trace/stop", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const targetId = resolveTargetIdFromBody(body);
     const out = toStringOrEmpty(body.path) || "";
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "trace stop");
-      if (!pw) {
-        return;
-      }
-      const id = crypto.randomUUID();
-      const dir = DEFAULT_TRACE_DIR;
-      await fs.mkdir(dir, { recursive: true });
-      const tracePathResult = resolvePathWithinRoot({
-        rootDir: dir,
-        requestedPath: out,
-        scopeLabel: "trace directory",
-        defaultFileName: `browser-trace-${id}.zip`,
-      });
-      if (!tracePathResult.ok) {
-        res.status(400).json({ error: tracePathResult.error });
-        return;
-      }
-      const tracePath = tracePathResult.path;
-      await pw.traceStopViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        path: tracePath,
-      });
-      res.json({
-        ok: true,
-        targetId: tab.targetId,
-        path: path.resolve(tracePath),
-      });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "trace stop",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const id = crypto.randomUUID();
+        const dir = DEFAULT_TRACE_DIR;
+        await fs.mkdir(dir, { recursive: true });
+        const tracePathResult = resolvePathWithinRoot({
+          rootDir: dir,
+          requestedPath: out,
+          scopeLabel: "trace directory",
+          defaultFileName: `browser-trace-${id}.zip`,
+        });
+        if (!tracePathResult.ok) {
+          res.status(400).json({ error: tracePathResult.error });
+          return;
+        }
+        const tracePath = tracePathResult.path;
+        await pw.traceStopViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          path: tracePath,
+        });
+        res.json({
+          ok: true,
+          targetId: tab.targetId,
+          path: path.resolve(tracePath),
+        });
+      },
+    });
   });
 }

--- a/src/browser/routes/agent.shared.test.ts
+++ b/src/browser/routes/agent.shared.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { readBody, resolveTargetIdFromBody, resolveTargetIdFromQuery } from "./agent.shared.js";
+import type { BrowserRequest } from "./types.js";
+
+function requestWithBody(body: unknown): BrowserRequest {
+  return {
+    params: {},
+    query: {},
+    body,
+  };
+}
+
+describe("browser route shared helpers", () => {
+  describe("readBody", () => {
+    it("returns object bodies", () => {
+      expect(readBody(requestWithBody({ one: 1 }))).toEqual({ one: 1 });
+    });
+
+    it("normalizes non-object bodies to empty object", () => {
+      expect(readBody(requestWithBody(null))).toEqual({});
+      expect(readBody(requestWithBody("text"))).toEqual({});
+      expect(readBody(requestWithBody(["x"]))).toEqual({});
+    });
+  });
+
+  describe("target id parsing", () => {
+    it("extracts and trims targetId from body", () => {
+      expect(resolveTargetIdFromBody({ targetId: "  tab-1  " })).toBe("tab-1");
+      expect(resolveTargetIdFromBody({ targetId: "   " })).toBeUndefined();
+      expect(resolveTargetIdFromBody({ targetId: 123 })).toBeUndefined();
+    });
+
+    it("extracts and trims targetId from query", () => {
+      expect(resolveTargetIdFromQuery({ targetId: "  tab-2  " })).toBe("tab-2");
+      expect(resolveTargetIdFromQuery({ targetId: "" })).toBeUndefined();
+      expect(resolveTargetIdFromQuery({ targetId: false })).toBeUndefined();
+    });
+  });
+});

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -194,6 +194,8 @@ export function registerBrowserAgentSnapshotRoutes(
       depthRaw ?? (mode === "efficient" ? DEFAULT_AI_SNAPSHOT_EFFICIENT_DEPTH : undefined);
     const selector = toStringOrEmpty(req.query.selector);
     const frameSelector = toStringOrEmpty(req.query.frame);
+    const selectorValue = selector.trim() || undefined;
+    const frameSelectorValue = frameSelector.trim() || undefined;
 
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
@@ -211,22 +213,23 @@ export function registerBrowserAgentSnapshotRoutes(
           interactive === true ||
           compact === true ||
           depth !== undefined ||
-          Boolean(selector.trim()) ||
-          Boolean(frameSelector.trim());
+          Boolean(selectorValue) ||
+          Boolean(frameSelectorValue);
+        const roleSnapshotArgs = {
+          cdpUrl: profileCtx.profile.cdpUrl,
+          targetId: tab.targetId,
+          selector: selectorValue,
+          frameSelector: frameSelectorValue,
+          refsMode,
+          options: {
+            interactive: interactive ?? undefined,
+            compact: compact ?? undefined,
+            maxDepth: depth ?? undefined,
+          },
+        };
 
         const snap = wantsRoleSnapshot
-          ? await pw.snapshotRoleViaPlaywright({
-              cdpUrl: profileCtx.profile.cdpUrl,
-              targetId: tab.targetId,
-              selector: selector.trim() || undefined,
-              frameSelector: frameSelector.trim() || undefined,
-              refsMode,
-              options: {
-                interactive: interactive ?? undefined,
-                compact: compact ?? undefined,
-                maxDepth: depth ?? undefined,
-              },
-            })
+          ? await pw.snapshotRoleViaPlaywright(roleSnapshotArgs)
           : await pw
               .snapshotAiViaPlaywright({
                 cdpUrl: profileCtx.profile.cdpUrl,
@@ -236,18 +239,7 @@ export function registerBrowserAgentSnapshotRoutes(
               .catch(async (err) => {
                 // Public-API fallback when Playwright's private _snapshotForAI is missing.
                 if (String(err).toLowerCase().includes("_snapshotforai")) {
-                  return await pw.snapshotRoleViaPlaywright({
-                    cdpUrl: profileCtx.profile.cdpUrl,
-                    targetId: tab.targetId,
-                    selector: selector.trim() || undefined,
-                    frameSelector: frameSelector.trim() || undefined,
-                    refsMode,
-                    options: {
-                      interactive: interactive ?? undefined,
-                      compact: compact ?? undefined,
-                      maxDepth: depth ?? undefined,
-                    },
-                  });
+                  return await pw.snapshotRoleViaPlaywright(roleSnapshotArgs);
                 }
                 throw err;
               });

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -187,7 +187,8 @@ export function registerBrowserAgentSnapshotRoutes(
     const compactRaw = toBoolean(req.query.compact);
     const depthRaw = toNumber(req.query.depth);
     const refsModeRaw = toStringOrEmpty(req.query.refs).trim();
-    const refsMode = refsModeRaw === "aria" ? "aria" : refsModeRaw === "role" ? "role" : undefined;
+    const refsMode: "aria" | "role" | undefined =
+      refsModeRaw === "aria" ? "aria" : refsModeRaw === "role" ? "role" : undefined;
     const interactive = interactiveRaw ?? (mode === "efficient" ? true : undefined);
     const compact = compactRaw ?? (mode === "efficient" ? true : undefined);
     const depth =

--- a/src/browser/routes/agent.storage.test.ts
+++ b/src/browser/routes/agent.storage.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseStorageKind, parseStorageMutationRequest } from "./agent.storage.js";
+import {
+  parseRequiredStorageMutationRequest,
+  parseStorageKind,
+  parseStorageMutationRequest,
+} from "./agent.storage.js";
 
 describe("browser storage route parsing", () => {
   describe("parseStorageKind", () => {
@@ -35,6 +39,27 @@ describe("browser storage route parsing", () => {
         kind: null,
         targetId: undefined,
       });
+    });
+  });
+
+  describe("parseRequiredStorageMutationRequest", () => {
+    it("returns parsed request for supported kinds", () => {
+      expect(
+        parseRequiredStorageMutationRequest("session", {
+          targetId: " tab-9 ",
+        }),
+      ).toEqual({
+        kind: "session",
+        targetId: "tab-9",
+      });
+    });
+
+    it("returns null for unsupported kind", () => {
+      expect(
+        parseRequiredStorageMutationRequest("cookie", {
+          targetId: "tab-1",
+        }),
+      ).toBeNull();
     });
   });
 });

--- a/src/browser/routes/agent.storage.test.ts
+++ b/src/browser/routes/agent.storage.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { parseStorageKind, parseStorageMutationRequest } from "./agent.storage.js";
+
+describe("browser storage route parsing", () => {
+  describe("parseStorageKind", () => {
+    it("accepts local and session", () => {
+      expect(parseStorageKind("local")).toBe("local");
+      expect(parseStorageKind("session")).toBe("session");
+    });
+
+    it("rejects unsupported values", () => {
+      expect(parseStorageKind("cookie")).toBeNull();
+      expect(parseStorageKind("")).toBeNull();
+    });
+  });
+
+  describe("parseStorageMutationRequest", () => {
+    it("returns parsed kind and trimmed target id", () => {
+      expect(
+        parseStorageMutationRequest("local", {
+          targetId: "  page-1  ",
+        }),
+      ).toEqual({
+        kind: "local",
+        targetId: "page-1",
+      });
+    });
+
+    it("returns null kind and undefined target id for invalid values", () => {
+      expect(
+        parseStorageMutationRequest("invalid", {
+          targetId: "   ",
+        }),
+      ).toEqual({
+        kind: null,
+        targetId: undefined,
+      });
+    });
+  });
+});

--- a/src/browser/routes/agent.storage.ts
+++ b/src/browser/routes/agent.storage.ts
@@ -1,60 +1,29 @@
 import type { BrowserRouteContext } from "../server-context.js";
-import { handleRouteError, readBody, requirePwAi, resolveProfileContext } from "./agent.shared.js";
-import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
+import {
+  readBody,
+  resolveTargetIdFromBody,
+  resolveTargetIdFromQuery,
+  withPlaywrightRouteContext,
+} from "./agent.shared.js";
+import type { BrowserRouteRegistrar } from "./types.js";
 import { jsonError, toBoolean, toNumber, toStringOrEmpty } from "./utils.js";
 
 type StorageKind = "local" | "session";
 
-function resolveBodyTargetId(body: unknown): string | undefined {
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return undefined;
-  }
-  const targetId = toStringOrEmpty((body as Record<string, unknown>).targetId);
-  return targetId || undefined;
-}
-
-function parseStorageKind(raw: string): StorageKind | null {
+export function parseStorageKind(raw: string): StorageKind | null {
   if (raw === "local" || raw === "session") {
     return raw;
   }
   return null;
 }
 
-function parseStorageMutationRequest(
+export function parseStorageMutationRequest(
   kindParam: unknown,
-  body: unknown,
+  body: Record<string, unknown>,
 ): { kind: StorageKind | null; targetId: string | undefined } {
   return {
     kind: parseStorageKind(toStringOrEmpty(kindParam)),
-    targetId: resolveBodyTargetId(body),
-  };
-}
-
-function resolveStorageMutationContext(params: {
-  req: BrowserRequest;
-  res: BrowserResponse;
-  ctx: BrowserRouteContext;
-}): {
-  profileCtx: NonNullable<ReturnType<typeof resolveProfileContext>>;
-  body: Record<string, unknown>;
-  kind: StorageKind;
-  targetId: string | undefined;
-} | null {
-  const profileCtx = resolveProfileContext(params.req, params.res, params.ctx);
-  if (!profileCtx) {
-    return null;
-  }
-  const body = readBody(params.req);
-  const parsed = parseStorageMutationRequest(params.req.params.kind, body);
-  if (!parsed.kind) {
-    jsonError(params.res, 400, "kind must be local|session");
-    return null;
-  }
-  return {
-    profileCtx,
-    body,
-    kind: parsed.kind,
-    targetId: parsed.targetId,
+    targetId: resolveTargetIdFromBody(body),
   };
 }
 
@@ -63,34 +32,26 @@ export function registerBrowserAgentStorageRoutes(
   ctx: BrowserRouteContext,
 ) {
   app.get("/cookies", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
-    const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
-      const pw = await requirePwAi(res, "cookies");
-      if (!pw) {
-        return;
-      }
-      const result = await pw.cookiesGetViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-      });
-      res.json({ ok: true, targetId: tab.targetId, ...result });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+    const targetId = resolveTargetIdFromQuery(req.query);
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "cookies",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const result = await pw.cookiesGetViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+        });
+        res.json({ ok: true, targetId: tab.targetId, ...result });
+      },
+    });
   });
 
   app.post("/cookies/set", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
+    const targetId = resolveTargetIdFromBody(body);
     const cookie =
       body.cookie && typeof body.cookie === "object" && !Array.isArray(body.cookie)
         ? (body.cookie as Record<string, unknown>)
@@ -98,176 +59,170 @@ export function registerBrowserAgentStorageRoutes(
     if (!cookie) {
       return jsonError(res, 400, "cookie is required");
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "cookies set");
-      if (!pw) {
-        return;
-      }
-      await pw.cookiesSetViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        cookie: {
-          name: toStringOrEmpty(cookie.name),
-          value: toStringOrEmpty(cookie.value),
-          url: toStringOrEmpty(cookie.url) || undefined,
-          domain: toStringOrEmpty(cookie.domain) || undefined,
-          path: toStringOrEmpty(cookie.path) || undefined,
-          expires: toNumber(cookie.expires) ?? undefined,
-          httpOnly: toBoolean(cookie.httpOnly) ?? undefined,
-          secure: toBoolean(cookie.secure) ?? undefined,
-          sameSite:
-            cookie.sameSite === "Lax" || cookie.sameSite === "None" || cookie.sameSite === "Strict"
-              ? cookie.sameSite
-              : undefined,
-        },
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "cookies set",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.cookiesSetViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          cookie: {
+            name: toStringOrEmpty(cookie.name),
+            value: toStringOrEmpty(cookie.value),
+            url: toStringOrEmpty(cookie.url) || undefined,
+            domain: toStringOrEmpty(cookie.domain) || undefined,
+            path: toStringOrEmpty(cookie.path) || undefined,
+            expires: toNumber(cookie.expires) ?? undefined,
+            httpOnly: toBoolean(cookie.httpOnly) ?? undefined,
+            secure: toBoolean(cookie.secure) ?? undefined,
+            sameSite:
+              cookie.sameSite === "Lax" ||
+              cookie.sameSite === "None" ||
+              cookie.sameSite === "Strict"
+                ? cookie.sameSite
+                : undefined,
+          },
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/cookies/clear", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "cookies clear");
-      if (!pw) {
-        return;
-      }
-      await pw.cookiesClearViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+    const targetId = resolveTargetIdFromBody(body);
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "cookies clear",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.cookiesClearViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.get("/storage/:kind", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const kind = parseStorageKind(toStringOrEmpty(req.params.kind));
     if (!kind) {
       return jsonError(res, 400, "kind must be local|session");
     }
-    const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
-    const key = typeof req.query.key === "string" ? req.query.key : "";
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
-      const pw = await requirePwAi(res, "storage get");
-      if (!pw) {
-        return;
-      }
-      const result = await pw.storageGetViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        kind,
-        key: key.trim() || undefined,
-      });
-      res.json({ ok: true, targetId: tab.targetId, ...result });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+    const targetId = resolveTargetIdFromQuery(req.query);
+    const key = toStringOrEmpty(req.query.key);
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "storage get",
+      run: async ({ cdpUrl, tab, pw }) => {
+        const result = await pw.storageGetViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          kind,
+          key: key.trim() || undefined,
+        });
+        res.json({ ok: true, targetId: tab.targetId, ...result });
+      },
+    });
   });
 
   app.post("/storage/:kind/set", async (req, res) => {
-    const mutation = resolveStorageMutationContext({ req, res, ctx });
-    if (!mutation) {
-      return;
+    const body = readBody(req);
+    const parsed = parseStorageMutationRequest(req.params.kind, body);
+    if (!parsed.kind) {
+      return jsonError(res, 400, "kind must be local|session");
     }
-    const { profileCtx, body, kind, targetId } = mutation;
+    const kind = parsed.kind;
     const key = toStringOrEmpty(body.key);
     if (!key) {
       return jsonError(res, 400, "key is required");
     }
     const value = typeof body.value === "string" ? body.value : "";
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "storage set");
-      if (!pw) {
-        return;
-      }
-      await pw.storageSetViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        kind,
-        key,
-        value,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId: parsed.targetId,
+      feature: "storage set",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.storageSetViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          kind,
+          key,
+          value,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/storage/:kind/clear", async (req, res) => {
-    const mutation = resolveStorageMutationContext({ req, res, ctx });
-    if (!mutation) {
-      return;
+    const body = readBody(req);
+    const parsed = parseStorageMutationRequest(req.params.kind, body);
+    if (!parsed.kind) {
+      return jsonError(res, 400, "kind must be local|session");
     }
-    const { profileCtx, kind, targetId } = mutation;
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "storage clear");
-      if (!pw) {
-        return;
-      }
-      await pw.storageClearViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        kind,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+    const kind = parsed.kind;
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId: parsed.targetId,
+      feature: "storage clear",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.storageClearViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          kind,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/set/offline", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
+    const targetId = resolveTargetIdFromBody(body);
     const offline = toBoolean(body.offline);
     if (offline === undefined) {
       return jsonError(res, 400, "offline is required");
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "offline");
-      if (!pw) {
-        return;
-      }
-      await pw.setOfflineViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        offline,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "offline",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.setOfflineViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          offline,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/set/headers", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
+    const targetId = resolveTargetIdFromBody(body);
     const headers =
       body.headers && typeof body.headers === "object" && !Array.isArray(body.headers)
         ? (body.headers as Record<string, unknown>)
@@ -275,98 +230,90 @@ export function registerBrowserAgentStorageRoutes(
     if (!headers) {
       return jsonError(res, 400, "headers is required");
     }
+
     const parsed: Record<string, string> = {};
     for (const [k, v] of Object.entries(headers)) {
       if (typeof v === "string") {
         parsed[k] = v;
       }
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "headers");
-      if (!pw) {
-        return;
-      }
-      await pw.setExtraHTTPHeadersViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        headers: parsed,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "headers",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.setExtraHTTPHeadersViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          headers: parsed,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/set/credentials", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
+    const targetId = resolveTargetIdFromBody(body);
     const clear = toBoolean(body.clear) ?? false;
     const username = toStringOrEmpty(body.username) || undefined;
     const password = typeof body.password === "string" ? body.password : undefined;
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "http credentials");
-      if (!pw) {
-        return;
-      }
-      await pw.setHttpCredentialsViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        username,
-        password,
-        clear,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "http credentials",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.setHttpCredentialsViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          username,
+          password,
+          clear,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/set/geolocation", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
+    const targetId = resolveTargetIdFromBody(body);
     const clear = toBoolean(body.clear) ?? false;
     const latitude = toNumber(body.latitude);
     const longitude = toNumber(body.longitude);
     const accuracy = toNumber(body.accuracy) ?? undefined;
     const origin = toStringOrEmpty(body.origin) || undefined;
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "geolocation");
-      if (!pw) {
-        return;
-      }
-      await pw.setGeolocationViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        latitude,
-        longitude,
-        accuracy,
-        origin,
-        clear,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "geolocation",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.setGeolocationViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          latitude,
+          longitude,
+          accuracy,
+          origin,
+          clear,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/set/media", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
+    const targetId = resolveTargetIdFromBody(body);
     const schemeRaw = toStringOrEmpty(body.colorScheme);
     const colorScheme =
       schemeRaw === "dark" || schemeRaw === "light" || schemeRaw === "no-preference"
@@ -377,104 +324,96 @@ export function registerBrowserAgentStorageRoutes(
     if (colorScheme === undefined) {
       return jsonError(res, 400, "colorScheme must be dark|light|no-preference|none");
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "media emulation");
-      if (!pw) {
-        return;
-      }
-      await pw.emulateMediaViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        colorScheme,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "media emulation",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.emulateMediaViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          colorScheme,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/set/timezone", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
+    const targetId = resolveTargetIdFromBody(body);
     const timezoneId = toStringOrEmpty(body.timezoneId);
     if (!timezoneId) {
       return jsonError(res, 400, "timezoneId is required");
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "timezone");
-      if (!pw) {
-        return;
-      }
-      await pw.setTimezoneViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        timezoneId,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "timezone",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.setTimezoneViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          timezoneId,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/set/locale", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
+    const targetId = resolveTargetIdFromBody(body);
     const locale = toStringOrEmpty(body.locale);
     if (!locale) {
       return jsonError(res, 400, "locale is required");
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "locale");
-      if (!pw) {
-        return;
-      }
-      await pw.setLocaleViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        locale,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "locale",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.setLocaleViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          locale,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 
   app.post("/set/device", async (req, res) => {
-    const profileCtx = resolveProfileContext(req, res, ctx);
-    if (!profileCtx) {
-      return;
-    }
     const body = readBody(req);
-    const targetId = resolveBodyTargetId(body);
+    const targetId = resolveTargetIdFromBody(body);
     const name = toStringOrEmpty(body.name);
     if (!name) {
       return jsonError(res, 400, "name is required");
     }
-    try {
-      const tab = await profileCtx.ensureTabAvailable(targetId);
-      const pw = await requirePwAi(res, "device emulation");
-      if (!pw) {
-        return;
-      }
-      await pw.setDeviceViaPlaywright({
-        cdpUrl: profileCtx.profile.cdpUrl,
-        targetId: tab.targetId,
-        name,
-      });
-      res.json({ ok: true, targetId: tab.targetId });
-    } catch (err) {
-      handleRouteError(ctx, res, err);
-    }
+
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "device emulation",
+      run: async ({ cdpUrl, tab, pw }) => {
+        await pw.setDeviceViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          name,
+        });
+        res.json({ ok: true, targetId: tab.targetId });
+      },
+    });
   });
 }

--- a/src/browser/routes/tabs.ts
+++ b/src/browser/routes/tabs.ts
@@ -1,144 +1,180 @@
-import type { BrowserRouteContext } from "../server-context.js";
-import type { BrowserRouteRegistrar } from "./types.js";
+import type { BrowserRouteContext, ProfileContext } from "../server-context.js";
+import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
 import { getProfileContext, jsonError, toNumber, toStringOrEmpty } from "./utils.js";
+
+function resolveTabsProfileContext(
+  req: BrowserRequest,
+  res: BrowserResponse,
+  ctx: BrowserRouteContext,
+) {
+  const profileCtx = getProfileContext(req, ctx);
+  if ("error" in profileCtx) {
+    jsonError(res, profileCtx.status, profileCtx.error);
+    return null;
+  }
+  return profileCtx;
+}
+
+function handleTabsRouteError(
+  ctx: BrowserRouteContext,
+  res: BrowserResponse,
+  err: unknown,
+  opts?: { mapTabError?: boolean },
+) {
+  if (opts?.mapTabError) {
+    const mapped = ctx.mapTabError(err);
+    if (mapped) {
+      return jsonError(res, mapped.status, mapped.message);
+    }
+  }
+  return jsonError(res, 500, String(err));
+}
+
+async function withTabsProfileRoute(params: {
+  req: BrowserRequest;
+  res: BrowserResponse;
+  ctx: BrowserRouteContext;
+  mapTabError?: boolean;
+  run: (profileCtx: ProfileContext) => Promise<void>;
+}) {
+  const profileCtx = resolveTabsProfileContext(params.req, params.res, params.ctx);
+  if (!profileCtx) {
+    return;
+  }
+  try {
+    await params.run(profileCtx);
+  } catch (err) {
+    handleTabsRouteError(params.ctx, params.res, err, { mapTabError: params.mapTabError });
+  }
+}
 
 export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: BrowserRouteContext) {
   app.get("/tabs", async (req, res) => {
-    const profileCtx = getProfileContext(req, ctx);
-    if ("error" in profileCtx) {
-      return jsonError(res, profileCtx.status, profileCtx.error);
-    }
-    try {
-      const reachable = await profileCtx.isReachable(300);
-      if (!reachable) {
-        return res.json({ running: false, tabs: [] as unknown[] });
-      }
-      const tabs = await profileCtx.listTabs();
-      res.json({ running: true, tabs });
-    } catch (err) {
-      jsonError(res, 500, String(err));
-    }
+    await withTabsProfileRoute({
+      req,
+      res,
+      ctx,
+      run: async (profileCtx) => {
+        const reachable = await profileCtx.isReachable(300);
+        if (!reachable) {
+          return res.json({ running: false, tabs: [] as unknown[] });
+        }
+        const tabs = await profileCtx.listTabs();
+        res.json({ running: true, tabs });
+      },
+    });
   });
 
   app.post("/tabs/open", async (req, res) => {
-    const profileCtx = getProfileContext(req, ctx);
-    if ("error" in profileCtx) {
-      return jsonError(res, profileCtx.status, profileCtx.error);
-    }
     const url = toStringOrEmpty((req.body as { url?: unknown })?.url);
     if (!url) {
       return jsonError(res, 400, "url is required");
     }
-    try {
-      await profileCtx.ensureBrowserAvailable();
-      const tab = await profileCtx.openTab(url);
-      res.json(tab);
-    } catch (err) {
-      jsonError(res, 500, String(err));
-    }
+
+    await withTabsProfileRoute({
+      req,
+      res,
+      ctx,
+      run: async (profileCtx) => {
+        await profileCtx.ensureBrowserAvailable();
+        const tab = await profileCtx.openTab(url);
+        res.json(tab);
+      },
+    });
   });
 
   app.post("/tabs/focus", async (req, res) => {
-    const profileCtx = getProfileContext(req, ctx);
-    if ("error" in profileCtx) {
-      return jsonError(res, profileCtx.status, profileCtx.error);
-    }
     const targetId = toStringOrEmpty((req.body as { targetId?: unknown })?.targetId);
     if (!targetId) {
       return jsonError(res, 400, "targetId is required");
     }
-    try {
-      if (!(await profileCtx.isReachable(300))) {
-        return jsonError(res, 409, "browser not running");
-      }
-      await profileCtx.focusTab(targetId);
-      res.json({ ok: true });
-    } catch (err) {
-      const mapped = ctx.mapTabError(err);
-      if (mapped) {
-        return jsonError(res, mapped.status, mapped.message);
-      }
-      jsonError(res, 500, String(err));
-    }
+
+    await withTabsProfileRoute({
+      req,
+      res,
+      ctx,
+      mapTabError: true,
+      run: async (profileCtx) => {
+        if (!(await profileCtx.isReachable(300))) {
+          return jsonError(res, 409, "browser not running");
+        }
+        await profileCtx.focusTab(targetId);
+        res.json({ ok: true });
+      },
+    });
   });
 
   app.delete("/tabs/:targetId", async (req, res) => {
-    const profileCtx = getProfileContext(req, ctx);
-    if ("error" in profileCtx) {
-      return jsonError(res, profileCtx.status, profileCtx.error);
-    }
     const targetId = toStringOrEmpty(req.params.targetId);
     if (!targetId) {
       return jsonError(res, 400, "targetId is required");
     }
-    try {
-      if (!(await profileCtx.isReachable(300))) {
-        return jsonError(res, 409, "browser not running");
-      }
-      await profileCtx.closeTab(targetId);
-      res.json({ ok: true });
-    } catch (err) {
-      const mapped = ctx.mapTabError(err);
-      if (mapped) {
-        return jsonError(res, mapped.status, mapped.message);
-      }
-      jsonError(res, 500, String(err));
-    }
+
+    await withTabsProfileRoute({
+      req,
+      res,
+      ctx,
+      mapTabError: true,
+      run: async (profileCtx) => {
+        if (!(await profileCtx.isReachable(300))) {
+          return jsonError(res, 409, "browser not running");
+        }
+        await profileCtx.closeTab(targetId);
+        res.json({ ok: true });
+      },
+    });
   });
 
   app.post("/tabs/action", async (req, res) => {
-    const profileCtx = getProfileContext(req, ctx);
-    if ("error" in profileCtx) {
-      return jsonError(res, profileCtx.status, profileCtx.error);
-    }
     const action = toStringOrEmpty((req.body as { action?: unknown })?.action);
     const index = toNumber((req.body as { index?: unknown })?.index);
-    try {
-      if (action === "list") {
-        const reachable = await profileCtx.isReachable(300);
-        if (!reachable) {
-          return res.json({ ok: true, tabs: [] as unknown[] });
-        }
-        const tabs = await profileCtx.listTabs();
-        return res.json({ ok: true, tabs });
-      }
 
-      if (action === "new") {
-        await profileCtx.ensureBrowserAvailable();
-        const tab = await profileCtx.openTab("about:blank");
-        return res.json({ ok: true, tab });
-      }
-
-      if (action === "close") {
-        const tabs = await profileCtx.listTabs();
-        const target = typeof index === "number" ? tabs[index] : tabs.at(0);
-        if (!target) {
-          return jsonError(res, 404, "tab not found");
+    await withTabsProfileRoute({
+      req,
+      res,
+      ctx,
+      mapTabError: true,
+      run: async (profileCtx) => {
+        if (action === "list") {
+          const reachable = await profileCtx.isReachable(300);
+          if (!reachable) {
+            return res.json({ ok: true, tabs: [] as unknown[] });
+          }
+          const tabs = await profileCtx.listTabs();
+          return res.json({ ok: true, tabs });
         }
-        await profileCtx.closeTab(target.targetId);
-        return res.json({ ok: true, targetId: target.targetId });
-      }
 
-      if (action === "select") {
-        if (typeof index !== "number") {
-          return jsonError(res, 400, "index is required");
+        if (action === "new") {
+          await profileCtx.ensureBrowserAvailable();
+          const tab = await profileCtx.openTab("about:blank");
+          return res.json({ ok: true, tab });
         }
-        const tabs = await profileCtx.listTabs();
-        const target = tabs[index];
-        if (!target) {
-          return jsonError(res, 404, "tab not found");
-        }
-        await profileCtx.focusTab(target.targetId);
-        return res.json({ ok: true, targetId: target.targetId });
-      }
 
-      return jsonError(res, 400, "unknown tab action");
-    } catch (err) {
-      const mapped = ctx.mapTabError(err);
-      if (mapped) {
-        return jsonError(res, mapped.status, mapped.message);
-      }
-      jsonError(res, 500, String(err));
-    }
+        if (action === "close") {
+          const tabs = await profileCtx.listTabs();
+          const target = typeof index === "number" ? tabs[index] : tabs.at(0);
+          if (!target) {
+            return jsonError(res, 404, "tab not found");
+          }
+          await profileCtx.closeTab(target.targetId);
+          return res.json({ ok: true, targetId: target.targetId });
+        }
+
+        if (action === "select") {
+          if (typeof index !== "number") {
+            return jsonError(res, 400, "index is required");
+          }
+          const tabs = await profileCtx.listTabs();
+          const target = tabs[index];
+          if (!target) {
+            return jsonError(res, 404, "tab not found");
+          }
+          await profileCtx.focusTab(target.targetId);
+          return res.json({ ok: true, targetId: target.targetId });
+        }
+
+        return jsonError(res, 400, "unknown tab action");
+      },
+    });
   });
 }

--- a/src/canvas-host/a2ui.ts
+++ b/src/canvas-host/a2ui.ts
@@ -13,14 +13,29 @@ export const CANVAS_WS_PATH = "/__openclaw__/ws";
 
 let cachedA2uiRootReal: string | null | undefined;
 let resolvingA2uiRoot: Promise<string | null> | null = null;
+let cachedA2uiResolvedAtMs = 0;
+const A2UI_ROOT_RETRY_NULL_AFTER_MS = 10_000;
 
 async function resolveA2uiRoot(): Promise<string | null> {
   const here = path.dirname(fileURLToPath(import.meta.url));
+  const entryDir = process.argv[1] ? path.dirname(path.resolve(process.argv[1])) : null;
   const candidates = [
-    // Running from source (bun) or dist (tsc + copied assets).
+    // Running from source (bun) or dist/canvas-host chunk.
     path.resolve(here, "a2ui"),
+    // Running from dist root chunk (common launchd path).
+    path.resolve(here, "canvas-host/a2ui"),
+    path.resolve(here, "../canvas-host/a2ui"),
+    // Entry path fallbacks (helps when cwd is not the repo root).
+    ...(entryDir
+      ? [
+          path.resolve(entryDir, "a2ui"),
+          path.resolve(entryDir, "canvas-host/a2ui"),
+          path.resolve(entryDir, "../canvas-host/a2ui"),
+        ]
+      : []),
     // Running from dist without copied assets (fallback to source).
     path.resolve(here, "../../src/canvas-host/a2ui"),
+    path.resolve(here, "../src/canvas-host/a2ui"),
     // Running from repo root.
     path.resolve(process.cwd(), "src/canvas-host/a2ui"),
     path.resolve(process.cwd(), "dist/canvas-host/a2ui"),
@@ -44,13 +59,19 @@ async function resolveA2uiRoot(): Promise<string | null> {
 }
 
 async function resolveA2uiRootReal(): Promise<string | null> {
-  if (cachedA2uiRootReal !== undefined) {
+  const nowMs = Date.now();
+  if (
+    cachedA2uiRootReal !== undefined &&
+    (cachedA2uiRootReal !== null || nowMs - cachedA2uiResolvedAtMs < A2UI_ROOT_RETRY_NULL_AFTER_MS)
+  ) {
     return cachedA2uiRootReal;
   }
   if (!resolvingA2uiRoot) {
     resolvingA2uiRoot = (async () => {
       const root = await resolveA2uiRoot();
       cachedA2uiRootReal = root ? await fs.realpath(root) : null;
+      cachedA2uiResolvedAtMs = Date.now();
+      resolvingA2uiRoot = null;
       return cachedA2uiRootReal;
     })();
   }

--- a/src/channels/plugins/group-mentions.ts
+++ b/src/channels/plugins/group-mentions.ts
@@ -9,7 +9,7 @@ import type {
   GroupToolPolicyBySenderConfig,
   GroupToolPolicyConfig,
 } from "../../config/types.tools.js";
-import { normalizeHyphenSlug } from "../../shared/string-normalization.js";
+import { normalizeAtHashSlug, normalizeHyphenSlug } from "../../shared/string-normalization.js";
 import { resolveSlackAccount } from "../../slack/accounts.js";
 
 type GroupMentionParams = {
@@ -25,18 +25,7 @@ type GroupMentionParams = {
 };
 
 function normalizeDiscordSlug(value?: string | null) {
-  if (!value) {
-    return "";
-  }
-  let text = value.trim().toLowerCase();
-  if (!text) {
-    return "";
-  }
-  text = text.replace(/^[@#]+/, "");
-  text = text.replace(/[\s_]+/g, "-");
-  text = text.replace(/[^a-z0-9-]+/g, "-");
-  text = text.replace(/-{2,}/g, "-").replace(/^-+|-+$/g, "");
-  return text;
+  return normalizeAtHashSlug(value);
 }
 
 function parseTelegramGroupId(value?: string | null) {

--- a/src/cli/browser-cli-actions-input/register.files-downloads.ts
+++ b/src/cli/browser-cli-actions-input/register.files-downloads.ts
@@ -22,6 +22,13 @@ export function registerBrowserFilesAndDownloadsCommands(
   browser: Command,
   parentOpts: (cmd: Command) => BrowserParentOpts,
 ) {
+  const resolveTimeoutAndTarget = (opts: { timeoutMs?: unknown; targetId?: unknown }) => {
+    const timeoutMs = Number.isFinite(opts.timeoutMs) ? Number(opts.timeoutMs) : undefined;
+    const targetId =
+      typeof opts.targetId === "string" ? opts.targetId.trim() || undefined : undefined;
+    return { timeoutMs, targetId };
+  };
+
   const runDownloadCommand = async (
     cmd: Command,
     opts: { timeoutMs?: unknown; targetId?: unknown },
@@ -29,7 +36,7 @@ export function registerBrowserFilesAndDownloadsCommands(
   ) => {
     const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);
     try {
-      const timeoutMs = Number.isFinite(opts.timeoutMs) ? Number(opts.timeoutMs) : undefined;
+      const { timeoutMs, targetId } = resolveTimeoutAndTarget(opts);
       const result = await callBrowserRequest<{ download: { path: string } }>(
         parent,
         {
@@ -38,8 +45,7 @@ export function registerBrowserFilesAndDownloadsCommands(
           query: profile ? { profile } : undefined,
           body: {
             ...request.body,
-            targetId:
-              typeof opts.targetId === "string" ? opts.targetId.trim() || undefined : undefined,
+            targetId,
             timeoutMs,
           },
         },
@@ -76,7 +82,7 @@ export function registerBrowserFilesAndDownloadsCommands(
       const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);
       try {
         const normalizedPaths = normalizeUploadPaths(paths);
-        const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : undefined;
+        const { timeoutMs, targetId } = resolveTimeoutAndTarget(opts);
         const result = await callBrowserRequest<{ download: { path: string } }>(
           parent,
           {
@@ -88,7 +94,7 @@ export function registerBrowserFilesAndDownloadsCommands(
               ref: opts.ref?.trim() || undefined,
               inputRef: opts.inputRef?.trim() || undefined,
               element: opts.element?.trim() || undefined,
-              targetId: opts.targetId?.trim() || undefined,
+              targetId,
               timeoutMs,
             },
           },
@@ -172,7 +178,7 @@ export function registerBrowserFilesAndDownloadsCommands(
         return;
       }
       try {
-        const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : undefined;
+        const { timeoutMs, targetId } = resolveTimeoutAndTarget(opts);
         const result = await callBrowserRequest(
           parent,
           {
@@ -182,7 +188,7 @@ export function registerBrowserFilesAndDownloadsCommands(
             body: {
               accept,
               promptText: opts.prompt?.trim() || undefined,
-              targetId: opts.targetId?.trim() || undefined,
+              targetId,
               timeoutMs,
             },
           },

--- a/src/cli/browser-cli-debug.ts
+++ b/src/cli/browser-cli-debug.ts
@@ -12,6 +12,20 @@ function runBrowserDebug(action: () => Promise<void>) {
   });
 }
 
+function resolveDebugQuery(params: {
+  targetId?: unknown;
+  clear?: unknown;
+  profile?: string;
+  filter?: unknown;
+}) {
+  return {
+    targetId: typeof params.targetId === "string" ? params.targetId.trim() || undefined : undefined,
+    filter: typeof params.filter === "string" ? params.filter.trim() || undefined : undefined,
+    clear: Boolean(params.clear),
+    profile: params.profile,
+  };
+}
+
 export function registerBrowserDebugCommands(
   browser: Command,
   parentOpts: (cmd: Command) => BrowserParentOpts,
@@ -62,11 +76,11 @@ export function registerBrowserDebugCommands(
           {
             method: "GET",
             path: "/errors",
-            query: {
-              targetId: opts.targetId?.trim() || undefined,
-              clear: Boolean(opts.clear),
+            query: resolveDebugQuery({
+              targetId: opts.targetId,
+              clear: opts.clear,
               profile,
-            },
+            }),
           },
           { timeoutMs: 20000 },
         );
@@ -110,12 +124,12 @@ export function registerBrowserDebugCommands(
           {
             method: "GET",
             path: "/requests",
-            query: {
-              targetId: opts.targetId?.trim() || undefined,
-              filter: opts.filter?.trim() || undefined,
-              clear: Boolean(opts.clear),
+            query: resolveDebugQuery({
+              targetId: opts.targetId,
+              filter: opts.filter,
+              clear: opts.clear,
               profile,
-            },
+            }),
           },
           { timeoutMs: 20000 },
         );

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -141,6 +141,65 @@ describe("cron cli", () => {
     expect(params?.delivery?.mode).toBe("announce");
   });
 
+  it("supports directCommand payload on cron add", async () => {
+    callGatewayFromCli.mockClear();
+
+    const program = buildProgram();
+
+    await program.parseAsync(
+      [
+        "cron",
+        "add",
+        "--name",
+        "Direct",
+        "--cron",
+        "* * * * *",
+        "--command",
+        "node",
+        "--arg",
+        "-e",
+        "--arg",
+        "console.log('hi')",
+        "--cwd",
+        "/tmp",
+        "--env",
+        "FOO=bar",
+        "--timeout-seconds",
+        "11",
+        "--max-output-bytes",
+        "2048",
+      ],
+      { from: "user" },
+    );
+
+    const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
+    const params = addCall?.[2] as {
+      sessionTarget?: string;
+      payload?: {
+        kind?: string;
+        command?: string;
+        args?: string[];
+        cwd?: string;
+        env?: Record<string, string>;
+        timeoutSeconds?: number;
+        maxOutputBytes?: number;
+      };
+      delivery?: { mode?: string };
+    };
+
+    expect(params?.sessionTarget).toBe("isolated");
+    expect(params?.payload).toMatchObject({
+      kind: "directCommand",
+      command: "node",
+      args: ["-e", "console.log('hi')"],
+      cwd: "/tmp",
+      env: { FOO: "bar" },
+      timeoutSeconds: 11,
+      maxOutputBytes: 2048,
+    });
+    expect(params?.delivery?.mode).toBe("announce");
+  });
+
   it("infers sessionTarget from payload when --session is omitted", async () => {
     resetGatewayMock();
 
@@ -316,6 +375,43 @@ describe("cron cli", () => {
     expect(patch?.patch?.delivery?.channel).toBe("telegram");
     expect(patch?.patch?.delivery?.to).toBe("19098680");
     expect(patch?.patch?.payload?.message).toBeUndefined();
+  });
+
+  it("supports directCommand payload updates on cron edit", async () => {
+    const patch = await runCronEditAndGetPatch([
+      "--command",
+      "node",
+      "--arg",
+      "-e",
+      "--arg",
+      "console.log('hi')",
+      "--cwd",
+      "/tmp",
+      "--env",
+      "FOO=bar",
+      "--timeout-seconds",
+      "17",
+      "--max-output-bytes",
+      "4096",
+      "--deliver",
+      "--channel",
+      "telegram",
+      "--to",
+      "19098680",
+    ]);
+
+    expect(patch?.patch?.payload).toMatchObject({
+      kind: "directCommand",
+      command: "node",
+      args: ["-e", "console.log('hi')"],
+      cwd: "/tmp",
+      env: { FOO: "bar" },
+      timeoutSeconds: 17,
+      maxOutputBytes: 4096,
+    });
+    expect(patch?.patch?.delivery?.mode).toBe("announce");
+    expect(patch?.patch?.delivery?.channel).toBe("telegram");
+    expect(patch?.patch?.delivery?.to).toBe("19098680");
   });
 
   it("supports --no-deliver on cron edit", async () => {

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -4,6 +4,33 @@ import { defaultRuntime } from "../../runtime.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { warnIfCronSchedulerDisabled } from "./shared.js";
 
+function registerCronToggleCommand(params: {
+  cron: Command;
+  name: "enable" | "disable";
+  description: string;
+  enabled: boolean;
+}) {
+  addGatewayClientOptions(
+    params.cron
+      .command(params.name)
+      .description(params.description)
+      .argument("<id>", "Job id")
+      .action(async (id, opts) => {
+        try {
+          const res = await callGatewayFromCli("cron.update", opts, {
+            id,
+            patch: { enabled: params.enabled },
+          });
+          defaultRuntime.log(JSON.stringify(res, null, 2));
+          await warnIfCronSchedulerDisabled(opts);
+        } catch (err) {
+          defaultRuntime.error(danger(String(err)));
+          defaultRuntime.exit(1);
+        }
+      }),
+  );
+}
+
 export function registerCronSimpleCommands(cron: Command) {
   addGatewayClientOptions(
     cron
@@ -24,45 +51,18 @@ export function registerCronSimpleCommands(cron: Command) {
       }),
   );
 
-  addGatewayClientOptions(
-    cron
-      .command("enable")
-      .description("Enable a cron job")
-      .argument("<id>", "Job id")
-      .action(async (id, opts) => {
-        try {
-          const res = await callGatewayFromCli("cron.update", opts, {
-            id,
-            patch: { enabled: true },
-          });
-          defaultRuntime.log(JSON.stringify(res, null, 2));
-          await warnIfCronSchedulerDisabled(opts);
-        } catch (err) {
-          defaultRuntime.error(danger(String(err)));
-          defaultRuntime.exit(1);
-        }
-      }),
-  );
-
-  addGatewayClientOptions(
-    cron
-      .command("disable")
-      .description("Disable a cron job")
-      .argument("<id>", "Job id")
-      .action(async (id, opts) => {
-        try {
-          const res = await callGatewayFromCli("cron.update", opts, {
-            id,
-            patch: { enabled: false },
-          });
-          defaultRuntime.log(JSON.stringify(res, null, 2));
-          await warnIfCronSchedulerDisabled(opts);
-        } catch (err) {
-          defaultRuntime.error(danger(String(err)));
-          defaultRuntime.exit(1);
-        }
-      }),
-  );
+  registerCronToggleCommand({
+    cron,
+    name: "enable",
+    description: "Enable a cron job",
+    enabled: true,
+  });
+  registerCronToggleCommand({
+    cron,
+    name: "disable",
+    description: "Disable a cron job",
+    enabled: false,
+  });
 
   addGatewayClientOptions(
     cron

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -84,6 +84,19 @@ async function handleServiceNotLoaded(params: {
   }
 }
 
+async function resolveServiceLoadedOrFail(params: {
+  serviceNoun: string;
+  service: GatewayService;
+  fail: ReturnType<typeof createActionIO>["fail"];
+}): Promise<boolean | null> {
+  try {
+    return await params.service.isLoaded({ env: process.env });
+  } catch (err) {
+    params.fail(`${params.serviceNoun} service check failed: ${String(err)}`);
+    return null;
+  }
+}
+
 export async function runServiceUninstall(params: {
   serviceNoun: string;
   service: GatewayService;
@@ -145,11 +158,12 @@ export async function runServiceStart(params: {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createActionIO({ action: "start", json });
 
-  let loaded = false;
-  try {
-    loaded = await params.service.isLoaded({ env: process.env });
-  } catch (err) {
-    fail(`${params.serviceNoun} service check failed: ${String(err)}`);
+  const loaded = await resolveServiceLoadedOrFail({
+    serviceNoun: params.serviceNoun,
+    service: params.service,
+    fail,
+  });
+  if (loaded === null) {
     return;
   }
   if (!loaded) {
@@ -192,11 +206,12 @@ export async function runServiceStop(params: {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createActionIO({ action: "stop", json });
 
-  let loaded = false;
-  try {
-    loaded = await params.service.isLoaded({ env: process.env });
-  } catch (err) {
-    fail(`${params.serviceNoun} service check failed: ${String(err)}`);
+  const loaded = await resolveServiceLoadedOrFail({
+    serviceNoun: params.serviceNoun,
+    service: params.service,
+    fail,
+  });
+  if (loaded === null) {
     return;
   }
   if (!loaded) {
@@ -241,11 +256,12 @@ export async function runServiceRestart(params: {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createActionIO({ action: "restart", json });
 
-  let loaded = false;
-  try {
-    loaded = await params.service.isLoaded({ env: process.env });
-  } catch (err) {
-    fail(`${params.serviceNoun} service check failed: ${String(err)}`);
+  const loaded = await resolveServiceLoadedOrFail({
+    serviceNoun: params.serviceNoun,
+    service: params.service,
+    fail,
+  });
+  if (loaded === null) {
     return false;
   }
   if (!loaded) {

--- a/src/cli/daemon-cli/shared.test.ts
+++ b/src/cli/daemon-cli/shared.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { theme } from "../../terminal/theme.js";
+import { resolveRuntimeStatusColor } from "./shared.js";
+
+describe("resolveRuntimeStatusColor", () => {
+  it("maps known runtime states to expected theme colors", () => {
+    expect(resolveRuntimeStatusColor("running")).toBe(theme.success);
+    expect(resolveRuntimeStatusColor("stopped")).toBe(theme.error);
+    expect(resolveRuntimeStatusColor("unknown")).toBe(theme.muted);
+  });
+
+  it("falls back to warning color for unexpected states", () => {
+    expect(resolveRuntimeStatusColor("degraded")).toBe(theme.warn);
+    expect(resolveRuntimeStatusColor(undefined)).toBe(theme.muted);
+  });
+});

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -27,6 +27,17 @@ export function createCliStatusTextStyles() {
   };
 }
 
+export function resolveRuntimeStatusColor(status: string | undefined): (value: string) => string {
+  const runtimeStatus = status ?? "unknown";
+  return runtimeStatus === "running"
+    ? theme.success
+    : runtimeStatus === "stopped"
+      ? theme.error
+      : runtimeStatus === "unknown"
+        ? theme.muted
+        : theme.warn;
+}
+
 export function parsePortFromArgs(programArguments: string[] | undefined): number | null {
   if (!programArguments?.length) {
     return null;

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -12,13 +12,14 @@ import {
 import { isWSLEnv } from "../../infra/wsl.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
 import { defaultRuntime } from "../../runtime.js";
-import { colorize, theme } from "../../terminal/theme.js";
+import { colorize } from "../../terminal/theme.js";
 import { shortenHomePath } from "../../utils.js";
 import { formatCliCommand } from "../command-format.js";
 import {
   createCliStatusTextStyles,
   filterDaemonEnv,
   formatRuntimeStatus,
+  resolveRuntimeStatusColor,
   renderRuntimeHints,
   safeDaemonEnv,
 } from "./shared.js";
@@ -165,15 +166,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
 
   const runtimeLine = formatRuntimeStatus(service.runtime);
   if (runtimeLine) {
-    const runtimeStatus = service.runtime?.status ?? "unknown";
-    const runtimeColor =
-      runtimeStatus === "running"
-        ? theme.success
-        : runtimeStatus === "stopped"
-          ? theme.error
-          : runtimeStatus === "unknown"
-            ? theme.muted
-            : theme.warn;
+    const runtimeColor = resolveRuntimeStatusColor(service.runtime?.status);
     defaultRuntime.log(`${label("Runtime:")} ${colorize(rich, runtimeColor, runtimeLine)}`);
   }
 

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -14,7 +14,7 @@ import { resolveNodeService } from "../../daemon/node-service.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import { loadNodeHostConfig } from "../../node-host/config.js";
 import { defaultRuntime } from "../../runtime.js";
-import { colorize, theme } from "../../terminal/theme.js";
+import { colorize } from "../../terminal/theme.js";
 import { formatCliCommand } from "../command-format.js";
 import {
   runServiceRestart,
@@ -27,7 +27,12 @@ import {
   createDaemonActionContext,
   installDaemonServiceAndEmit,
 } from "../daemon-cli/response.js";
-import { createCliStatusTextStyles, formatRuntimeStatus, parsePort } from "../daemon-cli/shared.js";
+import {
+  createCliStatusTextStyles,
+  formatRuntimeStatus,
+  parsePort,
+  resolveRuntimeStatusColor,
+} from "../daemon-cli/shared.js";
 
 type NodeDaemonInstallOptions = {
   host?: string;
@@ -261,15 +266,7 @@ export async function runNodeDaemonStatus(opts: NodeDaemonStatusOptions = {}) {
 
   const runtimeLine = formatRuntimeStatus(runtime);
   if (runtimeLine) {
-    const runtimeStatus = runtime?.status ?? "unknown";
-    const runtimeColor =
-      runtimeStatus === "running"
-        ? theme.success
-        : runtimeStatus === "stopped"
-          ? theme.error
-          : runtimeStatus === "unknown"
-            ? theme.muted
-            : theme.warn;
+    const runtimeColor = resolveRuntimeStatusColor(runtime?.status);
     defaultRuntime.log(`${label("Runtime:")} ${colorize(rich, runtimeColor, runtimeLine)}`);
   }
 

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -6,6 +6,7 @@ import {
   cameraTempPath,
   parseCameraClipPayload,
   parseCameraSnapPayload,
+  writeCameraClipPayloadToFile,
   writeBase64ToFile,
   writeUrlToFile,
 } from "./nodes-camera.js";
@@ -54,6 +55,27 @@ describe("nodes camera helpers", () => {
       id: "id1",
     });
     expect(p).toBe(path.join("/tmp", "openclaw-camera-snap-front-id1.jpg"));
+  });
+
+  it("writes camera clip payload to temp path", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    try {
+      const out = await writeCameraClipPayloadToFile({
+        payload: {
+          format: "mp4",
+          base64: "aGk=",
+          durationMs: 200,
+          hasAudio: false,
+        },
+        facing: "front",
+        tmpDir: dir,
+        id: "clip1",
+      });
+      expect(out).toBe(path.join(dir, "openclaw-camera-clip-front-clip1.mp4"));
+      await expect(fs.readFile(out, "utf8")).resolves.toBe("hi");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("writes base64 to file", async () => {

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -140,3 +140,26 @@ export async function writeBase64ToFile(filePath: string, base64: string) {
   await fs.writeFile(filePath, buf);
   return { path: filePath, bytes: buf.length };
 }
+
+export async function writeCameraClipPayloadToFile(params: {
+  payload: CameraClipPayload;
+  facing: CameraFacing;
+  tmpDir?: string;
+  id?: string;
+}): Promise<string> {
+  const filePath = cameraTempPath({
+    kind: "clip",
+    facing: params.facing,
+    ext: params.payload.format,
+    tmpDir: params.tmpDir,
+    id: params.id,
+  });
+  if (params.payload.url) {
+    await writeUrlToFile(filePath, params.payload.url);
+  } else if (params.payload.base64) {
+    await writeBase64ToFile(filePath, params.payload.base64);
+  } else {
+    throw new Error("invalid camera.clip payload");
+  }
+  return filePath;
+}

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -1,8 +1,13 @@
-import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
 import { resolveCliName } from "./cli-name.js";
+import {
+  asBoolean,
+  asNumber,
+  asRecord,
+  asString,
+  resolveTempPathParts,
+} from "./nodes-media-utils.js";
 
 const MAX_CAMERA_URL_DOWNLOAD_BYTES = 250 * 1024 * 1024;
 
@@ -23,22 +28,6 @@ export type CameraClipPayload = {
   durationMs: number;
   hasAudio: boolean;
 };
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
-function asBoolean(value: unknown): boolean | undefined {
-  return typeof value === "boolean" ? value : undefined;
-}
 
 export function parseCameraSnapPayload(value: unknown): CameraSnapPayload {
   const obj = asRecord(value);
@@ -73,10 +62,12 @@ export function cameraTempPath(opts: {
   tmpDir?: string;
   id?: string;
 }) {
-  const tmpDir = opts.tmpDir ?? os.tmpdir();
-  const id = opts.id ?? randomUUID();
+  const { tmpDir, id, ext } = resolveTempPathParts({
+    tmpDir: opts.tmpDir,
+    id: opts.id,
+    ext: opts.ext,
+  });
   const facingPart = opts.facing ? `-${opts.facing}` : "";
-  const ext = opts.ext.startsWith(".") ? opts.ext : `.${opts.ext}`;
   const cliName = resolveCliName();
   return path.join(tmpDir, `${cliName}-camera-${opts.kind}${facingPart}-${id}${ext}`);
 }

--- a/src/cli/nodes-canvas.ts
+++ b/src/cli/nodes-canvas.ts
@@ -1,20 +1,11 @@
-import { randomUUID } from "node:crypto";
-import * as os from "node:os";
 import * as path from "node:path";
 import { resolveCliName } from "./cli-name.js";
+import { asRecord, asString, resolveTempPathParts } from "./nodes-media-utils.js";
 
 export type CanvasSnapshotPayload = {
   format: string;
   base64: string;
 };
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
 
 export function parseCanvasSnapshotPayload(value: unknown): CanvasSnapshotPayload {
   const obj = asRecord(value);
@@ -27,9 +18,7 @@ export function parseCanvasSnapshotPayload(value: unknown): CanvasSnapshotPayloa
 }
 
 export function canvasSnapshotTempPath(opts: { ext: string; tmpDir?: string; id?: string }) {
-  const tmpDir = opts.tmpDir ?? os.tmpdir();
-  const id = opts.id ?? randomUUID();
-  const ext = opts.ext.startsWith(".") ? opts.ext : `.${opts.ext}`;
+  const { tmpDir, id, ext } = resolveTempPathParts(opts);
   const cliName = resolveCliName();
   return path.join(tmpDir, `${cliName}-canvas-snapshot-${id}${ext}`);
 }

--- a/src/cli/nodes-cli/format.ts
+++ b/src/cli/nodes-cli/format.ts
@@ -1,16 +1,4 @@
-import type { NodeListNode, PairedNode, PairingList, PendingRequest } from "./types.js";
-
-export function parsePairingList(value: unknown): PairingList {
-  const obj = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-  const pending = Array.isArray(obj.pending) ? (obj.pending as PendingRequest[]) : [];
-  const paired = Array.isArray(obj.paired) ? (obj.paired as PairedNode[]) : [];
-  return { pending, paired };
-}
-
-export function parseNodeList(value: unknown): NodeListNode[] {
-  const obj = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-  return Array.isArray(obj.nodes) ? (obj.nodes as NodeListNode[]) : [];
-}
+export { parseNodeList, parsePairingList } from "../../shared/node-list-parse.js";
 
 export function formatPermissions(raw: unknown) {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -8,6 +8,7 @@ import {
   parseCameraClipPayload,
   parseCameraSnapPayload,
   writeBase64ToFile,
+  writeCameraClipPayloadToFile,
   writeUrlToFile,
 } from "../nodes-camera.js";
 import { parseDurationMs } from "../parse-duration.js";
@@ -219,16 +220,10 @@ export function registerNodesCameraCommands(nodes: Command) {
           const raw = await callGatewayCli("node.invoke", opts, invokeParams);
           const res = typeof raw === "object" && raw !== null ? (raw as { payload?: unknown }) : {};
           const payload = parseCameraClipPayload(res.payload);
-          const filePath = cameraTempPath({
-            kind: "clip",
+          const filePath = await writeCameraClipPayloadToFile({
+            payload,
             facing,
-            ext: payload.format,
           });
-          if (payload.url) {
-            await writeUrlToFile(filePath, payload.url);
-          } else if (payload.base64) {
-            await writeBase64ToFile(filePath, payload.base64);
-          }
 
           if (opts.json) {
             defaultRuntime.log(

--- a/src/cli/nodes-cli/register.push.ts
+++ b/src/cli/nodes-cli/register.push.ts
@@ -1,0 +1,88 @@
+import type { Command } from "commander";
+import { defaultRuntime } from "../../runtime.js";
+import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
+import { callGatewayCli, nodesCallOpts, resolveNodeId } from "./rpc.js";
+import type { NodesRpcOpts } from "./types.js";
+
+type NodesPushOpts = NodesRpcOpts & {
+  node?: string;
+  title?: string;
+  body?: string;
+  environment?: string;
+};
+
+function normalizeEnvironment(value: unknown): "sandbox" | "production" | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "sandbox" || normalized === "production") {
+    return normalized;
+  }
+  return null;
+}
+
+export function registerNodesPushCommand(nodes: Command) {
+  nodesCallOpts(
+    nodes
+      .command("push")
+      .description("Send an APNs test push to an iOS node")
+      .requiredOption("--node <idOrNameOrIp>", "Node id, name, or IP")
+      .option("--title <text>", "Push title", "OpenClaw")
+      .option("--body <text>", "Push body")
+      .option("--environment <sandbox|production>", "Override APNs environment")
+      .action(async (opts: NodesPushOpts) => {
+        await runNodesCommand("push", async () => {
+          const nodeId = await resolveNodeId(opts, String(opts.node ?? ""));
+          const title = String(opts.title ?? "").trim() || "OpenClaw";
+          const body = String(opts.body ?? "").trim() || `Push test for node ${nodeId}`;
+          const environment = normalizeEnvironment(opts.environment);
+          if (opts.environment && !environment) {
+            throw new Error("invalid --environment (use sandbox|production)");
+          }
+
+          const params: Record<string, unknown> = {
+            nodeId,
+            title,
+            body,
+          };
+          if (environment) {
+            params.environment = environment;
+          }
+
+          const result = await callGatewayCli("push.test", opts, params);
+          if (opts.json) {
+            defaultRuntime.log(JSON.stringify(result, null, 2));
+            return;
+          }
+
+          const parsed =
+            typeof result === "object" && result !== null
+              ? (result as {
+                  ok?: unknown;
+                  status?: unknown;
+                  reason?: unknown;
+                  environment?: unknown;
+                })
+              : {};
+          const ok = parsed.ok === true;
+          const status = typeof parsed.status === "number" ? parsed.status : 0;
+          const reason =
+            typeof parsed.reason === "string" && parsed.reason.trim().length > 0
+              ? parsed.reason.trim()
+              : undefined;
+          const env =
+            typeof parsed.environment === "string" && parsed.environment.trim().length > 0
+              ? parsed.environment.trim()
+              : "unknown";
+          const { ok: okLabel, error: errorLabel } = getNodesTheme();
+          const label = ok ? okLabel : errorLabel;
+          defaultRuntime.log(label(`push.test status=${status} ok=${ok} env=${env}`));
+          if (reason) {
+            defaultRuntime.log(`reason: ${reason}`);
+          }
+        });
+      }),
+    { timeoutMs: 25_000 },
+  );
+}

--- a/src/cli/nodes-cli/register.ts
+++ b/src/cli/nodes-cli/register.ts
@@ -8,6 +8,7 @@ import { registerNodesInvokeCommands } from "./register.invoke.js";
 import { registerNodesLocationCommands } from "./register.location.js";
 import { registerNodesNotifyCommand } from "./register.notify.js";
 import { registerNodesPairingCommands } from "./register.pairing.js";
+import { registerNodesPushCommand } from "./register.push.js";
 import { registerNodesScreenCommands } from "./register.screen.js";
 import { registerNodesStatusCommands } from "./register.status.js";
 
@@ -30,6 +31,7 @@ export function registerNodesCli(program: Command) {
   registerNodesPairingCommands(nodes);
   registerNodesInvokeCommands(nodes);
   registerNodesNotifyCommand(nodes);
+  registerNodesPushCommand(nodes);
   registerNodesCanvasCommands(nodes);
   registerNodesCameraCommands(nodes);
   registerNodesScreenCommands(nodes);

--- a/src/cli/nodes-media-utils.test.ts
+++ b/src/cli/nodes-media-utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  asBoolean,
+  asNumber,
+  asRecord,
+  asString,
+  resolveTempPathParts,
+} from "./nodes-media-utils.js";
+
+describe("cli/nodes-media-utils", () => {
+  it("parses primitive helper values", () => {
+    expect(asRecord({ a: 1 })).toEqual({ a: 1 });
+    expect(asRecord("x")).toEqual({});
+    expect(asString("x")).toBe("x");
+    expect(asString(1)).toBeUndefined();
+    expect(asNumber(1)).toBe(1);
+    expect(asNumber(Number.NaN)).toBeUndefined();
+    expect(asBoolean(true)).toBe(true);
+    expect(asBoolean(1)).toBeUndefined();
+  });
+
+  it("normalizes temp path parts", () => {
+    expect(resolveTempPathParts({ ext: "png", tmpDir: "/tmp", id: "id1" })).toEqual({
+      tmpDir: "/tmp",
+      id: "id1",
+      ext: ".png",
+    });
+    expect(resolveTempPathParts({ ext: ".jpg", tmpDir: "/tmp", id: "id2" }).ext).toBe(".jpg");
+  });
+});

--- a/src/cli/nodes-media-utils.ts
+++ b/src/cli/nodes-media-utils.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from "node:crypto";
+import * as os from "node:os";
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+export function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+export function resolveTempPathParts(opts: { ext: string; tmpDir?: string; id?: string }): {
+  ext: string;
+  tmpDir: string;
+  id: string;
+} {
+  return {
+    tmpDir: opts.tmpDir ?? os.tmpdir(),
+    id: opts.id ?? randomUUID(),
+    ext: opts.ext.startsWith(".") ? opts.ext : `.${opts.ext}`,
+  };
+}

--- a/src/cli/nodes-screen.ts
+++ b/src/cli/nodes-screen.ts
@@ -1,7 +1,6 @@
-import { randomUUID } from "node:crypto";
-import * as os from "node:os";
 import * as path from "node:path";
 import { writeBase64ToFile } from "./nodes-camera.js";
+import { asRecord, asString, resolveTempPathParts } from "./nodes-media-utils.js";
 
 export type ScreenRecordPayload = {
   format: string;
@@ -11,14 +10,6 @@ export type ScreenRecordPayload = {
   screenIndex?: number;
   hasAudio?: boolean;
 };
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
 
 export function parseScreenRecordPayload(value: unknown): ScreenRecordPayload {
   const obj = asRecord(value);
@@ -38,9 +29,7 @@ export function parseScreenRecordPayload(value: unknown): ScreenRecordPayload {
 }
 
 export function screenRecordTempPath(opts: { ext: string; tmpDir?: string; id?: string }) {
-  const tmpDir = opts.tmpDir ?? os.tmpdir();
-  const id = opts.id ?? randomUUID();
-  const ext = opts.ext.startsWith(".") ? opts.ext : `.${opts.ext}`;
+  const { tmpDir, id, ext } = resolveTempPathParts(opts);
   return path.join(tmpDir, `openclaw-screen-record-${id}${ext}`);
 }
 

--- a/src/cli/skills-cli.test.ts
+++ b/src/cli/skills-cli.test.ts
@@ -113,14 +113,6 @@ describe("skills-cli", () => {
       expect(output).toContain("eligible-one");
       expect(output).not.toContain("not-eligible");
     });
-
-    it("outputs JSON with --json flag", () => {
-      const report = createMockReport([createMockSkill({ name: "json-skill" })]);
-      const output = formatSkillsList(report, { json: true });
-      const parsed = JSON.parse(output);
-      expect(parsed.skills).toHaveLength(1);
-      expect(parsed.skills[0].name).toBe("json-skill");
-    });
   });
 
   describe("formatSkillInfo", () => {
@@ -161,13 +153,6 @@ describe("skills-cli", () => {
       expect(output).toContain("Any binaries");
       expect(output).toContain("API_KEY");
     });
-
-    it("outputs JSON with --json flag", () => {
-      const report = createMockReport([createMockSkill({ name: "info-skill" })]);
-      const output = formatSkillInfo(report, "info-skill", { json: true });
-      const parsed = JSON.parse(output);
-      expect(parsed.name).toBe("info-skill");
-    });
   });
 
   describe("formatSkillsCheck", () => {
@@ -190,16 +175,50 @@ describe("skills-cli", () => {
       expect(output).toContain("go"); // missing binary
       expect(output).toContain("npx clawhub");
     });
+  });
 
-    it("outputs JSON with --json flag", () => {
-      const report = createMockReport([
-        createMockSkill({ name: "skill-1", eligible: true }),
-        createMockSkill({ name: "skill-2", eligible: false }),
-      ]);
-      const output = formatSkillsCheck(report, { json: true });
-      const parsed = JSON.parse(output);
-      expect(parsed.summary.eligible).toBe(1);
-      expect(parsed.summary.total).toBe(2);
+  describe("JSON output", () => {
+    it.each([
+      {
+        formatter: "list",
+        output: formatSkillsList(createMockReport([createMockSkill({ name: "json-skill" })]), {
+          json: true,
+        }),
+        assert: (parsed: Record<string, unknown>) => {
+          const skills = parsed.skills as Array<Record<string, unknown>>;
+          expect(skills).toHaveLength(1);
+          expect(skills[0]?.name).toBe("json-skill");
+        },
+      },
+      {
+        formatter: "info",
+        output: formatSkillInfo(
+          createMockReport([createMockSkill({ name: "info-skill" })]),
+          "info-skill",
+          { json: true },
+        ),
+        assert: (parsed: Record<string, unknown>) => {
+          expect(parsed.name).toBe("info-skill");
+        },
+      },
+      {
+        formatter: "check",
+        output: formatSkillsCheck(
+          createMockReport([
+            createMockSkill({ name: "skill-1", eligible: true }),
+            createMockSkill({ name: "skill-2", eligible: false }),
+          ]),
+          { json: true },
+        ),
+        assert: (parsed: Record<string, unknown>) => {
+          const summary = parsed.summary as Record<string, unknown>;
+          expect(summary.eligible).toBe(1);
+          expect(summary.total).toBe(2);
+        },
+      },
+    ])("outputs JSON with --json flag for $formatter", ({ output, assert }) => {
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      assert(parsed);
     });
   });
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -557,6 +557,16 @@ describe("update-cli", () => {
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("updateStatusCommand validates timeout option", async () => {
+    vi.mocked(defaultRuntime.error).mockClear();
+    vi.mocked(defaultRuntime.exit).mockClear();
+
+    await updateStatusCommand({ timeout: "invalid" });
+
+    expect(defaultRuntime.error).toHaveBeenCalledWith(expect.stringContaining("timeout"));
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("persists update channel when --channel is set", async () => {
     const mockResult: UpdateRunResult = {
       status: "ok",
@@ -608,6 +618,17 @@ describe("update-cli", () => {
     expect(defaultRuntime.error).toHaveBeenCalledWith(
       expect.stringContaining("Update wizard requires a TTY"),
     );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("updateWizardCommand validates timeout option", async () => {
+    setTty(true);
+    vi.mocked(defaultRuntime.error).mockClear();
+    vi.mocked(defaultRuntime.exit).mockClear();
+
+    await updateWizardCommand({ timeout: "invalid" });
+
+    expect(defaultRuntime.error).toHaveBeenCalledWith(expect.stringContaining("timeout"));
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -37,6 +37,18 @@ export type UpdateWizardOptions = {
   timeout?: string;
 };
 
+const INVALID_TIMEOUT_ERROR = "--timeout must be a positive integer (seconds)";
+
+export function parseTimeoutMsOrExit(timeout?: string): number | undefined | null {
+  const timeoutMs = timeout ? Number.parseInt(timeout, 10) * 1000 : undefined;
+  if (timeoutMs !== undefined && (Number.isNaN(timeoutMs) || timeoutMs <= 0)) {
+    defaultRuntime.error(INVALID_TIMEOUT_ERROR);
+    defaultRuntime.exit(1);
+    return null;
+  }
+  return timeoutMs;
+}
+
 const OPENCLAW_REPO_URL = "https://github.com/openclaw/openclaw.git";
 const MAX_LOG_CHARS = 8000;
 

--- a/src/cli/update-cli/status.ts
+++ b/src/cli/update-cli/status.ts
@@ -12,7 +12,7 @@ import { checkUpdateStatus } from "../../infra/update-check.js";
 import { defaultRuntime } from "../../runtime.js";
 import { renderTable } from "../../terminal/table.js";
 import { theme } from "../../terminal/theme.js";
-import { resolveUpdateRoot, type UpdateStatusOptions } from "./shared.js";
+import { parseTimeoutMsOrExit, resolveUpdateRoot, type UpdateStatusOptions } from "./shared.js";
 
 function formatGitStatusLine(params: {
   branch: string | null;
@@ -31,10 +31,8 @@ function formatGitStatusLine(params: {
 }
 
 export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<void> {
-  const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
-  if (timeoutMs !== undefined && (Number.isNaN(timeoutMs) || timeoutMs <= 0)) {
-    defaultRuntime.error("--timeout must be a positive integer (seconds)");
-    defaultRuntime.exit(1);
+  const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
+  if (timeoutMs === null) {
     return;
   }
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -40,6 +40,7 @@ import {
   DEFAULT_PACKAGE_NAME,
   ensureGitCheckout,
   normalizeTag,
+  parseTimeoutMsOrExit,
   readPackageName,
   readPackageVersion,
   resolveGitInstallDir,
@@ -468,12 +469,9 @@ async function maybeRestartService(params: {
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   suppressDeprecations();
 
-  const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
+  const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
   const shouldRestart = opts.restart !== false;
-
-  if (timeoutMs !== undefined && (Number.isNaN(timeoutMs) || timeoutMs <= 0)) {
-    defaultRuntime.error("--timeout must be a positive integer (seconds)");
-    defaultRuntime.exit(1);
+  if (timeoutMs === null) {
     return;
   }
 

--- a/src/cli/update-cli/wizard.ts
+++ b/src/cli/update-cli/wizard.ts
@@ -14,6 +14,7 @@ import { pathExists } from "../../utils.js";
 import {
   isEmptyDir,
   isGitCheckout,
+  parseTimeoutMsOrExit,
   resolveGitInstallDir,
   resolveUpdateRoot,
   type UpdateWizardOptions,
@@ -29,10 +30,8 @@ export async function updateWizardCommand(opts: UpdateWizardOptions = {}): Promi
     return;
   }
 
-  const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
-  if (timeoutMs !== undefined && (Number.isNaN(timeoutMs) || timeoutMs <= 0)) {
-    defaultRuntime.error("--timeout must be a positive integer (seconds)");
-    defaultRuntime.exit(1);
+  const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
+  if (timeoutMs === null) {
     return;
   }
 

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -1,4 +1,5 @@
 import {
+  listAgentEntries,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
@@ -31,14 +32,7 @@ export type AgentSummary = {
 type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
 
 export type AgentIdentity = AgentIdentityFile;
-
-export function listAgentEntries(cfg: OpenClawConfig): AgentEntry[] {
-  const list = cfg.agents?.list;
-  if (!Array.isArray(list)) {
-    return [];
-  }
-  return list.filter((entry): entry is AgentEntry => Boolean(entry && typeof entry === "object"));
-}
+export { listAgentEntries };
 
 export function findAgentEntryIndex(list: AgentEntry[], agentId: string): number {
   const id = normalizeAgentId(agentId);

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -5,6 +5,7 @@ import {
   normalizeApiKeyInput,
   validateApiKeyInput,
 } from "./auth-choice.api-key.js";
+import { createAuthChoiceAgentModelNoter } from "./auth-choice.apply-helpers.js";
 import { applyAuthChoiceHuggingface } from "./auth-choice.apply.huggingface.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyAuthChoiceOpenRouter } from "./auth-choice.apply.openrouter.js";
@@ -74,15 +75,7 @@ export async function applyAuthChoiceApiProviders(
 ): Promise<ApplyAuthChoiceResult | null> {
   let nextConfig = params.config;
   let agentModelOverride: string | undefined;
-  const noteAgentModel = async (model: string) => {
-    if (!params.agentId) {
-      return;
-    }
-    await params.prompter.note(
-      `Default model set to ${model} for agent "${params.agentId}".`,
-      "Model configured",
-    );
-  };
+  const noteAgentModel = createAuthChoiceAgentModelNoter(params);
 
   let authChoice = params.authChoice;
   if (

--- a/src/commands/auth-choice.apply.minimax.ts
+++ b/src/commands/auth-choice.apply.minimax.ts
@@ -4,6 +4,7 @@ import {
   normalizeApiKeyInput,
   validateApiKeyInput,
 } from "./auth-choice.api-key.js";
+import { createAuthChoiceAgentModelNoter } from "./auth-choice.apply-helpers.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyAuthChoicePluginProvider } from "./auth-choice.apply.plugin-provider.js";
 import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
@@ -47,15 +48,7 @@ export async function applyAuthChoiceMiniMax(
       await setMinimaxApiKey(normalizeApiKeyInput(String(key)), params.agentDir, opts.profileId);
     }
   };
-  const noteAgentModel = async (model: string) => {
-    if (!params.agentId) {
-      return;
-    }
-    await params.prompter.note(
-      `Default model set to ${model} for agent "${params.agentId}".`,
-      "Model configured",
-    );
-  };
+  const noteAgentModel = createAuthChoiceAgentModelNoter(params);
   if (params.authChoice === "minimax-portal") {
     // Let user choose between Global/CN endpoints
     const endpoint = await params.prompter.select({

--- a/src/commands/auth-choice.apply.openai.ts
+++ b/src/commands/auth-choice.apply.openai.ts
@@ -5,6 +5,7 @@ import {
   normalizeApiKeyInput,
   validateApiKeyInput,
 } from "./auth-choice.api-key.js";
+import { createAuthChoiceAgentModelNoter } from "./auth-choice.apply-helpers.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
 import { isRemoteEnvironment } from "./oauth-env.js";
@@ -24,6 +25,7 @@ import {
 export async function applyAuthChoiceOpenAI(
   params: ApplyAuthChoiceParams,
 ): Promise<ApplyAuthChoiceResult | null> {
+  const noteAgentModel = createAuthChoiceAgentModelNoter(params);
   let authChoice = params.authChoice;
   if (authChoice === "apiKey" && params.opts?.tokenProvider === "openai") {
     authChoice = "openai-api-key";
@@ -32,15 +34,6 @@ export async function applyAuthChoiceOpenAI(
   if (authChoice === "openai-api-key") {
     let nextConfig = params.config;
     let agentModelOverride: string | undefined;
-    const noteAgentModel = async (model: string) => {
-      if (!params.agentId) {
-        return;
-      }
-      await params.prompter.note(
-        `Default model set to ${model} for agent "${params.agentId}".`,
-        "Model configured",
-      );
-    };
 
     const applyOpenAiDefaultModelChoice = async (): Promise<ApplyAuthChoiceResult> => {
       const applied = await applyDefaultModelChoice({
@@ -106,15 +99,6 @@ export async function applyAuthChoiceOpenAI(
   if (params.authChoice === "openai-codex") {
     let nextConfig = params.config;
     let agentModelOverride: string | undefined;
-    const noteAgentModel = async (model: string) => {
-      if (!params.agentId) {
-        return;
-      }
-      await params.prompter.note(
-        `Default model set to ${model} for agent "${params.agentId}".`,
-        "Model configured",
-      );
-    };
 
     let creds;
     try {

--- a/src/commands/auth-choice.apply.openrouter.ts
+++ b/src/commands/auth-choice.apply.openrouter.ts
@@ -5,6 +5,7 @@ import {
   normalizeApiKeyInput,
   validateApiKeyInput,
 } from "./auth-choice.api-key.js";
+import { createAuthChoiceAgentModelNoter } from "./auth-choice.apply-helpers.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
 import {
@@ -20,15 +21,7 @@ export async function applyAuthChoiceOpenRouter(
 ): Promise<ApplyAuthChoiceResult> {
   let nextConfig = params.config;
   let agentModelOverride: string | undefined;
-  const noteAgentModel = async (model: string) => {
-    if (!params.agentId) {
-      return;
-    }
-    await params.prompter.note(
-      `Default model set to ${model} for agent "${params.agentId}".`,
-      "Model configured",
-    );
-  };
+  const noteAgentModel = createAuthChoiceAgentModelNoter(params);
 
   const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
   const profileOrder = resolveAuthProfileOrder({

--- a/src/commands/daemon-install-runtime-warning.test.ts
+++ b/src/commands/daemon-install-runtime-warning.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveSystemNodeInfo: vi.fn(),
+  renderSystemNodeWarning: vi.fn(),
+}));
+
+vi.mock("../daemon/runtime-paths.js", () => ({
+  resolveSystemNodeInfo: mocks.resolveSystemNodeInfo,
+  renderSystemNodeWarning: mocks.renderSystemNodeWarning,
+}));
+
+import { emitNodeRuntimeWarning } from "./daemon-install-runtime-warning.js";
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("emitNodeRuntimeWarning", () => {
+  it("skips lookup when runtime is not node", async () => {
+    const warn = vi.fn();
+    await emitNodeRuntimeWarning({
+      env: {},
+      runtime: "bun",
+      warn,
+      title: "Gateway runtime",
+    });
+    expect(mocks.resolveSystemNodeInfo).not.toHaveBeenCalled();
+    expect(mocks.renderSystemNodeWarning).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("emits warning when system node check returns one", async () => {
+    const warn = vi.fn();
+    mocks.resolveSystemNodeInfo.mockResolvedValue({ path: "/usr/bin/node", version: "18.0.0" });
+    mocks.renderSystemNodeWarning.mockReturnValue("Node too old");
+
+    await emitNodeRuntimeWarning({
+      env: { PATH: "/usr/bin" },
+      runtime: "node",
+      nodeProgram: "/opt/node",
+      warn,
+      title: "Node daemon runtime",
+    });
+
+    expect(mocks.resolveSystemNodeInfo).toHaveBeenCalledWith({
+      env: { PATH: "/usr/bin" },
+    });
+    expect(mocks.renderSystemNodeWarning).toHaveBeenCalledWith(
+      { path: "/usr/bin/node", version: "18.0.0" },
+      "/opt/node",
+    );
+    expect(warn).toHaveBeenCalledWith("Node too old", "Node daemon runtime");
+  });
+
+  it("does not emit when warning helper returns null", async () => {
+    const warn = vi.fn();
+    mocks.resolveSystemNodeInfo.mockResolvedValue(null);
+    mocks.renderSystemNodeWarning.mockReturnValue(null);
+
+    await emitNodeRuntimeWarning({
+      env: {},
+      runtime: "node",
+      nodeProgram: "node",
+      warn,
+      title: "Gateway runtime",
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/daemon-install-runtime-warning.ts
+++ b/src/commands/daemon-install-runtime-warning.ts
@@ -1,0 +1,20 @@
+import { renderSystemNodeWarning, resolveSystemNodeInfo } from "../daemon/runtime-paths.js";
+
+export type DaemonInstallWarnFn = (message: string, title?: string) => void;
+
+export async function emitNodeRuntimeWarning(params: {
+  env: Record<string, string | undefined>;
+  runtime: string;
+  nodeProgram?: string;
+  warn?: DaemonInstallWarnFn;
+  title: string;
+}): Promise<void> {
+  if (params.runtime !== "node") {
+    return;
+  }
+  const systemNode = await resolveSystemNodeInfo({ env: params.env });
+  const warning = renderSystemNodeWarning(systemNode, params.nodeProgram);
+  if (warning) {
+    params.warn?.(warning, params.title);
+  }
+}

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig, GatewayBindMode } from "../config/config.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { isLoopbackHost, resolveGatewayBindHost } from "../gateway/net.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+import { normalizeStringEntries } from "../shared/string-normalization.js";
 import { note } from "../terminal/note.js";
 
 export async function noteSecurityWarnings(cfg: OpenClawConfig) {
@@ -84,7 +85,9 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
   }) => {
     const dmPolicy = params.dmPolicy;
     const policyPath = params.policyPath ?? `${params.allowFromPath}policy`;
-    const configAllowFrom = (params.allowFrom ?? []).map((v) => String(v).trim());
+    const configAllowFrom = normalizeStringEntries(
+      Array.isArray(params.allowFrom) ? params.allowFrom : undefined,
+    );
     const hasWildcard = configAllowFrom.includes("*");
     const storeAllowFrom = await readChannelAllowFromStore(params.provider).catch(() => []);
     const normalizedCfg = configAllowFrom

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -5,8 +5,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig, GatewayBindMode } from "../config/config.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { isLoopbackHost, resolveGatewayBindHost } from "../gateway/net.js";
-import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
-import { normalizeStringEntries } from "../shared/string-normalization.js";
+import { resolveDmAllowState } from "../security/dm-policy-shared.js";
 import { note } from "../terminal/note.js";
 
 export async function noteSecurityWarnings(cfg: OpenClawConfig) {
@@ -85,23 +84,12 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
   }) => {
     const dmPolicy = params.dmPolicy;
     const policyPath = params.policyPath ?? `${params.allowFromPath}policy`;
-    const configAllowFrom = normalizeStringEntries(
-      Array.isArray(params.allowFrom) ? params.allowFrom : undefined,
-    );
-    const hasWildcard = configAllowFrom.includes("*");
-    const storeAllowFrom = await readChannelAllowFromStore(params.provider).catch(() => []);
-    const normalizedCfg = configAllowFrom
-      .filter((v) => v !== "*")
-      .map((v) => (params.normalizeEntry ? params.normalizeEntry(v) : v))
-      .map((v) => v.trim())
-      .filter(Boolean);
-    const normalizedStore = storeAllowFrom
-      .map((v) => (params.normalizeEntry ? params.normalizeEntry(v) : v))
-      .map((v) => v.trim())
-      .filter(Boolean);
-    const allowCount = Array.from(new Set([...normalizedCfg, ...normalizedStore])).length;
+    const { hasWildcard, allowCount, isMultiUserDm } = await resolveDmAllowState({
+      provider: params.provider,
+      allowFrom: params.allowFrom,
+      normalizeEntry: params.normalizeEntry,
+    });
     const dmScope = cfg.session?.dmScope ?? "main";
-    const isMultiUserDm = hasWildcard || allowCount > 1;
 
     if (dmPolicy === "open") {
       const allowFromPath = `${params.allowFromPath}allowFrom`;

--- a/src/commands/models/scan.ts
+++ b/src/commands/models/scan.ts
@@ -10,6 +10,7 @@ import {
   stylePromptMessage,
   stylePromptTitle,
 } from "../../terminal/prompt-style.js";
+import { pad, truncate } from "./list.format.js";
 import { formatMs, formatTokenK, updateConfig } from "./shared.js";
 
 const MODEL_PAD = 42;
@@ -32,18 +33,6 @@ function guardPromptCancel<T>(value: T | symbol, runtime: RuntimeEnv): T {
   }
   return value;
 }
-
-const pad = (value: string, size: number) => value.padEnd(size);
-
-const truncate = (value: string, max: number) => {
-  if (value.length <= max) {
-    return value;
-  }
-  if (max <= 3) {
-    return value.slice(0, max);
-  }
-  return `${value.slice(0, max - 3)}...`;
-};
 
 function sortScanResults(results: ModelScanResult[]): ModelScanResult[] {
   return results.slice().toSorted((a, b) => {

--- a/src/commands/models/shared.test.ts
+++ b/src/commands/models/shared.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+const mocks = vi.hoisted(() => ({
+  readConfigFileSnapshot: vi.fn(),
+  writeConfigFile: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  readConfigFileSnapshot: (...args: unknown[]) => mocks.readConfigFileSnapshot(...args),
+  writeConfigFile: (...args: unknown[]) => mocks.writeConfigFile(...args),
+}));
+
+import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
+
+describe("models/shared", () => {
+  beforeEach(() => {
+    mocks.readConfigFileSnapshot.mockReset();
+    mocks.writeConfigFile.mockReset();
+  });
+
+  it("returns config when snapshot is valid", async () => {
+    const cfg = { providers: {} } as unknown as OpenClawConfig;
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      config: cfg,
+    });
+
+    await expect(loadValidConfigOrThrow()).resolves.toBe(cfg);
+  });
+
+  it("throws formatted issues when snapshot is invalid", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      valid: false,
+      path: "/tmp/openclaw.json",
+      issues: [{ path: "providers.openai.apiKey", message: "Required" }],
+    });
+
+    await expect(loadValidConfigOrThrow()).rejects.toThrowError(
+      "Invalid config at /tmp/openclaw.json\n- providers.openai.apiKey: Required",
+    );
+  });
+
+  it("updateConfig writes mutated config", async () => {
+    const cfg = { update: { channel: "stable" } } as unknown as OpenClawConfig;
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      config: cfg,
+    });
+    mocks.writeConfigFile.mockResolvedValue(undefined);
+
+    await updateConfig((current) => ({
+      ...current,
+      update: { channel: "beta" },
+    }));
+
+    expect(mocks.writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: { channel: "beta" },
+      }),
+    );
+  });
+});

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -59,15 +59,20 @@ export const isLocalBaseUrl = (baseUrl: string) => {
   }
 };
 
-export async function updateConfig(
-  mutator: (cfg: OpenClawConfig) => OpenClawConfig,
-): Promise<OpenClawConfig> {
+export async function loadValidConfigOrThrow(): Promise<OpenClawConfig> {
   const snapshot = await readConfigFileSnapshot();
   if (!snapshot.valid) {
     const issues = snapshot.issues.map((issue) => `- ${issue.path}: ${issue.message}`).join("\n");
     throw new Error(`Invalid config at ${snapshot.path}\n${issues}`);
   }
-  const next = mutator(snapshot.config);
+  return snapshot.config;
+}
+
+export async function updateConfig(
+  mutator: (cfg: OpenClawConfig) => OpenClawConfig,
+): Promise<OpenClawConfig> {
+  const config = await loadValidConfigOrThrow();
+  const next = mutator(config);
   await writeConfigFile(next);
   return next;
 }

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -1,15 +1,13 @@
 import { formatNodeServiceDescription } from "../daemon/constants.js";
 import { resolveNodeProgramArguments } from "../daemon/program-args.js";
-import {
-  renderSystemNodeWarning,
-  resolvePreferredNodePath,
-  resolveSystemNodeInfo,
-} from "../daemon/runtime-paths.js";
+import { resolvePreferredNodePath } from "../daemon/runtime-paths.js";
 import { buildNodeServiceEnvironment } from "../daemon/service-env.js";
 import { resolveGatewayDevMode } from "./daemon-install-helpers.js";
+import {
+  emitNodeRuntimeWarning,
+  type DaemonInstallWarnFn,
+} from "./daemon-install-runtime-warning.js";
 import type { NodeDaemonRuntime } from "./node-daemon-runtime.js";
-
-type WarnFn = (message: string, title?: string) => void;
 
 export type NodeInstallPlan = {
   programArguments: string[];
@@ -29,7 +27,7 @@ export async function buildNodeInstallPlan(params: {
   runtime: NodeDaemonRuntime;
   devMode?: boolean;
   nodePath?: string;
-  warn?: WarnFn;
+  warn?: DaemonInstallWarnFn;
 }): Promise<NodeInstallPlan> {
   const devMode = params.devMode ?? resolveGatewayDevMode();
   const nodePath =
@@ -50,13 +48,13 @@ export async function buildNodeInstallPlan(params: {
     nodePath,
   });
 
-  if (params.runtime === "node") {
-    const systemNode = await resolveSystemNodeInfo({ env: params.env });
-    const warning = renderSystemNodeWarning(systemNode, programArguments[0]);
-    if (warning) {
-      params.warn?.(warning, "Node daemon runtime");
-    }
-  }
+  await emitNodeRuntimeWarning({
+    env: params.env,
+    runtime: params.runtime,
+    nodeProgram: programArguments[0],
+    warn: params.warn,
+    title: "Node daemon runtime",
+  });
 
   const environment = buildNodeServiceEnvironment({ env: params.env });
   const description = formatNodeServiceDescription({

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -8,6 +8,7 @@ import { enablePluginInConfig } from "../../plugins/enable.js";
 import { installPluginFromNpmSpec } from "../../plugins/install.js";
 import { recordPluginInstall } from "../../plugins/installs.js";
 import { loadOpenClawPlugins } from "../../plugins/loader.js";
+import { createPluginLoaderLogger } from "../../plugins/logger.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 
@@ -211,11 +212,6 @@ export function reloadOnboardingPluginRegistry(params: {
     config: params.cfg,
     workspaceDir,
     cache: false,
-    logger: {
-      info: (msg) => log.info(msg),
-      warn: (msg) => log.warn(msg),
-      error: (msg) => log.error(msg),
-      debug: (msg) => log.debug(msg),
-    },
+    logger: createPluginLoaderLogger(log),
   });
 }

--- a/src/commands/sandbox-formatters.e2e.test.ts
+++ b/src/commands/sandbox-formatters.e2e.test.ts
@@ -91,10 +91,6 @@ describe("sandbox-formatters", () => {
       expect(countRunning(items)).toBe(2);
     });
 
-    it("should return 0 for empty array", () => {
-      expect(countRunning([])).toBe(0);
-    });
-
     it("should return 0 when no items running", () => {
       const items = [
         { running: false, name: "a" },
@@ -128,10 +124,6 @@ describe("sandbox-formatters", () => {
       expect(countMismatches(items)).toBe(3);
     });
 
-    it("should return 0 for empty array", () => {
-      expect(countMismatches([])).toBe(0);
-    });
-
     it("should return 0 when all match", () => {
       const items = [
         { imageMatch: true, name: "a" },
@@ -149,6 +141,15 @@ describe("sandbox-formatters", () => {
       ];
 
       expect(countMismatches(items)).toBe(3);
+    });
+  });
+
+  describe("counter empty inputs", () => {
+    it.each([
+      { fn: countRunning as (items: unknown[]) => number },
+      { fn: countMismatches as (items: unknown[]) => number },
+    ])("should return 0 for empty array", ({ fn }) => {
+      expect(fn([])).toBe(0);
     });
   });
 });

--- a/src/commands/sandbox-formatters.e2e.test.ts
+++ b/src/commands/sandbox-formatters.e2e.test.ts
@@ -13,134 +13,116 @@ const formatAge = (ms: number) => formatDurationCompact(ms, { spaced: true }) ??
 
 describe("sandbox-formatters", () => {
   describe("formatStatus", () => {
-    it("should format running status", () => {
-      expect(formatStatus(true)).toBe("🟢 running");
-    });
-
-    it("should format stopped status", () => {
-      expect(formatStatus(false)).toBe("⚫ stopped");
+    it.each([
+      { running: true, expected: "🟢 running" },
+      { running: false, expected: "⚫ stopped" },
+    ])("formats running=$running", ({ running, expected }) => {
+      expect(formatStatus(running)).toBe(expected);
     });
   });
 
   describe("formatSimpleStatus", () => {
-    it("should format running status without emoji", () => {
-      expect(formatSimpleStatus(true)).toBe("running");
-    });
-
-    it("should format stopped status without emoji", () => {
-      expect(formatSimpleStatus(false)).toBe("stopped");
+    it.each([
+      { running: true, expected: "running" },
+      { running: false, expected: "stopped" },
+    ])("formats running=$running without emoji", ({ running, expected }) => {
+      expect(formatSimpleStatus(running)).toBe(expected);
     });
   });
 
   describe("formatImageMatch", () => {
-    it("should format matching image", () => {
-      expect(formatImageMatch(true)).toBe("✓");
-    });
-
-    it("should format mismatched image", () => {
-      expect(formatImageMatch(false)).toBe("⚠️  mismatch");
+    it.each([
+      { imageMatch: true, expected: "✓" },
+      { imageMatch: false, expected: "⚠️  mismatch" },
+    ])("formats imageMatch=$imageMatch", ({ imageMatch, expected }) => {
+      expect(formatImageMatch(imageMatch)).toBe(expected);
     });
   });
 
   describe("formatAge", () => {
-    it("should format seconds", () => {
-      expect(formatAge(5000)).toBe("5s");
-      expect(formatAge(45000)).toBe("45s");
-    });
-
-    it("should format minutes", () => {
-      expect(formatAge(60000)).toBe("1m");
-      expect(formatAge(90000)).toBe("1m 30s"); // 90 seconds = 1m 30s
-      expect(formatAge(300000)).toBe("5m");
-    });
-
-    it("should format hours and minutes", () => {
-      expect(formatAge(3600000)).toBe("1h");
-      expect(formatAge(3660000)).toBe("1h 1m");
-      expect(formatAge(7200000)).toBe("2h");
-      expect(formatAge(5400000)).toBe("1h 30m");
-    });
-
-    it("should format days and hours", () => {
-      expect(formatAge(86400000)).toBe("1d");
-      expect(formatAge(90000000)).toBe("1d 1h");
-      expect(formatAge(172800000)).toBe("2d");
-      expect(formatAge(183600000)).toBe("2d 3h");
-    });
-
-    it("should handle zero", () => {
-      expect(formatAge(0)).toBe("0s");
-    });
-
-    it("should handle edge cases", () => {
-      expect(formatAge(59999)).toBe("1m"); // Rounds to 1 minute exactly
-      expect(formatAge(3599999)).toBe("1h"); // Rounds to 1 hour exactly
-      expect(formatAge(86399999)).toBe("1d"); // Rounds to 1 day exactly
+    it.each([
+      { ms: 0, expected: "0s" },
+      { ms: 5000, expected: "5s" },
+      { ms: 45000, expected: "45s" },
+      { ms: 60000, expected: "1m" },
+      { ms: 90000, expected: "1m 30s" }, // 90 seconds = 1m 30s
+      { ms: 300000, expected: "5m" },
+      { ms: 3600000, expected: "1h" },
+      { ms: 3660000, expected: "1h 1m" },
+      { ms: 5400000, expected: "1h 30m" },
+      { ms: 7200000, expected: "2h" },
+      { ms: 86400000, expected: "1d" },
+      { ms: 90000000, expected: "1d 1h" },
+      { ms: 172800000, expected: "2d" },
+      { ms: 183600000, expected: "2d 3h" },
+      { ms: 59999, expected: "1m" }, // Rounds to 1 minute exactly
+      { ms: 3599999, expected: "1h" }, // Rounds to 1 hour exactly
+      { ms: 86399999, expected: "1d" }, // Rounds to 1 day exactly
+    ])("formats $ms ms", ({ ms, expected }) => {
+      expect(formatAge(ms)).toBe(expected);
     });
   });
 
   describe("countRunning", () => {
-    it("should count running items", () => {
-      const items = [
-        { running: true, name: "a" },
-        { running: false, name: "b" },
-        { running: true, name: "c" },
-        { running: false, name: "d" },
-      ];
-
-      expect(countRunning(items)).toBe(2);
-    });
-
-    it("should return 0 when no items running", () => {
-      const items = [
-        { running: false, name: "a" },
-        { running: false, name: "b" },
-      ];
-
-      expect(countRunning(items)).toBe(0);
-    });
-
-    it("should count all when all running", () => {
-      const items = [
-        { running: true, name: "a" },
-        { running: true, name: "b" },
-        { running: true, name: "c" },
-      ];
-
-      expect(countRunning(items)).toBe(3);
+    it.each([
+      {
+        items: [
+          { running: true, name: "a" },
+          { running: false, name: "b" },
+          { running: true, name: "c" },
+          { running: false, name: "d" },
+        ],
+        expected: 2,
+      },
+      {
+        items: [
+          { running: false, name: "a" },
+          { running: false, name: "b" },
+        ],
+        expected: 0,
+      },
+      {
+        items: [
+          { running: true, name: "a" },
+          { running: true, name: "b" },
+          { running: true, name: "c" },
+        ],
+        expected: 3,
+      },
+    ])("counts running items", ({ items, expected }) => {
+      expect(countRunning(items)).toBe(expected);
     });
   });
 
   describe("countMismatches", () => {
-    it("should count image mismatches", () => {
-      const items = [
-        { imageMatch: true, name: "a" },
-        { imageMatch: false, name: "b" },
-        { imageMatch: true, name: "c" },
-        { imageMatch: false, name: "d" },
-        { imageMatch: false, name: "e" },
-      ];
-
-      expect(countMismatches(items)).toBe(3);
-    });
-
-    it("should return 0 when all match", () => {
-      const items = [
-        { imageMatch: true, name: "a" },
-        { imageMatch: true, name: "b" },
-      ];
-
-      expect(countMismatches(items)).toBe(0);
-    });
-
-    it("should count all when none match", () => {
-      const items = [
-        { imageMatch: false, name: "a" },
-        { imageMatch: false, name: "b" },
-        { imageMatch: false, name: "c" },
-      ];
-
-      expect(countMismatches(items)).toBe(3);
+    it.each([
+      {
+        items: [
+          { imageMatch: true, name: "a" },
+          { imageMatch: false, name: "b" },
+          { imageMatch: true, name: "c" },
+          { imageMatch: false, name: "d" },
+          { imageMatch: false, name: "e" },
+        ],
+        expected: 3,
+      },
+      {
+        items: [
+          { imageMatch: true, name: "a" },
+          { imageMatch: true, name: "b" },
+        ],
+        expected: 0,
+      },
+      {
+        items: [
+          { imageMatch: false, name: "a" },
+          { imageMatch: false, name: "b" },
+          { imageMatch: false, name: "c" },
+        ],
+        expected: 3,
+      },
+    ])("counts image mismatches", ({ items, expected }) => {
+      expect(countMismatches(items)).toBe(expected);
     });
   });
 

--- a/src/config/commands.test.ts
+++ b/src/config/commands.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveNativeSkillsEnabled } from "./commands.js";
+import {
+  isNativeCommandsExplicitlyDisabled,
+  resolveNativeCommandsEnabled,
+  resolveNativeSkillsEnabled,
+} from "./commands.js";
 
 describe("resolveNativeSkillsEnabled", () => {
   it("uses provider defaults for auto", () => {
@@ -43,6 +47,53 @@ describe("resolveNativeSkillsEnabled", () => {
         providerSetting: false,
         globalSetting: true,
       }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveNativeCommandsEnabled", () => {
+  it("follows the same provider default heuristic", () => {
+    expect(resolveNativeCommandsEnabled({ providerId: "discord", globalSetting: "auto" })).toBe(
+      true,
+    );
+    expect(resolveNativeCommandsEnabled({ providerId: "telegram", globalSetting: "auto" })).toBe(
+      true,
+    );
+    expect(resolveNativeCommandsEnabled({ providerId: "slack", globalSetting: "auto" })).toBe(
+      false,
+    );
+  });
+
+  it("honors explicit provider/global booleans", () => {
+    expect(
+      resolveNativeCommandsEnabled({
+        providerId: "slack",
+        providerSetting: true,
+        globalSetting: false,
+      }),
+    ).toBe(true);
+    expect(
+      resolveNativeCommandsEnabled({
+        providerId: "discord",
+        globalSetting: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isNativeCommandsExplicitlyDisabled", () => {
+  it("returns true only for explicit false at provider or fallback global", () => {
+    expect(
+      isNativeCommandsExplicitlyDisabled({ providerSetting: false, globalSetting: true }),
+    ).toBe(true);
+    expect(
+      isNativeCommandsExplicitlyDisabled({ providerSetting: undefined, globalSetting: false }),
+    ).toBe(true);
+    expect(
+      isNativeCommandsExplicitlyDisabled({ providerSetting: true, globalSetting: false }),
+    ).toBe(false);
+    expect(
+      isNativeCommandsExplicitlyDisabled({ providerSetting: "auto", globalSetting: false }),
     ).toBe(false);
   });
 });

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -21,18 +21,18 @@ export function resolveNativeSkillsEnabled(params: {
   providerSetting?: NativeCommandsSetting;
   globalSetting?: NativeCommandsSetting;
 }): boolean {
-  const { providerId, providerSetting, globalSetting } = params;
-  const setting = providerSetting === undefined ? globalSetting : providerSetting;
-  if (setting === true) {
-    return true;
-  }
-  if (setting === false) {
-    return false;
-  }
-  return resolveAutoDefault(providerId);
+  return resolveNativeCommandSetting(params);
 }
 
 export function resolveNativeCommandsEnabled(params: {
+  providerId: ChannelId;
+  providerSetting?: NativeCommandsSetting;
+  globalSetting?: NativeCommandsSetting;
+}): boolean {
+  return resolveNativeCommandSetting(params);
+}
+
+function resolveNativeCommandSetting(params: {
   providerId: ChannelId;
   providerSetting?: NativeCommandsSetting;
   globalSetting?: NativeCommandsSetting;
@@ -45,7 +45,6 @@ export function resolveNativeCommandsEnabled(params: {
   if (setting === false) {
     return false;
   }
-  // auto or undefined -> heuristic
   return resolveAutoDefault(providerId);
 }
 

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -198,6 +198,18 @@ describe("cron webhook schema", () => {
 
     expect(res.success).toBe(false);
   });
+
+  it("accepts cron.directCommand.enforceAllowlist", () => {
+    const res = OpenClawSchema.safeParse({
+      cron: {
+        directCommand: {
+          enforceAllowlist: false,
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
 });
 
 describe("broadcast", () => {

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -198,18 +198,6 @@ describe("cron webhook schema", () => {
 
     expect(res.success).toBe(false);
   });
-
-  it("accepts cron.directCommand.enforceAllowlist", () => {
-    const res = OpenClawSchema.safeParse({
-      cron: {
-        directCommand: {
-          enforceAllowlist: false,
-        },
-      },
-    });
-
-    expect(res.success).toBe(true);
-  });
 });
 
 describe("broadcast", () => {

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { migrateLegacyConfig } from "./legacy-migrate.js";
+
+describe("legacy migrate audio transcription", () => {
+  it("moves routing.transcribeAudio into tools.media.audio.models", () => {
+    const res = migrateLegacyConfig({
+      routing: {
+        transcribeAudio: {
+          command: ["whisper", "--model", "base"],
+          timeoutSeconds: 2,
+        },
+      },
+    });
+
+    expect(res.changes).toContain("Moved routing.transcribeAudio → tools.media.audio.models.");
+    expect(res.config?.tools?.media?.audio).toEqual({
+      enabled: true,
+      models: [
+        {
+          command: "whisper",
+          type: "cli",
+          args: ["--model", "base"],
+          timeoutSeconds: 2,
+        },
+      ],
+    });
+    expect((res.config as { routing?: unknown } | null)?.routing).toBeUndefined();
+  });
+
+  it("keeps existing tools media model and drops legacy routing value", () => {
+    const res = migrateLegacyConfig({
+      routing: {
+        transcribeAudio: {
+          command: ["whisper", "--model", "tiny"],
+        },
+      },
+      tools: {
+        media: {
+          audio: {
+            models: [{ command: "existing", type: "cli" }],
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Removed routing.transcribeAudio (tools.media.audio.models already set).",
+    );
+    expect(res.config?.tools?.media?.audio?.models).toEqual([{ command: "existing", type: "cli" }]);
+    expect((res.config as { routing?: unknown } | null)?.routing).toBeUndefined();
+  });
+
+  it("drops invalid audio.transcription payloads", () => {
+    const res = migrateLegacyConfig({
+      audio: {
+        transcription: {
+          command: [{}],
+        },
+      },
+    });
+
+    expect(res.changes).toContain("Removed audio.transcription (invalid or empty command).");
+    expect(res.config?.audio).toBeUndefined();
+    expect(res.config?.tools?.media?.audio).toBeUndefined();
+  });
+});

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -64,3 +64,43 @@ describe("legacy migrate audio transcription", () => {
     expect(res.config?.tools?.media?.audio).toBeUndefined();
   });
 });
+
+describe("legacy migrate mention routing", () => {
+  it("moves routing.groupChat.requireMention into channel group defaults", () => {
+    const res = migrateLegacyConfig({
+      routing: {
+        groupChat: {
+          requireMention: true,
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      'Moved routing.groupChat.requireMention → channels.telegram.groups."*".requireMention.',
+    );
+    expect(res.changes).toContain(
+      'Moved routing.groupChat.requireMention → channels.imessage.groups."*".requireMention.',
+    );
+    expect(res.config?.channels?.telegram?.groups?.["*"]?.requireMention).toBe(true);
+    expect(res.config?.channels?.imessage?.groups?.["*"]?.requireMention).toBe(true);
+    expect((res.config as { routing?: unknown } | null)?.routing).toBeUndefined();
+  });
+
+  it("moves channels.telegram.requireMention into groups.*.requireMention", () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        telegram: {
+          requireMention: false,
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      'Moved telegram.requireMention → channels.telegram.groups."*".requireMention.',
+    );
+    expect(res.config?.channels?.telegram?.groups?.["*"]?.requireMention).toBe(false);
+    expect(
+      (res.config?.channels?.telegram as { requireMention?: unknown } | undefined)?.requireMention,
+    ).toBeUndefined();
+  });
+});

--- a/src/config/legacy.migrations.part-1.ts
+++ b/src/config/legacy.migrations.part-1.ts
@@ -39,6 +39,16 @@ function migrateBindings(
   }
 }
 
+function ensureDefaultGroupEntry(section: Record<string, unknown>): {
+  groups: Record<string, unknown>;
+  entry: Record<string, unknown>;
+} {
+  const groups: Record<string, unknown> = isRecord(section.groups) ? section.groups : {};
+  const defaultKey = "*";
+  const entry: Record<string, unknown> = isRecord(groups[defaultKey]) ? groups[defaultKey] : {};
+  return { groups, entry };
+}
+
 export const LEGACY_CONFIG_MIGRATIONS_PART_1: LegacyConfigMigration[] = [
   {
     id: "bindings.match.provider->bindings.match.channel",
@@ -268,15 +278,8 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_1: LegacyConfigMigration[] = [
           channels[key] && typeof channels[key] === "object"
             ? (channels[key] as Record<string, unknown>)
             : {};
-        const groups =
-          section.groups && typeof section.groups === "object"
-            ? (section.groups as Record<string, unknown>)
-            : {};
+        const { groups, entry } = ensureDefaultGroupEntry(section);
         const defaultKey = "*";
-        const entry =
-          groups[defaultKey] && typeof groups[defaultKey] === "object"
-            ? (groups[defaultKey] as Record<string, unknown>)
-            : {};
         if (entry.requireMention === undefined) {
           entry.requireMention = requireMention;
           groups[defaultKey] = entry;
@@ -354,16 +357,8 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_1: LegacyConfigMigration[] = [
         return;
       }
 
-      const groups =
-        (telegram as Record<string, unknown>).groups &&
-        typeof (telegram as Record<string, unknown>).groups === "object"
-          ? ((telegram as Record<string, unknown>).groups as Record<string, unknown>)
-          : {};
+      const { groups, entry } = ensureDefaultGroupEntry(telegram as Record<string, unknown>);
       const defaultKey = "*";
-      const entry =
-        groups[defaultKey] && typeof groups[defaultKey] === "object"
-          ? (groups[defaultKey] as Record<string, unknown>)
-          : {};
 
       if (entry.requireMention === undefined) {
         entry.requireMention = requireMention;

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -2,6 +2,13 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
+  directCommand?: {
+    /**
+     * When true (default), isolated directCommand jobs must satisfy exec allowlist checks.
+     * Set to false only for trusted environments that intentionally allow unrestricted commands.
+     */
+    enforceAllowlist?: boolean;
+  };
   /**
    * Deprecated legacy fallback webhook URL used only for stored jobs with notify=true.
    * Prefer per-job delivery.mode="webhook" with delivery.to.

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -2,13 +2,6 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
-  directCommand?: {
-    /**
-     * When true (default), isolated directCommand jobs must satisfy exec allowlist checks.
-     * Set to false only for trusted environments that intentionally allow unrestricted commands.
-     */
-    enforceAllowlist?: boolean;
-  };
   /**
    * Deprecated legacy fallback webhook URL used only for stored jobs with notify=true.
    * Prefer per-job delivery.mode="webhook" with delivery.to.

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -28,7 +28,22 @@ export type MediaUnderstandingAttachmentsConfig = {
   prefer?: "first" | "last" | "path" | "url";
 };
 
-export type MediaUnderstandingModelConfig = {
+type MediaProviderRequestConfig = {
+  /** Optional provider-specific query params (merged into requests). */
+  providerOptions?: Record<string, Record<string, string | number | boolean>>;
+  /** @deprecated Use providerOptions.deepgram instead. */
+  deepgram?: {
+    detectLanguage?: boolean;
+    punctuate?: boolean;
+    smartFormat?: boolean;
+  };
+  /** Optional base URL override for provider requests. */
+  baseUrl?: string;
+  /** Optional headers merged into provider requests. */
+  headers?: Record<string, string>;
+};
+
+export type MediaUnderstandingModelConfig = MediaProviderRequestConfig & {
   /** provider API id (e.g. openai, google). */
   provider?: string;
   /** Model id for provider-based understanding. */
@@ -51,25 +66,13 @@ export type MediaUnderstandingModelConfig = {
   timeoutSeconds?: number;
   /** Optional language hint for audio transcription. */
   language?: string;
-  /** Optional provider-specific query params (merged into requests). */
-  providerOptions?: Record<string, Record<string, string | number | boolean>>;
-  /** @deprecated Use providerOptions.deepgram instead. */
-  deepgram?: {
-    detectLanguage?: boolean;
-    punctuate?: boolean;
-    smartFormat?: boolean;
-  };
-  /** Optional base URL override for provider requests. */
-  baseUrl?: string;
-  /** Optional headers merged into provider requests. */
-  headers?: Record<string, string>;
   /** Auth profile id to use for this provider. */
   profile?: string;
   /** Preferred profile id if multiple are available. */
   preferredProfile?: string;
 };
 
-export type MediaUnderstandingConfig = {
+export type MediaUnderstandingConfig = MediaProviderRequestConfig & {
   /** Enable media understanding when models are configured. */
   enabled?: boolean;
   /** Optional scope gating for understanding. */
@@ -84,18 +87,6 @@ export type MediaUnderstandingConfig = {
   timeoutSeconds?: number;
   /** Default language hint (audio). */
   language?: string;
-  /** Optional provider-specific query params (merged into requests). */
-  providerOptions?: Record<string, Record<string, string | number | boolean>>;
-  /** @deprecated Use providerOptions.deepgram instead. */
-  deepgram?: {
-    detectLanguage?: boolean;
-    punctuate?: boolean;
-    smartFormat?: boolean;
-  };
-  /** Optional base URL override for provider requests. */
-  baseUrl?: string;
-  /** Optional headers merged into provider requests. */
-  headers?: Record<string, string>;
   /** Attachment selection policy. */
   attachments?: MediaUnderstandingAttachmentsConfig;
   /** Ordered model list (fallbacks in order). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -303,6 +303,12 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
+        directCommand: z
+          .object({
+            enforceAllowlist: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
         webhook: HttpUrlSchema.optional(),
         webhookToken: z.string().optional().register(sensitive),
         sessionRetention: z.union([z.string(), z.literal(false)]).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -303,12 +303,6 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
-        directCommand: z
-          .object({
-            enforceAllowlist: z.boolean().optional(),
-          })
-          .strict()
-          .optional(),
         webhook: HttpUrlSchema.optional(),
         webhookToken: z.string().optional().register(sensitive),
         sessionRetention: z.union([z.string(), z.literal(false)]).optional(),

--- a/src/cron/direct-command-delivery.ts
+++ b/src/cron/direct-command-delivery.ts
@@ -1,0 +1,15 @@
+import { formatDirectCommandResult, type DirectCommandResultObject } from "./direct-command.js";
+
+export function resolveDirectCommandDeliveryBestEffort(job: {
+  delivery?: { bestEffort?: boolean };
+}): boolean {
+  return job.delivery?.bestEffort === true;
+}
+
+export function formatDirectCommandDeliveryMessage(params: {
+  jobName: string;
+  result: DirectCommandResultObject;
+}): string {
+  const name = params.jobName.trim() || "directCommand";
+  return `[cron:${name}] ${formatDirectCommandResult(params.result)}`;
+}

--- a/src/cron/direct-command.test.ts
+++ b/src/cron/direct-command.test.ts
@@ -30,4 +30,38 @@ describe("runCronDirectCommand", () => {
     expect(result.error).toContain("code 4");
     expect(result.summary).toContain("boom");
   });
+
+  it("times out long-running commands", async () => {
+    const result = await runCronDirectCommand({
+      jobId: "job-timeout",
+      payload: {
+        kind: "directCommand",
+        command: process.execPath,
+        args: ["-e", "setTimeout(() => {}, 10_000)"],
+        timeoutSeconds: 0.5,
+      },
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("timed out");
+    expect(result.error).toContain("500ms");
+  });
+
+  it("truncates output when exceeding maxOutputBytes", async () => {
+    const longOutput = "a".repeat(1000);
+    const result = await runCronDirectCommand({
+      jobId: "job-truncate",
+      payload: {
+        kind: "directCommand",
+        command: process.execPath,
+        args: ["-e", `process.stdout.write("${longOutput}")`],
+        maxOutputBytes: 50,
+      },
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toBeDefined();
+    expect(result.summary!.length).toBeLessThanOrEqual(50);
+    expect(result.summary).toMatch(/^a+$/);
+  });
 });

--- a/src/cron/direct-command.test.ts
+++ b/src/cron/direct-command.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { runCronDirectCommand } from "./direct-command.js";
+
+describe("runCronDirectCommand", () => {
+  it("executes argv commands without shell interpolation", async () => {
+    const result = await runCronDirectCommand({
+      jobId: "job-1",
+      payload: {
+        kind: "directCommand",
+        command: process.execPath,
+        args: ["-e", "process.stdout.write(process.argv[1])", "hello world"],
+      },
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toBe("hello world");
+  });
+
+  it("returns an error for non-zero exits", async () => {
+    const result = await runCronDirectCommand({
+      jobId: "job-2",
+      payload: {
+        kind: "directCommand",
+        command: process.execPath,
+        args: ["-e", "process.stderr.write('boom'); process.exit(4)"],
+      },
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("code 4");
+    expect(result.summary).toContain("boom");
+  });
+});

--- a/src/cron/direct-command.test.ts
+++ b/src/cron/direct-command.test.ts
@@ -51,6 +51,23 @@ describe("runCronDirectCommand", () => {
     expect(parsed.captured.stderr).toContain("boom");
   });
 
+  it("returns deterministic summary payload when command fails to start", async () => {
+    const result = await runCronDirectCommand({
+      jobId: "job-start-fail",
+      payload: {
+        kind: "directCommand",
+        command: "/definitely-not-a-real-openclaw-command",
+      },
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("failed to start command");
+    const parsed = parseSummary(result.summary);
+    expect(parsed.status).toBe("error");
+    expect(parsed.summary).toContain("failed to start command");
+    expect(parsed.captured.stderr).toContain("failed to start command");
+  });
+
   it("times out long-running commands", async () => {
     const result = await runCronDirectCommand({
       jobId: "job-timeout",

--- a/src/cron/direct-command.ts
+++ b/src/cron/direct-command.ts
@@ -1,0 +1,130 @@
+import { spawn } from "node:child_process";
+import type { CronJob } from "./types.js";
+
+type DirectCommandPayload = Extract<CronJob["payload"], { kind: "directCommand" }>;
+
+export type DirectCommandRunResult = {
+  status: "ok" | "error" | "skipped";
+  summary?: string;
+  error?: string;
+};
+
+const DEFAULT_MAX_OUTPUT_BYTES = 16 * 1024;
+
+function clampMaxOutputBytes(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_MAX_OUTPUT_BYTES;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function toUtf8(buffer: Buffer): string {
+  return buffer.toString("utf8").trim();
+}
+
+function summarizeOutput(stdout: Buffer, stderr: Buffer): string {
+  const stdoutText = toUtf8(stdout);
+  const stderrText = toUtf8(stderr);
+  if (stdoutText && stderrText) {
+    return `${stdoutText}\n${stderrText}`;
+  }
+  return stdoutText || stderrText;
+}
+
+export async function runCronDirectCommand(params: {
+  jobId: string;
+  payload: DirectCommandPayload;
+}): Promise<DirectCommandRunResult> {
+  const { payload, jobId } = params;
+  const command = payload.command?.trim();
+  if (!command) {
+    return { status: "skipped", error: "directCommand requires a non-empty command" };
+  }
+
+  const args = Array.isArray(payload.args) ? payload.args.map(String) : [];
+  const maxOutputBytes = clampMaxOutputBytes(payload.maxOutputBytes);
+
+  return await new Promise<DirectCommandRunResult>((resolve) => {
+    let settled = false;
+    let timedOut = false;
+    let stdout = Buffer.alloc(0);
+    let stderr = Buffer.alloc(0);
+
+    const child = spawn(command, args, {
+      shell: false,
+      cwd: payload.cwd,
+      env: payload.env ? { ...process.env, ...payload.env } : process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const timeoutMs =
+      typeof payload.timeoutSeconds === "number" && payload.timeoutSeconds > 0
+        ? Math.floor(payload.timeoutSeconds * 1000)
+        : undefined;
+
+    const killTimer =
+      typeof timeoutMs === "number"
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill("SIGTERM");
+            setTimeout(() => {
+              if (!settled) {
+                child.kill("SIGKILL");
+              }
+            }, 1_000).unref();
+          }, timeoutMs)
+        : undefined;
+
+    const finish = (result: DirectCommandRunResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+      resolve(result);
+    };
+
+    child.on("error", (err) => {
+      finish({ status: "error", error: `failed to start command: ${String(err)}` });
+    });
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      stdout = Buffer.concat([stdout, data]).subarray(0, maxOutputBytes);
+    });
+
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      stderr = Buffer.concat([stderr, data]).subarray(0, maxOutputBytes);
+    });
+
+    child.on("close", (code, signal) => {
+      if (timedOut) {
+        finish({
+          status: "error",
+          error: `directCommand timed out after ${timeoutMs}ms`,
+          summary: summarizeOutput(stdout, stderr),
+        });
+        return;
+      }
+
+      const summary = summarizeOutput(stdout, stderr);
+      if (code === 0) {
+        finish({ status: "ok", summary });
+        return;
+      }
+
+      const exitReason =
+        typeof code === "number"
+          ? `command exited with code ${code}`
+          : `command exited with signal ${signal ?? "unknown"}`;
+      finish({
+        status: "error",
+        error: `${exitReason} (job: ${jobId})`,
+        summary,
+      });
+    });
+  });
+}

--- a/src/cron/direct-command.ts
+++ b/src/cron/direct-command.ts
@@ -128,7 +128,18 @@ export async function runCronDirectCommand(params: {
     };
 
     child.on("error", (err) => {
-      finish({ status: "error", error: `failed to start command: ${String(err)}` });
+      const error = `failed to start command: ${String(err)}`;
+      const result = createResultObject({
+        status: "error",
+        stdout,
+        stderr: Buffer.from(error, "utf8"),
+      });
+      finish({
+        status: "error",
+        error,
+        summary: formatDirectCommandResult(result),
+        result,
+      });
     });
 
     child.stdout.on("data", (chunk: Buffer | string) => {

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -246,6 +246,22 @@ describe("normalizeCronJobCreate", () => {
     expect(delivery.mode).toBe("announce");
   });
 
+  it("defaults isolated directCommand delivery to announce", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "default-direct-command-announce",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      payload: {
+        kind: "directCommand",
+        command: "echo",
+        args: ["hi"],
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const delivery = normalized.delivery as Record<string, unknown>;
+    expect(delivery.mode).toBe("announce");
+  });
+
   it("migrates legacy delivery fields to delivery", () => {
     const normalized = normalizeCronJobCreate({
       name: "legacy deliver",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -515,17 +515,19 @@ export function normalizeCronJobInput(
     const payload = isRecord(next.payload) ? next.payload : null;
     const payloadKind = payload && typeof payload.kind === "string" ? payload.kind : "";
     const sessionTarget = typeof next.sessionTarget === "string" ? next.sessionTarget : "";
-    const isIsolatedAgentTurn =
+    const isIsolatedAgentLike =
       sessionTarget === "isolated" || (sessionTarget === "" && payloadKind === "agentTurn");
     const hasDelivery = "delivery" in next && next.delivery !== undefined;
     const hasLegacyDelivery = payload ? hasLegacyDeliveryHints(payload) : false;
-    if (!hasDelivery && isIsolatedAgentTurn && payloadKind === "agentTurn") {
+    if (!hasDelivery && isIsolatedAgentLike && payloadKind === "agentTurn") {
       if (payload && hasLegacyDelivery) {
         next.delivery = buildDeliveryFromLegacyPayload(payload);
         stripLegacyDeliveryFields(payload);
       } else {
         next.delivery = { mode: "announce" };
       }
+    } else if (!hasDelivery && sessionTarget === "isolated" && payloadKind === "directCommand") {
+      next.delivery = { mode: "announce" };
     }
   }
 

--- a/src/cron/service.direct-command-executor.test.ts
+++ b/src/cron/service.direct-command-executor.test.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+describe("cron directCommand execution path", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs directCommand payloads through runDirectCommandJob only", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-direct-command-"));
+    const storePath = path.join(fixtureRoot, "cron", "jobs.json");
+
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const runDirectCommandJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob,
+      runDirectCommandJob,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "run-direct",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "directCommand", command: "echo", args: ["hello"] },
+    });
+
+    await cron.run(job.id, "force");
+
+    expect(runDirectCommandJob).toHaveBeenCalledTimes(1);
+    expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(requestHeartbeatNow).not.toHaveBeenCalled();
+
+    cron.stop();
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+});

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -683,6 +683,54 @@ describe("Cron issue regressions", () => {
     expect(job?.state.lastStatus).toBe("ok");
   });
 
+  it("respects directCommand timeoutSeconds above default outer timeout", async () => {
+    const store = await makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+
+    const cronJob = createIsolatedRegressionJob({
+      id: "direct-command-timeout-override",
+      name: "direct-timeout",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: {
+        kind: "directCommand",
+        command: "echo",
+        args: ["work"],
+        timeoutSeconds: 700,
+      },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    const deferredRun = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok", summary: "unused" })),
+      runDirectCommandJob: vi.fn(async () => deferredRun.promise),
+    });
+
+    const timerPromise = onTimer(state);
+    let settled = false;
+    void timerPromise.finally(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(600_000);
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    deferredRun.resolve({ status: "ok", summary: "done" });
+    await timerPromise;
+
+    const job = state.store?.jobs.find((j) => j.id === "direct-command-timeout-override");
+    expect(job?.state.lastStatus).toBe("ok");
+  });
+
   it("retries cron schedule computation from the next second when the first attempt returns undefined (#17821)", () => {
     const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
     const cronJob = createIsolatedRegressionJob({

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -710,7 +710,7 @@ describe("Cron issue regressions", () => {
       nowMs: () => scheduledAt,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeatNow: vi.fn(),
-      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok", summary: "unused" })),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const, summary: "unused" })),
       runDirectCommandJob: vi.fn(async () => deferredRun.promise),
     });
 

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -49,14 +49,16 @@ export function normalizeOptionalSessionKey(raw: unknown) {
 
 export function inferLegacyName(job: {
   schedule?: { kind?: unknown; everyMs?: unknown; expr?: unknown };
-  payload?: { kind?: unknown; text?: unknown; message?: unknown };
+  payload?: { kind?: unknown; text?: unknown; message?: unknown; command?: unknown };
 }) {
   const text =
     job?.payload?.kind === "systemEvent" && typeof job.payload.text === "string"
       ? job.payload.text
       : job?.payload?.kind === "agentTurn" && typeof job.payload.message === "string"
         ? job.payload.message
-        : "";
+        : job?.payload?.kind === "directCommand" && typeof job.payload.command === "string"
+          ? job.payload.command
+          : "";
   const firstLine =
     text
       .split("\n")
@@ -83,5 +85,8 @@ export function normalizePayloadToSystemText(payload: CronPayload) {
   if (payload.kind === "systemEvent") {
     return payload.text.trim();
   }
-  return payload.message.trim();
+  if (payload.kind === "agentTurn") {
+    return payload.message.trim();
+  }
+  return payload.command.trim();
 }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -75,6 +75,15 @@ export type CronServiceDeps = {
     } & CronRunOutcome &
       CronRunTelemetry
   >;
+  runDirectCommandJob?: (params: {
+    job: CronJob;
+    command: string;
+    args?: string[];
+    cwd?: string;
+    env?: Record<string, string>;
+    timeoutSeconds?: number;
+    maxOutputBytes?: number;
+  }) => Promise<CronRunOutcome>;
   onEvent?: (evt: CronEvent) => void;
 };
 

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -86,6 +86,10 @@ function normalizePayloadKind(payload: Record<string, unknown>) {
     payload.kind = "systemEvent";
     return true;
   }
+  if (raw === "directcommand") {
+    payload.kind = "directCommand";
+    return true;
+  }
   return false;
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -456,6 +456,21 @@ async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
 ): Promise<CronRunOutcome & CronRunTelemetry> {
+  if (job.payload.kind === "directCommand") {
+    if (!state.deps.runDirectCommandJob) {
+      return { status: "skipped", error: "directCommand executor is not configured" };
+    }
+    return await state.deps.runDirectCommandJob({
+      job,
+      command: job.payload.command,
+      args: job.payload.args,
+      cwd: job.payload.cwd,
+      env: job.payload.env,
+      timeoutSeconds: job.payload.timeoutSeconds,
+      maxOutputBytes: job.payload.maxOutputBytes,
+    });
+  }
+
   if (job.sessionTarget === "main") {
     const text = resolveJobPayloadTextForMain(job);
     if (!text) {
@@ -522,7 +537,10 @@ async function executeJobCore(
   }
 
   if (job.payload.kind !== "agentTurn") {
-    return { status: "skipped", error: "isolated job requires payload.kind=agentTurn" };
+    return {
+      status: "skipped",
+      error: "isolated job requires payload.kind=agentTurn or payload.kind=directCommand",
+    };
   }
 
   const res = await state.deps.runIsolatedAgentJob({

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -244,7 +244,8 @@ export async function onTimer(state: CronServiceState) {
       emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
 
       const configuredTimeoutMs =
-        job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+        (job.payload.kind === "agentTurn" || job.payload.kind === "directCommand") &&
+        typeof job.payload.timeoutSeconds === "number"
           ? Math.floor(job.payload.timeoutSeconds * 1_000)
           : undefined;
       const jobTimeoutMs =

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -65,6 +65,15 @@ export type CronPayload =
       channel?: CronMessageChannel;
       to?: string;
       bestEffortDeliver?: boolean;
+    }
+  | {
+      kind: "directCommand";
+      command: string;
+      args?: string[];
+      cwd?: string;
+      env?: Record<string, string>;
+      timeoutSeconds?: number;
+      maxOutputBytes?: number;
     };
 
 export type CronPayloadPatch =
@@ -80,6 +89,15 @@ export type CronPayloadPatch =
       channel?: CronMessageChannel;
       to?: string;
       bestEffortDeliver?: boolean;
+    }
+  | {
+      kind: "directCommand";
+      command?: string;
+      args?: string[];
+      cwd?: string;
+      env?: Record<string, string>;
+      timeoutSeconds?: number;
+      maxOutputBytes?: number;
     };
 
 export type CronJobState = {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -151,6 +151,26 @@ describe("launchd install", () => {
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
     expect(enableIndex).toBeLessThan(bootstrapIndex);
   });
+
+  it("writes TMPDIR to LaunchAgent environment when provided", async () => {
+    const env: Record<string, string | undefined> = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+    const tmpDir = "/var/folders/xy/abc123/T/";
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: ["node", "-e", "process.exit(0)"],
+      environment: { TMPDIR: tmpDir },
+    });
+
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const plist = state.files.get(plistPath) ?? "";
+    expect(plist).toContain("<key>EnvironmentVariables</key>");
+    expect(plist).toContain("<key>TMPDIR</key>");
+    expect(plist).toContain(`<string>${tmpDir}</string>`);
+  });
 });
 
 describe("resolveLaunchAgentPlistPath", () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -11,7 +11,7 @@ import {
   buildLaunchAgentPlist as buildLaunchAgentPlistImpl,
   readLaunchAgentProgramArgumentsFromFile,
 } from "./launchd-plist.js";
-import { formatLine, toPosixPath } from "./output.js";
+import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
@@ -407,9 +407,14 @@ export async function installLaunchAgent({
   await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
 
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
-  stdout.write("\n");
-  stdout.write(`${formatLine("Installed LaunchAgent", plistPath)}\n`);
-  stdout.write(`${formatLine("Logs", stdoutPath)}\n`);
+  writeFormattedLines(
+    stdout,
+    [
+      { label: "Installed LaunchAgent", value: plistPath },
+      { label: "Logs", value: stdoutPath },
+    ],
+    { leadingBlankLine: true },
+  );
   return { plistPath };
 }
 

--- a/src/daemon/output.ts
+++ b/src/daemon/output.ts
@@ -6,3 +6,16 @@ export function formatLine(label: string, value: string): string {
   const rich = isRich();
   return `${colorize(rich, theme.muted, `${label}:`)} ${colorize(rich, theme.command, value)}`;
 }
+
+export function writeFormattedLines(
+  stdout: NodeJS.WritableStream,
+  lines: Array<{ label: string; value: string }>,
+  opts?: { leadingBlankLine?: boolean },
+): void {
+  if (opts?.leadingBlankLine) {
+    stdout.write("\n");
+  }
+  for (const line of lines) {
+    stdout.write(`${formatLine(line.label, line.value)}\n`);
+  }
+}

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -65,147 +65,150 @@ describe("resolveTaskScriptPath", () => {
 });
 
 describe("readScheduledTaskCommand", () => {
-  it("parses script with quoted arguments containing spaces", async () => {
+  async function withScheduledTaskScript(
+    options: {
+      scriptLines?: string[];
+      env?:
+        | Record<string, string | undefined>
+        | ((tmpDir: string) => Record<string, string | undefined>);
+    },
+    run: (env: Record<string, string | undefined>) => Promise<void>,
+  ) {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-test-"));
     try {
-      const scriptPath = path.join(tmpDir, ".openclaw", "gateway.cmd");
-      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-      // Use forward slashes which work in Windows cmd and avoid escape parsing issues
-      await fs.writeFile(
-        scriptPath,
-        ["@echo off", '"C:/Program Files/Node/node.exe" gateway.js'].join("\r\n"),
-        "utf8",
-      );
-
-      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
-      const result = await readScheduledTaskCommand(env);
-      expect(result).toEqual({
-        programArguments: ["C:/Program Files/Node/node.exe", "gateway.js"],
-      });
+      const extraEnv = typeof options.env === "function" ? options.env(tmpDir) : options.env;
+      const env = {
+        USERPROFILE: tmpDir,
+        OPENCLAW_PROFILE: "default",
+        ...extraEnv,
+      };
+      if (options.scriptLines) {
+        const scriptPath = resolveTaskScriptPath(env);
+        await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+        await fs.writeFile(scriptPath, options.scriptLines.join("\r\n"), "utf8");
+      }
+      await run(env);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
+  }
+
+  it("parses script with quoted arguments containing spaces", async () => {
+    await withScheduledTaskScript(
+      {
+        // Use forward slashes which work in Windows cmd and avoid escape parsing issues.
+        scriptLines: ["@echo off", '"C:/Program Files/Node/node.exe" gateway.js'],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["C:/Program Files/Node/node.exe", "gateway.js"],
+        });
+      },
+    );
   });
 
   it("returns null when script does not exist", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-test-"));
-    try {
-      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
+    await withScheduledTaskScript({}, async (env) => {
       const result = await readScheduledTaskCommand(env);
       expect(result).toBeNull();
-    } finally {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("returns null when script has no command", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-test-"));
-    try {
-      const scriptPath = path.join(tmpDir, ".openclaw", "gateway.cmd");
-      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-      await fs.writeFile(
-        scriptPath,
-        ["@echo off", "rem This is just a comment"].join("\r\n"),
-        "utf8",
-      );
-
-      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
-      const result = await readScheduledTaskCommand(env);
-      expect(result).toBeNull();
-    } finally {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    }
+    await withScheduledTaskScript(
+      { scriptLines: ["@echo off", "rem This is just a comment"] },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toBeNull();
+      },
+    );
   });
 
   it("parses full script with all components", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-test-"));
-    try {
-      const scriptPath = path.join(tmpDir, ".openclaw", "gateway.cmd");
-      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-      await fs.writeFile(
-        scriptPath,
-        [
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
           "@echo off",
           "rem OpenClaw Gateway",
           "cd /d C:\\Projects\\openclaw",
           "set NODE_ENV=production",
           "set OPENCLAW_PORT=18789",
           "node gateway.js --verbose",
-        ].join("\r\n"),
-        "utf8",
-      );
-
-      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
-      const result = await readScheduledTaskCommand(env);
-      expect(result).toEqual({
-        programArguments: ["node", "gateway.js", "--verbose"],
-        workingDirectory: "C:\\Projects\\openclaw",
-        environment: {
-          NODE_ENV: "production",
-          OPENCLAW_PORT: "18789",
-        },
-      });
-    } finally {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    }
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--verbose"],
+          workingDirectory: "C:\\Projects\\openclaw",
+          environment: {
+            NODE_ENV: "production",
+            OPENCLAW_PORT: "18789",
+          },
+        });
+      },
+    );
   });
+
   it("parses command with Windows backslash paths", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-test-"));
-    try {
-      const scriptPath = path.join(tmpDir, ".openclaw", "gateway.cmd");
-      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-      await fs.writeFile(
-        scriptPath,
-        [
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
           "@echo off",
           '"C:\\Program Files\\nodejs\\node.exe" C:\\Users\\test\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js gateway --port 18789',
-        ].join("\r\n"),
-        "utf8",
-      );
-
-      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
-      const result = await readScheduledTaskCommand(env);
-      expect(result).toEqual({
-        programArguments: [
-          "C:\\Program Files\\nodejs\\node.exe",
-          "C:\\Users\\test\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
-          "gateway",
-          "--port",
-          "18789",
         ],
-      });
-    } finally {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    }
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: [
+            "C:\\Program Files\\nodejs\\node.exe",
+            "C:\\Users\\test\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+            "gateway",
+            "--port",
+            "18789",
+          ],
+        });
+      },
+    );
   });
 
   it("preserves UNC paths in command arguments", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-test-"));
-    try {
-      const scriptPath = path.join(tmpDir, ".openclaw", "gateway.cmd");
-      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-      await fs.writeFile(
-        scriptPath,
-        [
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
           "@echo off",
           '"\\\\fileserver\\OpenClaw Share\\node.exe" "\\\\fileserver\\OpenClaw Share\\dist\\index.js" gateway --port 18789',
-        ].join("\r\n"),
-        "utf8",
-      );
-
-      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
-      const result = await readScheduledTaskCommand(env);
-      expect(result).toEqual({
-        programArguments: [
-          "\\\\fileserver\\OpenClaw Share\\node.exe",
-          "\\\\fileserver\\OpenClaw Share\\dist\\index.js",
-          "gateway",
-          "--port",
-          "18789",
         ],
-      });
-    } finally {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    }
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: [
+            "\\\\fileserver\\OpenClaw Share\\node.exe",
+            "\\\\fileserver\\OpenClaw Share\\dist\\index.js",
+            "gateway",
+            "--port",
+            "18789",
+          ],
+        });
+      },
+    );
+  });
+
+  it("reads script from OPENCLAW_STATE_DIR override", async () => {
+    await withScheduledTaskScript(
+      {
+        env: (tmpDir) => ({ OPENCLAW_STATE_DIR: path.join(tmpDir, "custom-state") }),
+        scriptLines: ["@echo off", "node gateway.js --from-state-dir"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--from-state-dir"],
+        });
+      },
+    );
   });
 });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
-import { formatLine } from "./output.js";
+import { formatLine, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import { execSchtasks } from "./schtasks-exec.js";
@@ -230,9 +230,14 @@ export async function installScheduledTask({
 
   await execSchtasks(["/Run", "/TN", taskName]);
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
-  stdout.write("\n");
-  stdout.write(`${formatLine("Installed Scheduled Task", taskName)}\n`);
-  stdout.write(`${formatLine("Task script", scriptPath)}\n`);
+  writeFormattedLines(
+    stdout,
+    [
+      { label: "Installed Scheduled Task", value: taskName },
+      { label: "Task script", value: scriptPath },
+    ],
+    { leadingBlankLine: true },
+  );
   return { scriptPath };
 }
 

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveGatewayStateDir } from "./paths.js";
@@ -282,6 +283,22 @@ describe("buildServiceEnvironment", () => {
     }
   });
 
+  it("forwards TMPDIR from the host environment", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user", TMPDIR: "/var/folders/xw/abc123/T/" },
+      port: 18789,
+    });
+    expect(env.TMPDIR).toBe("/var/folders/xw/abc123/T/");
+  });
+
+  it("falls back to os.tmpdir when TMPDIR is not set", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+    });
+    expect(env.TMPDIR).toBe(os.tmpdir());
+  });
+
   it("uses profile-specific unit and label", () => {
     const env = buildServiceEnvironment({
       env: { HOME: "/home/user", OPENCLAW_PROFILE: "work" },
@@ -300,6 +317,20 @@ describe("buildNodeServiceEnvironment", () => {
       env: { HOME: "/home/user" },
     });
     expect(env.HOME).toBe("/home/user");
+  });
+
+  it("forwards TMPDIR for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", TMPDIR: "/tmp/custom" },
+    });
+    expect(env.TMPDIR).toBe("/tmp/custom");
+  });
+
+  it("falls back to os.tmpdir for node services when TMPDIR is not set", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user" },
+    });
+    expect(env.TMPDIR).toBe(os.tmpdir());
   });
 });
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { VERSION } from "../version.js";
 import {
@@ -212,8 +213,11 @@ export function buildServiceEnvironment(params: {
   const systemdUnit = `${resolveGatewaySystemdServiceName(profile)}.service`;
   const stateDir = env.OPENCLAW_STATE_DIR;
   const configPath = env.OPENCLAW_CONFIG_PATH;
+  // Keep a usable temp directory for supervised services even when the host env omits TMPDIR.
+  const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
   return {
     HOME: env.HOME,
+    TMPDIR: tmpDir,
     PATH: buildMinimalServicePath({ env }),
     OPENCLAW_PROFILE: profile,
     OPENCLAW_STATE_DIR: stateDir,
@@ -234,8 +238,10 @@ export function buildNodeServiceEnvironment(params: {
   const { env } = params;
   const stateDir = env.OPENCLAW_STATE_DIR;
   const configPath = env.OPENCLAW_CONFIG_PATH;
+  const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
   return {
     HOME: env.HOME,
+    TMPDIR: tmpDir,
     PATH: buildMinimalServicePath({ env }),
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -6,7 +6,7 @@ import {
   resolveGatewaySystemdServiceName,
 } from "./constants.js";
 import { execFileUtf8 } from "./exec-file.js";
-import { formatLine, toPosixPath } from "./output.js";
+import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
 import { resolveHomeDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
@@ -227,8 +227,16 @@ export async function installSystemdService({
   }
 
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
-  stdout.write("\n");
-  stdout.write(`${formatLine("Installed systemd service", unitPath)}\n`);
+  writeFormattedLines(
+    stdout,
+    [
+      {
+        label: "Installed systemd service",
+        value: unitPath,
+      },
+    ],
+    { leadingBlankLine: true },
+  );
   return { unitPath };
 }
 

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -170,13 +170,7 @@ describe("processDiscordMessage ack reactions", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     const runPromise = processDiscordMessage(ctx as any);
 
-    let settled = false;
-    void runPromise.finally(() => {
-      settled = true;
-    });
-    for (let i = 0; i < 120 && !settled; i++) {
-      await vi.advanceTimersByTimeAsync(1_000);
-    }
+    await vi.advanceTimersByTimeAsync(120_000);
 
     await runPromise;
     const emojis = (

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -170,7 +170,7 @@ describe("processDiscordMessage ack reactions", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     const runPromise = processDiscordMessage(ctx as any);
 
-    await vi.advanceTimersByTimeAsync(120_000);
+    await vi.advanceTimersByTimeAsync(40_000);
 
     await runPromise;
     const emojis = (

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -159,10 +159,12 @@ describe("processDiscordMessage ack reactions", () => {
 
   it("shows stall emojis for long no-progress runs", async () => {
     vi.useFakeTimers();
+    let releaseDispatch!: () => void;
+    const dispatchGate = new Promise<void>((resolve) => {
+      releaseDispatch = () => resolve();
+    });
     dispatchInboundMessage.mockImplementationOnce(async () => {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 31_000);
-      });
+      await dispatchGate;
       return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
     });
 
@@ -170,7 +172,9 @@ describe("processDiscordMessage ack reactions", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     const runPromise = processDiscordMessage(ctx as any);
 
-    await vi.advanceTimersByTimeAsync(40_000);
+    await vi.advanceTimersByTimeAsync(30_001);
+    releaseDispatch();
+    await vi.runAllTimersAsync();
 
     await runPromise;
     const emojis = (

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -244,9 +244,7 @@ describe("channel-health-monitor", () => {
       cooldownCycles: 1,
       maxRestartsPerHour: 3,
     });
-    await vi.advanceTimersByTimeAsync(1_500);
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_500);
     expect(manager.startChannel).toHaveBeenCalledTimes(3);
     await vi.advanceTimersByTimeAsync(2_000);
     expect(manager.startChannel).toHaveBeenCalledTimes(3);

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -67,7 +67,7 @@ async function startAndRunCheck(
   const monitor = startDefaultMonitor(manager, overrides);
   const startupGraceMs = overrides.startupGraceMs ?? 0;
   const checkIntervalMs = overrides.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS;
-  await vi.advanceTimersByTimeAsync(startupGraceMs + checkIntervalMs + 500);
+  await vi.advanceTimersByTimeAsync(startupGraceMs + checkIntervalMs + 1);
   return monitor;
 }
 

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -91,7 +91,7 @@ describe("channel-health-monitor", () => {
   it("does not run before the grace period", async () => {
     const manager = createMockChannelManager();
     const monitor = startDefaultMonitor(manager, { startupGraceMs: 60_000 });
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(5_001);
     expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
     monitor.stop();
   });
@@ -244,9 +244,9 @@ describe("channel-health-monitor", () => {
       cooldownCycles: 1,
       maxRestartsPerHour: 3,
     });
-    await vi.advanceTimersByTimeAsync(5_500);
+    await vi.advanceTimersByTimeAsync(5_001);
     expect(manager.startChannel).toHaveBeenCalledTimes(3);
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(1_001);
     expect(manager.startChannel).toHaveBeenCalledTimes(3);
     monitor.stop();
   });
@@ -282,7 +282,7 @@ describe("channel-health-monitor", () => {
     const manager = createMockChannelManager();
     const monitor = startDefaultMonitor(manager);
     monitor.stop();
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(5_001);
     expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
   });
 
@@ -291,7 +291,7 @@ describe("channel-health-monitor", () => {
     const abort = new AbortController();
     const monitor = startDefaultMonitor(manager, { abortSignal: abort.signal });
     abort.abort();
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(5_001);
     expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
     monitor.stop();
   });

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -141,6 +141,18 @@ function coerceRequest(val: unknown): OpenAiChatCompletionRequest {
   return val as OpenAiChatCompletionRequest;
 }
 
+function resolveAgentResponseText(result: unknown): string {
+  const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
+  if (!Array.isArray(payloads) || payloads.length === 0) {
+    return "No response from OpenClaw.";
+  }
+  const content = payloads
+    .map((p) => (typeof p.text === "string" ? p.text : ""))
+    .filter(Boolean)
+    .join("\n\n");
+  return content || "No response from OpenClaw.";
+}
+
 export async function handleOpenAiHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -197,14 +209,7 @@ export async function handleOpenAiHttpRequest(
         deps,
       );
 
-      const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
-      const content =
-        Array.isArray(payloads) && payloads.length > 0
-          ? payloads
-              .map((p) => (typeof p.text === "string" ? p.text : ""))
-              .filter(Boolean)
-              .join("\n\n")
-          : "No response from OpenClaw.";
+      const content = resolveAgentResponseText(result);
 
       sendJson(res, 200, {
         id: runId,
@@ -325,14 +330,7 @@ export async function handleOpenAiHttpRequest(
           });
         }
 
-        const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
-        const content =
-          Array.isArray(payloads) && payloads.length > 0
-            ? payloads
-                .map((p) => (typeof p.text === "string" ? p.text : ""))
-                .filter(Boolean)
-                .join("\n\n")
-            : "No response from OpenClaw.";
+        const content = resolveAgentResponseText(result);
 
         sawAssistantDelta = true;
         writeSse(res, {

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateCronAddParams,
+  validateCronRemoveParams,
+  validateCronRunParams,
+  validateCronRunsParams,
+  validateCronUpdateParams,
+} from "./index.js";
+
+const minimalAddParams = {
+  name: "daily-summary",
+  schedule: { kind: "every", everyMs: 60_000 },
+  sessionTarget: "main",
+  wakeMode: "next-heartbeat",
+  payload: { kind: "systemEvent", text: "tick" },
+} as const;
+
+describe("cron protocol validators", () => {
+  it("accepts minimal add params", () => {
+    expect(validateCronAddParams(minimalAddParams)).toBe(true);
+  });
+
+  it("rejects add params when required scheduling fields are missing", () => {
+    const { wakeMode: _wakeMode, ...withoutWakeMode } = minimalAddParams;
+    expect(validateCronAddParams(withoutWakeMode)).toBe(false);
+  });
+
+  it("accepts update params for id and jobId selectors", () => {
+    expect(validateCronUpdateParams({ id: "job-1", patch: { enabled: false } })).toBe(true);
+    expect(validateCronUpdateParams({ jobId: "job-2", patch: { enabled: true } })).toBe(true);
+  });
+
+  it("accepts remove params for id and jobId selectors", () => {
+    expect(validateCronRemoveParams({ id: "job-1" })).toBe(true);
+    expect(validateCronRemoveParams({ jobId: "job-2" })).toBe(true);
+  });
+
+  it("accepts run params mode for id and jobId selectors", () => {
+    expect(validateCronRunParams({ id: "job-1", mode: "force" })).toBe(true);
+    expect(validateCronRunParams({ jobId: "job-2", mode: "due" })).toBe(true);
+  });
+
+  it("enforces runs limit minimum for id and jobId selectors", () => {
+    expect(validateCronRunsParams({ id: "job-1", limit: 1 })).toBe(true);
+    expect(validateCronRunsParams({ jobId: "job-2", limit: 1 })).toBe(true);
+    expect(validateCronRunsParams({ id: "job-1", limit: 0 })).toBe(false);
+    expect(validateCronRunsParams({ jobId: "job-2", limit: 0 })).toBe(false);
+  });
+});

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -157,6 +157,9 @@ import {
   type PollParams,
   PollParamsSchema,
   PROTOCOL_VERSION,
+  type PushTestParams,
+  PushTestParamsSchema,
+  PushTestResultSchema,
   type PresenceEntry,
   PresenceEntrySchema,
   ProtocolSchemas,
@@ -277,6 +280,7 @@ export const validateNodeInvokeResultParams = ajv.compile<NodeInvokeResultParams
   NodeInvokeResultParamsSchema,
 );
 export const validateNodeEventParams = ajv.compile<NodeEventParams>(NodeEventParamsSchema);
+export const validatePushTestParams = ajv.compile<PushTestParams>(PushTestParamsSchema);
 export const validateSessionsListParams = ajv.compile<SessionsListParams>(SessionsListParamsSchema);
 export const validateSessionsPreviewParams = ajv.compile<SessionsPreviewParams>(
   SessionsPreviewParamsSchema,
@@ -428,6 +432,8 @@ export {
   AgentIdentityParamsSchema,
   AgentIdentityResultSchema,
   WakeParamsSchema,
+  PushTestParamsSchema,
+  PushTestResultSchema,
   NodePairRequestParamsSchema,
   NodePairListParamsSchema,
   NodePairApproveParamsSchema,

--- a/src/gateway/protocol/schema.ts
+++ b/src/gateway/protocol/schema.ts
@@ -10,6 +10,7 @@ export * from "./schema/frames.js";
 export * from "./schema/logs-chat.js";
 export * from "./schema/nodes.js";
 export * from "./schema/protocol-schemas.js";
+export * from "./schema/push.js";
 export * from "./schema/sessions.js";
 export * from "./schema/snapshot.js";
 export * from "./schema/types.js";

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -19,6 +19,35 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
   );
 }
 
+const CronSessionTargetSchema = Type.Union([Type.Literal("main"), Type.Literal("isolated")]);
+const CronWakeModeSchema = Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]);
+const CronCommonOptionalFields = {
+  agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+  description: Type.Optional(Type.String()),
+  enabled: Type.Optional(Type.Boolean()),
+  deleteAfterRun: Type.Optional(Type.Boolean()),
+};
+
+function cronIdOrJobIdParams(extraFields: Record<string, TSchema>) {
+  return Type.Union([
+    Type.Object(
+      {
+        id: NonEmptyString,
+        ...extraFields,
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        jobId: NonEmptyString,
+        ...extraFields,
+      },
+      { additionalProperties: false },
+    ),
+  ]);
+}
+
 export const CronScheduleSchema = Type.Union([
   Type.Object(
     {
@@ -144,8 +173,8 @@ export const CronJobSchema = Type.Object(
     createdAtMs: Type.Integer({ minimum: 0 }),
     updatedAtMs: Type.Integer({ minimum: 0 }),
     schedule: CronScheduleSchema,
-    sessionTarget: Type.Union([Type.Literal("main"), Type.Literal("isolated")]),
-    wakeMode: Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]),
+    sessionTarget: CronSessionTargetSchema,
+    wakeMode: CronWakeModeSchema,
     payload: CronPayloadSchema,
     delivery: Type.Optional(CronDeliverySchema),
     state: CronJobStateSchema,
@@ -165,14 +194,10 @@ export const CronStatusParamsSchema = Type.Object({}, { additionalProperties: fa
 export const CronAddParamsSchema = Type.Object(
   {
     name: NonEmptyString,
-    agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    description: Type.Optional(Type.String()),
-    enabled: Type.Optional(Type.Boolean()),
-    deleteAfterRun: Type.Optional(Type.Boolean()),
+    ...CronCommonOptionalFields,
     schedule: CronScheduleSchema,
-    sessionTarget: Type.Union([Type.Literal("main"), Type.Literal("isolated")]),
-    wakeMode: Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]),
+    sessionTarget: CronSessionTargetSchema,
+    wakeMode: CronWakeModeSchema,
     payload: CronPayloadSchema,
     delivery: Type.Optional(CronDeliverySchema),
   },
@@ -182,14 +207,10 @@ export const CronAddParamsSchema = Type.Object(
 export const CronJobPatchSchema = Type.Object(
   {
     name: Type.Optional(NonEmptyString),
-    agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-    description: Type.Optional(Type.String()),
-    enabled: Type.Optional(Type.Boolean()),
-    deleteAfterRun: Type.Optional(Type.Boolean()),
+    ...CronCommonOptionalFields,
     schedule: Type.Optional(CronScheduleSchema),
-    sessionTarget: Type.Optional(Type.Union([Type.Literal("main"), Type.Literal("isolated")])),
-    wakeMode: Type.Optional(Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")])),
+    sessionTarget: Type.Optional(CronSessionTargetSchema),
+    wakeMode: Type.Optional(CronWakeModeSchema),
     payload: Type.Optional(CronPayloadPatchSchema),
     delivery: Type.Optional(CronDeliveryPatchSchema),
     state: Type.Optional(Type.Partial(CronJobStateSchema)),
@@ -197,71 +218,19 @@ export const CronJobPatchSchema = Type.Object(
   { additionalProperties: false },
 );
 
-export const CronUpdateParamsSchema = Type.Union([
-  Type.Object(
-    {
-      id: NonEmptyString,
-      patch: CronJobPatchSchema,
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      jobId: NonEmptyString,
-      patch: CronJobPatchSchema,
-    },
-    { additionalProperties: false },
-  ),
-]);
+export const CronUpdateParamsSchema = cronIdOrJobIdParams({
+  patch: CronJobPatchSchema,
+});
 
-export const CronRemoveParamsSchema = Type.Union([
-  Type.Object(
-    {
-      id: NonEmptyString,
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      jobId: NonEmptyString,
-    },
-    { additionalProperties: false },
-  ),
-]);
+export const CronRemoveParamsSchema = cronIdOrJobIdParams({});
 
-export const CronRunParamsSchema = Type.Union([
-  Type.Object(
-    {
-      id: NonEmptyString,
-      mode: Type.Optional(Type.Union([Type.Literal("due"), Type.Literal("force")])),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      jobId: NonEmptyString,
-      mode: Type.Optional(Type.Union([Type.Literal("due"), Type.Literal("force")])),
-    },
-    { additionalProperties: false },
-  ),
-]);
+export const CronRunParamsSchema = cronIdOrJobIdParams({
+  mode: Type.Optional(Type.Union([Type.Literal("due"), Type.Literal("force")])),
+});
 
-export const CronRunsParamsSchema = Type.Union([
-  Type.Object(
-    {
-      id: NonEmptyString,
-      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      jobId: NonEmptyString,
-      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
-    },
-    { additionalProperties: false },
-  ),
-]);
+export const CronRunsParamsSchema = cronIdOrJobIdParams({
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
+});
 
 export const CronRunLogEntrySchema = Type.Object(
   {

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -19,6 +19,21 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
   );
 }
 
+function cronDirectCommandPayloadSchema(params: { command: TSchema }) {
+  return Type.Object(
+    {
+      kind: Type.Literal("directCommand"),
+      command: params.command,
+      args: Type.Optional(Type.Array(Type.String())),
+      cwd: Type.Optional(Type.String()),
+      env: Type.Optional(Type.Record(Type.String(), Type.String())),
+      timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
+      maxOutputBytes: Type.Optional(Type.Integer({ minimum: 1 })),
+    },
+    { additionalProperties: false },
+  );
+}
+
 export const CronScheduleSchema = Type.Union([
   Type.Object(
     {
@@ -55,6 +70,7 @@ export const CronPayloadSchema = Type.Union([
     { additionalProperties: false },
   ),
   cronAgentTurnPayloadSchema({ message: NonEmptyString }),
+  cronDirectCommandPayloadSchema({ command: NonEmptyString }),
 ]);
 
 export const CronPayloadPatchSchema = Type.Union([
@@ -66,6 +82,7 @@ export const CronPayloadPatchSchema = Type.Union([
     { additionalProperties: false },
   ),
   cronAgentTurnPayloadSchema({ message: Type.Optional(NonEmptyString) }),
+  cronDirectCommandPayloadSchema({ command: Type.Optional(NonEmptyString) }),
 ]);
 
 const CronDeliverySharedProperties = {

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -118,6 +118,7 @@ import {
   NodePairVerifyParamsSchema,
   NodeRenameParamsSchema,
 } from "./nodes.js";
+import { PushTestParamsSchema, PushTestResultSchema } from "./push.js";
 import {
   SessionsCompactParamsSchema,
   SessionsDeleteParamsSchema,
@@ -171,6 +172,8 @@ export const ProtocolSchemas: Record<string, TSchema> = {
   NodeInvokeResultParams: NodeInvokeResultParamsSchema,
   NodeEventParams: NodeEventParamsSchema,
   NodeInvokeRequestEvent: NodeInvokeRequestEventSchema,
+  PushTestParams: PushTestParamsSchema,
+  PushTestResult: PushTestResultSchema,
   SessionsListParams: SessionsListParamsSchema,
   SessionsPreviewParams: SessionsPreviewParamsSchema,
   SessionsResolveParams: SessionsResolveParamsSchema,

--- a/src/gateway/protocol/schema/push.ts
+++ b/src/gateway/protocol/schema/push.ts
@@ -1,0 +1,27 @@
+import { Type } from "@sinclair/typebox";
+import { NonEmptyString } from "./primitives.js";
+
+const ApnsEnvironmentSchema = Type.String({ enum: ["sandbox", "production"] });
+
+export const PushTestParamsSchema = Type.Object(
+  {
+    nodeId: NonEmptyString,
+    title: Type.Optional(Type.String()),
+    body: Type.Optional(Type.String()),
+    environment: Type.Optional(ApnsEnvironmentSchema),
+  },
+  { additionalProperties: false },
+);
+
+export const PushTestResultSchema = Type.Object(
+  {
+    ok: Type.Boolean(),
+    status: Type.Integer(),
+    apnsId: Type.Optional(Type.String()),
+    reason: Type.Optional(Type.String()),
+    tokenSuffix: Type.String(),
+    topic: Type.String(),
+    environment: ApnsEnvironmentSchema,
+  },
+  { additionalProperties: false },
+);

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -111,6 +111,7 @@ import type {
   NodePairVerifyParamsSchema,
   NodeRenameParamsSchema,
 } from "./nodes.js";
+import type { PushTestParamsSchema, PushTestResultSchema } from "./push.js";
 import type {
   SessionsCompactParamsSchema,
   SessionsDeleteParamsSchema,
@@ -160,6 +161,8 @@ export type NodeDescribeParams = Static<typeof NodeDescribeParamsSchema>;
 export type NodeInvokeParams = Static<typeof NodeInvokeParamsSchema>;
 export type NodeInvokeResultParams = Static<typeof NodeInvokeResultParamsSchema>;
 export type NodeEventParams = Static<typeof NodeEventParamsSchema>;
+export type PushTestParams = Static<typeof PushTestParamsSchema>;
+export type PushTestResult = Static<typeof PushTestResultSchema>;
 export type SessionsListParams = Static<typeof SessionsListParamsSchema>;
 export type SessionsPreviewParams = Static<typeof SessionsPreviewParamsSchema>;
 export type SessionsResolveParams = Static<typeof SessionsResolveParamsSchema>;

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -124,7 +124,7 @@ describe("server-channels auto restart", () => {
     const manager = createManager();
 
     await manager.startChannels();
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(200);
 
     expect(startAccount).toHaveBeenCalledTimes(11);
     const snapshot = manager.getRuntimeSnapshot();
@@ -132,7 +132,7 @@ describe("server-channels auto restart", () => {
     expect(account?.running).toBe(false);
     expect(account?.reconnectAttempts).toBe(10);
 
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(200);
     expect(startAccount).toHaveBeenCalledTimes(11);
   });
 
@@ -149,7 +149,7 @@ describe("server-channels auto restart", () => {
     vi.runAllTicks();
     await manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
 
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(200);
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
 

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -12,11 +12,6 @@ const fetchWithSsrFGuardMock = vi.fn();
 const deliverOutboundPayloadsMock = vi.fn();
 const resolveDeliveryTargetMock = vi.fn();
 const cronLoggerWarnMock = vi.fn();
-const execApprovalsMocks = vi.hoisted(() => ({
-  resolveExecApprovals: vi.fn(),
-  evaluateShellAllowlist: vi.fn(),
-  resolveSafeBins: vi.fn(),
-}));
 
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
@@ -59,13 +54,6 @@ vi.mock("../logging.js", async () => {
   };
 });
 
-vi.mock("../infra/exec-approvals.js", () => ({
-  resolveExecApprovals: (...args: unknown[]) => execApprovalsMocks.resolveExecApprovals(...args),
-  evaluateShellAllowlist: (...args: unknown[]) =>
-    execApprovalsMocks.evaluateShellAllowlist(...args),
-  resolveSafeBins: (...args: unknown[]) => execApprovalsMocks.resolveSafeBins(...args),
-}));
-
 import { buildGatewayCronService } from "./server-cron.js";
 
 describe("buildGatewayCronService", () => {
@@ -77,9 +65,6 @@ describe("buildGatewayCronService", () => {
     deliverOutboundPayloadsMock.mockReset();
     resolveDeliveryTargetMock.mockReset();
     cronLoggerWarnMock.mockReset();
-    execApprovalsMocks.resolveExecApprovals.mockReset();
-    execApprovalsMocks.evaluateShellAllowlist.mockReset();
-    execApprovalsMocks.resolveSafeBins.mockReset();
     resolveDeliveryTargetMock.mockResolvedValue({
       channel: "telegram",
       to: "123",
@@ -87,15 +72,6 @@ describe("buildGatewayCronService", () => {
       accountId: undefined,
       threadId: undefined,
     });
-    execApprovalsMocks.resolveExecApprovals.mockReturnValue({ allowlist: [] });
-    execApprovalsMocks.evaluateShellAllowlist.mockReturnValue({
-      analysisOk: true,
-      allowlistSatisfied: true,
-      allowlistMatches: [],
-      segments: [],
-      segmentSatisfiedBy: [],
-    });
-    execApprovalsMocks.resolveSafeBins.mockReturnValue(new Set());
   });
 
   it("canonicalizes non-agent sessionKey to agent store key for enqueue + wake", async () => {
@@ -333,102 +309,6 @@ describe("buildGatewayCronService", () => {
         }),
         "cron: direct command delivery failed (best-effort)",
       );
-    } finally {
-      state.cron.stop();
-    }
-  });
-
-  it("denies direct-command jobs on allowlist miss by default", async () => {
-    const tmpDir = path.join(os.tmpdir(), `server-cron-${Date.now()}`);
-    const cfg = {
-      session: { mainKey: "main" },
-      cron: { store: path.join(tmpDir, "cron.json") },
-    } as OpenClawConfig;
-    loadConfigMock.mockReturnValue(cfg);
-    execApprovalsMocks.evaluateShellAllowlist.mockReturnValue({
-      analysisOk: true,
-      allowlistSatisfied: false,
-      allowlistMatches: [],
-      segments: [],
-      segmentSatisfiedBy: [],
-    });
-
-    const broadcastMock = vi.fn();
-    const state = buildGatewayCronService({ cfg, deps: {} as CliDeps, broadcast: broadcastMock });
-    try {
-      const job = await state.cron.add({
-        name: "direct-allowlist-denied",
-        enabled: true,
-        schedule: { kind: "at", at: new Date(1).toISOString() },
-        sessionTarget: "isolated",
-        wakeMode: "next-heartbeat",
-        payload: {
-          kind: "directCommand",
-          command: process.execPath,
-          args: ["-e", "process.stdout.write('hi')"],
-        },
-      });
-
-      await state.cron.run(job.id, "force");
-
-      expect(execApprovalsMocks.evaluateShellAllowlist).toHaveBeenCalledTimes(1);
-      const finishedEvent = broadcastMock.mock.calls
-        .map(
-          (call) =>
-            call[1] as { action?: string; status?: string; error?: string; summary?: string },
-        )
-        .find((evt) => evt?.action === "finished");
-      expect(finishedEvent?.status).toBe("error");
-      expect(finishedEvent?.error).toContain("allowlist miss");
-
-      const parsed = JSON.parse(finishedEvent?.summary ?? "{}") as { status?: string };
-      expect(parsed.status).toBe("error");
-    } finally {
-      state.cron.stop();
-    }
-  });
-
-  it("allows opting out of direct-command allowlist enforcement", async () => {
-    const tmpDir = path.join(os.tmpdir(), `server-cron-${Date.now()}`);
-    const cfg = {
-      session: { mainKey: "main" },
-      cron: {
-        store: path.join(tmpDir, "cron.json"),
-        directCommand: { enforceAllowlist: false },
-      },
-    } as OpenClawConfig;
-    loadConfigMock.mockReturnValue(cfg);
-    execApprovalsMocks.evaluateShellAllowlist.mockReturnValue({
-      analysisOk: true,
-      allowlistSatisfied: false,
-      allowlistMatches: [],
-      segments: [],
-      segmentSatisfiedBy: [],
-    });
-
-    const broadcastMock = vi.fn();
-    const state = buildGatewayCronService({ cfg, deps: {} as CliDeps, broadcast: broadcastMock });
-    try {
-      const job = await state.cron.add({
-        name: "direct-allowlist-opt-out",
-        enabled: true,
-        schedule: { kind: "at", at: new Date(1).toISOString() },
-        sessionTarget: "isolated",
-        wakeMode: "next-heartbeat",
-        payload: {
-          kind: "directCommand",
-          command: process.execPath,
-          args: ["-e", "process.stdout.write('hi')"],
-        },
-      });
-
-      await state.cron.run(job.id, "force");
-
-      expect(execApprovalsMocks.evaluateShellAllowlist).not.toHaveBeenCalled();
-      const finishedEvent = broadcastMock.mock.calls
-        .map((call) => call[1] as { action?: string; status?: string })
-        .find((evt) => evt?.action === "finished");
-      expect(finishedEvent?.status).toBe("ok");
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -305,6 +305,10 @@ export function buildGatewayCronService(params: {
         if (!bestEffort) {
           return withDirectCommandDeliveryError(directCommandResult, String(err));
         }
+        cronLogger.warn(
+          { err: String(err), jobId: job.id },
+          "cron: direct command delivery failed (best-effort)",
+        );
       }
 
       return directCommandResult;

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -7,6 +7,7 @@ import {
   resolveAgentMainSessionKey,
 } from "../config/sessions.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
+import { runCronDirectCommand } from "../cron/direct-command.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { appendCronRunLog, resolveCronRunLogPath } from "../cron/run-log.js";
 import { CronService } from "../cron/service.js";
@@ -195,6 +196,28 @@ export function buildGatewayCronService(params: {
         agentId,
         sessionKey: `cron:${job.id}`,
         lane: "cron",
+      });
+    },
+    runDirectCommandJob: async ({
+      job,
+      command,
+      args,
+      cwd,
+      env,
+      timeoutSeconds,
+      maxOutputBytes,
+    }) => {
+      return await runCronDirectCommand({
+        jobId: job.id,
+        payload: {
+          kind: "directCommand",
+          command,
+          args,
+          cwd,
+          env,
+          timeoutSeconds,
+          maxOutputBytes,
+        },
       });
     },
     log: getChildLogger({ module: "cron", storePath }),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1,4 +1,4 @@
-import { resolveAgentConfig, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { CliDeps } from "../cli/deps.js";
 import { createOutboundSendDeps } from "../cli/deps.js";
 import { loadConfig } from "../config/config.js";
@@ -21,11 +21,6 @@ import { CronService } from "../cron/service.js";
 import { resolveCronStorePath } from "../cron/store.js";
 import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import {
-  evaluateShellAllowlist,
-  resolveExecApprovals,
-  resolveSafeBins,
-} from "../infra/exec-approvals.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
@@ -44,10 +39,6 @@ export type GatewayCronState = {
 };
 
 const CRON_WEBHOOK_TIMEOUT_MS = 10_000;
-
-function shouldEnforceDirectCommandAllowlist(cfg: ReturnType<typeof loadConfig>): boolean {
-  return cfg.cron?.directCommand?.enforceAllowlist !== false;
-}
 
 function withDirectCommandDeliveryError(
   result: Awaited<ReturnType<typeof runCronDirectCommand>>,
@@ -241,40 +232,6 @@ export function buildGatewayCronService(params: {
       timeoutSeconds,
       maxOutputBytes,
     }) => {
-      const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
-      if (shouldEnforceDirectCommandAllowlist(runtimeConfig)) {
-        const resolvedAgentConfig = resolveAgentConfig(runtimeConfig, agentId);
-        const safeBins = resolveSafeBins(
-          resolvedAgentConfig?.tools?.exec?.safeBins ?? runtimeConfig.tools?.exec?.safeBins,
-        );
-        const approvals = resolveExecApprovals(agentId, { security: "allowlist" });
-        const allowlistEval = evaluateShellAllowlist({
-          command,
-          allowlist: approvals.allowlist,
-          safeBins,
-          platform: process.platform,
-        });
-        if (!allowlistEval.analysisOk || !allowlistEval.allowlistSatisfied) {
-          const reason = !allowlistEval.analysisOk
-            ? "directCommand denied: allowlist analysis failed"
-            : "directCommand denied: allowlist miss";
-          const result = {
-            status: "error" as const,
-            summary: reason,
-            captured: {
-              stdout: "",
-              stderr: reason,
-            },
-          };
-          return {
-            status: "error" as const,
-            error: reason,
-            summary: formatDirectCommandResult(result),
-            result,
-          };
-        }
-      }
-
       const directCommandResult = await runCronDirectCommand({
         jobId: job.id,
         payload: {
@@ -297,6 +254,7 @@ export function buildGatewayCronService(params: {
         return directCommandResult;
       }
 
+      const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       const resolvedDelivery = await resolveDeliveryTarget(runtimeConfig, agentId, {
         channel: deliveryPlan.channel ?? "last",
         to: deliveryPlan.to,

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -13,6 +13,7 @@ import { healthHandlers } from "./server-methods/health.js";
 import { logsHandlers } from "./server-methods/logs.js";
 import { modelsHandlers } from "./server-methods/models.js";
 import { nodeHandlers } from "./server-methods/nodes.js";
+import { pushHandlers } from "./server-methods/push.js";
 import { sendHandlers } from "./server-methods/send.js";
 import { sessionsHandlers } from "./server-methods/sessions.js";
 import { skillsHandlers } from "./server-methods/skills.js";
@@ -95,6 +96,7 @@ const WRITE_METHODS = new Set([
   "chat.send",
   "chat.abort",
   "browser.request",
+  "push.test",
 ]);
 
 function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["client"]) {
@@ -190,6 +192,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...systemHandlers,
   ...updateHandlers,
   ...nodeHandlers,
+  ...pushHandlers,
   ...sendHandlers,
   ...usageHandlers,
   ...agentHandlers,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -898,7 +898,6 @@ export const chatHandlers: GatewayRequestHandlers = {
           runId: clientRunId,
           abortSignal: abortController.signal,
           images: parsedImages.length > 0 ? parsedImages : undefined,
-          disableBlockStreaming: true,
           onAgentRunStart: (runId) => {
             agentRunStarted = true;
             const connId = typeof client?.connId === "string" ? client.connId : undefined;

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -86,6 +86,15 @@ function toExecApprovalsPayload(snapshot: ExecApprovalsSnapshot) {
   };
 }
 
+function resolveNodeIdOrRespond(nodeId: string, respond: RespondFn): string | null {
+  const id = nodeId.trim();
+  if (!id) {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId required"));
+    return null;
+  }
+  return id;
+}
+
 export const execApprovalsHandlers: GatewayRequestHandlers = {
   "exec.approvals.get": ({ params, respond }) => {
     if (!assertValidParams(params, validateExecApprovalsGetParams, "exec.approvals.get", respond)) {
@@ -131,9 +140,8 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
       return;
     }
     const { nodeId } = params as { nodeId: string };
-    const id = nodeId.trim();
+    const id = resolveNodeIdOrRespond(nodeId, respond);
     if (!id) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId required"));
       return;
     }
     await respondUnavailableOnThrow(respond, async () => {
@@ -165,9 +173,8 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
       file: ExecApprovalsFile;
       baseHash?: string;
     };
-    const id = nodeId.trim();
+    const id = resolveNodeIdOrRespond(nodeId, respond);
     if (!id) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId required"));
       return;
     }
     await respondUnavailableOnThrow(respond, async () => {

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -49,6 +49,8 @@ type TestNodeSession = {
   commands: string[];
 };
 
+const WAKE_WAIT_TIMEOUT_MS = 3_001;
+
 function makeNodeInvokeParams(overrides?: Partial<Record<string, unknown>>) {
   return {
     nodeId: "ios-node-1",
@@ -180,7 +182,7 @@ describe("node.invoke APNs wake path", () => {
       connected = true;
     }, 300);
 
-    await vi.advanceTimersByTimeAsync(4_000);
+    await vi.advanceTimersByTimeAsync(WAKE_WAIT_TIMEOUT_MS);
     const respond = await invokePromise;
 
     expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledTimes(1);
@@ -230,14 +232,14 @@ describe("node.invoke APNs wake path", () => {
       nodeRegistry,
       requestParams: { nodeId: "ios-node-throttle", idempotencyKey: "idem-throttle-1" },
     });
-    await vi.advanceTimersByTimeAsync(4_000);
+    await vi.advanceTimersByTimeAsync(WAKE_WAIT_TIMEOUT_MS);
     await first;
 
     const second = invokeNode({
       nodeRegistry,
       requestParams: { nodeId: "ios-node-throttle", idempotencyKey: "idem-throttle-2" },
     });
-    await vi.advanceTimersByTimeAsync(4_000);
+    await vi.advanceTimersByTimeAsync(WAKE_WAIT_TIMEOUT_MS);
     await second;
 
     expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledTimes(1);

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../protocol/index.js";
+import { nodeHandlers } from "./nodes.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+  resolveNodeCommandAllowlist: vi.fn(() => []),
+  isNodeCommandAllowed: vi.fn(() => ({ ok: true })),
+  sanitizeNodeInvokeParamsForForwarding: vi.fn(({ rawParams }: { rawParams: unknown }) => ({
+    ok: true,
+    params: rawParams,
+  })),
+  loadApnsRegistration: vi.fn(),
+  resolveApnsAuthConfigFromEnv: vi.fn(),
+  sendApnsBackgroundWake: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../node-command-policy.js", () => ({
+  resolveNodeCommandAllowlist: mocks.resolveNodeCommandAllowlist,
+  isNodeCommandAllowed: mocks.isNodeCommandAllowed,
+}));
+
+vi.mock("../node-invoke-sanitize.js", () => ({
+  sanitizeNodeInvokeParamsForForwarding: mocks.sanitizeNodeInvokeParamsForForwarding,
+}));
+
+vi.mock("../../infra/push-apns.js", () => ({
+  loadApnsRegistration: mocks.loadApnsRegistration,
+  resolveApnsAuthConfigFromEnv: mocks.resolveApnsAuthConfigFromEnv,
+  sendApnsBackgroundWake: mocks.sendApnsBackgroundWake,
+}));
+
+type RespondCall = [
+  boolean,
+  unknown?,
+  {
+    code?: number;
+    message?: string;
+    details?: unknown;
+  }?,
+];
+
+type TestNodeSession = {
+  nodeId: string;
+  commands: string[];
+};
+
+function makeNodeInvokeParams(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    nodeId: "ios-node-1",
+    command: "camera.capture",
+    params: { quality: "high" },
+    timeoutMs: 5000,
+    idempotencyKey: "idem-node-invoke",
+    ...overrides,
+  };
+}
+
+async function invokeNode(params: {
+  nodeRegistry: {
+    get: (nodeId: string) => TestNodeSession | undefined;
+    invoke: (payload: {
+      nodeId: string;
+      command: string;
+      params?: unknown;
+      timeoutMs?: number;
+      idempotencyKey?: string;
+    }) => Promise<{
+      ok: boolean;
+      payload?: unknown;
+      payloadJSON?: string | null;
+      error?: { code?: string; message?: string } | null;
+    }>;
+  };
+  requestParams?: Partial<Record<string, unknown>>;
+}) {
+  const respond = vi.fn();
+  await nodeHandlers["node.invoke"]({
+    params: makeNodeInvokeParams(params.requestParams),
+    respond: respond as never,
+    context: {
+      nodeRegistry: params.nodeRegistry,
+      execApprovalManager: undefined,
+    } as never,
+    client: null,
+    req: { type: "req", id: "req-node-invoke", method: "node.invoke" },
+    isWebchatConnect: () => false,
+  });
+  return respond;
+}
+
+describe("node.invoke APNs wake path", () => {
+  beforeEach(() => {
+    mocks.loadConfig.mockReset();
+    mocks.loadConfig.mockReturnValue({});
+    mocks.resolveNodeCommandAllowlist.mockReset();
+    mocks.resolveNodeCommandAllowlist.mockReturnValue([]);
+    mocks.isNodeCommandAllowed.mockReset();
+    mocks.isNodeCommandAllowed.mockReturnValue({ ok: true });
+    mocks.sanitizeNodeInvokeParamsForForwarding.mockReset();
+    mocks.sanitizeNodeInvokeParamsForForwarding.mockImplementation(
+      ({ rawParams }: { rawParams: unknown }) => ({ ok: true, params: rawParams }),
+    );
+    mocks.loadApnsRegistration.mockReset();
+    mocks.resolveApnsAuthConfigFromEnv.mockReset();
+    mocks.sendApnsBackgroundWake.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the existing not-connected response when wake path is unavailable", async () => {
+    mocks.loadApnsRegistration.mockResolvedValue(null);
+
+    const nodeRegistry = {
+      get: vi.fn(() => undefined),
+      invoke: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    const respond = await invokeNode({ nodeRegistry });
+    const call = respond.mock.calls[0] as RespondCall | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.code).toBe(ErrorCodes.UNAVAILABLE);
+    expect(call?.[2]?.message).toBe("node not connected");
+    expect(mocks.sendApnsBackgroundWake).not.toHaveBeenCalled();
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+  });
+
+  it("wakes and retries invoke after the node reconnects", async () => {
+    vi.useFakeTimers();
+    mocks.loadApnsRegistration.mockResolvedValue({
+      nodeId: "ios-node-reconnect",
+      token: "abcd1234abcd1234abcd1234abcd1234",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      updatedAtMs: 1,
+    });
+    mocks.resolveApnsAuthConfigFromEnv.mockResolvedValue({
+      ok: true,
+      value: {
+        teamId: "TEAM123",
+        keyId: "KEY123",
+        privateKey: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+      },
+    });
+    mocks.sendApnsBackgroundWake.mockResolvedValue({
+      ok: true,
+      status: 200,
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+    });
+
+    let connected = false;
+    const session: TestNodeSession = { nodeId: "ios-node-reconnect", commands: ["camera.capture"] };
+    const nodeRegistry = {
+      get: vi.fn((nodeId: string) => {
+        if (nodeId !== "ios-node-reconnect") {
+          return undefined;
+        }
+        return connected ? session : undefined;
+      }),
+      invoke: vi.fn().mockResolvedValue({
+        ok: true,
+        payload: { ok: true },
+        payloadJSON: '{"ok":true}',
+      }),
+    };
+
+    const invokePromise = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId: "ios-node-reconnect", idempotencyKey: "idem-reconnect" },
+    });
+    setTimeout(() => {
+      connected = true;
+    }, 300);
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    const respond = await invokePromise;
+
+    expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledTimes(1);
+    expect(nodeRegistry.invoke).toHaveBeenCalledTimes(1);
+    expect(nodeRegistry.invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "ios-node-reconnect",
+        command: "camera.capture",
+      }),
+    );
+    const call = respond.mock.calls[0] as RespondCall | undefined;
+    expect(call?.[0]).toBe(true);
+    expect(call?.[1]).toMatchObject({ ok: true, nodeId: "ios-node-reconnect" });
+  });
+
+  it("throttles repeated wake attempts for the same disconnected node", async () => {
+    vi.useFakeTimers();
+    mocks.loadApnsRegistration.mockResolvedValue({
+      nodeId: "ios-node-throttle",
+      token: "abcd1234abcd1234abcd1234abcd1234",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      updatedAtMs: 1,
+    });
+    mocks.resolveApnsAuthConfigFromEnv.mockResolvedValue({
+      ok: true,
+      value: {
+        teamId: "TEAM123",
+        keyId: "KEY123",
+        privateKey: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+      },
+    });
+    mocks.sendApnsBackgroundWake.mockResolvedValue({
+      ok: true,
+      status: 200,
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+    });
+
+    const nodeRegistry = {
+      get: vi.fn(() => undefined),
+      invoke: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    const first = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId: "ios-node-throttle", idempotencyKey: "idem-throttle-1" },
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    await first;
+
+    const second = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId: "ios-node-throttle", idempotencyKey: "idem-throttle-2" },
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    await second;
+
+    expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledTimes(1);
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/push.test.ts
+++ b/src/gateway/server-methods/push.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../protocol/index.js";
+import { pushHandlers } from "./push.js";
+
+vi.mock("../../infra/push-apns.js", () => ({
+  loadApnsRegistration: vi.fn(),
+  normalizeApnsEnvironment: vi.fn(),
+  resolveApnsAuthConfigFromEnv: vi.fn(),
+  sendApnsAlert: vi.fn(),
+}));
+
+import {
+  loadApnsRegistration,
+  normalizeApnsEnvironment,
+  resolveApnsAuthConfigFromEnv,
+  sendApnsAlert,
+} from "../../infra/push-apns.js";
+
+type RespondCall = [boolean, unknown?, { code: number; message: string }?];
+
+function createInvokeParams(params: Record<string, unknown>) {
+  const respond = vi.fn();
+  return {
+    respond,
+    invoke: async () =>
+      await pushHandlers["push.test"]({
+        params,
+        respond: respond as never,
+        context: {} as never,
+        client: null,
+        req: { type: "req", id: "req-1", method: "push.test" },
+        isWebchatConnect: () => false,
+      }),
+  };
+}
+
+describe("push.test handler", () => {
+  beforeEach(() => {
+    vi.mocked(loadApnsRegistration).mockReset();
+    vi.mocked(normalizeApnsEnvironment).mockReset();
+    vi.mocked(resolveApnsAuthConfigFromEnv).mockReset();
+    vi.mocked(sendApnsAlert).mockReset();
+  });
+
+  it("rejects invalid params", async () => {
+    const { respond, invoke } = createInvokeParams({ title: "hello" });
+    await invoke();
+    const call = respond.mock.calls[0] as RespondCall | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.code).toBe(ErrorCodes.INVALID_REQUEST);
+    expect(call?.[2]?.message).toContain("invalid push.test params");
+  });
+
+  it("returns invalid request when node has no APNs registration", async () => {
+    vi.mocked(loadApnsRegistration).mockResolvedValue(null);
+    const { respond, invoke } = createInvokeParams({ nodeId: "ios-node-1" });
+    await invoke();
+    const call = respond.mock.calls[0] as RespondCall | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.code).toBe(ErrorCodes.INVALID_REQUEST);
+    expect(call?.[2]?.message).toContain("has no APNs registration");
+  });
+
+  it("sends push test when registration and auth are available", async () => {
+    vi.mocked(loadApnsRegistration).mockResolvedValue({
+      nodeId: "ios-node-1",
+      token: "abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      updatedAtMs: 1,
+    });
+    vi.mocked(resolveApnsAuthConfigFromEnv).mockResolvedValue({
+      ok: true,
+      value: {
+        teamId: "TEAM123",
+        keyId: "KEY123",
+        privateKey: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+      },
+    });
+    vi.mocked(normalizeApnsEnvironment).mockReturnValue(null);
+    vi.mocked(sendApnsAlert).mockResolvedValue({
+      ok: true,
+      status: 200,
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+    });
+
+    const { respond, invoke } = createInvokeParams({
+      nodeId: "ios-node-1",
+      title: "Wake",
+      body: "Ping",
+    });
+    await invoke();
+
+    expect(sendApnsAlert).toHaveBeenCalledTimes(1);
+    const call = respond.mock.calls[0] as RespondCall | undefined;
+    expect(call?.[0]).toBe(true);
+    expect(call?.[1]).toMatchObject({ ok: true, status: 200 });
+  });
+});

--- a/src/gateway/server-methods/push.ts
+++ b/src/gateway/server-methods/push.ts
@@ -1,0 +1,73 @@
+import {
+  loadApnsRegistration,
+  normalizeApnsEnvironment,
+  resolveApnsAuthConfigFromEnv,
+  sendApnsAlert,
+} from "../../infra/push-apns.js";
+import { ErrorCodes, errorShape, validatePushTestParams } from "../protocol/index.js";
+import { respondInvalidParams, respondUnavailableOnThrow } from "./nodes.helpers.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export const pushHandlers: GatewayRequestHandlers = {
+  "push.test": async ({ params, respond }) => {
+    if (!validatePushTestParams(params)) {
+      respondInvalidParams({
+        respond,
+        method: "push.test",
+        validator: validatePushTestParams,
+      });
+      return;
+    }
+
+    const nodeId = String(params.nodeId ?? "").trim();
+    if (!nodeId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId required"));
+      return;
+    }
+
+    const title = normalizeOptionalString(params.title) ?? "OpenClaw";
+    const body = normalizeOptionalString(params.body) ?? `Push test for node ${nodeId}`;
+
+    await respondUnavailableOnThrow(respond, async () => {
+      const registration = await loadApnsRegistration(nodeId);
+      if (!registration) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `node ${nodeId} has no APNs registration (connect iOS node first)`,
+          ),
+        );
+        return;
+      }
+
+      const auth = await resolveApnsAuthConfigFromEnv(process.env);
+      if (!auth.ok) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, auth.error));
+        return;
+      }
+
+      const overrideEnvironment = normalizeApnsEnvironment(params.environment);
+      const result = await sendApnsAlert({
+        auth: auth.value,
+        registration: {
+          ...registration,
+          environment: overrideEnvironment ?? registration.environment,
+        },
+        nodeId,
+        title,
+        body,
+      });
+      respond(true, result, undefined);
+    });
+  },
+};

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -154,6 +154,18 @@ const parseDateRange = (params: {
 
 type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
 
+function buildStoreBySessionId(
+  store: Record<string, SessionEntry>,
+): Map<string, { key: string; entry: SessionEntry }> {
+  const storeBySessionId = new Map<string, { key: string; entry: SessionEntry }>();
+  for (const [key, entry] of Object.entries(store)) {
+    if (entry?.sessionId) {
+      storeBySessionId.set(entry.sessionId, { key, entry });
+    }
+  }
+  return storeBySessionId;
+}
+
 async function discoverAllSessionsForUsage(params: {
   config: ReturnType<typeof loadConfig>;
   startMs: number;
@@ -353,12 +365,7 @@ export const usageHandlers: GatewayRequestHandlers = {
 
       // Prefer the store entry when available, even if the caller provides a discovered key
       // (`agent:<id>:<sessionId>`) for a session that now has a canonical store key.
-      const storeBySessionId = new Map<string, { key: string; entry: SessionEntry }>();
-      for (const [key, entry] of Object.entries(store)) {
-        if (entry?.sessionId) {
-          storeBySessionId.set(entry.sessionId, { key, entry });
-        }
-      }
+      const storeBySessionId = buildStoreBySessionId(store);
 
       const storeMatch = store[specificKey]
         ? { key: specificKey, entry: store[specificKey] }
@@ -409,12 +416,7 @@ export const usageHandlers: GatewayRequestHandlers = {
       });
 
       // Build a map of sessionId -> store entry for quick lookup
-      const storeBySessionId = new Map<string, { key: string; entry: SessionEntry }>();
-      for (const [key, entry] of Object.entries(store)) {
-        if (entry?.sessionId) {
-          storeBySessionId.set(entry.sessionId, { key, entry });
-        }
-      }
+      const storeBySessionId = buildStoreBySessionId(store);
 
       for (const discovered of discoveredSessions) {
         const storeMatch = storeBySessionId.get(discovered.sessionId);

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -8,6 +8,7 @@ import { updateSessionStore } from "../config/sessions.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
+import { registerApnsToken } from "../infra/push-apns.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { normalizeMainKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
@@ -506,6 +507,33 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
 
       enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
       requestHeartbeatNow({ reason: "exec-event" });
+      return;
+    }
+    case "push.apns.register": {
+      if (!evt.payloadJSON) {
+        return;
+      }
+      let payload: unknown;
+      try {
+        payload = JSON.parse(evt.payloadJSON) as unknown;
+      } catch {
+        return;
+      }
+      const obj =
+        typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>) : {};
+      const token = typeof obj.token === "string" ? obj.token : "";
+      const topic = typeof obj.topic === "string" ? obj.topic : "";
+      const environment = obj.environment;
+      try {
+        await registerApnsToken({
+          nodeId,
+          token,
+          topic,
+          environment,
+        });
+      } catch (err) {
+        ctx.logGateway.warn(`push apns register failed node=${nodeId}: ${formatForLog(err)}`);
+      }
       return;
     }
     default:

--- a/src/gateway/server.node-invoke-approval-bypass.e2e.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.e2e.test.ts
@@ -21,8 +21,8 @@ installGatewayTestHooks({ scope: "suite" });
 
 async function expectNoForwardedInvoke(hasInvoke: () => boolean): Promise<void> {
   // Yield a couple of macrotasks so any accidental async forwarding would fire.
-  await sleep(0);
-  await sleep(0);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
   expect(hasInvoke()).toBe(false);
 }
 

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -4,7 +4,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Mock, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { GetReplyOptions, ReplyPayload } from "../auto-reply/types.js";
 import type { ChannelPlugin, ChannelOutboundAdapter } from "../channels/plugins/types.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { AgentBinding } from "../config/types.agents.js";
 import type { HooksConfig } from "../config/types.hooks.js";
@@ -18,6 +21,12 @@ type StubChannelOptions = {
   label: string;
   summary?: Record<string, unknown>;
 };
+
+type GetReplyFromConfigFn = (
+  ctx: MsgContext,
+  opts?: GetReplyOptions,
+  configOverride?: OpenClawConfig,
+) => Promise<ReplyPayload | ReplyPayload[] | undefined>;
 
 const createStubOutboundAdapter = (channelId: ChannelPlugin["id"]): ChannelOutboundAdapter => ({
   deliveryMode: "direct",
@@ -169,7 +178,7 @@ const hoisted = vi.hoisted(() => ({
     waitResults: new Map<string, boolean>(),
   },
   testTailscaleWhois: { value: null as TailscaleWhoisIdentity | null },
-  getReplyFromConfig: vi.fn().mockResolvedValue(undefined),
+  getReplyFromConfig: vi.fn<GetReplyFromConfigFn>().mockResolvedValue(undefined),
   sendWhatsAppMock: vi.fn().mockResolvedValue({ messageId: "msg-1", toJid: "jid-1" }),
 }));
 
@@ -202,7 +211,7 @@ export const testTailscaleWhois = hoisted.testTailscaleWhois;
 export const piSdkMock = hoisted.piSdkMock;
 export const cronIsolatedRun = hoisted.cronIsolatedRun;
 export const agentCommand: Mock<() => void> = hoisted.agentCommand;
-export const getReplyFromConfig: Mock<() => void> = hoisted.getReplyFromConfig;
+export const getReplyFromConfig: Mock<GetReplyFromConfigFn> = hoisted.getReplyFromConfig;
 
 export const testState = {
   agentConfig: undefined as Record<string, unknown> | undefined,

--- a/src/hooks/gmail-setup-utils.ts
+++ b/src/hooks/gmail-setup-utils.ts
@@ -23,13 +23,17 @@ function trimOutput(value: string): string {
   return `${trimmed.slice(0, MAX_OUTPUT_CHARS)}…`;
 }
 
-function formatCommandFailure(command: string, result: SpawnResult): string {
+function formatCommandResultInternal(
+  command: string,
+  result: SpawnResult,
+  statusLabel: "failed" | "exited",
+): string {
   const code = result.code ?? "null";
   const signal = result.signal ? `, signal=${result.signal}` : "";
   const killed = result.killed ? ", killed=true" : "";
   const stderr = trimOutput(result.stderr);
   const stdout = trimOutput(result.stdout);
-  const lines = [`${command} failed (code=${code}${signal}${killed})`];
+  const lines = [`${command} ${statusLabel} (code=${code}${signal}${killed})`];
   if (stderr) {
     lines.push(`stderr: ${stderr}`);
   }
@@ -39,20 +43,12 @@ function formatCommandFailure(command: string, result: SpawnResult): string {
   return lines.join("\n");
 }
 
+function formatCommandFailure(command: string, result: SpawnResult): string {
+  return formatCommandResultInternal(command, result, "failed");
+}
+
 function formatCommandResult(command: string, result: SpawnResult): string {
-  const code = result.code ?? "null";
-  const signal = result.signal ? `, signal=${result.signal}` : "";
-  const killed = result.killed ? ", killed=true" : "";
-  const stderr = trimOutput(result.stderr);
-  const stdout = trimOutput(result.stdout);
-  const lines = [`${command} exited (code=${code}${signal}${killed})`];
-  if (stderr) {
-    lines.push(`stderr: ${stderr}`);
-  }
-  if (stdout) {
-    lines.push(`stdout: ${stdout}`);
-  }
-  return lines.join("\n");
+  return formatCommandResultInternal(command, result, "exited");
 }
 
 function formatJsonParseFailure(command: string, result: SpawnResult, err: unknown): string {

--- a/src/hooks/hooks-status.ts
+++ b/src/hooks/hooks-status.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
-import { evaluateEntryMetadataRequirements } from "../shared/entry-status.js";
+import { evaluateEntryMetadataRequirementsForCurrentPlatform } from "../shared/entry-status.js";
 import type { RequirementConfigCheck, Requirements } from "../shared/requirements.js";
 import { CONFIG_DIR } from "../utils.js";
 import { hasBinary, isConfigPathTruthy, resolveHookConfig } from "./config.js";
@@ -87,18 +87,21 @@ function buildHookStatus(
   const disabled = managedByPlugin ? false : hookConfig?.enabled === false;
   const always = entry.metadata?.always === true;
   const events = entry.metadata?.events ?? [];
+  const isEnvSatisfied = (envName: string) =>
+    Boolean(process.env[envName] || hookConfig?.env?.[envName]);
+  const isConfigSatisfied = (pathStr: string) => isConfigPathTruthy(config, pathStr);
 
+  const requirementStatus = evaluateEntryMetadataRequirementsForCurrentPlatform({
+    always,
+    metadata: entry.metadata,
+    frontmatter: entry.frontmatter,
+    hasLocalBin: hasBinary,
+    remote: eligibility?.remote,
+    isEnvSatisfied,
+    isConfigSatisfied,
+  });
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =
-    evaluateEntryMetadataRequirements({
-      always,
-      metadata: entry.metadata,
-      frontmatter: entry.frontmatter,
-      hasLocalBin: hasBinary,
-      localPlatform: process.platform,
-      remote: eligibility?.remote,
-      isEnvSatisfied: (envName) => Boolean(process.env[envName] || hookConfig?.env?.[envName]),
-      isConfigSatisfied: (pathStr) => isConfigPathTruthy(config, pathStr),
-    });
+    requirementStatus;
 
   const eligible = !disabled && requirementsSatisfied;
 

--- a/src/imessage/monitor.shutdown.unhandled-rejection.test.ts
+++ b/src/imessage/monitor.shutdown.unhandled-rejection.test.ts
@@ -30,13 +30,7 @@ describe("monitorIMessageProvider", () => {
       });
       abortController.abort();
       // Give the event loop a turn to surface any unhandledRejection, if present.
-      await new Promise<void>((resolve) => {
-        if (typeof setImmediate === "function") {
-          setImmediate(resolve);
-          return;
-        }
-        setTimeout(resolve, 0);
-      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
       detach();
     } finally {
       process.off("unhandledRejection", onUnhandled);

--- a/src/infra/bonjour.test.ts
+++ b/src/infra/bonjour.test.ts
@@ -259,7 +259,7 @@ describe("gateway bonjour advertiser", () => {
 
     await started.stop();
 
-    await vi.advanceTimersByTimeAsync(120_000);
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(advertise).toHaveBeenCalledTimes(2);
   });
 

--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -66,9 +66,9 @@ describe("format-duration", () => {
 
   describe("formatDurationHuman", () => {
     it("returns fallback for invalid input", () => {
-      expect(formatDurationHuman(null)).toBe("n/a");
-      expect(formatDurationHuman(undefined)).toBe("n/a");
-      expect(formatDurationHuman(-100)).toBe("n/a");
+      for (const value of [null, undefined, -100]) {
+        expect(formatDurationHuman(value)).toBe("n/a");
+      }
       expect(formatDurationHuman(null, "unknown")).toBe("unknown");
     });
 
@@ -163,9 +163,9 @@ describe("format-datetime", () => {
 describe("format-relative", () => {
   describe("formatTimeAgo", () => {
     it("returns fallback for invalid input", () => {
-      expect(formatTimeAgo(null)).toBe("unknown");
-      expect(formatTimeAgo(undefined)).toBe("unknown");
-      expect(formatTimeAgo(-100)).toBe("unknown");
+      for (const value of [null, undefined, -100]) {
+        expect(formatTimeAgo(value)).toBe("unknown");
+      }
       expect(formatTimeAgo(null, { fallback: "n/a" })).toBe("n/a");
     });
 
@@ -192,8 +192,9 @@ describe("format-relative", () => {
 
   describe("formatRelativeTimestamp", () => {
     it("returns fallback for invalid input", () => {
-      expect(formatRelativeTimestamp(null)).toBe("n/a");
-      expect(formatRelativeTimestamp(undefined)).toBe("n/a");
+      for (const value of [null, undefined]) {
+        expect(formatRelativeTimestamp(value)).toBe("n/a");
+      }
       expect(formatRelativeTimestamp(null, { fallback: "unknown" })).toBe("unknown");
     });
 

--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -120,42 +120,46 @@ describe("format-duration", () => {
 
 describe("format-datetime", () => {
   describe("resolveTimezone", () => {
-    it("returns valid IANA timezone strings", () => {
-      expect(resolveTimezone("America/New_York")).toBe("America/New_York");
-      expect(resolveTimezone("Europe/London")).toBe("Europe/London");
-      expect(resolveTimezone("UTC")).toBe("UTC");
-    });
-
-    it("returns undefined for invalid timezones", () => {
-      expect(resolveTimezone("Invalid/Timezone")).toBeUndefined();
-      expect(resolveTimezone("garbage")).toBeUndefined();
-      expect(resolveTimezone("")).toBeUndefined();
+    it.each([
+      { input: "America/New_York", expected: "America/New_York" },
+      { input: "Europe/London", expected: "Europe/London" },
+      { input: "UTC", expected: "UTC" },
+      { input: "Invalid/Timezone", expected: undefined },
+      { input: "garbage", expected: undefined },
+      { input: "", expected: undefined },
+    ] as const)("resolves $input", ({ input, expected }) => {
+      expect(resolveTimezone(input)).toBe(expected);
     });
   });
 
   describe("formatUtcTimestamp", () => {
-    it("formats without seconds by default", () => {
+    it.each([
+      { displaySeconds: false, expected: "2024-01-15T14:30Z" },
+      { displaySeconds: true, expected: "2024-01-15T14:30:45Z" },
+    ])("formats UTC timestamp (displaySeconds=$displaySeconds)", ({ displaySeconds, expected }) => {
       const date = new Date("2024-01-15T14:30:45.000Z");
-      expect(formatUtcTimestamp(date)).toBe("2024-01-15T14:30Z");
-    });
-
-    it("includes seconds when requested", () => {
-      const date = new Date("2024-01-15T14:30:45.000Z");
-      expect(formatUtcTimestamp(date, { displaySeconds: true })).toBe("2024-01-15T14:30:45Z");
+      const result = displaySeconds
+        ? formatUtcTimestamp(date, { displaySeconds: true })
+        : formatUtcTimestamp(date);
+      expect(result).toBe(expected);
     });
   });
 
   describe("formatZonedTimestamp", () => {
-    it("formats with timezone abbreviation", () => {
-      const date = new Date("2024-01-15T14:30:00.000Z");
-      const result = formatZonedTimestamp(date, { timeZone: "UTC" });
-      expect(result).toMatch(/2024-01-15 14:30/);
-    });
-
-    it("includes seconds when requested", () => {
-      const date = new Date("2024-01-15T14:30:45.000Z");
-      const result = formatZonedTimestamp(date, { timeZone: "UTC", displaySeconds: true });
-      expect(result).toMatch(/2024-01-15 14:30:45/);
+    it.each([
+      {
+        date: new Date("2024-01-15T14:30:00.000Z"),
+        options: { timeZone: "UTC" },
+        expected: /2024-01-15 14:30/,
+      },
+      {
+        date: new Date("2024-01-15T14:30:45.000Z"),
+        options: { timeZone: "UTC", displaySeconds: true },
+        expected: /2024-01-15 14:30:45/,
+      },
+    ] as const)("formats zoned timestamp", ({ date, options, expected }) => {
+      const result = formatZonedTimestamp(date, options);
+      expect(result).toMatch(expected);
     });
   });
 });
@@ -198,18 +202,16 @@ describe("format-relative", () => {
       expect(formatRelativeTimestamp(null, { fallback: "unknown" })).toBe("unknown");
     });
 
-    it("formats past timestamps", () => {
+    it.each([
+      { offsetMs: -10000, expected: "just now" },
+      { offsetMs: -300000, expected: "5m ago" },
+      { offsetMs: -7200000, expected: "2h ago" },
+      { offsetMs: 30000, expected: "in <1m" },
+      { offsetMs: 300000, expected: "in 5m" },
+      { offsetMs: 7200000, expected: "in 2h" },
+    ])("formats relative timestamp for offset $offsetMs", ({ offsetMs, expected }) => {
       const now = Date.now();
-      expect(formatRelativeTimestamp(now - 10000)).toBe("just now");
-      expect(formatRelativeTimestamp(now - 300000)).toBe("5m ago");
-      expect(formatRelativeTimestamp(now - 7200000)).toBe("2h ago");
-    });
-
-    it("formats future timestamps", () => {
-      const now = Date.now();
-      expect(formatRelativeTimestamp(now + 30000)).toBe("in <1m");
-      expect(formatRelativeTimestamp(now + 300000)).toBe("in 5m");
-      expect(formatRelativeTimestamp(now + 7200000)).toBe("in 2h");
+      expect(formatRelativeTimestamp(now + offsetMs)).toBe(expected);
     });
 
     it("falls back to date for old timestamps when enabled", () => {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -103,6 +103,27 @@ export type MessagePollResult = {
   dryRun?: boolean;
 };
 
+async function resolveRequiredChannel(params: {
+  cfg: OpenClawConfig;
+  channel?: string;
+}): Promise<string> {
+  const channel = params.channel?.trim()
+    ? normalizeChannelId(params.channel)
+    : (await resolveMessageChannelSelection({ cfg: params.cfg })).channel;
+  if (!channel) {
+    throw new Error(`Unknown channel: ${params.channel}`);
+  }
+  return channel;
+}
+
+function resolveRequiredPlugin(channel: string) {
+  const plugin = getChannelPlugin(channel);
+  if (!plugin) {
+    throw new Error(`Unknown channel: ${channel}`);
+  }
+  return plugin;
+}
+
 function resolveGatewayOptions(opts?: MessageGatewayOptions) {
   // Security: backend callers (tools/agents) must not accept user-controlled gateway URLs.
   // Use config-derived gateway target only.
@@ -144,16 +165,8 @@ async function callMessageGateway<T>(params: {
 
 export async function sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
   const cfg = params.cfg ?? loadConfig();
-  const channel = params.channel?.trim()
-    ? normalizeChannelId(params.channel)
-    : (await resolveMessageChannelSelection({ cfg })).channel;
-  if (!channel) {
-    throw new Error(`Unknown channel: ${params.channel}`);
-  }
-  const plugin = getChannelPlugin(channel);
-  if (!plugin) {
-    throw new Error(`Unknown channel: ${channel}`);
-  }
+  const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
+  const plugin = resolveRequiredPlugin(channel);
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
   const normalizedPayloads = normalizeReplyPayloadsForDelivery([
     {
@@ -256,12 +269,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
 
 export async function sendPoll(params: MessagePollParams): Promise<MessagePollResult> {
   const cfg = params.cfg ?? loadConfig();
-  const channel = params.channel?.trim()
-    ? normalizeChannelId(params.channel)
-    : (await resolveMessageChannelSelection({ cfg })).channel;
-  if (!channel) {
-    throw new Error(`Unknown channel: ${params.channel}`);
-  }
+  const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
 
   const pollInput: PollInput = {
     question: params.question,
@@ -270,7 +278,7 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
     durationSeconds: params.durationSeconds,
     durationHours: params.durationHours,
   };
-  const plugin = getChannelPlugin(channel);
+  const plugin = resolveRequiredPlugin(channel);
   const outbound = plugin?.outbound;
   if (!outbound?.sendPoll) {
     throw new Error(`Unsupported poll channel: ${channel}`);

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   dispatchChannelMessageAction: vi.fn(),
   sendMessage: vi.fn(),
+  sendPoll: vi.fn(),
 }));
 
 vi.mock("../../channels/plugins/message-actions.js", () => ({
@@ -11,15 +12,16 @@ vi.mock("../../channels/plugins/message-actions.js", () => ({
 
 vi.mock("./message.js", () => ({
   sendMessage: (...args: unknown[]) => mocks.sendMessage(...args),
-  sendPoll: vi.fn(),
+  sendPoll: (...args: unknown[]) => mocks.sendPoll(...args),
 }));
 
-import { executeSendAction } from "./outbound-send-service.js";
+import { executePollAction, executeSendAction } from "./outbound-send-service.js";
 
 describe("executeSendAction", () => {
   beforeEach(() => {
     mocks.dispatchChannelMessageAction.mockReset();
     mocks.sendMessage.mockReset();
+    mocks.sendPoll.mockReset();
   });
 
   it("forwards ctx.agentId to sendMessage on core outbound path", async () => {
@@ -49,6 +51,79 @@ describe("executeSendAction", () => {
         channel: "discord",
         to: "channel:123",
         content: "hello",
+      }),
+    );
+  });
+
+  it("uses plugin poll action when available", async () => {
+    mocks.dispatchChannelMessageAction.mockResolvedValue({
+      ok: true,
+      value: { messageId: "poll-plugin" },
+      continuePrompt: "",
+      output: "",
+      sessionId: "s1",
+      model: "gpt-5.2",
+      usage: {},
+    });
+
+    const result = await executePollAction({
+      ctx: {
+        cfg: {},
+        channel: "discord",
+        params: {},
+        dryRun: false,
+      },
+      to: "channel:123",
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+      maxSelections: 1,
+    });
+
+    expect(result.handledBy).toBe("plugin");
+    expect(mocks.sendPoll).not.toHaveBeenCalled();
+  });
+
+  it("forwards poll args to sendPoll on core outbound path", async () => {
+    mocks.dispatchChannelMessageAction.mockResolvedValue(null);
+    mocks.sendPoll.mockResolvedValue({
+      channel: "discord",
+      to: "channel:123",
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+      maxSelections: 1,
+      durationSeconds: null,
+      durationHours: null,
+      via: "gateway",
+    });
+
+    await executePollAction({
+      ctx: {
+        cfg: {},
+        channel: "discord",
+        params: {},
+        accountId: "acc-1",
+        dryRun: false,
+      },
+      to: "channel:123",
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+      maxSelections: 1,
+      durationSeconds: 300,
+      threadId: "thread-1",
+      isAnonymous: true,
+    });
+
+    expect(mocks.sendPoll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        accountId: "acc-1",
+        to: "channel:123",
+        question: "Lunch?",
+        options: ["Pizza", "Sushi"],
+        maxSelections: 1,
+        durationSeconds: 300,
+        threadId: "thread-1",
+        isAnonymous: true,
       }),
     );
   });

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadApnsRegistration,
+  normalizeApnsEnvironment,
+  registerApnsToken,
+  resolveApnsAuthConfigFromEnv,
+} from "./push-apns.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-push-apns-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("push APNs registration store", () => {
+  it("stores and reloads node APNs registration", async () => {
+    const baseDir = await makeTempDir();
+    const saved = await registerApnsToken({
+      nodeId: "ios-node-1",
+      token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      baseDir,
+    });
+
+    const loaded = await loadApnsRegistration("ios-node-1", baseDir);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.nodeId).toBe("ios-node-1");
+    expect(loaded?.token).toBe("abcd1234abcd1234abcd1234abcd1234");
+    expect(loaded?.topic).toBe("ai.openclaw.ios");
+    expect(loaded?.environment).toBe("sandbox");
+    expect(loaded?.updatedAtMs).toBe(saved.updatedAtMs);
+  });
+
+  it("rejects invalid APNs tokens", async () => {
+    const baseDir = await makeTempDir();
+    await expect(
+      registerApnsToken({
+        nodeId: "ios-node-1",
+        token: "not-a-token",
+        topic: "ai.openclaw.ios",
+        baseDir,
+      }),
+    ).rejects.toThrow("invalid APNs token");
+  });
+});
+
+describe("push APNs env config", () => {
+  it("normalizes APNs environment values", () => {
+    expect(normalizeApnsEnvironment("sandbox")).toBe("sandbox");
+    expect(normalizeApnsEnvironment("PRODUCTION")).toBe("production");
+    expect(normalizeApnsEnvironment("staging")).toBeNull();
+  });
+
+  it("resolves inline private key and unescapes newlines", async () => {
+    const env = {
+      OPENCLAW_APNS_TEAM_ID: "TEAM123",
+      OPENCLAW_APNS_KEY_ID: "KEY123",
+      OPENCLAW_APNS_PRIVATE_KEY_P8:
+        "-----BEGIN PRIVATE KEY-----\\nline-a\\nline-b\\n-----END PRIVATE KEY-----",
+    } as NodeJS.ProcessEnv;
+    const resolved = await resolveApnsAuthConfigFromEnv(env);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      return;
+    }
+    expect(resolved.value.privateKey).toContain("\nline-a\n");
+    expect(resolved.value.teamId).toBe("TEAM123");
+    expect(resolved.value.keyId).toBe("KEY123");
+  });
+
+  it("returns an error when required APNs auth vars are missing", async () => {
+    const resolved = await resolveApnsAuthConfigFromEnv({} as NodeJS.ProcessEnv);
+    expect(resolved.ok).toBe(false);
+    if (resolved.ok) {
+      return;
+    }
+    expect(resolved.error).toContain("OPENCLAW_APNS_TEAM_ID");
+  });
+});

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -1,15 +1,21 @@
+import { generateKeyPairSync } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   loadApnsRegistration,
   normalizeApnsEnvironment,
   registerApnsToken,
   resolveApnsAuthConfigFromEnv,
+  sendApnsAlert,
+  sendApnsBackgroundWake,
 } from "./push-apns.js";
 
 const tempDirs: string[] = [];
+const testAuthPrivateKey = generateKeyPairSync("ec", { namedCurve: "prime256v1" })
+  .privateKey.export({ format: "pem", type: "pkcs8" })
+  .toString();
 
 async function makeTempDir(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-push-apns-test-"));
@@ -90,5 +96,98 @@ describe("push APNs env config", () => {
       return;
     }
     expect(resolved.error).toContain("OPENCLAW_APNS_TEAM_ID");
+  });
+});
+
+describe("push APNs send semantics", () => {
+  it("sends alert pushes with alert headers and payload", async () => {
+    const send = vi.fn().mockResolvedValue({
+      status: 200,
+      apnsId: "apns-alert-id",
+      body: "",
+    });
+
+    const result = await sendApnsAlert({
+      auth: {
+        teamId: "TEAM123",
+        keyId: "KEY123",
+        privateKey: testAuthPrivateKey,
+      },
+      registration: {
+        nodeId: "ios-node-alert",
+        token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+        topic: "ai.openclaw.ios",
+        environment: "sandbox",
+        updatedAtMs: 1,
+      },
+      nodeId: "ios-node-alert",
+      title: "Wake",
+      body: "Ping",
+      requestSender: send,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent?.pushType).toBe("alert");
+    expect(sent?.priority).toBe("10");
+    expect(sent?.payload).toMatchObject({
+      aps: {
+        alert: { title: "Wake", body: "Ping" },
+        sound: "default",
+      },
+      openclaw: {
+        kind: "push.test",
+        nodeId: "ios-node-alert",
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+  });
+
+  it("sends background wake pushes with silent payload semantics", async () => {
+    const send = vi.fn().mockResolvedValue({
+      status: 200,
+      apnsId: "apns-wake-id",
+      body: "",
+    });
+
+    const result = await sendApnsBackgroundWake({
+      auth: {
+        teamId: "TEAM123",
+        keyId: "KEY123",
+        privateKey: testAuthPrivateKey,
+      },
+      registration: {
+        nodeId: "ios-node-wake",
+        token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+        topic: "ai.openclaw.ios",
+        environment: "production",
+        updatedAtMs: 1,
+      },
+      nodeId: "ios-node-wake",
+      wakeReason: "node.invoke",
+      requestSender: send,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent?.pushType).toBe("background");
+    expect(sent?.priority).toBe("5");
+    expect(sent?.payload).toMatchObject({
+      aps: {
+        "content-available": 1,
+      },
+      openclaw: {
+        kind: "node.wake",
+        reason: "node.invoke",
+        nodeId: "ios-node-wake",
+      },
+    });
+    const sentPayload = sent?.payload as { aps?: { alert?: unknown; sound?: unknown } } | undefined;
+    const aps = sentPayload?.aps;
+    expect(aps?.alert).toBeUndefined();
+    expect(aps?.sound).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.environment).toBe("production");
   });
 });

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -1,0 +1,409 @@
+import { createHash, createPrivateKey, sign as signJwt } from "node:crypto";
+import fs from "node:fs/promises";
+import http2 from "node:http2";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { createAsyncLock, readJsonFile, writeJsonAtomic } from "./json-files.js";
+
+export type ApnsEnvironment = "sandbox" | "production";
+
+export type ApnsRegistration = {
+  nodeId: string;
+  token: string;
+  topic: string;
+  environment: ApnsEnvironment;
+  updatedAtMs: number;
+};
+
+export type ApnsAuthConfig = {
+  teamId: string;
+  keyId: string;
+  privateKey: string;
+};
+
+export type ApnsAuthConfigResolution =
+  | { ok: true; value: ApnsAuthConfig }
+  | { ok: false; error: string };
+
+export type ApnsPushAlertResult = {
+  ok: boolean;
+  status: number;
+  apnsId?: string;
+  reason?: string;
+  tokenSuffix: string;
+  topic: string;
+  environment: ApnsEnvironment;
+};
+
+type ApnsRegistrationState = {
+  registrationsByNodeId: Record<string, ApnsRegistration>;
+};
+
+const APNS_STATE_FILENAME = "push/apns-registrations.json";
+const APNS_JWT_TTL_MS = 50 * 60 * 1000;
+const DEFAULT_APNS_TIMEOUT_MS = 10_000;
+const withLock = createAsyncLock();
+
+let cachedJwt: { cacheKey: string; token: string; expiresAtMs: number } | null = null;
+
+function resolveApnsRegistrationPath(baseDir?: string): string {
+  const root = baseDir ?? resolveStateDir();
+  return path.join(root, APNS_STATE_FILENAME);
+}
+
+function normalizeNodeId(value: string): string {
+  return value.trim();
+}
+
+function normalizeApnsToken(value: string): string {
+  return value
+    .trim()
+    .replace(/[<>\s]/g, "")
+    .toLowerCase();
+}
+
+function normalizeTopic(value: string): string {
+  return value.trim();
+}
+
+function isLikelyApnsToken(value: string): boolean {
+  return /^[0-9a-f]{32,}$/i.test(value);
+}
+
+function parseReason(body: string): string | undefined {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as { reason?: unknown };
+    return typeof parsed.reason === "string" && parsed.reason.trim().length > 0
+      ? parsed.reason.trim()
+      : trimmed.slice(0, 200);
+  } catch {
+    return trimmed.slice(0, 200);
+  }
+}
+
+function toBase64UrlBytes(value: Uint8Array): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function toBase64UrlJson(value: object): string {
+  return toBase64UrlBytes(Buffer.from(JSON.stringify(value)));
+}
+
+function getJwtCacheKey(auth: ApnsAuthConfig): string {
+  const keyHash = createHash("sha256").update(auth.privateKey).digest("hex");
+  return `${auth.teamId}:${auth.keyId}:${keyHash}`;
+}
+
+function getApnsBearerToken(auth: ApnsAuthConfig, nowMs: number = Date.now()): string {
+  const cacheKey = getJwtCacheKey(auth);
+  if (cachedJwt && cachedJwt.cacheKey === cacheKey && nowMs < cachedJwt.expiresAtMs) {
+    return cachedJwt.token;
+  }
+
+  const iat = Math.floor(nowMs / 1000);
+  const header = toBase64UrlJson({ alg: "ES256", kid: auth.keyId, typ: "JWT" });
+  const payload = toBase64UrlJson({ iss: auth.teamId, iat });
+  const signingInput = `${header}.${payload}`;
+  const signature = signJwt("sha256", Buffer.from(signingInput, "utf8"), {
+    key: createPrivateKey(auth.privateKey),
+    dsaEncoding: "ieee-p1363",
+  });
+  const token = `${signingInput}.${toBase64UrlBytes(signature)}`;
+  cachedJwt = {
+    cacheKey,
+    token,
+    expiresAtMs: nowMs + APNS_JWT_TTL_MS,
+  };
+  return token;
+}
+
+function normalizePrivateKey(value: string): string {
+  return value.trim().replace(/\\n/g, "\n");
+}
+
+function normalizeNonEmptyString(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function loadRegistrationsState(baseDir?: string): Promise<ApnsRegistrationState> {
+  const filePath = resolveApnsRegistrationPath(baseDir);
+  const existing = await readJsonFile<ApnsRegistrationState>(filePath);
+  if (!existing || typeof existing !== "object") {
+    return { registrationsByNodeId: {} };
+  }
+  const registrations =
+    existing.registrationsByNodeId &&
+    typeof existing.registrationsByNodeId === "object" &&
+    !Array.isArray(existing.registrationsByNodeId)
+      ? existing.registrationsByNodeId
+      : {};
+  return { registrationsByNodeId: registrations };
+}
+
+async function persistRegistrationsState(
+  state: ApnsRegistrationState,
+  baseDir?: string,
+): Promise<void> {
+  const filePath = resolveApnsRegistrationPath(baseDir);
+  await writeJsonAtomic(filePath, state);
+}
+
+export function normalizeApnsEnvironment(value: unknown): ApnsEnvironment | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "sandbox" || normalized === "production") {
+    return normalized;
+  }
+  return null;
+}
+
+export async function registerApnsToken(params: {
+  nodeId: string;
+  token: string;
+  topic: string;
+  environment?: unknown;
+  baseDir?: string;
+}): Promise<ApnsRegistration> {
+  const nodeId = normalizeNodeId(params.nodeId);
+  const token = normalizeApnsToken(params.token);
+  const topic = normalizeTopic(params.topic);
+  const environment = normalizeApnsEnvironment(params.environment) ?? "sandbox";
+
+  if (!nodeId) {
+    throw new Error("nodeId required");
+  }
+  if (!topic) {
+    throw new Error("topic required");
+  }
+  if (!isLikelyApnsToken(token)) {
+    throw new Error("invalid APNs token");
+  }
+
+  return await withLock(async () => {
+    const state = await loadRegistrationsState(params.baseDir);
+    const next: ApnsRegistration = {
+      nodeId,
+      token,
+      topic,
+      environment,
+      updatedAtMs: Date.now(),
+    };
+    state.registrationsByNodeId[nodeId] = next;
+    await persistRegistrationsState(state, params.baseDir);
+    return next;
+  });
+}
+
+export async function loadApnsRegistration(
+  nodeId: string,
+  baseDir?: string,
+): Promise<ApnsRegistration | null> {
+  const normalizedNodeId = normalizeNodeId(nodeId);
+  if (!normalizedNodeId) {
+    return null;
+  }
+  const state = await loadRegistrationsState(baseDir);
+  return state.registrationsByNodeId[normalizedNodeId] ?? null;
+}
+
+export async function resolveApnsAuthConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ApnsAuthConfigResolution> {
+  const teamId = normalizeNonEmptyString(env.OPENCLAW_APNS_TEAM_ID);
+  const keyId = normalizeNonEmptyString(env.OPENCLAW_APNS_KEY_ID);
+  if (!teamId || !keyId) {
+    return {
+      ok: false,
+      error: "APNs auth missing: set OPENCLAW_APNS_TEAM_ID and OPENCLAW_APNS_KEY_ID",
+    };
+  }
+
+  const inlineKeyRaw =
+    normalizeNonEmptyString(env.OPENCLAW_APNS_PRIVATE_KEY_P8) ??
+    normalizeNonEmptyString(env.OPENCLAW_APNS_PRIVATE_KEY);
+  if (inlineKeyRaw) {
+    return {
+      ok: true,
+      value: {
+        teamId,
+        keyId,
+        privateKey: normalizePrivateKey(inlineKeyRaw),
+      },
+    };
+  }
+
+  const keyPath = normalizeNonEmptyString(env.OPENCLAW_APNS_PRIVATE_KEY_PATH);
+  if (!keyPath) {
+    return {
+      ok: false,
+      error:
+        "APNs private key missing: set OPENCLAW_APNS_PRIVATE_KEY_P8 or OPENCLAW_APNS_PRIVATE_KEY_PATH",
+    };
+  }
+  try {
+    const privateKey = normalizePrivateKey(await fs.readFile(keyPath, "utf8"));
+    return {
+      ok: true,
+      value: {
+        teamId,
+        keyId,
+        privateKey,
+      },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `failed reading OPENCLAW_APNS_PRIVATE_KEY_PATH (${keyPath}): ${message}`,
+    };
+  }
+}
+
+async function sendApnsRequest(params: {
+  token: string;
+  topic: string;
+  environment: ApnsEnvironment;
+  bearerToken: string;
+  payload: object;
+  timeoutMs: number;
+}): Promise<{ status: number; apnsId?: string; body: string }> {
+  const authority =
+    params.environment === "production"
+      ? "https://api.push.apple.com"
+      : "https://api.sandbox.push.apple.com";
+
+  const body = JSON.stringify(params.payload);
+  const requestPath = `/3/device/${params.token}`;
+
+  return await new Promise((resolve, reject) => {
+    const client = http2.connect(authority);
+    let settled = false;
+    const fail = (err: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      client.destroy();
+      reject(err);
+    };
+    const finish = (result: { status: number; apnsId?: string; body: string }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      client.close();
+      resolve(result);
+    };
+
+    client.once("error", (err) => fail(err));
+
+    const req = client.request({
+      ":method": "POST",
+      ":path": requestPath,
+      authorization: `bearer ${params.bearerToken}`,
+      "apns-topic": params.topic,
+      "apns-push-type": "alert",
+      "apns-priority": "10",
+      "apns-expiration": "0",
+      "content-type": "application/json",
+      "content-length": Buffer.byteLength(body).toString(),
+    });
+
+    let statusCode = 0;
+    let apnsId: string | undefined;
+    let responseBody = "";
+
+    req.setEncoding("utf8");
+    req.setTimeout(params.timeoutMs, () => {
+      req.close(http2.constants.NGHTTP2_CANCEL);
+      fail(new Error(`APNs request timed out after ${params.timeoutMs}ms`));
+    });
+    req.on("response", (headers) => {
+      const statusHeader = headers[":status"];
+      statusCode = typeof statusHeader === "number" ? statusHeader : Number(statusHeader ?? 0);
+      const idHeader = headers["apns-id"];
+      if (typeof idHeader === "string" && idHeader.trim().length > 0) {
+        apnsId = idHeader.trim();
+      }
+    });
+    req.on("data", (chunk) => {
+      if (typeof chunk === "string") {
+        responseBody += chunk;
+      }
+    });
+    req.on("end", () => {
+      finish({ status: statusCode, apnsId, body: responseBody });
+    });
+    req.on("error", (err) => fail(err));
+
+    req.end(body);
+  });
+}
+
+export async function sendApnsAlert(params: {
+  auth: ApnsAuthConfig;
+  registration: ApnsRegistration;
+  nodeId: string;
+  title: string;
+  body: string;
+  timeoutMs?: number;
+}): Promise<ApnsPushAlertResult> {
+  const token = normalizeApnsToken(params.registration.token);
+  if (!isLikelyApnsToken(token)) {
+    throw new Error("invalid APNs token");
+  }
+  const topic = normalizeTopic(params.registration.topic);
+  if (!topic) {
+    throw new Error("topic required");
+  }
+  const environment = params.registration.environment;
+  const bearerToken = getApnsBearerToken(params.auth);
+
+  const payload = {
+    aps: {
+      alert: {
+        title: params.title,
+        body: params.body,
+      },
+      sound: "default",
+    },
+    openclaw: {
+      kind: "push.test",
+      nodeId: params.nodeId,
+      ts: Date.now(),
+    },
+  };
+
+  const response = await sendApnsRequest({
+    token,
+    topic,
+    environment,
+    bearerToken,
+    payload,
+    timeoutMs:
+      typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+        ? Math.max(1000, Math.trunc(params.timeoutMs))
+        : DEFAULT_APNS_TIMEOUT_MS,
+  });
+
+  return {
+    ok: response.status === 200,
+    status: response.status,
+    apnsId: response.apnsId,
+    reason: parseReason(response.body),
+    tokenSuffix: token.slice(-8),
+    topic,
+    environment,
+  };
+}

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -87,6 +87,13 @@ describe("shell env fallback", () => {
       exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
     });
 
+    if (process.platform === "win32") {
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      expect(exec).not.toHaveBeenCalled();
+      return;
+    }
+
     expect(first).toBe("/usr/local/bin:/usr/bin");
     expect(second).toBe("/usr/local/bin:/usr/bin");
     expect(exec).toHaveBeenCalledOnce();
@@ -109,6 +116,10 @@ describe("shell env fallback", () => {
 
     expect(first).toBeNull();
     expect(second).toBeNull();
+    if (process.platform === "win32") {
+      expect(exec).not.toHaveBeenCalled();
+      return;
+    }
     expect(exec).toHaveBeenCalledOnce();
   });
 });

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -87,9 +87,15 @@ describe("shell env fallback", () => {
       exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
     });
 
-    expect(first).toBe("/usr/local/bin:/usr/bin");
-    expect(second).toBe("/usr/local/bin:/usr/bin");
-    expect(exec).toHaveBeenCalledOnce();
+    if (process.platform === "win32") {
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      expect(exec).not.toHaveBeenCalled();
+    } else {
+      expect(first).toBe("/usr/local/bin:/usr/bin");
+      expect(second).toBe("/usr/local/bin:/usr/bin");
+      expect(exec).toHaveBeenCalledOnce();
+    }
   });
 
   it("returns null on shell env read failure and caches null", () => {
@@ -109,6 +115,10 @@ describe("shell env fallback", () => {
 
     expect(first).toBeNull();
     expect(second).toBeNull();
-    expect(exec).toHaveBeenCalledOnce();
+    if (process.platform === "win32") {
+      expect(exec).not.toHaveBeenCalled();
+    } else {
+      expect(exec).toHaveBeenCalledOnce();
+    }
   });
 });

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -35,19 +35,12 @@ describe("isAbortError", () => {
     expect(isAbortError(new Error("Request was aborted"))).toBe(false);
   });
 
-  it("returns false for null and undefined", () => {
-    expect(isAbortError(null)).toBe(false);
-    expect(isAbortError(undefined)).toBe(false);
-  });
-
-  it("returns false for non-error values", () => {
-    expect(isAbortError("string error")).toBe(false);
-    expect(isAbortError(42)).toBe(false);
-  });
-
-  it("returns false for plain objects without AbortError name", () => {
-    expect(isAbortError({ message: "plain object" })).toBe(false);
-  });
+  it.each([null, undefined, "string error", 42, { message: "plain object" }])(
+    "returns false for non-abort input %#",
+    (value) => {
+      expect(isAbortError(value)).toBe(false);
+    },
+  );
 });
 
 describe("isTransientNetworkError", () => {
@@ -110,16 +103,12 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(false);
   });
 
-  it("returns false for null and undefined", () => {
-    expect(isTransientNetworkError(null)).toBe(false);
-    expect(isTransientNetworkError(undefined)).toBe(false);
-  });
-
-  it("returns false for non-error values", () => {
-    expect(isTransientNetworkError("string error")).toBe(false);
-    expect(isTransientNetworkError(42)).toBe(false);
-    expect(isTransientNetworkError({ message: "plain object" })).toBe(false);
-  });
+  it.each([null, undefined, "string error", 42, { message: "plain object" }])(
+    "returns false for non-network input %#",
+    (value) => {
+      expect(isTransientNetworkError(value)).toBe(false);
+    },
+  );
 
   it("returns false for AggregateError with only non-network errors", () => {
     const error = new AggregateError([new Error("regular error")], "Multiple errors");

--- a/src/line/rich-menu.test.ts
+++ b/src/line/rich-menu.test.ts
@@ -22,13 +22,6 @@ describe("messageAction", () => {
 
     expect((action as { text: string }).text).toBe("Click");
   });
-
-  it("truncates label to 20 characters", () => {
-    const action = messageAction("This is a very long label text");
-
-    expect((action.label ?? "").length).toBe(20);
-    expect(action.label).toBe("This is a very long ");
-  });
 });
 
 describe("uriAction", () => {
@@ -39,10 +32,21 @@ describe("uriAction", () => {
     expect(action.label).toBe("Open");
     expect((action as { uri: string }).uri).toBe("https://example.com");
   });
+});
 
-  it("truncates label to 20 characters", () => {
-    const action = uriAction("Click here to visit our website", "https://example.com");
-
+describe("action label truncation", () => {
+  it.each([
+    {
+      createAction: () => messageAction("This is a very long label text"),
+      expectedLabel: "This is a very long ",
+    },
+    {
+      createAction: () => uriAction("Click here to visit our website", "https://example.com"),
+      expectedLabel: "Click here to visit ",
+    },
+  ])("truncates labels to 20 characters", ({ createAction, expectedLabel }) => {
+    const action = createAction();
+    expect(action.label).toBe(expectedLabel);
     expect((action.label ?? "").length).toBe(20);
   });
 });

--- a/src/line/template-messages.test.ts
+++ b/src/line/template-messages.test.ts
@@ -69,17 +69,6 @@ describe("createButtonTemplate", () => {
   });
 });
 
-describe("createTemplateCarousel", () => {
-  it("limits columns to 10", () => {
-    const columns = Array.from({ length: 15 }, () =>
-      createCarouselColumn({ text: "Text", actions: [messageAction("OK")] }),
-    );
-    const template = createTemplateCarousel(columns);
-
-    expect((template.template as { columns: unknown[] }).columns.length).toBe(10);
-  });
-});
-
 describe("createCarouselColumn", () => {
   it("limits actions to 3", () => {
     const column = createCarouselColumn({
@@ -104,13 +93,26 @@ describe("createCarouselColumn", () => {
   });
 });
 
-describe("createImageCarousel", () => {
-  it("limits columns to 10", () => {
-    const columns = Array.from({ length: 15 }, (_, i) =>
-      createImageCarouselColumn(`https://example.com/${i}.jpg`, messageAction("View")),
-    );
-    const template = createImageCarousel(columns);
-
+describe("carousel column limits", () => {
+  it.each([
+    {
+      createTemplate: () =>
+        createTemplateCarousel(
+          Array.from({ length: 15 }, () =>
+            createCarouselColumn({ text: "Text", actions: [messageAction("OK")] }),
+          ),
+        ),
+    },
+    {
+      createTemplate: () =>
+        createImageCarousel(
+          Array.from({ length: 15 }, (_, i) =>
+            createImageCarouselColumn(`https://example.com/${i}.jpg`, messageAction("View")),
+          ),
+        ),
+    },
+  ])("limits columns to 10", ({ createTemplate }) => {
+    const template = createTemplate();
     expect((template.template as { columns: unknown[] }).columns.length).toBe(10);
   });
 });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -298,6 +298,28 @@ function resolveEntryRunOptions(params: {
   return { maxBytes, maxChars, timeoutMs, prompt };
 }
 
+async function resolveProviderExecutionAuth(params: {
+  providerId: string;
+  cfg: OpenClawConfig;
+  entry: MediaUnderstandingModelConfig;
+  agentDir?: string;
+}) {
+  const auth = await resolveApiKeyForProvider({
+    provider: params.providerId,
+    cfg: params.cfg,
+    profileId: params.entry.profile,
+    preferredProfile: params.entry.preferredProfile,
+    agentDir: params.agentDir,
+  });
+  return {
+    apiKeys: collectProviderApiKeysForExecution({
+      provider: params.providerId,
+      primaryApiKey: requireApiKey(auth, params.providerId),
+    }),
+    providerConfig: params.cfg.models?.providers?.[params.providerId],
+  };
+}
+
 export function formatDecisionSummary(decision: MediaUnderstandingDecision): string {
   const total = decision.attachments.length;
   const success = decision.attachments.filter(
@@ -406,18 +428,12 @@ export async function runProviderEntry(params: {
       maxBytes,
       timeoutMs,
     });
-    const auth = await resolveApiKeyForProvider({
-      provider: providerId,
+    const { apiKeys, providerConfig } = await resolveProviderExecutionAuth({
+      providerId,
       cfg,
-      profileId: entry.profile,
-      preferredProfile: entry.preferredProfile,
+      entry,
       agentDir: params.agentDir,
     });
-    const apiKeys = collectProviderApiKeysForExecution({
-      provider: providerId,
-      primaryApiKey: requireApiKey(auth, providerId),
-    });
-    const providerConfig = cfg.models?.providers?.[providerId];
     const baseUrl = entry.baseUrl ?? params.config?.baseUrl ?? providerConfig?.baseUrl;
     const mergedHeaders = {
       ...providerConfig?.headers,
@@ -475,18 +491,12 @@ export async function runProviderEntry(params: {
       `Video attachment ${params.attachmentIndex + 1} base64 payload ${estimatedBase64Bytes} exceeds ${maxBase64Bytes}`,
     );
   }
-  const auth = await resolveApiKeyForProvider({
-    provider: providerId,
+  const { apiKeys, providerConfig } = await resolveProviderExecutionAuth({
+    providerId,
     cfg,
-    profileId: entry.profile,
-    preferredProfile: entry.preferredProfile,
+    entry,
     agentDir: params.agentDir,
   });
-  const apiKeys = collectProviderApiKeysForExecution({
-    provider: providerId,
-    primaryApiKey: requireApiKey(auth, providerId),
-  });
-  const providerConfig = cfg.models?.providers?.[providerId];
   const result = await executeWithApiKeyRotation({
     provider: providerId,
     apiKeys,

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -20,13 +20,15 @@ async function makeOoxmlZip(opts: { mainMime: string; partPath: string }): Promi
 }
 
 describe("mime detection", () => {
-  it("maps common image formats to mime types", () => {
-    expect(imageMimeFromFormat("jpg")).toBe("image/jpeg");
-    expect(imageMimeFromFormat("jpeg")).toBe("image/jpeg");
-    expect(imageMimeFromFormat("png")).toBe("image/png");
-    expect(imageMimeFromFormat("webp")).toBe("image/webp");
-    expect(imageMimeFromFormat("gif")).toBe("image/gif");
-    expect(imageMimeFromFormat("unknown")).toBeUndefined();
+  it.each([
+    { format: "jpg", expected: "image/jpeg" },
+    { format: "jpeg", expected: "image/jpeg" },
+    { format: "png", expected: "image/png" },
+    { format: "webp", expected: "image/webp" },
+    { format: "gif", expected: "image/gif" },
+    { format: "unknown", expected: undefined },
+  ])("maps $format image format", ({ format, expected }) => {
+    expect(imageMimeFromFormat(format)).toBe(expected);
   });
 
   it("detects docx from buffer", async () => {
@@ -61,46 +63,30 @@ describe("mime detection", () => {
 });
 
 describe("extensionForMime", () => {
-  it("maps image MIME types to extensions", () => {
-    expect(extensionForMime("image/jpeg")).toBe(".jpg");
-    expect(extensionForMime("image/png")).toBe(".png");
-    expect(extensionForMime("image/webp")).toBe(".webp");
-    expect(extensionForMime("image/gif")).toBe(".gif");
-    expect(extensionForMime("image/heic")).toBe(".heic");
-  });
-
-  it("maps audio MIME types to extensions", () => {
-    expect(extensionForMime("audio/mpeg")).toBe(".mp3");
-    expect(extensionForMime("audio/ogg")).toBe(".ogg");
-    expect(extensionForMime("audio/x-m4a")).toBe(".m4a");
-    expect(extensionForMime("audio/mp4")).toBe(".m4a");
-  });
-
-  it("maps video MIME types to extensions", () => {
-    expect(extensionForMime("video/mp4")).toBe(".mp4");
-    expect(extensionForMime("video/quicktime")).toBe(".mov");
-  });
-
-  it("maps document MIME types to extensions", () => {
-    expect(extensionForMime("application/pdf")).toBe(".pdf");
-    expect(extensionForMime("text/plain")).toBe(".txt");
-    expect(extensionForMime("text/markdown")).toBe(".md");
-  });
-
-  it("handles case insensitivity", () => {
-    expect(extensionForMime("IMAGE/JPEG")).toBe(".jpg");
-    expect(extensionForMime("Audio/X-M4A")).toBe(".m4a");
-    expect(extensionForMime("Video/QuickTime")).toBe(".mov");
-  });
-
-  it("returns undefined for unknown MIME types", () => {
-    expect(extensionForMime("video/unknown")).toBeUndefined();
-    expect(extensionForMime("application/x-custom")).toBeUndefined();
-  });
-
-  it("returns undefined for null or undefined input", () => {
-    expect(extensionForMime(null)).toBeUndefined();
-    expect(extensionForMime(undefined)).toBeUndefined();
+  it.each([
+    { mime: "image/jpeg", expected: ".jpg" },
+    { mime: "image/png", expected: ".png" },
+    { mime: "image/webp", expected: ".webp" },
+    { mime: "image/gif", expected: ".gif" },
+    { mime: "image/heic", expected: ".heic" },
+    { mime: "audio/mpeg", expected: ".mp3" },
+    { mime: "audio/ogg", expected: ".ogg" },
+    { mime: "audio/x-m4a", expected: ".m4a" },
+    { mime: "audio/mp4", expected: ".m4a" },
+    { mime: "video/mp4", expected: ".mp4" },
+    { mime: "video/quicktime", expected: ".mov" },
+    { mime: "application/pdf", expected: ".pdf" },
+    { mime: "text/plain", expected: ".txt" },
+    { mime: "text/markdown", expected: ".md" },
+    { mime: "IMAGE/JPEG", expected: ".jpg" },
+    { mime: "Audio/X-M4A", expected: ".m4a" },
+    { mime: "Video/QuickTime", expected: ".mov" },
+    { mime: "video/unknown", expected: undefined },
+    { mime: "application/x-custom", expected: undefined },
+    { mime: null, expected: undefined },
+    { mime: undefined, expected: undefined },
+  ] as const)("maps $mime to extension", ({ mime, expected }) => {
+    expect(extensionForMime(mime)).toBe(expected);
   });
 });
 
@@ -119,25 +105,23 @@ describe("isAudioFileName", () => {
 });
 
 describe("normalizeMimeType", () => {
-  it("normalizes case and strips parameters", () => {
-    expect(normalizeMimeType("Audio/MP4; codecs=mp4a.40.2")).toBe("audio/mp4");
-  });
-
-  it("returns undefined for empty input", () => {
-    expect(normalizeMimeType("   ")).toBeUndefined();
-    expect(normalizeMimeType(null)).toBeUndefined();
-    expect(normalizeMimeType(undefined)).toBeUndefined();
+  it.each([
+    { input: "Audio/MP4; codecs=mp4a.40.2", expected: "audio/mp4" },
+    { input: "   ", expected: undefined },
+    { input: null, expected: undefined },
+    { input: undefined, expected: undefined },
+  ] as const)("normalizes $input", ({ input, expected }) => {
+    expect(normalizeMimeType(input)).toBe(expected);
   });
 });
 
 describe("mediaKindFromMime", () => {
-  it("classifies text mimes as document", () => {
-    expect(mediaKindFromMime("text/plain")).toBe("document");
-    expect(mediaKindFromMime("text/csv")).toBe("document");
-    expect(mediaKindFromMime("text/html; charset=utf-8")).toBe("document");
-  });
-
-  it("keeps unknown mimes as unknown", () => {
-    expect(mediaKindFromMime("model/gltf+json")).toBe("unknown");
+  it.each([
+    { mime: "text/plain", expected: "document" },
+    { mime: "text/csv", expected: "document" },
+    { mime: "text/html; charset=utf-8", expected: "document" },
+    { mime: "model/gltf+json", expected: "unknown" },
+  ] as const)("classifies $mime", ({ mime, expected }) => {
+    expect(mediaKindFromMime(mime)).toBe(expected);
   });
 });

--- a/src/memory/manager.async-search.test.ts
+++ b/src/memory/manager.async-search.test.ts
@@ -64,25 +64,14 @@ describe("memory search async sync", () => {
     manager = result.manager as unknown as MemoryIndexManager;
 
     const pending = new Promise<void>(() => {});
-    (manager as unknown as { sync: () => Promise<void> }).sync = vi.fn(async () => pending);
+    const syncMock = vi.fn(async () => pending);
+    (manager as unknown as { sync: () => Promise<void> }).sync = syncMock;
 
-    const resolved = await new Promise<boolean>((resolve, reject) => {
-      const timeout = setTimeout(() => resolve(false), 1000);
-      const activeManager = manager;
-      if (!activeManager) {
-        throw new Error("manager missing");
-      }
-      void activeManager
-        .search("hello")
-        .then(() => {
-          clearTimeout(timeout);
-          resolve(true);
-        })
-        .catch((err) => {
-          clearTimeout(timeout);
-          reject(err);
-        });
-    });
-    expect(resolved).toBe(true);
+    const activeManager = manager;
+    if (!activeManager) {
+      throw new Error("manager missing");
+    }
+    await activeManager.search("hello");
+    expect(syncMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/memory/mmr.test.ts
+++ b/src/memory/mmr.test.ts
@@ -108,12 +108,15 @@ describe("computeMMRScore", () => {
   });
 });
 
+describe("empty input behavior", () => {
+  it("returns empty array for empty input", () => {
+    expect(mmrRerank([])).toEqual([]);
+    expect(applyMMRToHybridResults([])).toEqual([]);
+  });
+});
+
 describe("mmrRerank", () => {
   describe("edge cases", () => {
-    it("returns empty array for empty input", () => {
-      expect(mmrRerank([])).toEqual([]);
-    });
-
     it("returns single item unchanged", () => {
       const items: MMRItem[] = [{ id: "1", score: 0.9, content: "hello" }];
       expect(mmrRerank(items)).toEqual(items);
@@ -270,10 +273,6 @@ describe("applyMMRToHybridResults", () => {
     snippet: string;
     source: string;
   };
-
-  it("returns empty array for empty input", () => {
-    expect(applyMMRToHybridResults([])).toEqual([]);
-  });
 
   it("preserves all original fields", () => {
     const results: HybridResult[] = [

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -381,6 +381,48 @@ async function runViaMacAppExecHost(params: {
   });
 }
 
+async function sendJsonPayloadResult(
+  client: GatewayClient,
+  frame: NodeInvokeRequestPayload,
+  payload: unknown,
+) {
+  await sendInvokeResult(client, frame, {
+    ok: true,
+    payloadJSON: JSON.stringify(payload),
+  });
+}
+
+async function sendRawPayloadResult(
+  client: GatewayClient,
+  frame: NodeInvokeRequestPayload,
+  payloadJSON: string,
+) {
+  await sendInvokeResult(client, frame, {
+    ok: true,
+    payloadJSON,
+  });
+}
+
+async function sendErrorResult(
+  client: GatewayClient,
+  frame: NodeInvokeRequestPayload,
+  code: string,
+  message: string,
+) {
+  await sendInvokeResult(client, frame, {
+    ok: false,
+    error: { code, message },
+  });
+}
+
+async function sendInvalidRequestResult(
+  client: GatewayClient,
+  frame: NodeInvokeRequestPayload,
+  err: unknown,
+) {
+  await sendErrorResult(client, frame, "INVALID_REQUEST", String(err));
+}
+
 export async function handleInvoke(
   frame: NodeInvokeRequestPayload,
   client: GatewayClient,
@@ -397,17 +439,11 @@ export async function handleInvoke(
         hash: snapshot.hash,
         file: redactExecApprovals(snapshot.file),
       };
-      await sendInvokeResult(client, frame, {
-        ok: true,
-        payloadJSON: JSON.stringify(payload),
-      });
+      await sendJsonPayloadResult(client, frame, payload);
     } catch (err) {
       const message = String(err);
       const code = message.toLowerCase().includes("timed out") ? "TIMEOUT" : "INVALID_REQUEST";
-      await sendInvokeResult(client, frame, {
-        ok: false,
-        error: { code, message },
-      });
+      await sendErrorResult(client, frame, code, message);
     }
     return;
   }
@@ -431,15 +467,9 @@ export async function handleInvoke(
         hash: nextSnapshot.hash,
         file: redactExecApprovals(nextSnapshot.file),
       };
-      await sendInvokeResult(client, frame, {
-        ok: true,
-        payloadJSON: JSON.stringify(payload),
-      });
+      await sendJsonPayloadResult(client, frame, payload);
     } catch (err) {
-      await sendInvokeResult(client, frame, {
-        ok: false,
-        error: { code: "INVALID_REQUEST", message: String(err) },
-      });
+      await sendInvalidRequestResult(client, frame, err);
     }
     return;
   }
@@ -452,15 +482,9 @@ export async function handleInvoke(
       }
       const env = sanitizeEnv(undefined);
       const payload = await handleSystemWhich(params, env);
-      await sendInvokeResult(client, frame, {
-        ok: true,
-        payloadJSON: JSON.stringify(payload),
-      });
+      await sendJsonPayloadResult(client, frame, payload);
     } catch (err) {
-      await sendInvokeResult(client, frame, {
-        ok: false,
-        error: { code: "INVALID_REQUEST", message: String(err) },
-      });
+      await sendInvalidRequestResult(client, frame, err);
     }
     return;
   }
@@ -468,24 +492,15 @@ export async function handleInvoke(
   if (command === "browser.proxy") {
     try {
       const payload = await runBrowserProxyCommand(frame.paramsJSON);
-      await sendInvokeResult(client, frame, {
-        ok: true,
-        payloadJSON: payload,
-      });
+      await sendRawPayloadResult(client, frame, payload);
     } catch (err) {
-      await sendInvokeResult(client, frame, {
-        ok: false,
-        error: { code: "INVALID_REQUEST", message: String(err) },
-      });
+      await sendInvalidRequestResult(client, frame, err);
     }
     return;
   }
 
   if (command !== "system.run") {
-    await sendInvokeResult(client, frame, {
-      ok: false,
-      error: { code: "UNAVAILABLE", message: "command not supported" },
-    });
+    await sendErrorResult(client, frame, "UNAVAILABLE", "command not supported");
     return;
   }
 
@@ -493,18 +508,12 @@ export async function handleInvoke(
   try {
     params = decodeParams<SystemRunParams>(frame.paramsJSON);
   } catch (err) {
-    await sendInvokeResult(client, frame, {
-      ok: false,
-      error: { code: "INVALID_REQUEST", message: String(err) },
-    });
+    await sendInvalidRequestResult(client, frame, err);
     return;
   }
 
   if (!Array.isArray(params.command) || params.command.length === 0) {
-    await sendInvokeResult(client, frame, {
-      ok: false,
-      error: { code: "INVALID_REQUEST", message: "command required" },
-    });
+    await sendErrorResult(client, frame, "INVALID_REQUEST", "command required");
     return;
   }
 
@@ -515,10 +524,7 @@ export async function handleInvoke(
     rawCommand: rawCommand || null,
   });
   if (!consistency.ok) {
-    await sendInvokeResult(client, frame, {
-      ok: false,
-      error: { code: "INVALID_REQUEST", message: consistency.message },
-    });
+    await sendErrorResult(client, frame, "INVALID_REQUEST", consistency.message);
     return;
   }
 

--- a/src/plugins/logger.test.ts
+++ b/src/plugins/logger.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPluginLoaderLogger } from "./logger.js";
+
+describe("plugins/logger", () => {
+  it("forwards logger methods", () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+    const error = vi.fn();
+    const debug = vi.fn();
+    const logger = createPluginLoaderLogger({ info, warn, error, debug });
+
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+    logger.debug?.("d");
+
+    expect(info).toHaveBeenCalledWith("i");
+    expect(warn).toHaveBeenCalledWith("w");
+    expect(error).toHaveBeenCalledWith("e");
+    expect(debug).toHaveBeenCalledWith("d");
+  });
+});

--- a/src/plugins/logger.ts
+++ b/src/plugins/logger.ts
@@ -1,0 +1,17 @@
+import type { PluginLogger } from "./types.js";
+
+type LoggerLike = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+  debug?: (message: string) => void;
+};
+
+export function createPluginLoaderLogger(logger: LoggerLike): PluginLogger {
+  return {
+    info: (msg) => logger.info(msg),
+    warn: (msg) => logger.warn(msg),
+    error: (msg) => logger.error(msg),
+    debug: (msg) => logger.debug?.(msg),
+  };
+}

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -1,5 +1,6 @@
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { loadOpenClawPlugins, type PluginLoadOptions } from "./loader.js";
+import { createPluginLoaderLogger } from "./logger.js";
 import type { ProviderPlugin } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
@@ -11,12 +12,7 @@ export function resolvePluginProviders(params: {
   const registry = loadOpenClawPlugins({
     config: params.config,
     workspaceDir: params.workspaceDir,
-    logger: {
-      info: (msg) => log.info(msg),
-      warn: (msg) => log.warn(msg),
-      error: (msg) => log.error(msg),
-      debug: (msg) => log.debug(msg),
-    },
+    logger: createPluginLoaderLogger(log),
   });
 
   return registry.providers.map((entry) => entry.provider);

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -3,6 +3,7 @@ import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import { loadConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { loadOpenClawPlugins } from "./loader.js";
+import { createPluginLoaderLogger } from "./logger.js";
 import type { PluginRegistry } from "./registry.js";
 
 export type PluginStatusReport = PluginRegistry & {
@@ -24,12 +25,7 @@ export function buildPluginStatusReport(params?: {
   const registry = loadOpenClawPlugins({
     config,
     workspaceDir,
-    logger: {
-      info: (msg) => log.info(msg),
-      warn: (msg) => log.warn(msg),
-      error: (msg) => log.error(msg),
-      debug: (msg) => log.debug(msg),
-    },
+    logger: createPluginLoaderLogger(log),
   });
 
   return {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -3,6 +3,7 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.js";
 import { loadOpenClawPlugins } from "./loader.js";
+import { createPluginLoaderLogger } from "./logger.js";
 import type { OpenClawPluginToolContext } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
@@ -57,12 +58,7 @@ export function resolvePluginTools(params: {
   const registry = loadOpenClawPlugins({
     config: effectiveConfig,
     workspaceDir: params.context.workspaceDir,
-    logger: {
-      info: (msg) => log.info(msg),
-      warn: (msg) => log.warn(msg),
-      error: (msg) => log.error(msg),
-      debug: (msg) => log.debug(msg),
-    },
+    logger: createPluginLoaderLogger(log),
   });
 
   const tools: AnyAgentTool[] = [];

--- a/src/polls.test.ts
+++ b/src/polls.test.ts
@@ -24,10 +24,14 @@ describe("polls", () => {
     ).toThrow(/at most 2/);
   });
 
-  it("clamps poll duration with defaults", () => {
-    expect(normalizePollDurationHours(undefined, { defaultHours: 24, maxHours: 48 })).toBe(24);
-    expect(normalizePollDurationHours(999, { defaultHours: 24, maxHours: 48 })).toBe(48);
-    expect(normalizePollDurationHours(1, { defaultHours: 24, maxHours: 48 })).toBe(1);
+  it.each([
+    { durationHours: undefined, expected: 24 },
+    { durationHours: 999, expected: 48 },
+    { durationHours: 1, expected: 1 },
+  ])("clamps poll duration for $durationHours hours", ({ durationHours, expected }) => {
+    expect(normalizePollDurationHours(durationHours, { defaultHours: 24, maxHours: 48 })).toBe(
+      expected,
+    );
   });
 
   it("rejects both durationSeconds and durationHours", () => {

--- a/src/process/supervisor/adapters/pty.test.ts
+++ b/src/process/supervisor/adapters/pty.test.ts
@@ -124,7 +124,7 @@ describe("createPtyAdapter", () => {
 
     await expect(waitPromise).resolves.toEqual({ code: 0, signal: 9 });
 
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(4_001);
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: 9 });
   });
 

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -9,13 +9,11 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { resolveNativeCommandsEnabled, resolveNativeSkillsEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+import { normalizeStringEntries } from "../shared/string-normalization.js";
 import type { SecurityAuditFinding, SecurityAuditSeverity } from "./audit.js";
 
 function normalizeAllowFromList(list: Array<string | number> | undefined | null): string[] {
-  if (!Array.isArray(list)) {
-    return [];
-  }
-  return list.map((v) => String(v).trim()).filter(Boolean);
+  return normalizeStringEntries(Array.isArray(list) ? list : undefined);
 }
 
 function classifyChannelWarningSeverity(message: string): SecurityAuditSeverity {

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 import type { SecurityAuditFinding, SecurityAuditSeverity } from "./audit.js";
+import { resolveDmAllowState } from "./dm-policy-shared.js";
 
 function normalizeAllowFromList(list: Array<string | number> | undefined | null): string[] {
   return normalizeStringEntries(Array.isArray(list) ? list : undefined);
@@ -63,22 +64,12 @@ export async function collectChannelSecurityFindings(params: {
     normalizeEntry?: (raw: string) => string;
   }) => {
     const policyPath = input.policyPath ?? `${input.allowFromPath}policy`;
-    const configAllowFrom = normalizeAllowFromList(input.allowFrom);
-    const hasWildcard = configAllowFrom.includes("*");
+    const { hasWildcard, isMultiUserDm } = await resolveDmAllowState({
+      provider: input.provider,
+      allowFrom: input.allowFrom,
+      normalizeEntry: input.normalizeEntry,
+    });
     const dmScope = params.cfg.session?.dmScope ?? "main";
-    const storeAllowFrom = await readChannelAllowFromStore(input.provider).catch(() => []);
-    const normalizeEntry = input.normalizeEntry ?? ((value: string) => value);
-    const normalizedCfg = configAllowFrom
-      .filter((value) => value !== "*")
-      .map((value) => normalizeEntry(value))
-      .map((value) => value.trim())
-      .filter(Boolean);
-    const normalizedStore = storeAllowFrom
-      .map((value) => normalizeEntry(value))
-      .map((value) => value.trim())
-      .filter(Boolean);
-    const allowCount = Array.from(new Set([...normalizedCfg, ...normalizedStore])).length;
-    const isMultiUserDm = hasWildcard || allowCount > 1;
 
     if (input.dmPolicy === "open") {
       const allowFromKey = `${input.allowFromPath}allowFrom`;

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -96,6 +96,26 @@ function formatCodeSafetyDetails(findings: SkillScanFinding[], rootDir: string):
     .join("\n");
 }
 
+async function listInstalledPluginDirs(params: {
+  stateDir: string;
+  onReadError?: (error: unknown) => void;
+}): Promise<{ extensionsDir: string; pluginDirs: string[] }> {
+  const extensionsDir = path.join(params.stateDir, "extensions");
+  const st = await safeStat(extensionsDir);
+  if (!st.ok || !st.isDir) {
+    return { extensionsDir, pluginDirs: [] };
+  }
+  const entries = await fs.readdir(extensionsDir, { withFileTypes: true }).catch((err) => {
+    params.onReadError?.(err);
+    return [];
+  });
+  const pluginDirs = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter(Boolean);
+  return { extensionsDir, pluginDirs };
+}
+
 function resolveToolPolicies(params: {
   cfg: OpenClawConfig;
   agentTools?: AgentToolsConfig;
@@ -204,17 +224,9 @@ export async function collectPluginsTrustFindings(params: {
   stateDir: string;
 }): Promise<SecurityAuditFinding[]> {
   const findings: SecurityAuditFinding[] = [];
-  const extensionsDir = path.join(params.stateDir, "extensions");
-  const st = await safeStat(extensionsDir);
-  if (!st.ok || !st.isDir) {
-    return findings;
-  }
-
-  const entries = await fs.readdir(extensionsDir, { withFileTypes: true }).catch(() => []);
-  const pluginDirs = entries
-    .filter((e) => e.isDirectory())
-    .map((e) => e.name)
-    .filter(Boolean);
+  const { extensionsDir, pluginDirs } = await listInstalledPluginDirs({
+    stateDir: params.stateDir,
+  });
   if (pluginDirs.length === 0) {
     return findings;
   }
@@ -619,24 +631,19 @@ export async function collectPluginsCodeSafetyFindings(params: {
   stateDir: string;
 }): Promise<SecurityAuditFinding[]> {
   const findings: SecurityAuditFinding[] = [];
-  const extensionsDir = path.join(params.stateDir, "extensions");
-  const st = await safeStat(extensionsDir);
-  if (!st.ok || !st.isDir) {
-    return findings;
-  }
-
-  const entries = await fs.readdir(extensionsDir, { withFileTypes: true }).catch((err) => {
-    findings.push({
-      checkId: "plugins.code_safety.scan_failed",
-      severity: "warn",
-      title: "Plugin extensions directory scan failed",
-      detail: `Static code scan could not list extensions directory: ${String(err)}`,
-      remediation:
-        "Check file permissions and plugin layout, then rerun `openclaw security audit --deep`.",
-    });
-    return [];
+  const { extensionsDir, pluginDirs } = await listInstalledPluginDirs({
+    stateDir: params.stateDir,
+    onReadError: (err) => {
+      findings.push({
+        checkId: "plugins.code_safety.scan_failed",
+        severity: "warn",
+        title: "Plugin extensions directory scan failed",
+        detail: `Static code scan could not list extensions directory: ${String(err)}`,
+        remediation:
+          "Check file permissions and plugin layout, then rerun `openclaw security audit --deep`.",
+      });
+    },
   });
-  const pluginDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
 
   for (const pluginName of pluginDirs) {
     const pluginPath = path.join(extensionsDir, pluginName);

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { resolveDmAllowState } from "./dm-policy-shared.js";
+
+describe("security/dm-policy-shared", () => {
+  it("normalizes config + store allow entries and counts distinct senders", async () => {
+    const state = await resolveDmAllowState({
+      provider: "telegram",
+      allowFrom: [" * ", " alice ", "ALICE", "bob"],
+      normalizeEntry: (value) => value.toLowerCase(),
+      readStore: async () => [" Bob ", "carol", ""],
+    });
+    expect(state.configAllowFrom).toEqual(["*", "alice", "ALICE", "bob"]);
+    expect(state.hasWildcard).toBe(true);
+    expect(state.allowCount).toBe(3);
+    expect(state.isMultiUserDm).toBe(true);
+  });
+
+  it("handles empty allowlists and store failures", async () => {
+    const state = await resolveDmAllowState({
+      provider: "slack",
+      allowFrom: undefined,
+      readStore: async () => {
+        throw new Error("offline");
+      },
+    });
+    expect(state.configAllowFrom).toEqual([]);
+    expect(state.hasWildcard).toBe(false);
+    expect(state.allowCount).toBe(0);
+    expect(state.isMultiUserDm).toBe(false);
+  });
+});

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -1,0 +1,40 @@
+import type { ChannelId } from "../channels/plugins/types.js";
+import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+import { normalizeStringEntries } from "../shared/string-normalization.js";
+
+export async function resolveDmAllowState(params: {
+  provider: ChannelId;
+  allowFrom?: Array<string | number> | null;
+  normalizeEntry?: (raw: string) => string;
+  readStore?: (provider: ChannelId) => Promise<string[]>;
+}): Promise<{
+  configAllowFrom: string[];
+  hasWildcard: boolean;
+  allowCount: number;
+  isMultiUserDm: boolean;
+}> {
+  const configAllowFrom = normalizeStringEntries(
+    Array.isArray(params.allowFrom) ? params.allowFrom : undefined,
+  );
+  const hasWildcard = configAllowFrom.includes("*");
+  const storeAllowFrom = await (params.readStore ?? readChannelAllowFromStore)(
+    params.provider,
+  ).catch(() => []);
+  const normalizeEntry = params.normalizeEntry ?? ((value: string) => value);
+  const normalizedCfg = configAllowFrom
+    .filter((value) => value !== "*")
+    .map((value) => normalizeEntry(value))
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const normalizedStore = storeAllowFrom
+    .map((value) => normalizeEntry(value))
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const allowCount = Array.from(new Set([...normalizedCfg, ...normalizedStore])).length;
+  return {
+    configAllowFrom,
+    hasWildcard,
+    allowCount,
+    isMultiUserDm: hasWildcard || allowCount > 1,
+  };
+}

--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { hasErrnoCode } from "../infra/errors.js";
+import { isPathInside } from "./scan-paths.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -250,13 +251,6 @@ function normalizeScanOptions(opts?: SkillScanOptions): Required<SkillScanOption
     maxFiles: Math.max(1, opts?.maxFiles ?? DEFAULT_MAX_SCAN_FILES),
     maxFileBytes: Math.max(1, opts?.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES),
   };
-}
-
-function isPathInside(basePath: string, candidatePath: string): boolean {
-  const base = path.resolve(basePath);
-  const candidate = path.resolve(candidatePath);
-  const rel = path.relative(base, candidate);
-  return rel === "" || (!rel.startsWith(`..${path.sep}`) && rel !== ".." && !path.isAbsolute(rel));
 }
 
 async function walkDirWithLimit(dirPath: string, maxFiles: number): Promise<string[]> {

--- a/src/shared/entry-status.ts
+++ b/src/shared/entry-status.ts
@@ -7,6 +7,10 @@ import {
   type RequirementsMetadata,
 } from "./requirements.js";
 
+export type EntryMetadataRequirementsParams = Parameters<
+  typeof evaluateEntryMetadataRequirements
+>[0];
+
 export function evaluateEntryMetadataRequirements(params: {
   always: boolean;
   metadata?: (RequirementsMetadata & { emoji?: string; homepage?: string }) | null;
@@ -50,4 +54,13 @@ export function evaluateEntryMetadataRequirements(params: {
     requirementsSatisfied: eligible,
     configChecks,
   };
+}
+
+export function evaluateEntryMetadataRequirementsForCurrentPlatform(
+  params: Omit<EntryMetadataRequirementsParams, "localPlatform">,
+): ReturnType<typeof evaluateEntryMetadataRequirements> {
+  return evaluateEntryMetadataRequirements({
+    ...params,
+    localPlatform: process.platform,
+  });
 }

--- a/src/shared/node-list-parse.test.ts
+++ b/src/shared/node-list-parse.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { parseNodeList, parsePairingList } from "./node-list-parse.js";
+
+describe("shared/node-list-parse", () => {
+  it("parses node.list payloads", () => {
+    expect(parseNodeList({ nodes: [{ nodeId: "node-1" }] })).toEqual([{ nodeId: "node-1" }]);
+    expect(parseNodeList({ nodes: "nope" })).toEqual([]);
+    expect(parseNodeList(null)).toEqual([]);
+  });
+
+  it("parses node.pair.list payloads", () => {
+    expect(
+      parsePairingList({
+        pending: [{ requestId: "r1", nodeId: "n1", ts: 1 }],
+        paired: [{ nodeId: "n1" }],
+      }),
+    ).toEqual({
+      pending: [{ requestId: "r1", nodeId: "n1", ts: 1 }],
+      paired: [{ nodeId: "n1" }],
+    });
+    expect(parsePairingList({ pending: 1, paired: "x" })).toEqual({ pending: [], paired: [] });
+    expect(parsePairingList(undefined)).toEqual({ pending: [], paired: [] });
+  });
+});

--- a/src/shared/node-list-parse.ts
+++ b/src/shared/node-list-parse.ts
@@ -1,0 +1,17 @@
+import type { NodeListNode, PairedNode, PairingList, PendingRequest } from "./node-list-types.js";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+export function parsePairingList(value: unknown): PairingList {
+  const obj = asRecord(value);
+  const pending = Array.isArray(obj.pending) ? (obj.pending as PendingRequest[]) : [];
+  const paired = Array.isArray(obj.paired) ? (obj.paired as PairedNode[]) : [];
+  return { pending, paired };
+}
+
+export function parseNodeList(value: unknown): NodeListNode[] {
+  const obj = asRecord(value);
+  return Array.isArray(obj.nodes) ? (obj.nodes as NodeListNode[]) : [];
+}

--- a/src/shared/string-normalization.test.ts
+++ b/src/shared/string-normalization.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  normalizeAtHashSlug,
   normalizeHyphenSlug,
   normalizeStringEntries,
   normalizeStringEntriesLower,
@@ -21,5 +22,12 @@ describe("shared/string-normalization", () => {
     expect(normalizeHyphenSlug("..foo---bar..")).toBe("foo-bar");
     expect(normalizeHyphenSlug(undefined)).toBe("");
     expect(normalizeHyphenSlug(null)).toBe("");
+  });
+
+  it("normalizes @/# prefixed slugs used by channel allowlists", () => {
+    expect(normalizeAtHashSlug(" #My_Channel + Alerts ")).toBe("my-channel-alerts");
+    expect(normalizeAtHashSlug("@@Room___Name")).toBe("room-name");
+    expect(normalizeAtHashSlug(undefined)).toBe("");
+    expect(normalizeAtHashSlug(null)).toBe("");
   });
 });

--- a/src/shared/string-normalization.ts
+++ b/src/shared/string-normalization.ts
@@ -15,3 +15,14 @@ export function normalizeHyphenSlug(raw?: string | null) {
   const cleaned = dashed.replace(/[^a-z0-9#@._+-]+/g, "-");
   return cleaned.replace(/-{2,}/g, "-").replace(/^[-.]+|[-.]+$/g, "");
 }
+
+export function normalizeAtHashSlug(raw?: string | null) {
+  const trimmed = raw?.trim().toLowerCase() ?? "";
+  if (!trimmed) {
+    return "";
+  }
+  const withoutPrefix = trimmed.replace(/^[@#]+/, "");
+  const dashed = withoutPrefix.replace(/[\s_]+/g, "-");
+  const cleaned = dashed.replace(/[^a-z0-9-]+/g, "-");
+  return cleaned.replace(/-{2,}/g, "-").replace(/^-+|-+$/g, "");
+}

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -7,33 +7,20 @@ import type { SignalReactionNotificationMode } from "../config/types.js";
 import { waitForTransportReady } from "../infra/transport-ready.js";
 import { saveMediaBuffer } from "../media/store.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
+import { normalizeStringEntries } from "../shared/string-normalization.js";
 import { normalizeE164 } from "../utils.js";
 import { resolveSignalAccount } from "./accounts.js";
 import { signalCheck, signalRpcRequest } from "./client.js";
 import { spawnSignalDaemon } from "./daemon.js";
 import { isSignalSenderAllowed, type resolveSignalSender } from "./identity.js";
 import { createSignalEventHandler } from "./monitor/event-handler.js";
+import type {
+  SignalAttachment,
+  SignalReactionMessage,
+  SignalReactionTarget,
+} from "./monitor/event-handler.types.js";
 import { sendMessageSignal } from "./send.js";
 import { runSignalSseLoop } from "./sse-reconnect.js";
-
-type SignalReactionMessage = {
-  emoji?: string | null;
-  targetAuthor?: string | null;
-  targetAuthorUuid?: string | null;
-  targetSentTimestamp?: number | null;
-  isRemove?: boolean | null;
-  groupInfo?: {
-    groupId?: string | null;
-    groupName?: string | null;
-  } | null;
-};
-
-type SignalAttachment = {
-  id?: string | null;
-  contentType?: string | null;
-  filename?: string | null;
-  size?: number | null;
-};
 
 export type MonitorSignalOpts = {
   runtime?: RuntimeEnv;
@@ -61,14 +48,8 @@ function resolveRuntime(opts: MonitorSignalOpts): RuntimeEnv {
 }
 
 function normalizeAllowList(raw?: Array<string | number>): string[] {
-  return (raw ?? []).map((entry) => String(entry).trim()).filter(Boolean);
+  return normalizeStringEntries(raw);
 }
-
-type SignalReactionTarget = {
-  kind: "phone" | "uuid";
-  id: string;
-  display: string;
-};
 
 function resolveSignalReactionTargets(reaction: SignalReactionMessage): SignalReactionTarget[] {
   const targets: SignalReactionTarget[] = [];

--- a/src/slack/format.ts
+++ b/src/slack/format.ts
@@ -94,6 +94,20 @@ type SlackMarkdownOptions = {
   tableMode?: MarkdownTableMode;
 };
 
+function buildSlackRenderOptions() {
+  return {
+    styleMarkers: {
+      bold: { open: "*", close: "*" },
+      italic: { open: "_", close: "_" },
+      strikethrough: { open: "~", close: "~" },
+      code: { open: "`", close: "`" },
+      code_block: { open: "```\n", close: "```" },
+    },
+    escapeText: escapeSlackMrkdwnText,
+    buildLink: buildSlackLink,
+  };
+}
+
 export function markdownToSlackMrkdwn(
   markdown: string,
   options: SlackMarkdownOptions = {},
@@ -105,17 +119,7 @@ export function markdownToSlackMrkdwn(
     blockquotePrefix: "> ",
     tableMode: options.tableMode,
   });
-  return renderMarkdownWithMarkers(ir, {
-    styleMarkers: {
-      bold: { open: "*", close: "*" },
-      italic: { open: "_", close: "_" },
-      strikethrough: { open: "~", close: "~" },
-      code: { open: "`", close: "`" },
-      code_block: { open: "```\n", close: "```" },
-    },
-    escapeText: escapeSlackMrkdwnText,
-    buildLink: buildSlackLink,
-  });
+  return renderMarkdownWithMarkers(ir, buildSlackRenderOptions());
 }
 
 export function markdownToSlackMrkdwnChunks(
@@ -131,17 +135,6 @@ export function markdownToSlackMrkdwnChunks(
     tableMode: options.tableMode,
   });
   const chunks = chunkMarkdownIR(ir, limit);
-  return chunks.map((chunk) =>
-    renderMarkdownWithMarkers(chunk, {
-      styleMarkers: {
-        bold: { open: "*", close: "*" },
-        italic: { open: "_", close: "_" },
-        strikethrough: { open: "~", close: "~" },
-        code: { open: "`", close: "`" },
-        code_block: { open: "```\n", close: "```" },
-      },
-      escapeText: escapeSlackMrkdwnText,
-      buildLink: buildSlackLink,
-    }),
-  );
+  const renderOptions = buildSlackRenderOptions();
+  return chunks.map((chunk) => renderMarkdownWithMarkers(chunk, renderOptions));
 }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -22,14 +22,17 @@ import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
-  firstDefined,
   isSenderAllowed,
   normalizeAllowFromWithStore,
   type NormalizedAllowFrom,
 } from "./bot-access.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
-import { MEDIA_GROUP_TIMEOUT_MS, type MediaGroupEntry } from "./bot-updates.js";
+import {
+  MEDIA_GROUP_TIMEOUT_MS,
+  type MediaGroupEntry,
+  type TelegramUpdateKeyContext,
+} from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
 import {
   buildTelegramGroupPeerId,
@@ -1035,25 +1038,33 @@ export const registerTelegramHandlers = ({
     }
   });
 
-  bot.on("message", async (ctx) => {
+  type InboundTelegramEvent = {
+    ctxForDedupe: TelegramUpdateKeyContext;
+    ctx: TelegramContext;
+    msg: Message;
+    chatId: number;
+    isGroup: boolean;
+    isForum: boolean;
+    messageThreadId?: number;
+    senderId: string;
+    senderUsername: string;
+    requireConfiguredGroup: boolean;
+    sendOversizeWarning: boolean;
+    oversizeLogMessage: string;
+    errorMessage: string;
+  };
+
+  const handleInboundMessageLike = async (event: InboundTelegramEvent) => {
     try {
-      const msg = ctx.message;
-      if (!msg) {
-        return;
-      }
-      if (shouldSkipUpdate(ctx)) {
+      if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
       }
 
-      const chatId = msg.chat.id;
-      const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
-      const messageThreadId = msg.message_thread_id;
-      const isForum = msg.chat.is_forum === true;
       const groupAllowContext = await resolveTelegramGroupAllowFromContext({
-        chatId,
+        chatId: event.chatId,
         accountId,
-        isForum,
-        messageThreadId,
+        isForum: event.isForum,
+        messageThreadId: event.messageThreadId,
         groupAllowFrom,
         resolveTelegramGroupConfig,
       });
@@ -1066,16 +1077,19 @@ export const registerTelegramHandlers = ({
         hasGroupAllowOverride,
       } = groupAllowContext;
 
-      const senderId = msg.from?.id != null ? String(msg.from.id) : "";
-      const senderUsername = msg.from?.username ?? "";
+      if (event.requireConfiguredGroup && (!groupConfig || groupConfig.enabled === false)) {
+        logVerbose(`Blocked telegram channel ${event.chatId} (channel disabled)`);
+        return;
+      }
+
       if (
         shouldSkipGroupMessage({
-          isGroup,
-          chatId,
-          chatTitle: msg.chat.title,
+          isGroup: event.isGroup,
+          chatId: event.chatId,
+          chatTitle: event.msg.chat.title,
           resolvedThreadId,
-          senderId,
-          senderUsername,
+          senderId: event.senderId,
+          senderUsername: event.senderUsername,
           effectiveGroupAllow,
           hasGroupAllowOverride,
           groupConfig,
@@ -1086,155 +1100,91 @@ export const registerTelegramHandlers = ({
       }
 
       await processInboundMessage({
-        ctx,
-        msg,
-        chatId,
+        ctx: event.ctx,
+        msg: event.msg,
+        chatId: event.chatId,
         resolvedThreadId,
         storeAllowFrom,
-        sendOversizeWarning: true,
-        oversizeLogMessage: "media exceeds size limit",
+        sendOversizeWarning: event.sendOversizeWarning,
+        oversizeLogMessage: event.oversizeLogMessage,
       });
     } catch (err) {
-      runtime.error?.(danger(`handler failed: ${String(err)}`));
+      runtime.error?.(danger(`${event.errorMessage}: ${String(err)}`));
     }
+  };
+
+  bot.on("message", async (ctx) => {
+    const msg = ctx.message;
+    if (!msg) {
+      return;
+    }
+    await handleInboundMessageLike({
+      ctxForDedupe: ctx,
+      ctx: buildSyntheticContext(ctx, msg),
+      msg,
+      chatId: msg.chat.id,
+      isGroup: msg.chat.type === "group" || msg.chat.type === "supergroup",
+      isForum: msg.chat.is_forum === true,
+      messageThreadId: msg.message_thread_id,
+      senderId: msg.from?.id != null ? String(msg.from.id) : "",
+      senderUsername: msg.from?.username ?? "",
+      requireConfiguredGroup: false,
+      sendOversizeWarning: true,
+      oversizeLogMessage: "media exceeds size limit",
+      errorMessage: "handler failed",
+    });
   });
 
   // Handle channel posts — enables bot-to-bot communication via Telegram channels.
   // Telegram bots cannot see other bot messages in groups, but CAN in channels.
   // This handler normalizes channel_post updates into the standard message pipeline.
   bot.on("channel_post", async (ctx) => {
-    try {
-      const post = ctx.channelPost;
-      if (!post) {
-        return;
-      }
-
-      // Deduplication check — same as the regular message handler
-      if (shouldSkipUpdate(ctx)) {
-        return;
-      }
-
-      const chatId = post.chat.id;
-
-      // Use the full group allow-from context for access control (same as message handler)
-      const groupAllowContext = await resolveTelegramGroupAllowFromContext({
-        chatId,
-        accountId,
-        isForum: false,
-        messageThreadId: undefined,
-        groupAllowFrom,
-        resolveTelegramGroupConfig,
-      });
-      const { storeAllowFrom, groupConfig, effectiveGroupAllow, hasGroupAllowOverride } =
-        groupAllowContext;
-
-      // Check group allowlist (channels use the same groups config)
-      const groupAllowlist = resolveGroupPolicy(chatId);
-      if (groupAllowlist.allowlistEnabled && !groupAllowlist.allowed) {
-        return;
-      }
-
-      if (!groupConfig || groupConfig.enabled === false) {
-        logVerbose(`Blocked telegram channel ${chatId} (channel disabled)`);
-        return;
-      }
-
-      // Group policy filtering (same as message handler)
-      const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = firstDefined(
-        groupConfig?.groupPolicy,
-        telegramCfg.groupPolicy,
-        defaultGroupPolicy,
-        "open",
-      );
-      if (groupPolicy === "disabled") {
-        logVerbose(`Blocked telegram channel message (groupPolicy: disabled)`);
-        return;
-      }
-
-      if (hasGroupAllowOverride) {
-        const senderId = post.sender_chat?.id ?? post.from?.id;
-        const senderUsername = post.sender_chat?.username ?? post.from?.username ?? "";
-        const allowed =
-          senderId != null &&
-          isSenderAllowed({
-            allow: effectiveGroupAllow,
-            senderId: String(senderId),
-            senderUsername,
-          });
-        if (!allowed) {
-          logVerbose(
-            `Blocked telegram channel sender ${senderId ?? "unknown"} (group allowFrom override)`,
-          );
-          return;
-        }
-      }
-
-      if (groupPolicy === "allowlist") {
-        const senderId = post.sender_chat?.id ?? post.from?.id;
-        if (senderId == null) {
-          logVerbose(`Blocked telegram channel message (no sender ID, groupPolicy: allowlist)`);
-          return;
-        }
-        if (!effectiveGroupAllow.hasEntries) {
-          logVerbose(
-            "Blocked telegram channel message (groupPolicy: allowlist, no allowlist entries)",
-          );
-          return;
-        }
-        const senderUsername = post.sender_chat?.username ?? post.from?.username ?? "";
-        if (
-          !isSenderAllowed({
-            allow: effectiveGroupAllow,
-            senderId: String(senderId),
-            senderUsername,
-          })
-        ) {
-          logVerbose(`Blocked telegram channel message from ${senderId} (groupPolicy: allowlist)`);
-          return;
-        }
-      }
-
-      // Build a synthetic `from` field since channel posts may not have one.
-      // Use sender_chat (the bot/user that posted) if available.
-      const syntheticFrom = post.sender_chat
-        ? {
-            id: post.sender_chat.id,
-            is_bot: true as const,
-            first_name: post.sender_chat.title || "Channel",
-            username: post.sender_chat.username,
-          }
-        : {
-            id: chatId,
-            is_bot: true as const,
-            first_name: post.chat.title || "Channel",
-            username: post.chat.username,
-          };
-
-      const syntheticMsg: Message = {
-        ...post,
-        from: post.from ?? syntheticFrom,
-        chat: {
-          ...post.chat,
-          type: "supergroup" as const,
-        },
-      } as Message;
-
-      const syntheticCtx = Object.create(ctx, {
-        message: { value: syntheticMsg, writable: true, enumerable: true },
-      });
-
-      await processInboundMessage({
-        ctx: syntheticCtx as TelegramContext,
-        msg: syntheticMsg,
-        chatId,
-        resolvedThreadId: undefined,
-        storeAllowFrom,
-        sendOversizeWarning: false,
-        oversizeLogMessage: "channel post media exceeds size limit",
-      });
-    } catch (err) {
-      runtime.error?.(danger(`channel_post handler failed: ${String(err)}`));
+    const post = ctx.channelPost;
+    if (!post) {
+      return;
     }
+
+    const chatId = post.chat.id;
+    const syntheticFrom = post.sender_chat
+      ? {
+          id: post.sender_chat.id,
+          is_bot: true as const,
+          first_name: post.sender_chat.title || "Channel",
+          username: post.sender_chat.username,
+        }
+      : {
+          id: chatId,
+          is_bot: true as const,
+          first_name: post.chat.title || "Channel",
+          username: post.chat.username,
+        };
+    const syntheticMsg: Message = {
+      ...post,
+      from: post.from ?? syntheticFrom,
+      chat: {
+        ...post.chat,
+        type: "supergroup" as const,
+      },
+    } as Message;
+
+    await handleInboundMessageLike({
+      ctxForDedupe: ctx,
+      ctx: buildSyntheticContext(ctx, syntheticMsg),
+      msg: syntheticMsg,
+      chatId,
+      isGroup: true,
+      isForum: false,
+      senderId:
+        post.sender_chat?.id != null
+          ? String(post.sender_chat.id)
+          : post.from?.id != null
+            ? String(post.from.id)
+            : "",
+      senderUsername: post.sender_chat?.username ?? post.from?.username ?? "",
+      requireConfiguredGroup: true,
+      sendOversizeWarning: false,
+      oversizeLogMessage: "channel post media exceeds size limit",
+      errorMessage: "channel_post handler failed",
+    });
   });
 };

--- a/src/telegram/bot-updates.ts
+++ b/src/telegram/bot-updates.ts
@@ -19,9 +19,13 @@ export type TelegramUpdateKeyContext = {
     update_id?: number;
     message?: Message;
     edited_message?: Message;
+    channel_post?: Message;
+    edited_channel_post?: Message;
   };
   update_id?: number;
   message?: Message;
+  channelPost?: Message;
+  editedChannelPost?: Message;
   callbackQuery?: { id?: string; message?: Message };
 };
 
@@ -38,7 +42,14 @@ export const buildTelegramUpdateKey = (ctx: TelegramUpdateKeyContext) => {
     return `callback:${callbackId}`;
   }
   const msg =
-    ctx.message ?? ctx.update?.message ?? ctx.update?.edited_message ?? ctx.callbackQuery?.message;
+    ctx.message ??
+    ctx.channelPost ??
+    ctx.editedChannelPost ??
+    ctx.update?.message ??
+    ctx.update?.edited_message ??
+    ctx.update?.channel_post ??
+    ctx.update?.edited_channel_post ??
+    ctx.callbackQuery?.message;
   const chatId = msg?.chat?.id;
   const messageId = msg?.message_id;
   if (typeof chatId !== "undefined" && typeof messageId === "number") {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -66,9 +66,13 @@ export function getTelegramSequentialKey(ctx: {
   chat?: { id?: number };
   me?: UserFromGetMe;
   message?: Message;
+  channelPost?: Message;
+  editedChannelPost?: Message;
   update?: {
     message?: Message;
     edited_message?: Message;
+    channel_post?: Message;
+    edited_channel_post?: Message;
     callback_query?: { message?: Message };
     message_reaction?: { chat?: { id?: number } };
   };
@@ -80,8 +84,12 @@ export function getTelegramSequentialKey(ctx: {
   }
   const msg =
     ctx.message ??
+    ctx.channelPost ??
+    ctx.editedChannelPost ??
     ctx.update?.message ??
     ctx.update?.edited_message ??
+    ctx.update?.channel_post ??
+    ctx.update?.edited_channel_post ??
     ctx.update?.callback_query?.message;
   const chatId = msg?.chat?.id ?? ctx.chat?.id;
   const rawText = msg?.text ?? msg?.caption;

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -64,12 +64,6 @@ describe("buildTelegramThreadParams", () => {
       message_thread_id: 0,
     });
   });
-
-  it("normalizes thread ids to integers", () => {
-    expect(buildTelegramThreadParams({ id: 42.9, scope: "forum" })).toEqual({
-      message_thread_id: 42,
-    });
-  });
 });
 
 describe("buildTypingThreadParams", () => {
@@ -80,9 +74,20 @@ describe("buildTypingThreadParams", () => {
   it("includes General topic thread id for typing indicators", () => {
     expect(buildTypingThreadParams(1)).toEqual({ message_thread_id: 1 });
   });
+});
 
-  it("normalizes thread ids to integers", () => {
-    expect(buildTypingThreadParams(42.9)).toEqual({ message_thread_id: 42 });
+describe("thread id normalization", () => {
+  it.each([
+    {
+      build: () => buildTelegramThreadParams({ id: 42.9, scope: "forum" }),
+      expected: { message_thread_id: 42 },
+    },
+    {
+      build: () => buildTypingThreadParams(42.9),
+      expected: { message_thread_id: 42 },
+    },
+  ])("normalizes thread ids to integers", ({ build, expected }) => {
+    expect(build()).toEqual(expected);
   });
 });
 

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -8,18 +8,13 @@ import {
 } from "./helpers.js";
 
 describe("resolveTelegramForumThreadId", () => {
-  it("returns undefined for non-forum groups even with messageThreadId", () => {
-    // Reply threads in regular groups should not create separate sessions
-    expect(resolveTelegramForumThreadId({ isForum: false, messageThreadId: 42 })).toBeUndefined();
-  });
-
-  it("returns undefined for non-forum groups without messageThreadId", () => {
-    expect(
-      resolveTelegramForumThreadId({ isForum: false, messageThreadId: undefined }),
-    ).toBeUndefined();
-    expect(
-      resolveTelegramForumThreadId({ isForum: undefined, messageThreadId: 99 }),
-    ).toBeUndefined();
+  it.each([
+    { isForum: false, messageThreadId: 42 },
+    { isForum: false, messageThreadId: undefined },
+    { isForum: undefined, messageThreadId: 99 },
+  ])("returns undefined for non-forum groups", (params) => {
+    // Reply threads in regular groups should not create separate sessions.
+    expect(resolveTelegramForumThreadId(params)).toBeUndefined();
   });
 
   it("returns General topic (1) for forum groups without messageThreadId", () => {

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -17,62 +17,38 @@ describe("resolveTelegramForumThreadId", () => {
     expect(resolveTelegramForumThreadId(params)).toBeUndefined();
   });
 
-  it("returns General topic (1) for forum groups without messageThreadId", () => {
-    expect(resolveTelegramForumThreadId({ isForum: true, messageThreadId: undefined })).toBe(1);
-    expect(resolveTelegramForumThreadId({ isForum: true, messageThreadId: null })).toBe(1);
-  });
-
-  it("returns the topic id for forum groups with messageThreadId", () => {
-    expect(resolveTelegramForumThreadId({ isForum: true, messageThreadId: 99 })).toBe(99);
+  it.each([
+    { isForum: true, messageThreadId: undefined, expected: 1 },
+    { isForum: true, messageThreadId: null, expected: 1 },
+    { isForum: true, messageThreadId: 99, expected: 99 },
+  ])("resolves forum topic ids", ({ expected, ...params }) => {
+    expect(resolveTelegramForumThreadId(params)).toBe(expected);
   });
 });
 
 describe("buildTelegramThreadParams", () => {
-  it("omits General topic thread id for message sends", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "forum" })).toBeUndefined();
-  });
-
-  it("includes non-General topic thread ids", () => {
-    expect(buildTelegramThreadParams({ id: 99, scope: "forum" })).toEqual({
-      message_thread_id: 99,
-    });
-  });
-
-  it("includes thread id for dm topics", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
-      message_thread_id: 1,
-    });
-    expect(buildTelegramThreadParams({ id: 2, scope: "dm" })).toEqual({
-      message_thread_id: 2,
-    });
-  });
-
-  it("normalizes dm thread ids and skips non-positive values", () => {
-    expect(buildTelegramThreadParams({ id: 0, scope: "dm" })).toBeUndefined();
-    expect(buildTelegramThreadParams({ id: -1, scope: "dm" })).toBeUndefined();
-    expect(buildTelegramThreadParams({ id: 1.9, scope: "dm" })).toEqual({
-      message_thread_id: 1,
-    });
-  });
-
-  it("handles thread id 0 for non-dm scopes", () => {
+  it.each([
+    { input: { id: 1, scope: "forum" as const }, expected: undefined },
+    { input: { id: 99, scope: "forum" as const }, expected: { message_thread_id: 99 } },
+    { input: { id: 1, scope: "dm" as const }, expected: { message_thread_id: 1 } },
+    { input: { id: 2, scope: "dm" as const }, expected: { message_thread_id: 2 } },
+    { input: { id: 0, scope: "dm" as const }, expected: undefined },
+    { input: { id: -1, scope: "dm" as const }, expected: undefined },
+    { input: { id: 1.9, scope: "dm" as const }, expected: { message_thread_id: 1 } },
     // id=0 should be included for forum and none scopes (not falsy)
-    expect(buildTelegramThreadParams({ id: 0, scope: "forum" })).toEqual({
-      message_thread_id: 0,
-    });
-    expect(buildTelegramThreadParams({ id: 0, scope: "none" })).toEqual({
-      message_thread_id: 0,
-    });
+    { input: { id: 0, scope: "forum" as const }, expected: { message_thread_id: 0 } },
+    { input: { id: 0, scope: "none" as const }, expected: { message_thread_id: 0 } },
+  ])("builds thread params", ({ input, expected }) => {
+    expect(buildTelegramThreadParams(input)).toEqual(expected);
   });
 });
 
 describe("buildTypingThreadParams", () => {
-  it("returns undefined when no thread id is provided", () => {
-    expect(buildTypingThreadParams(undefined)).toBeUndefined();
-  });
-
-  it("includes General topic thread id for typing indicators", () => {
-    expect(buildTypingThreadParams(1)).toEqual({ message_thread_id: 1 });
+  it.each([
+    { input: undefined, expected: undefined },
+    { input: 1, expected: { message_thread_id: 1 } },
+  ])("builds typing params", ({ input, expected }) => {
+    expect(buildTypingThreadParams(input)).toEqual(expected);
   });
 });
 

--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -26,8 +26,8 @@ describe("probeTelegram retry logic", () => {
 
   async function expectSuccessfulProbe(expectedCalls: number, retryCount = 0) {
     const probePromise = probeTelegram(token, timeoutMs);
-    for (let i = 0; i < retryCount; i += 1) {
-      await vi.advanceTimersByTimeAsync(1000);
+    if (retryCount > 0) {
+      await vi.advanceTimersByTimeAsync(retryCount * 1000);
     }
 
     const result = await probePromise;
@@ -80,8 +80,7 @@ describe("probeTelegram retry logic", () => {
     const probePromise = probeTelegram(token, timeoutMs);
 
     // Fast-forward for all retries
-    await vi.advanceTimersByTimeAsync(1000);
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(2000);
 
     const result = await probePromise;
 

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -20,6 +20,26 @@ const {
   sendStickerTelegram,
 } = await importTelegramSendModule();
 
+async function expectChatNotFoundWithChatId(
+  action: Promise<unknown>,
+  expectedChatId: string,
+): Promise<void> {
+  try {
+    await action;
+    throw new Error("Expected action to reject with chat-not-found context");
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Expected action to reject with chat-not-found context"
+    ) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    expect(message).toMatch(/chat not found/i);
+    expect(message).toMatch(new RegExp(`chat_id=${expectedChatId}`));
+  }
+}
+
 describe("sent-message-cache", () => {
   afterEach(() => {
     clearSentMessageCache();
@@ -285,11 +305,9 @@ describe("sendMessageTelegram", () => {
       sendMessage: typeof sendMessage;
     };
 
-    await expect(sendMessageTelegram(chatId, "hi", { token: "tok", api })).rejects.toThrow(
-      /chat not found/i,
-    );
-    await expect(sendMessageTelegram(chatId, "hi", { token: "tok", api })).rejects.toThrow(
-      /chat_id=123/,
+    await expectChatNotFoundWithChatId(
+      sendMessageTelegram(chatId, "hi", { token: "tok", api }),
+      chatId,
     );
   });
 
@@ -1236,11 +1254,9 @@ describe("sendStickerTelegram", () => {
       sendSticker: typeof sendSticker;
     };
 
-    await expect(sendStickerTelegram(chatId, "fileId123", { token: "tok", api })).rejects.toThrow(
-      /chat not found/i,
-    );
-    await expect(sendStickerTelegram(chatId, "fileId123", { token: "tok", api })).rejects.toThrow(
-      /chat_id=123/,
+    await expectChatNotFoundWithChatId(
+      sendStickerTelegram(chatId, "fileId123", { token: "tok", api }),
+      chatId,
     );
   });
 

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1102,47 +1102,44 @@ describe("sendMessageTelegram", () => {
 });
 
 describe("reactMessageTelegram", () => {
-  it("sends emoji reactions", async () => {
-    const setMessageReaction = vi.fn().mockResolvedValue(undefined);
-    const api = { setMessageReaction } as unknown as {
-      setMessageReaction: typeof setMessageReaction;
-    };
-
-    await reactMessageTelegram("telegram:123", "456", "✅", {
-      token: "tok",
-      api,
-    });
-
-    expect(setMessageReaction).toHaveBeenCalledWith("123", 456, [{ type: "emoji", emoji: "✅" }]);
-  });
-
-  it("removes reactions when emoji is empty", async () => {
-    const setMessageReaction = vi.fn().mockResolvedValue(undefined);
-    const api = { setMessageReaction } as unknown as {
-      setMessageReaction: typeof setMessageReaction;
-    };
-
-    await reactMessageTelegram("123", 456, "", {
-      token: "tok",
-      api,
-    });
-
-    expect(setMessageReaction).toHaveBeenCalledWith("123", 456, []);
-  });
-
-  it("removes reactions when remove flag is set", async () => {
-    const setMessageReaction = vi.fn().mockResolvedValue(undefined);
-    const api = { setMessageReaction } as unknown as {
-      setMessageReaction: typeof setMessageReaction;
-    };
-
-    await reactMessageTelegram("123", 456, "✅", {
-      token: "tok",
-      api,
+  it.each([
+    {
+      testName: "sends emoji reactions",
+      target: "telegram:123",
+      messageId: "456",
+      emoji: "✅",
+      remove: false,
+      expected: [{ type: "emoji", emoji: "✅" }],
+    },
+    {
+      testName: "removes reactions when emoji is empty",
+      target: "123",
+      messageId: 456,
+      emoji: "",
+      remove: false,
+      expected: [],
+    },
+    {
+      testName: "removes reactions when remove flag is set",
+      target: "123",
+      messageId: 456,
+      emoji: "✅",
       remove: true,
+      expected: [],
+    },
+  ] as const)("$testName", async (testCase) => {
+    const setMessageReaction = vi.fn().mockResolvedValue(undefined);
+    const api = { setMessageReaction } as unknown as {
+      setMessageReaction: typeof setMessageReaction;
+    };
+
+    await reactMessageTelegram(testCase.target, testCase.messageId, testCase.emoji, {
+      token: "tok",
+      api,
+      ...(testCase.remove ? { remove: true } : {}),
     });
 
-    expect(setMessageReaction).toHaveBeenCalledWith("123", 456, []);
+    expect(setMessageReaction).toHaveBeenCalledWith("123", 456, testCase.expected);
   });
 });
 

--- a/src/tui/theme/theme.test.ts
+++ b/src/tui/theme/theme.test.ts
@@ -7,7 +7,8 @@ const cliHighlightMocks = vi.hoisted(() => ({
 
 vi.mock("cli-highlight", () => cliHighlightMocks);
 
-const { markdownTheme, theme } = await import("./theme.js");
+const { markdownTheme, searchableSelectListTheme, selectListTheme, theme } =
+  await import("./theme.js");
 
 const stripAnsi = (str: string) =>
   str.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"), "");
@@ -57,5 +58,25 @@ describe("theme", () => {
   it("keeps assistant text in terminal default foreground", () => {
     expect(theme.assistantText("hello")).toBe("hello");
     expect(stripAnsi(theme.assistantText("hello"))).toBe("hello");
+  });
+});
+
+describe("list themes", () => {
+  it("reuses shared select-list styles in searchable list theme", () => {
+    expect(searchableSelectListTheme.selectedPrefix(">")).toBe(selectListTheme.selectedPrefix(">"));
+    expect(searchableSelectListTheme.selectedText("entry")).toBe(
+      selectListTheme.selectedText("entry"),
+    );
+    expect(searchableSelectListTheme.description("desc")).toBe(selectListTheme.description("desc"));
+    expect(searchableSelectListTheme.scrollInfo("scroll")).toBe(
+      selectListTheme.scrollInfo("scroll"),
+    );
+    expect(searchableSelectListTheme.noMatch("none")).toBe(selectListTheme.noMatch("none"));
+  });
+
+  it("keeps searchable list specific renderers readable", () => {
+    expect(stripAnsi(searchableSelectListTheme.searchPrompt("Search:"))).toBe("Search:");
+    expect(stripAnsi(searchableSelectListTheme.searchInput("query"))).toBe("query");
+    expect(stripAnsi(searchableSelectListTheme.matchHighlight("match"))).toBe("match");
   });
 });

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -99,7 +99,7 @@ export const markdownTheme: MarkdownTheme = {
   highlightCode,
 };
 
-export const selectListTheme: SelectListTheme = {
+const baseSelectListTheme: SelectListTheme = {
   selectedPrefix: (text) => fg(palette.accent)(text),
   selectedText: (text) => chalk.bold(fg(palette.accent)(text)),
   description: (text) => fg(palette.dim)(text),
@@ -107,8 +107,10 @@ export const selectListTheme: SelectListTheme = {
   noMatch: (text) => fg(palette.dim)(text),
 };
 
+export const selectListTheme: SelectListTheme = baseSelectListTheme;
+
 export const filterableSelectListTheme = {
-  ...selectListTheme,
+  ...baseSelectListTheme,
   filterLabel: (text: string) => fg(palette.dim)(text),
 };
 
@@ -127,11 +129,7 @@ export const editorTheme: EditorTheme = {
 };
 
 export const searchableSelectListTheme: SearchableSelectListTheme = {
-  selectedPrefix: (text) => fg(palette.accent)(text),
-  selectedText: (text) => chalk.bold(fg(palette.accent)(text)),
-  description: (text) => fg(palette.dim)(text),
-  scrollInfo: (text) => fg(palette.dim)(text),
-  noMatch: (text) => fg(palette.dim)(text),
+  ...baseSelectListTheme,
   searchPrompt: (text) => fg(palette.accentSoft)(text),
   searchInput: (text) => fg(palette.text)(text),
   matchHighlight: (text) => chalk.bold(fg(palette.accent)(text)),

--- a/ui/src/ui/app-defaults.ts
+++ b/ui/src/ui/app-defaults.ts
@@ -25,8 +25,13 @@ export const DEFAULT_CRON_FORM: CronFormState = {
   wakeMode: "now",
   payloadKind: "agentTurn",
   payloadText: "",
+  payloadCommand: "",
+  payloadArgs: "",
+  payloadCwd: "",
+  payloadEnv: "",
   deliveryMode: "announce",
   deliveryChannel: "last",
   deliveryTo: "",
   timeoutSeconds: "",
+  maxOutputBytes: "",
 };

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -67,7 +67,10 @@ export function formatCronPayload(job: CronJob) {
   if (p.kind === "systemEvent") {
     return `System: ${p.text}`;
   }
-  const base = `Agent: ${p.message}`;
+  const base =
+    p.kind === "agentTurn"
+      ? `Agent: ${p.message}`
+      : `Command: ${p.command}${p.args?.length ? ` ${p.args.join(" ")}` : ""}`;
   const delivery = job.delivery;
   if (delivery && delivery.mode !== "none") {
     const target =

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -449,6 +449,16 @@ export type CronPayload =
       message: string;
       thinking?: string;
       timeoutSeconds?: number;
+      model?: string;
+    }
+  | {
+      kind: "directCommand";
+      command: string;
+      args?: string[];
+      cwd?: string;
+      env?: Record<string, string>;
+      timeoutSeconds?: number;
+      maxOutputBytes?: number;
     };
 
 export type CronDelivery = {

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -27,10 +27,15 @@ export type CronFormState = {
   cronTz: string;
   sessionTarget: "main" | "isolated";
   wakeMode: "next-heartbeat" | "now";
-  payloadKind: "systemEvent" | "agentTurn";
+  payloadKind: "systemEvent" | "agentTurn" | "directCommand";
   payloadText: string;
+  payloadCommand: string;
+  payloadArgs: string;
+  payloadCwd: string;
+  payloadEnv: string;
   deliveryMode: "none" | "announce" | "webhook";
   deliveryChannel: string;
   deliveryTo: string;
   timeoutSeconds: string;
+  maxOutputBytes: string;
 };

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -222,4 +222,41 @@ describe("cron view", () => {
     expect(container.textContent).toContain("webhook");
     expect(container.textContent).toContain("https://example.invalid/cron");
   });
+
+  it("shows direct command payload fields in the form", () => {
+    const container = document.createElement("div");
+    render(
+      renderCron(
+        createProps({
+          form: {
+            ...DEFAULT_CRON_FORM,
+            payloadKind: "directCommand",
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Command");
+    expect(container.textContent).toContain("Args (one per line)");
+    expect(container.textContent).toContain("Env (KEY=VALUE, one per line)");
+    expect(container.textContent).toContain("Max output bytes (optional)");
+  });
+
+  it("shows direct command details for jobs", () => {
+    const container = document.createElement("div");
+    const job = {
+      ...createJob("job-3"),
+      sessionTarget: "isolated" as const,
+      payload: {
+        kind: "directCommand" as const,
+        command: "node",
+        args: ["-e", "console.log('hi')"],
+      },
+    };
+    render(renderCron(createProps({ jobs: [job] })), container);
+
+    expect(container.textContent).toContain("Command");
+    expect(container.textContent).toContain("node -e console.log('hi')");
+  });
 });


### PR DESCRIPTION
## Problem
Right now, many OpenClaw cron jobs end up going through model-driven paths, so even simple recurring tasks (weather checks, status probes, periodic sync checks) can consume tokens on every run.

## What this PR adds
`directCommand` cron jobs: simple scheduled commands that run directly (no LLM call per execution), with structured results that can still be delivered into OpenClaw logs/channels/context.

## Why this matters
- Reduces token usage for routine, deterministic recurring work.
- Makes periodic checks more predictable by removing model dependency from each run.
- Gives agents steady background signal over time (status, snapshots, checks) without constant LLM oversight.

## Why this matches OpenClaw vision
- Terminal-first, practical automation for real tasks.
- Focused and incremental: one capability in cron, no heavy orchestration layer.
- Foundation for future scheduling/group policy controls.
- Fewer routine LLM touchpoints for everyday tasks, which can reduce prompt-injection exposure in those paths.

## Included
- Runtime:
  - Spawn-based direct-command executor.
  - Deterministic success/failure result payloads.
  - Delivery integration through existing cron delivery config.
  - Error-summary/status alignment and spawn-failure normalization.
- CLI:
  - Add/edit support for `directCommand` jobs.
  - Validation/schema updates and CLI tests.
- Dashboard (`/cron`):
  - UI type/schema/default updates for `directCommand`.
  - Controller/view updates and UI tests.
- Docs:
  - Cron docs updates (including schema + wording adjustments).

## Testing
- `pnpm vitest run src/cron/direct-command.test.ts src/cron/service.direct-command-executor.test.ts src/gateway/server-cron.test.ts src/cli/cron-cli.test.ts`
- `pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/controllers/cron.test.ts src/ui/views/cron.test.ts`

Both suites pass locally.

## Notes
- Intentionally scoped to one topic: direct-command cron support end-to-end.
- No unrelated provider/channel abstractions or broad refactors.
- TODO (follow-up PR): if this feature is accepted, I’ll add a default-on policy check so `directCommand` follows the same allowlist rules as `tools.exec`.
- AI-assisted (Codex 5.3)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds end-to-end support for `directCommand` cron jobs — a new payload kind that runs shell commands via `spawn` (with `shell: false`) instead of LLM agent turns. The implementation spans the runtime executor, CLI add/edit commands, gateway integration with delivery support, dashboard UI, schema validation, and documentation.

- **Runtime**: New spawn-based executor in `direct-command.ts` with output capping, timeout handling (SIGTERM → SIGKILL), and deterministic JSON result payloads. Integrated into `timer.ts`'s `executeJobCore` and `server-cron.ts`'s delivery pipeline.
- **CLI**: `cron add` and `cron edit` support `--command`, `--arg`, `--cwd`, `--env`, `--timeout-seconds`, and `--max-output-bytes` flags with mutual exclusion validation against `--system-event` and `--message`.
- **Dashboard**: Form and view updates for `directCommand` payload type selection with appropriate conditional field rendering.
- **Schema/types**: `CronPayload`, `CronPayloadPatch`, and gateway TypeBox schemas extended for `directCommand`.
- **Two issues found**: (1) The outer safety-net timeout in `timer.ts` doesn't read `timeoutSeconds` from `directCommand` payloads, so jobs with timeout > 10 minutes will be killed prematurely. (2) The normalizer doesn't apply default `announce` delivery for `directCommand` jobs created via the API, contradicting the docs.

<h3>Confidence Score: 3/5</h3>

- PR is well-structured and tested, but has two logic gaps that should be addressed before merge.
- The implementation is clean, well-tested across all layers (unit, integration, CLI, UI), and follows existing patterns. However, two logic issues reduce confidence: (1) the outer timeout safety-net in timer.ts ignores directCommand's timeoutSeconds, which can cause premature job termination, and (2) the normalizer doesn't apply default announce delivery for directCommand jobs via the API, contradicting docs. Both are fixable but should be resolved.
- `src/cron/service/timer.ts` (outer timeout doesn't respect directCommand timeoutSeconds), `src/cron/normalize.ts` (missing default delivery for directCommand)

<sub>Last reviewed commit: 2512b99</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->