### PR TITLE
fix: address EADDRINUSE on Nextcloud Talk webhook restart

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -183,12 +183,14 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
     });
   };
 
-  const stop = () => {
-    server.close();
+  const stop = (): Promise<void> => {
+    return new Promise((resolve) => {
+      server.close(() => resolve());
+    });
   };
 
   if (abortSignal) {
-    abortSignal.addEventListener("abort", stop, { once: true });
+    abortSignal.addEventListener("abort", () => stop(), { once: true });
   }
 
   return { server, start, stop };

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -82,7 +82,7 @@ export function readNextcloudTalkWebhookBody(
 export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServerOptions): {
   server: Server;
   start: () => Promise<void>;
-  stop: () => void;
+  stop: () => Promise<void>;
 } {
   const { port, host, path, secret, onMessage, onError, abortSignal } = opts;
   const maxBodyBytes =
@@ -190,7 +190,13 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
   };
 
   if (abortSignal) {
-    abortSignal.addEventListener("abort", () => stop(), { once: true });
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        stop().catch((err) => onError?.(err instanceof Error ? err : new Error(String(err))));
+      },
+      { once: true },
+    );
   }
 
   return { server, start, stop };
@@ -207,7 +213,7 @@ export type NextcloudTalkMonitorOptions = {
 
 export async function monitorNextcloudTalkProvider(
   opts: NextcloudTalkMonitorOptions,
-): Promise<{ stop: () => void }> {
+): Promise<{ stop: () => Promise<void> }> {
   const core = getNextcloudTalkRuntime();
   const cfg = opts.config ?? (core.config.loadConfig() as CoreConfig);
   const account = resolveNextcloudTalkAccount({


### PR DESCRIPTION
Fixes #20468

## What changed
Modified the `stop` function in `createNextcloudTalkWebhookServer` to return a Promise that properly waits for `server.close()` to complete via callback, instead of calling `server.close()` synchronously without waiting.

## Why this fixes the issue
After upgrading to 2026.2.17, the Nextcloud Talk webhook would crash with "EADDRINUSE: address already in use" because the port wasn't being released before the webhook restarted. The previous synchronous `server.close()` didn't wait for the port to be fully released. By wrapping it in a Promise with a callback, the stop function now properly awaits port release before the webhook attempts to bind again.

## AI-assisted contribution
- This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build && pnpm check && pnpm test
- The fix addresses the root cause by ensuring server.close() completes before the port is reused

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed the `stop` function in `createNextcloudTalkWebhookServer` to return a Promise and properly wait for `server.close()` to complete via callback. This prevents EADDRINUSE errors when restarting the webhook by ensuring the port is fully released before attempting to bind again.

However, the implementation has critical type mismatches:
- The return type signature on line 85 still declares `stop: () => void` but the implementation returns `Promise<void>`
- The `monitorNextcloudTalkProvider` return type on line 210 also needs updating to match
- The abort signal handler on line 193 calls the now-async `stop()` without error handling, which could result in unhandled promise rejections

<h3>Confidence Score: 1/5</h3>

- This PR has critical type errors that will cause TypeScript compilation failures
- The implementation changes are correct in principle (properly awaiting server.close() fixes EADDRINUSE), but the PR introduces type signature mismatches that break the type system. The return type declarations don't match the implementation, which will fail `pnpm build` and `pnpm check`.
- `extensions/nextcloud-talk/src/monitor.ts` requires immediate attention to fix type signatures on lines 85, 193, and 210

<sub>Last reviewed commit: 1602cad</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
