### PR TITLE
docs: clarify slash command authorization model and ownerAllowFrom

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -25,9 +25,9 @@ Access to commands is controlled by three independent layers, applied in order:
 
 **Command access** (`commands.allowFrom`) controls slash commands and directives independently of channel access. Useful when you have multiple chatters but only want some to run commands. When not set, command access falls back to `commands.useAccessGroups` (uses channel allowlists).
 
-**Owner access** (`commands.ownerAllowFrom`) designates the privileged owner. Owners can use all commands including owner-only ones (e.g. `/config`, `/debug`, `/send`). The owner's identity is also injected into the agent's system prompt as `Owner numbers: ...`. When not set, ownership is derived from channel allowlists — so in single-user setups you usually don't need to set this explicitly.
+**Owner access** (`commands.ownerAllowFrom`) designates the privileged owner. Owners can use all commands including owner-only ones (e.g. `/config`, `/debug`, `/send`). The owner's identity is also injected into the agent's system prompt as `Owner numbers: ...`. When not set, ownership is derived from `commands.allowFrom` or channel allowlists — so in single-user setups you usually don't need to set this explicitly.
 
-> **Common setup:** Lock `commands.allowFrom` to yourself across each channel. Leave `commands.ownerAllowFrom` unset — the gateway will derive ownership from your channel `allowFrom`. Only configure `ownerAllowFrom` explicitly if you want a different person to have owner-level command access than general command access.
+> **Common setup:** Lock `commands.allowFrom` to yourself across each channel. Leave `commands.ownerAllowFrom` unset — the gateway will derive ownership from your `commands.allowFrom`. Only configure `ownerAllowFrom` explicitly if you want a different person to have owner-level command access than general command access.
 
 There are two related systems:
 
@@ -61,6 +61,7 @@ They run immediately, are stripped before the model sees the message, and the re
       discord: ["user:123"],
     },
     useAccessGroups: true,
+    // ownerAllowFrom: ["user1", "whatsapp:+15551234567"], // explicit owner override (optional)
   },
 }
 ```

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -11,6 +11,24 @@ title: "Slash Commands"
 Commands are handled by the Gateway. Most commands must be sent as a **standalone** message that starts with `/`.
 The host-only bash chat command uses `! <cmd>` (with `/bash <cmd>` as an alias).
 
+## Authorization model
+
+Access to commands is controlled by three independent layers, applied in order:
+
+| Layer              | Config                                                 | Controls                                                                   |
+| ------------------ | ------------------------------------------------------ | -------------------------------------------------------------------------- |
+| **Channel access** | `channels.<provider>.allowFrom` / `dmPolicy` / pairing | Who can send messages to the agent at all                                  |
+| **Command access** | `commands.allowFrom`                                   | Who can use slash commands and directives                                  |
+| **Owner access**   | `commands.ownerAllowFrom`                              | Who is the privileged owner (owner-only commands + system prompt identity) |
+
+**Channel access** is the outer gate — if someone can't chat with the agent, they can't use commands either.
+
+**Command access** (`commands.allowFrom`) controls slash commands and directives independently of channel access. Useful when you have multiple chatters but only want some to run commands. When not set, command access falls back to `commands.useAccessGroups` (uses channel allowlists).
+
+**Owner access** (`commands.ownerAllowFrom`) designates the privileged owner. Owners can use all commands including owner-only ones (e.g. `/config`, `/debug`, `/send`). The owner's identity is also injected into the agent's system prompt as `Owner numbers: ...`. When not set, ownership is derived from channel allowlists — so in single-user setups you usually don't need to set this explicitly.
+
+> **Common setup:** Lock `commands.allowFrom` to yourself across each channel. Leave `commands.ownerAllowFrom` unset — the gateway will derive ownership from your channel `allowFrom`. Only configure `ownerAllowFrom` explicitly if you want a different person to have owner-level command access than general command access.
+
 There are two related systems:
 
 - **Commands**: standalone `/...` messages.
@@ -61,9 +79,14 @@ They run immediately, are stripped before the model sees the message, and the re
 - `commands.config` (default `false`) enables `/config` (reads/writes `openclaw.json`).
 - `commands.debug` (default `false`) enables `/debug` (runtime-only overrides).
 - `commands.allowFrom` (optional) sets a per-provider allowlist for command authorization. When configured, it is the
-  only authorization source for commands and directives (channel allowlists/pairing and `commands.useAccessGroups`
-  are ignored). Use `"*"` for a global default; provider-specific keys override it.
+  only authorization source for commands and directives — channel allowlists/pairing and `commands.useAccessGroups`
+  are ignored. Use `"*"` for a global default; provider-specific keys override it.
 - `commands.useAccessGroups` (default `true`) enforces allowlists/policies for commands when `commands.allowFrom` is not set.
+- `commands.ownerAllowFrom` (optional) sets the explicit owner allowlist. Owners can use all commands including
+  owner-only ones (marked † in the command list below). The owner's ID is also injected into the agent's system
+  prompt. Accepts plain channel-native IDs or provider-prefixed IDs (e.g. `"whatsapp:+15551234567"`). `"*"` is
+  ignored. When not set, the owner is derived from `commands.allowFrom` or channel allowlists — sufficient for
+  single-user setups where command access and owner access are the same person.
 
 ## Command list
 
@@ -88,8 +111,8 @@ Text + native (when enabled):
 - `/kill <id|#|all>` (immediately abort one or all running sub-agents for this session; no confirmation message)
 - `/steer <id|#> <message>` (steer a running sub-agent immediately: in-run when possible, otherwise abort current work and restart on the steer message)
 - `/tell <id|#> <message>` (alias for `/steer`)
