### PR TITLE
feat(discord): attach sender presence context metadata

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -465,7 +465,9 @@ Use `bindings[].match.roles` to route Discord guild members to different agents 
     - Message Content Intent
     - Server Members Intent (recommended)
 
-    Presence intent is optional and only required if you want to receive presence updates. Setting bot presence (`setPresence`) does not require enabling presence updates for members.
+    Presence intent is optional and only required if you want OpenClaw to receive member presence updates (status + activities) and include them as untrusted context in replies.
+
+    Setting bot presence (`setPresence`) does not require enabling member presence updates.
 
   </Accordion>
 
@@ -706,6 +708,32 @@ See [Slash commands](/tools/slash-commands) for command catalog and behavior.
     - 3: Watching
     - 4: Custom (uses the activity text as the status state; emoji is optional)
     - 5: Competing
+
+  </Accordion>
+
+  <Accordion title="Sender presence context (opt-in)">
+    OpenClaw can attach Discord sender presence metadata (for example `idle`, `dnd`, `Playing`, `Listening`) to the inbound prompt context.
+
+    This is opt-in and only active when `channels.discord.intents.presence=true`.
+
+```json5
+{
+  channels: {
+    discord: {
+      intents: {
+        presence: true,
+      },
+    },
+  },
+}
+```
+
+    Notes:
+
+    - Presence updates come from Discord gateway `PRESENCE_UPDATE` events and may be stale or missing.
+    - Presence metadata is appended as **untrusted context** (never as system instructions).
+    - Discord only emits these updates when the privileged Presence intent is enabled in both OpenClaw config and the Discord Developer Portal.
+    - DM-only workflows may not have presence data unless the same user is observed in guild presence updates.
 
   </Accordion>
 

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -383,7 +383,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       })
     : undefined;
   const senderPresenceMetadata = discordConfig?.intents?.presence
