### PR TITLE
Control UI: show refresh in-flight state on Overview

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -7,6 +7,7 @@ export const en: TranslationMap = {
     offline: "Offline",
     connect: "Connect",
     refresh: "Refresh",
+    refreshing: "Refreshing…",
     enabled: "Enabled",
     disabled: "Disabled",
     na: "n/a",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -7,6 +7,7 @@ export const pt_BR: TranslationMap = {
     offline: "Offline",
     connect: "Conectar",
     refresh: "Atualizar",
+    refreshing: "Atualizando…",
     enabled: "Ativado",
     disabled: "Desativado",
     na: "n/a",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -7,6 +7,7 @@ export const zh_CN: TranslationMap = {
     offline: "离线",
     connect: "连接",
     refresh: "刷新",
+    refreshing: "刷新中…",
     enabled: "已启用",
     disabled: "已禁用",
     na: "不适用",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -7,6 +7,7 @@ export const zh_TW: TranslationMap = {
     offline: "離線",
     connect: "連接",
     refresh: "刷新",
+    refreshing: "刷新中…",
     enabled: "已啟用",
     disabled: "已禁用",
     na: "不適用",

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -212,6 +212,13 @@ export function renderApp(state: AppViewState) {
                 cronEnabled: state.cronStatus?.enabled ?? null,
                 cronNext,
                 lastChannelsRefresh: state.channelsLastSuccess,
+                refreshing:
+                  state.connected &&
+                  (state.channelsLoading ||
+                    state.presenceLoading ||
+                    state.sessionsLoading ||
+                    state.debugLoading ||
+                    state.cronLoading),
                 onSettingsChange: (next) => state.applySettings(next),
                 onPasswordChange: (next) => (state.password = next),
                 onSessionKeyChange: (next) => {

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -16,6 +16,7 @@ export type OverviewProps = {
   cronEnabled: boolean | null;
   cronNext: number | null;
   lastChannelsRefresh: number | null;
+  refreshing: boolean;
   onSettingsChange: (next: UiSettings) => void;
   onPasswordChange: (next: string) => void;
   onSessionKeyChange: (next: string) => void;
@@ -205,7 +206,13 @@ export function renderOverview(props: OverviewProps) {
         </div>
         <div class="row" style="margin-top: 14px;">
           <button class="btn" @click=${() => props.onConnect()}>${t("common.connect")}</button>
-          <button class="btn" @click=${() => props.onRefresh()}>${t("common.refresh")}</button>
+          <button
+            class="btn"
+            ?disabled=${props.refreshing}
+            @click=${() => props.onRefresh()}
+          >
+            ${props.refreshing ? t("common.refreshing") : t("common.refresh")}
+          </button>
           <span class="muted">${
             isTrustedProxy ? t("overview.access.trustedProxy") : t("overview.access.connectHint")
           }</span>


### PR DESCRIPTION
Adds a visible in-flight state to the Overview page Refresh button (disabled + "Refreshing…") while overview data is reloading (channels/presence/sessions/debug/cron requests). This makes it clear the refresh action is working.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a visible in-flight state to the Overview page Refresh button: while overview data is reloading (channels, presence, sessions, debug, cron requests), the button shows "Refreshing…" and is disabled. Translations added for all four supported locales (en, pt-BR, zh-CN, zh-TW).

- `OverviewProps` gains a `refreshing: boolean` prop, computed in `app-render.ts` from the OR of `state.connected` and the five `*Loading` flags
- The Refresh button in `overview.ts` uses lit's `?disabled` binding and conditionally renders the `common.refreshing` translation key
- All four locale files (`en.ts`, `pt-BR.ts`, `zh-CN.ts`, `zh-TW.ts`) add a `refreshing` key to the `common` section with appropriate translations
- Note: `state.cronLoading` is included in the OR but is never set by `loadCronStatus` (the function `loadOverview` actually calls) — this is harmless and defensive, but could be cleaned up if desired

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a straightforward UI indicator with no logic or behavioral changes beyond button state.
- The changes are minimal, well-scoped, and follow existing patterns. The new `refreshing` prop is correctly typed, the locale strings are consistent across all four locales, and the button behavior (disabled + label swap) is standard. The only minor note is that `cronLoading` won't actually be set during an overview refresh, but this is harmless.
- No files require special attention.

<sub>Last reviewed commit: 50a772b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->