### PR TITLE
docs: fix bluebubbles add command

### DIFF
--- a/docs/channels/bluebubbles.md
+++ b/docs/channels/bluebubbles.md
@@ -141,7 +141,7 @@ The wizard prompts for:
 You can also add BlueBubbles via CLI:
 
 ```
-openclaw channels add bluebubbles --http-url http://192.168.1.100:1234 --password <password>
+openclaw channels add --channel bluebubbles --http-url http://192.168.1.100:1234 --password <password>
 ```
 
 ## Access control (DMs + groups)


### PR DESCRIPTION
## Summary

- The command was failing without --channel

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Human Verification (required)

With `--channel` it works

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the documented CLI command for adding a BlueBubbles channel by adding the required `--channel` flag. The `channels add` subcommand in non-interactive mode (i.e., when other flags like `--http-url` and `--password` are provided) requires `--channel <name>` to identify the channel type — the old command incorrectly passed `bluebubbles` as a positional argument, which the parser does not accept.

- Adds `--channel` flag to the example CLI command in `docs/channels/bluebubbles.md`, changing `openclaw channels add bluebubbles` to `openclaw channels add --channel bluebubbles`

<h3>Confidence Score: 5/5</h3>

- This is a minimal, correct documentation fix with no risk to runtime behavior.
- Single-line documentation change that correctly adds the required --channel flag to match the CLI's actual argument parser. Verified against source code in src/cli/channels-cli.ts and consistent with docs/cli/channels.md examples.
- No files require special attention.

<sub>Last reviewed commit: 427b014</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->