### PR TITLE
iOS: add APNs registration and notification signing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- iOS/APNs: add push registration and notification-signing configuration for node delivery. (#20308) Thanks @mbelinky.
 - Gateway/APNs: add a push-test pipeline for APNs delivery validation in gateway flows. (#20307) Thanks @mbelinky.
 - iOS/Watch: add an Apple Watch companion MVP with watch inbox UI, watch notification relay handling, and gateway command surfaces for watch status/send flows. (#20054) Thanks @mbelinky.
 - Gateway/CLI: add paired-device hygiene flows with `device.pair.remove`, plus `openclaw devices remove` and guarded `openclaw devices clear --yes [--pending]` commands for removing paired entries and optionally rejecting pending requests. (#20057) Thanks @mbelinky.

--- a/apps/ios/.swiftlint.yml
+++ b/apps/ios/.swiftlint.yml
@@ -3,3 +3,7 @@ parent_config: ../../.swiftlint.yml
 included:
   - Sources
   - ../shared/ClawdisNodeKit/Sources
+
+type_body_length:
+  warning: 900
+  error: 1300

--- a/apps/ios/Config/Signing.xcconfig
+++ b/apps/ios/Config/Signing.xcconfig
@@ -1,10 +1,14 @@
 // Shared iOS signing defaults for local development + CI.
 OPENCLAW_IOS_DEFAULT_TEAM = Y5PE65HELJ
 OPENCLAW_IOS_SELECTED_TEAM = $(OPENCLAW_IOS_DEFAULT_TEAM)
+OPENCLAW_APP_BUNDLE_ID = ai.openclaw.ios
+OPENCLAW_WATCH_APP_BUNDLE_ID = ai.openclaw.ios.watchkitapp
+OPENCLAW_WATCH_EXTENSION_BUNDLE_ID = ai.openclaw.ios.watchkitapp.extension
 
 // Local contributors can override this by running scripts/ios-configure-signing.sh.
 // Keep include after defaults: xcconfig is evaluated top-to-bottom.
 #include? "../.local-signing.xcconfig"
+#include? "../LocalSigning.xcconfig"
 
 CODE_SIGN_STYLE = Automatic
 CODE_SIGN_IDENTITY = Apple Development

--- a/apps/ios/LocalSigning.xcconfig.example
+++ b/apps/ios/LocalSigning.xcconfig.example
@@ -6,6 +6,8 @@ OPENCLAW_DEVELOPMENT_TEAM = P5Z8X89DJL
 
 OPENCLAW_APP_BUNDLE_ID = ai.openclaw.ios.test.mariano
 OPENCLAW_SHARE_BUNDLE_ID = ai.openclaw.ios.test.mariano.share
+OPENCLAW_WATCH_APP_BUNDLE_ID = ai.openclaw.ios.test.mariano.watchkitapp
+OPENCLAW_WATCH_EXTENSION_BUNDLE_ID = ai.openclaw.ios.test.mariano.watchkitapp.extension
 
 // Leave empty with automatic signing.
 OPENCLAW_APP_PROFILE =

--- a/apps/ios/ShareExtension/Info.plist
+++ b/apps/ios/ShareExtension/Info.plist
@@ -4,14 +4,14 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>OpenClaw Share</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleDisplayName</key>
-	<string>OpenClaw Share</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
@@ -28,6 +28,8 @@
 			<dict>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
 				<integer>10</integer>
+				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
+				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -62,6 +62,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/apps/ios/Sources/OpenClaw.entitlements
+++ b/apps/ios/Sources/OpenClaw.entitlements
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>
+

--- a/apps/ios/WatchApp/Info.plist
+++ b/apps/ios/WatchApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.16</string>
+	<string>2026.2.18</string>
 	<key>CFBundleVersion</key>
-	<string>20260216</string>
+	<string>20260218</string>
 	<key>WKCompanionAppBundleIdentifier</key>
-	<string>ai.openclaw.ios</string>
+	<string>$(OPENCLAW_APP_BUNDLE_ID)</string>
 	<key>WKWatchKitApp</key>
 	<true/>
 </dict>

--- a/apps/ios/WatchExtension/Info.plist
+++ b/apps/ios/WatchExtension/Info.plist
@@ -15,15 +15,15 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.16</string>
+	<string>2026.2.18</string>
 	<key>CFBundleVersion</key>
-	<string>20260216</string>
+	<string>20260218</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>WKAppBundleIdentifier</key>
-			<string>ai.openclaw.ios.watchkitapp</string>
+			<string>$(OPENCLAW_WATCH_APP_BUNDLE_ID)</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>

--- a/apps/ios/WatchExtension/Sources/WatchConnectivityReceiver.swift
+++ b/apps/ios/WatchExtension/Sources/WatchConnectivityReceiver.swift
@@ -70,9 +70,9 @@ extension WatchConnectivityReceiver: WCSessionDelegate {
             replyHandler(["ok": false])
             return
         }
+        replyHandler(["ok": true])
         Task { @MainActor in
             self.store.consume(message: incoming, transport: "sendMessage")
-            replyHandler(["ok": true])
         }
     }
 

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -75,6 +75,7 @@ targets:
     settings:
       base:
         CODE_SIGN_IDENTITY: "Apple Development"
+        CODE_SIGN_ENTITLEMENTS: Sources/OpenClaw.entitlements
         CODE_SIGN_STYLE: "$(OPENCLAW_CODE_SIGN_STYLE)"
         DEVELOPMENT_TEAM: "$(OPENCLAW_DEVELOPMENT_TEAM)"
         PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_APP_BUNDLE_ID)"
@@ -98,6 +99,7 @@ targets:
           UIApplicationSupportsMultipleScenes: false
         UIBackgroundModes:
           - audio
+          - remote-notification
         NSLocalNetworkUsageDescription: OpenClaw discovers and connects to your OpenClaw gateway on the local network.
         NSAppTransportSecurity:
           NSAllowsArbitraryLoadsInWebContent: true
@@ -140,6 +142,19 @@ targets:
         SWIFT_STRICT_CONCURRENCY: complete
     info:
       path: ShareExtension/Info.plist
+      properties:
+        CFBundleDisplayName: OpenClaw Share
+        CFBundleShortVersionString: "2026.2.18"
+        CFBundleVersion: "20260218"
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.share-services
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).ShareViewController"
+          NSExtensionAttributes:
+            NSExtensionActivationRule:
+              NSExtensionActivationSupportsText: true
+              NSExtensionActivationSupportsWebURLWithMaxCount: 1
+              NSExtensionActivationSupportsImageWithMaxCount: 10
+              NSExtensionActivationSupportsMovieWithMaxCount: 1
 
   OpenClawWatchApp:
     type: application.watchapp2
@@ -154,14 +169,14 @@ targets:
       Release: Config/Signing.xcconfig
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: ai.openclaw.ios.watchkitapp
+        PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_WATCH_APP_BUNDLE_ID)"
     info:
       path: WatchApp/Info.plist
       properties:
         CFBundleDisplayName: OpenClaw
