### PR TITLE
Security: scrub untrusted metadata from user-facing replies

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
@@ -120,6 +120,25 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("\n\n")).toBe("");
     expect(sanitizeUserFacingText("  \n  ")).toBe("");
   });
+
+  it("strips untrusted metadata blocks from user-facing text", () => {
+    const text = [
+      "Summary line",
+      "",
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"abc","sender":"+15550001111"}',
+      "```",
+      "",
+      "Sender (untrusted metadata):",
+      "```json",
+      '{"name":"Alice","e164":"+15550001111"}',
+      "```",
+      "",
+      "Visible body",
+    ].join("\n");
+    expect(sanitizeUserFacingText(text)).toBe("Summary line\n\nVisible body");
+  });
 });
 
 describe("stripThoughtSignatures", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
+import { stripUntrustedMetadataBlocks } from "../../shared/untrusted-metadata.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
 import { stableStringify } from "../stable-stringify.js";
 import type { FailoverReason } from "./types.js";
@@ -506,7 +507,7 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     return text;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripFinalTagsFromText(text);
+  const stripped = stripUntrustedMetadataBlocks(stripFinalTagsFromText(text));
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -114,6 +114,24 @@ describe("normalizeReplyPayload", () => {
     expect(normalized).toBeNull();
     expect(reasons).toEqual(["empty"]);
   });
+
+  it("strips untrusted metadata blocks while keeping visible text", () => {
+    const payload = {
+      text: [
+        "Visible start",
+        "",
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"msg-1"}',
+        "```",
+        "",
+        "Visible end",
+      ].join("\n"),
+    };
+
+    const normalized = normalizeReplyPayload(payload);
+    expect(normalized?.text).toBe("Visible start\n\nVisible end");
+  });
 });
 
 describe("typing controller", () => {

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -39,4 +39,43 @@ describe("stripEnvelopeFromMessage", () => {
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("note\n[message_id: 123]");
   });
+
+  test("strips untrusted metadata blocks from user messages", () => {
+    const input = {
+      role: "user",
+      content: [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"123","sender":"+15550001111"}',
+        "```",
+        "",
+        "hello",
+      ].join("\n"),
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("hello");
+  });
+
+  test("strips untrusted metadata blocks from user text content arrays", () => {
+    const input = {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: [
+            "Sender (untrusted metadata):",
+            "```json",
+            '{"name":"Alice"}',
+            "```",
+            "",
+            "hi",
+          ].join("\n"),
+        },
+      ],
+    };
+    const result = stripEnvelopeFromMessage(input) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    expect(result.content?.[0]?.text).toBe("hi");
+  });
 });

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,4 +1,5 @@
 import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
+import { stripUntrustedMetadataBlocks } from "../shared/untrusted-metadata.js";
 
 export { stripEnvelope };
 
@@ -12,7 +13,7 @@ function stripEnvelopeFromContent(content: unknown[]): { content: unknown[]; cha
     if (entry.type !== "text" || typeof entry.text !== "string") {
       return item;
     }
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripUntrustedMetadataBlocks(stripMessageIdHints(stripEnvelope(entry.text)));
     if (stripped === entry.text) {
       return item;
     }
@@ -39,7 +40,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   const next: Record<string, unknown> = { ...entry };
 
   if (typeof entry.content === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.content));
+    const stripped = stripUntrustedMetadataBlocks(
+      stripMessageIdHints(stripEnvelope(entry.content)),
+    );
     if (stripped !== entry.content) {
       next.content = stripped;
       changed = true;
@@ -51,7 +54,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripUntrustedMetadataBlocks(stripMessageIdHints(stripEnvelope(entry.text)));
     if (stripped !== entry.text) {
       next.text = stripped;
       changed = true;

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -87,9 +87,15 @@ describe("shell env fallback", () => {
       exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
     });
 
-    expect(first).toBe("/usr/local/bin:/usr/bin");
-    expect(second).toBe("/usr/local/bin:/usr/bin");
-    expect(exec).toHaveBeenCalledOnce();
+    if (process.platform === "win32") {
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      expect(exec).not.toHaveBeenCalled();
+    } else {
+      expect(first).toBe("/usr/local/bin:/usr/bin");
+      expect(second).toBe("/usr/local/bin:/usr/bin");
+      expect(exec).toHaveBeenCalledOnce();
+    }
   });
 
   it("returns null on shell env read failure and caches null", () => {
@@ -109,6 +115,10 @@ describe("shell env fallback", () => {
 
     expect(first).toBeNull();
     expect(second).toBeNull();
-    expect(exec).toHaveBeenCalledOnce();
+    if (process.platform === "win32") {
+      expect(exec).not.toHaveBeenCalled();
+    } else {
+      expect(exec).toHaveBeenCalledOnce();
+    }
   });
 });

