### PR TITLE
iOS/Gateway: wake disconnected iOS nodes via APNs before invoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- iOS/Gateway: wake disconnected iOS nodes via APNs before `nodes.invoke` and auto-reconnect gateway sessions on silent push wake to reduce invoke failures while the app is backgrounded. (#20332) Thanks @mbelinky.
 - iOS/APNs: add push registration and notification-signing configuration for node delivery. (#20308) Thanks @mbelinky.
 - Gateway/APNs: add a push-test pipeline for APNs delivery validation in gateway flows. (#20307) Thanks @mbelinky.
 - iOS/Watch: add an Apple Watch companion MVP with watch inbox UI, watch notification relay handling, and gateway command surfaces for watch status/send flows. (#20054) Thanks @mbelinky.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -1,73 +1,110 @@
-# OpenClaw (iOS)
+# OpenClaw iOS (Super Alpha)
 
-This is an **alpha** iOS app that connects to an OpenClaw Gateway as a `role: node`.
+NO TEST FLIGHT AVAILABLE AT THIS POINT
 
-Expect rough edges:
+This iPhone app is super-alpha and internal-use only. It connects to an OpenClaw Gateway as a `role: node`.
 
-- UI and onboarding are changing quickly.
-- Background behavior is not stable yet (foreground app is the supported mode right now).
-- Permissions are opt-in and the app should be treated as sensitive while we harden it.
+## Distribution Status
 
-## What It Does
+NO TEST FLIGHT AVAILABLE AT THIS POINT
 
-- Connects to a Gateway over `ws://` / `wss://`
-- Pairs a new device (approved from your bot)
-- Exposes phone services as node commands (camera, location, photos, calendar, reminders, etc; gated by iOS permissions)
-- Provides Talk + Chat surfaces (alpha)
+- Current distribution: local/manual deploy from source via Xcode.
+- App Store flow is not part of the current internal development path.
 
-## Pairing (Recommended Flow)
+## Super-Alpha Disclaimer
 
-If your Gateway has the `device-pair` plugin installed:
+- Breaking changes are expected.
+- UI and onboarding flows can change without migration guarantees.
+- Foreground use is the only reliable mode right now.
+- Treat this build as sensitive while permissions and background behavior are still being hardened.
 
-1. In Telegram, message your bot: `/pair`
-2. Copy the **setup code** message
-3. On iOS: OpenClaw → Settings → Gateway → paste setup code → Connect
-4. Back in Telegram: `/pair approve`
+## Exact Xcode Manual Deploy Flow
 
-## Build And Run
-
-Prereqs:
-
-- Xcode (current stable)
-- `pnpm`
-- `xcodegen`
-
-From the repo root:
+1. Prereqs:
+   - Xcode 16+
+   - `pnpm`
+   - `xcodegen`
+   - Apple Development signing set up in Xcode
+2. From repo root:
 
 ```bash
 pnpm install
+./scripts/ios-configure-signing.sh
+cd apps/ios
+xcodegen generate
+open OpenClaw.xcodeproj
+```
+
+3. In Xcode:
+   - Scheme: `OpenClaw`
+   - Destination: connected iPhone (recommended for real behavior)
+   - Build configuration: `Debug`
+   - Run (`Product` -> `Run`)
+4. If signing fails on a personal team:
+   - Use unique local bundle IDs via `apps/ios/LocalSigning.xcconfig`.
+   - Start from `apps/ios/LocalSigning.xcconfig.example`.
+
+Shortcut command (same flow + open project):
+
+```bash
 pnpm ios:open
 ```
 
-`pnpm ios:open` now runs `scripts/ios-configure-signing.sh` before `xcodegen`:
+## APNs Expectations For Local/Manual Builds
 
-- If `IOS_DEVELOPMENT_TEAM` is set, it uses that team.
-- Otherwise it prefers the canonical OpenClaw team (`Y5PE65HELJ`) when that team exists locally.
-- If not present, it picks the first non-personal team from your Xcode account (falls back to personal team if needed).
-- It writes the selected team to `apps/ios/.local-signing.xcconfig` (local-only, gitignored).
+- The app calls `registerForRemoteNotifications()` at launch.
+- `apps/ios/Sources/OpenClaw.entitlements` sets `aps-environment` to `development`.
+- APNs token registration to gateway happens only after gateway connection (`push.apns.register`).
+- Your selected team/profile must support Push Notifications for the app bundle ID you are signing.
+- If push capability or provisioning is wrong, APNs registration fails at runtime (check Xcode logs for `APNs registration failed`).
+- Debug builds register as APNs sandbox; Release builds use production.
 
-Then in Xcode:
+## What Works Now (Concrete)
 
-1. Select the `OpenClaw` scheme
-2. Select a simulator or a connected device
-3. Run
+- Pairing via setup code flow (`/pair` then `/pair approve` in Telegram).
+- Gateway connection via discovery or manual host/port with TLS fingerprint trust prompt.
+- Chat + Talk surfaces through the operator gateway session.
+- iPhone node commands in foreground: camera snap/clip, canvas present/navigate/eval/snapshot, screen record, location, contacts, calendar, reminders, photos, motion, local notifications.
+- Share extension deep-link forwarding into the connected gateway session.
 
-If you're using a personal Apple Development team, you may still need to change the bundle identifier in Xcode to a unique value so signing succeeds.
+## Known Issues / Limitations / Problems
 
-## Build From CLI
+- Foreground-first: iOS can suspend sockets in background; reconnect recovery is still being tuned.
+- Background command limits are strict: `canvas.*`, `camera.*`, `screen.*`, and `talk.*` are blocked when backgrounded.
+- Background location requires `Always` location permission.
+- Pairing/auth errors intentionally pause reconnect loops until a human fixes auth/pairing state.
+- Voice Wake and Talk contend for the same microphone; Talk suppresses wake capture while active.
+- APNs reliability depends on local signing/provisioning/topic alignment.
+- Expect rough UX edges and occasional reconnect churn during active development.
 
-```bash
-pnpm ios:build
-```
+## Current In-Progress Workstream
 
-## Tests
+Automatic wake/reconnect hardening:
 
-```bash
-cd apps/ios
-xcodegen generate
-xcodebuild test -project OpenClaw.xcodeproj -scheme OpenClaw -destination "platform=iOS Simulator,name=iPhone 17"
-```
+- improve wake/resume behavior across scene transitions
+- reduce dead-socket states after background -> foreground
+- tighten node/operator session reconnect coordination
+- reduce manual recovery steps after transient network failures
 
-## Shared Code
+## Debugging Checklist
 
-- `apps/shared/OpenClawKit` contains the shared transport/types used by the iOS app.
+1. Confirm build/signing baseline:
+   - regenerate project (`xcodegen generate`)
+   - verify selected team + bundle IDs
+2. In app `Settings -> Gateway`:
+   - confirm status text, server, and remote address
+   - verify whether status shows pairing/auth gating
+3. If pairing is required:
+   - run `/pair approve` from Telegram, then reconnect
+4. If discovery is flaky:
+   - enable `Discovery Debug Logs`
+   - inspect `Settings -> Gateway -> Discovery Logs`
+5. If network path is unclear:
+   - switch to manual host/port + TLS in Gateway Advanced settings
+6. In Xcode console, filter for subsystem/category signals:
+   - `ai.openclaw.ios`
+   - `GatewayDiag`
+   - `APNs registration failed`
+7. Validate background expectations:
+   - repro in foreground first
+   - then test background transitions and confirm reconnect on return

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../protocol/index.js";
+import { nodeHandlers } from "./nodes.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+  resolveNodeCommandAllowlist: vi.fn(() => []),
+  isNodeCommandAllowed: vi.fn(() => ({ ok: true })),
+  sanitizeNodeInvokeParamsForForwarding: vi.fn(({ rawParams }: { rawParams: unknown }) => ({
+    ok: true,
+    params: rawParams,
+  })),
+  loadApnsRegistration: vi.fn(),
+  resolveApnsAuthConfigFromEnv: vi.fn(),
+  sendApnsBackgroundWake: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../node-command-policy.js", () => ({
+  resolveNodeCommandAllowlist: mocks.resolveNodeCommandAllowlist,
+  isNodeCommandAllowed: mocks.isNodeCommandAllowed,
+}));
+
+vi.mock("../node-invoke-sanitize.js", () => ({
+  sanitizeNodeInvokeParamsForForwarding: mocks.sanitizeNodeInvokeParamsForForwarding,
+}));
+
+vi.mock("../../infra/push-apns.js", () => ({
+  loadApnsRegistration: mocks.loadApnsRegistration,
+  resolveApnsAuthConfigFromEnv: mocks.resolveApnsAuthConfigFromEnv,
+  sendApnsBackgroundWake: mocks.sendApnsBackgroundWake,
+}));
+
+type RespondCall = [
+  boolean,
+  unknown?,
+  {
+    code?: number;
+    message?: string;
+    details?: unknown;
+  }?,
+];
+
+type TestNodeSession = {
+  nodeId: string;
+  commands: string[];
+};
+
+function makeNodeInvokeParams(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    nodeId: "ios-node-1",
+    command: "camera.capture",
+    params: { quality: "high" },
+    timeoutMs: 5000,
+    idempotencyKey: "idem-node-invoke",
+    ...overrides,
+  };
+}
+
+async function invokeNode(params: {
+  nodeRegistry: {
+    get: (nodeId: string) => TestNodeSession | undefined;
+    invoke: (payload: {
+      nodeId: string;
+      command: string;
+      params?: unknown;
+      timeoutMs?: number;
+      idempotencyKey?: string;
+    }) => Promise<{
+      ok: boolean;
+      payload?: unknown;
+      payloadJSON?: string | null;
+      error?: { code?: string; message?: string } | null;
+    }>;
+  };
+  requestParams?: Partial<Record<string, unknown>>;
+}) {
+  const respond = vi.fn();
+  await nodeHandlers["node.invoke"]({
+    params: makeNodeInvokeParams(params.requestParams),
+    respond: respond as never,
+    context: {
+      nodeRegistry: params.nodeRegistry,
+      execApprovalManager: undefined,
+    } as never,
+    client: null,
+    req: { type: "req", id: "req-node-invoke", method: "node.invoke" },
+    isWebchatConnect: () => false,
+  });
+  return respond;
+}
+
+describe("node.invoke APNs wake path", () => {
+  beforeEach(() => {
+    mocks.loadConfig.mockReset();
+    mocks.loadConfig.mockReturnValue({});
+    mocks.resolveNodeCommandAllowlist.mockReset();
+    mocks.resolveNodeCommandAllowlist.mockReturnValue([]);
+    mocks.isNodeCommandAllowed.mockReset();
+    mocks.isNodeCommandAllowed.mockReturnValue({ ok: true });
+    mocks.sanitizeNodeInvokeParamsForForwarding.mockReset();
+    mocks.sanitizeNodeInvokeParamsForForwarding.mockImplementation(
+      ({ rawParams }: { rawParams: unknown }) => ({ ok: true, params: rawParams }),
+    );
+    mocks.loadApnsRegistration.mockReset();
+    mocks.resolveApnsAuthConfigFromEnv.mockReset();
+    mocks.sendApnsBackgroundWake.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the existing not-connected response when wake path is unavailable", async () => {
+    mocks.loadApnsRegistration.mockResolvedValue(null);
+
+    const nodeRegistry = {
+      get: vi.fn(() => undefined),
+      invoke: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    const respond = await invokeNode({ nodeRegistry });
+    const call = respond.mock.calls[0] as RespondCall | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.code).toBe(ErrorCodes.UNAVAILABLE);
+    expect(call?.[2]?.message).toBe("node not connected");
+    expect(mocks.sendApnsBackgroundWake).not.toHaveBeenCalled();
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+  });
+
+  it("wakes and retries invoke after the node reconnects", async () => {
+    vi.useFakeTimers();
+    mocks.loadApnsRegistration.mockResolvedValue({
+      nodeId: "ios-node-reconnect",
+      token: "abcd1234abcd1234abcd1234abcd1234",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      updatedAtMs: 1,
+    });
+    mocks.resolveApnsAuthConfigFromEnv.mockResolvedValue({
+      ok: true,
+      value: {
+        teamId: "TEAM123",
+        keyId: "KEY123",
+        privateKey: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+      },
+    });
+    mocks.sendApnsBackgroundWake.mockResolvedValue({
+      ok: true,
+      status: 200,
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+    });
+
+    let connected = false;
+    const session: TestNodeSession = { nodeId: "ios-node-reconnect", commands: ["camera.capture"] };
+    const nodeRegistry = {
+      get: vi.fn((nodeId: string) => {
+        if (nodeId !== "ios-node-reconnect") {
+          return undefined;
+        }
+        return connected ? session : undefined;
+      }),
+      invoke: vi.fn().mockResolvedValue({
+        ok: true,
+        payload: { ok: true },
+        payloadJSON: '{"ok":true}',
+      }),
+    };
+
+    const invokePromise = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId: "ios-node-reconnect", idempotencyKey: "idem-reconnect" },
+    });
+    setTimeout(() => {
+      connected = true;
+    }, 300);
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    const respond = await invokePromise;
+
+    expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledTimes(1);
+    expect(nodeRegistry.invoke).toHaveBeenCalledTimes(1);
+    expect(nodeRegistry.invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "ios-node-reconnect",
+        command: "camera.capture",
+      }),
+    );
+    const call = respond.mock.calls[0] as RespondCall | undefined;
+    expect(call?.[0]).toBe(true);
+    expect(call?.[1]).toMatchObject({ ok: true, nodeId: "ios-node-reconnect" });
+  });
+
+  it("throttles repeated wake attempts for the same disconnected node", async () => {
+    vi.useFakeTimers();
+    mocks.loadApnsRegistration.mockResolvedValue({
+      nodeId: "ios-node-throttle",
+      token: "abcd1234abcd1234abcd1234abcd1234",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      updatedAtMs: 1,
+    });
+    mocks.resolveApnsAuthConfigFromEnv.mockResolvedValue({
+      ok: true,
+      value: {
+        teamId: "TEAM123",
+        keyId: "KEY123",
+        privateKey: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+      },
+    });
+    mocks.sendApnsBackgroundWake.mockResolvedValue({
+      ok: true,
+      status: 200,
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+    });
+
+    const nodeRegistry = {
+      get: vi.fn(() => undefined),
+      invoke: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    const first = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId: "ios-node-throttle", idempotencyKey: "idem-throttle-1" },
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    await first;
+
+    const second = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId: "ios-node-throttle", idempotencyKey: "idem-throttle-2" },
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    await second;
+
+    expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledTimes(1);
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -1,15 +1,21 @@
+import { generateKeyPairSync } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   loadApnsRegistration,
   normalizeApnsEnvironment,
   registerApnsToken,
   resolveApnsAuthConfigFromEnv,
+  sendApnsAlert,
+  sendApnsBackgroundWake,
 } from "./push-apns.js";
 
 const tempDirs: string[] = [];