-        CFBundleShortVersionString: "2026.2.16"
-        CFBundleVersion: "20260216"
-        WKCompanionAppBundleIdentifier: ai.openclaw.ios
+        CFBundleShortVersionString: "2026.2.18"
+        CFBundleVersion: "20260218"
+        WKCompanionAppBundleIdentifier: "$(OPENCLAW_APP_BUNDLE_ID)"
         WKWatchKitApp: true
 
   OpenClawWatchExtension:
@@ -178,16 +193,16 @@ targets:
       Release: Config/Signing.xcconfig
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: ai.openclaw.ios.watchkitapp.extension
+        PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_WATCH_EXTENSION_BUNDLE_ID)"
     info:
       path: WatchExtension/Info.plist
       properties:
         CFBundleDisplayName: OpenClaw
-        CFBundleShortVersionString: "2026.2.16"
-        CFBundleVersion: "20260216"
+        CFBundleShortVersionString: "2026.2.18"
+        CFBundleVersion: "20260218"
         NSExtension:
           NSExtensionAttributes:
-            WKAppBundleIdentifier: ai.openclaw.ios.watchkitapp
+            WKAppBundleIdentifier: "$(OPENCLAW_WATCH_APP_BUNDLE_ID)"
           NSExtensionPointIdentifier: com.apple.watchkit
 
   OpenClawTests:


### PR DESCRIPTION
## Summary
- register for remote notifications in iOS app lifecycle
- add APNs entitlements/signing/plist wiring across iOS targets
- align bundle-id placeholders for watch/extension targets for signing consistency

## Testing
- not run in this PR prep flow

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds APNs (Apple Push Notification service) registration to the iOS app, along with signing/entitlements configuration and bundle ID variable alignment for watch targets.

- **APNs registration**: Adds `OpenClawAppDelegate` that registers for remote notifications on launch, forwards device tokens to `NodeAppModel`, which persists them in `UserDefaults` and sends a `push.apns.register` event to the gateway on connect. Includes sandbox/production environment detection.
- **Entitlements**: New `OpenClaw.entitlements` file with `aps-environment` capability, wired in `project.yml`.
- **Signing config**: Adds default bundle ID variables for watch app/extension targets in `Config/Signing.xcconfig`, with corresponding overrides in `LocalSigning.xcconfig.example`.
- **Bundle ID alignment**: Replaces hardcoded bundle IDs in watch `Info.plist` files and `project.yml` with xcconfig variables for signing consistency across all targets.
- **WatchConnectivity fix**: Moves `replyHandler` call outside of `Task { @MainActor }` in `WatchConnectivityReceiver`, fixing a potential crash where the reply handler could be called after the system timeout.
- **Share extension**: Adds movie support (`NSExtensionActivationSupportsMovieWithMaxCount`) and adds `info.properties` in `project.yml` for XcodeGen.
- **SwiftLint**: Raises `type_body_length` limits to accommodate `NodeAppModel` growth.
- **Version bump**: All targets updated to 2026.2.18.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge with one timing concern to consider in the app delegate wiring.
- The changes are well-structured: APNs registration follows standard iOS patterns, bundle ID variables improve maintainability, and the WatchConnectivity replyHandler fix addresses a real correctness issue. The one concern is a potential race condition where the APNs device token callback could fire before appModel is wired to the delegate (since it's set in a .task modifier), which could silently drop the token on first launch or warm re-registration. This is mitigated by the token usually arriving after view appearance and by the best-effort nature of push registration, but it would be more robust to wire the model in didFinishLaunchingWithOptions or buffer the token in the delegate.
- `apps/ios/Sources/OpenClawApp.swift` - potential race between APNs token delivery and `appModel` wiring

<sub>Last reviewed commit: 0c6ba66</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->