### PR TITLE
feat(tts): add instructions field to OpenAI TTS provider

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -61,6 +61,7 @@ export type TtsConfig = {
     baseUrl?: string;
     model?: string;
     voice?: string;
+    instructions?: string;
   };
   /** Microsoft Edge (node-edge-tts) configuration. */
   edge?: {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -406,6 +406,7 @@ export const TtsConfigSchema = z
         baseUrl: z.string().optional(),
         model: z.string().optional(),
         voice: z.string().optional(),
+        instructions: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -619,10 +619,11 @@ export async function openaiTTS(params: {
   baseUrl: string;
   model: string;
   voice: string;
+  instructions?: string;
   responseFormat: "mp3" | "opus" | "pcm";
   timeoutMs: number;
 }): Promise<Buffer> {
-  const { text, apiKey, baseUrl, model, voice, responseFormat, timeoutMs } = params;
+  const { text, apiKey, baseUrl, model, voice, instructions, responseFormat, timeoutMs } = params;
 
   if (!isValidOpenAIModel(model, baseUrl)) {
     throw new Error(`Invalid model: ${model}`);
@@ -645,6 +646,7 @@ export async function openaiTTS(params: {
         model,
         input: text,
         voice,
+        ...(instructions ? { instructions } : {}),
         response_format: responseFormat,
       }),
       signal: controller.signal,

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -117,6 +117,7 @@ export type ResolvedTtsConfig = {
     baseUrl: string;
     model: string;
     voice: string;
+    instructions?: string;
   };
   edge: {
     enabled: boolean;
@@ -304,6 +305,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       ).replace(/\/+$/, ""),
       model: raw.openai?.model ?? DEFAULT_OPENAI_MODEL,
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
+      instructions: raw.openai?.instructions,
     },
     edge: {
       enabled: raw.edge?.enabled ?? true,
@@ -692,6 +694,7 @@ export async function textToSpeech(params: {
           baseUrl: config.openai.baseUrl,
           model: openaiModelOverride ?? config.openai.model,
           voice: openaiVoiceOverride ?? config.openai.voice,
+          instructions: config.openai.instructions,
           responseFormat: output.openai,
           timeoutMs: config.timeoutMs,
         });
@@ -789,6 +792,7 @@ export async function textToSpeechTelephony(params: {
         baseUrl: config.openai.baseUrl,
         model: config.openai.model,
         voice: config.openai.voice,
+        instructions: config.openai.instructions,
         responseFormat: output.format,
         timeoutMs: config.timeoutMs,
       });


### PR DESCRIPTION
Add support for the `instructions` field in the OpenAI TTS provider config, enabling voice personality/style control.

```json
{
  "messages": {
    "tts": {
      "provider": "openai",
      "openai": {
        "model": "gpt-4o-mini-tts",
        "voice": "onyx",
        "instructions": "Speak in a calm, measured tone with slight pauses before key information."
      }
    }
  }
}
```

## Context

The OpenAI `/v1/audio/speech` API supports an `instructions` parameter that controls voice affect, personality, pacing, accent, and pronunciation. This field was not previously exposed in the OpenClaw config.