### PR TITLE
macOS app: avoid forced gateway reinstall on startup to stop auth/restart loops

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -77,6 +77,26 @@ import Testing
         #expect(plan[1] == ["install", "--force", "--port", "18789", "--runtime", "node"])
     }
 
+    @Test func enableCommandPlanRepairsUnloadedServiceWhenPlistIsStale() {
+        let snapshot = LaunchAgentPlistSnapshot(
+            programArguments: ["/usr/local/bin/node", "/path/to/dist/index.js", "gateway", "--port", "9999"],
+            environment: [:],
+            stdoutPath: nil,
+            stderrPath: nil,
+            port: 9999,
+            bind: nil,
+            token: nil,
+            password: nil)
+        let plan = GatewayLaunchAgentManager.enableCommandPlan(
+            isAlreadyLoaded: false,
+            snapshot: snapshot,
+            desiredPort: 18789,
+            desiredRuntime: "node")
+        #expect(plan.count == 2)
+        #expect(plan[0] == ["install", "--port", "18789", "--runtime", "node"])
+        #expect(plan[1] == ["install", "--force", "--port", "18789", "--runtime", "node"])
+    }
+
     @Test func enableCommandPlanPrefersStartThenInstallThenForceInstall() {
         let plan = GatewayLaunchAgentManager.enableCommandPlan(
             isAlreadyLoaded: false,
@@ -110,5 +130,19 @@ import Testing
             success: true,
             daemonResult: "already-installed")
         #expect(shouldStop == true)
+    }
+
+    @Test func nonTerminalSuccessRecognizesExpectedContinueSignals() {
+        let startNonTerminal = GatewayLaunchAgentManager.isNonTerminalSuccessfulStep(
+            command: ["start"],
+            success: true,
+            daemonResult: "not-loaded")
+        #expect(startNonTerminal == true)
+
+        let installNonTerminal = GatewayLaunchAgentManager.isNonTerminalSuccessfulStep(
+            command: ["install", "--port", "18789", "--runtime", "node"],
+            success: true,
+            daemonResult: "already-installed")
+        #expect(installNonTerminal == true)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -38,4 +38,17 @@ import Testing
         #expect(snapshot.port == 18789)
         #expect(snapshot.bind == nil)
     }
+
+    @Test func enableCommandPlanSkipsWhenAlreadyLoaded() {
+        let plan = GatewayLaunchAgentManager.enableCommandPlan(isAlreadyLoaded: true, port: 18789)
+        #expect(plan.isEmpty)
+    }
+
+    @Test func enableCommandPlanPrefersStartThenInstallThenForceInstall() {
+        let plan = GatewayLaunchAgentManager.enableCommandPlan(isAlreadyLoaded: false, port: 18789)
+        #expect(plan.count == 3)
+        #expect(plan[0] == ["start"])
+        #expect(plan[1] == ["install", "--port", "18789", "--runtime", "node"])
+        #expect(plan[2] == ["install", "--force", "--port", "18789", "--runtime", "node"])
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -51,6 +51,7 @@ import Testing
             password: nil)
         let plan = GatewayLaunchAgentManager.enableCommandPlan(
             isAlreadyLoaded: true,
+            isRunning: true,
             snapshot: snapshot,
             desiredPort: 18789,
             desiredRuntime: "node")