--- a/src/shared/untrusted-metadata.ts
+++ b/src/shared/untrusted-metadata.ts
@@ -1,0 +1,35 @@
+const UNTRUSTED_METADATA_HEADERS = [
+  "Conversation info (untrusted metadata):",
+  "Sender (untrusted metadata):",
+  "Thread starter (untrusted, for context):",
+  "Replied message (untrusted, for context):",
+  "Forwarded message context (untrusted metadata):",
+  "Chat history since last reply (untrusted, for context):",
+] as const;
+
+export function stripUntrustedMetadataBlocks(text: string): string {
+  if (!text) {
+    return text;
+  }
+  const lines = text.split("\n");
+  const kept: string[] = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
+    if (!UNTRUSTED_METADATA_HEADERS.includes(line as (typeof UNTRUSTED_METADATA_HEADERS)[number])) {
+      kept.push(line);
+      continue;
+    }
+    if (lines[i + 1] !== "```json") {
+      kept.push(line);
+      continue;
+    }
+    i += 2;
+    while (i < lines.length && lines[i] !== "```") {
+      i += 1;
+    }
+  }
+  return kept
+    .join("\n")
+    .replace(/^\n+/, "")
+    .replace(/\n{3,}/g, "\n\n");
+}

--- a/src/web/auto-reply/deliver-reply.test.ts
+++ b/src/web/auto-reply/deliver-reply.test.ts
@@ -173,9 +173,11 @@ describe("deliverWebReply", () => {
     });
 
     expect(msg.reply).toHaveBeenCalledTimes(1);
-    expect(
-      String((msg.reply as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]?.[0]),
-    ).toContain("⚠️ Media failed");
+    const fallback = String(
+      (msg.reply as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]?.[0],
+    );
+    expect(fallback).toContain("⚠️ Media failed. Sending text only.");
+    expect(fallback).not.toContain("boom");
     expect(replyLogger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ mediaUrl: "http://example.com/img.jpg" }),
       "failed to send web media reply",

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -176,8 +176,7 @@ export async function deliverWebReply(params: {
       whatsappOutboundLog.error(`Failed sending web media to ${msg.from}: ${formatError(err)}`);
       replyLogger.warn({ err, mediaUrl }, "failed to send web media reply");
       if (index === 0) {
-        const warning =
-          err instanceof Error ? `⚠️ Media failed: ${err.message}` : "⚠️ Media failed.";
+        const warning = "⚠️ Media failed. Sending text only.";
         const fallbackTextParts = [remainingText.shift() ?? caption ?? "", warning].filter(Boolean);
         const fallbackText = fallbackTextParts.join("\n");
         if (fallbackText) {


### PR DESCRIPTION
## Summary
- add a shared scrubber to remove untrusted metadata JSON blocks from user-facing text
- apply the scrubber in `sanitizeUserFacingText` and in gateway history sanitization for user messages
- harden WhatsApp media-failure fallback copy to avoid exposing raw internal error messages

## Changes
- Added `src/shared/untrusted-metadata.ts`
- Updated `src/agents/pi-embedded-helpers/errors.ts`
- Updated `src/gateway/chat-sanitize.ts`
- Updated `src/web/auto-reply/deliver-reply.ts`
- Added/updated regression tests for all affected paths

## Verification
- `pnpm test -- src/gateway/chat-sanitize.test.ts`
- `pnpm test -- src/auto-reply/reply/reply-utils.test.ts`
- `pnpm test -- src/web/auto-reply/deliver-reply.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a shared `stripUntrustedMetadataBlocks` scrubber that removes internal metadata JSON blocks (conversation info, sender info, thread context, etc.) from user-facing text, preventing untrusted envelope metadata from leaking into replies. The scrubber is integrated into both `sanitizeUserFacingText` (for outbound reply normalization) and the gateway history sanitization path (for user messages sent to the LLM). Additionally hardens the WhatsApp media-failure fallback to use a static message instead of exposing raw `err.message`.

- New `src/shared/untrusted-metadata.ts` with `stripUntrustedMetadataBlocks` that matches all 6 metadata header types generated by `buildInboundUserContextPrefix` in `inbound-meta.ts`
- Integrated into `sanitizeUserFacingText` in `errors.ts` to strip metadata from outbound replies
- Integrated into `chat-sanitize.ts` to strip metadata from user messages before they reach the LLM context
- WhatsApp media-failure fallback now uses a static `"⚠️ Media failed. Sending text only."` instead of interpolating `err.message`
- Regression tests added across all affected paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds defensive stripping of internal metadata and hardens error messages with no behavioral regressions.
- The changes are focused and well-scoped: a new shared utility with clear, testable logic; straightforward integration at three call sites; and a simple hardening fix for the WhatsApp fallback. The metadata header list exactly matches the generation source in inbound-meta.ts. All edge cases (missing closing fence, multi-line JSON, residual blank lines) are handled correctly. Comprehensive regression tests cover all affected paths. No logic errors, security issues, or regressions identified.
- No files require special attention.

<sub>Last reviewed commit: fb14d8a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->