### PR TITLE
fix: skip heartbeat when HEARTBEAT.md does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/Hooks: run BOOT.md startup checks per configured agent scope, including per-agent session-key resolution, startup-hook regression coverage, and non-success boot outcome logging for diagnosability. (#20569) thanks @mcaxtr.
 - Telegram: unify message-like inbound handling so `message` and `channel_post` share the same dedupe/access/media pipeline and remain behaviorally consistent. (#20591) Thanks @obviyus.
+- Heartbeat/Cron: skip interval heartbeats when `HEARTBEAT.md` is missing and no tagged cron events are queued, while preserving cron-event fallback for queued tagged reminders. (#20461) thanks @vikpos.
 - Telegram/Agents: gate exec/bash tool-failure warnings behind verbose mode so default Telegram replies stay clean while verbose sessions still surface diagnostics. (#20560) Thanks @obviyus.
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
 - Agents/Billing: include the active model that produced a billing error in user-facing billing messages (for example, `OpenAI (gpt-5.3)`) across payload, failover, and lifecycle error paths, so users can identify exactly which key needs credits. (#20510) Thanks @echoVic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/Hooks: run BOOT.md startup checks per configured agent scope, including per-agent session-key resolution, startup-hook regression coverage, and non-success boot outcome logging for diagnosability. (#20569) thanks @mcaxtr.
 - Telegram: unify message-like inbound handling so `message` and `channel_post` share the same dedupe/access/media pipeline and remain behaviorally consistent. (#20591) Thanks @obviyus.
-- Heartbeat/Cron: skip interval heartbeats when `HEARTBEAT.md` is missing and no tagged cron events are queued, while preserving cron-event fallback for queued tagged reminders. (#20461) thanks @vikpos.
+- Heartbeat/Cron: skip interval heartbeats when `HEARTBEAT.md` is missing or empty and no tagged cron events are queued, while preserving cron-event fallback for queued tagged reminders. (#20461) thanks @vikpos.
 - Telegram/Agents: gate exec/bash tool-failure warnings behind verbose mode so default Telegram replies stay clean while verbose sessions still surface diagnostics. (#20560) Thanks @obviyus.
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
 - Agents/Billing: include the active model that produced a billing error in user-facing billing messages (for example, `OpenAI (gpt-5.3)`) across payload, failover, and lifecycle error paths, so users can identify exactly which key needs credits. (#20510) Thanks @echoVic.

--- a/docs/automation/troubleshooting.md
+++ b/docs/automation/troubleshooting.md
@@ -90,6 +90,7 @@ Common signatures:
 - `heartbeat skipped` with `reason=quiet-hours` → outside `activeHours`.
 - `requests-in-flight` → main lane busy; heartbeat deferred.
 - `empty-heartbeat-file` → `HEARTBEAT.md` exists but has no actionable content.
+- `no-heartbeat-file` → interval heartbeat skipped because `HEARTBEAT.md` is missing and no tagged cron event is queued.
 - `alerts-disabled` → visibility settings suppress outbound heartbeat messages.
 
 ## Timezone and activeHours gotchas

--- a/docs/automation/troubleshooting.md
+++ b/docs/automation/troubleshooting.md
@@ -89,7 +89,7 @@ Common signatures:
 
 - `heartbeat skipped` with `reason=quiet-hours` → outside `activeHours`.
 - `requests-in-flight` → main lane busy; heartbeat deferred.
-- `empty-heartbeat-file` → `HEARTBEAT.md` exists but has no actionable content.
+- `empty-heartbeat-file` → interval heartbeat skipped because `HEARTBEAT.md` has no actionable content and no tagged cron event is queued.
 - `no-heartbeat-file` → interval heartbeat skipped because `HEARTBEAT.md` is missing and no tagged cron event is queued.
 - `alerts-disabled` → visibility settings suppress outbound heartbeat messages.
 

--- a/src/infra/heartbeat-reason.test.ts
+++ b/src/infra/heartbeat-reason.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  isHeartbeatActionWakeReason,
+  isHeartbeatEventDrivenReason,
+  normalizeHeartbeatWakeReason,
+  resolveHeartbeatReasonKind,
+} from "./heartbeat-reason.js";
+
+describe("heartbeat-reason", () => {
+  it("normalizes wake reasons with trim + requested fallback", () => {
+    expect(normalizeHeartbeatWakeReason("  cron:job-1  ")).toBe("cron:job-1");
+    expect(normalizeHeartbeatWakeReason("  ")).toBe("requested");
+    expect(normalizeHeartbeatWakeReason(undefined)).toBe("requested");
+  });
+
+  it("classifies known reason kinds", () => {
+    expect(resolveHeartbeatReasonKind("retry")).toBe("retry");
+    expect(resolveHeartbeatReasonKind("interval")).toBe("interval");
+    expect(resolveHeartbeatReasonKind("manual")).toBe("manual");
+    expect(resolveHeartbeatReasonKind("exec-event")).toBe("exec-event");
+    expect(resolveHeartbeatReasonKind("wake")).toBe("wake");
+    expect(resolveHeartbeatReasonKind("cron:job-1")).toBe("cron");
+    expect(resolveHeartbeatReasonKind("hook:wake")).toBe("hook");
+    expect(resolveHeartbeatReasonKind("  hook:wake  ")).toBe("hook");
+  });
+
+  it("classifies unknown reasons as other", () => {
+    expect(resolveHeartbeatReasonKind("requested")).toBe("other");
+    expect(resolveHeartbeatReasonKind("slow")).toBe("other");
+    expect(resolveHeartbeatReasonKind("")).toBe("other");
+    expect(resolveHeartbeatReasonKind(undefined)).toBe("other");
+  });
+
+  it("matches event-driven behavior used by heartbeat preflight", () => {
+    expect(isHeartbeatEventDrivenReason("exec-event")).toBe(true);
+    expect(isHeartbeatEventDrivenReason("cron:job-1")).toBe(true);
+    expect(isHeartbeatEventDrivenReason("wake")).toBe(true);
+    expect(isHeartbeatEventDrivenReason("hook:gmail:sync")).toBe(true);
+    expect(isHeartbeatEventDrivenReason("interval")).toBe(false);
+    expect(isHeartbeatEventDrivenReason("manual")).toBe(false);
+    expect(isHeartbeatEventDrivenReason("other")).toBe(false);
+  });
+
+  it("matches action-priority wake behavior", () => {
+    expect(isHeartbeatActionWakeReason("manual")).toBe(true);
+    expect(isHeartbeatActionWakeReason("exec-event")).toBe(true);
+    expect(isHeartbeatActionWakeReason("hook:wake")).toBe(true);
+    expect(isHeartbeatActionWakeReason("interval")).toBe(false);
+    expect(isHeartbeatActionWakeReason("cron:job-1")).toBe(false);
+    expect(isHeartbeatActionWakeReason("retry")).toBe(false);
+  });
+});

--- a/src/infra/heartbeat-reason.ts
+++ b/src/infra/heartbeat-reason.ts
@@ -1,0 +1,54 @@
+export type HeartbeatReasonKind =
+  | "retry"
+  | "interval"
+  | "manual"
+  | "exec-event"
+  | "wake"
+  | "cron"
+  | "hook"
+  | "other";
+
+function trimReason(reason?: string): string {
+  return typeof reason === "string" ? reason.trim() : "";
+}
+
+export function normalizeHeartbeatWakeReason(reason?: string): string {
+  const trimmed = trimReason(reason);
+  return trimmed.length > 0 ? trimmed : "requested";
+}
+
+export function resolveHeartbeatReasonKind(reason?: string): HeartbeatReasonKind {
+  const trimmed = trimReason(reason);
+  if (trimmed === "retry") {
+    return "retry";
+  }
+  if (trimmed === "interval") {
+    return "interval";
+  }
+  if (trimmed === "manual") {
+    return "manual";
+  }
+  if (trimmed === "exec-event") {
+    return "exec-event";
+  }
+  if (trimmed === "wake") {
+    return "wake";
+  }
+  if (trimmed.startsWith("cron:")) {
+    return "cron";
+  }
+  if (trimmed.startsWith("hook:")) {
+    return "hook";
+  }
+  return "other";
+}
+
+export function isHeartbeatEventDrivenReason(reason?: string): boolean {
+  const kind = resolveHeartbeatReasonKind(reason);
+  return kind === "exec-event" || kind === "cron" || kind === "wake" || kind === "hook";
+}
+
+export function isHeartbeatActionWakeReason(reason?: string): boolean {
+  const kind = resolveHeartbeatReasonKind(reason);
+  return kind === "manual" || kind === "exec-event" || kind === "hook";
+}

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -182,6 +182,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
 
   it("uses CRON_EVENT_PROMPT for tagged cron events on interval wake", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-interval-"));
+    await fs.writeFile(path.join(tmpDir, "HEARTBEAT.md"), "- Check status\n", "utf-8");
     const sendTelegram = vi.fn().mockResolvedValue({
       messageId: "m1",
       chatId: "155462274",

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -51,6 +51,8 @@ async function withHeartbeatFixture(
     );
   };
 
+  await fs.writeFile(path.join(tmpDir, "HEARTBEAT.md"), "- Check status\n", "utf-8");
+
   try {
     return await run({ tmpDir, storePath, seedSession });
   } finally {
@@ -136,7 +138,7 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
   });
 
   it("passes per-agent heartbeat model override (merged with defaults)", async () => {
-    await withHeartbeatFixture(async ({ storePath, seedSession }) => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, seedSession }) => {
       const cfg: OpenClawConfig = {
         agents: {
           defaults: {
@@ -149,6 +151,7 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
             { id: "main", default: true },
             {
               id: "ops",
+              workspace: tmpDir,
               heartbeat: {
                 every: "5m",
                 target: "whatsapp",

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -35,9 +35,12 @@ let testRegistry: ReturnType<typeof getActivePluginRegistry> | null = null;
 let fixtureRoot = "";
 let fixtureCount = 0;
 
-const createCaseDir = async (prefix: string) => {
+const createCaseDir = async (prefix: string, { skipHeartbeatFile = false } = {}) => {
   const dir = path.join(fixtureRoot, `${prefix}-${fixtureCount++}`);
   await fs.mkdir(dir, { recursive: true });
+  if (!skipHeartbeatFile) {
+    await fs.writeFile(path.join(dir, "HEARTBEAT.md"), "- Check status\n", "utf-8");
+  }
   return dir;
 };
 
@@ -542,6 +545,7 @@ describe("runHeartbeatOnce", () => {
             { id: "main", default: true },
             {
               id: "ops",
+              workspace: tmpDir,
               heartbeat: { every: "5m", target: "whatsapp", prompt: "Ops check" },
             },
           ],
@@ -611,6 +615,7 @@ describe("runHeartbeatOnce", () => {
             { id: "main", default: true },
             {
               id: agentId,
+              workspace: tmpDir,
               heartbeat: { every: "5m", target: "whatsapp", prompt: "Ops check" },
             },
           ],

--- a/src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts
+++ b/src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts
@@ -16,6 +16,7 @@ installHeartbeatRunnerTestRuntime({ includeSlack: true });
 describe("runHeartbeatOnce", () => {
   it("uses the delivery target as sender when lastTo differs", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-"));
+    await fs.writeFile(path.join(tmpDir, "HEARTBEAT.md"), "- Check status\n", "utf-8");
     const storePath = path.join(tmpDir, "sessions.json");
     const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
     try {

--- a/src/infra/heartbeat-runner.test-utils.ts
+++ b/src/infra/heartbeat-runner.test-utils.ts
@@ -45,6 +45,7 @@ export async function withTempHeartbeatSandbox<T>(
   },
 ): Promise<T> {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), options?.prefix ?? "openclaw-hb-"));
+  await fs.writeFile(path.join(tmpDir, "HEARTBEAT.md"), "- Check status\n", "utf-8");
   const storePath = path.join(tmpDir, "sessions.json");
   const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
   const previousEnv = new Map<string, string | undefined>();

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -49,6 +49,7 @@ import {
   isExecCompletionEvent,
 } from "./heartbeat-events-filter.js";
 import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
+import { resolveHeartbeatReasonKind } from "./heartbeat-reason.js";
 import { resolveHeartbeatVisibility } from "./heartbeat-visibility.js";
 import {
   type HeartbeatRunResult,
@@ -491,10 +492,11 @@ type HeartbeatPreflight = HeartbeatReasonFlags & {
 };
 
 function resolveHeartbeatReasonFlags(reason?: string): HeartbeatReasonFlags {
+  const reasonKind = resolveHeartbeatReasonKind(reason);
   return {
-    isExecEventReason: reason === "exec-event",
-    isCronEventReason: Boolean(reason?.startsWith("cron:")),
-    isWakeReason: reason === "wake" || Boolean(reason?.startsWith("hook:")),
+    isExecEventReason: reasonKind === "exec-event",
+    isCronEventReason: reasonKind === "cron",
+    isWakeReason: reasonKind === "wake" || reasonKind === "hook",
   };
 }
 

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -1,3 +1,9 @@
+import {
+  isHeartbeatActionWakeReason,
+  normalizeHeartbeatWakeReason,
+  resolveHeartbeatReasonKind,
+} from "./heartbeat-reason.js";
+
 export type HeartbeatRunResult =
   | { status: "ran"; durationMs: number }
   | { status: "skipped"; reason: string }
@@ -29,7 +35,6 @@ let timerKind: WakeTimerKind | null = null;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
-const HOOK_REASON_PREFIX = "hook:";
 const REASON_PRIORITY = {
   RETRY: 0,
   INTERVAL: 1,
@@ -37,29 +42,22 @@ const REASON_PRIORITY = {
   ACTION: 3,
 } as const;
 
-function isActionWakeReason(reason: string): boolean {
-  return reason === "manual" || reason === "exec-event" || reason.startsWith(HOOK_REASON_PREFIX);
-}
-
 function resolveReasonPriority(reason: string): number {
-  if (reason === "retry") {
+  const kind = resolveHeartbeatReasonKind(reason);
+  if (kind === "retry") {
     return REASON_PRIORITY.RETRY;
   }
-  if (reason === "interval") {
+  if (kind === "interval") {
     return REASON_PRIORITY.INTERVAL;
   }
-  if (isActionWakeReason(reason)) {
+  if (isHeartbeatActionWakeReason(reason)) {
     return REASON_PRIORITY.ACTION;
   }
   return REASON_PRIORITY.DEFAULT;
 }
 
 function normalizeWakeReason(reason?: string): string {
-  if (typeof reason !== "string") {
-    return "requested";
-  }
-  const trimmed = reason.trim();
-  return trimmed.length > 0 ? trimmed : "requested";
+  return normalizeHeartbeatWakeReason(reason);
 }
 
 function normalizeWakeTarget(value?: string): string | undefined {


### PR DESCRIPTION
## Problem

When `HEARTBEAT.md` does not exist, `runHeartbeatOnce()` attempts to read the file, catches the `ENOENT` error with an empty `catch {}` block, and falls through to a full LLM API call. The default prompt says "Read HEARTBEAT.md **if it exists**" — so when it doesn't, the model has nothing actionable to do and always responds `HEARTBEAT_OK`.

This wastes significant API costs. With the default 30-minute heartbeat interval on Claude Opus, users without a `HEARTBEAT.md` burn ~$7-10/day on no-op heartbeat calls.

## Fix

Catch `ENOENT` specifically in the `catch` block and return early with `{ status: "skipped", reason: "no-heartbeat-file" }`, consistent with the existing `empty-heartbeat-file` skip path.

Event-triggered heartbeats (exec, cron, wake) still proceed as before, since they have pending system events to process regardless of `HEARTBEAT.md`.

## Changes

- **`src/infra/heartbeat-runner.ts`** — Replace empty `catch {}` with ENOENT-aware handler that skips when no file exists and no events are pending
- **`src/infra/heartbeat-runner.test-utils.ts`** — Add `HEARTBEAT.md` to shared test sandbox helper so tests that expect heartbeat to run have a file present
- **`src/infra/heartbeat-runner.returns-default-unset.test.ts`** — Update existing test to expect skip when file missing; add new test for wake-triggered heartbeat with missing file; set explicit `workspace` for per-agent tests
- **`src/infra/heartbeat-runner.model-override.test.ts`** — Set explicit `workspace` for per-agent test
- **`src/infra/heartbeat-runner.ghost-reminder.test.ts`** — Add `HEARTBEAT.md` for interval-triggered test
- **`src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts`** — Add `HEARTBEAT.md` to test fixture

## Testing

- All 59 heartbeat tests passing locally (vitest)
- Applied equivalent patch to compiled `dist/` on a live OpenClaw 2026.2.13 instance
- Confirmed heartbeats skip silently when `HEARTBEAT.md` is absent (48h+ observation)
- Confirmed wake/cron/exec-triggered heartbeats still fire correctly
- Format check clean (oxfmt)

## Related Issues

- #14377 (token burn from heartbeats)
- #1949 (heartbeat cost concerns)

---

🤖 AI-assisted (OpenClaw + Claude Opus). Fully tested locally and on a live instance.