### PR TITLE
fix(slack): inject thread history on first thread turn, not only on session reset

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -184,8 +184,9 @@ export async function runPreparedReply(
       })
     : "";
   const groupSystemPrompt = sessionCtx.GroupSystemPrompt?.trim() ?? "";
+  const shouldInjectThreadContext = isNewSession || ctx.IsFirstThreadTurn;
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
-    isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
+    shouldInjectThreadContext ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
   );
   const extraSystemPrompt = [inboundMetaPrompt, groupChatContext, groupIntro, groupSystemPrompt]
     .filter(Boolean)
@@ -209,7 +210,7 @@ export async function runPreparedReply(
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
   const baseBodyFinal = isBareSessionReset ? BARE_SESSION_RESET_PROMPT : baseBody;
   const inboundUserContext = buildInboundUserContextPrefix(
-    isNewSession
+    shouldInjectThreadContext
       ? {
           ...sessionCtx,
           ...(sessionCtx.ThreadHistoryBody?.trim()
@@ -259,7 +260,6 @@ export async function runPreparedReply(
   prefixedBodyBase = appendUntrustedContext(prefixedBodyBase, sessionCtx.UntrustedContext);
   const threadStarterBody = ctx.ThreadStarterBody?.trim();
   const threadHistoryBody = ctx.ThreadHistoryBody?.trim();
-  const shouldInjectThreadContext = isNewSession || ctx.IsFirstThreadTurn;
   const threadContextNote =
     shouldInjectThreadContext && threadHistoryBody
       ? `[Thread history - for context]\n${threadHistoryBody}`

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -259,10 +259,11 @@ export async function runPreparedReply(
   prefixedBodyBase = appendUntrustedContext(prefixedBodyBase, sessionCtx.UntrustedContext);
   const threadStarterBody = ctx.ThreadStarterBody?.trim();
   const threadHistoryBody = ctx.ThreadHistoryBody?.trim();
+  const shouldInjectThreadContext = isNewSession || ctx.IsFirstThreadTurn;
   const threadContextNote =
-    isNewSession && threadHistoryBody
+    shouldInjectThreadContext && threadHistoryBody
       ? `[Thread history - for context]\n${threadHistoryBody}`
-      : isNewSession && threadStarterBody
+      : shouldInjectThreadContext && threadStarterBody
         ? `[Thread starter - for context]\n${threadStarterBody}`
         : undefined;
   const skillResult = await ensureSkillSnapshot({

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -1,4 +1,5 @@
 import type { WebClient as SlackWebClient } from "@slack/web-api";
+import { logVerbose } from "../../globals.js";
 import { normalizeHostname } from "../../infra/net/hostname.js";
 import type { FetchLike } from "../../media/fetch.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
@@ -485,7 +486,10 @@ export async function resolveSlackThreadHistory(params: {
       ts: msg.ts,
       files: msg.files,
     }));
-  } catch {
+  } catch (err) {
+    logVerbose(
+      `slack: resolveSlackThreadHistory failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return [];
   }
 }


### PR DESCRIPTION
## Summary

- Thread history fetched by `resolveSlackThreadHistory` was silently discarded because `threadContextNote` was gated on `isNewSession` (which only means "user triggered a reset"), not on "first inbound message in a new thread session"
- Use the already-computed `ctx.IsFirstThreadTurn` alongside `isNewSession` so thread context is injected when it should be
- Log errors in `resolveSlackThreadHistory` instead of silently swallowing them via bare `catch {}`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test src/slack/monitor/message-handler/prepare.test.ts` — 12 tests pass
- [x] `pnpm test src/auto-reply/reply/` — 474 tests pass
- [x] Verified fix on a live instance with `replyToMode: "first"` and `thread.initialHistoryLimit: 20`

🤖 AI-assisted (Claude) — fully tested on a live OpenClaw instance. Root-caused via debug patch instrumentation on the bundled output. We understand the change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where Slack thread history (fetched by `resolveSlackThreadHistory`) was silently discarded on the first message in a new thread session. The root cause was that `threadContextNote` in `get-reply-run.ts` was gated solely on `isNewSession` (which only reflects a user-triggered `/new` or `/reset`), rather than also checking `ctx.IsFirstThreadTurn` (which is true for the first inbound message in a new thread). Additionally improves observability by logging errors in `resolveSlackThreadHistory` instead of silently swallowing them.

- **Core fix**: `shouldInjectThreadContext = isNewSession || ctx.IsFirstThreadTurn` ensures thread history/starter context is injected on first thread turn, not only on explicit session resets
- **Error logging**: `catch {}` in `resolveSlackThreadHistory` now logs the error via `logVerbose` before returning the empty fallback
- **Backward-compatible**: `IsFirstThreadTurn` is `undefined` for non-Slack channels, so the `||` fallback preserves existing behavior

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the fix is narrowly scoped, backward-compatible, and well-tested.
- The change is small, logically sound, and addresses a clear bug. The `IsFirstThreadTurn` property is only set in Slack's prepare.ts and is `undefined` for all other channels, so the `||` fallback preserves existing behavior perfectly. The error logging improvement is unambiguously positive. One minor inconsistency (parallel `isNewSession` gates at lines 188 and 211-219 not updated) prevents a score of 5 but is non-breaking.
- `src/auto-reply/reply/get-reply-run.ts` — lines 188 and 211-219 still gate `ThreadStarterBody` on `isNewSession` alone, which is inconsistent with the new `shouldInjectThreadContext` logic at line 262.

<sub>Last reviewed commit: 4f8196a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->