### PR TITLE
Fix plugin extension path traversal in discovery/install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,12 @@ jobs:
         with:
           submodules: false
 
+      - name: Normalize line endings in working tree
+        run: |
+          git config core.autocrlf false
+          git config core.eol lf
+          git checkout -f src/plugins/discovery.ts src/plugins/install.e2e.test.ts
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,12 +172,6 @@ jobs:
         with:
           submodules: false
 
-      - name: Normalize line endings in working tree
-        run: |
-          git config core.autocrlf false
-          git config core.eol lf
-          git checkout -f src/plugins/discovery.ts src/plugins/install.e2e.test.ts
-
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -589,6 +589,31 @@ describe("installPluginFromArchive", () => {
     expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
   });
 
+  it("rejects extensions that escape plugin directory", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+    fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "escape-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["../outside.js"] },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(path.join(pluginDir, "dist", "index.js"), "export {};", "utf-8");
+    fs.writeFileSync(path.join(pluginDir, "..", "outside.js"), "export {};", "utf-8");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("openclaw.extensions entry escapes plugin directory");
+  });
+
   it("continues install when scanner throws", async () => {
     const scanSpy = vi
       .spyOn(skillScanner, "scanDirectoryWithSummary")

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -267,10 +267,11 @@ async function installPluginFromPackageDir(
 
   const packageDir = path.resolve(params.packageDir);
   const forcedScanEntries: string[] = [];
+  const invalidExtensions: string[] = [];
   for (const entry of extensions) {
     const resolvedEntry = path.resolve(packageDir, entry);
     if (!isPathInside(packageDir, resolvedEntry)) {
-      logger.warn?.(`extension entry escapes plugin directory and will not be scanned: ${entry}`);
+      invalidExtensions.push(entry);
       continue;
     }
     if (extensionUsesSkippedScannerPath(entry)) {
@@ -279,6 +280,13 @@ async function installPluginFromPackageDir(
       );
     }
     forcedScanEntries.push(resolvedEntry);
+  }
+
+  if (invalidExtensions.length > 0) {
+    return {
+      ok: false,
+      error: `openclaw.extensions entry escapes plugin directory: ${invalidExtensions.join(", ")}`,
+    };
   }
 
   // Scan plugin source for dangerous code patterns (warn-only; never blocks install)
@@ -350,14 +358,11 @@ async function installPluginFromPackageDir(
     hasDeps,
     depsLogMessage: "Installing plugin dependencies…",
     afterCopy: async () => {
-      for (const entry of extensions) {
-        const resolvedEntry = path.resolve(targetDir, entry);
-        if (!isPathInside(targetDir, resolvedEntry)) {
-          logger.warn?.(`extension entry escapes plugin directory: ${entry}`);
-          continue;
-        }
-        if (!(await fileExists(resolvedEntry))) {
-          logger.warn?.(`extension entry not found: ${entry}`);
+      for (const entry of forcedScanEntries) {
+        const relativeEntry = path.relative(packageDir, entry);
+        const installedEntry = path.join(targetDir, relativeEntry);
+        if (!(await fileExists(installedEntry))) {
+          logger.warn?.(`extension entry not found: ${relativeEntry}`);
         }
       }
     },


### PR DESCRIPTION
## Summary
Hardens plugin package handling to prevent `openclaw.extensions` from escaping plugin package directories.

## Changes
- `src/plugins/discovery.ts`
  - Add canonical path resolution + containment checks (`isPathInside`) for manifest extension entries.
  - Manifest entries resolving outside the package directory are ignored and emit warnings in discovery diagnostics.
- `src/plugins/install.ts`
  - Validate `openclaw.extensions` entries against package root before install.
  - Reject install when any extension entry escapes the package directory (fail-closed).
  - Keep existing scan behavior for valid entries and maintain install copy checks using validated paths.
- `src/plugins/discovery.test.ts`
  - Added regression test for escaped manifest extension in discovery.
- `src/plugins/install.e2e.test.ts`
  - Added regression test for install-time rejection of escaped extension entries.

## Security Impact
- Prevents plugin manifest path traversal / trusted-load confusion where a package could point extension loading outside its extracted directory.
- Enforces explicit integrity boundary between package artifacts and loaded extensions.

## Validation
Ran focused tests on the working dependency tree containing the same changes:
- `pnpm --dir /Users/mmusson/projects/openclaw/claw-mem/openclaw-latest exec vitest run --config vitest.unit.config.ts src/plugins/discovery.test.ts` (pass)
- `pnpm --dir /Users/mmusson/projects/openclaw/claw-mem/openclaw-latest exec vitest run --config vitest.e2e.config.ts src/plugins/install.e2e.test.ts` (pass)

## Commit
- `a75b6df7f` Harden plugin extension path handling

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens plugin extension path handling to prevent `openclaw.extensions` manifest entries from escaping their package directory via path traversal (e.g., `../outside.js`).

- **`discovery.ts`**: Adds `isManifestExtensionInsidePackage` check using the existing `isPathInside` utility. Invalid entries are skipped with a diagnostic warning (warn-and-continue), which is appropriate for the read-only discovery phase.
- **`install.ts`**: Upgrades the traversal check from warn-and-skip to fail-closed — if any extension entry escapes the package directory, the entire install is rejected. The `afterCopy` callback is simplified to iterate over the already-validated `forcedScanEntries` rather than re-validating against `targetDir`.
- **Tests**: Both `discovery.test.ts` and `install.e2e.test.ts` add regression tests covering the `../outside.js` traversal vector, verifying that discovery ignores the entry and install rejects the package respectively.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a well-scoped security hardening with correct logic and appropriate test coverage.
- The changes are focused and correct. The `isPathInside` utility is well-tested and handles edge cases (traversal, same-path, cross-drive). Discovery uses warn-and-skip (appropriate for read-only), install uses fail-closed (appropriate for write operations). The `afterCopy` refactor correctly maps validated entries to the target directory. Both code paths have regression tests. No issues found.
- No files require special attention

<sub>Last reviewed commit: a75b6df</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->