### PR TITLE
docs: add AgentFlow to Built with OpenClaw section

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,10 @@ Use these when you’re past the onboarding flow and want the deeper reference.
 
 - [docs.openclaw.ai/gmail-pubsub](https://docs.openclaw.ai/automation/gmail-pubsub)
 
+## Built with OpenClaw
+
+- **[AgentFlow](https://agentflow.frexida.com)** — Visual AI agent organization designer. Drag-and-drop org chart editor → OpenClaw config export. Design multi-agent teams visually, then deploy in one click. ([GitHub](https://github.com/Frexida/agentflow))
+
 ## Molty
 
 OpenClaw was built for **Molty**, a space lobster AI assistant. 🦞


### PR DESCRIPTION
## AgentFlow — Visual AI Agent Organization Designer

Adds AgentFlow to a new "Built with OpenClaw" section in the README.

**What is AgentFlow?**
- Visual drag-and-drop org chart editor for AI agent teams
- Exports OpenClaw-compatible YAML configs
- Built with Next.js, React Flow, and Supabase
- MIT licensed

🔗 **Live:** https://agentflow.frexida.com
📦 **Repo:** https://github.com/Frexida/agentflow

Built entirely by an AI agent team running on OpenClaw. 🦞

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new "Built with OpenClaw" community showcase section to the README, featuring AgentFlow — a visual drag-and-drop org chart editor that exports OpenClaw-compatible YAML configs.

- New `## Built with OpenClaw` section added between "Email hooks (Gmail)" and "Molty" sections
- Single entry links to both the [live site](https://agentflow.frexida.com) and [GitHub repo](https://github.com/Frexida/agentflow)
- Documentation-only change with no code impact

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds 4 lines of markdown to the README with no code changes.
- Documentation-only change that adds a community project link to the README. No code, configuration, or dependency changes. The markdown is well-formatted and consistent with the existing README style.
- No files require special attention.

<sub>Last reviewed commit: 082f17a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->