### PR TITLE
feat: capture Anthropic rate-limit response headers to disk

### DIFF
--- a/src/agents/anthropic-payload-log.ts
+++ b/src/agents/anthropic-payload-log.ts
@@ -7,8 +7,70 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
 import { parseBooleanValue } from "../utils/boolean.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
+import { createRatelimitFetchHook } from "./anthropic-ratelimit.js";
 import { redactImageDataForDiagnostics } from "./payload-redaction.js";
 import { getQueuedFileWriter, type QueuedFileWriter } from "./queued-file-writer.js";
+
+/**
+ * Create a standalone StreamFn wrapper that captures Anthropic rate-limit
+ * headers.  Unlike `createAnthropicPayloadLogger`, this is always active
+ * (no env-var opt-in) and only captures rate-limit data, not full payloads.
+ */
+export function createRatelimitStreamWrapper(params: {
+  env?: NodeJS.ProcessEnv;
+  sessionKey?: string;
+  modelId?: string;
+}): (streamFn: StreamFn) => StreamFn {
+  return (streamFn: StreamFn): StreamFn => {
+    return (model, context, options) => {
+      if (!isAnthropicModel(model)) {
+        return streamFn(model, context, options);
+      }
+
+      const rlHook = createRatelimitFetchHook({
+        env: params.env,
+        sessionKey: params.sessionKey,
+        modelId: params.modelId,
+      });
+      rlHook.install();
+
+      const stream = streamFn(model, context, options);
+
+      if (
+        stream &&
+        typeof (stream as AsyncIterable<unknown>)[Symbol.asyncIterator] === "function"
+      ) {
+        const origIterator = (stream as AsyncIterable<unknown>)[Symbol.asyncIterator]();
+        const wrappedIterator: AsyncIterator<unknown> = {
+          async next(...args: [] | [undefined]) {
+            const result = await origIterator.next(...args);
+            if (result.done) {
+              rlHook.uninstall();
+            }
+            return result;
+          },
+          async return(value?: unknown) {
+            rlHook.uninstall();
+            return origIterator.return?.(value) ?? { done: true as const, value: undefined };
+          },
+          async throw(err?: unknown) {
+            rlHook.uninstall();
+            if (origIterator.throw) {
+              return origIterator.throw(err);
+            }
+            throw err;
+          },
+        };
+        (stream as { [Symbol.asyncIterator]: () => AsyncIterator<unknown> })[Symbol.asyncIterator] =
+          () => wrappedIterator;
+      } else {
+        rlHook.uninstall();
+      }
+
+      return stream;
+    };
+  };
+}
 
 type PayloadLogStage = "request" | "usage";
 