+const testAuthPrivateKey = generateKeyPairSync("ec", { namedCurve: "prime256v1" })
+  .privateKey.export({ format: "pem", type: "pkcs8" })
+  .toString();
 
 async function makeTempDir(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-push-apns-test-"));
@@ -90,5 +96,98 @@ describe("push APNs env config", () => {
       return;
     }
     expect(resolved.error).toContain("OPENCLAW_APNS_TEAM_ID");
+  });
+});
+
+describe("push APNs send semantics", () => {
+  it("sends alert pushes with alert headers and payload", async () => {
+    const send = vi.fn().mockResolvedValue({
+      status: 200,
+      apnsId: "apns-alert-id",
+      body: "",
+    });
+
+    const result = await sendApnsAlert({
+      auth: {
+        teamId: "TEAM123",
+        keyId: "KEY123",
+        privateKey: testAuthPrivateKey,
+      },
+      registration: {
+        nodeId: "ios-node-alert",
+        token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+        topic: "ai.openclaw.ios",
+        environment: "sandbox",
+        updatedAtMs: 1,
+      },
+      nodeId: "ios-node-alert",
+      title: "Wake",
+      body: "Ping",
+      requestSender: send,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent?.pushType).toBe("alert");
+    expect(sent?.priority).toBe("10");
+    expect(sent?.payload).toMatchObject({
+      aps: {
+        alert: { title: "Wake", body: "Ping" },
+        sound: "default",
+      },
+      openclaw: {
+        kind: "push.test",
+        nodeId: "ios-node-alert",
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+  });
+
+  it("sends background wake pushes with silent payload semantics", async () => {
+    const send = vi.fn().mockResolvedValue({
+      status: 200,
+      apnsId: "apns-wake-id",
+      body: "",
+    });
+
+    const result = await sendApnsBackgroundWake({
+      auth: {
+        teamId: "TEAM123",
+        keyId: "KEY123",
+        privateKey: testAuthPrivateKey,
+      },
+      registration: {
+        nodeId: "ios-node-wake",
+        token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+        topic: "ai.openclaw.ios",
+        environment: "production",
+        updatedAtMs: 1,
+      },
+      nodeId: "ios-node-wake",
+      wakeReason: "node.invoke",
+      requestSender: send,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent?.pushType).toBe("background");
+    expect(sent?.priority).toBe("5");
+    expect(sent?.payload).toMatchObject({
+      aps: {
+        "content-available": 1,
+      },
+      openclaw: {
+        kind: "node.wake",
+        reason: "node.invoke",
+        nodeId: "ios-node-wake",
+      },
+    });
+    const sentPayload = sent?.payload as { aps?: { alert?: unknown; sound?: unknown } } | undefined;
+    const aps = sentPayload?.aps;
+    expect(aps?.alert).toBeUndefined();
+    expect(aps?.sound).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.environment).toBe("production");
   });
 });


### PR DESCRIPTION
## Summary

- Problem: iOS nodes disconnect in background and `node.invoke` fails immediately with `node not connected`.
- Why it matters: node-targeted commands fail unless users foreground the app manually.
- What changed: gateway now sends APNs silent wake for disconnected iOS nodes before invoke, waits briefly for reconnect, and then retries invoke; iOS app now handles silent push wake to trigger reconnect; iOS README rewritten with alpha/manual deploy/push guidance.
- What did NOT change (scope boundary): no Android work, no TestFlight/App Store distribution pipeline, no changes to command allowlist policy.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `node.invoke` now attempts APNs background wake for disconnected iOS nodes (throttled), waits up to ~3s for reconnect, then proceeds.
- iOS app now responds to silent APNs wake notifications and triggers gateway reconnect while backgrounded.
- iOS README now explicitly states `NO TEST FLIGHT AVAILABLE AT THIS POINT` and documents manual Xcode deploy + current alpha limitations.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Gateway now sends APNs background pushes in addition to alert pushes. Mitigations: existing APNs auth config is reused, wake attempts are best-effort, and per-node wake attempts are throttled.

## Repro + Verification

### Environment

- OS: macOS host + physical iPhone
- Runtime/container: Node 22+/pnpm
- Model/provider: N/A
- Integration/channel (if any): APNs sandbox
- Relevant config (redacted): `OPENCLAW_APNS_TEAM_ID`, `OPENCLAW_APNS_KEY_ID`, `OPENCLAW_APNS_PRIVATE_KEY_PATH`

### Steps

1. Put paired iOS app in background so node is disconnected.
2. Call `node.invoke` against iOS node.
3. Observe APNs wake + reconnect path and invoke result.

### Expected

- Gateway attempts wake, node reconnects, invoke succeeds when reconnect lands in wait window.

### Actual

- Verified on physical device; invoke succeeded after wake/reconnect.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Targeted tests pass:
    - `pnpm test -- src/infra/push-apns.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts`
  - Physical iPhone redeploy and background wake test succeeded end-to-end.
- Edge cases checked:
  - No APNs registration -> retains existing `node not connected` behavior.
  - Wake throttling avoids repeated APNs spam for same disconnected node.
- What you did **not** verify:
  - Production APNs env behavior.
  - Long background suspension / low-power edge behavior.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR or disable APNs env vars so wake path becomes no-op and existing behavior remains.
- Files/config to restore:
  - `src/gateway/server-methods/nodes.ts`
  - `src/infra/push-apns.ts`
  - iOS app changes in `apps/ios/Sources/OpenClawApp.swift` and `apps/ios/Sources/Model/NodeAppModel.swift`
- Known bad symptoms reviewers should watch for:
  - Unexpected repeated APNs wake attempts.
  - iOS app reconnect loops while foregrounded.

## Risks and Mitigations

- Risk: silent push may not be delivered under some iOS background conditions.
  - Mitigation: behavior remains best-effort and falls back to current `node not connected` failure mode.
- Risk: wake path might add latency to failed invokes on disconnected nodes.
  - Mitigation: reconnect wait window is capped (~3s) and wake attempts are throttled.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds APNs silent push wake support so the gateway can wake disconnected iOS nodes before `node.invoke` fails. The implementation spans three layers:

- **Gateway (`nodes.ts`, `push-apns.ts`)**: When `node.invoke` finds a disconnected node, it sends an APNs background push, then polls for up to ~3s for the node to reconnect. Wake attempts are throttled per-node (15s). A new `push.test` gateway method and CLI command are also added for debugging APNs delivery.
- **iOS app (`OpenClawApp.swift`, `NodeAppModel.swift`)**: The app registers for remote notifications at launch, sends the APNs device token to the gateway via `push.apns.register` node event on connect, and handles silent push wakes by triggering a gateway reconnect when backgrounded.
- **Supporting changes**: session key alias matching (`"main"` ↔ `"agent:main:main"`) fixes chat event routing, A2UI asset resolution is improved with retry-on-null caching and additional path candidates, Watch bundle IDs are parameterized via xcconfig, and the iOS README is rewritten for the current alpha state.

Key observations:
- The `nodeWakeById` throttle map in `nodes.ts` never evicts entries — acceptable for personal gateway usage but worth noting for long-lived processes.
- There is a race condition where the APNs device token delivery to `appDelegate.appModel` could be missed on first-ever launch since the model is assigned asynchronously via `.task {}`. Recovery via `UserDefaults` and `onNodeGatewayConnected` mitigates this.
- The WatchConnectivity `replyHandler` is now called before dispatching to `@MainActor`, fixing a potential WatchKit timeout.
- Test coverage is solid with dedicated tests for the wake path, throttling, push.test handler, and APNs send semantics.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor concerns around a timing race and unbounded map growth, both of which have reasonable mitigations.
- The core wake-before-invoke logic is well-structured with throttling, best-effort semantics, and proper fallback to existing behavior. The APNs integration follows Apple's documented patterns correctly. Test coverage is thorough. The two issues flagged (unbounded map, token race) are low-severity and have built-in recovery paths. The overall design is defensive and backward-compatible.
- `apps/ios/Sources/OpenClawApp.swift` (APNs token delivery race) and `src/gateway/server-methods/nodes.ts` (unbounded wake state map)

<sub>Last reviewed commit: 2001b84</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->