### PR TITLE
fix: trigger model fallback on 503 UNAVAILABLE and high-demand errors

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -580,7 +580,15 @@ const ERROR_PATTERNS = {
     "resource_exhausted",
     "usage limit",
   ],
-  overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
+  overloaded: [
+    /overloaded_error|"type"\s*:\s*"overloaded_error"/i,
+    "overloaded",
+    // Google/Gemini 503 UNAVAILABLE errors (issue #20096)
+    /"status"\s*:\s*"unavailable"/i,
+    "high demand",
+    "temporarily unavailable",
+    /\b503\b/i,
+  ],
   timeout: [
     "timeout",
     "timed out",


### PR DESCRIPTION
Fixes #20096

## What
Expands `isOverloadedErrorMessage` pattern matching to recognize Google/Gemini-style 503 errors.

## Why
When Gemini returns a 503 UNAVAILABLE error with message "This model is currently experiencing high demand", OpenClaw does not trigger model fallback. Users are stuck until they manually switch models.

## How
Added patterns to the overloaded error detection:
- `/"status"\s*:\s*"unavailable"/i` — matches Gemini's status field
- `"high demand"` — matches Gemini's error message text  
- `"temporarily unavailable"` — common server error phrase
- `/\b503\b/i` — matches HTTP 503 status code in error strings

## Testing
- [x] `pnpm build` passes
- [x] `pnpm oxfmt --check` passes  
- [x] Added unit tests for the new patterns (8 test cases)
- [x] All 40 tests in `pi-embedded-helpers.isbillingerrormessage.e2e.test.ts` pass

## AI-Assisted 🤖
This PR was built with AI assistance (Claude via OpenClaw).
- [x] Code reviewed and understood
- [x] Tests pass
- [x] Session available on request

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Expands `isOverloadedErrorMessage` pattern matching to recognize Google/Gemini-style 503 errors, fixing issue #20096 where Gemini returning `503 UNAVAILABLE` with "high demand" messages did not trigger model fallback.

- Adds four new patterns to the `overloaded` error category: `/"status"\s*:\s*"unavailable"/i`, `"high demand"`, `"temporarily unavailable"`, and `/\b503\b/i`
- The interaction with `classifyFailoverReason` is correct: `isTransientHttpError` is checked first for leading HTTP status codes (classified as `"timeout"` for infrastructure retry), while embedded JSON 503 errors from model APIs reach the new overloaded patterns and get classified as `"rate_limit"` (triggering model fallback)
- Comprehensive test coverage added with 8 test cases including negative assertions and end-to-end fallback verification via `classifyFailoverReason`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds well-scoped error pattern matching with solid test coverage and no changes to control flow.
- The changes are narrowly focused on adding pattern strings/regexes to an existing error classification system. The new patterns correctly target the Gemini 503 use case. Test coverage is thorough with positive and negative assertions. The interaction with the existing `isTransientHttpError` precedence in `classifyFailoverReason` is correct and verified by tests. Minor style nit (redundant `i` flag) does not affect correctness.
- No files require special attention. The changes in `src/agents/pi-embedded-helpers/errors.ts` are additive pattern additions with no structural changes.

<sub>Last reviewed commit: b5af1a6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->