### PR TITLE
Providers: add DigitalOcean Gradient AI inference endpoint

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1,8 +1,8 @@
-import { type Api, getEnvApiKey, type Model } from "@mariozechner/pi-ai";
 import path from "node:path";
+import { type Api, getEnvApiKey, type Model } from "@mariozechner/pi-ai";
+import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
-import { formatCliCommand } from "../cli/command-format.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import {
   normalizeOptionalSecretInput,

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1,8 +1,8 @@
-import path from "node:path";
 import { type Api, getEnvApiKey, type Model } from "@mariozechner/pi-ai";
-import { formatCliCommand } from "../cli/command-format.js";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
+import { formatCliCommand } from "../cli/command-format.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import {
   normalizeOptionalSecretInput,
@@ -315,6 +315,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     qianfan: "QIANFAN_API_KEY",
     ollama: "OLLAMA_API_KEY",
     vllm: "VLLM_API_KEY",
+    digitalocean: "DIGITALOCEAN_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -1,6 +1,6 @@
 import type { AuthProfileStore } from "../agents/auth-profiles.js";
-import type { AuthChoice, AuthChoiceGroupId } from "./onboard-types.js";
 import { AUTH_CHOICE_LEGACY_ALIASES_FOR_CLI } from "./auth-choice-legacy.js";
+import type { AuthChoice, AuthChoiceGroupId } from "./onboard-types.js";
 
 export type { AuthChoiceGroupId };
 

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -1,6 +1,6 @@
 import type { AuthProfileStore } from "../agents/auth-profiles.js";
-import { AUTH_CHOICE_LEGACY_ALIASES_FOR_CLI } from "./auth-choice-legacy.js";
 import type { AuthChoice, AuthChoiceGroupId } from "./onboard-types.js";
+import { AUTH_CHOICE_LEGACY_ALIASES_FOR_CLI } from "./auth-choice-legacy.js";
 
 export type { AuthChoiceGroupId };
 
@@ -155,6 +155,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     choices: ["cloudflare-ai-gateway-api-key"],
   },
   {
+    value: "digitalocean",
+    label: "DigitalOcean",
+    hint: "Gradient AI API key",
+    choices: ["digitalocean-gradient-api-key"],
+  },
+  {
     value: "custom",
     label: "Custom Provider",
     hint: "Any OpenAI or Anthropic compatible endpoint",
@@ -295,6 +301,11 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     value: "minimax-api-lightning",
     label: "MiniMax M2.5 Lightning",
     hint: "Faster, higher output cost",
+  },
+  {
+    value: "digitalocean-gradient-api-key",
+    label: "DigitalOcean Gradient API key",
+    hint: "Access Llama models via Gradient AI",
   },
   { value: "custom-api-key", label: "Custom Provider" },
 ];

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -1,4 +1,3 @@
-import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../agents/auth-profiles.js";
 import { resolveEnvApiKey } from "../agents/model-auth.js";
 import {
@@ -8,6 +7,7 @@ import {
 } from "./auth-choice.api-key.js";
 import { createAuthChoiceAgentModelNoter } from "./auth-choice.apply-helpers.js";
 import { applyAuthChoiceHuggingface } from "./auth-choice.apply.huggingface.js";
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyAuthChoiceOpenRouter } from "./auth-choice.apply.openrouter.js";
 import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
 import { applyDigitalOceanGradientAuthChoice } from "./digitalocean-gradient-config.js";

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -1,3 +1,4 @@
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../agents/auth-profiles.js";
 import { resolveEnvApiKey } from "../agents/model-auth.js";
 import {
@@ -7,9 +8,9 @@ import {
 } from "./auth-choice.api-key.js";
 import { createAuthChoiceAgentModelNoter } from "./auth-choice.apply-helpers.js";
 import { applyAuthChoiceHuggingface } from "./auth-choice.apply.huggingface.js";
-import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyAuthChoiceOpenRouter } from "./auth-choice.apply.openrouter.js";
 import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