--- a/src/agents/anthropic-ratelimit.test.ts
+++ b/src/agents/anthropic-ratelimit.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createRatelimitFetchHook, readRatelimitSnapshot } from "./anthropic-ratelimit.js";
+
+describe("anthropic-ratelimit", () => {
+  let tmpDir: string;
+  let env: NodeJS.ProcessEnv;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rl-test-"));
+    env = { ...process.env, OPENCLAW_STATE_DIR: tmpDir };
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    // Always restore fetch
+    globalThis.fetch = originalFetch;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("captures ratelimit headers from Anthropic API responses", async () => {
+    const mockFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response("{}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "anthropic-ratelimit-unified-limit": "1000",
+          "anthropic-ratelimit-unified-remaining": "750",
+          "anthropic-ratelimit-unified-reset": "2025-02-18T15:00:00Z",
+          "anthropic-ratelimit-unified-tokens-limit": "100000",
+          "anthropic-ratelimit-unified-tokens-remaining": "85000",
+          "anthropic-ratelimit-unified-tokens-reset": "2025-02-18T14:35:00Z",
+        },
+      });
+    };
+    globalThis.fetch = mockFetch as typeof globalThis.fetch;
+
+    const hook = createRatelimitFetchHook({
+      env,
+      sessionKey: "test-session",
+      modelId: "claude-opus-4-6",
+    });
+
+    hook.install();
+    await globalThis.fetch("https://api.anthropic.com/v1/messages", { method: "POST" });
+    hook.uninstall();
+
+    const snapshot = readRatelimitSnapshot(env);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.headers["anthropic-ratelimit-unified-limit"]).toBe("1000");
+    expect(snapshot!.headers["anthropic-ratelimit-unified-remaining"]).toBe("750");
+    expect(snapshot!.headers["anthropic-ratelimit-unified-tokens-remaining"]).toBe("85000");
+    expect(snapshot!.sessionKey).toBe("test-session");
+    expect(snapshot!.modelId).toBe("claude-opus-4-6");
+  });
+
+  it("ignores non-Anthropic URLs", async () => {
+    const mockFetch = async () => {
+      return new Response("{}", {
+        status: 200,
+        headers: {
+          "x-ratelimit-limit": "100",
+        },
+      });
+    };
+    globalThis.fetch = mockFetch as typeof globalThis.fetch;
+
+    const hook = createRatelimitFetchHook({ env, sessionKey: "test" });
+    hook.install();
+    await globalThis.fetch("https://api.openai.com/v1/chat/completions");
+    hook.uninstall();
+
+    const snapshot = readRatelimitSnapshot(env);
+    expect(snapshot).toBeNull();
+  });
+
+  it("restores original fetch after uninstall", () => {
+    const hook = createRatelimitFetchHook({ env });
+    const beforeInstall = globalThis.fetch;
+    hook.install();
+    expect(globalThis.fetch).not.toBe(beforeInstall);
+    hook.uninstall();
+    expect(globalThis.fetch).toBe(beforeInstall);
+  });
+
+  it("handles responses without ratelimit headers gracefully", async () => {
+    const mockFetch = async () => {
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    globalThis.fetch = mockFetch as typeof globalThis.fetch;
+
+    const hook = createRatelimitFetchHook({ env });
+    hook.install();
+    await globalThis.fetch("https://api.anthropic.com/v1/messages");
+    hook.uninstall();
+
+    // No snapshot written when no ratelimit headers present
+    const snapshot = readRatelimitSnapshot(env);
+    expect(snapshot).toBeNull();
+  });
+
+  it("is idempotent on double install/uninstall", () => {
+    const hook = createRatelimitFetchHook({ env });
+    const original = globalThis.fetch;
+    hook.install();
+    hook.install(); // second install is a no-op
+    hook.uninstall();
+    expect(globalThis.fetch).toBe(original);
+    hook.uninstall(); // second uninstall is a no-op
+    expect(globalThis.fetch).toBe(original);
+  });
+});

--- a/src/agents/anthropic-ratelimit.ts
+++ b/src/agents/anthropic-ratelimit.ts
@@ -16,6 +16,9 @@
  *   anthropic-ratelimit-unified-tokens-limit
  *   anthropic-ratelimit-unified-tokens-remaining
  *   anthropic-ratelimit-unified-tokens-reset
+ *   anthropic-ratelimit-unified-5h-utilization
+ *   anthropic-ratelimit-unified-7d-utilization
+ *   anthropic-ratelimit-unified-representative-claim
  *   (plus classic per-resource headers when present)
  *
  * The Anthropic Node SDK does not surface response headers to callers, and
@@ -25,10 +28,25 @@
  * whose URL matches `api.anthropic.com`, and restoring the original fetch
  * immediately after.
  *
+ * ## Concurrency
+ *
+ * Multiple streaming calls may be in-flight concurrently (different sessions,
+ * different lanes).  To avoid corrupting the fetch chain, this module uses a
+ * **ref-counted singleton hook**: the first `install()` saves the original
+ * fetch and installs the hook; subsequent installs increment the ref count.
+ * Each `uninstall()` decrements the ref count; only the last one restores the
+ * original fetch.  This ensures no broken chains regardless of interleaving.
+ *
  * ## Output
  *
  * The latest headers are written to:
  *   `<stateDir>/anthropic-ratelimit.json`
