### PR TITLE
Fix cron announce fallback to stay on main session when delivery target is unpinned

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -128,4 +128,31 @@ describe("resolveDeliveryTarget", () => {
 
     expect(result.accountId).toBeUndefined();
   });
+
+  it("prefers origin session context for implicit last-target resolution", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:test:main": {
+        sessionId: "main-session",
+        updatedAt: 1000,
+        lastChannel: "telegram",
+        lastTo: "main-target",
+        lastAccountId: "main-account",
+      },
+      "agent:test:bluebubbles:direct:+19257864429": {
+        sessionId: "origin-session",
+        updatedAt: 1001,
+        lastChannel: "telegram",
+        lastTo: "origin-target",
+        lastAccountId: "origin-account",
+      },
+    });
+
+    const result = await resolveDeliveryTarget(makeCfg(), "agent-b", {
+      channel: "last",
+      sessionKey: "agent:test:bluebubbles:direct:+19257864429",
+    });
+
+    expect(result.channel).toBe("telegram");
+    expect(result.accountId).toBe("origin-account");
+  });
 });

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -21,6 +21,7 @@ export async function resolveDeliveryTarget(
   jobPayload: {
     channel?: "last" | ChannelId;
     to?: string;
+    sessionKey?: string;
   },
 ): Promise<{
   channel: Exclude<OutboundChannel, "none">;
@@ -32,6 +33,8 @@ export async function resolveDeliveryTarget(
 }> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";
   const explicitTo = typeof jobPayload.to === "string" ? jobPayload.to : undefined;
+  const originSessionKey =
+    typeof jobPayload.sessionKey === "string" ? jobPayload.sessionKey.trim() : "";
   const allowMismatchedLastTo = requestedChannel === "last";
 
   const sessionCfg = cfg.session;
@@ -39,13 +42,31 @@ export async function resolveDeliveryTarget(
   const storePath = resolveStorePath(sessionCfg?.store, { agentId });
   const store = loadSessionStore(storePath);
   const main = store[mainSessionKey];
+  const origin = originSessionKey ? store[originSessionKey] : undefined;
 
-  const preliminary = resolveSessionDeliveryTarget({
+  const preliminaryFromOrigin = origin
+    ? resolveSessionDeliveryTarget({
+        entry: origin,
+        requestedChannel,
+        explicitTo,
+        allowMismatchedLastTo,
+      })
+    : undefined;
+  const preliminaryFromMain = resolveSessionDeliveryTarget({
     entry: main,
     requestedChannel,
     explicitTo,
     allowMismatchedLastTo,
   });
+
+  const hasResolvedTarget = (value?: { channel?: string; to?: string }) =>
+    Boolean(value?.channel && value?.to);
+  const useMainContext =
+    hasResolvedTarget(preliminaryFromMain) && !hasResolvedTarget(preliminaryFromOrigin);
+  const contextEntry = useMainContext ? main : (origin ?? main);
+  const preliminary = useMainContext
+    ? preliminaryFromMain
+    : (preliminaryFromOrigin ?? preliminaryFromMain);
 
   let fallbackChannel: Exclude<OutboundChannel, "none"> | undefined;
   if (!preliminary.channel) {
@@ -59,7 +80,7 @@ export async function resolveDeliveryTarget(
 
   const resolved = fallbackChannel
     ? resolveSessionDeliveryTarget({
-        entry: main,
+        entry: contextEntry,
         requestedChannel,
         explicitTo,
         fallbackChannel,


### PR DESCRIPTION
## Summary
- fix isolated cron announce routing to keep announcements on the agent main session when delivery does not pin a target (`to` / non-`last` channel)
- preserve existing behavior for pinned targets by still resolving the peer-specific session key when a delivery target is explicitly pinned
- add regression coverage proving unpinned announce delivery now uses `agent:<id>:main` while still carrying resolved channel/to context

## Why
When a cron job used `delivery: { mode: "announce" }` with no pinned `to`/`channel`, the resolved recipient could still cause announce routing to switch into a peer-specific session key. That bypassed the main agent session context and could surface as direct iMessage-style delivery instead of a main-session announce.

## Testing
- `/Users/tyleryust/Development/openclaw/node_modules/.bin/vitest run --config vitest.e2e.config.ts src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.e2e.test.ts`
- `/Users/tyleryust/Development/openclaw/node_modules/.bin/vitest run --config vitest.unit.config.ts src/cron/delivery.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed isolated cron announce routing to use the agent's main session key when delivery targets are unpinned (no explicit `to` or non-`last` channel), preventing unintended peer-specific session routing.

**Key changes:**
- Added `hasPinnedCronAnnounceTarget` helper to check if delivery plan explicitly pins a target via `to` or specific `channel` (excluding "last")
- Modified announce session key resolution to conditionally call `resolveCronAnnounceSessionKey` only when target is pinned, otherwise defaulting to main session key
- Added regression test verifying unpinned announce delivery uses `agent:main:main` while preserving resolved channel/to context in `requesterOrigin`

**Impact:**
- Unpinned cron announces now correctly stay on the main agent session context instead of inadvertently switching to peer-specific session keys based on resolved delivery targets from session store

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a specific routing issue with a clear, targeted solution. The new helper function `hasPinnedCronAnnounceTarget` has straightforward logic that correctly distinguishes pinned vs unpinned targets. The regression test provides strong coverage of the fixed behavior, and the change preserves existing behavior for pinned targets by conditionally calling the original resolution logic.
- No files require special attention

<sub>Last reviewed commit: da44000</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->