### PR TITLE
Add openclaw-workspace-sync to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -1,0 +1,51 @@
+---
+summary: "Community plugins: quality bar, hosting requirements, and PR submission path"
+read_when:
+  - You want to publish a third-party OpenClaw plugin
+  - You want to propose a plugin for docs listing
+title: "Community plugins"
+---
+
+# Community plugins
+
+This page tracks high-quality **community-maintained plugins** for OpenClaw.
+
+We accept PRs that add community plugins here when they meet the quality bar.
+
+## Required for listing
+
+- Plugin package is published on npmjs (installable via `openclaw plugins install <npm-spec>`).
+- Source code is hosted on GitHub (public repository).
+- Repository includes setup/use docs and an issue tracker.
+- Plugin has a clear maintenance signal (active maintainer, recent updates, or responsive issue handling).
+
+## How to submit
+
+Open a PR that adds your plugin to this page with:
+
+- Plugin name
+- npm package name
+- GitHub repository URL
+- One-line description
+- Install command
+
+## Review bar
+
+We prefer plugins that are useful, documented, and safe to operate.
+Low-effort wrappers, unclear ownership, or unmaintained packages may be declined.
+
+## Candidate format
+
+Use this format when adding entries:
+
+- **Plugin Name** — short description
+  npm: `@scope/package`
+  repo: `https://github.com/org/repo`
+  install: `openclaw plugins install @scope/package`
+
+## Listed plugins
+
+- **Workspace Cloud Sync** — Bidirectional workspace sync with cloud storage (Dropbox, Google Drive, OneDrive, S3, 70+ providers) via rclone
+  npm: `openclaw-workspace-sync`
+  repo: `https://github.com/ashbrener/openclaw-workspace-sync`
+  install: `openclaw plugins install openclaw-workspace-sync`


### PR DESCRIPTION
## Summary

- Adds **Workspace Cloud Sync** (`openclaw-workspace-sync`) to the community plugins listing page

This is a standalone community plugin for bidirectional workspace sync via rclone, supporting Dropbox, Google Drive, OneDrive, S3, and 70+ cloud providers. Zero LLM cost.

- **npm:** [openclaw-workspace-sync](https://www.npmjs.com/package/openclaw-workspace-sync)
- **Repo:** [ashbrener/openclaw-workspace-sync](https://github.com/ashbrener/openclaw-workspace-sync)
- **Install:** `openclaw plugins install openclaw-workspace-sync`

Built as a community plugin per @steipete's feedback on #19052. Tracked in #18106.

Addresses community requests: #17913, #17418, #13616, #7598, #8255, #2597

## Test plan

- [ ] Verify `docs/plugins/community.md` renders correctly
- [ ] Verify the install command works: `openclaw plugins install openclaw-workspace-sync`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `docs/plugins/community.md` to document community-maintained plugins for OpenClaw. The file establishes quality requirements (npm publishing, GitHub hosting, documentation, maintenance signals) and submission guidelines for third-party plugins. Currently lists one plugin: `openclaw-workspace-sync` for bidirectional cloud storage sync.

**Note:** The new file is not yet referenced in the Mintlify navigation configuration (`docs/docs.json`). It should be added to the "Extensions" group under the "Tools" tab (around line 1004-1006) to make it discoverable in the documentation site.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it only adds documentation and does not change any code
- The change only adds a new documentation file establishing community plugin guidelines and listing one plugin. The file structure is clean and follows documentation patterns. Score of 4 (not 5) because the file is not yet linked in the Mintlify navigation, which means it won't be discoverable on the docs site without that addition
- Verify that `docs/docs.json` is updated to include the new `plugins/community` page in the navigation structure

<sub>Last reviewed commit: d1d3437</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->