### PR TITLE
feat(whatsapp): surface inbound reaction events to agent session

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -35,6 +35,8 @@ export type WhatsAppAckReactionConfig = {
   group?: "always" | "mentions" | "never";
 };
 
+export type WhatsAppReactionNotificationMode = "off" | "own" | "all";
+
 export type WhatsAppConfig = {
   /** Optional per-account WhatsApp configuration (multi-account). */
   accounts?: Record<string, WhatsAppAccountConfig>;
@@ -97,6 +99,13 @@ export type WhatsAppConfig = {
   groups?: Record<string, WhatsAppGroupConfig>;
   /** Acknowledgment reaction sent immediately upon message receipt. */
   ackReaction?: WhatsAppAckReactionConfig;
+  /**
+   * Controls which user reactions trigger notifications:
+   * - "off" (default): ignore all reactions
+   * - "own": notify when users react to bot messages
+   * - "all": notify agent of all reactions
+   */
+  reactionNotifications?: WhatsAppReactionNotificationMode;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
   debounceMs?: number;
   /** Heartbeat visibility settings for this channel. */
@@ -145,6 +154,13 @@ export type WhatsAppAccountConfig = {
   groups?: Record<string, WhatsAppGroupConfig>;
   /** Acknowledgment reaction sent immediately upon message receipt. */
   ackReaction?: WhatsAppAckReactionConfig;
+  /**
+   * Controls which user reactions trigger notifications:
+   * - "off" (default): ignore all reactions
+   * - "own": notify when users react to bot messages
+   * - "all": notify agent of all reactions
+   */
+  reactionNotifications?: WhatsAppReactionNotificationMode;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
   debounceMs?: number;
   /** Heartbeat visibility settings for this account. */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -52,6 +52,7 @@ const WhatsAppSharedSchema = z.object({
   blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
   groups: WhatsAppGroupsSchema,
   ackReaction: WhatsAppAckReactionSchema,
+  reactionNotifications: z.enum(["off", "own", "all"]).optional(),
   debounceMs: z.number().int().nonnegative().optional().default(0),
   heartbeat: ChannelHeartbeatVisibilitySchema,
 });

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveOAuthDir } from "../config/paths.js";
-import type { DmPolicy, GroupPolicy, WhatsAppAccountConfig } from "../config/types.js";
+import type {
+  DmPolicy,
+  GroupPolicy,
+  WhatsAppAccountConfig,
+  WhatsAppReactionNotificationMode,
+} from "../config/types.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 import { hasWebCredsSync } from "./auth-store.js";
@@ -26,6 +31,7 @@ export type ResolvedWhatsAppAccount = {
   mediaMaxMb?: number;
   blockStreaming?: boolean;
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
+  reactionNotifications?: WhatsAppReactionNotificationMode;
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
 };
@@ -146,6 +152,7 @@ export function resolveWhatsAppAccount(params: {
     mediaMaxMb: accountCfg?.mediaMaxMb ?? rootCfg?.mediaMaxMb,
     blockStreaming: accountCfg?.blockStreaming ?? rootCfg?.blockStreaming,
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
+    reactionNotifications: accountCfg?.reactionNotifications ?? rootCfg?.reactionNotifications,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
   };

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -74,6 +74,7 @@ export async function monitorWebChannel(
       whatsapp: {
         ...baseCfg.channels?.whatsapp,
         ackReaction: account.ackReaction,
+        reactionNotifications: account.reactionNotifications,
         messagePrefix: account.messagePrefix,
         allowFrom: account.allowFrom,
         groupAllowFrom: account.groupAllowFrom,
@@ -197,6 +198,7 @@ export async function monitorWebChannel(
       sendReadReceipts: account.sendReadReceipts,
       debounceMs: inboundDebounceMs,
       shouldDebounce,
+      reactionNotifications: account.reactionNotifications,
       onMessage: async (msg: WebInboundMsg) => {
         handledMessages += 1;
         lastMessageAt = Date.now();


### PR DESCRIPTION
Subscribes to Baileys messages.reaction events and surfaces them as system events into the agent session. Adds reactionNotifications config for WhatsApp.

### Changes
- Listen for messages.reaction events in WhatsApp monitor
- Add reactionNotifications config support
- Emit reactions as system events into the agent session

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for surfacing WhatsApp reaction events into agent sessions. It introduces a `reactionNotifications` config option (`"off"` | `"own"` | `"all"`) at both the root and per-account level, subscribes to Baileys `messages.reaction` events, and emits them as system events routed to the correct agent session.

- Config plumbing is clean and consistent: type definitions, Zod schema, account resolution, and threading through the monitor all follow established patterns.
- The reaction handler correctly identifies the reactor via `reaction.key` fields and filters for "own" mode using `key.fromMe` on the target message.
- Event cleanup on socket close properly deregisters the new `messages.reaction` listener.
- **Issue**: The reaction handler does not enforce access control (`allowFrom`, `dmPolicy`, `groupPolicy`) or filter `@status`/`@broadcast` JIDs, unlike the message handler. This means reactions from unauthorized senders or on status updates could generate system events reaching the agent.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge but the reaction handler lacks access control checks present in the message handler, which could surface events from unauthorized senders.
- The config plumbing, type definitions, and event lifecycle management are all well-done and follow existing patterns. The reaction handler's core logic (reactor identification, mode filtering, routing) is correct. However, the missing access control check means reactions bypass `allowFrom`, `dmPolicy`, and `groupPolicy` restrictions, which is inconsistent with the message handler and could leak information to the agent from unauthorized users. The feature defaults to "off" which mitigates risk for existing users.
- `src/web/inbound/monitor.ts` — the reaction handler should be reviewed for access control consistency with the message handler.

<sub>Last reviewed commit: 87cc9b8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->