@@ -69,6 +70,50 @@ import Testing
             password: nil)
         let plan = GatewayLaunchAgentManager.enableCommandPlan(
             isAlreadyLoaded: true,
+            isRunning: true,
+            snapshot: snapshot,
+            desiredPort: 18789,
+            desiredRuntime: "node")
+        #expect(plan.count == 2)
+        #expect(plan[0] == ["install", "--port", "18789", "--runtime", "node"])
+        #expect(plan[1] == ["install", "--force", "--port", "18789", "--runtime", "node"])
+    }
+
+    @Test func enableCommandPlanStartsLoadedButStoppedServiceWhenConfigMatches() {
+        let snapshot = LaunchAgentPlistSnapshot(
+            programArguments: ["/usr/local/bin/node", "/path/to/dist/index.js", "gateway", "--port", "18789"],
+            environment: [:],
+            stdoutPath: nil,
+            stderrPath: nil,
+            port: 18789,
+            bind: nil,
+            token: nil,
+            password: nil)
+        let plan = GatewayLaunchAgentManager.enableCommandPlan(
+            isAlreadyLoaded: true,
+            isRunning: false,
+            snapshot: snapshot,
+            desiredPort: 18789,
+            desiredRuntime: "node")
+        #expect(plan.count == 3)
+        #expect(plan[0] == ["start"])
+        #expect(plan[1] == ["install", "--port", "18789", "--runtime", "node"])
+        #expect(plan[2] == ["install", "--force", "--port", "18789", "--runtime", "node"])
+    }
+
+    @Test func enableCommandPlanRepairsLoadedButStoppedServiceWhenConfigIsStale() {
+        let snapshot = LaunchAgentPlistSnapshot(
+            programArguments: ["/usr/local/bin/node", "/path/to/dist/index.js", "gateway", "--port", "9999"],
+            environment: [:],
+            stdoutPath: nil,
+            stderrPath: nil,
+            port: 9999,
+            bind: nil,
+            token: nil,
+            password: nil)
+        let plan = GatewayLaunchAgentManager.enableCommandPlan(
+            isAlreadyLoaded: true,
+            isRunning: false,
             snapshot: snapshot,
             desiredPort: 18789,
             desiredRuntime: "node")

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -39,13 +39,49 @@ import Testing
         #expect(snapshot.bind == nil)
     }
 
-    @Test func enableCommandPlanSkipsWhenAlreadyLoaded() {
-        let plan = GatewayLaunchAgentManager.enableCommandPlan(isAlreadyLoaded: true, port: 18789)
+    @Test func enableCommandPlanSkipsWhenAlreadyLoadedAndConfigMatches() {
+        let snapshot = LaunchAgentPlistSnapshot(
+            programArguments: ["/usr/local/bin/node", "/path/to/dist/index.js", "gateway", "--port", "18789"],
+            environment: [:],
+            stdoutPath: nil,
+            stderrPath: nil,
+            port: 18789,
+            bind: nil,
+            token: nil,
+            password: nil)
+        let plan = GatewayLaunchAgentManager.enableCommandPlan(
+            isAlreadyLoaded: true,
+            snapshot: snapshot,
+            desiredPort: 18789,
+            desiredRuntime: "node")
         #expect(plan.isEmpty)
     }
 
+    @Test func enableCommandPlanRepairsLoadedServiceWhenPortChanged() {
+        let snapshot = LaunchAgentPlistSnapshot(
+            programArguments: ["/usr/local/bin/node", "/path/to/dist/index.js", "gateway", "--port", "9999"],
+            environment: [:],
+            stdoutPath: nil,
+            stderrPath: nil,
+            port: 9999,
+            bind: nil,
+            token: nil,
+            password: nil)
+        let plan = GatewayLaunchAgentManager.enableCommandPlan(
+            isAlreadyLoaded: true,
+            snapshot: snapshot,
+            desiredPort: 18789,
+            desiredRuntime: "node")
+        #expect(plan.count == 2)
+        #expect(plan[0] == ["install", "--port", "18789", "--runtime", "node"])
+        #expect(plan[1] == ["install", "--force", "--port", "18789", "--runtime", "node"])
+    }
+
     @Test func enableCommandPlanPrefersStartThenInstallThenForceInstall() {
-        let plan = GatewayLaunchAgentManager.enableCommandPlan(isAlreadyLoaded: false, port: 18789)
+        let plan = GatewayLaunchAgentManager.enableCommandPlan(
+            isAlreadyLoaded: false,
+            desiredPort: 18789,
+            desiredRuntime: "node")
         #expect(plan.count == 3)
         #expect(plan[0] == ["start"])
         #expect(plan[1] == ["install", "--port", "18789", "--runtime", "node"])

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -87,4 +87,28 @@ import Testing
         #expect(plan[1] == ["install", "--port", "18789", "--runtime", "node"])
         #expect(plan[2] == ["install", "--force", "--port", "18789", "--runtime", "node"])
     }
+
+    @Test func terminalSuccessTreatsStartNotLoadedAsNonTerminal() {
+        let shouldStop = GatewayLaunchAgentManager.isTerminalEnableSuccess(
+            command: ["start"],
+            success: true,
+            daemonResult: "not-loaded")
+        #expect(shouldStop == false)
+    }
+
+    @Test func terminalSuccessTreatsInstallAlreadyInstalledAsNonTerminal() {
+        let shouldStop = GatewayLaunchAgentManager.isTerminalEnableSuccess(
+            command: ["install", "--port", "18789", "--runtime", "node"],
+            success: true,
+            daemonResult: "already-installed")
+        #expect(shouldStop == false)
+    }
+
+    @Test func terminalSuccessTreatsForceInstallAsTerminal() {
+        let shouldStop = GatewayLaunchAgentManager.isTerminalEnableSuccess(
+            command: ["install", "--force", "--port", "18789", "--runtime", "node"],
+            success: true,
+            daemonResult: "already-installed")
+        #expect(shouldStop == true)
+    }
 }


