### PR TITLE
fix: add customBindHost to gateway config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 - Providers/Copilot: add `claude-sonnet-4.6` and `claude-sonnet-4.5` to the default GitHub Copilot model catalog and add coverage for model-list/definition helpers. (#20270, fixes #20091) Thanks @Clawborn.
 - Dependencies/Agents: bump embedded Pi SDK packages (`@mariozechner/pi-agent-core`, `@mariozechner/pi-ai`, `@mariozechner/pi-coding-agent`, `@mariozechner/pi-tui`) to `0.54.0`. (#21578) Thanks @Takhoffman.
+- Gateway/Config: allow `gateway.customBindHost` in strict config validation when `gateway.bind="custom"` so valid custom bind-host configurations no longer fail startup. (#20318, fixes #20289) Thanks @MisterGuy420.
 - Config/Agents: expose Pi compaction tuning values `agents.defaults.compaction.reserveTokens` and `agents.defaults.compaction.keepRecentTokens` in config schema/types and apply them in embedded Pi runner settings overrides with floor enforcement via `reserveTokensFloor`. (#21568) Thanks @Takhoffman.
 - Auto-reply/WebChat: avoid defaulting inbound runtime channel labels to unrelated providers (for example `whatsapp`) for webchat sessions so channel-specific formatting guidance stays accurate. (#21534) Thanks @lbo728.
 - Status: include persisted `cacheRead`/`cacheWrite` in session summaries so compact `/status` output consistently shows cache hit percentages from real session data.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -404,6 +404,7 @@ export const OpenClawSchema = z
             z.literal("tailnet"),
           ])
           .optional(),
+        customBindHost: z.string().optional(),
         controlUi: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
Fixes #20289

## What changed
Added the missing `customBindHost` field to the Zod validation schema in `src/config/zod-schema.ts`. The TypeScript type definition already included `customBindHost?: string` as an optional string property, but it was missing from the Zod schema, causing configuration validation to reject valid configurations using `bind: "custom"` with `customBindHost`.

## Why this fixes the issue
The gateway configuration schema uses `.strict()`, which rejects any fields not explicitly defined. While the `customBindHost` option was already defined in the TypeScript types and used throughout the codebase, it was not included in the Zod validation schema. This caused the gateway to fail validation and exit when users tried to use `bind: "custom"` with a custom host IP. Adding `customBindHost: z.string().optional()` to the schema fixes this by allowing the field in valid configurations.

## AI-assisted contribution
This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build && pnpm tsgo && pnpm test
- The fix addresses the root cause described in the issue by adding the missing field to the validation schema, allowing the customBindHost option to be used when bind mode is set to custom.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the missing `customBindHost` field to the gateway Zod validation schema in `src/config/zod-schema.ts`. The TypeScript type definition already included `customBindHost?: string`, but the Zod schema omitted it. Because the gateway schema uses `.strict()`, any configuration with `gateway.customBindHost` was rejected at validation time, preventing users from using `bind: "custom"` mode. This one-line fix aligns the runtime validation with the type definition and the many call sites that already read `customBindHost`.

- Added `customBindHost: z.string().optional()` to the gateway object in the Zod schema
- No other files or logic changes required — the field was already consumed throughout the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, correct fix that aligns the Zod validation schema with the existing TypeScript type.
- The change is a single line that adds a missing optional string field to a Zod schema, matching an already-defined TypeScript type. The field is already consumed by dozens of call sites across the codebase. The fix is narrowly scoped, correct in type and optionality, and placed in the right position. No regressions are possible since the field was previously rejected by .strict() validation.
- No files require special attention.

<sub>Last reviewed commit: 38971fe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->