### PR TITLE
fix(protocol): regenerate Swift models for push.test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Protocol/Apple: regenerate Swift gateway models for `push.test` so `pnpm protocol:check` stays green on main. Thanks @mbelinky.
 - Canvas/A2UI: improve bundled-asset resolution and empty-state handling so UI fallbacks render reliably. (#20312) Thanks @mbelinky.
 - UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -925,6 +925,68 @@ public struct NodeInvokeRequestEvent: Codable, Sendable {
     }
 }
 
+public struct PushTestParams: Codable, Sendable {
+    public let nodeid: String
+    public let title: String?
+    public let body: String?
+    public let environment: String?
+
+    public init(
+        nodeid: String,
+        title: String?,
+        body: String?,
+        environment: String?
+    ) {
+        self.nodeid = nodeid
+        self.title = title
+        self.body = body
+        self.environment = environment
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case title
+        case body
+        case environment
+    }
+}
+
+public struct PushTestResult: Codable, Sendable {
+    public let ok: Bool
+    public let status: Int
+    public let apnsid: String?
+    public let reason: String?
+    public let tokensuffix: String
+    public let topic: String
+    public let environment: String
+
+    public init(
+        ok: Bool,
+        status: Int,
+        apnsid: String?,
+        reason: String?,
+        tokensuffix: String,
+        topic: String,
+        environment: String
+    ) {
+        self.ok = ok
+        self.status = status
+        self.apnsid = apnsid
+        self.reason = reason
+        self.tokensuffix = tokensuffix
+        self.topic = topic
+        self.environment = environment
+    }
+    private enum CodingKeys: String, CodingKey {
+        case ok
+        case status
+        case apnsid = "apnsId"
+        case reason
+        case tokensuffix = "tokenSuffix"
+        case topic
+        case environment
+    }
+}
+
 public struct SessionsListParams: Codable, Sendable {
     public let limit: Int?
     public let activeminutes: Int?

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -925,6 +925,68 @@ public struct NodeInvokeRequestEvent: Codable, Sendable {
     }
 }
 
+public struct PushTestParams: Codable, Sendable {
+    public let nodeid: String
+    public let title: String?
+    public let body: String?
+    public let environment: String?
+
+    public init(
+        nodeid: String,
+        title: String?,
+        body: String?,
+        environment: String?
+    ) {
+        self.nodeid = nodeid
+        self.title = title
+        self.body = body
+        self.environment = environment
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case title
+        case body
+        case environment
+    }
+}
+
+public struct PushTestResult: Codable, Sendable {
+    public let ok: Bool
+    public let status: Int
+    public let apnsid: String?
+    public let reason: String?
+    public let tokensuffix: String
+    public let topic: String
+    public let environment: String
+
+    public init(
+        ok: Bool,
+        status: Int,
+        apnsid: String?,
+        reason: String?,
+        tokensuffix: String,
+        topic: String,
+        environment: String
+    ) {
+        self.ok = ok
+        self.status = status
+        self.apnsid = apnsid
+        self.reason = reason
+        self.tokensuffix = tokensuffix
+        self.topic = topic
+        self.environment = environment
+    }
+    private enum CodingKeys: String, CodingKey {
+        case ok
+        case status
+        case apnsid = "apnsId"
+        case reason
+        case tokensuffix = "tokenSuffix"
+        case topic
+        case environment
+    }
+}
+
 public struct SessionsListParams: Codable, Sendable {
     public let limit: Int?
     public let activeminutes: Int?


### PR DESCRIPTION
## Summary
- regenerate generated Swift gateway models so `push.test` protocol types are present in Apple model outputs
- add a changelog note for the protocol-check regression fix

## Why
`pnpm protocol:check` on `main` was failing due to missing generated Swift model updates for the recently added `push.test` protocol schema.

## Validation
- `pnpm protocol:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Regenerates the auto-generated Swift gateway models (`GatewayModels.swift`) in both `apps/macos` and `apps/shared` to include the `PushTestParams` and `PushTestResult` structs for the `push.test` protocol schema, which was previously added but whose Swift models were not regenerated. Adds a changelog entry for the fix.

- The generated Swift structs correctly match the TypeBox schema definitions in `src/gateway/protocol/schema/push.ts` — all property names, types, optionality, and CodingKeys mappings are accurate.
- Both Swift output files receive identical changes, consistent with the dual-output behavior of `scripts/protocol-gen-swift.ts`.
- No hand-edited changes to auto-generated code; this is purely a re-generation to catch up with the `push.test` schema that was already merged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only auto-generated Swift model output that matches the existing protocol schema, plus a changelog entry.
- All changes are auto-generated by the existing protocol-gen-swift.ts script from an already-merged schema. The generated structs exactly match the TypeBox schema definitions (verified field-by-field). Both Swift files are updated identically as expected. The changelog entry follows existing conventions. There are no logic changes, no manual edits to generated code, and no risk of behavioral regression.
- No files require special attention — all Swift changes are auto-generated output.

<sub>Last reviewed commit: 9281e7a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->