### PR DESCRIPTION
## Summary

This PR hardens macOS launch-agent enablement for the OpenClaw app.

The original problem looked simple (avoid force-reinstall churn), but the launchd lifecycle has several coupled states. The fixes in this PR intentionally model those states explicitly and make progress step-by-step until the gateway is actually recoverable.

## Why these changes were needed (detailed)

### 1) Remove unconditional `gateway install --force`

**Problem:** The app previously used `openclaw gateway install --force` as the first enable action.

**Why this is bad:** It is heavy-handed, can rewrite service/config state during normal startup, and can contribute to restart/config churn loops.

**Change:** Introduced a planned fallback flow instead of immediate force-install.

---

### 2) Treat `loaded` and `running` as different states

**Problem:** launchd "loaded" means service registration, not necessarily a live gateway process.

**Why this is bad:** Returning no-op for loaded-but-stopped services leaves the app waiting for health until timeout.

**Change:** Read daemon service state from `gateway status --json --no-probe` and distinguish:
- loaded + running
- loaded + not running

Plan logic now uses both signals.

---

### 3) Repair config drift (port/runtime) before trusting loaded state

**Problem:** launchd may be loaded (or even stopped) with stale args (old `--port`/runtime).

**Why this is bad:** A `start` can resurrect old args, while app probes new config port/runtime.

**Change:** Compare desired config against launchd plist snapshot and, if stale/unknown for desired args, reinstall first (`install`, then `install --force` fallback).

This applies to:
- loaded + running + stale
- loaded + stopped + stale
- unloaded + stale plist

---

### 4) Interpret daemon `result` semantics, not just `ok: true`

**Problem:** Some daemon responses are `ok: true` but are non-terminal for enable flow:
- `start` with `result: not-loaded`
- `install` (non-force) with `result: already-installed`

**Why this is bad:** Treating all `ok:true` as terminal exits fallback too early and can leave service stale/uninstalled.

**Change:** Added terminal-success classification by command + daemon `result`.

Terminal examples:
- `install --force` success => terminal

Non-terminal examples (continue fallback):
- `start` + `not-loaded`
- `install` + `already-installed` (non-force)

---

### 5) Fix misleading logs for expected continuation paths

**Problem:** non-terminal success steps were logged as failures.

**Why this is bad:** Produces noisy/misleading diagnostics when behavior is actually expected.

**Change:** Non-terminal successful steps now log as informational continuation messages.

## Final state machine behavior

When enabling launchd from macOS app:

1. **Loaded + running + matching port/runtime:** no-op.
2. **Loaded + stale (running or stopped):**
   - `gateway install --port <port> --runtime node`
   - fallback `gateway install --force --port <port> --runtime node`
3. **Loaded + stopped + matching config:**
   - `gateway start`
   - fallback `gateway install --port <port> --runtime node`
   - fallback `gateway install --force --port <port> --runtime node`
4. **Unloaded + stale plist:**
   - `gateway install --port <port> --runtime node`
   - fallback `gateway install --force --port <port> --runtime node`
5. **Unloaded + no stale mismatch signal:**
   - `gateway start`
   - fallback `gateway install --port <port> --runtime node`
   - fallback `gateway install --force --port <port> --runtime node`

## Files changed

- `/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift`
- `/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift`

## Validation

```bash
swift test --package-path apps/macos --filter GatewayLaunchAgentManagerTests
```

Result: pass (12 tests).

## Related issues

- https://github.com/openclaw/openclaw/issues/20344
- https://github.com/openclaw/openclaw/issues/20189
- https://github.com/openclaw/openclaw/issues/20257
- https://github.com/openclaw/openclaw/issues/20030