+import { applyDigitalOceanGradientAuthChoice } from "./digitalocean-gradient-config.js";
 import {
   applyGoogleGeminiModelDefault,
   GOOGLE_GEMINI_DEFAULT_MODEL,
@@ -951,6 +952,10 @@ export async function applyAuthChoiceApiProviders(
       agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
     }
     return { config: nextConfig, agentModelOverride };
+  }
+
+  if (authChoice === "digitalocean-gradient-api-key") {
+    return await applyDigitalOceanGradientAuthChoice(params);
   }
 
   return null;

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -43,6 +43,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "qwen-portal": "qwen-portal",
   "minimax-portal": "minimax-portal",
   "qianfan-api-key": "qianfan",
+  "digitalocean-gradient-api-key": "digitalocean",
   "custom-api-key": "custom",
 };
 

--- a/src/commands/digitalocean-gradient-config.ts
+++ b/src/commands/digitalocean-gradient-config.ts
@@ -1,12 +1,12 @@
-import type { ModelApi, OpenClawConfig } from "../config/types.js";
-import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../agents/auth-profiles.js";
 import { resolveEnvApiKey } from "../agents/model-auth.js";
+import type { ModelApi, OpenClawConfig } from "../config/types.js";
 import {
   formatApiKeyPreview,
   normalizeApiKeyInput,
   validateApiKeyInput,
 } from "./auth-choice.api-key.js";
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
 import { applyAuthProfileConfig } from "./onboard-auth.config-core.js";
 import { setDigitalOceanGradientApiKey } from "./onboard-auth.credentials.js";

