### PR TITLE
fix(discord): pass mediaLocalRoots to sendMessageDiscord

### DIFF
--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import type { DiscordActionConfig } from "../../config/config.js";
+import type { DiscordActionConfig, OpenClawConfig } from "../../config/config.js";
+import type { DiscordSendComponents, DiscordSendEmbeds } from "../../discord/send.shared.js";
 import { readDiscordComponentSpec } from "../../discord/components.js";
 import {
   createThreadDiscord,
@@ -23,8 +24,8 @@ import {
   sendVoiceMessageDiscord,
   unpinMessageDiscord,
 } from "../../discord/send.js";
-import type { DiscordSendComponents, DiscordSendEmbeds } from "../../discord/send.shared.js";
 import { resolveDiscordChannelId } from "../../discord/targets.js";
+import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { withNormalizedTimestamp } from "../date-time.js";
 import { assertMediaNotDataUrl } from "../sandbox-paths.js";
 import {
@@ -56,6 +57,7 @@ export async function handleDiscordMessagingAction(
   action: string,
   params: Record<string, unknown>,
   isActionEnabled: ActionGate<DiscordActionConfig>,
+  cfg?: OpenClawConfig,
 ): Promise<AgentToolResult<unknown>> {
   const resolveChannelId = () =>
     resolveDiscordChannelId(
@@ -305,9 +307,13 @@ export async function handleDiscordMessagingAction(
         return jsonResult({ ok: true, result, voiceMessage: true });
       }
 
+      const mediaLocalRoots = cfg
+        ? getAgentScopedMediaLocalRoots(cfg, agentId ?? undefined)
+        : undefined;
       const result = await sendMessageDiscord(to, content ?? "", {
         ...(accountId ? { accountId } : {}),
         mediaUrl,
+        mediaLocalRoots,
         replyTo,
         components,
         embeds,

--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -64,7 +64,7 @@ export async function handleDiscordAction(
   const isActionEnabled = createDiscordActionGate({ cfg, accountId });
 
   if (messagingActions.has(action)) {
-    return await handleDiscordMessagingAction(action, params, isActionEnabled);
+    return await handleDiscordMessagingAction(action, params, isActionEnabled, cfg);
   }
   if (guildActions.has(action)) {
     return await handleDiscordGuildAction(action, params, isActionEnabled);


### PR DESCRIPTION
## Summary

- **Problem:** `handleDiscordMessagingAction` never passed `mediaLocalRoots` to `sendMessageDiscord`, so agent-scoped local file paths in media URLs could not be resolved when sending Discord messages with attachments.
- **Why it matters:** Discord messages with local media references silently fail to attach files, while other channels (Slack, WhatsApp) resolve them correctly.
- **What changed:** Thread `OpenClawConfig` into `handleDiscordMessagingAction` and call `getAgentScopedMediaLocalRoots` to resolve local roots, then pass them to `sendMessageDiscord`.
- **What did NOT change:** No changes to media resolution logic itself, no changes to other channels, no config schema changes.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## User-visible / Behavior Changes

Discord messages that reference local media files (e.g. from sandbox workspaces) now correctly resolve and attach files. Previously these silently failed.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Docker gateway)
- Runtime/container: Node 22
- Integration/channel: Discord

### Steps

1. Have an agent generate or reference a local media file
2. Send a Discord message with that media URL
3. Before fix: attachment missing. After fix: attachment resolves correctly.

### Expected

- Media file is attached to the Discord message

### Actual (before fix)

- `mediaLocalRoots` is `undefined`, so local file paths cannot be resolved

## Evidence

- [x] Trace/log snippets — confirmed `mediaLocalRoots` is populated and files resolve after fix

## Human Verification (required)

- Verified scenarios: Discord message with local media file attachment
- Edge cases checked: Messages without media (no-op, `mediaLocalRoots` unused), missing config (graceful `undefined` fallback)
- What I did **not** verify: All media file types

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this commit; media resolution falls back to previous behavior (no local roots)
- Known bad symptoms: unexpected file access errors if `getAgentScopedMediaLocalRoots` returns wrong paths

## Risks and Mitigations

None — this aligns Discord with the same pattern already used by other channels.

🤖 AI-assisted (Claude Opus 4.6). Tested on local instance with Discord media messages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `sendMessageDiscord` to receive `mediaLocalRoots` for resolving agent-scoped local file paths in media URLs. The fix correctly threads `OpenClawConfig` through `handleDiscordAction` → `handleDiscordMessagingAction` and calls `getAgentScopedMediaLocalRoots` to resolve local roots before passing them to `sendMessageDiscord`.

However, the fix is incomplete:
- Component messages with media (line 277) still missing `mediaLocalRoots`
- Voice messages (line 302) don't pass `mediaLocalRoots` and need changes to `VoiceMessageOpts` type and `materializeVoiceMessageInput` function
- Thread replies with media (line 422) still missing `mediaLocalRoots`

All three cases have the same media resolution requirements as regular messages but were not updated.

<h3>Confidence Score: 2/5</h3>

- This PR fixes one of four Discord message paths that need `mediaLocalRoots`, leaving three cases broken
- The implementation is correct for the `sendMessage` action, but three other message-sending code paths (component messages, voice messages, and thread replies) have the exact same issue and were not fixed. These will still fail to resolve local media files.
- src/agents/tools/discord-actions-messaging.ts needs `mediaLocalRoots` added to three more message-sending code paths (component messages line 277, voice messages line 302, thread replies line 422)

<sub>Last reviewed commit: ff3026d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->