-    ? buildDiscordPresenceMetadata(getPresence(accountId, senderId))
+    ? buildDiscordPresenceMetadata({ presence: getPresence(accountId, senderId) })
     : undefined;
   const untrustedContext = [untrustedChannelMetadata, senderPresenceMetadata].filter(
     (entry): entry is string => Boolean(entry),

--- a/src/discord/monitor/presence-context.test.ts
+++ b/src/discord/monitor/presence-context.test.ts
@@ -1,0 +1,173 @@
+import {
+  ActivityType,
+  PresenceUpdateStatus,
+  type PresenceUpdateReceiveStatus,
+  type GatewayPresenceUpdate,
+  type GatewayActivity,
+} from "discord-api-types/v10";
+import { describe, expect, it, vi } from "vitest";
+import { __testing, buildDiscordPresenceMetadata } from "./presence-context.js";
+import { PRESENCE_CONTEXT_LABEL, PRESENCE_MAX_ACTIVITY_ENTRIES } from "./presence.constants.js";
+
+function createActivity(params: {
+  id: string;
+  name: string;
+  type?: ActivityType;
+  createdAt: number;
+  details?: string;
+  startMs?: number;
+}): GatewayActivity {
+  return {
+    id: params.id,
+    name: params.name,
+    type: params.type ?? ActivityType.Playing,
+    created_at: params.createdAt,
+    details: params.details,
+    timestamps: params.startMs ? { start: params.startMs } : undefined,
+  };
+}
+
+function createPresence(params: {
+  status: PresenceUpdateReceiveStatus;
+  activities?: GatewayActivity[];
+}): GatewayPresenceUpdate {
+  return {
+    guild_id: "123456789012345678",
+    user: { id: "876543210987654321" },
+    status: params.status,
+    activities: params.activities ?? [],
+  };
+}
+
+describe("presence-context helpers", () => {
+  it("resolves known activity labels and falls back for unknown type", () => {
+    expect(__testing.resolveActivityTypeLabel({ activityType: ActivityType.Playing })).toBe(
+      "Playing",
+    );
+    expect(__testing.resolveActivityTypeLabel({ activityType: 99 })).toBe("Activity 99");
+    expect(__testing.resolveActivityTypeLabel({ activityType: undefined })).toBe("Activity");
+  });
+
+  it("resolves activity duration from start/end timestamps", () => {
+    const nowMs = Date.UTC(2026, 1, 18, 10, 0, 0);
+    const activity = createActivity({
+      id: "duration-test",
+      name: "Game",
+      createdAt: nowMs - 5000,
+      startMs: nowMs - 5000,
+    });
+    expect(__testing.resolveActivityDurationMs({ activity, nowMs })).toBe(5000);
+
+    const endedActivity = {
+      ...activity,
+      timestamps: {
+        start: nowMs - 5000,
+        end: nowMs - 1000,
+      },
+    };
+    expect(__testing.resolveActivityDurationMs({ activity: endedActivity, nowMs })).toBe(4000);
+  });
+
+  it("returns undefined duration for invalid timestamps", () => {
+    const nowMs = Date.UTC(2026, 1, 18, 10, 0, 0);
+    const invalidActivity = {
+      ...createActivity({
+        id: "invalid-duration",
+        name: "Game",
+        createdAt: nowMs,
+      }),
+      timestamps: {
+        start: Number.NaN,
+      },
+    };
+    expect(
+      __testing.resolveActivityDurationMs({ activity: invalidActivity, nowMs }),
+    ).toBeUndefined();
+  });
+
+  it("builds presence metadata entry lines", () => {
+    expect(
+      __testing.resolvePresenceMetadataEntries({
+        status: "idle",
+        activities: ["Listening: Spotify"],
+      }),
+    ).toEqual(["Sender status: idle", "Sender activities: Listening: Spotify"]);
+  });
+});
+
+describe("buildDiscordPresenceMetadata", () => {
+  it("returns undefined when presence is missing", () => {
+    expect(buildDiscordPresenceMetadata({})).toBeUndefined();
+  });
+
+  it("includes status, activity name and duration", () => {
+    const nowMs = Date.UTC(2026, 1, 18, 10, 0, 0);
+    const startMs = nowMs - 75_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    let metadata: string | undefined;
+    try {
+      metadata = buildDiscordPresenceMetadata({
+        presence: createPresence({
+          status: PresenceUpdateStatus.Idle,
+          activities: [
+            createActivity({
+              id: "activity-spotify",
+              name: "Spotify",
+              type: ActivityType.Listening,
+              createdAt: startMs,
+              details: "Lo-fi beats",
+              startMs,
+            }),
+          ],
+        }),
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(metadata).toContain(PRESENCE_CONTEXT_LABEL);
+    expect(metadata).toContain("Sender status: idle");
+    expect(metadata).toContain("Listening: Spotify");
+    expect(metadata).toContain("details=Lo-fi beats");
+    expect(metadata).toContain("duration=1m 15s");
+  });
+
+  it("limits activities to configured max entries", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 1, 18, 10, 0, 0));
+    let metadata: string | undefined;
+    try {
+      const activities = Array.from({ length: PRESENCE_MAX_ACTIVITY_ENTRIES + 2 }, (_, index) => ({
+        id: `activity-${index}`,
+        name: `Game ${index}`,
+        created_at: Date.now(),
+        type: ActivityType.Playing,
+      }));
+      metadata = buildDiscordPresenceMetadata({
+        presence: createPresence({
+          status: PresenceUpdateStatus.DoNotDisturb,
+          activities,
+        }),
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(metadata).toContain(`Game ${PRESENCE_MAX_ACTIVITY_ENTRIES - 1}`);
+    expect(metadata).not.toContain(`Game ${PRESENCE_MAX_ACTIVITY_ENTRIES}`);
+  });
+
+  it("caps activity summaries through helper", () => {
+    const nowMs = Date.UTC(2026, 1, 18, 10, 0, 0);
+    const summaries = __testing.resolvePresenceActivitySummaries({
+      nowMs,
+      activities: Array.from({ length: PRESENCE_MAX_ACTIVITY_ENTRIES + 5 }, (_, index) =>
+        createActivity({
+          id: `a-${index}`,
+          name: `Game ${index}`,
+          createdAt: nowMs,
+        }),
+      ),
+    });
+    expect(summaries).toHaveLength(PRESENCE_MAX_ACTIVITY_ENTRIES);
+  });
+});

--- a/src/discord/monitor/presence-context.ts
+++ b/src/discord/monitor/presence-context.ts
@@ -1,73 +1,201 @@
-import type { GatewayPresenceUpdate } from "discord-api-types/v10";
+import type { GatewayActivity, GatewayPresenceUpdate } from "discord-api-types/v10";
+import { formatDurationCompact } from "../../infra/format-time/format-duration.ts";
 import { buildUntrustedChannelMetadata } from "../../security/channel-metadata.js";
+import {
+  ACTIVITY_LABEL,
+  PRESENCE_CONTEXT_LABEL,
+  PRESENCE_MAX_ACTIVITY_ENTRIES,
+  ACTIVITY_TYPE_LABELS,
+} from "./presence.constants.js";
 
-const MAX_ACTIVITY_ENTRIES = 3;
+const normalizeTimestamp = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
 
-const ACTIVITY_TYPE_LABELS: Record<number, string> = {
-  0: "Playing",
-  1: "Streaming",
-  2: "Listening",
-  3: "Watching",
-  4: "Custom",
-  5: "Competing",
+/**
+ * Resolve a human label for a Discord activity type.
+ *
+ * @param params.activityType Discord activity type integer.
+ * @returns Human-readable activity type label.
+ * @see https://discord.com/developers/docs/events/gateway-events#activity-object-activity-types
+ */
+type ResolveActivityTypeLabelProps = {
+  activityType?: number;
 };
 
-function normalizeText(value: unknown): string {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function resolveActivityLabel(activity: {
-  type?: number;
-  name?: string;
-  state?: string | null;
-  details?: string | null;
-}): string | null {
-  const typeLabel =
-    typeof activity.type === "number"
-      ? (ACTIVITY_TYPE_LABELS[activity.type] ?? `Activity ${activity.type}`)
-      : "Activity";
-  const name = normalizeText(activity.name);
-  const details = normalizeText(activity.details);
-  const state = normalizeText(activity.state);
-  const headline = name || details || state;
-  if (!headline) {
-    return null;
+const resolveActivityTypeLabel = ({ activityType }: ResolveActivityTypeLabelProps): string => {
+  if (typeof activityType !== "number") {
+    return ACTIVITY_LABEL;
   }
+
+  const known = ACTIVITY_TYPE_LABELS[activityType as keyof typeof ACTIVITY_TYPE_LABELS];
+
+  return known ?? `${ACTIVITY_LABEL} ${activityType}`;
+};
+
+/**
+ * Resolve activity duration in milliseconds when a start timestamp exists.
+ *
+ * @param params.activity Discord activity payload.
+ * @param params.nowMs Current timestamp in milliseconds.
+ * @returns Duration in milliseconds or undefined when unavailable.
+ * @see https://discord.com/developers/docs/events/gateway-events#activity-object-activity-timestamps
+ * @see https://discord.js.org/docs/packages/discord.js/main/Activity:Class
+ */
+type ResolveActivityDurationMsProps = {
+  activity: GatewayActivity;
+  nowMs: number;
+};
+
+const resolveActivityDurationMs = ({
+  activity,
+  nowMs,
+}: ResolveActivityDurationMsProps): number | undefined => {
+  const startedAtMs = normalizeTimestamp(activity.timestamps?.start);
+  const endedAtMs = normalizeTimestamp(activity.timestamps?.end);
+
+  if (startedAtMs === undefined) {
+    return undefined;
+  }
+
+  return Math.max(0, (endedAtMs ?? nowMs) - startedAtMs);
+};
+
+/**
+ * Formats one Discord activity entry from presence updates.
+ *
+ * @param params.activity Activity item from Discord presence payload.
+ * @param params.nowMs Current timestamp in milliseconds.
+ * @returns Formatted activity summary string.
+ * @see https://discord.com/developers/docs/events/gateway-events#presence-update
+ * @see https://discord.com/developers/docs/events/gateway-events#activity-object
+ * @see https://discord.js.org/docs/packages/discord.js/main/Presence:Class
+ */
+type ResolveActivityLabelProps = {
+  activity: GatewayActivity;
+  nowMs: number;
+};
+
+const resolveActivityLabel = ({
+  activity,
+  nowMs,
+}: ResolveActivityLabelProps): string | undefined => {
+  const typeLabel = resolveActivityTypeLabel({ activityType: activity.type });
+
+  const name = activity.name.trim();
+  const details = activity.details?.trim() ?? "";
+  const state = activity.state?.trim() ?? "";
+
+  const headline = name || details || state;
+
+  if (!headline) {
+    return undefined;
+  }
+
+  const durationMs = resolveActivityDurationMs({ activity, nowMs });
+
+  const duration = formatDurationCompact(durationMs, { spaced: true });
+
   const segments = [`${typeLabel}: ${headline}`];
+
   if (details && details !== headline) {
     segments.push(`details=${details}`);
   }
+
   if (state && state !== headline) {
     segments.push(`state=${state}`);
   }
-  return segments.join(" | ");
-}
 
-export function buildDiscordPresenceMetadata(
-  presence: GatewayPresenceUpdate | undefined,
-): string | undefined {
+  if (duration) {
+    segments.push(`duration=${duration}`);
+  }
+
+  return segments.join(" | ");
+};
+
+/**
+ * Build bounded formatted activity summaries from presence activities.
+ *
+ * @param params.activities Raw Discord activity list.
+ * @param params.nowMs Current timestamp in milliseconds.
+ * @returns Formatted activity summaries capped by configured max entries.
+ */
+type ResolvePresenceActivitySummariesProps = {
+  activities?: GatewayActivity[];
+  nowMs: number;
+};
+
+const resolvePresenceActivitySummaries = ({
+  activities = [],
+  nowMs,
+}: ResolvePresenceActivitySummariesProps): string[] =>
+  activities
+    .map((activity) => resolveActivityLabel({ activity, nowMs }))
+    .filter((entry): entry is string => Boolean(entry))
+    .slice(0, PRESENCE_MAX_ACTIVITY_ENTRIES);
+
+/**
+ * Build untrusted metadata lines for sender status + activities.
+ *
+ * @param params.status Presence status string.
+ * @param params.activities Formatted activity summaries.
+ * @returns Non-empty metadata lines.
+ */
+type ResolvePresenceMetadataEntriesProps = {
+  status?: string;
+  activities: string[];
+};
+
+const resolvePresenceMetadataEntries = ({
+  status,
+  activities,
+}: ResolvePresenceMetadataEntriesProps): string[] =>
+  [
+    status ? `Sender status: ${status}` : undefined,
+    activities.length > 0 ? `Sender activities: ${activities.join("; ")}` : undefined,
+  ].filter((entry): entry is string => Boolean(entry));
+
+type BuildDiscordPresenceMetadataParams = {
+  presence?: GatewayPresenceUpdate;
+};
+
+/**
+ * Convert Discord presence payload into a safe, untrusted metadata block.
+ *
+ * @param params.presence Discord gateway presence update payload.
+ * @returns Wrapped untrusted metadata block or undefined when no useful presence data exists.
+ * @see https://discord.com/developers/docs/events/gateway-events#presence-update
+ */
+export const buildDiscordPresenceMetadata = ({
+  presence,
+}: BuildDiscordPresenceMetadataParams): string | undefined => {
   if (!presence) {
     return undefined;
   }
 
-  const status = normalizeText(presence.status);
-  const activities = (presence.activities ?? [])
-    .map((activity) => resolveActivityLabel(activity))
-    .filter((entry): entry is string => Boolean(entry))
-    .slice(0, MAX_ACTIVITY_ENTRIES);
+  const nowMs = Date.now();
+  const status = presence.status?.trim() ?? "";
+
+  const activities = resolvePresenceActivitySummaries({
+    activities: presence.activities,
+    nowMs,
+  });
 
   if (!status && activities.length === 0) {
     return undefined;
   }
 
-  const entries = [
-    status ? `Sender status: ${status}` : null,
-    activities.length > 0 ? `Sender activities: ${activities.join("; ")}` : null,
-  ].filter((entry): entry is string => Boolean(entry));
+  const entries = resolvePresenceMetadataEntries({ status, activities });
 
   return buildUntrustedChannelMetadata({
     source: "discord",
-    label: "Discord sender presence (best-effort, may be stale)",
+    label: PRESENCE_CONTEXT_LABEL,
     entries,
   });
-}
+};
+
+export const __testing = {
+  resolveActivityTypeLabel,
+  resolveActivityDurationMs,
+  resolvePresenceActivitySummaries,
+  resolvePresenceMetadataEntries,
+};

--- a/src/discord/monitor/presence-context.ts
+++ b/src/discord/monitor/presence-context.ts
@@ -1,0 +1,73 @@
+import type { GatewayPresenceUpdate } from "discord-api-types/v10";
+import { buildUntrustedChannelMetadata } from "../../security/channel-metadata.js";
+
+const MAX_ACTIVITY_ENTRIES = 3;
+
+const ACTIVITY_TYPE_LABELS: Record<number, string> = {
+  0: "Playing",
+  1: "Streaming",
+  2: "Listening",
+  3: "Watching",
+  4: "Custom",
+  5: "Competing",
+};
+
+function normalizeText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function resolveActivityLabel(activity: {
+  type?: number;
+  name?: string;
+  state?: string | null;
+  details?: string | null;
+}): string | null {
+  const typeLabel =
+    typeof activity.type === "number"
+      ? (ACTIVITY_TYPE_LABELS[activity.type] ?? `Activity ${activity.type}`)
+      : "Activity";
+  const name = normalizeText(activity.name);
+  const details = normalizeText(activity.details);
+  const state = normalizeText(activity.state);
+  const headline = name || details || state;
+  if (!headline) {
+    return null;
+  }
+  const segments = [`${typeLabel}: ${headline}`];
+  if (details && details !== headline) {
+    segments.push(`details=${details}`);
+  }
+  if (state && state !== headline) {
+    segments.push(`state=${state}`);
+  }
+  return segments.join(" | ");
+}
+
+export function buildDiscordPresenceMetadata(
+  presence: GatewayPresenceUpdate | undefined,
+): string | undefined {
+  if (!presence) {
+    return undefined;
+  }
+
+  const status = normalizeText(presence.status);
+  const activities = (presence.activities ?? [])
+    .map((activity) => resolveActivityLabel(activity))
+    .filter((entry): entry is string => Boolean(entry))
+    .slice(0, MAX_ACTIVITY_ENTRIES);
+
+  if (!status && activities.length === 0) {
+    return undefined;
+  }
+
+  const entries = [
+    status ? `Sender status: ${status}` : null,
+    activities.length > 0 ? `Sender activities: ${activities.join("; ")}` : null,
+  ].filter((entry): entry is string => Boolean(entry));
+
+  return buildUntrustedChannelMetadata({
+    source: "discord",
+    label: "Discord sender presence (best-effort, may be stale)",
+    entries,
+  });
+}

--- a/src/discord/monitor/presence.constants.ts
+++ b/src/discord/monitor/presence.constants.ts
@@ -1,0 +1,16 @@
+import { ActivityType } from "discord-api-types/v10";
+
+export const PRESENCE_CONTEXT_LABEL = "Discord sender presence (best-effort, may be stale)";
+
+export const PRESENCE_MAX_ACTIVITY_ENTRIES = 3;
+
+export const ACTIVITY_LABEL = "Activity";
+
+export const ACTIVITY_TYPE_LABELS: Partial<Record<ActivityType, string>> = {
+  [ActivityType.Playing]: "Playing",
+  [ActivityType.Streaming]: "Streaming",
+  [ActivityType.Listening]: "Listening",
+  [ActivityType.Watching]: "Watching",
+  [ActivityType.Custom]: "Custom",
+  [ActivityType.Competing]: "Competing",
+};


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

Discord supports a "rich" presence context, including its activity feature. The context available from presence status, activities and headlines would allow the Agent to understand if the user is busy and what they are doing and for how long on both on heartbeats (follow-up PR) and direct messages. It can be useful if you want to have your Bot keeping track of, i.e.: remind me if Im playing for too long; or: while conversation happens for them to be aware of what you're doing.

To keep this PR minimal, a follow-up PR with heartbeat plugin implementation will be done.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration (I assume?)
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

Updates the Untrusted Context with Discord Presence Context

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
  - More context on untrusted context, the likelihood of a prompt injection is pretty small, given that only allowedFrom users will have their presence context read explicitly on an incoming message (processDiscordMessage)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Doable with a git revert
- Files/config to restore: Remove the entries from the config
- Known bad symptoms reviewers should watch for: Hmm, not really.

## Risks and Mitigations

Prompt Injection, but pretty low given the surface of from who it comes from and how OpenClaw already handles untrusted context. Only if you want to pwn yourself I'd say.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in Discord sender presence context (status, activities, durations) as untrusted metadata attached to inbound message context, gated behind `channels.discord.intents.presence=true`.

- Introduces `presence-context.ts` that formats Discord presence data (status like `idle`/`dnd`, activities like `Playing`/`Listening` with durations) and wraps it using the existing `buildUntrustedChannelMetadata` security pipeline.
- Integrates presence lookup into `message-handler.process.ts` via the existing `presence-cache.js`, only when the presence intent is explicitly enabled in config.
- Extracts a `senderId` variable (`sender.id ?? author.id`) used consistently for presence lookup, `ownerAllowFrom`, and the `SenderId` context field — a minor cleanup alongside the feature addition.
- Refactors `UntrustedContext` from a single-entry conditional to a filtered array of both channel metadata and presence metadata.
- Includes thorough unit tests for the presence context helpers and integration tests for the message handler presence flow.
- Documentation clearly explains the opt-in nature, configuration, and caveats (staleness, privileged intent requirement, DM limitations).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a well-guarded, opt-in feature with proper security wrapping and thorough test coverage.
- The feature is strictly opt-in (requires explicit config flag), presence data is correctly wrapped as untrusted content using existing security infrastructure, activity entries are bounded, edge cases (missing presence, invalid timestamps, disabled intent) are all handled and tested. The `senderId` refactor is a minor cleanup that doesn't change behavior. No new attack surface is introduced beyond what's documented and mitigated.
- No files require special attention.

<sub>Last reviewed commit: 0dc4346</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->