### PR TITLE
test: isolate gateway auth env vars in test runner

### DIFF
--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -289,9 +289,13 @@ const runOnce = (entry, extraArgs = []) =>
       : nextNodeOptions;
     let child;
     try {
+      // Remove gateway auth env vars to ensure test isolation
+      const testEnv = { ...process.env };
+      delete testEnv.OPENCLAW_GATEWAY_TOKEN;
+      delete testEnv.OPENCLAW_GATEWAY_PASSWORD;
       child = spawn(pnpm, args, {
         stdio: "inherit",
-        env: { ...process.env, VITEST_GROUP: entry.name, NODE_OPTIONS: resolvedNodeOptions },
+        env: { ...testEnv, VITEST_GROUP: entry.name, NODE_OPTIONS: resolvedNodeOptions },
         shell: isWindows,
       });
     } catch (err) {
@@ -353,9 +357,13 @@ if (passthroughArgs.length > 0) {
   const code = await new Promise((resolve) => {
     let child;
     try {
+      // Remove gateway auth env vars to ensure test isolation
+      const testEnv = { ...process.env };
+      delete testEnv.OPENCLAW_GATEWAY_TOKEN;
+      delete testEnv.OPENCLAW_GATEWAY_PASSWORD;
       child = spawn(pnpm, args, {
         stdio: "inherit",
-        env: { ...process.env, NODE_OPTIONS: nextNodeOptions },
+        env: { ...testEnv, NODE_OPTIONS: nextNodeOptions },
         shell: isWindows,
       });
     } catch (err) {


### PR DESCRIPTION
## Summary

- **Problem**: Tests fail when running locally with `OPENCLAW_GATEWAY_TOKEN` or `OPENCLAW_GATEWAY_PASSWORD` environment variables set. Specifically:
  - `src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts` - expects 400 but gets 401
  - `src/gateway/server-runtime-config.test.ts` - expects rejection but gets resolved config with token
- **Why it matters**: Developers who have gateway auth env vars set for local development cannot run tests successfully
- **What changed**: Strip `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_PASSWORD` from the environment before spawning test processes in `scripts/test-parallel.mjs`
- **What did NOT change**: Individual test files remain unchanged; this elevates the isolation pattern to the test runner level

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

None

## User-visible / Behavior Changes

None

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Set gateway auth env vars: `export OPENCLAW_GATEWAY_TOKEN=test`
2. Run tests: `pnpm test -- --run src/gateway/server-runtime-config.test.ts`
3. Observe failures before fix, passes after fix

### Expected

Tests should pass regardless of local environment variables

### Actual

Tests fail when env vars are set

## Evidence

- [x] Failing test/log before + passing after

Before fix:
```
OPENCLAW_GATEWAY_TOKEN=test pnpm test -- --run src/gateway/server-runtime-config.test.ts
# ❌ fails - expects rejection but resolves with token
```

After fix:
```
OPENCLAW_GATEWAY_TOKEN=test pnpm test -- --run src/gateway/server-runtime-config.test.ts
# ✅ passes
```

## Human Verification

- Verified scenarios: Tests pass with env vars set, tests pass without env vars
- Edge cases checked: Both `runOnce` and passthrough-args spawn paths
- What was **not** verified: Windows environment (no access)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery

- How to disable/revert: Revert commit `879a77498`
- Known bad symptoms: None expected

## Risks and Mitigations

None - this is a minimal test infrastructure fix with no production code changes.