### PR TITLE
fix(memory): correct search help example to use positional argument [AI-assisted]

### DIFF
--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -523,7 +523,7 @@ export function registerMemoryCli(program: Command) {
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
           ["openclaw memory status", "Show index and provider status."],
           ["openclaw memory index --force", "Force a full reindex."],
-          ['openclaw memory search --query "deployment notes"', "Search indexed memory entries."],
+          ['openclaw memory search "deployment notes"', "Search indexed memory entries."],
           ["openclaw memory status --json", "Output machine-readable JSON."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
     );


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw memory -h` shows `openclaw memory search --query "deployment notes"` as an example, but `search` takes a positional argument, not a `--query` option — running the example as shown returns `error: unknown option '--query'`
- **Why it matters:** Users copy the example from help text and get an immediate error
- **What changed:** Removed `--query` from the help example in `src/cli/memory-cli.ts`
- **What did NOT change:** The command itself, its argument parsing, or any behavior

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #

## User-visible / Behavior Changes

The help text example for `openclaw memory search` now correctly shows the positional argument syntax.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Run `openclaw memory -h`
2. Copy the search example: `openclaw memory search --query "deployment notes"`
3. Run it → `error: unknown option '--query'`

### Expected

Example in help text matches the actual command signature (positional argument).

### Actual

Help text showed `--query` flag which doesn't exist.

## Evidence

- [x] Verified `openclaw memory search --help` shows `<query>` as a positional argument
- [x] Confirmed `openclaw memory search "deployment notes"` works correctly
- [x] `pnpm build && pnpm check` pass clean

## Human Verification (required)

- Verified scenarios: reproduced the broken example, confirmed fix works
- Edge cases checked: no other occurrences of `memory search --query` in docs or tests
- What you did **not** verify: full E2E memory search flow

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: revert the one-line change in `src/cli/memory-cli.ts`

## Risks and Mitigations

None — single-line help text change with no behavioral impact.

---
🤖 AI-assisted via Claude Code (claude-sonnet-4-6). Fix identified by reproducing the error from the help text example. One-line change, fully verified.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed help text example for `openclaw memory search` to use the correct positional argument syntax instead of the non-existent `--query` flag. The command implementation (line 688) confirms it takes `<query>` as a positional argument, so the help example now correctly shows `openclaw memory search "deployment notes"` instead of `openclaw memory search --query "deployment notes"`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line help text correction with zero behavioral changes. The fix aligns the help example with the actual command signature (positional argument on line 688), and verification shows no other instances of the incorrect syntax exist in the codebase.
- No files require special attention

<sub>Last reviewed commit: 9842ec5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->