### PR TITLE
fix: remove WORKFLOW_AUTO.md from default post-compaction audit reads

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 
-// Default required files — constants, extensible to config later
+// Default required files — constants, extensible to config later.
+// Only include files that are reliably present. WORKFLOW_AUTO.md was removed
+// because it is never auto-generated and caused spurious warnings (#20444).
 const DEFAULT_REQUIRED_READS: Array<string | RegExp> = [
-  "WORKFLOW_AUTO.md",
   /memory\/\d{4}-\d{2}-\d{2}\.md/, // daily memory files
 ];
 


### PR DESCRIPTION
## Summary

Removes `WORKFLOW_AUTO.md` from `DEFAULT_REQUIRED_READS` in the post-compaction audit.

## Problem

`WORKFLOW_AUTO.md` was hardcoded in the default required reads list but is never auto-generated by `openclaw setup`, `openclaw onboard`, or any bootstrap process. It's also undocumented. This caused a spurious warning on every compaction for most users:

> ⚠️ Post-Compaction Audit: The following required startup files were not read after context reset:
> - WORKFLOW_AUTO.md

The agent then either gets a read error or wastes a tool call trying to read a missing file.

## Fix

Remove `WORKFLOW_AUTO.md` from the default list. The `requiredReads` parameter still accepts custom entries, so users who create this file can pass it explicitly.

## Testing

- Updated existing tests to use explicit required reads where `WORKFLOW_AUTO.md` behavior was being tested
- Added new test verifying defaults no longer include `WORKFLOW_AUTO.md`
- All 16 tests pass, plus 10 post-compaction-context tests unaffected

Fixes #20444

[AI-assisted] — lightly tested (unit tests pass, no e2e)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `WORKFLOW_AUTO.md` from the default required reads list in the post-compaction audit to eliminate spurious warnings for users who don't have this file. The file was never auto-generated by setup/onboard commands and is undocumented, causing unnecessary warnings on every compaction. Users who create this file can still pass it explicitly via the `requiredReads` parameter.

- Updated `DEFAULT_REQUIRED_READS` constant to only include the memory file pattern
- Modified all existing tests to use explicit required reads where `WORKFLOW_AUTO.md` behavior was tested
- Added new test case verifying defaults no longer include `WORKFLOW_AUTO.md`
- Added clear comments explaining the rationale (references #20444)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-isolated, thoroughly tested, and solves a real user-facing issue. The removal of `WORKFLOW_AUTO.md` from defaults is the correct fix since the file is never auto-generated. Tests have been properly updated to explicitly pass the file when testing its behavior, and a new test validates the fix. The change is backwards-compatible since users can still pass `WORKFLOW_AUTO.md` via the `requiredReads` parameter.
- No files require special attention

<sub>Last reviewed commit: e44e3ec</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->