### PR TITLE
fix(test): shell-env tests pass on Windows CI

### DIFF
--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -75,40 +75,52 @@ describe("shell env fallback", () => {
   });
 
   it("resolves PATH via login shell and caches it", () => {
-    resetShellPathCacheForTests();
-    const exec = vi.fn(() => Buffer.from("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0"));
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      resetShellPathCacheForTests();
+      const exec = vi.fn(() => Buffer.from("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0"));
 
-    const first = getShellPathFromLoginShell({
-      env: {} as NodeJS.ProcessEnv,
-      exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
-    });
-    const second = getShellPathFromLoginShell({
-      env: {} as NodeJS.ProcessEnv,
-      exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
-    });
+      const first = getShellPathFromLoginShell({
+        env: {} as NodeJS.ProcessEnv,
+        exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
+      });
+      const second = getShellPathFromLoginShell({
+        env: {} as NodeJS.ProcessEnv,
+        exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
+      });
 
-    expect(first).toBe("/usr/local/bin:/usr/bin");
-    expect(second).toBe("/usr/local/bin:/usr/bin");
-    expect(exec).toHaveBeenCalledOnce();
+      expect(first).toBe("/usr/local/bin:/usr/bin");
+      expect(second).toBe("/usr/local/bin:/usr/bin");
+      expect(exec).toHaveBeenCalledOnce();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
   });
 
   it("returns null on shell env read failure and caches null", () => {
-    resetShellPathCacheForTests();
-    const exec = vi.fn(() => {
-      throw new Error("exec failed");
-    });
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      resetShellPathCacheForTests();
+      const exec = vi.fn(() => {
+        throw new Error("exec failed");
+      });
 
-    const first = getShellPathFromLoginShell({
-      env: {} as NodeJS.ProcessEnv,
-      exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
-    });
-    const second = getShellPathFromLoginShell({
-      env: {} as NodeJS.ProcessEnv,
-      exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
-    });
+      const first = getShellPathFromLoginShell({
+        env: {} as NodeJS.ProcessEnv,
+        exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
+      });
+      const second = getShellPathFromLoginShell({
+        env: {} as NodeJS.ProcessEnv,
+        exec: exec as unknown as Parameters<typeof getShellPathFromLoginShell>[0]["exec"],
+      });
 
-    expect(first).toBeNull();
-    expect(second).toBeNull();
-    expect(exec).toHaveBeenCalledOnce();
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      expect(exec).toHaveBeenCalledOnce();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
   });
 });


### PR DESCRIPTION
Fixes #20362

The two getShellPathFromLoginShell tests failed on Windows because process.platform === "win32" short-circuits before using the injected exec mock.

Fix: stub process.platform to "linux" in those tests so the platform guard doesn't trigger and the mock exec is exercised as intended.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two `getShellPathFromLoginShell` tests that failed on Windows CI because `process.platform === "win32"` short-circuits before the injected `exec` mock is reached. The fix stubs `process.platform` to `"linux"` in those tests using `Object.defineProperty` with `try/finally` cleanup — a pattern already established in `pty.test.ts`, `kill-tree.test.ts`, and `restart-helper.test.ts`.

- Adds `process.platform` stub to "resolves PATH via login shell and caches it" test
- Adds `process.platform` stub to "returns null on shell env read failure and caches null" test
- Both use `try/finally` to guarantee platform restoration even on assertion failure

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only modifies test code with a well-established pattern already used across the codebase.
- The change is test-only, minimal, and follows an existing codebase convention (Object.defineProperty on process.platform with try/finally). The try/finally blocks ensure proper cleanup. No production code is touched. The fix directly addresses the documented issue (#20362).
- No files require special attention.

<sub>Last reviewed commit: 40efff3</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->