### PR TITLE
Chat UI: accept canonical main session key alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - OpenClawKit/Protocol: preserve JSON boolean literals (`true`/`false`) when bridging through `AnyCodable` so Apple client RPC params no longer re-encode booleans as `1`/`0`. Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -447,7 +447,10 @@ public final class OpenClawChatViewModel {
         // even when this view currently uses an alias key (for example "main").
         // Never drop events for our own pending run on key mismatch, or the UI can stay
         // stuck at "thinking" until the user reopens and forces a history reload.
-        if let sessionKey = chat.sessionKey, sessionKey != self.sessionKey, !isOurRun {
+        if let sessionKey = chat.sessionKey,
+           !Self.matchesCurrentSessionKey(incoming: sessionKey, current: self.sessionKey),
+           !isOurRun
+        {
             return
         }
         if !isOurRun {
@@ -479,6 +482,21 @@ public final class OpenClawChatViewModel {
         default:
             break
         }
+    }
+
+    private static func matchesCurrentSessionKey(incoming: String, current: String) -> Bool {
+        let incomingNormalized = incoming.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let currentNormalized = current.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if incomingNormalized == currentNormalized {
+            return true
+        }
+        // Common alias pair in operator clients: UI uses "main" while gateway emits canonical.
+        if (incomingNormalized == "agent:main:main" && currentNormalized == "main") ||
+            (incomingNormalized == "main" && currentNormalized == "agent:main:main")
+        {
+            return true
+        }
+        return false
     }
 
     private func handleAgentEvent(_ evt: OpenClawAgentEventPayload) {


### PR DESCRIPTION
## Summary
- treat canonical `main` session-key alias as equivalent in ChatViewModel
- add/adjust tests to cover alias handling and avoid A2UI waiting-state mismatch

## Testing
- not run in this PR prep flow

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where the Chat UI's `ChatViewModel` would silently drop external-run completion events when the gateway published the canonical session key `"agent:main:main"` but the UI was initialized with the short alias `"main"`. This caused the UI to miss history refreshes from runs completed by other clients or agent surfaces.

- Extracts session key comparison into a new `matchesCurrentSessionKey` static method in `ChatViewModel.swift` that normalizes and compares keys, with a special-case bidirectional alias match for `"main"` ↔ `"agent:main:main"` — consistent with how the TypeScript UI already handles this in `app-render.helpers.ts`
- Adds `acceptsCanonicalSessionKeyEventsForExternalRuns` test covering the fix, and an `acceptsCanonicalSessionKeyEventsForOwnPendingRun` test documenting that own-run events already bypassed the session key guard via the `isOurRun` flag

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted bug fix with good test coverage and no risky side effects.
- The change is narrow and well-scoped: it replaces a raw string inequality check with a method that also handles a known alias pair. The alias pattern is already established in the TypeScript codebase. The new static method is pure (no side effects), the guard logic is preserved, and the test directly exercises the fixed scenario. No regressions are expected.
- No files require special attention.

<sub>Last reviewed commit: 8a45e9a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->