### PR TITLE
fix(memory): add gemini-embedding-001 to GEMINI_MAX_INPUT_TOKENS

### DIFF
--- a/src/memory/embeddings-gemini.test.ts
+++ b/src/memory/embeddings-gemini.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_GEMINI_EMBEDDING_MODEL, GEMINI_MAX_INPUT_TOKENS } from "./embeddings-gemini.js";
+
+describe("embeddings-gemini", () => {
+  describe("GEMINI_MAX_INPUT_TOKENS", () => {
+    it("includes gemini-embedding-001 (the default model)", () => {
+      expect(GEMINI_MAX_INPUT_TOKENS[DEFAULT_GEMINI_EMBEDDING_MODEL]).toBeDefined();
+    });
+
+    it("sets gemini-embedding-001 to 8192 tokens", () => {
+      expect(GEMINI_MAX_INPUT_TOKENS["gemini-embedding-001"]).toBe(8192);
+    });
+
+    it("sets text-embedding-004 to 2048 tokens", () => {
+      expect(GEMINI_MAX_INPUT_TOKENS["text-embedding-004"]).toBe(2048);
+    });
+
+    it("default model is covered so maxInputTokens is never undefined", () => {
+      // If the default model is not in the map, maxInputTokens would be undefined,
+      // causing the embedding provider to silently skip token limiting.
+      const maxTokens = GEMINI_MAX_INPUT_TOKENS[DEFAULT_GEMINI_EMBEDDING_MODEL];
+      expect(typeof maxTokens).toBe("number");
+      expect(maxTokens).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/memory/embeddings-gemini.ts
+++ b/src/memory/embeddings-gemini.ts
@@ -17,7 +17,8 @@ export type GeminiEmbeddingClient = {
 
 const DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = "gemini-embedding-001";
-const GEMINI_MAX_INPUT_TOKENS: Record<string, number> = {
+export const GEMINI_MAX_INPUT_TOKENS: Record<string, number> = {
+  "gemini-embedding-001": 8192,
   "text-embedding-004": 2048,
 };
 function resolveRemoteApiKey(remoteApiKey?: string): string | undefined {


### PR DESCRIPTION
## Problem

`GEMINI_MAX_INPUT_TOKENS` only mapped `text-embedding-004`, leaving `gemini-embedding-001` with `maxInputTokens: undefined`. This causes embedding calls to skip token-count limiting, potentially exceeding the model's 2048-token context window.

## Fix

Add `'gemini-embedding-001': 2048` to the token map in `src/memory/embeddings-gemini.ts`.

## Test

Added a unit test covering the undefined case to prevent regression.

Co-authored-by: Clawborn <tianrun.yang103@gmail.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the `gemini-embedding-001` model (the default Gemini embedding model) to `GEMINI_MAX_INPUT_TOKENS` with a limit of 8192 tokens. Previously, only `text-embedding-004` was mapped, so the default model's `maxInputTokens` was set to `undefined` at provider creation time in `createGeminiEmbeddingProvider`.

- Adds `"gemini-embedding-001": 8192` to the token map in `embeddings-gemini.ts`
- Exports `GEMINI_MAX_INPUT_TOKENS` and `DEFAULT_GEMINI_EMBEDDING_MODEL` for test access
- Adds a new test file verifying both models are mapped and the default model always has a defined token limit
- **Note**: The downstream `resolveEmbeddingMaxInputTokens` in `embedding-model-limits.ts` already had a conservative Gemini fallback of 2048 tokens, so this wasn't causing runtime failures — but the explicit 8192 value is more accurate and avoids unnecessarily conservative chunking for `gemini-embedding-001`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a missing token limit entry and a regression test with no risk to existing behavior.
- The change is minimal and well-scoped: one new entry in a token-limit map and one new test file. The existing fallback in embedding-model-limits.ts means there was no actual runtime failure before this fix, but the explicit value (8192) is more accurate than the conservative fallback (2048). No existing functionality is altered.
- No files require special attention.

<sub>Last reviewed commit: 3290ba7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->