### PR TITLE
fix: strip metadata envelope from webchat UI

### DIFF
--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -46,7 +46,10 @@ export function stripEnvelope(text: string): string {
 
   // Then strip "Conversation info (untrusted metadata):" blocks (all occurrences)
   // Note: UNTRUSTED_METADATA_PATTERN has 'g' flag for global matching
+  // Reset lastIndex before replace to avoid the test()/replace() lastIndex issue
+  UNTRUSTED_METADATA_PATTERN.lastIndex = 0;
   if (UNTRUSTED_METADATA_PATTERN.test(stripped)) {
+    UNTRUSTED_METADATA_PATTERN.lastIndex = 0;
     return stripped.replace(UNTRUSTED_METADATA_PATTERN, "").trim();
   }
 

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -19,7 +19,9 @@ const MESSAGE_ID_LINE = /^\s*\[message_id:\s*[^\]]+\]\s*$/i;
 
 // Pattern to match untrusted metadata blocks like:
 // "Conversation info (untrusted metadata):\n```json\n{...}\n```"
-const UNTRUSTED_METADATA_PATTERN = /^Conversation info \(untrusted metadata\):[\s\S]*?```\s*/m;
+// Explicitly matches: header line, opening fence (```json), content, closing fence (```)
+const UNTRUSTED_METADATA_PATTERN =
+  /^Conversation info \(untrusted metadata\):\n```[^\n]*\n[\s\S]*?\n```\s*/gm;
 
 function looksLikeEnvelopeHeader(header: string): boolean {
   if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z\b/.test(header)) {
@@ -42,10 +44,10 @@ export function stripEnvelope(text: string): string {
     }
   }
 
-  // Then strip "Conversation info (untrusted metadata):" blocks
-  const metadataMatch = stripped.match(UNTRUSTED_METADATA_PATTERN);
-  if (metadataMatch) {
-    return stripped.replace(metadataMatch[0], "").trim();
+  // Then strip "Conversation info (untrusted metadata):" blocks (all occurrences)
+  // Note: UNTRUSTED_METADATA_PATTERN has 'g' flag for global matching
+  if (UNTRUSTED_METADATA_PATTERN.test(stripped)) {
+    return stripped.replace(UNTRUSTED_METADATA_PATTERN, "").trim();
   }
 
   return stripped;


### PR DESCRIPTION
Fixes #20297

## Bug
The webchat UI was rendering raw metadata envelope blocks in chat bubbles. Instead of showing only the agent's reply, users saw:

```
Conversation info (untrusted metadata):
{
  "message_id": "a2a19267-56f0-4236-ac4e-3a6089f44d24",
  "sender": "openclaw-control-ui"
}
[Wed 2026-02-18 09:10 MST] <user message text>
```

This was introduced in version 2026.2.17 when the envelope pattern was added.

## What changed
Added `UNTRUSTED_METADATA_PATTERN` regex to `stripEnvelopeFromMessages()` in `src/shared/chat-envelope.ts` that matches and removes the "Conversation info (untrusted metadata):" block including its JSON content and code fences.

The fix:
1. Adds a new regex pattern `UNTRUSTED_METADATA_PATTERN` that matches the full metadata block (header line + opening code fence + JSON content + closing code fence)
2. Modifies `stripEnvelope()` to first strip the envelope header, then remove any untrusted metadata blocks
3. Uses global matching to handle multiple occurrences in message history

## Why this fixes the issue
The webchat UI receives messages with prepended metadata that was intended for internal processing but should not be shown to users. By stripping these blocks in `stripEnvelope()` (which is already used by the webchat message pipeline), the raw metadata is removed before rendering.

## AI-assisted contribution
This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build && pnpm check && pnpm test
- The fix addresses the root cause described in the issue by stripping the untrusted metadata envelope pattern from messages in the webchat UI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds untrusted metadata stripping to `stripEnvelope` in `src/shared/chat-envelope.ts`, intended to prevent raw metadata blocks (like `Conversation info (untrusted metadata):`) from appearing in the webchat UI. The approach restructures the existing function to also match and remove these blocks after stripping the envelope header.

- **Critical regex bug**: The `UNTRUSTED_METADATA_PATTERN` regex uses non-greedy `[\s\S]*?` followed by ` `` `, which will match only up to the **opening** code fence (` ``json `), not the closing one. This means the JSON metadata content and closing fence will remain in the displayed text — the opposite of the intended behavior.
- **No tests added**: The PR does not include any test cases for the new metadata stripping logic. Given this is shared code used in both the webchat UI (`message-extract.ts`) and the gateway (`chat-sanitize.ts`), tests would help catch issues like the regex bug above.
- **Partial stripping**: Only `Conversation info` blocks are targeted, while `buildInboundUserContextPrefix` also produces `Sender`, `Thread starter`, `Replied message`, `Forwarded message context`, and `Chat history` untrusted blocks that could also leak into the webchat UI.

<h3>Confidence Score: 1/5</h3>

- This PR has a critical regex bug that causes it to not actually strip the metadata content it intends to strip, and may produce garbled output instead.
- The core regex `UNTRUSTED_METADATA_PATTERN` has a non-greedy matching issue that causes it to stop at the opening code fence rather than the closing one, effectively breaking the intended stripping behavior. No tests were added to validate the new logic, and the issue would be immediately visible to webchat users as leaked JSON metadata in messages.
- `src/shared/chat-envelope.ts` — the `UNTRUSTED_METADATA_PATTERN` regex needs to be fixed to match through both opening and closing code fences.

<sub>Last reviewed commit: 1d7f2bd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->