### PR TITLE
feat: per-model thinkingDefault config and /think default directive

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -132,6 +132,21 @@ export async function handleDirectiveOnly(
   const resolvedProvider = modelSelection?.provider ?? provider;
   const resolvedModel = modelSelection?.model ?? model;
 
+  if (
+    directives.hasThinkDirective &&
+    !directives.thinkLevel &&
+    directives.rawThinkLevel?.toLowerCase() === "default"
+  ) {
+    delete sessionEntry.thinkingLevel;
+    sessionEntry.updatedAt = Date.now();
+    sessionStore[sessionKey] = sessionEntry;
+    if (storePath) {
+      await updateSessionStore(storePath, (store) => {
+        store[sessionKey] = sessionEntry;
+      });
+    }
+    return { text: "Thinking level reset to default." };
+  }
   if (directives.hasThinkDirective && !directives.thinkLevel) {
     // If no argument was provided, show the current level
     if (!directives.rawThinkLevel) {

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -1,7 +1,9 @@
+import { loadModelCatalog } from "../../agents/model-catalog.js";
+import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { MsgContext } from "../templating.js";
-import type { ElevatedLevel } from "../thinking.js";
+import type { ElevatedLevel, ThinkLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import { buildStatusReply } from "./commands.js";
 import {
@@ -17,6 +19,30 @@ import type { createModelSelectionState } from "./model-selection.js";
 import type { TypingController } from "./typing.js";
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
+
+/**
+ * Resolve thinking default for the currently active model (accounting for overrides).
+ * Used by both directive-only and inline-with-content paths.
+ */
+async function resolveThinkingForActiveModel(params: {
+  sessionEntry: SessionEntry;
+  provider: string;
+  model: string;
+  cfg: OpenClawConfig;
+}): Promise<ThinkLevel> {
+  const activeProvider = params.sessionEntry.providerOverride ?? params.provider;
+  const activeModel = params.sessionEntry.modelOverride ?? params.model;
+  const catalog = await loadModelCatalog({ config: params.cfg });
+  return (
+    (params.sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
+    resolveThinkingDefault({
+      cfg: params.cfg,
+      provider: activeProvider,
+      model: activeModel,
+      catalog,
+    })
+  );
+}
 
 export type ApplyDirectiveResult =
   | { kind: "reply"; reply: ReplyPayload | ReplyPayload[] | undefined }
@@ -148,7 +174,7 @@ export async function applyInlineDirectiveOverrides(params: {
       typing.cleanup();
       return { kind: "reply", reply: undefined };
     }
-    const {
+    let {
       currentThinkLevel: resolvedDefaultThinkLevel,
       currentVerboseLevel,
       currentReasoningLevel,
@@ -167,6 +193,13 @@ export async function applyInlineDirectiveOverrides(params: {
       currentElevatedLevel,
       surface: ctx.Surface,
     });
+    resolvedDefaultThinkLevel = await resolveThinkingForActiveModel({
+      sessionEntry,
+      provider,
+      model,
+      cfg,
+    });
+
     let statusReply: ReplyPayload | undefined;
     if (directives.hasStatusDirective && allowTextCommands && command.isAuthorizedSender) {
       statusReply = await buildStatusReply({
@@ -235,7 +268,8 @@ export async function applyInlineDirectiveOverrides(params: {
       formatModelSwitchEvent,
       agentCfg,
       modelState: {
-        resolveDefaultThinkingLevel: modelState.resolveDefaultThinkingLevel,
+        resolveDefaultThinkingLevel: () =>
+          resolveThinkingForActiveModel({ sessionEntry, provider, model, cfg }),
         ...directiveModelState,
       },
     });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -14,6 +14,8 @@ export type AgentModelEntryConfig = {
   params?: Record<string, unknown>;
   /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
   streaming?: boolean;
+  /** Per-model default thinking level (overrides global thinkingDefault). */
+  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 };
 
 export type AgentModelListConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -27,6 +27,17 @@ export const AgentDefaultsSchema = z
             params: z.record(z.string(), z.unknown()).optional(),
             /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
             streaming: z.boolean().optional(),
+            /** Per-model default thinking level (overrides global thinkingDefault). */
+            thinkingDefault: z
+              .union([
+                z.literal("off"),
+                z.literal("minimal"),
+                z.literal("low"),
+                z.literal("medium"),
+                z.literal("high"),
+                z.literal("xhigh"),
+              ])
+              .optional(),
           })
           .strict(),
       )


### PR DESCRIPTION
## Summary

Add per-model thinkingDefault to resolve thinking level based on which
model is active, so users running different models (e.g. gemini-3-pro
for chat, gemini-3-flash for heartbeats) get appropriate thinking levels
automatically without manually toggling /think per session.

Resolution priority: per-model → global → catalog auto-detect (existing
fallback behavior unchanged). Config keys are normalized via parseModelRef
so aliases like "anthropic/opus-4.6" resolve correctly.

Also adds:
- /think default directive to undo a session-level thinking override and
  cascade back to the per-model default
- Re-resolve thinking default after inline /model switch for both
  directive-only and inline-with-content paths
- Memory flush passes provider/model through for correct resolution

Discussion: #20612
Related: #18152 (built independently, shares the per-model config concept
but adds /think default and model-switch re-resolution)

### Config example

```json
{
  "agents": {
    "defaults": {
      "thinkingDefault": "low",
      "models": {
        "google/gemini-2.5-pro":              {},
        "google/gemini-3-flash":              { "thinkingDefault": "high" },
        "google/gemini-flash-lite-latest":    { "thinkingDefault": "off" }
      }
    }
  }
}
```

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (clean on changed files)
- [x] `pnpm test` passes (456 tests, 47 files)
- [x] Manually verified `/think default` resets level and per-model config resolves correctly via `openclaw doctor`
- [x] E2E tested with live gateway

AI-assisted (Claude Code), fully tested.