### PR TITLE
fix(control-ui): show device pairing approval prompt when a new device requests access

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1,10 +1,10 @@
 import { html, nothing } from "lit";
+import type { AppViewState } from "./app-view-state.ts";
 import { parseAgentSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers.ts";
-import type { AppViewState } from "./app-view-state.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
 import { loadAgentSkills } from "./controllers/agent-skills.ts";
@@ -60,6 +60,7 @@ import { renderChat } from "./views/chat.ts";
 import { renderConfig } from "./views/config.ts";
 import { renderCron } from "./views/cron.ts";
 import { renderDebug } from "./views/debug.ts";
+import { renderDevicePairPrompt } from "./views/device-pair-prompt.ts";
 import { renderExecApprovalPrompt } from "./views/exec-approval.ts";
 import { renderGatewayUrlConfirmation } from "./views/gateway-url-confirmation.ts";
 import { renderInstances } from "./views/instances.ts";
@@ -947,6 +948,7 @@ export function renderApp(state: AppViewState) {
         }
       </main>
       ${renderExecApprovalPrompt(state)}
+      ${renderDevicePairPrompt(state)}
       ${renderGatewayUrlConfirmation(state)}
     </div>
   `;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -1,6 +1,6 @@
 import type { EventLogEntry } from "./app-events.ts";
 import type { CompactionStatus } from "./app-tool-stream.ts";
-import type { DevicePairingList } from "./controllers/devices.ts";
+import type { DevicePairingList, PendingDevice } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
 import type { SkillMessage } from "./controllers/skills.ts";
@@ -87,6 +87,9 @@ export type AppViewState = {
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalBusy: boolean;
   execApprovalError: string | null;
+  devicePairingQueue: PendingDevice[];
+  devicePairBusy: boolean;
+  devicePairError: string | null;
   pendingGatewayUrl: string | null;
   configLoading: boolean;
   configRaw: string;
@@ -242,6 +245,7 @@ export type AppViewState = {
   handleNostrProfileImport: () => Promise<void>;
   handleNostrProfileToggleAdvanced: () => void;
   handleExecApprovalDecision: (decision: "allow-once" | "allow-always" | "deny") => Promise<void>;
+  handleDevicePairDecision: (decision: "approve" | "reject") => Promise<void>;
   handleGatewayUrlConfirm: () => void;
   handleGatewayUrlCancel: () => void;
   handleConfigLoad: () => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1,5 +1,34 @@
 import { LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import type { EventLogEntry } from "./app-events.ts";
+import type { AppViewState } from "./app-view-state.ts";
+import type { DevicePairingList, PendingDevice } from "./controllers/devices.ts";
+import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
+import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
+import type { SkillMessage } from "./controllers/skills.ts";
+import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
+import type { Tab } from "./navigation.ts";
+import type { ResolvedTheme, ThemeMode } from "./theme.ts";
+import type {
+  AgentsListResult,
+  AgentsFilesListResult,
+  AgentIdentityResult,
+  ConfigSnapshot,
+  ConfigUiHints,
+  CronJob,
+  CronRunLogEntry,
+  CronStatus,
+  HealthSnapshot,
+  LogEntry,
+  LogLevel,
+  PresenceEntry,
+  ChannelsStatusSnapshot,
+  SessionsListResult,
+  SkillStatusReport,
+  StatusSummary,
+  NostrProfile,
+} from "./types.ts";
+import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
 import { i18n, I18nController, isSupportedLocale } from "../i18n/index.ts";
 import {
   handleChannelConfigReload as handleChannelConfigReloadInternal,
@@ -20,7 +49,6 @@ import {
   removeQueuedMessage as removeQueuedMessageInternal,
 } from "./app-chat.ts";
 import { DEFAULT_CRON_FORM, DEFAULT_LOG_LEVEL_FILTERS } from "./app-defaults.ts";
-import type { EventLogEntry } from "./app-events.ts";
 import { connectGateway as connectGatewayInternal } from "./app-gateway.ts";
 import {
   handleConnected,
@@ -49,38 +77,10 @@ import {
   type ToolStreamEntry,
   type CompactionStatus,
 } from "./app-tool-stream.ts";
-import type { AppViewState } from "./app-view-state.ts";
 import { normalizeAssistantIdentity } from "./assistant-identity.ts";
 import { loadAssistantIdentity as loadAssistantIdentityInternal } from "./controllers/assistant-identity.ts";
-import type { DevicePairingList } from "./controllers/devices.ts";
-import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
-import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
-import type { SkillMessage } from "./controllers/skills.ts";
-import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
-import type { Tab } from "./navigation.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
-import type { ResolvedTheme, ThemeMode } from "./theme.ts";
-import type {
-  AgentsListResult,
-  AgentsFilesListResult,
-  AgentIdentityResult,
-  ConfigSnapshot,
-  ConfigUiHints,
-  CronJob,
-  CronRunLogEntry,
-  CronStatus,
-  HealthSnapshot,
-  LogEntry,
-  LogLevel,
-  PresenceEntry,
-  ChannelsStatusSnapshot,
-  SessionsListResult,
-  SkillStatusReport,
-  StatusSummary,
-  NostrProfile,
-} from "./types.ts";
 import { type ChatAttachment, type ChatQueueItem, type CronFormState } from "./ui-types.ts";
-import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
 
 declare global {
   interface Window {
@@ -167,6 +167,9 @@ export class OpenClawApp extends LitElement {
   @state() execApprovalQueue: ExecApprovalRequest[] = [];
   @state() execApprovalBusy = false;
   @state() execApprovalError: string | null = null;
+  @state() devicePairingQueue: PendingDevice[] = [];
+  @state() devicePairBusy = false;
+  @state() devicePairError: string | null = null;
   @state() pendingGatewayUrl: string | null = null;
 
   @state() configLoading = false;
@@ -522,6 +525,29 @@ export class OpenClawApp extends LitElement {
       this.execApprovalError = `Exec approval failed: ${String(err)}`;
     } finally {
       this.execApprovalBusy = false;
+    }
+  }
+
+  async handleDevicePairDecision(decision: "approve" | "reject") {
+    const active = this.devicePairingQueue[0];
+    if (!active || !this.client || this.devicePairBusy) {
+      return;
+    }
+    this.devicePairBusy = true;
+    this.devicePairError = null;
+    try {
+      if (decision === "approve") {
+        await this.client.request("device.pair.approve", { requestId: active.requestId });
+      } else {
+        await this.client.request("device.pair.reject", { requestId: active.requestId });
+      }
+      this.devicePairingQueue = this.devicePairingQueue.filter(
+        (d) => d.requestId !== active.requestId,
+      );
+    } catch (err) {
+      this.devicePairError = `Device pairing failed: ${String(err)}`;
+    } finally {
+      this.devicePairBusy = false;
     }
   }
 

--- a/ui/src/ui/views/device-pair-prompt.ts
+++ b/ui/src/ui/views/device-pair-prompt.ts
@@ -1,0 +1,56 @@
+import { html, nothing } from "lit";
+import type { AppViewState } from "../app-view-state.ts";
+
+export function renderDevicePairPrompt(state: AppViewState) {
+  const active = state.devicePairingQueue[0];
+  if (!active) {
+    return nothing;
+  }
+  const queueCount = state.devicePairingQueue.length;
+  const displayName = active.displayName?.trim() || active.deviceId;
+  const role = active.role || "operator";
+  return html`
+    <div class="exec-approval-overlay" role="dialog" aria-live="polite">
+      <div class="exec-approval-card">
+        <div class="exec-approval-header">
+          <div>
+            <div class="exec-approval-title">Device pairing request</div>
+            <div class="exec-approval-sub">A new device is requesting access</div>
+          </div>
+          ${
+            queueCount > 1
+              ? html`<div class="exec-approval-queue">${queueCount} pending</div>`
+              : nothing
+          }
+        </div>
+        <div class="exec-approval-command mono">${displayName}</div>
+        <div class="exec-approval-meta">
+          <div class="exec-approval-meta-row"><span>Role</span><span>${role}</span></div>
+          ${active.remoteIp ? html`<div class="exec-approval-meta-row"><span>IP</span><span>${active.remoteIp}</span></div>` : nothing}
+          ${active.deviceId !== displayName ? html`<div class="exec-approval-meta-row"><span>Device ID</span><span class="mono">${active.deviceId.slice(0, 16)}…</span></div>` : nothing}
+        </div>
+        ${
+          state.devicePairError
+            ? html`<div class="exec-approval-error">${state.devicePairError}</div>`
+            : nothing
+        }
+        <div class="exec-approval-actions">
+          <button
+            class="btn primary"
+            ?disabled=${state.devicePairBusy}
+            @click=${() => state.handleDevicePairDecision("approve")}
+          >
+            Approve
+          </button>
+          <button
+            class="btn danger"
+            ?disabled=${state.devicePairBusy}
+            @click=${() => state.handleDevicePairDecision("reject")}
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary

Fixes #20447

When a new browser/device requests pairing, the gateway broadcasts `device.pair.requested` to all connected Control UI clients with `operator.pairing` scope. Previously this event only silently refreshed the device list (`loadDevices({ quiet: true })`), giving the already-connected operator UI no visible indication that action was needed.

- **Root cause:** `app-gateway.ts` handled `device.pair.requested` the same way as `device.pair.resolved` — just a quiet background list refresh. No queue, no overlay, no badge.
- **Fix:** Mirror the `exec.approval.requested` pattern: queue incoming requests in `devicePairingQueue` and render them as an overlay prompt that lets the operator approve or reject without navigating away. Queue entry is removed when `device.pair.resolved` is received (regardless of decision) or when the operator acts via the prompt.

### Files changed

| File | Change |
|------|--------|
| `ui/src/ui/views/device-pair-prompt.ts` | New overlay component (reuses `exec-approval-*` CSS classes) |
| `ui/src/ui/app-gateway.ts` | Populates/clears `devicePairingQueue` on events; resets on reconnect |
| `ui/src/ui/app-view-state.ts` | Adds `devicePairingQueue`, `devicePairBusy`, `devicePairError`, `handleDevicePairDecision` to view state type |
| `ui/src/ui/app.ts` | Adds reactive state fields and `handleDevicePairDecision` method |
| `ui/src/ui/app-render.ts` | Renders `renderDevicePairPrompt(state)` alongside the exec approval prompt |

## Test plan

- [ ] Open Control UI in browser A (paired)
- [ ] Open Control UI in browser B (new profile, no keypair)
- [ ] Browser A should show the device pairing overlay immediately — device name, role, IP
- [ ] Click **Approve** → overlay disappears, browser B connects
- [ ] Repeat and click **Reject** → overlay disappears, browser B shows pairing-required error
- [ ] Multiple pending requests queue correctly (counter badge shown)
- [ ] Reconnecting clears the queue (`devicePairingQueue = []` on `connectGateway`)
- [ ] All 896 existing tests pass (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added device pairing approval prompt to Control UI by mirroring the existing exec approval pattern. When `device.pair.requested` events arrive, they're now queued in `devicePairingQueue` and rendered as an overlay that lets operators approve or reject without navigating away. The queue is cleared on reconnect and items are removed when `device.pair.resolved` events arrive or when the operator makes a decision.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly mirrors the existing exec approval pattern with consistent queue management, event handling, and UI rendering. All state is properly initialized and cleared on reconnect. No logical errors or race conditions detected.
- No files require special attention

<sub>Last reviewed commit: ad9af1d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->