### PR TITLE
Canvas: improve A2UI asset resolution and empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Canvas/A2UI: improve bundled-asset resolution and empty-state handling so UI fallbacks render reliably. (#20312) Thanks @mbelinky.
 - UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - OpenClawKit/Protocol: preserve JSON boolean literals (`true`/`false`) when bridging through `AnyCodable` so Apple client RPC params no longer re-encode booleans as `1`/`0`. Thanks @mbelinky.

--- a/apps/shared/OpenClawKit/Tools/CanvasA2UI/bootstrap.js
+++ b/apps/shared/OpenClawKit/Tools/CanvasA2UI/bootstrap.js
@@ -451,7 +451,6 @@ class OpenClawA2UIHost extends LitElement {
     if (this.surfaces.length === 0) {
       return html`<div class="empty">
         <div class="empty-title">Canvas (A2UI)</div>
-        <div>Waiting for A2UI messages…</div>
       </div>`;
     }
 

--- a/src/canvas-host/a2ui.ts
+++ b/src/canvas-host/a2ui.ts
@@ -13,14 +13,29 @@ export const CANVAS_WS_PATH = "/__openclaw__/ws";
 
 let cachedA2uiRootReal: string | null | undefined;
 let resolvingA2uiRoot: Promise<string | null> | null = null;
+let cachedA2uiResolvedAtMs = 0;
+const A2UI_ROOT_RETRY_NULL_AFTER_MS = 10_000;
 
 async function resolveA2uiRoot(): Promise<string | null> {
   const here = path.dirname(fileURLToPath(import.meta.url));
+  const entryDir = process.argv[1] ? path.dirname(path.resolve(process.argv[1])) : null;
   const candidates = [
-    // Running from source (bun) or dist (tsc + copied assets).
+    // Running from source (bun) or dist/canvas-host chunk.
     path.resolve(here, "a2ui"),
+    // Running from dist root chunk (common launchd path).
+    path.resolve(here, "canvas-host/a2ui"),
+    path.resolve(here, "../canvas-host/a2ui"),
+    // Entry path fallbacks (helps when cwd is not the repo root).
+    ...(entryDir
+      ? [
+          path.resolve(entryDir, "a2ui"),
+          path.resolve(entryDir, "canvas-host/a2ui"),
+          path.resolve(entryDir, "../canvas-host/a2ui"),
+        ]
+      : []),
     // Running from dist without copied assets (fallback to source).
     path.resolve(here, "../../src/canvas-host/a2ui"),
+    path.resolve(here, "../src/canvas-host/a2ui"),
     // Running from repo root.
     path.resolve(process.cwd(), "src/canvas-host/a2ui"),
     path.resolve(process.cwd(), "dist/canvas-host/a2ui"),
@@ -44,13 +59,19 @@ async function resolveA2uiRoot(): Promise<string | null> {
 }
 
 async function resolveA2uiRootReal(): Promise<string | null> {
-  if (cachedA2uiRootReal !== undefined) {
+  const nowMs = Date.now();
+  if (
+    cachedA2uiRootReal !== undefined &&
+    (cachedA2uiRootReal !== null || nowMs - cachedA2uiResolvedAtMs < A2UI_ROOT_RETRY_NULL_AFTER_MS)
+  ) {
     return cachedA2uiRootReal;
   }
   if (!resolvingA2uiRoot) {
     resolvingA2uiRoot = (async () => {
       const root = await resolveA2uiRoot();
       cachedA2uiRootReal = root ? await fs.realpath(root) : null;
+      cachedA2uiResolvedAtMs = Date.now();
+      resolvingA2uiRoot = null;
       return cachedA2uiRootReal;
     })();
   }


### PR DESCRIPTION
## Summary
- improve A2UI asset resolution fallback logic for Canvas host bootstrap
- clean up Canvas empty-state handling when no assets are available

## Testing
- not run in this PR prep flow

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the A2UI asset resolution logic in the Canvas host bootstrap and simplifies the empty-state UI.

- **Asset resolution (`a2ui.ts`)**: Adds several new candidate paths for locating A2UI assets (entry-dir-based fallbacks, additional `here`-relative paths) to support various deployment layouts (launchd, dist root chunks, non-standard cwd). Introduces a 10-second retry-on-null cache so that if assets aren't found at startup, the system re-checks periodically instead of caching the failure permanently.
- **Empty state (`bootstrap.js`)**: Removes the "Waiting for A2UI messages…" subtitle from the Canvas empty state, leaving only the title.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — it only adds fallback paths and a retry mechanism for asset resolution, plus a minor UI text removal.
- The changes are well-scoped: expanded path candidates for robustness, a sound retry-on-null cache mechanism, and a trivial UI cleanup. The caching logic handles concurrency correctly due to JS single-threaded execution. No tests were added, but the changes are low-risk infrastructure improvements. The PR description notes testing was not run in this prep flow, which is the only minor concern.
- No files require special attention

<sub>Last reviewed commit: ddf51ea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->