-- `/config show|get|set|unset` (persist config to disk, owner-only; requires `commands.config: true`)
-- `/debug show|set|unset|reset` (runtime overrides, owner-only; requires `commands.debug: true`)
+- `/config show|get|set|unset` (persist config to disk; requires `commands.config: true`) †
+- `/debug show|set|unset|reset` (runtime overrides; requires `commands.debug: true`) †
 - `/usage off|tokens|full|cost` (per-response usage footer or local cost summary)
 - `/tts off|always|inbound|tagged|status|provider|limit|summary|audio` (control TTS; see [/tts](/tts))
   - Discord: native command is `/voice` (Discord reserves `/tts`); text `/tts` still works.
@@ -99,7 +122,7 @@ Text + native (when enabled):
 - `/dock-discord` (alias: `/dock_discord`) (switch replies to Discord)
 - `/dock-slack` (alias: `/dock_slack`) (switch replies to Slack)
 - `/activation mention|always` (groups only)
-- `/send on|off|inherit` (owner-only)
+- `/send on|off|inherit` †
 - `/reset` or `/new [model]` (optional model hint; remainder is passed through)
 - `/think <off|minimal|low|medium|high|xhigh>` (dynamic choices by model/provider; aliases: `/thinking`, `/t`)
 - `/verbose on|full|off` (alias: `/v`)
@@ -109,6 +132,8 @@ Text + native (when enabled):
 - `/model <name>` (alias: `/models`; or `/<alias>` from `agents.defaults.models.*.alias`)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
 - `/bash <command>` (host-only; alias for `! <command>`; requires `commands.bash: true` + `tools.elevated` allowlists)
