### PR TITLE
fix: preserve newlines for markdown table rendering in WebChat

### DIFF
--- a/src/shared/chat-content.ts
+++ b/src/shared/chat-content.ts
@@ -6,7 +6,10 @@ export function extractTextFromChatContent(
     normalizeText?: (text: string) => string;
   },
 ): string | null {
-  const normalize = opts?.normalizeText ?? ((text: string) => text.replace(/\s+/g, " ").trim());
+  // Preserve newlines for proper markdown table/list rendering in WebChat (#20410)
+  // Only collapse non-newline whitespace, keep newlines intact
+  const normalize =
+    opts?.normalizeText ?? ((text: string) => text.replace(/[^\S\n]+/g, " ").trim());
   const joinWith = opts?.joinWith ?? " ";
 
   if (typeof content === "string") {

--- a/src/shared/shared-misc.test.ts
+++ b/src/shared/shared-misc.test.ts
@@ -10,7 +10,8 @@ import { resolveNodeIdFromCandidates } from "./node-match.js";
 
 describe("extractTextFromChatContent", () => {
   it("normalizes string content", () => {
-    expect(extractTextFromChatContent("  hello\nworld  ")).toBe("hello world");
+    // Preserve newlines for markdown table rendering in WebChat (#20410)
+    expect(extractTextFromChatContent("  hello\nworld  ")).toBe("hello\nworld");
   });
 
   it("extracts text blocks from array content", () => {


### PR DESCRIPTION
Fixes #20410

## What changed

Preserve newlines before markdown parsing in Gateway WebChat so tables render as proper HTML tables instead of jammed inline text.

## AI-assisted contribution

This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)

## Testing

Validated with `pnpm build && pnpm check && pnpm test`

## Root cause

The fix addresses the root cause by not collapsing newlines before the markdown parser runs. Changed text normalization in `extractTextFromChatContent` to preserve newlines while collapsing other whitespace. The regex change from `/\\s+/g` to `/[^\\S\\n]+/g` allows markdown tables and lists to render properly in the Gateway WebChat UI by maintaining line breaks that the markdown parser (`marked`) needs to recognize table syntax.

---

**Greptile Summary**

Changed text normalization in `extractTextFromChatContent` to preserve newlines while collapsing other whitespace. The regex change from `/\\s+/g` to `/[^\\S\\n]+/g` allows markdown tables and lists to render properly in the Gateway WebChat UI by maintaining line breaks that the markdown parser (`marked`) needs to recognize table syntax.

**Confidence Score: 5/5**

- This PR is safe to merge with minimal risk
- The change is surgical (one regex modification), well-documented with inline comments referencing the issue, includes updated test coverage, and the regex pattern `/[^\\S\\n]+/g` is a standard technique for preserving newlines while normalizing other whitespace
- The PR passed the full test suite (`pnpm build && pnpm check && pnpm test`)
- Usage analysis shows that code paths with custom normalization functions bypass this change, limiting the impact scope to only those relying on the default behavior
- No files require special attention

<sub>Last reviewed commit: 5eecc8b</sub>