### PR TITLE
fix(ios): refactor screen webview lifecycle handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - Protocol/Apple: regenerate Swift gateway models for `push.test` so `pnpm protocol:check` stays green on main. Thanks @mbelinky.
 - Canvas/A2UI: improve bundled-asset resolution and empty-state handling so UI fallbacks render reliably. (#20312) Thanks @mbelinky.
 - UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -73,26 +73,6 @@ final class NodeAppModel {
     var lastShareEventText: String = "No share events yet."
     var openChatRequestID: Int = 0
 
-    var mainSessionKey: String {
-        let base = SessionKey.normalizeMainKey(self.mainSessionBaseKey)
-        let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if agentId.isEmpty || (!defaultId.isEmpty && agentId == defaultId) { return base }
-        return SessionKey.makeAgentSessionKey(agentId: agentId, baseKey: base)
-    }
-
-    var activeAgentName: String {
-        let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedId = agentId.isEmpty ? defaultId : agentId
-        if resolvedId.isEmpty { return "Main" }
-        if let match = self.gatewayAgents.first(where: { $0.id == resolvedId }) {
-            let name = (match.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-            return name.isEmpty ? match.id : name
-        }
-        return resolvedId
-    }
-
     // Primary "node" connection: used for device capabilities and node.invoke requests.
     private let nodeGateway = GatewayNodeSession()
     // Secondary "operator" connection: used for chat/talk/config/voicewake requests.
@@ -1615,6 +1595,26 @@ private extension NodeAppModel {
 }
 
 extension NodeAppModel {
+    var mainSessionKey: String {
+        let base = SessionKey.normalizeMainKey(self.mainSessionBaseKey)
+        let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if agentId.isEmpty || (!defaultId.isEmpty && agentId == defaultId) { return base }
+        return SessionKey.makeAgentSessionKey(agentId: agentId, baseKey: base)
+    }
+
+    var activeAgentName: String {
+        let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedId = agentId.isEmpty ? defaultId : agentId
+        if resolvedId.isEmpty { return "Main" }
+        if let match = self.gatewayAgents.first(where: { $0.id == resolvedId }) {
+            let name = (match.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            return name.isEmpty ? match.id : name
+        }
+        return resolvedId
+    }
+
     func connectToGateway(
         url: URL,
         gatewayStableID: String,

--- a/apps/ios/Sources/Screen/ScreenWebView.swift
+++ b/apps/ios/Sources/Screen/ScreenWebView.swift
@@ -5,11 +5,189 @@ import WebKit
 struct ScreenWebView: UIViewRepresentable {
     var controller: ScreenController
 
-    func makeUIView(context: Context) -> WKWebView {
-        self.controller.webView
+    func makeCoordinator() -> ScreenWebViewCoordinator {
+        ScreenWebViewCoordinator(controller: self.controller)
     }
 
-    func updateUIView(_ webView: WKWebView, context: Context) {
-        // State changes are driven by ScreenController.
+    func makeUIView(context: Context) -> UIView {
+        context.coordinator.makeContainerView()
+    }
+
+    func updateUIView(_: UIView, context: Context) {
+        context.coordinator.updateController(self.controller)
+    }
+
+    static func dismantleUIView(_: UIView, coordinator: ScreenWebViewCoordinator) {
+        coordinator.teardown()
+    }
+}
+
+@MainActor
+final class ScreenWebViewCoordinator: NSObject {
+    private weak var controller: ScreenController?
+    private let navigationDelegate = ScreenNavigationDelegate()
+    private let a2uiActionHandler = CanvasA2UIActionMessageHandler()
+    private let userContentController = WKUserContentController()
+
+    private(set) var managedWebView: WKWebView?
+    private weak var containerView: UIView?
+
+    init(controller: ScreenController) {
+        self.controller = controller
+        super.init()
+        self.navigationDelegate.controller = controller
+        self.a2uiActionHandler.controller = controller
+    }
+
+    func makeContainerView() -> UIView {
+        if let containerView {
+            return containerView
+        }
+
+        let container = UIView(frame: .zero)
+        container.backgroundColor = .black
+
+        let webView = Self.makeWebView(userContentController: self.userContentController)
+        webView.navigationDelegate = self.navigationDelegate
+        self.installA2UIHandlers()
+
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: container.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        self.managedWebView = webView
+        self.containerView = container
+        self.controller?.attachWebView(webView)
+        return container
+    }
+
+    func updateController(_ controller: ScreenController) {
+        let previousController = self.controller
+        let controllerChanged = self.controller !== controller
+        self.controller = controller
+        self.navigationDelegate.controller = controller
+        self.a2uiActionHandler.controller = controller
+        if controllerChanged, let managedWebView {
+            previousController?.detachWebView(managedWebView)
+            controller.attachWebView(managedWebView)
+        }
+    }
+
+    func teardown() {
+        if let managedWebView {
+            self.controller?.detachWebView(managedWebView)
+            managedWebView.navigationDelegate = nil
+        }
+        self.removeA2UIHandlers()
+        self.navigationDelegate.controller = nil
+        self.a2uiActionHandler.controller = nil
+        self.managedWebView = nil
+        self.containerView = nil
+    }
+
+    private static func makeWebView(userContentController: WKUserContentController) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+        config.userContentController = userContentController
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        // Canvas scaffold is a fully self-contained HTML page; avoid relying on transparency underlays.
+        webView.isOpaque = true
+        webView.backgroundColor = .black
+
+        let scrollView = webView.scrollView
+        scrollView.backgroundColor = .black
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.contentInset = .zero
+        scrollView.scrollIndicatorInsets = .zero
+        scrollView.automaticallyAdjustsScrollIndicatorInsets = false
+
+        return webView
+    }
+
+    private func installA2UIHandlers() {
+        for name in CanvasA2UIActionMessageHandler.handlerNames {
+            self.userContentController.add(self.a2uiActionHandler, name: name)
+        }
+    }
+
+    private func removeA2UIHandlers() {
+        for name in CanvasA2UIActionMessageHandler.handlerNames {
+            self.userContentController.removeScriptMessageHandler(forName: name)
+        }
+    }
+}
+
+// MARK: - Navigation Delegate
+
+/// Handles navigation policy to intercept openclaw:// deep links from canvas
+@MainActor
+private final class ScreenNavigationDelegate: NSObject, WKNavigationDelegate {
+    weak var controller: ScreenController?
+
+    func webView(
+        _: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void)
+    {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        // Intercept openclaw:// deep links.
+        if url.scheme?.lowercased() == "openclaw" {
+            decisionHandler(.cancel)
+            self.controller?.onDeepLink?(url)
+            return
+        }
+
+        decisionHandler(.allow)
+    }
+
+    func webView(
+        _: WKWebView,
+        didFailProvisionalNavigation _: WKNavigation?,
+        withError error: any Error)
+    {
+        self.controller?.errorText = error.localizedDescription
+    }
+
+    func webView(_: WKWebView, didFinish _: WKNavigation?) {
+        self.controller?.errorText = nil
+        self.controller?.applyDebugStatusIfNeeded()
+    }
+
+    func webView(_: WKWebView, didFail _: WKNavigation?, withError error: any Error) {
+        self.controller?.errorText = error.localizedDescription
+    }
+}
+
+private final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {
+    static let messageName = "openclawCanvasA2UIAction"
+    static let handlerNames = [messageName]
+
+    weak var controller: ScreenController?
+
+    func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard Self.handlerNames.contains(message.name) else { return }
+        guard let controller else { return }
+
+        guard let url = message.webView?.url else { return }
+        if url.isFileURL {
+            guard controller.isTrustedCanvasUIURL(url) else { return }
+        } else {
+            // For security, only accept actions from local-network pages (e.g. the canvas host).
+            guard controller.isLocalNetworkCanvasURL(url) else { return }
+        }
+
+        guard let body = ScreenController.parseA2UIActionBody(message.body) else { return }
+
+        controller.onA2UIAction?(body)
     }
 }

--- a/apps/ios/Tests/ScreenControllerTests.swift
+++ b/apps/ios/Tests/ScreenControllerTests.swift
@@ -2,25 +2,38 @@ import Testing
 import WebKit
 @testable import OpenClaw
 
+@MainActor
+private func mountScreen(_ screen: ScreenController) throws -> (ScreenWebViewCoordinator, WKWebView) {
+    let coordinator = ScreenWebViewCoordinator(controller: screen)
+    _ = coordinator.makeContainerView()
+    let webView = try #require(coordinator.managedWebView)
+    return (coordinator, webView)
+}
+
 @Suite struct ScreenControllerTests {
-    @Test @MainActor func canvasModeConfiguresWebViewForTouch() {
+    @Test @MainActor func canvasModeConfiguresWebViewForTouch() throws {
         let screen = ScreenController()
+        let (coordinator, webView) = try mountScreen(screen)
+        defer { coordinator.teardown() }
 
-        #expect(screen.webView.isOpaque == true)
-        #expect(screen.webView.backgroundColor == .black)
+        #expect(webView.isOpaque == true)
+        #expect(webView.backgroundColor == .black)
 
-        let scrollView = screen.webView.scrollView
+        let scrollView = webView.scrollView
         #expect(scrollView.backgroundColor == .black)
         #expect(scrollView.contentInsetAdjustmentBehavior == .never)
         #expect(scrollView.isScrollEnabled == false)
         #expect(scrollView.bounces == false)
     }
 
-    @Test @MainActor func navigateEnablesScrollForWebPages() {
+    @Test @MainActor func navigateEnablesScrollForWebPages() throws {
         let screen = ScreenController()
+        let (coordinator, webView) = try mountScreen(screen)
+        defer { coordinator.teardown() }
+
         screen.navigate(to: "https://example.com")
 
-        let scrollView = screen.webView.scrollView
+        let scrollView = webView.scrollView
         #expect(scrollView.isScrollEnabled == true)
         #expect(scrollView.bounces == true)
     }
@@ -34,6 +47,9 @@ import WebKit
 
     @Test @MainActor func evalExecutesJavaScript() async throws {
         let screen = ScreenController()
+        let (coordinator, _) = try mountScreen(screen)
+        defer { coordinator.teardown() }
+
         let deadline = ContinuousClock().now.advanced(by: .seconds(3))
 
         while true {


### PR DESCRIPTION
## Summary
- refactor iOS screen rendering so `ScreenController` no longer owns a long-lived `WKWebView`
- move `WKWebView` creation, delegate wiring, script handler setup, and teardown into `ScreenWebViewCoordinator`
- keep `ScreenController` focused on state/navigation/debug commands and attach/detach a weak active web view
- update `ScreenControllerTests` to mount via coordinator-owned web view lifecycle

## Why
We were seeing crashes around gesture handlers and `__NSArrayM insertObject:atIndex:`. Reusing a shared `WKWebView` instance across SwiftUI lifecycle transitions can lead to unstable UIKit/WebKit internals. This change aligns ownership with `UIViewRepresentable` lifecycle (`makeUIView`/`dismantleUIView`) and ensures delegates/script handlers are cleaned up deterministically.

## Validation
- `xcodebuild build -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,OS=18.6,name=iPhone 16'` ✅
- `xcodebuild test ... -only-testing:OpenClawTests/ScreenControllerTests` could not run to completion because of an unrelated existing compile failure in `GatewayConnectionSecurityTests` (`GatewayTLSStore` not found)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the iOS `ScreenController` / `ScreenWebView` lifecycle so that `WKWebView` creation, delegate wiring, and teardown are owned by a new `ScreenWebViewCoordinator`, aligned with the `UIViewRepresentable` lifecycle (`makeUIView`/`dismantleUIView`). This fixes crashes related to gesture handlers and `__NSArrayM insertObject:atIndex:` caused by reusing a shared `WKWebView` across SwiftUI lifecycle transitions.

- `ScreenController` no longer owns a `WKWebView`; it holds a weak reference set via `attachWebView`/`detachWebView`
- `ScreenWebViewCoordinator` handles web view creation, AutoLayout, navigation delegate wiring, A2UI script handler install/teardown
- `ScreenNavigationDelegate` and `CanvasA2UIActionMessageHandler` moved from `ScreenController.swift` to `ScreenWebView.swift` (logic unchanged)
- Tests updated to use the coordinator-based mount lifecycle with proper `teardown()` in `defer` blocks
- Clean separation of concerns: `ScreenController` handles state/navigation/debug, coordinator handles UIKit/WebKit lifecycle

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a well-structured ownership refactor with no behavioral changes to delegate/handler logic.
- The refactor cleanly separates WebView lifecycle ownership from state management. Delegate and handler logic is moved verbatim. The weak/strong reference patterns are correct for the UIViewRepresentable lifecycle. Tests are updated to exercise the new coordinator path. Minor concern: the `reload()` call in `init()` is now dead code but harmless.
- No files require special attention. The `ScreenWebView.swift` coordinator is the most significant new code but follows standard UIViewRepresentable patterns.

<sub>Last reviewed commit: 28452d9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->