--- a/src/commands/digitalocean-gradient-config.ts
+++ b/src/commands/digitalocean-gradient-config.ts
@@ -101,9 +101,9 @@ export async function applyDigitalOceanGradientAuthChoice(
   if (!hasCredential) {
     const store = ensureAuthProfileStore();
     const profiles = resolveAuthProfileOrder({
+      cfg: params.config,
       provider: "digitalocean",
       store,
-      preferredProfileId: params.config.agents?.defaults?.authProfile?.profileId,
     });
     if (profiles.length > 0) {
       const profileId = profiles[0];

--- a/src/commands/digitalocean-gradient-config.ts
+++ b/src/commands/digitalocean-gradient-config.ts
@@ -1,0 +1,175 @@
+import type { ModelApi, OpenClawConfig } from "../config/types.js";
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../agents/auth-profiles.js";
+import { resolveEnvApiKey } from "../agents/model-auth.js";
+import {
+  formatApiKeyPreview,
+  normalizeApiKeyInput,
+  validateApiKeyInput,
+} from "./auth-choice.api-key.js";
+import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
+import { applyAuthProfileConfig } from "./onboard-auth.config-core.js";
+import { setDigitalOceanGradientApiKey } from "./onboard-auth.credentials.js";
+import {
+  DIGITALOCEAN_GRADIENT_BASE_URL,
+  DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF,
+  buildDigitalOceanGradientModels,
+} from "./onboard-auth.models.js";
+
+export function applyDigitalOceanGradientProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  const modelRef = DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF;
+  models[modelRef] = {
+    ...models[modelRef],
+    alias: models[modelRef]?.alias ?? "DigitalOcean Gradient",
+  };
+
+  const providers = { ...cfg.models?.providers };
+  const existingProvider = providers.digitalocean;
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
+  const defaultModels = buildDigitalOceanGradientModels();
+
+  // Merge existing models with default models, avoiding duplicates
+  const existingModelIds = new Set(existingModels.map((m) => m.id));
+  const newModels = defaultModels.filter((m) => !existingModelIds.has(m.id));
+  const mergedModels =
+    existingModels.length > 0 ? [...existingModels, ...newModels] : defaultModels;
+
+  const { apiKey: existingApiKey, ...existingProviderRest } = (existingProvider ?? {}) as Record<
+    string,
+    unknown
+  > as { apiKey?: string };
+  const resolvedApiKey = typeof existingApiKey === "string" ? existingApiKey : undefined;
+  const normalizedApiKey = resolvedApiKey?.trim();
+  providers.digitalocean = {
+    ...existingProviderRest,
+    baseUrl: DIGITALOCEAN_GRADIENT_BASE_URL,
+    api: "openai-completions" as ModelApi,
+    ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
+    models: mergedModels,
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+    models: {
+      mode: cfg.models?.mode ?? "merge",
+      providers,
+    },
+  };
+}
+
+export function applyDigitalOceanGradientConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const next = applyDigitalOceanGradientProviderConfig(cfg);
+  const existingModel = next.agents?.defaults?.model;
+  return {
+    ...next,
+    agents: {
+      ...next.agents,
+      defaults: {
+        ...next.agents?.defaults,
+        model: {
+          ...(existingModel && "fallbacks" in (existingModel as Record<string, unknown>)
+            ? {
+                fallbacks: (existingModel as { fallbacks?: string[] }).fallbacks,
+              }
+            : {}),
+          primary: DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF,
+        },
+      },
+    },
+  };
+}
+
+export async function applyDigitalOceanGradientAuthChoice(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult> {
+  let nextConfig = params.config;
+  let hasCredential = false;
+
+  if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "digitalocean") {
+    setDigitalOceanGradientApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+    hasCredential = true;
+  }
+
+  if (!hasCredential) {
+    const store = ensureAuthProfileStore();
+    const profiles = resolveAuthProfileOrder({
+      provider: "digitalocean",
+      store,
+      preferredProfileId: params.config.agents?.defaults?.authProfile?.profileId,
+    });
+    if (profiles.length > 0) {
+      const profileId = profiles[0];
+      nextConfig = applyAuthProfileConfig(nextConfig, {
+        profileId,
+        provider: "digitalocean",
+        mode: "api_key",
+      });
+      hasCredential = true;
+    }
+  }
+
+  if (!hasCredential) {
+    await params.prompter.note(
+      "Get your API key at: https://cloud.digitalocean.com/account/api/tokens",
+      "DigitalOcean Gradient AI",
+    );
+  }
+
+  const envKey = resolveEnvApiKey("digitalocean");
+  if (envKey) {
+    const useExisting = await params.prompter.confirm({
+      message: `Use existing DIGITALOCEAN_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+      initialValue: true,
+    });
+    if (useExisting) {
+      setDigitalOceanGradientApiKey(envKey.apiKey, params.agentDir);
+      hasCredential = true;
+    }
+  }
+
+  if (!hasCredential) {
+    const key = await params.prompter.text({
+      message: "Enter DigitalOcean API key",
+      validate: validateApiKeyInput,
+    });
+    setDigitalOceanGradientApiKey(normalizeApiKeyInput(String(key ?? "")), params.agentDir);
+  }
+
+  nextConfig = applyAuthProfileConfig(nextConfig, {
+    profileId: "digitalocean:default",
+    provider: "digitalocean",
+    mode: "api_key",
+  });
+
+  const applied = await applyDefaultModelChoice({
+    config: nextConfig,
+    setDefaultModel: params.setDefaultModel,
+    defaultModel: DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF,
+    applyDefaultConfig: applyDigitalOceanGradientConfig,
+    applyProviderConfig: applyDigitalOceanGradientProviderConfig,
+    noteDefault: DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF,
+    noteAgentModel: async (model: string) => {
+      if (!params.agentId) {
+        return;
+      }
+      await params.prompter.note(
+        `Default model set to ${model} for agent "${params.agentId}".`,
+        "Model configured",
+      );
+    },
+    prompter: params.prompter,
+  });
+
+  return {
+    config: applied.config,
+    agentModelOverride: applied.agentModelOverride,
+  };
+}

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -263,6 +263,18 @@ export function setQianfanApiKey(key: string, agentDir?: string) {
   });
 }
 
+export function setDigitalOceanGradientApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "digitalocean:default",
+    credential: {
+      type: "api_key",
+      provider: "digitalocean",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
 export function setXaiApiKey(key: string, agentDir?: string) {
   upsertAuthProfile({
     profileId: "xai:default",

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -27,7 +27,7 @@ export const ZAI_GLOBAL_BASE_URL = "https://api.z.ai/api/paas/v4";
 export const ZAI_CN_BASE_URL = "https://open.bigmodel.cn/api/paas/v4";
 export const ZAI_DEFAULT_MODEL_ID = "glm-5";
 
-export const DIGITALOCEAN_GRADIENT_BASE_URL = "https://api.digitalocean.com/v2/ai/v1";
+export const DIGITALOCEAN_GRADIENT_BASE_URL = "https://inference.do-ai.run/v1";
 export const DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_ID = "llama3.3-70b-instruct";
 export const DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF = `digitalocean/${DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_ID}`;
 

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -27,7 +27,7 @@ export const ZAI_GLOBAL_BASE_URL = "https://api.z.ai/api/paas/v4";
 export const ZAI_CN_BASE_URL = "https://open.bigmodel.cn/api/paas/v4";
 export const ZAI_DEFAULT_MODEL_ID = "glm-5";
 
-export const DIGITALOCEAN_GRADIENT_BASE_URL = "https://api.digitalocean.com/v2/ai";
+export const DIGITALOCEAN_GRADIENT_BASE_URL = "https://api.digitalocean.com/v2/ai/v1";
 export const DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_ID = "llama3.3-70b-instruct";
 export const DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF = `digitalocean/${DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_ID}`;
 

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -66,6 +66,13 @@ export function buildDigitalOceanGradientModels(): ModelDefinitionConfig[] {
       maxTokens: 8192,
     }),
     buildDigitalOceanGradientModelDefinition({
+      modelId: "openai-gpt-oss-120b",
+      name: "GPT OSS 120B",
+      reasoning: false,
+      contextWindow: 131072,
+      maxTokens: 8192,
+    }),
+    buildDigitalOceanGradientModelDefinition({
       modelId: "deepseek-r1-distill-llama-70b",
       name: "DeepSeek R1 Distill Llama 70B",
       reasoning: true,

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -31,16 +31,26 @@ export const DIGITALOCEAN_GRADIENT_BASE_URL = "https://api.digitalocean.com/v2/a
 export const DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_ID = "llama3.3-70b-instruct";
 export const DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF = `digitalocean/${DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_ID}`;
 
+const DIGITALOCEAN_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 export function buildDigitalOceanGradientModelDefinition(params: {
   modelId: string;
-  displayName?: string;
+  name?: string;
+  reasoning?: boolean;
   contextWindow?: number;
   maxTokens?: number;
 }): ModelDefinitionConfig {
   return {
     id: params.modelId,
-    reference: `digitalocean/${params.modelId}`,
-    displayName: params.displayName || params.modelId,
+    name: params.name || params.modelId,
+    reasoning: params.reasoning ?? true,
+    input: ["text"],
+    cost: DIGITALOCEAN_DEFAULT_COST,
     contextWindow: params.contextWindow ?? 128000,
     maxTokens: params.maxTokens ?? 8192,
   };
@@ -50,13 +60,15 @@ export function buildDigitalOceanGradientModels(): ModelDefinitionConfig[] {
   return [
     buildDigitalOceanGradientModelDefinition({
       modelId: "llama3.3-70b-instruct",
-      displayName: "Llama 3.3 70B Instruct",
+      name: "Llama 3.3 70B Instruct",
+      reasoning: false,
       contextWindow: 128000,
       maxTokens: 8192,
     }),
     buildDigitalOceanGradientModelDefinition({
       modelId: "deepseek-r1-distill-llama-70b",
-      displayName: "DeepSeek R1 Distill Llama 70B",
+      name: "DeepSeek R1 Distill Llama 70B",
+      reasoning: true,
       contextWindow: 128000,
       maxTokens: 8192,
     }),

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -1,5 +1,5 @@
-import { QIANFAN_BASE_URL, QIANFAN_DEFAULT_MODEL_ID } from "../agents/models-config.providers.js";
 import type { ModelDefinitionConfig } from "../config/types.js";
+import { QIANFAN_BASE_URL, QIANFAN_DEFAULT_MODEL_ID } from "../agents/models-config.providers.js";
 
 export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 export const MINIMAX_API_BASE_URL = "https://api.minimax.io/anthropic";
@@ -26,6 +26,48 @@ export const ZAI_CODING_CN_BASE_URL = "https://open.bigmodel.cn/api/coding/paas/
 export const ZAI_GLOBAL_BASE_URL = "https://api.z.ai/api/paas/v4";
 export const ZAI_CN_BASE_URL = "https://open.bigmodel.cn/api/paas/v4";
 export const ZAI_DEFAULT_MODEL_ID = "glm-5";
+
+export const DIGITALOCEAN_GRADIENT_BASE_URL = "https://api.digitalocean.com/v2/ai";
+export const DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_ID = "llama3.3-70b-instruct";
+export const DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF = `digitalocean/${DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_ID}`;
+
+export function buildDigitalOceanGradientModelDefinition(params: {
+  modelId: string;
+  displayName?: string;
+  contextWindow?: number;
+  maxTokens?: number;
+}): ModelDefinitionConfig {
+  return {
+    id: params.modelId,
+    reference: `digitalocean/${params.modelId}`,
+    displayName: params.displayName || params.modelId,
+    contextWindow: params.contextWindow ?? 128000,
+    maxTokens: params.maxTokens ?? 8192,
+  };
+}
+
+export function buildDigitalOceanGradientModels(): ModelDefinitionConfig[] {
+  return [
+    buildDigitalOceanGradientModelDefinition({
+      modelId: "llama3.3-70b-instruct",
+      displayName: "Llama 3.3 70B Instruct",
+      contextWindow: 128000,
+      maxTokens: 8192,
+    }),
+    buildDigitalOceanGradientModelDefinition({
+      modelId: "llama3.1-70b-instruct",
+      displayName: "Llama 3.1 70B Instruct",
+      contextWindow: 128000,
+      maxTokens: 8192,
+    }),
+    buildDigitalOceanGradientModelDefinition({
+      modelId: "llama3.1-8b-instruct",
+      displayName: "Llama 3.1 8B Instruct",
+      contextWindow: 128000,
+      maxTokens: 8192,
+    }),
+  ];
+}
 
 export function resolveZaiBaseUrl(endpoint?: string): string {
   switch (endpoint) {

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -1,5 +1,5 @@
-import type { ModelDefinitionConfig } from "../config/types.js";
 import { QIANFAN_BASE_URL, QIANFAN_DEFAULT_MODEL_ID } from "../agents/models-config.providers.js";
+import type { ModelDefinitionConfig } from "../config/types.js";
 
 export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 export const MINIMAX_API_BASE_URL = "https://api.minimax.io/anthropic";
@@ -55,14 +55,8 @@ export function buildDigitalOceanGradientModels(): ModelDefinitionConfig[] {
       maxTokens: 8192,
     }),
     buildDigitalOceanGradientModelDefinition({
-      modelId: "llama3.1-70b-instruct",
-      displayName: "Llama 3.1 70B Instruct",
-      contextWindow: 128000,
-      maxTokens: 8192,
-    }),
-    buildDigitalOceanGradientModelDefinition({
-      modelId: "llama3.1-8b-instruct",
-      displayName: "Llama 3.1 8B Instruct",
+      modelId: "deepseek-r1-distill-llama-70b",
+      displayName: "DeepSeek R1 Distill Llama 70B",
       contextWindow: 128000,
       maxTokens: 8192,
     }),

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -4,6 +4,11 @@ export {
 } from "../agents/synthetic-models.js";
 export { VENICE_DEFAULT_MODEL_ID, VENICE_DEFAULT_MODEL_REF } from "../agents/venice-models.js";
 export {
+  applyDigitalOceanGradientAuthChoice,
+  applyDigitalOceanGradientConfig,
+  applyDigitalOceanGradientProviderConfig,
+} from "./digitalocean-gradient-config.js";
+export {
   applyAuthProfileConfig,
   applyCloudflareAiGatewayConfig,
   applyCloudflareAiGatewayProviderConfig,
@@ -58,6 +63,7 @@ export {
   setAnthropicApiKey,
   setCloudflareAiGatewayConfig,
   setQianfanApiKey,
+  setDigitalOceanGradientApiKey,
   setGeminiApiKey,
   setLitellmApiKey,
   setKimiCodingApiKey,
@@ -106,4 +112,9 @@ export {
   ZAI_CODING_GLOBAL_BASE_URL,
   ZAI_CN_BASE_URL,
   ZAI_GLOBAL_BASE_URL,
+  DIGITALOCEAN_GRADIENT_BASE_URL,
+  DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_ID,
+  DIGITALOCEAN_GRADIENT_DEFAULT_MODEL_REF,
+  buildDigitalOceanGradientModelDefinition,
+  buildDigitalOceanGradientModels,
 } from "./onboard-auth.models.js";

--- a/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
@@ -1,5 +1,5 @@
-import type { AuthChoice, OnboardOptions } from "../../onboard-types.js";
 import { ONBOARD_PROVIDER_AUTH_FLAGS } from "../../onboard-provider-auth-flags.js";
+import type { AuthChoice, OnboardOptions } from "../../onboard-types.js";
 
 type AuthChoiceFlag = {
   optionKey: keyof AuthChoiceFlagOptions;

--- a/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
@@ -1,5 +1,5 @@
-import { ONBOARD_PROVIDER_AUTH_FLAGS } from "../../onboard-provider-auth-flags.js";
 import type { AuthChoice, OnboardOptions } from "../../onboard-types.js";
+import { ONBOARD_PROVIDER_AUTH_FLAGS } from "../../onboard-provider-auth-flags.js";
 
 type AuthChoiceFlag = {
   optionKey: keyof AuthChoiceFlagOptions;
@@ -28,6 +28,7 @@ type AuthChoiceFlagOptions = Pick<
   | "xaiApiKey"
   | "litellmApiKey"
   | "qianfanApiKey"
+  | "digitaloceanApiKey"
   | "customBaseUrl"
   | "customModelId"
   | "customApiKey"

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -1,10 +1,9 @@
-import type { OpenClawConfig } from "../../../config/config.js";
-import type { RuntimeEnv } from "../../../runtime.js";
-import type { AuthChoice, OnboardOptions } from "../../onboard-types.js";
 import { upsertAuthProfile } from "../../../agents/auth-profiles.js";
 import { normalizeProviderId } from "../../../agents/model-selection.js";
 import { parseDurationMs } from "../../../cli/parse-duration.js";
+import type { OpenClawConfig } from "../../../config/config.js";
 import { upsertSharedEnvVar } from "../../../infra/env-file.js";
+import type { RuntimeEnv } from "../../../runtime.js";
 import { shortenHomePath } from "../../../utils.js";
 import { normalizeSecretInput } from "../../../utils/normalize-secret-input.js";
 import { buildTokenProfileId, validateAnthropicSetupToken } from "../../auth-token.js";
@@ -57,6 +56,7 @@ import {
   parseNonInteractiveCustomApiFlags,
   resolveCustomProviderId,
 } from "../../onboard-custom.js";
+import type { AuthChoice, OnboardOptions } from "../../onboard-types.js";
 import { applyOpenAIConfig } from "../../openai-model-default.js";
 import { detectZaiEndpoint } from "../../zai-endpoint-detect.js";
 import { resolveNonInteractiveApiKey } from "../api-keys.js";

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -29,7 +29,7 @@ import {
   applyXaiConfig,
   applyXiaomiConfig,
   applyZaiConfig,
-  applyDigitalOceanGradientAuthChoice,
+  applyDigitalOceanGradientConfig,
   setAnthropicApiKey,
   setCloudflareAiGatewayConfig,
   setQianfanApiKey,
@@ -680,10 +680,12 @@ export async function applyNonInteractiveAuthChoice(params: {
     if (resolved.source !== "profile") {
       setDigitalOceanGradientApiKey(resolved.key);
     }
-    return applyDigitalOceanGradientAuthChoice({
-      ...params,
-      nextConfig,
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "digitalocean:default",
+      provider: "digitalocean",
+      mode: "api_key",
     });
+    return applyDigitalOceanGradientConfig(nextConfig);
   }
 
   if (authChoice === "custom-api-key") {

--- a/src/commands/onboard-provider-auth-flags.ts
+++ b/src/commands/onboard-provider-auth-flags.ts
@@ -21,6 +21,7 @@ type OnboardProviderAuthOptionKey = keyof Pick<
   | "xaiApiKey"
   | "litellmApiKey"
   | "qianfanApiKey"
+  | "digitaloceanApiKey"
 >;
 
 export type OnboardProviderAuthFlag = {
@@ -165,5 +166,12 @@ export const ONBOARD_PROVIDER_AUTH_FLAGS: ReadonlyArray<OnboardProviderAuthFlag>
     cliFlag: "--qianfan-api-key",
     cliOption: "--qianfan-api-key <key>",
     description: "QIANFAN API key",
+  },
+  {
+    optionKey: "digitaloceanApiKey",
+    authChoice: "digitalocean-gradient-api-key",
+    cliFlag: "--digitalocean-api-key",
+    cliOption: "--digitalocean-api-key <key>",
+    description: "DigitalOcean Gradient AI API key",
   },
 ];

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -46,6 +46,7 @@ export type AuthChoice =
   | "qwen-portal"
   | "xai-api-key"
   | "qianfan-api-key"
+  | "digitalocean-gradient-api-key"
   | "custom-api-key"
   | "skip";
 export type AuthChoiceGroupId =
@@ -71,6 +72,7 @@ export type AuthChoiceGroupId =
   | "huggingface"
   | "qianfan"
   | "xai"
+  | "digitalocean"
   | "custom";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -122,6 +122,7 @@ export type OnboardOptions = {
   opencodeZenApiKey?: string;
   xaiApiKey?: string;
   qianfanApiKey?: string;
+  digitaloceanApiKey?: string;
   customBaseUrl?: string;
   customApiKey?: string;
   customModelId?: string;


### PR DESCRIPTION
#### Summary

Adds DigitalOcean Gradient AI inference endpoint as a default provider option in the onboarding flow. Users can now select DigitalOcean Gradient when configuring OpenClaw for the first time, with support for multiple models including Llama 3.3 70B Instruct, GPT OSS 120B, and DeepSeek R1 Distill Llama 70B.

lobster-biscuit

#### Behavior Changes

- New provider group "DigitalOcean Gradient" appears in onboarding auth choice prompts
- New `--digitalocean-api-key` flag available for non-interactive onboarding
- `DIGITALOCEAN_API_KEY` environment variable is now recognized
- Default model: `digitalocean/llama3.3-70b-instruct`
- API endpoint: `https://inference.do-ai.run/v1` (OpenAI-compatible)
- Three model options supported:
  - Llama 3.3 70B Instruct (default)
  - GPT OSS 120B
  - DeepSeek R1 Distill Llama 70B (reasoning model)

#### Codebase and GitHub Search

- [x] I searched the codebase for existing functionality.
      Searches performed:
  - Searched for similar provider integration patterns (xAI, Moonshot, Venice, Qwen)
  - Verified no existing DigitalOcean Gradient integration
  - Checked onboarding flow structure and auth choice patterns

#### Tests

- Manual testing performed (see below)
- No new automated tests added (follows existing pattern for provider additions)
- Integration follows established patterns used by other API-key-based providers

#### Manual Testing

### Prerequisites

- DigitalOcean Gradient API key (from DigitalOcean console)
- OpenClaw development environment

### Steps

1. Run `pnpm openclaw onboard` and select "DigitalOcean Gradient" from provider list
2. Enter API key when prompted
3. Verify model configuration in `~/.openclaw/openclaw.json`
4. Test inference with `openclaw chat` or gateway
5. Verify non-interactive onboarding: `pnpm openclaw onboard --digitalocean-api-key=<key>`
6. Test environment variable: `DIGITALOCEAN_API_KEY=<key> pnpm openclaw onboard`

**Sign-Off**

- Models used: Claude Sonnet 4.5 (via GitHub Copilot)
- Submitter effort (self-reported): ~3 hours (research, implementation, testing, refinement)
- Agent notes: Implementation follows established patterns for OpenAI-compatible providers; added comprehensive model catalog with reasoning capability flags; removed anthropic-claude model that was routing incorrectly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds DigitalOcean Gradient AI as a provider option, following established patterns for OpenAI-compatible providers. The implementation includes:
- Three model options (Llama 3.3 70B, GPT OSS 120B, DeepSeek R1 Distill Llama 70B)
- API key authentication via flag, environment variable, or interactive prompt
- Integration with both interactive and non-interactive onboarding flows
- Proper configuration for OpenAI-compatible inference endpoint (`https://inference.do-ai.run/v1`)

The changes are consistent with similar providers (xAI, Venice, Moonshot) and integrate cleanly across all necessary touchpoints: auth choices, credential storage, model definitions, and CLI flags.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - implementation follows established provider patterns with no logical errors
- The implementation closely follows existing patterns for OpenAI-compatible providers (Venice, xAI), includes all necessary integration points (auth options, credentials, models, flags, types), and has been manually tested by the author. The code is well-structured and consistent with the codebase conventions.
- No files require special attention

<sub>Last reviewed commit: cecd27a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->