### PR TITLE
fix(macos): resolve 120%+ CPU regression and gateway stability

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
@@ -87,11 +87,16 @@ final class NodePairingApprovalPrompter {
         self.reconcileTask = nil
         self.task = Task { [weak self] in
             guard let self else { return }
-            _ = try? await GatewayConnection.shared.refresh()
-            await self.loadPendingRequestsFromGateway()
+            // Subscribe without calling refresh() — piggyback on the connection
+            // already established by ControlChannel to avoid a duplicate WebSocket.
             let stream = await GatewayConnection.shared.subscribe(bufferingNewest: 200)
+            var didInitialLoad = false
             for await push in stream {
                 if Task.isCancelled { return }
+                if !didInitialLoad, case .snapshot = push {
+                    didInitialLoad = true
+                    await self.loadPendingRequestsFromGateway()
+                }
                 await MainActor.run { [weak self] in self?.handle(push: push) }
             }
         }

--- a/apps/macos/Sources/OpenClaw/TalkOverlayView.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlayView.swift
@@ -145,13 +145,14 @@ private struct TalkOrbView: View {
     let isPaused: Bool
 
     var body: some View {
-        if self.isPaused {
+        if self.isPaused || self.phase == .idle {
+            // Static orb — no 60fps TimelineView needed when idle or paused.
             Circle()
                 .fill(self.orbGradient)
-                .overlay(Circle().stroke(Color.white.opacity(0.35), lineWidth: 1))
-                .shadow(color: Color.black.opacity(0.18), radius: 10, x: 0, y: 5)
+                .overlay(Circle().stroke(self.isPaused ? Color.white.opacity(0.35) : Color.white.opacity(0.45), lineWidth: 1))
+                .shadow(color: Color.black.opacity(self.isPaused ? 0.18 : 0.22), radius: 10, x: 0, y: 5)
         } else {
-            TimelineView(.animation) { context in
+            TimelineView(.animation(minimumInterval: 1.0 / 15.0)) { context in
                 let t = context.date.timeIntervalSinceReferenceDate
                 let listenScale = self.phase == .listening ? (1 + CGFloat(self.level) * 0.12) : 1
                 let pulse = self.phase == .speaking ? (1 + 0.06 * sin(t * 6)) : 1

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -39,6 +39,8 @@ const APPROVAL_METHODS = new Set([
   "exec.approval.resolve",
 ]);
 const NODE_ROLE_METHODS = new Set(["node.invoke.result", "node.event", "skills.bins"]);
+// Methods allowed for any authenticated connection regardless of role (keepalive, status).
+const ANY_ROLE_METHODS = new Set(["health"]);
 const PAIRING_METHODS = new Set([
   "node.pair.request",
   "node.pair.list",
@@ -105,6 +107,9 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
   }
   const role = client.connect.role ?? "operator";
   const scopes = client.connect.scopes ?? [];
+  if (ANY_ROLE_METHODS.has(method)) {
+    return null;
+  }
   if (NODE_ROLE_METHODS.has(method)) {
     if (role === "node") {
       return null;

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -54,6 +54,9 @@ function normalizeTalkConfigSection(value: unknown): Record<string, unknown> | u
   if (typeof source.interruptOnSpeech === "boolean") {
     talk.interruptOnSpeech = source.interruptOnSpeech;
   }
+  if (typeof source.systemVoice === "string") {
+    talk.systemVoice = source.systemVoice;
+  }
   return Object.keys(talk).length > 0 ? talk : undefined;
 }
 


### PR DESCRIPTION
## Summary

- **GatewayChannel CPU fix**: Replace `JSONDecoder` + `AnyCodable` decode with native `JSONSerialization`, eliminating the recursive try/catch cascade that was burning 120%+ CPU on every gateway message. Includes `wrapJSONValue()` helper using `CFBooleanGetTypeID()` to preserve JSON bool/int distinction through NSNumber bridging.
- **keepaliveLoop busy-spin fix**: `try? await Task.sleep(...)` silently swallowed `CancellationError`, causing cancelled tasks to spin indefinitely. Now exits cleanly on cancellation.
- **TalkOverlayView performance**: Use static `Circle()` when idle/paused instead of 60fps `TimelineView`; throttle active animation to 15fps.
- **Duplicate WebSocket prevention**: `DevicePairingApprovalPrompter`, `NodePairingApprovalPrompter`, and `VoiceWakeGlobalSettingsSync` now subscribe to the existing gateway connection instead of calling `refresh()` which spawned duplicate WebSocket connections.
- **talk.config systemVoice**: `normalizeTalkConfigSection()` was missing `systemVoice` from its field whitelist, silently dropping it from the response.
- **TalkModeRuntime**: Default to Edge TTS (free, no API key) when no ElevenLabs key is configured; system voice only when explicitly requested. Add error logging to `fetchTalkConfig()` catch block.
- **Gateway auth**: Allow `health` method for any authenticated role.
- **Nextcloud Talk**: Keep channel task alive to prevent framework auto-restart collision.

## Test plan

- [ ] Launch macOS app, verify CPU settles below 10% after startup (was 120%+)
- [ ] Enter talk mode, verify TTS playback works (Edge TTS default or configured voice)
- [ ] Verify gateway WebSocket shows single connection (not duplicates)
- [ ] Verify device/node pairing prompts still appear on `device.pair.requested` events
- [ ] Verify `talk.config` response includes `systemVoice` when set in config

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses a critical 120%+ CPU regression caused by expensive JSON decoding and implements several gateway stability improvements:

- **GatewayChannel CPU fix**: Replaces `JSONDecoder` + `AnyCodable` with native `JSONSerialization` to eliminate recursive try/catch overhead. Includes `wrapJSONValue()` helper using `CFBooleanGetTypeID()` to preserve JSON bool/int distinctions.
- **keepaliveLoop busy-spin fix**: Properly handles `CancellationError` instead of silently swallowing it with `try?`, preventing infinite busy-spinning on cancelled tasks.
- **TalkOverlayView performance**: Uses static `Circle()` when idle/paused instead of 60fps `TimelineView`, and throttles active animation to 15fps.
- **Duplicate WebSocket prevention**: Three components (`DevicePairingApprovalPrompter`, `NodePairingApprovalPrompter`, `VoiceWakeGlobalSettingsSync`) now subscribe to existing gateway connection instead of calling `refresh()`.
- **talk.config systemVoice**: Adds missing `systemVoice` field to `normalizeTalkConfigSection()` whitelist.
- **Gateway auth**: Allows `health` method for any authenticated role.
- **Nextcloud Talk**: Keeps channel task alive to prevent framework auto-restart collision.

**Critical Issue**: The PR introduces references to `TalkGatewayTTSSynthesizer` and `TalkSayCommandSynthesizer` classes that don't exist in the codebase, which will cause compilation failures.

<h3>Confidence Score: 0/5</h3>

- This PR cannot be merged due to missing class definitions that will cause compilation failures
- The PR references `TalkGatewayTTSSynthesizer` and `TalkSayCommandSynthesizer` on lines 672-673 and 734-735 of `TalkModeRuntime.swift`, but these classes are not defined anywhere in the codebase. This will cause Swift compilation to fail. While the other changes (CPU fix, keepalive loop, WebSocket deduplication) appear well-implemented and address important issues, the missing synthesizer implementations are blocking issues that must be resolved before merge.
- apps/macos/Sources/OpenClaw/TalkModeRuntime.swift requires missing synthesizer implementations

<sub>Last reviewed commit: dde0ce5</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->