### PR TITLE
feat(gateway): make systemd KillMode configurable for gateway install

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const buildGatewayInstallPlan = vi.fn(async () => ({
+  programArguments: ["/usr/bin/node", "/tmp/openclaw/dist/index.js", "gateway"],
+  workingDirectory: "/tmp/openclaw",
+  environment: {
+    OPENCLAW_BUNDLED_VERSION: "test",
+  },
+}));
+
+const loadConfig = vi.fn(() => ({
+  gateway: {
+    auth: {
+      mode: "token",
+      token: "cfg-token",
+    },
+    tailscale: {
+      mode: "off",
+    },
+  },
+}));
+
+const readConfigFileSnapshot = vi.fn(async () => ({
+  exists: false,
+  valid: true,
+  config: {},
+}));
+
+const resolveGatewayPort = vi.fn(() => 18789);
+const writeConfigFile = vi.fn(async () => {});
+
+const resolveIsNixMode = vi.fn(() => false);
+const randomToken = vi.fn(() => "generated-token");
+const resolveGatewayAuth = vi.fn(() => ({
+  mode: "token",
+  token: "cfg-token",
+  allowTailscale: false,
+}));
+
+const serviceInstall = vi.fn(async () => {});
+const serviceIsLoaded = vi.fn(async () => false);
+const resolveGatewayService = vi.fn(() => ({
+  label: "systemd",
+  loadedText: "enabled",
+  notLoadedText: "disabled",
+  install: (args: unknown) => serviceInstall(args),
+  uninstall: vi.fn(),
+  stop: vi.fn(),
+  restart: vi.fn(),
+  isLoaded: (args: unknown) => serviceIsLoaded(args),
+  readCommand: vi.fn(),
+  readRuntime: vi.fn(),
+}));
+
+const runtimeLogs: string[] = [];
+const defaultRuntime = {
+  log: (message: string) => runtimeLogs.push(message),
+  error: vi.fn(),
+  exit: (code: number) => {
+    throw new Error(`__exit__:${code}`);
+  },
+};
+
+vi.mock("../../commands/daemon-install-helpers.js", () => ({
+  buildGatewayInstallPlan: (args: unknown) => buildGatewayInstallPlan(args),
+}));
+
+vi.mock("../../commands/daemon-runtime.js", () => ({
+  DEFAULT_GATEWAY_DAEMON_RUNTIME: "node",
+  isGatewayDaemonRuntime: (value: string) => value === "node" || value === "bun",
+}));
+
+vi.mock("../../commands/onboard-helpers.js", () => ({
+  randomToken: () => randomToken(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => loadConfig(),
+  readConfigFileSnapshot: () => readConfigFileSnapshot(),
+  resolveGatewayPort: (cfg: unknown) => resolveGatewayPort(cfg),
+  writeConfigFile: (cfg: unknown) => writeConfigFile(cfg),
+}));
+
+vi.mock("../../config/paths.js", () => ({
+  resolveIsNixMode: (env: unknown) => resolveIsNixMode(env),
+}));
+
+vi.mock("../../daemon/service.js", () => ({
+  resolveGatewayService: () => resolveGatewayService(),
+}));
+
+vi.mock("../../gateway/auth.js", () => ({
+  resolveGatewayAuth: (input: unknown) => resolveGatewayAuth(input),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime,
+}));
+
+describe("runDaemonInstall", () => {
+  beforeEach(() => {
+    runtimeLogs.length = 0;
+    buildGatewayInstallPlan.mockClear();
+    loadConfig.mockClear();
+    readConfigFileSnapshot.mockClear();
+    resolveGatewayPort.mockClear();
+    writeConfigFile.mockClear();
+    resolveIsNixMode.mockClear();
+    randomToken.mockClear();
+    resolveGatewayAuth.mockClear();
+    serviceInstall.mockClear();
+    serviceIsLoaded.mockClear();
+    resolveGatewayService.mockClear();
+    serviceIsLoaded.mockResolvedValue(false);
+  });
+
+  it("passes normalized systemd kill mode to service install", async () => {
+    const { runDaemonInstall } = await import("./install.js");
+
+    await runDaemonInstall({
+      json: true,
+      force: true,
+      systemdKillMode: " MIXED ",
+      token: "cli-token",
+    });
+
+    expect(serviceInstall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemdKillMode: "mixed",
+      }),
+    );
+  });
+
+  it("fails fast on invalid systemd kill mode", async () => {
+    const { runDaemonInstall } = await import("./install.js");
+
+    await expect(
+      runDaemonInstall({
+        json: true,
+        systemdKillMode: "bad-mode",
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(serviceInstall).not.toHaveBeenCalled();
+    const payload = JSON.parse(runtimeLogs.find((line) => line.includes('"action"')) ?? "{}") as {
+      error?: string;
+    };
+    expect(payload.error).toContain("Invalid --systemd-kill-mode");
+  });
+});

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const buildGatewayInstallPlan = vi.fn(async () => ({
+const buildGatewayInstallPlan = vi.fn(async (_args?: unknown) => ({
   programArguments: ["/usr/bin/node", "/tmp/openclaw/dist/index.js", "gateway"],
   workingDirectory: "/tmp/openclaw",
   environment: {
@@ -26,19 +26,19 @@ const readConfigFileSnapshot = vi.fn(async () => ({
   config: {},
 }));
 
-const resolveGatewayPort = vi.fn(() => 18789);
-const writeConfigFile = vi.fn(async () => {});
+const resolveGatewayPort = vi.fn((_cfg?: unknown) => 18789);
+const writeConfigFile = vi.fn(async (_cfg?: unknown) => {});
 
-const resolveIsNixMode = vi.fn(() => false);
+const resolveIsNixMode = vi.fn((_env?: unknown) => false);
 const randomToken = vi.fn(() => "generated-token");
-const resolveGatewayAuth = vi.fn(() => ({
+const resolveGatewayAuth = vi.fn((_input?: unknown) => ({
   mode: "token",
   token: "cfg-token",
   allowTailscale: false,
 }));
 
-const serviceInstall = vi.fn(async () => {});
-const serviceIsLoaded = vi.fn(async () => false);
+const serviceInstall = vi.fn(async (_args?: unknown) => {});
+const serviceIsLoaded = vi.fn(async (_args?: unknown) => false);
 const resolveGatewayService = vi.fn(() => ({
   label: "systemd",
   loadedText: "enabled",

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -124,9 +124,10 @@ describe("runDaemonInstall", () => {
       token: "cli-token",
     });
 
+    const expectedKillMode = process.platform === "linux" ? "mixed" : undefined;
     expect(serviceInstall).toHaveBeenCalledWith(
       expect.objectContaining({
-        systemdKillMode: "mixed",
+        systemdKillMode: expectedKillMode,
       }),
     );
   });

--- a/src/cli/daemon-cli/register-service-commands.test.ts
+++ b/src/cli/daemon-cli/register-service-commands.test.ts
@@ -22,6 +22,10 @@ function createGatewayParentLikeCommand() {
   const gateway = new Command().name("gateway");
   // Mirror overlapping root gateway options that conflict with service subcommand options.
   gateway.option("--port <port>", "Port for the gateway WebSocket");
+  gateway.option(
+    "--systemd-kill-mode <mode>",
+    'Linux/systemd only: KillMode ("process"|"mixed"|"control-group").',
+  );
   gateway.option("--token <token>", "Gateway token");
   gateway.option("--password <password>", "Gateway password");
   gateway.option("--force", "Gateway run --force", false);
@@ -41,14 +45,27 @@ describe("addGatewayServiceCommands", () => {
 
   it("forwards install option collisions from parent gateway command", async () => {
     const gateway = createGatewayParentLikeCommand();
-    await gateway.parseAsync(["install", "--force", "--port", "19000", "--token", "tok_test"], {
-      from: "user",
-    });
+    await gateway.parseAsync(
+      [
+        "install",
+        "--force",
+        "--port",
+        "19000",
+        "--systemd-kill-mode",
+        "mixed",
+        "--token",
+        "tok_test",
+      ],
+      {
+        from: "user",
+      },
+    );
 
     expect(runDaemonInstall).toHaveBeenCalledWith(
       expect.objectContaining({
         force: true,
         port: "19000",
+        systemdKillMode: "mixed",
         token: "tok_test",
       }),
     );

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -16,11 +16,13 @@ function resolveInstallOptions(
 ): DaemonInstallOptions {
   const parentForce = inheritOptionFromParent<boolean>(command, "force");
   const parentPort = inheritOptionFromParent<string>(command, "port");
+  const parentSystemdKillMode = inheritOptionFromParent<string>(command, "systemdKillMode");
   const parentToken = inheritOptionFromParent<string>(command, "token");
   return {
     ...cmdOpts,
     force: Boolean(cmdOpts.force || parentForce),
     port: cmdOpts.port ?? parentPort,
+    systemdKillMode: cmdOpts.systemdKillMode ?? parentSystemdKillMode,
     token: cmdOpts.token ?? parentToken,
   };
 }
@@ -60,6 +62,10 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
     .description("Install the Gateway service (launchd/systemd/schtasks)")
     .option("--port <port>", "Gateway port")
     .option("--runtime <runtime>", "Daemon runtime (node|bun). Default: node")
+    .option(
+      "--systemd-kill-mode <mode>",
+      'Linux/systemd only: KillMode ("process"|"mixed"|"control-group").',
+    )
     .option("--token <token>", "Gateway token (token auth)")
     .option("--force", "Reinstall/overwrite if already installed", false)
     .option("--json", "Output JSON", false)

--- a/src/cli/daemon-cli/types.ts
+++ b/src/cli/daemon-cli/types.ts
@@ -18,6 +18,7 @@ export type DaemonInstallOptions = {
   port?: string | number;
   runtime?: string;
   token?: string;
+  systemdKillMode?: string;
   force?: boolean;
   json?: boolean;
 };

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -1,5 +1,6 @@
+import type { SystemdKillMode } from "./systemd-unit.js";
+
 export type GatewayServiceEnv = Record<string, string | undefined>;
-export type SystemdKillMode = "process" | "mixed" | "control-group";
 
 export type GatewayServiceInstallArgs = {
   env: GatewayServiceEnv;

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -1,4 +1,5 @@
 export type GatewayServiceEnv = Record<string, string | undefined>;
+export type SystemdKillMode = "process" | "mixed" | "control-group";
 
 export type GatewayServiceInstallArgs = {
   env: GatewayServiceEnv;
@@ -7,6 +8,7 @@ export type GatewayServiceInstallArgs = {
   workingDirectory?: string;
   environment?: GatewayServiceEnv;
   description?: string;
+  systemdKillMode?: SystemdKillMode;
 };
 
 export type GatewayServiceManageArgs = {
@@ -35,4 +37,5 @@ export type GatewayServiceRenderArgs = {
   programArguments: string[];
   workingDirectory?: string;
   environment?: GatewayServiceEnv;
+  killMode?: SystemdKillMode;
 };

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemdUnit } from "./systemd-unit.js";
+
+describe("buildSystemdUnit", () => {
+  it("uses KillMode=process by default", () => {
+    const unit = buildSystemdUnit({
+      programArguments: ["/usr/bin/node", "/tmp/openclaw/dist/index.js", "gateway"],
+    });
+    expect(unit).toContain("KillMode=process");
+  });
+
+  it("supports KillMode=mixed", () => {
+    const unit = buildSystemdUnit({
+      programArguments: ["/usr/bin/node", "/tmp/openclaw/dist/index.js", "gateway"],
+      killMode: "mixed",
+    });
+    expect(unit).toContain("KillMode=mixed");
+  });
+
+  it("supports KillMode=control-group", () => {
+    const unit = buildSystemdUnit({
+      programArguments: ["/usr/bin/node", "/tmp/openclaw/dist/index.js", "gateway"],
+      killMode: "control-group",
+    });
+    expect(unit).toContain("KillMode=control-group");
+  });
+});

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -188,6 +188,7 @@ export async function installSystemdService({
   workingDirectory,
   environment,
   description,
+  systemdKillMode,
 }: GatewayServiceInstallArgs): Promise<{ unitPath: string }> {
   await assertSystemdAvailable();
 
@@ -199,6 +200,7 @@ export async function installSystemdService({
     programArguments,
     workingDirectory,
     environment,
+    killMode: systemdKillMode,
   });
   await fs.writeFile(unitPath, unit, "utf8");
 


### PR DESCRIPTION
Closes #11257

## Summary
This PR makes systemd `KillMode` configurable for gateway service installs on Linux while preserving current behavior by default.

- Adds `--systemd-kill-mode <mode>` to `openclaw gateway install`
- Valid values: `process`, `mixed`, `control-group`
- Defaults to `process` when flag is omitted (no behavior change)
- Wires selected mode into generated systemd unit
- Adds tests for default + override behavior and CLI validation/forwarding

## Why
Issue: `#11257`

Some deployments running heavy browser automation observed orphaned browser children surviving gateway restarts when unit files use `KillMode=process` and shutdown paths are bypassed. Making this configurable gives operators an explicit service-manager safety lever (`mixed` / `control-group`) without breaking existing podman-oriented default behavior.

Reference evidence comment:
- https://github.com/openclaw/openclaw/issues/11257#issuecomment-3923032592

## Design
- Keep default `KillMode=process` in systemd unit builder
- Add typed KillMode constants/type in daemon layer
- Thread optional `systemdKillMode` through service install API
- Parse and validate CLI input in `runDaemonInstall`
- On non-Linux platforms, accept option but emit warning and ignore it

## Files changed
- `src/daemon/systemd-unit.ts`
- `src/daemon/systemd.ts`
- `src/daemon/service.ts`
- `src/cli/daemon-cli/types.ts`
- `src/cli/daemon-cli/register-service-commands.ts`
- `src/cli/daemon-cli/install.ts`
- `src/daemon/systemd-unit.test.ts` (new)
- `src/cli/daemon-cli/install.test.ts` (new)
- `src/cli/daemon-cli/register-service-commands.test.ts`

## Testing
Targeted tests run locally:

```bash
pnpm -s vitest run \
  src/cli/daemon-cli/install.test.ts \
  src/daemon/systemd-unit.test.ts \
  src/daemon/systemd.test.ts \
  src/cli/daemon-cli/register-service-commands.test.ts
```

Result: 4 test files passed, 19 tests passed.

Formatting/lint on touched files:

```bash
pnpm -s oxfmt --check <touched-files>
pnpm -s oxlint --type-aware <touched-files>
```

Both passed.

## Backward compatibility
- Existing installs without the new flag continue generating `KillMode=process`
- No change to non-systemd platforms

## AI assistance disclosure
- [x] AI-assisted PR
- [x] Fully tested (targeted unit/integration-relevant tests for changed paths)
- [x] Prompt/session context available on request
- [x] I understand and verified the code paths changed in this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added configurable `KillMode` setting for systemd gateway installs via `--systemd-kill-mode` flag while preserving backward compatibility with `process` as default. Implementation correctly validates input, normalizes casing, threads the option through CLI layers to systemd unit generation, and warns on non-Linux platforms.

- Added CLI flag `--systemd-kill-mode` with validation for values: `process`, `mixed`, `control-group`
- Implemented input normalization (trim + lowercase) and validation in `install.ts:27-41`
- Properly threaded through service install API with platform check
- Added tests covering default behavior, override functionality, and input validation
- Minor duplication: `SystemdKillMode` type defined in both `systemd-unit.ts` and `service-types.ts`

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style consideration
- Implementation is sound with proper validation, platform checks, backward compatibility, and test coverage. Only minor style issue is duplicate type definition across two files (functionally equivalent but creates maintenance overhead). Core logic correctly validates inputs, normalizes values, and safely ignores flag on non-Linux platforms.
- No files require special attention

<sub>Last reviewed commit: 55a7b98</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->