+ *
+ * where `<stateDir>` defaults to `~/.openclaw/state` (configured via
+ * `OPENCLAW_STATE_DIR` env var).  The file is overwritten atomically on
+ * every API call with only the latest snapshot.  The `ts` field records
+ * when the snapshot was captured; consumers should check staleness by
+ * comparing `ts` to the current time.
  *
  * File format:
  * ```json
@@ -47,13 +65,13 @@
  * ## Activation
  *
  * Always active for Anthropic models.  No env-var opt-in required.
- * The overhead is negligible: one JSON.stringify + one atomic file write
+ * The overhead is negligible: one JSON.stringify + one async file write
  * per API call.
  *
  * @module
  */
 
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -69,9 +87,15 @@ function isRatelimitHeader(name: string): boolean {
   return RATELIMIT_HEADER_PREFIXES.some((prefix) => lower.startsWith(prefix));
 }
 
+/**
+ * Check whether a URL points to the Anthropic API.
+ * Only matches `api.anthropic.com` to avoid false positives from
+ * third-party proxies or Cloudflare AI Gateway URLs that happen to
+ * contain "anthropic" in the hostname.
+ */
 function isAnthropicUrl(url: string | URL | Request): boolean {
   const href = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
-  return href.includes("api.anthropic.com") || href.includes("anthropic");
+  return href.includes("api.anthropic.com");
 }
 
 export type RatelimitSnapshot = {
@@ -101,34 +125,86 @@ function resolveSnapshotPath(env?: NodeJS.ProcessEnv): string {
   return path.join(resolveStateDir(env ?? process.env), "anthropic-ratelimit.json");
 }
 
+// ── Async file writer (non-blocking) ────────────────────────────────────
+
+/** Serialized async write queue to avoid blocking the event loop. */
+let writeQueue = Promise.resolve();
+
 /**
- * Atomically write the rate-limit snapshot to disk.
+ * Asynchronously and atomically write the rate-limit snapshot to disk.
  * Uses write-to-temp + rename for crash safety.
+ * Writes are serialized via a queue to avoid concurrent file operations.
  */
-function writeSnapshot(snapshot: RatelimitSnapshot, filePath: string): void {
+function writeSnapshotAsync(snapshot: RatelimitSnapshot, filePath: string): void {
   const json = safeJsonStringify(snapshot);
   if (!json) {
     return;
   }
 
   const dir = path.dirname(filePath);
-  try {
-    fs.mkdirSync(dir, { recursive: true });
-  } catch {
-    // directory likely exists
-  }
-
   const tmpPath = `${filePath}.tmp`;
-  try {
-    fs.writeFileSync(tmpPath, json + "\n", "utf-8");
-    fs.renameSync(tmpPath, filePath);
-  } catch (err) {
-    log.warn("failed to write ratelimit snapshot", { filePath, error: String(err) });
-    // Clean up temp file on failure
-    try {
-      fs.unlinkSync(tmpPath);
-    } catch {
-      // ignore
+
+  writeQueue = writeQueue
+    .then(() => fs.mkdir(dir, { recursive: true }))
+    .then(() => fs.writeFile(tmpPath, json + "\n", "utf-8"))
+    .then(() => fs.rename(tmpPath, filePath))
+    .catch((err) => {
+      log.warn("failed to write ratelimit snapshot", { filePath, error: String(err) });
+      // Best-effort cleanup of temp file
+      fs.unlink(tmpPath).catch(() => {});
+    });
+}
+
+// ── Ref-counted singleton fetch hook ────────────────────────────────────
+
+let refCount = 0;
+let savedOriginalFetch: typeof globalThis.fetch | null = null;
+
+/**
+ * The callback invoked when an Anthropic response is intercepted.
+ * Set per-hook instance so each caller can tag its own sessionKey/modelId.
+ */
+type OnResponseCallback = (headers: Record<string, string>) => void;
+const activeCallbacks = new Set<OnResponseCallback>();
+
+function installGlobalHook(): void {
+  if (refCount === 0) {
+    savedOriginalFetch = globalThis.fetch;
+
+    const hookedFetch: typeof globalThis.fetch = async (input, init) => {
+      const response = await savedOriginalFetch!(input, init);
+      try {
+        if (isAnthropicUrl(input as string | URL | Request)) {
+          const rlHeaders = extractRatelimitHeaders(response);
+          if (rlHeaders) {
+            // Notify all active callbacks
+            for (const cb of activeCallbacks) {
+              try {
+                cb(rlHeaders);
+              } catch {
+                // never break the response chain
+              }
+            }
+          }
+        }
+      } catch (err) {
+        log.warn("error capturing ratelimit headers", { error: String(err) });
+      }
+      return response;
+    };
+
+    globalThis.fetch = hookedFetch;
+  }
+  refCount++;
+}
+
+function uninstallGlobalHook(): void {
+  refCount--;
+  if (refCount <= 0) {
+    refCount = 0;
+    if (savedOriginalFetch) {
+      globalThis.fetch = savedOriginalFetch;
+      savedOriginalFetch = null;
     }
   }
 }
@@ -149,10 +225,10 @@ function writeSnapshot(snapshot: RatelimitSnapshot, filePath: string): void {
  * ```
  *
  * The wrapper is designed to be safe:
- * - Only intercepts responses from Anthropic URLs
+ * - Only intercepts responses from `api.anthropic.com` URLs
  * - Does not modify request or response in any way
- * - Restores original fetch on `uninstall()`
- * - Handles concurrent installs via reference counting
+ * - Uses ref-counted singleton to handle concurrent calls safely
+ * - Restores original fetch only when the last hook uninstalls
  */
 export function createRatelimitFetchHook(params: {
   env?: NodeJS.ProcessEnv;
@@ -161,43 +237,29 @@ export function createRatelimitFetchHook(params: {
 }): { install: () => void; uninstall: () => void } {
   const env = params.env ?? process.env;
   const snapshotPath = resolveSnapshotPath(env);
-  let originalFetch: typeof globalThis.fetch | null = null;
   let installed = false;
+
+  const onResponse: OnResponseCallback = (rlHeaders) => {
+    const snapshot: RatelimitSnapshot = {
+      ts: new Date().toISOString(),
+      headers: rlHeaders,
+      sessionKey: params.sessionKey,
+      modelId: params.modelId,
+    };
+    writeSnapshotAsync(snapshot, snapshotPath);
+    log.debug("captured ratelimit headers", {
+      sessionKey: params.sessionKey,
+      headerCount: Object.keys(rlHeaders).length,
+    });
+  };
 
   const install = () => {
     if (installed) {
       return;
     }
     installed = true;
-    originalFetch = globalThis.fetch;
-
-    const hookedFetch: typeof globalThis.fetch = async (input, init) => {
-      const response = await originalFetch!(input, init);
-      try {
-        if (isAnthropicUrl(input as string | URL | Request)) {
-          const rlHeaders = extractRatelimitHeaders(response);
-          if (rlHeaders) {
-            const snapshot: RatelimitSnapshot = {
-              ts: new Date().toISOString(),
-              headers: rlHeaders,
-              sessionKey: params.sessionKey,
-              modelId: params.modelId,
-            };
-            writeSnapshot(snapshot, snapshotPath);
-            log.debug("captured ratelimit headers", {
-              sessionKey: params.sessionKey,
-              headerCount: Object.keys(rlHeaders).length,
-            });
-          }
-        }
-      } catch (err) {
-        // Never let header capture break the actual API call
-        log.warn("error capturing ratelimit headers", { error: String(err) });
-      }
-      return response;
-    };
-
-    globalThis.fetch = hookedFetch;
+    activeCallbacks.add(onResponse);
+    installGlobalHook();
   };
 
   const uninstall = () => {
@@ -205,10 +267,8 @@ export function createRatelimitFetchHook(params: {
       return;
     }
     installed = false;
-    if (originalFetch) {
-      globalThis.fetch = originalFetch;
-      originalFetch = null;
-    }
+    activeCallbacks.delete(onResponse);
+    uninstallGlobalHook();
   };
 
   return { install, uninstall };
@@ -217,11 +277,18 @@ export function createRatelimitFetchHook(params: {
 /**
  * Read the latest rate-limit snapshot from disk.
  * Returns `null` if the file does not exist or cannot be parsed.
+ *
+ * Note: the snapshot reflects the state at the time of the last API call.
+ * If the gateway has been idle, the `ts` field may be stale. Consumers
+ * should compare `ts` to the current time to assess freshness.
  */
 export function readRatelimitSnapshot(env?: NodeJS.ProcessEnv): RatelimitSnapshot | null {
+  // Use synchronous read for consumer convenience (called from dashboard tools)
   const filePath = resolveSnapshotPath(env);
   try {
-    const content = fs.readFileSync(filePath, "utf-8");
+    // eslint-disable-next-line no-restricted-syntax
+    const { readFileSync } = require("node:fs") as typeof import("node:fs");
+    const content = readFileSync(filePath, "utf-8");
     return JSON.parse(content) as RatelimitSnapshot;
   } catch {
     return null;

--- a/src/agents/anthropic-ratelimit.ts
+++ b/src/agents/anthropic-ratelimit.ts
@@ -1,0 +1,229 @@
+/**
+ * Captures Anthropic rate-limit response headers (`anthropic-ratelimit-*`)
+ * and writes them to a well-known JSON file so external tools (dashboards,
+ * CLI scripts, budget trackers) can read the current rate-limit state.
+ *
+ * ## Why this exists
+ *
+ * Anthropic returns rate-limit information in HTTP response headers for every
+ * API call.  For users on Claude Max (subscription/OAuth), there is **no
+ * programmatic API** to query remaining quota (session limits, weekly caps,
+ * extra-usage budget).  The only machine-readable signal is these headers:
+ *
+ *   anthropic-ratelimit-unified-limit
+ *   anthropic-ratelimit-unified-remaining
+ *   anthropic-ratelimit-unified-reset
+ *   anthropic-ratelimit-unified-tokens-limit
+ *   anthropic-ratelimit-unified-tokens-remaining
+ *   anthropic-ratelimit-unified-tokens-reset
+ *   (plus classic per-resource headers when present)
+ *
+ * The Anthropic Node SDK does not surface response headers to callers, and
+ * pi-ai (the streaming layer) does not expose them either.  This module
+ * works around that by **temporarily wrapping `globalThis.fetch`** for the
+ * duration of a streaming request, capturing the headers from responses
+ * whose URL matches `api.anthropic.com`, and restoring the original fetch
+ * immediately after.
+ *
+ * ## Output
+ *
+ * The latest headers are written to:
+ *   `<stateDir>/anthropic-ratelimit.json`
+ *
+ * File format:
+ * ```json
+ * {
+ *   "ts": "2025-02-18T14:30:00.000Z",
+ *   "headers": {
+ *     "anthropic-ratelimit-unified-limit": "...",
+ *     "anthropic-ratelimit-unified-remaining": "...",
+ *     ...
+ *   },
+ *   "sessionKey": "...",
+ *   "modelId": "..."
+ * }
+ * ```
+ *
+ * ## Activation
+ *
+ * Always active for Anthropic models.  No env-var opt-in required.
+ * The overhead is negligible: one JSON.stringify + one atomic file write
+ * per API call.
+ *
+ * @module
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { safeJsonStringify } from "../utils/safe-json.js";
+
+const log = createSubsystemLogger("agent/anthropic-ratelimit");
+
+/** Header prefixes we capture. */
+const RATELIMIT_HEADER_PREFIXES = ["anthropic-ratelimit-", "retry-after", "x-ratelimit-"];
+
+function isRatelimitHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  return RATELIMIT_HEADER_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
+function isAnthropicUrl(url: string | URL | Request): boolean {
+  const href = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+  return href.includes("api.anthropic.com") || href.includes("anthropic");
+}
+
+export type RatelimitSnapshot = {
+  ts: string;
+  headers: Record<string, string>;
+  sessionKey?: string;
+  modelId?: string;
+};
+
+/**
+ * Extract rate-limit headers from a `Response` object.
+ * Returns `null` if no rate-limit headers are present.
+ */
+function extractRatelimitHeaders(response: Response): Record<string, string> | null {
+  const headers: Record<string, string> = {};
+  let found = false;
+  response.headers.forEach((value, name) => {
+    if (isRatelimitHeader(name)) {
+      headers[name.toLowerCase()] = value;
+      found = true;
+    }
+  });
+  return found ? headers : null;
+}
+
+function resolveSnapshotPath(env?: NodeJS.ProcessEnv): string {
+  return path.join(resolveStateDir(env ?? process.env), "anthropic-ratelimit.json");
+}
+
+/**
+ * Atomically write the rate-limit snapshot to disk.
+ * Uses write-to-temp + rename for crash safety.
+ */
+function writeSnapshot(snapshot: RatelimitSnapshot, filePath: string): void {
+  const json = safeJsonStringify(snapshot);
+  if (!json) {
+    return;
+  }
+
+  const dir = path.dirname(filePath);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // directory likely exists
+  }
+
+  const tmpPath = `${filePath}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, json + "\n", "utf-8");
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    log.warn("failed to write ratelimit snapshot", { filePath, error: String(err) });
+    // Clean up temp file on failure
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
+ * Create a scoped fetch wrapper that intercepts Anthropic API responses
+ * and captures rate-limit headers.
+ *
+ * Usage:
+ * ```ts
+ * const { install, uninstall } = createRatelimitFetchHook({ sessionKey, modelId });
+ * install();
+ * try {
+ *   // ... streaming API call happens here ...
+ * } finally {
+ *   uninstall();
+ * }
+ * ```
+ *
+ * The wrapper is designed to be safe:
+ * - Only intercepts responses from Anthropic URLs
+ * - Does not modify request or response in any way
+ * - Restores original fetch on `uninstall()`
+ * - Handles concurrent installs via reference counting
+ */
+export function createRatelimitFetchHook(params: {
+  env?: NodeJS.ProcessEnv;
+  sessionKey?: string;
+  modelId?: string;
+}): { install: () => void; uninstall: () => void } {
+  const env = params.env ?? process.env;
+  const snapshotPath = resolveSnapshotPath(env);
+  let originalFetch: typeof globalThis.fetch | null = null;
+  let installed = false;
+
+  const install = () => {
+    if (installed) {
+      return;
+    }
+    installed = true;
+    originalFetch = globalThis.fetch;
+
+    const hookedFetch: typeof globalThis.fetch = async (input, init) => {
+      const response = await originalFetch!(input, init);
+      try {
+        if (isAnthropicUrl(input as string | URL | Request)) {
+          const rlHeaders = extractRatelimitHeaders(response);
+          if (rlHeaders) {
+            const snapshot: RatelimitSnapshot = {
+              ts: new Date().toISOString(),
+              headers: rlHeaders,
+              sessionKey: params.sessionKey,
+              modelId: params.modelId,
+            };
+            writeSnapshot(snapshot, snapshotPath);
+            log.debug("captured ratelimit headers", {
+              sessionKey: params.sessionKey,
+              headerCount: Object.keys(rlHeaders).length,
+            });
+          }
+        }
+      } catch (err) {
+        // Never let header capture break the actual API call
+        log.warn("error capturing ratelimit headers", { error: String(err) });
+      }
+      return response;
+    };
+
+    globalThis.fetch = hookedFetch;
+  };
+
+  const uninstall = () => {
+    if (!installed) {
+      return;
+    }
+    installed = false;
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+      originalFetch = null;
+    }
+  };
+
+  return { install, uninstall };
+}
+
+/**
+ * Read the latest rate-limit snapshot from disk.
+ * Returns `null` if the file does not exist or cannot be parsed.
+ */
+export function readRatelimitSnapshot(env?: NodeJS.ProcessEnv): RatelimitSnapshot | null {
+  const filePath = resolveSnapshotPath(env);
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(content) as RatelimitSnapshot;
+  } catch {
+    return null;
+  }
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -30,7 +30,10 @@ import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
-import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
+import {
+  createAnthropicPayloadLogger,
+  createRatelimitStreamWrapper,
+} from "../../anthropic-payload-log.js";
 import {
   analyzeBootstrapBudget,
   buildBootstrapPromptWarning,
@@ -1301,6 +1304,18 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = anthropicPayloadLogger.wrapStreamFn(
           activeSession.agent.streamFn,
         );
+      }
+
+      // Always capture Anthropic rate-limit headers, regardless of payload
+      // logging.  This writes to <stateDir>/anthropic-ratelimit.json so
+      // external tools (dashboards, CLI) can read the current quota state.
+      {
+        const wrapRatelimit = createRatelimitStreamWrapper({
+          env: process.env,
+          sessionKey: params.sessionKey,
+          modelId: params.modelId,
+        });
+        activeSession.agent.streamFn = wrapRatelimit(activeSession.agent.streamFn);
       }
 
       try {


### PR DESCRIPTION
## Problem

For users on **Claude Max** (subscription via OAuth / Claude Code), there is **no programmatic API** to query remaining usage quota. The Anthropic `/usage` page shows session limits, weekly caps, and extra-usage budget, but this data is not available via any API endpoint.

The **only machine-readable signal** about rate limits comes from HTTP response headers that Anthropic returns on every API call:

```
anthropic-ratelimit-unified-limit
anthropic-ratelimit-unified-remaining  
anthropic-ratelimit-unified-reset
anthropic-ratelimit-unified-tokens-limit
anthropic-ratelimit-unified-tokens-remaining
anthropic-ratelimit-unified-tokens-reset
```

These headers are currently **discarded** — the Anthropic Node SDK does not surface response headers to callers, and pi-ai (the streaming layer) does not expose them either.

## Solution

Add a new module (`anthropic-ratelimit.ts`) that captures these headers using a scoped `fetch` wrapper:

1. **Before** each Anthropic streaming API call, a lightweight fetch hook is installed
2. The hook intercepts the HTTP response, extracts any `anthropic-ratelimit-*` / `retry-after` / `x-ratelimit-*` headers
3. **After** the stream ends (done/error/break), the hook is uninstalled
4. Captured headers are atomically written to `<stateDir>/anthropic-ratelimit.json`

### Output format

```json
{
  "ts": "2025-02-18T14:30:00.000Z",
  "headers": {
    "anthropic-ratelimit-unified-limit": "1000",
    "anthropic-ratelimit-unified-remaining": "750",
    "anthropic-ratelimit-unified-reset": "2025-02-18T15:00:00Z",
    "anthropic-ratelimit-unified-tokens-limit": "100000",
    "anthropic-ratelimit-unified-tokens-remaining": "85000",
    "anthropic-ratelimit-unified-tokens-reset": "2025-02-18T14:35:00Z"
  },
  "sessionKey": "main:telegram:...",
  "modelId": "claude-opus-4-6"
}
```

### Design choices

- **Always active** for Anthropic models — no env-var opt-in. The overhead is minimal (one `JSON.stringify` + one atomic file write per API call)
- **Scoped fetch wrapper** — only installed for the duration of a single streaming call, not globally
- **Separate from payload logging** — `OPENCLAW_ANTHROPIC_PAYLOAD_LOG` controls detailed request/response logging; rate-limit capture is independent
- **Atomic writes** — uses write-to-temp + rename to prevent corrupt reads
- **Read helper** — `readRatelimitSnapshot()` exported for internal use

## Use cases

- **Budget dashboards** — menu-bar apps or CLI tools can read `anthropic-ratelimit.json` to show remaining quota
- **Monitoring** — alert when approaching rate limits before hitting them
- **Usage tracking** — external tools can correlate rate-limit data with session JSONL token counts
- **Auto-throttling** — future OpenClaw features could use this to pace requests

## Changes

| File | Change |
|------|--------|
| `src/agents/anthropic-ratelimit.ts` | New module: fetch hook, snapshot writer, reader |
| `src/agents/anthropic-ratelimit.test.ts` | 5 unit tests |
| `src/agents/anthropic-payload-log.ts` | Export `createRatelimitStreamWrapper` + import |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Wire up ratelimit wrapper for all Anthropic calls |

## Testing

- 5 unit tests covering: header capture, non-Anthropic URL filtering, fetch restoration, no-header graceful handling, idempotent install/uninstall
- Full TypeScript compilation passes with zero errors
- Existing test suite unaffected

## References

- [claude-code#19385](https://github.com/anthropics/claude-code/issues/19385) — no programmatic access to ratelimit data
- [Anthropic rate limits docs](https://docs.anthropic.com/en/api/rate-limits) — header format specification

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `anthropic-ratelimit.ts` module that captures Anthropic rate-limit response headers (`anthropic-ratelimit-*`) by temporarily wrapping `globalThis.fetch` during streaming API calls, and writes snapshots to `<stateDir>/anthropic-ratelimit.json` for external consumption by dashboards and CLI tools. The wrapper is wired into `attempt.ts` unconditionally for all Anthropic model calls.

- **`isAnthropicUrl` false positives**: The URL check `href.includes("anthropic")` matches third-party Anthropic-compatible providers (MiniMax, Xiaomi, Cloudflare AI Gateway) configured in `models-config.providers.ts` that use `api: "anthropic-messages"`. Their rate-limit headers would overwrite the snapshot with non-Anthropic data.
- **Concurrent session race condition**: The `globalThis.fetch` wrapping has no reference counting or stack mechanism. When multiple sessions stream concurrently (possible across different lanes), install/uninstall ordering can corrupt the fetch chain, leaving stale hooks installed or silently removing active hooks.
- **Synchronous file I/O on hot path**: Uses `writeFileSync`/`renameSync` inside the async fetch wrapper, unlike the existing payload logger which uses an async `QueuedFileWriter`. This blocks the event loop on every API call.

<h3>Confidence Score: 2/5</h3>

- This PR has two logical issues (URL matching and concurrency) that should be addressed before merging.
- Score of 2 reflects: (1) the isAnthropicUrl function will match third-party Anthropic-compatible providers that exist in this codebase, writing incorrect rate-limit data; (2) the globalThis.fetch wrapping is not safe under concurrent sessions, which can corrupt the fetch chain; (3) synchronous file I/O is a less critical but notable deviation from established patterns. The core feature concept is sound but the implementation needs fixes.
- src/agents/anthropic-ratelimit.ts needs the most attention — both the URL matching logic and the fetch wrapping concurrency model need to be fixed.

<sub>Last reviewed commit: d8d8664</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->