### PR TITLE
iOS onboarding: prevent pairing flicker during auto-resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - OpenClawKit/Protocol: preserve JSON boolean literals (`true`/`false`) when bridging through `AnyCodable` so Apple client RPC params no longer re-encode booleans as `1`/`0`. Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.
 - Browser/Relay: reuse an already-running extension relay when the relay port is occupied by another OpenClaw process, while still failing on non-relay port collisions to avoid masking unrelated listeners. (#20035) Thanks @mbelinky.


### PR DESCRIPTION
## Summary
- avoid reopening QR pairing UI while auto-resume approval is in-flight
- keep onboarding state stable until approval result resolves

## Testing
- not run in this PR prep flow

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents QR pairing UI flicker during iOS onboarding by introducing a background auto-resume mechanism. Instead of only retrying pairing when the app returns to the foreground, it now polls every 2 seconds (throttled to one actual attempt per 6 seconds) via a Combine timer. The retry uses a new "silent" mode that avoids updating visible status/connect messages, keeping the onboarding state stable while probing for approval.

- Added `pairingAutoResumeTicker` (2s `Timer.publish`) with `.onReceive` to periodically call `attemptAutomaticPairingResumeIfNeeded()`
- New `resumeAfterPairingApprovalInBackground()` keeps the pairing issue sticky (no `self.issue = .none`) unlike the user-initiated `resumeAfterPairingApproval()`, preventing UI state flip-flop
- `retryLastAttempt(silent:)` now accepts a `silent` flag to suppress status line updates and uses a distinct `connectingGatewayID` ("retry-auto") so the retry button spinner isn't triggered
- QR scanner is now dismissed (`showQRScanner = false`) when `gatewayServerName` becomes non-nil, ensuring the scanner closes on successful connection
- Added `scenePhase == .active` guard to prevent background-state retries

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the changes are narrowly scoped to onboarding UX polish with appropriate guards against overlapping retries.
- Score of 4 reflects that the changes are well-structured, logically sound, and narrowly scoped to preventing UI flicker during pairing auto-resume. The timer is properly throttled by the existing 6-second debounce, the connectingGatewayID guard prevents concurrent connection attempts, and the silent retry mode correctly avoids updating user-visible state. The only minor concern is that the static timer runs for the lifetime of the type (not just while pairing is needed), but the guards in attemptAutomaticPairingResumeIfNeeded bail out quickly when conditions aren't met, making this a negligible cost. The PR description notes testing was not run, which prevents a full score of 5.
- No files require special attention — the single changed file has clear, well-commented logic.

<sub>Last reviewed commit: be150af</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->