### PR TITLE
Fix Slack thread streaming missing recipient IDs (#20337)

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.streaming.test.ts
+++ b/src/slack/monitor/message-handler/dispatch.streaming.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isSlackStreamingEnabled, resolveSlackStreamingThreadHint } from "./dispatch.js";
+import {
+  isSlackStreamingEnabled,
+  resolveSlackStreamingThreadHint,
+  shouldUseSlackNativeStreaming,
+} from "./dispatch.js";
 
 describe("slack native streaming defaults", () => {
   it("is enabled when config is undefined", () => {
@@ -41,5 +45,29 @@ describe("slack native streaming thread hint", () => {
         messageTs: "1000.3",
       }),
     ).toBe("2000.1");
+  });
+});
+
+describe("slack native streaming recipient gating", () => {
+  it("is disabled when team id is missing", () => {
+    expect(
+      shouldUseSlackNativeStreaming({
+        streamingEnabled: true,
+        threadTs: "1234.56",
+        recipientTeamId: undefined,
+        recipientUserId: "U123",
+      }),
+    ).toBe(false);
+  });
+
+  it("is disabled when user id is missing", () => {
+    expect(
+      shouldUseSlackNativeStreaming({
+        streamingEnabled: true,
+        threadTs: "1234.56",
+        recipientTeamId: "T123",
+        recipientUserId: undefined,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/slack/streaming.test.ts
+++ b/src/slack/streaming.test.ts
@@ -1,0 +1,57 @@
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+import { startSlackStream, stopSlackStream } from "./streaming.js";
+
+describe("startSlackStream", () => {
+  it("passes recipient ids to chatStream", async () => {
+    const streamer = {
+      append: vi.fn(),
+      stop: vi.fn(),
+    };
+    const chatStream = vi.fn().mockReturnValue(streamer);
+    const client = {
+      chatStream,
+    } as unknown as WebClient;
+
+    await startSlackStream({
+      client,
+      channelId: "C123",
+      threadTs: "1730.1",
+      recipientTeamId: "T123",
+      recipientUserId: "U123",
+    });
+
+    expect(chatStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        thread_ts: "1730.1",
+        recipient_team_id: "T123",
+        recipient_user_id: "U123",
+      }),
+    );
+  });
+});
+
+describe("stopSlackStream", () => {
+  it("does not throw when Slack rejects stop", async () => {
+    const streamer = {
+      append: vi.fn(),
+      stop: vi.fn().mockRejectedValue(new Error("stop failed")),
+    };
+    const chatStream = vi.fn().mockReturnValue(streamer);
+    const client = {
+      chatStream,
+    } as unknown as WebClient;
+
+    const session = await startSlackStream({
+      client,
+      channelId: "C123",
+      threadTs: "1730.2",
+      recipientTeamId: "T123",
+      recipientUserId: "U123",
+    });
+
+    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    expect(streamer.stop).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: Slack thread replies could silently fail when Slack native streaming is enabled, with gateway logs showing missing_recipient_team_id and no assistant reply posted to the triggering thread.
- Why it matters: Threaded workflows become unreliable (runs complete but users see no response), which breaks Slack usage and erodes trust.
- What changed: Slack stream start now includes recipient_team_id and recipient_user_id; streaming is gated to only run when streamingEnabled, thread_ts, ctx.teamId, and message.user are present; stop-stream errors are caught/logged to avoid crashing/failing delivery.
- What did NOT change (scope boundary): No changes to Slack non-thread delivery semantics; fallback non-streaming delivery behavior remains intact; no changes to other channel integrations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20337
- Related https://github.com/openclaw/openclaw/issues/20337

## User-visible / Behavior Changes
- Slack thread mentions now reliably receive streamed assistant replies in the same thread when Slack native streaming is enabled and recipient IDs are available.
- If recipient IDs are missing, OpenClaw will skip native streaming and fall back to the normal (non-streaming) reply path instead of failing with missing_recipient_team_id.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows (dev), reported issue on Debian GNU/Linux 12 (arm64)
- Runtime/container: Node.js + pnpm
- Model/provider: N/A
- Integration/channel (if any): Slack (Socket Mode + native streaming)
- Relevant config (redacted): channels.slack.mode=socket, streaming enabled (default), thread messages with thread_ts

### Steps

1. Run OpenClaw gateway with Slack Socket Mode enabled and Slack streaming enabled.
2. In a Slack channel where the bot is active, start or reply in a thread and mention the bot (e.g. @openclaw ...).
3. Observe OpenClaw processes the run; verify the assistant reply is posted into the same Slack thread.

### Expected

- Assistant reply posts into the same Slack thread; no missing_recipient_team_id errors from slack-stream.

### Actual

- Run completes but no thread reply is posted; logs show slack-stream errors missing_recipient_team_id.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- Added unit tests:
                             - src/slack/streaming.test.ts asserts chatStream called with recipient_team_id and recipient_user_id, and                                                                      stopSlackStream swallows stop failures.
                             - src/slack/monitor/message-handler/dispatch.streaming.test.ts covers gating when teamId or userId is missing.

- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Unit tests for streaming start parameters (recipient_team_id, recipient_user_id) and defensive stop behavior.
                                Gating logic: streaming disabled when recipient IDs missing; fallback delivery remains reachable.

- Edge cases checked: 
                             - Missing ctx.teamId ⇒ streaming is skipped.
                             - Missing message.user ⇒ streaming is skipped.
                             - Stream stop failure ⇒ caught/logged, no crash/throw path.
                             
- What you did **not** verify: Full end-to-end Slack thread streaming on a live Slack workspace in Socket Mode (left to CI / maintainers to validate in real environment).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Disable Slack streaming: openclaw config set channels.slack.streaming false and restart gateway, or revert this PR.

- Files/config to restore: src/slack/streaming.ts - src/slack/monitor/message-handler/dispatch.ts

- Known bad symptoms reviewers should watch for: Slack thread replies not appearing when streaming is enabled -- Reappearance of missing_recipient_team_id errors in slack-stream logs

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Streaming could be skipped more often if recipient IDs are unavailable in some Slack event variants.
  - Mitigation: Explicit gating ensures we fall back to non-streaming delivery rather than failing silently; behavior remains correct and safer than attempting a stream without required fields.

## AI Usage Disclosure

- AI-assisted: Yes (GPT/Codex)
- Used for: implementing change + adding regression tests
- Human verification: ran checks/tests listed above and reviewed logic for scope/behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Slack thread streaming failures caused by missing `recipient_team_id` and `recipient_user_id` when calling `chat.startStream`. The fix adds these required fields to `startSlackStream`, gates native streaming on their presence via the new `shouldUseSlackNativeStreaming` function, and wraps `stopSlackStream` in a try/catch to prevent unhandled rejections from disrupting delivery.

- `startSlackStream` now accepts and forwards `recipientTeamId` and `recipientUserId` to `client.chatStream()`
- New `shouldUseSlackNativeStreaming` gating function ensures streaming is only attempted when all required IDs are present; otherwise falls back to normal (non-streaming) delivery
- `stopSlackStream` now catches and logs errors instead of throwing, preventing delivery disruptions
- Parameter `channel` renamed to `channelId` for clarity in `StartSlackStreamParams`
- New unit tests cover recipient ID gating and defensive stop behavior
- Minor style note: the outer try/catch around `stopSlackStream` in `dispatch.ts` is now dead code since `stopSlackStream` internally swallows errors

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a real bug with proper fallback behavior and adds no new risk.
- The changes are well-scoped, correctly address the missing recipient ID issue, and include defensive fallbacks. The only deductions are for minor dead code (redundant guard and dead try/catch) and a small test coverage gap (no positive test case for the gating function). No functional risks identified.
- No files require special attention. The core logic in `src/slack/monitor/message-handler/dispatch.ts` has minor dead code but no functional issues.

<sub>Last reviewed commit: 7b28b33</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->