+
+† **Owner-only** — requires the sender to match `commands.ownerAllowFrom`. If not configured, ownership is derived from `commands.allowFrom` or channel allowlists. See [Authorization model](#authorization-model) above.
 
 Text-only:
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -25,9 +25,9 @@ Access to commands is controlled by three independent layers, applied in order:
 
 **Command access** (`commands.allowFrom`) controls slash commands and directives independently of channel access. Useful when you have multiple chatters but only want some to run commands. When not set, command access falls back to `commands.useAccessGroups` (uses channel allowlists).
 
-**Owner access** (`commands.ownerAllowFrom`) designates the privileged owner. The owner's identity is injected into the agent's system prompt as `Owner numbers: ...`, and owner-gated agent tools (e.g. `whatsapp_login`) are restricted to owners only. Owner status does not gate any slash commands — all slash commands use the same command access check. When not set, ownership is derived from channel allowlists (`channels.<provider>.allowFrom` / pairing) — so in single-user setups you usually don't need to set this explicitly.
+**Owner access** (`commands.ownerAllowFrom`) designates the privileged owner. The owner's identity is injected into the agent's system prompt as `Owner numbers: ...`, and owner-gated agent tools (e.g. `whatsapp_login`) are restricted to owners only. Slash commands themselves do not distinguish owner from non-owner — all use the same authorized-sender check — unless a provider enforces owner-for-commands (e.g. WhatsApp when `commands.allowFrom` is not set). When not set, ownership is derived from channel allowlists (`channels.<provider>.allowFrom` / pairing) — so in single-user setups you usually don't need to set this explicitly.
 
-> **Common setup:** Lock `commands.allowFrom` to yourself across each channel. Leave `commands.ownerAllowFrom` unset — the gateway will derive ownership from your channel allowlists. Only configure `ownerAllowFrom` explicitly if you want a different person to have owner-level command access than general command access.
+> **Common setup:** Lock `commands.allowFrom` to yourself across each channel. Leave `commands.ownerAllowFrom` unset — the gateway will derive ownership from your channel allowlists. Only configure `ownerAllowFrom` explicitly if you want a different person to have owner designation (system prompt identity + owner-gated tools) than command access.
 
 There are two related systems:
 
@@ -198,7 +198,7 @@ Notes:
 
 ## Debug overrides
 
-`/debug` lets you set **runtime-only** config overrides (memory, not disk). Owner-only. Disabled by default; enable with `commands.debug: true`.
+`/debug` lets you set **runtime-only** config overrides (memory, not disk). Disabled by default; enable with `commands.debug: true`. Requires command access (authorized sender).
 
 Examples:
 
@@ -217,7 +217,7 @@ Notes:
 
 ## Config updates
 
-`/config` writes to your on-disk config (`openclaw.json`). Owner-only. Disabled by default; enable with `commands.config: true`.
+`/config` writes to your on-disk config (`openclaw.json`). Disabled by default; enable with `commands.config: true`. Requires command access (authorized sender).
 
 Examples:
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -15,19 +15,19 @@ The host-only bash chat command uses `! <cmd>` (with `/bash <cmd>` as an alias).
 
 Access to commands is controlled by three independent layers, applied in order:
 
-| Layer              | Config                                                 | Controls                                                                   |
-| ------------------ | ------------------------------------------------------ | -------------------------------------------------------------------------- |
-| **Channel access** | `channels.<provider>.allowFrom` / `dmPolicy` / pairing | Who can send messages to the agent at all                                  |
-| **Command access** | `commands.allowFrom`                                   | Who can use slash commands and directives                                  |
-| **Owner access**   | `commands.ownerAllowFrom`                              | Who is the privileged owner (owner-only commands + system prompt identity) |
+| Layer              | Config                                                 | Controls                                                                 |
+| ------------------ | ------------------------------------------------------ | ------------------------------------------------------------------------ |
+| **Channel access** | `channels.<provider>.allowFrom` / `dmPolicy` / pairing | Who can send messages to the agent at all                                |
+| **Command access** | `commands.allowFrom`                                   | Who can use slash commands and directives                                |
+| **Owner access**   | `commands.ownerAllowFrom`                              | Who is the privileged owner (system prompt identity + owner-gated tools) |
 
 **Channel access** is the outer gate — if someone can't chat with the agent, they can't use commands either.
 
 **Command access** (`commands.allowFrom`) controls slash commands and directives independently of channel access. Useful when you have multiple chatters but only want some to run commands. When not set, command access falls back to `commands.useAccessGroups` (uses channel allowlists).
 
-**Owner access** (`commands.ownerAllowFrom`) designates the privileged owner. Owners can use all commands including owner-only ones (e.g. `/config`, `/debug`, `/send`). The owner's identity is also injected into the agent's system prompt as `Owner numbers: ...`. When not set, ownership is derived from `commands.allowFrom` or channel allowlists — so in single-user setups you usually don't need to set this explicitly.
+**Owner access** (`commands.ownerAllowFrom`) designates the privileged owner. The owner's identity is injected into the agent's system prompt as `Owner numbers: ...`, and owner-gated agent tools (e.g. `whatsapp_login`) are restricted to owners only. Owner status does not gate any slash commands — all slash commands use the same command access check. When not set, ownership is derived from channel allowlists (`channels.<provider>.allowFrom` / pairing) — so in single-user setups you usually don't need to set this explicitly.
 
-> **Common setup:** Lock `commands.allowFrom` to yourself across each channel. Leave `commands.ownerAllowFrom` unset — the gateway will derive ownership from your `commands.allowFrom`. Only configure `ownerAllowFrom` explicitly if you want a different person to have owner-level command access than general command access.
+> **Common setup:** Lock `commands.allowFrom` to yourself across each channel. Leave `commands.ownerAllowFrom` unset — the gateway will derive ownership from your channel allowlists. Only configure `ownerAllowFrom` explicitly if you want a different person to have owner-level command access than general command access.
 
 There are two related systems:
 
@@ -83,11 +83,11 @@ They run immediately, are stripped before the model sees the message, and the re
   only authorization source for commands and directives — channel allowlists/pairing and `commands.useAccessGroups`
   are ignored. Use `"*"` for a global default; provider-specific keys override it.
 - `commands.useAccessGroups` (default `true`) enforces allowlists/policies for commands when `commands.allowFrom` is not set.
-- `commands.ownerAllowFrom` (optional) sets the explicit owner allowlist. Owners can use all commands including
-  owner-only ones (marked † in the command list below). The owner's ID is also injected into the agent's system
-  prompt. Accepts plain channel-native IDs or provider-prefixed IDs (e.g. `"whatsapp:+15551234567"`). `"*"` is
-  ignored. When not set, the owner is derived from `commands.allowFrom` or channel allowlists — sufficient for
-  single-user setups where command access and owner access are the same person.
+- `commands.ownerAllowFrom` (optional) sets the explicit owner allowlist. The owner's ID is injected into the
+  agent's system prompt as `Owner numbers: ...` and gates owner-only agent tools (e.g. `whatsapp_login`). Accepts
+  plain channel-native IDs or provider-prefixed IDs (e.g. `"whatsapp:+15551234567"`). Do not use `"*"` — it
+  results in no owner being designated. When not set, ownership is derived from channel allowlists — sufficient
+  for single-user setups.
 
 ## Command list
 
@@ -112,8 +112,8 @@ Text + native (when enabled):
 - `/kill <id|#|all>` (immediately abort one or all running sub-agents for this session; no confirmation message)
 - `/steer <id|#> <message>` (steer a running sub-agent immediately: in-run when possible, otherwise abort current work and restart on the steer message)
 - `/tell <id|#> <message>` (alias for `/steer`)
-- `/config show|get|set|unset` (persist config to disk; requires `commands.config: true`) †
-- `/debug show|set|unset|reset` (runtime overrides; requires `commands.debug: true`) †
+- `/config show|get|set|unset` (persist config to disk; requires `commands.config: true`)
+- `/debug show|set|unset|reset` (runtime overrides; requires `commands.debug: true`)
 - `/usage off|tokens|full|cost` (per-response usage footer or local cost summary)
 - `/tts off|always|inbound|tagged|status|provider|limit|summary|audio` (control TTS; see [/tts](/tts))
   - Discord: native command is `/voice` (Discord reserves `/tts`); text `/tts` still works.
@@ -123,7 +123,7 @@ Text + native (when enabled):
 - `/dock-discord` (alias: `/dock_discord`) (switch replies to Discord)
 - `/dock-slack` (alias: `/dock_slack`) (switch replies to Slack)
 - `/activation mention|always` (groups only)
-- `/send on|off|inherit` †
+- `/send on|off|inherit`
 - `/reset` or `/new [model]` (optional model hint; remainder is passed through)
 - `/think <off|minimal|low|medium|high|xhigh>` (dynamic choices by model/provider; aliases: `/thinking`, `/t`)
 - `/verbose on|full|off` (alias: `/v`)
@@ -133,8 +133,6 @@ Text + native (when enabled):
 - `/model <name>` (alias: `/models`; or `/<alias>` from `agents.defaults.models.*.alias`)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
 - `/bash <command>` (host-only; alias for `! <command>`; requires `commands.bash: true` + `tools.elevated` allowlists)
-
-† **Owner-only** — requires the sender to match `commands.ownerAllowFrom`. If not configured, ownership is derived from `commands.allowFrom` or channel allowlists. See [Authorization model](#authorization-model) above.
 
 Text-only:
 


### PR DESCRIPTION
## Summary

Clarifies the slash command access model, which generated real user confusion around `commands.allowFrom` vs `commands.ownerAllowFrom`. The `ownerAllowFrom` field was entirely absent from the docs despite being in the schema.

## Changes

### New: Authorization model section
Adds a three-tier summary table and explanatory prose near the top of the page:

| Layer | Config | Controls |
|---|---|---|
| Channel access | `channels.<provider>.allowFrom` / `dmPolicy` / pairing | Who can send messages |
| Command access | `commands.allowFrom` | Who can use slash commands and directives |
| Owner access | `commands.ownerAllowFrom` | System prompt identity + owner-gated tools |

Includes a "Common setup" callout for single-user deployments.

### New: `commands.ownerAllowFrom` documented in Config section
Was entirely missing from the docs. Now documents:
- What it actually controls: system prompt `Owner numbers:` injection + `whatsapp_login` tool gating
- Accepted formats: plain IDs or provider-prefixed (e.g. `"whatsapp:+15551234567"`)
- `"*"` behaviour: do not use — results in no owner being designated
- Fallback behaviour when not set: derived from channel allowlists

### Fixed: "Owner-only" labels removed
The `## Debug overrides` and `## Config updates` sections previously said "Owner-only." — both `/config` and `/debug` gate on `isAuthorizedSender` (command access), not `senderIsOwner`. Updated to "Requires command access (authorized sender)."

## Validation
All claims were validated against source before merging:
- `src/auto-reply/command-auth.ts` — ownership derivation chain
- `src/agents/tool-policy.ts` — `OWNER_ONLY_TOOL_NAMES` (`whatsapp_login` only)
- `src/agents/system-prompt.ts` — `Owner numbers:` injection
- `src/auto-reply/commands-config.ts` / `commands-session.ts` — `/config`, `/debug`, `/send` command handlers
- WhatsApp dock — `enforceOwnerForCommands` behaviour documented

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only PR that clarifies the slash command authorization model. Adds a new three-tier authorization model section (channel access, command access, owner access), documents the previously-missing `commands.ownerAllowFrom` config option, and corrects inaccurate "owner-only" labels on `/config`, `/debug`, and `/send` to reflect that they check command-level authorization (`isAuthorizedSender`), not owner-level (`senderIsOwner`).

- All documentation claims were verified against source: `command-auth.ts` (ownership derivation chain), `tool-policy.ts` (`OWNER_ONLY_TOOL_NAMES` = `whatsapp_login` only), `system-prompt.ts` (`Owner numbers:` injection), `commands-config.ts` and `commands-session.ts` (command handlers use `isAuthorizedSender`)
- The authorization table and prose are clear and accurately represent the three independent layers
- The `"*"` caveat for `ownerAllowFrom` (results in no owner being designated) is correct per the derivation logic in `command-auth.ts:278-288`
- No issues found — the changes are accurate, well-structured, and address a real documentation gap that was causing user confusion

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only documentation changes with all claims validated against source code.
- Documentation-only PR with no code changes. All technical claims in the documentation were verified against the source files referenced in the PR description. The authorization model description accurately reflects the code behavior. No inaccuracies found.
- No files require special attention.

<sub>Last reviewed commit: e59db48</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->