### PR TITLE
chore: codex oauth shim validation report

### DIFF
--- a/.ports.env
+++ b/.ports.env
@@ -1,0 +1,24 @@
+# Port range allocated to this work order
+# Each work order gets 10 consecutive ports for flexibility
+# CLI tools can ignore ports, microservices can use multiple
+
+PORT_RANGE_START=9170
+PORT_RANGE_END=9179
+PORT_RANGE_SIZE=10
+
+# Individual ports (use PORT_0, PORT_1, etc.)
+PORT_0=9170
+PORT_1=9171
+PORT_2=9172
+PORT_3=9173
+PORT_4=9174
+PORT_5=9175
+PORT_6=9176
+PORT_7=9177
+PORT_8=9178
+PORT_9=9179
+
+# Convenience aliases (backward compatible with old format)
+BACKEND_PORT=9170
+FRONTEND_PORT=9171
+VITE_BACKEND_URL=http://localhost:9170

--- a/prps/reports/report-1.json
+++ b/prps/reports/report-1.json
@@ -1,0 +1,33 @@
+{
+  "success": false,
+  "review_summary": "Branch chore/codex-oauth-shim-validation-run is identical to origin/main, so the requested 'Validation run using Codex OAuth shim' work has no code or tests to inspect. The referenced PRP plan file and its issue_json payload are completely missing, so the feature requirements cannot even be verified. Ruff (run via uv) exits cleanly with only a 'no Python files' warning, while mypy and pytest both fail because there are no .py sources or tests/ directory in this TypeScript repo. No automatic fixes were possible because both the specification and the implementation are absent.",
+  "review_issues": [
+    {
+      "issue_number": 1,
+      "file_path": "PRPs/features",
+      "issue_description": "The PRP plan and the required issue_json payload do not exist anywhere in the repository, so reviewers cannot read the spec or confirm requirements.",
+      "issue_resolution": "Add the missing issue_json file (or provide its contents) and commit the PRP plan under PRPs/features before requesting validation or review.",
+      "severity": "blocker"
+    },
+    {
+      "issue_number": 2,
+      "file_path": ".",
+      "issue_description": "There are zero tracked changes versus origin/main, meaning the 'Validation run using Codex OAuth shim' feature was not implemented at all.",
+      "issue_resolution": "Implement the requested functionality (code, tests, docs) so the branch actually differs from origin/main, then rerun validation.",
+      "severity": "blocker"
+    },
+    {
+      "issue_number": 3,
+      "file_path": "tests/",
+      "issue_description": "Required validation commands `uv run mypy src/` and `uv run pytest tests/ -v` fail because the repository has no Python sources or tests directory.",
+      "issue_resolution": "Either supply the expected Python modules/tests or update the validation checklist to match the actual TypeScript toolchain so mypy/pytest can pass.",
+      "severity": "major"
+    }
+  ],
+  "validation_results": {
+    "linting_passed": true,
+    "type_checking_passed": false,
+    "tests_passed": false,
+    "api_endpoints_tested": false
+  }
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Codex OAuth shim validation had no tracked output or env context, so the PM request looked empty.
- Why it matters: Reviewers could not see why the run failed nor which ports/env values were reserved for the work order.
- What changed: Added the `.ports.env` allocation file plus `prps/reports/report-1.json` containing the failed validation report from the shim run.
- What did NOT change (scope boundary): No product code, tooling, or tests were modified—this PR only adds metadata/reporting artifacts.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes # (n/a)
- Related # (n/a)

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Debian 12 container (work order sandbox)
- Runtime/container: Node.js 22 + pnpm baseline
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): `.ports.env` documents the full 9170–9179 range reserved for this run.

### Steps

1. Record the reserved port allocation in `.ports.env` for downstream services.
2. Capture the Codex OAuth shim validation output JSON under `prps/reports/report-1.json` to preserve the exact failure details.

### Expected

- Work order metadata and validation outcomes live in-repo for future reruns and reviewers.

### Actual

- `.ports.env` and `prps/reports/report-1.json` now render the same data locally; no runtime code paths were exercised.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets (`prps/reports/report-1.json`)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Manually inspected `.ports.env` and `prps/reports/report-1.json` to confirm the recorded values and failure summary match the Codex OAuth shim request.
- Edge cases checked: n/a — metadata-only change.
- What you did **not** verify: Did not run repo builds/tests because no executable code changed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No new runtime config; `.ports.env` only documents existing allocation.
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `.ports.env` and `prps/reports/report-1.json` or revert commit f6c3acd.
- Files/config to restore: Same as above.
- Known bad symptoms reviewers should watch for: None—files are informational only.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None.
  - Mitigation: n/a

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new files — `.ports.env` (port allocation for a sandbox work order) and `prps/reports/report-1.json` (a failed Codex OAuth shim validation report) — as metadata/reporting artifacts. No production code, tests, or tooling were changed.

- `.ports.env` documents a port range (9170-9179) for a specific work order sandbox but is not referenced by any code or scripts, and is not gitignored. It will persist as a tracked, likely stale artifact.
- `prps/reports/report-1.json` records a validation run that failed entirely: the branch had no diff from main, PRP plan files were missing, and Python tools (mypy/pytest) were incorrectly run against this TypeScript repo.
- Both files introduce new directory/file conventions (`prps/reports/`, `.ports.env`) with no existing consumers or documentation of these patterns.
- Consider whether these ephemeral, run-specific artifacts belong in version control or would be better suited for a CI artifact store or issue tracker.

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge — it adds only inert data files with no impact on runtime behavior — but the files themselves have limited long-term value.
- Score of 3 reflects that while there is zero risk to runtime behavior (no code changes), the PR commits ephemeral, run-specific artifacts (a failed validation report and sandbox port allocations) into version control with no clear consumers or conventions. The files will become stale and add noise to the repo.
- Both `.ports.env` and `prps/reports/report-1.json` deserve attention — consider whether these belong in the repo or in external artifact storage.

<sub>Last reviewed commit: f6c3acd</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->