### PR TITLE
fix(message): thread mediaLocalRoots through channel plugin dispatch

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -194,10 +194,14 @@ export async function handleTelegramAction(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
       );
     }
+    const mediaLocalRoots = Array.isArray(params.mediaLocalRoots)
+      ? (params.mediaLocalRoots as readonly string[])
+      : undefined;
     const result = await sendMessageTelegram(to, content, {
       token,
       accountId: accountId ?? undefined,
       mediaUrl: mediaUrl || undefined,
+      mediaLocalRoots,
       buttons,
       replyToMessageId: replyToMessageId ?? undefined,
       messageThreadId: messageThreadId ?? undefined,

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -88,7 +88,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
   extractToolSend: ({ args }) => {
     return extractToolSend(args, "sendMessage");
   },
-  handleAction: async ({ action, params, cfg, accountId }) => {
+  handleAction: async ({ action, params, cfg, accountId, mediaLocalRoots }) => {
     if (action === "send") {
       const sendParams = readTelegramSendParams(params);
       return await handleTelegramAction(
@@ -96,6 +96,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           action: "sendMessage",
           ...sendParams,
           accountId: accountId ?? undefined,
+          mediaLocalRoots,
         },
         cfg,
       );

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -314,6 +314,8 @@ export type ChannelMessageActionContext = {
   };
   toolContext?: ChannelThreadingToolContext;
   dryRun?: boolean;
+  /** Allowed local media roots for the active agent (includes agent workspace when scoped). */
+  mediaLocalRoots?: readonly string[];
 };
 
 export type ChannelToolSend = {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -13,6 +13,7 @@ import type {
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -511,6 +512,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   }
   const mirrorMediaUrls =
     mergedMediaUrls.length > 0 ? mergedMediaUrls : mediaUrl ? [mediaUrl] : undefined;
+  const mediaLocalRoots = agentId ? getAgentScopedMediaLocalRoots(cfg, agentId) : undefined;
   throwIfAborted(abortSignal);
   const send = await executeSendAction({
     ctx: {
@@ -523,6 +525,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       toolContext: input.toolContext,
       deps: input.deps,
       dryRun,
+      mediaLocalRoots,
       mirror:
         outboundRoute && !dryRun
           ? {

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -38,6 +38,8 @@ export type OutboundSendContext = {
   };
   abortSignal?: AbortSignal;
   silent?: boolean;
+  /** Allowed local media roots for the active agent. */
+  mediaLocalRoots?: readonly string[];
 };
 
 export async function executeSendAction(params: {
@@ -67,6 +69,7 @@ export async function executeSendAction(params: {
       gateway: params.ctx.gateway,
       toolContext: params.ctx.toolContext,
       dryRun: params.ctx.dryRun,
+      mediaLocalRoots: params.ctx.mediaLocalRoots,
     });
     if (handled) {
       if (params.ctx.mirror) {


### PR DESCRIPTION
## Problem

When a sandboxed agent with `workspaceAccess: "rw"` calls the `message` tool to send media files, the file path validation fails with:

```
Local media path is not under an allowed directory: ~/.openclaw/workspace-leon/output/file.png
```

**Root cause:** With `workspaceAccess: "rw"`, the agent workspace lives at `~/.openclaw/workspace-<agent>/` (outside the `sandboxes/` tree). The `workspace-*` hardening in `assertLocalMediaAllowed` blocks this path, and the channel plugin dispatch path never calls `getAgentScopedMediaLocalRoots()` to add the agent workspace to the allowed roots.

The auto-reply/delivery paths (`deliver.ts`, `bot-message-dispatch.ts`, etc.) already correctly use `getAgentScopedMediaLocalRoots(cfg, agentId)` — this change threads the same `mediaLocalRoots` through the tool-invoked send path.

## Changes

5 files, +14/-1 lines:

1. **`types.core.ts`**: Add `mediaLocalRoots` to `ChannelMessageActionContext`
2. **`message-action-runner.ts`**: Compute `mediaLocalRoots` via `getAgentScopedMediaLocalRoots(cfg, agentId)` in `handleSendAction`
3. **`outbound-send-service.ts`**: Add `mediaLocalRoots` to `OutboundSendContext`, pass to `dispatchChannelMessageAction`
4. **`telegram.ts`** (plugin): Forward `ctx.mediaLocalRoots` to `handleTelegramAction`
5. **`telegram-actions.ts`**: Pass `mediaLocalRoots` to `sendMessageTelegram`

## Notes

- Only the Telegram plugin is patched here since that's the affected channel. Other channel plugins (Discord, WhatsApp, etc.) can follow the same pattern if needed.
- Zero compile errors, no test changes needed (existing tests pass).

Fixes #20258

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where sandboxed agents with `workspaceAccess: "rw"` couldn't send media files via the Telegram channel plugin dispatch path. The root cause was that `mediaLocalRoots` (which includes the agent's workspace directory) was never threaded through the tool-invoked send path — only the auto-reply/delivery paths (`deliver.ts`, `bot-message-dispatch.ts`) already computed and passed these roots.

- Adds `mediaLocalRoots` to `ChannelMessageActionContext` and `OutboundSendContext` types
- Computes `mediaLocalRoots` via `getAgentScopedMediaLocalRoots(cfg, agentId)` in `handleSendAction`
- Threads the value through `executeSendAction` → `dispatchChannelMessageAction` → Telegram plugin → `sendMessageTelegram`
- Only Telegram is patched since it's the only channel plugin with its own dedicated send path that uses `loadWebMedia`; Discord and Signal action adapters don't handle media directly in their action paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal plumbing fix that threads an existing value through a missing code path.
- The change is small (+14/-1 lines), purely additive (no existing behavior is altered), and follows the exact same pattern already established in the delivery paths (deliver.ts, bot-message-dispatch.ts). The type additions are optional fields, so no callers break. The Telegram plugin correctly extracts and forwards the value. The Array.isArray runtime guard in telegram-actions.ts is appropriate given the untyped params record. No security concerns — mediaLocalRoots restricts access rather than expanding it, and the computation uses the same getAgentScopedMediaLocalRoots function already trusted elsewhere.
- No files require special attention.

<sub>Last reviewed commit: 30775a8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->