### PR TITLE
fix(signal): add groups config to Signal channel schema

### DIFF
--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -6,9 +6,16 @@ import type {
 } from "./types.base.js";
 import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
+import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
 export type SignalReactionNotificationMode = "off" | "own" | "all" | "allowlist";
 export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
+
+export type SignalGroupConfig = {
+  requireMention?: boolean;
+  tools?: GroupToolPolicyConfig;
+  toolsBySender?: GroupToolPolicyBySenderConfig;
+};
 
 export type SignalAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
@@ -57,6 +64,8 @@ export type SignalAccountConfig = {
   dmHistoryLimit?: number;
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
+  /** Per-group config overrides keyed by group ID. */
+  groups?: Record<string, SignalGroupConfig>;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
   /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -641,6 +641,17 @@ export const SlackConfigSchema = SlackAccountSchema.safeExtend({
   }
 });
 
+const SignalGroupEntrySchema = z
+  .object({
+    requireMention: z.boolean().optional(),
+    tools: ToolPolicySchema,
+    toolsBySender: ToolPolicyBySenderSchema,
+  })
+  .strict()
+  .optional();
+
+const SignalGroupsSchema = z.record(z.string(), SignalGroupEntrySchema).optional();
+
 export const SignalAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -666,6 +677,7 @@ export const SignalAccountSchemaBase = z
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
+    groups: SignalGroupsSchema,
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),

--- a/src/config/zod-schema.signal-groups.test.ts
+++ b/src/config/zod-schema.signal-groups.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { SignalAccountSchema, SignalConfigSchema } from "./zod-schema.providers-core.js";
+
+describe("Signal groups schema", () => {
+  it("accepts groups with requireMention override", () => {
+    const result = SignalConfigSchema.safeParse({
+      groups: {
+        "*": { requireMention: false },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts groups with per-group requireMention", () => {
+    const result = SignalConfigSchema.safeParse({
+      groups: {
+        "group-id-abc": { requireMention: false },
+        "group-id-xyz": { requireMention: true },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts groups with tools policy", () => {
+    const result = SignalConfigSchema.safeParse({
+      groups: {
+        "group-id-abc": {
+          requireMention: false,
+          tools: { allow: ["exec", "read"] },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts account-level groups config", () => {
+    const result = SignalAccountSchema.safeParse({
+      groups: {
+        "*": { requireMention: false },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts multi-account config with groups", () => {
+    const result = SignalConfigSchema.safeParse({
+      accounts: {
+        main: {
+          groups: {
+            "*": { requireMention: false },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown keys in group config (strict mode)", () => {
+    const result = SignalConfigSchema.safeParse({
+      groups: {
+        "*": { requireMention: false, unknownKey: true },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts empty groups object", () => {
+    const result = SignalConfigSchema.safeParse({
+      groups: {},
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Signal runtime already supports per-group mention gating via resolveChannelGroupRequireMention, but config validation rejects channels.signal.groups with `Unrecognized key: "groups"` because Signal schema was missing that field.

This PR adds groups support to Signal config schema (top-level + per-account), matching Telegram/WhatsApp behavior.

## Changes
- add SignalGroupConfig type (requireMention, tools, toolsBySender)
- add `groups?: Record<string, SignalGroupConfig>` to SignalAccountConfig
- add SignalGroupEntrySchema + SignalGroupsSchema in Zod providers schema
- wire groups into SignalAccountSchemaBase
- add focused tests in `src/config/zod-schema.signal-groups.test.ts`

## Why this matters
Signal has no native @mentions, so many setups need per-group requireMention: false. Without schema support, users cannot set this and group messages are silently dropped by mention gating.

Closes #20397

## Validation
- `npx vitest run src/config/zod-schema.signal-groups.test.ts`
- `npx vitest run src/signal/monitor/event-handler.mention-gating.test.ts`
- `npx vitest run src/config/schema.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `groups` config support to the Signal channel schema, enabling per-group `requireMention`, `tools`, and `toolsBySender` overrides. The Signal runtime (`resolveChannelGroupRequireMention` in `group-policy.ts`) already supported reading group configs, but the Zod schema rejected `channels.signal.groups` as an unrecognized key. This PR closes that gap.

- Added `SignalGroupConfig` type to `types.signal.ts` matching the existing `WhatsAppGroupConfig` and `ChannelGroupConfig` patterns
- Added `SignalGroupEntrySchema` + `SignalGroupsSchema` Zod schemas in `zod-schema.providers-core.ts`, identical to the WhatsApp group schema structure
- Wired `groups: SignalGroupsSchema` into `SignalAccountSchemaBase` (propagates to both top-level and per-account Signal configs)
- Added focused test file (`zod-schema.signal-groups.test.ts`) covering wildcard groups, per-group overrides, tools policy, multi-account configs, strict mode rejection, and empty groups

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds schema validation for a feature the runtime already supports, with no behavioral changes to existing code paths.
- The changes are minimal and follow an established, well-tested pattern used identically by WhatsApp and iMessage group schemas. The new `SignalGroupEntrySchema` is structurally identical to `WhatsAppGroupEntrySchema`. The type definitions match the generic `ChannelGroupConfig` used by the runtime resolution functions. The runtime code in `group-policy.ts` already handles Signal groups via the generic `resolveChannelGroups` function — this PR simply unblocks config validation so users can actually set these values. Test coverage is solid.
- No files require special attention

<sub>Last reviewed commit: 9b60b3f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->