### PR TITLE
feat(skill): add Loudly AI music generation skill

### DIFF
--- a/skills/loudly/SKILL.md
+++ b/skills/loudly/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: loudly
+description: Generate royalty-free AI music via Loudly Music API.
+homepage: https://www.loudly.com/developers
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🎵",
+        "requires": { "bins": ["uv"], "env": ["LOUDLY_API_KEY"] },
+        "primaryEnv": "LOUDLY_API_KEY",
+        "install":
+          [
+            {
+              "id": "uv-brew",
+              "kind": "brew",
+              "formula": "uv",
+              "bins": ["uv"],
+              "label": "Install uv (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# Loudly (AI Music Generator)
+
+Use the bundled scripts to generate royalty-free AI music.
+
+## Generate music by parameters
+
+```bash
+uv run {baseDir}/scripts/generate_music.py --genre "House" --duration 30 --energy 0.8 --bpm 125 --filename "house-track.mp3"
+```
+
+## Generate music by text prompt
+
+```bash
+uv run {baseDir}/scripts/generate_music.py --prompt "upbeat electronic track for a workout video" --duration 60 --filename "workout-music.mp3"
+```
+
+## List available genres
+
+```bash
+uv run {baseDir}/scripts/list_genres.py
+```
+
+## All options
+
+| Flag             | Short | Description                                   |
+| ---------------- | ----- | --------------------------------------------- |
+| `--prompt`       | `-p`  | Text description for text-to-music generation |
+| `--genre`        | `-g`  | Genre name (e.g. House, Ambient, Hip Hop)     |
+| `--genre-blend`  |       | Second genre to blend with the primary        |
+| `--duration`     | `-d`  | Duration in seconds (default: 30)             |
+| `--energy`       | `-e`  | Energy level 0.0–1.0 (default: 0.5)           |
+| `--bpm`          | `-b`  | Tempo in BPM (leave blank for genre default)  |
+| `--key-root`     |       | Musical key root (e.g. C, D, F#)              |
+| `--key-quality`  |       | Key quality: major or minor                   |
+| `--instruments`  |       | Comma-separated instrument list               |
+| `--structure-id` |       | Structure template ID                         |
+| `--filename`     | `-f`  | Output filename (required)                    |
+| `--api-key`      | `-k`  | Override LOUDLY_API_KEY env var               |
+
+## API key
+
+- `LOUDLY_API_KEY` env var
+- Or set `skills."loudly".apiKey` / `skills."loudly".env.LOUDLY_API_KEY` in `~/.openclaw/openclaw.json`
+
+## Available genres
+
+Ambient, Downtempo, Drum 'n' Bass, EDM, Epic Score, Hip Hop, House, Lo Fi, Reggaeton, Rock, Synthwave, Techno, Trap Double Tempo, Trap Half Tempo, Zen
+
+## Notes
+
+- Use timestamps in filenames: `yyyy-mm-dd-hh-mm-ss-name.mp3`.
+- The script prints a `MEDIA:` line for OpenClaw to auto-attach on supported chat providers.
+- Do not play the audio back; report the saved path only.
+- All generated music is royalty-free and commercially licensed.
+- Either `--prompt` or `--genre` must be provided. If both are given, `--prompt` takes priority (text-to-music mode).

--- a/skills/loudly/SKILL.md
+++ b/skills/loudly/SKILL.md
@@ -25,18 +25,20 @@ metadata:
 
 # Loudly (AI Music Generator)
 
-Use the bundled scripts to generate royalty-free AI music.
+Use the bundled scripts to generate royalty-free AI music. The `--genre` flag is always required.
 
-## Generate music by parameters
+## Generate music by genre
 
 ```bash
-uv run {baseDir}/scripts/generate_music.py --genre "House" --duration 30 --energy 0.8 --bpm 125 --filename "house-track.mp3"
+uv run {baseDir}/scripts/generate_music.py --genre "House" --duration 30 --energy high --bpm 125 --filename "house-track.mp3"
 ```
 
-## Generate music by text prompt
+## Generate music with a text prompt
+
+The prompt guides the AI alongside the genre (genre is still required):
 
 ```bash
-uv run {baseDir}/scripts/generate_music.py --prompt "upbeat electronic track for a workout video" --duration 60 --filename "workout-music.mp3"
+uv run {baseDir}/scripts/generate_music.py --genre "Lo Fi" --prompt "chill study beats with vinyl crackle" --duration 60 --filename "study-music.mp3"
 ```
 
 ## List available genres
@@ -47,29 +49,29 @@ uv run {baseDir}/scripts/list_genres.py
 
 ## All options
 
-| Flag             | Short | Description                                   |
-| ---------------- | ----- | --------------------------------------------- |
-| `--prompt`       | `-p`  | Text description for text-to-music generation |
-| `--genre`        | `-g`  | Genre name (e.g. House, Ambient, Hip Hop)     |
-| `--genre-blend`  |       | Second genre to blend with the primary        |
-| `--duration`     | `-d`  | Duration in seconds (default: 30)             |
-| `--energy`       | `-e`  | Energy level 0.0–1.0 (default: 0.5)           |
-| `--bpm`          | `-b`  | Tempo in BPM (leave blank for genre default)  |
-| `--key-root`     |       | Musical key root (e.g. C, D, F#)              |
-| `--key-quality`  |       | Key quality: major or minor                   |
-| `--instruments`  |       | Comma-separated instrument list               |
-| `--structure-id` |       | Structure template ID                         |
-| `--filename`     | `-f`  | Output filename (required)                    |
-| `--api-key`      | `-k`  | Override LOUDLY_API_KEY env var               |
+| Flag             | Short | Description                                            |
+| ---------------- | ----- | ------------------------------------------------------ |
+| `--genre`        | `-g`  | Genre name — **required** (e.g. House, Lo Fi, EDM)     |
+| `--prompt`       | `-p`  | Text description to guide generation (alongside genre) |
+| `--genre-blend`  |       | Second genre to blend with the primary                 |
+| `--duration`     | `-d`  | Duration in seconds (default: 30)                      |
+| `--energy`       | `-e`  | Energy level: `low`, `high`, or `original`             |
+| `--bpm`          | `-b`  | Tempo in BPM (leave blank for genre default)           |
+| `--key-root`     |       | Musical key root (e.g. C, D, F#)                       |
+| `--key-quality`  |       | Key quality: `major` or `minor`                        |
+| `--instruments`  |       | Comma-separated instrument list                        |
+| `--structure-id` |       | Structure template ID                                  |
+| `--filename`     | `-f`  | Output filename — **required**                         |
 
 ## API key
 
-- `LOUDLY_API_KEY` env var
-- Or set `skills."loudly".apiKey` / `skills."loudly".env.LOUDLY_API_KEY` in `~/.openclaw/openclaw.json`
+Set `LOUDLY_API_KEY` via `skills."loudly".env.LOUDLY_API_KEY` in `~/.openclaw/openclaw.json`. The key is injected as an environment variable at runtime — never pass it as a CLI argument.
 
 ## Available genres
 
 Ambient, Downtempo, Drum 'n' Bass, EDM, Epic Score, Hip Hop, House, Lo Fi, Reggaeton, Rock, Synthwave, Techno, Trap Double Tempo, Trap Half Tempo, Zen
+
+Each genre has micro-genres (e.g. House → Afro House, Deep House, Tech House). Run `list_genres.py` to see the full tree.
 
 ## Notes
 
@@ -77,4 +79,4 @@ Ambient, Downtempo, Drum 'n' Bass, EDM, Epic Score, Hip Hop, House, Lo Fi, Regga
 - The script prints a `MEDIA:` line for OpenClaw to auto-attach on supported chat providers.
 - Do not play the audio back; report the saved path only.
 - All generated music is royalty-free and commercially licensed.
-- Either `--prompt` or `--genre` must be provided. If both are given, `--prompt` takes priority (text-to-music mode).
+- The API is synchronous — results return immediately (no polling).

--- a/skills/loudly/scripts/generate_music.py
+++ b/skills/loudly/scripts/generate_music.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "requests>=2.31.0",
+# ]
+# ///
+"""
+Generate royalty-free AI music using the Loudly Music API.
+
+Parametric generation:
+    uv run generate_music.py --genre "House" --duration 30 --energy 0.8 --filename "output.mp3"
+
+Text-to-music generation:
+    uv run generate_music.py --prompt "upbeat electronic track" --duration 60 --filename "output.mp3"
+"""
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+API_BASE = "https://soundtracks.loudly.com/api"
+POLL_INTERVAL = 3
+MAX_POLL_ATTEMPTS = 120  # 6 minutes max wait
+
+
+def get_api_key(provided_key: str | None) -> str | None:
+    """Get API key from argument first, then environment."""
+    if provided_key:
+        return provided_key
+    return os.environ.get("LOUDLY_API_KEY")
+
+
+def build_headers(api_key: str) -> dict:
+    """Build common request headers."""
+    return {
+        "API-KEY": api_key,
+        "Accept": "application/json",
+    }
+
+
+def generate_parametric(api_key: str, params: dict) -> dict:
+    """Generate music using parametric controls (genre, bpm, energy, etc.)."""
+    import requests
+
+    headers = build_headers(api_key)
+
+    # Build multipart form data from params
+    form_data = {}
+    for key, value in params.items():
+        if value is not None:
+            form_data[key] = (None, str(value))
+
+    response = requests.post(
+        f"{API_BASE}/ai/songs",
+        headers=headers,
+        files=form_data,
+    )
+
+    if response.status_code != 200:
+        print(f"Error: API returned status {response.status_code}", file=sys.stderr)
+        print(f"Response: {response.text}", file=sys.stderr)
+        sys.exit(1)
+
+    return response.json()
+
+
+def generate_text_to_music(api_key: str, prompt: str, duration: int | None = None) -> dict:
+    """Generate music from a text prompt."""
+    import requests
+
+    headers = build_headers(api_key)
+
+    form_data = {"prompt": (None, prompt)}
+    if duration is not None:
+        form_data["duration"] = (None, str(duration))
+
+    response = requests.post(
+        f"{API_BASE}/ai/songs",
+        headers=headers,
+        files=form_data,
+    )
+
+    if response.status_code != 200:
+        print(f"Error: API returned status {response.status_code}", file=sys.stderr)
+        print(f"Response: {response.text}", file=sys.stderr)
+        sys.exit(1)
+
+    return response.json()
+
+
+def poll_for_completion(api_key: str, song_id: str) -> dict | None:
+    """Poll the API for song completion if generation is async."""
+    import requests
+
+    headers = build_headers(api_key)
+
+    for attempt in range(MAX_POLL_ATTEMPTS):
+        response = requests.get(
+            f"{API_BASE}/ai/songs/{song_id}",
+            headers=headers,
+        )
+
+        if response.status_code != 200:
+            print(f"Warning: Poll returned status {response.status_code}", file=sys.stderr)
+            time.sleep(POLL_INTERVAL)
+            continue
+
+        data = response.json()
+        status = data.get("status", "").lower()
+
+        if status in ("completed", "done", "ready"):
+            return data
+        elif status in ("failed", "error"):
+            print(f"Error: Music generation failed: {data}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"  Generating... ({attempt + 1}/{MAX_POLL_ATTEMPTS})")
+        time.sleep(POLL_INTERVAL)
+
+    print("Error: Generation timed out.", file=sys.stderr)
+    sys.exit(1)
+
+
+def find_audio_url(data: dict) -> str | None:
+    """Extract the audio download URL from the API response."""
+    # Try common response field names
+    for key in ("url", "audio_url", "download_url", "file_url", "mp3_url",
+                "wav_url", "file", "audio", "download", "link", "src"):
+        if key in data and data[key]:
+            return data[key]
+
+    # Check nested structures
+    if "song" in data and isinstance(data["song"], dict):
+        return find_audio_url(data["song"])
+    if "data" in data and isinstance(data["data"], dict):
+        return find_audio_url(data["data"])
+    if "result" in data and isinstance(data["result"], dict):
+        return find_audio_url(data["result"])
+
+    # Check for list of results
+    for key in ("songs", "results", "items", "tracks"):
+        if key in data and isinstance(data[key], list) and len(data[key]) > 0:
+            return find_audio_url(data[key][0])
+
+    return None
+
+
+def download_audio(url: str, output_path: Path) -> None:
+    """Download the generated audio file."""
+    import requests
+
+    print(f"Downloading audio from: {url}")
+    response = requests.get(url, stream=True)
+
+    if response.status_code != 200:
+        print(f"Error: Download failed with status {response.status_code}", file=sys.stderr)
+        sys.exit(1)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate royalty-free AI music using the Loudly Music API"
+    )
+    parser.add_argument(
+        "--prompt", "-p",
+        help="Text description for text-to-music generation"
+    )
+    parser.add_argument(
+        "--genre", "-g",
+        help="Genre name (e.g. House, Ambient, Hip Hop, EDM)"
+    )
+    parser.add_argument(
+        "--genre-blend",
+        help="Secondary genre to blend with the primary genre"
+    )
+    parser.add_argument(
+        "--duration", "-d",
+        type=int,
+        default=30,
+        help="Duration in seconds (default: 30)"
+    )
+    parser.add_argument(
+        "--energy", "-e",
+        type=float,
+        help="Energy level between 0.0 and 1.0"
+    )
+    parser.add_argument(
+        "--bpm", "-b",
+        type=int,
+        help="Tempo in beats per minute"
+    )
+    parser.add_argument(
+        "--key-root",
+        help="Musical key root (e.g. C, D, F#)"
+    )
+    parser.add_argument(
+        "--key-quality",
+        choices=["major", "minor"],
+        help="Key quality: major or minor"
+    )
+    parser.add_argument(
+        "--instruments",
+        help="Comma-separated list of instruments"
+    )
+    parser.add_argument(
+        "--structure-id",
+        help="Structure template ID"
+    )
+    parser.add_argument(
+        "--filename", "-f",
+        required=True,
+        help="Output filename (e.g. house-track.mp3)"
+    )
+    parser.add_argument(
+        "--api-key", "-k",
+        help="Loudly API key (overrides LOUDLY_API_KEY env var)"
+    )
+
+    args = parser.parse_args()
+
+    if not args.prompt and not args.genre:
+        print("Error: Either --prompt or --genre must be provided.", file=sys.stderr)
+        sys.exit(1)
+
+    # Get API key
+    api_key = get_api_key(args.api_key)
+    if not api_key:
+        print("Error: No API key provided.", file=sys.stderr)
+        print("Please either:", file=sys.stderr)
+        print("  1. Provide --api-key argument", file=sys.stderr)
+        print("  2. Set LOUDLY_API_KEY environment variable", file=sys.stderr)
+        sys.exit(1)
+
+    output_path = Path(args.filename)
+
+    # Generate music
+    if args.prompt:
+        print(f"Generating music from prompt: \"{args.prompt}\"")
+        print(f"Duration: {args.duration}s")
+        data = generate_text_to_music(api_key, args.prompt, args.duration)
+    else:
+        params = {
+            "genre": args.genre,
+            "duration": args.duration,
+        }
+        if args.genre_blend:
+            params["genre_blend"] = args.genre_blend
+        if args.energy is not None:
+            params["energy"] = args.energy
+        if args.bpm is not None:
+            params["bpm"] = args.bpm
+        if args.key_root:
+            params["key_root"] = args.key_root
+        if args.key_quality:
+            params["key_quality"] = args.key_quality
+        if args.instruments:
+            params["instruments"] = args.instruments
+        if args.structure_id:
+            params["structure_id"] = args.structure_id
+
+        print(f"Generating {args.genre} music...")
+        print(f"Duration: {args.duration}s | Energy: {args.energy or 'default'} | BPM: {args.bpm or 'default'}")
+        data = generate_parametric(api_key, params)
+
+    print(f"API response: {data}")
+
+    # If the response contains a song ID but no direct URL, poll for completion
+    song_id = data.get("id") or data.get("song_id") or data.get("job_id")
+    audio_url = find_audio_url(data)
+
+    if not audio_url and song_id:
+        print(f"Song ID: {song_id} — waiting for generation to complete...")
+        completed_data = poll_for_completion(api_key, song_id)
+        if completed_data:
+            audio_url = find_audio_url(completed_data)
+            data = completed_data
+
+    if not audio_url:
+        print("Error: Could not find audio URL in API response.", file=sys.stderr)
+        print(f"Full response: {data}", file=sys.stderr)
+        sys.exit(1)
+
+    # Download the audio file
+    download_audio(audio_url, output_path)
+
+    full_path = output_path.resolve()
+    size_kb = full_path.stat().st_size / 1024
+    print(f"\nMusic saved: {full_path} ({size_kb:.1f} KB)")
+    # OpenClaw parses MEDIA tokens and will attach the file on supported providers.
+    print(f"MEDIA: {full_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/loudly/scripts/generate_music.py
+++ b/skills/loudly/scripts/generate_music.py
@@ -2,52 +2,80 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "requests>=2.31.0",
+#     "requests>=2.31.0,<3",
 # ]
 # ///
 """
 Generate royalty-free AI music using the Loudly Music API.
 
 Parametric generation:
-    uv run generate_music.py --genre "House" --duration 30 --energy 0.8 --filename "output.mp3"
+    uv run generate_music.py --genre "House" --duration 30 --energy high --filename "output.mp3"
 
-Text-to-music generation:
-    uv run generate_music.py --prompt "upbeat electronic track" --duration 60 --filename "output.mp3"
+With a text prompt (genre is still required):
+    uv run generate_music.py --genre "Lo Fi" --prompt "chill study beats" --duration 60 --filename "output.mp3"
 """
 
 import argparse
 import os
 import sys
-import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 API_BASE = "https://soundtracks.loudly.com/api"
-POLL_INTERVAL = 3
-MAX_POLL_ATTEMPTS = 120  # 6 minutes max wait
+ALLOWED_DOWNLOAD_HOSTS = (".cloudfront.net", ".loudly.com")
+MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
 
 
-def get_api_key(provided_key: str | None) -> str | None:
-    """Get API key from argument first, then environment."""
-    if provided_key:
-        return provided_key
+def get_api_key() -> str | None:
     return os.environ.get("LOUDLY_API_KEY")
 
 
 def build_headers(api_key: str) -> dict:
-    """Build common request headers."""
     return {
         "API-KEY": api_key,
         "Accept": "application/json",
     }
 
 
-def generate_parametric(api_key: str, params: dict) -> dict:
-    """Generate music using parametric controls (genre, bpm, energy, etc.)."""
+def validate_output_path(filename: str) -> Path:
+    """Resolve the output path and block writes to sensitive locations."""
+    output_path = Path(filename).resolve()
+    path_str = str(output_path)
+    home = Path.home().resolve()
+
+    # Block sensitive system directories
+    for prefix in ("/etc", "/usr", "/var", "/sys", "/proc", "/dev", "/boot", "/sbin"):
+        if path_str.startswith(prefix + "/") or path_str == prefix:
+            print(f"Error: cannot write to system directory ({prefix}).", file=sys.stderr)
+            sys.exit(1)
+
+    # Block sensitive dotdirs in home
+    for dotdir in (".ssh", ".gnupg", ".openclaw", ".config"):
+        sensitive = str(home / dotdir)
+        if path_str.startswith(sensitive + "/") or path_str == sensitive:
+            print(f"Error: cannot write to {dotdir}/.", file=sys.stderr)
+            sys.exit(1)
+
+    return output_path
+
+
+def validate_download_url(url: str) -> None:
+    """Validate that the download URL points to an expected host over HTTPS."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        print(f"Error: download URL must use HTTPS, got '{parsed.scheme}'.", file=sys.stderr)
+        sys.exit(1)
+    if not parsed.hostname or not any(parsed.hostname.endswith(h) for h in ALLOWED_DOWNLOAD_HOSTS):
+        print(f"Error: download URL host '{parsed.hostname}' is not in the allowlist.", file=sys.stderr)
+        sys.exit(1)
+
+
+def generate_music(api_key: str, params: dict) -> dict:
+    """Generate music via POST /ai/songs. The API is synchronous."""
     import requests
 
     headers = build_headers(api_key)
 
-    # Build multipart form data from params
     form_data = {}
     for key, value in params.items():
         if value is not None:
@@ -57,112 +85,45 @@ def generate_parametric(api_key: str, params: dict) -> dict:
         f"{API_BASE}/ai/songs",
         headers=headers,
         files=form_data,
+        timeout=(10, 120),
     )
 
     if response.status_code != 200:
-        print(f"Error: API returned status {response.status_code}", file=sys.stderr)
-        print(f"Response: {response.text}", file=sys.stderr)
+        print(f"Error: API returned status {response.status_code}.", file=sys.stderr)
         sys.exit(1)
 
-    return response.json()
-
-
-def generate_text_to_music(api_key: str, prompt: str, duration: int | None = None) -> dict:
-    """Generate music from a text prompt."""
-    import requests
-
-    headers = build_headers(api_key)
-
-    form_data = {"prompt": (None, prompt)}
-    if duration is not None:
-        form_data["duration"] = (None, str(duration))
-
-    response = requests.post(
-        f"{API_BASE}/ai/songs",
-        headers=headers,
-        files=form_data,
-    )
-
-    if response.status_code != 200:
-        print(f"Error: API returned status {response.status_code}", file=sys.stderr)
-        print(f"Response: {response.text}", file=sys.stderr)
+    try:
+        return response.json()
+    except ValueError:
+        print("Error: API returned non-JSON response.", file=sys.stderr)
         sys.exit(1)
-
-    return response.json()
-
-
-def poll_for_completion(api_key: str, song_id: str) -> dict | None:
-    """Poll the API for song completion if generation is async."""
-    import requests
-
-    headers = build_headers(api_key)
-
-    for attempt in range(MAX_POLL_ATTEMPTS):
-        response = requests.get(
-            f"{API_BASE}/ai/songs/{song_id}",
-            headers=headers,
-        )
-
-        if response.status_code != 200:
-            print(f"Warning: Poll returned status {response.status_code}", file=sys.stderr)
-            time.sleep(POLL_INTERVAL)
-            continue
-
-        data = response.json()
-        status = data.get("status", "").lower()
-
-        if status in ("completed", "done", "ready"):
-            return data
-        elif status in ("failed", "error"):
-            print(f"Error: Music generation failed: {data}", file=sys.stderr)
-            sys.exit(1)
-
-        print(f"  Generating... ({attempt + 1}/{MAX_POLL_ATTEMPTS})")
-        time.sleep(POLL_INTERVAL)
-
-    print("Error: Generation timed out.", file=sys.stderr)
-    sys.exit(1)
-
-
-def find_audio_url(data: dict) -> str | None:
-    """Extract the audio download URL from the API response."""
-    # Try common response field names
-    for key in ("url", "audio_url", "download_url", "file_url", "mp3_url",
-                "wav_url", "file", "audio", "download", "link", "src"):
-        if key in data and data[key]:
-            return data[key]
-
-    # Check nested structures
-    if "song" in data and isinstance(data["song"], dict):
-        return find_audio_url(data["song"])
-    if "data" in data and isinstance(data["data"], dict):
-        return find_audio_url(data["data"])
-    if "result" in data and isinstance(data["result"], dict):
-        return find_audio_url(data["result"])
-
-    # Check for list of results
-    for key in ("songs", "results", "items", "tracks"):
-        if key in data and isinstance(data[key], list) and len(data[key]) > 0:
-            return find_audio_url(data[key][0])
-
-    return None
 
 
 def download_audio(url: str, output_path: Path) -> None:
-    """Download the generated audio file."""
     import requests
 
-    print(f"Downloading audio from: {url}")
-    response = requests.get(url, stream=True)
+    validate_download_url(url)
+
+    print("Downloading audio...")
+    response = requests.get(url, stream=True, timeout=(10, 300))
 
     if response.status_code != 200:
-        print(f"Error: Download failed with status {response.status_code}", file=sys.stderr)
+        print(f"Error: Download failed with status {response.status_code}.", file=sys.stderr)
         sys.exit(1)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "wb") as f:
-        for chunk in response.iter_content(chunk_size=8192):
-            f.write(chunk)
+    written = 0
+    try:
+        with open(output_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                written += len(chunk)
+                if written > MAX_DOWNLOAD_BYTES:
+                    raise RuntimeError("download exceeded 100 MB limit")
+                f.write(chunk)
+    except (RuntimeError, OSError) as exc:
+        output_path.unlink(missing_ok=True)
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 def main():
@@ -170,12 +131,13 @@ def main():
         description="Generate royalty-free AI music using the Loudly Music API"
     )
     parser.add_argument(
-        "--prompt", "-p",
-        help="Text description for text-to-music generation"
+        "--genre", "-g",
+        required=True,
+        help="Genre name (required). E.g. House, Ambient, Lo Fi, Hip Hop, EDM"
     )
     parser.add_argument(
-        "--genre", "-g",
-        help="Genre name (e.g. House, Ambient, Hip Hop, EDM)"
+        "--prompt", "-p",
+        help="Text description to guide the generation (used alongside genre)"
     )
     parser.add_argument(
         "--genre-blend",
@@ -189,8 +151,8 @@ def main():
     )
     parser.add_argument(
         "--energy", "-e",
-        type=float,
-        help="Energy level between 0.0 and 1.0"
+        choices=["low", "high", "original"],
+        help="Energy level: low, high, or original"
     )
     parser.add_argument(
         "--bpm", "-b",
@@ -219,83 +181,63 @@ def main():
         required=True,
         help="Output filename (e.g. house-track.mp3)"
     )
-    parser.add_argument(
-        "--api-key", "-k",
-        help="Loudly API key (overrides LOUDLY_API_KEY env var)"
-    )
 
     args = parser.parse_args()
 
-    if not args.prompt and not args.genre:
-        print("Error: Either --prompt or --genre must be provided.", file=sys.stderr)
-        sys.exit(1)
-
-    # Get API key
-    api_key = get_api_key(args.api_key)
+    api_key = get_api_key()
     if not api_key:
-        print("Error: No API key provided.", file=sys.stderr)
-        print("Please either:", file=sys.stderr)
-        print("  1. Provide --api-key argument", file=sys.stderr)
-        print("  2. Set LOUDLY_API_KEY environment variable", file=sys.stderr)
+        print("Error: LOUDLY_API_KEY environment variable is not set.", file=sys.stderr)
         sys.exit(1)
 
-    output_path = Path(args.filename)
+    output_path = validate_output_path(args.filename)
 
-    # Generate music
+    # Build parameters
+    params = {"genre": args.genre, "duration": args.duration}
     if args.prompt:
-        print(f"Generating music from prompt: \"{args.prompt}\"")
-        print(f"Duration: {args.duration}s")
-        data = generate_text_to_music(api_key, args.prompt, args.duration)
-    else:
-        params = {
-            "genre": args.genre,
-            "duration": args.duration,
-        }
-        if args.genre_blend:
-            params["genre_blend"] = args.genre_blend
-        if args.energy is not None:
-            params["energy"] = args.energy
-        if args.bpm is not None:
-            params["bpm"] = args.bpm
-        if args.key_root:
-            params["key_root"] = args.key_root
-        if args.key_quality:
-            params["key_quality"] = args.key_quality
-        if args.instruments:
-            params["instruments"] = args.instruments
-        if args.structure_id:
-            params["structure_id"] = args.structure_id
+        params["prompt"] = args.prompt
+    if args.genre_blend:
+        params["genre_blend"] = args.genre_blend
+    if args.energy:
+        params["energy"] = args.energy
+    if args.bpm is not None:
+        params["bpm"] = args.bpm
+    if args.key_root:
+        params["key_root"] = args.key_root
+    if args.key_quality:
+        params["key_quality"] = args.key_quality
+    if args.instruments:
+        params["instruments"] = args.instruments
+    if args.structure_id:
+        params["structure_id"] = args.structure_id
 
-        print(f"Generating {args.genre} music...")
-        print(f"Duration: {args.duration}s | Energy: {args.energy or 'default'} | BPM: {args.bpm or 'default'}")
-        data = generate_parametric(api_key, params)
+    print(f"Generating {args.genre} music...")
+    if args.prompt:
+        print(f"Prompt: \"{args.prompt}\"")
+    print(f"Duration: {args.duration}s | Energy: {args.energy or 'default'} | BPM: {args.bpm or 'default'}")
 
-    print(f"API response: {data}")
+    data = generate_music(api_key, params)
 
-    # If the response contains a song ID but no direct URL, poll for completion
-    song_id = data.get("id") or data.get("song_id") or data.get("job_id")
-    audio_url = find_audio_url(data)
-
-    if not audio_url and song_id:
-        print(f"Song ID: {song_id} — waiting for generation to complete...")
-        completed_data = poll_for_completion(api_key, song_id)
-        if completed_data:
-            audio_url = find_audio_url(completed_data)
-            data = completed_data
-
+    # The API returns the audio URL in music_file_path
+    audio_url = data.get("music_file_path")
     if not audio_url:
-        print("Error: Could not find audio URL in API response.", file=sys.stderr)
-        print(f"Full response: {data}", file=sys.stderr)
+        print("Error: No music_file_path in API response.", file=sys.stderr)
         sys.exit(1)
 
-    # Download the audio file
+    title = data.get("title", "Untitled")
+    duration_ms = data.get("duration", 0)
+    bpm = data.get("bpm", "?")
+    key_info = data.get("key", {})
+    key_name = key_info.get("name", "?") if isinstance(key_info, dict) else "?"
+
+    print(f"Generated: \"{title}\" | {duration_ms / 1000:.0f}s | {bpm} BPM | Key: {key_name}")
+
+    # Download
     download_audio(audio_url, output_path)
 
-    full_path = output_path.resolve()
-    size_kb = full_path.stat().st_size / 1024
-    print(f"\nMusic saved: {full_path} ({size_kb:.1f} KB)")
+    size_kb = output_path.stat().st_size / 1024
+    print(f"\nMusic saved: {output_path} ({size_kb:.1f} KB)")
     # OpenClaw parses MEDIA tokens and will attach the file on supported providers.
-    print(f"MEDIA: {full_path}")
+    print(f"MEDIA: {output_path}")
 
 
 if __name__ == "__main__":

--- a/skills/loudly/scripts/list_genres.py
+++ b/skills/loudly/scripts/list_genres.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "requests>=2.31.0",
+# ]
+# ///
+"""
+List available genres from the Loudly Music API.
+
+Usage:
+    uv run list_genres.py [--api-key KEY]
+"""
+
+import argparse
+import os
+import sys
+
+
+API_BASE = "https://soundtracks.loudly.com/api"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List available Loudly music genres")
+    parser.add_argument("--api-key", "-k", help="Loudly API key (overrides LOUDLY_API_KEY env var)")
+    args = parser.parse_args()
+
+    api_key = args.api_key or os.environ.get("LOUDLY_API_KEY")
+    if not api_key:
+        print("Error: No API key. Set LOUDLY_API_KEY or pass --api-key.", file=sys.stderr)
+        sys.exit(1)
+
+    import requests
+
+    response = requests.get(
+        f"{API_BASE}/ai/genres",
+        headers={"API-KEY": api_key, "Accept": "application/json"},
+    )
+
+    if response.status_code != 200:
+        print(f"Error: API returned status {response.status_code}", file=sys.stderr)
+        print(f"Response: {response.text}", file=sys.stderr)
+        sys.exit(1)
+
+    data = response.json()
+
+    # Handle different response shapes
+    genres = data if isinstance(data, list) else data.get("genres", data.get("data", []))
+
+    if not genres:
+        print("No genres found. Raw response:")
+        print(data)
+        return
+
+    print("Available Loudly Genres:")
+    print("=" * 50)
+    for genre in genres:
+        if isinstance(genre, dict):
+            name = genre.get("name", genre.get("title", "Unknown"))
+            bpm_min = genre.get("bpm_min", genre.get("minBpm", ""))
+            bpm_max = genre.get("bpm_max", genre.get("maxBpm", ""))
+            bpm_range = f" ({bpm_min}-{bpm_max} BPM)" if bpm_min and bpm_max else ""
+            desc = genre.get("description", "")
+            print(f"  {name}{bpm_range}")
+            if desc:
+                print(f"    {desc}")
+
+            # Print sub-genres / micro-genres if present
+            sub = genre.get("micro_genres", genre.get("subgenres", genre.get("children", [])))
+            if sub:
+                for sg in sub:
+                    sg_name = sg.get("name", sg) if isinstance(sg, dict) else sg
+                    print(f"    - {sg_name}")
+        else:
+            print(f"  {genre}")
+
+    print(f"\nTotal: {len(genres)} genres")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a new **Loudly** skill for generating royalty-free AI music via the [Loudly Music API](https://www.loudly.com/developers)
- Supports parametric generation (genre, energy, BPM, key, instruments, genre-blending) and text-prompted generation (prompt alongside genre)
- Includes `generate_music.py` and `list_genres.py` scripts, executed via `uv run` with inline PEP 723 dependency metadata — zero setup beyond having `uv` installed
- 15 genres available (Ambient, House, Lo Fi, Hip Hop, EDM, etc.) each with micro-genre sub-categories

### Security hardening

- API key via `LOUDLY_API_KEY` env var only (no CLI flag — avoids `ps aux` exposure)
- Download URL validated: HTTPS-only + hostname allowlist (`*.cloudfront.net`, `*.loudly.com`) to prevent SSRF
- Output path denylist blocks writes to `/etc`, `~/.ssh`, `~/.openclaw`, and other sensitive locations
- Request timeouts on all HTTP calls (10s connect, 120s/300s read)
- Download capped at 100 MB with partial-file cleanup on failure
- Raw API error responses suppressed from output
- `requests` dependency pinned with upper bound (`>=2.31.0,<3`)

### Skill structure

```
skills/loudly/
├── SKILL.md                      # Manifest + agent instructions
└── scripts/
    ├── generate_music.py         # Music generation (parametric + prompt)
    └── list_genres.py            # Genre listing with micro-genres
```

## Test plan

- [x] Parametric generation (genre + energy + BPM) — verified via API
- [x] Genre + text prompt combo — verified via API
- [x] Genre blending + musical key params — verified via API
- [x] List genres (15 genres, micro-genres displayed) — verified via API
- [x] End-to-end agent test via `openclaw agent` — skill loaded, music generated, MP3 saved
- [x] Path traversal blocked: `/etc/evil.mp3`, `~/.ssh/authorized_keys`, `~/.openclaw/...`
- [x] SSRF blocked: HTTP URLs, localhost, AWS metadata, spoofed hostnames
- [x] Missing API key rejected cleanly
- [x] Skill appears as "ready" in `openclaw skills list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new **Loudly** skill for AI music generation with two scripts (`generate_music.py` and `list_genres.py`), following the existing skill conventions (PEP 723 inline deps, `uv run`, `MEDIA:` output tokens). The PR includes notably strong security hardening — HTTPS-only URL allowlist, output path denylist, streamed download with 100 MB cap and partial-file cleanup — which sets a higher bar than some existing skills.

- One logic issue found: `data.get("duration", 0)` on line 227 of `generate_music.py` does not guard against the API returning an explicit `null`, which would cause a `TypeError` crash on line 232 during the division.
- Skill manifest (`SKILL.md`) is well-structured and follows existing patterns.
- `list_genres.py` is clean with proper error handling and timeout configuration.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor fix needed for a potential crash when the API returns null duration.
- Score of 4 reflects well-written, security-hardened code with one edge-case bug that could cause a runtime crash. The overall structure follows repo conventions and the security measures are thorough.
- `skills/loudly/scripts/generate_music.py` — line 227 has a null-safety issue that could cause a `TypeError`.

<sub>Last reviewed commit: 9c623b8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->