### PR TITLE
feat(cron): gate script evaluated before agent turn

### DIFF
--- a/src/cron/gate.test.ts
+++ b/src/cron/gate.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for cron gate script evaluation.
+ */
+
+import { platform } from "node:os";
+import { describe, expect, it } from "vitest";
+import { runGate } from "./gate.js";
+
+// Minimal no-op logger satisfying the Logger interface
+const log = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+// Portable commands that work on both POSIX and Windows.
+const TRUE_CMD = platform() === "win32" ? "exit 0" : "true";
+const EXIT_1_CMD = platform() === "win32" ? "exit 1" : "exit 1";
+const EXIT_2_CMD = platform() === "win32" ? "exit 2" : "exit 2";
+
+describe("runGate", () => {
+  it("passes when command exits with default trigger code (0)", async () => {
+    const result = await runGate({ command: TRUE_CMD }, log);
+    expect(result.passed).toBe(true);
+  });
+
+  it("does not pass when command exits with non-zero code", async () => {
+    const result = await runGate({ command: EXIT_1_CMD }, log);
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.exitCode).toBe(1);
+      expect(result.timedOut).toBe(false);
+    }
+  });
+
+  it("passes when triggerExitCode matches exit code", async () => {
+    // Treat exit code 1 as the 'condition met' code.
+    const result = await runGate({ command: EXIT_1_CMD, triggerExitCode: 1 }, log);
+    expect(result.passed).toBe(true);
+  });
+
+  it("does not pass when triggerExitCode does not match", async () => {
+    const result = await runGate({ command: EXIT_2_CMD, triggerExitCode: 1 }, log);
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.exitCode).toBe(2);
+    }
+  });
+
+  it("does not pass and sets timedOut when script exceeds timeoutMs", async () => {
+    // Sleep for 10 s but kill after 50 ms.
+    const sleepCmd = platform() === "win32" ? "timeout /t 10" : "sleep 10";
+    const result = await runGate({ command: sleepCmd, timeoutMs: 50 }, log);
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.timedOut).toBe(true);
+    }
+  }, 5_000);
+
+  it("does not pass for empty command and surfaces an error", async () => {
+    const result = await runGate({ command: "   " }, log);
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.timedOut).toBe(false);
+    }
+  });
+
+  it("passes on command with shell features (pipeline)", async () => {
+    if (platform() === "win32") {
+      return;
+    } // skip on Windows
+    // echo pipes to grep — gate passes if the string is found.
+    const result = await runGate({ command: "echo 'hello' | grep -q hello" }, log);
+    expect(result.passed).toBe(true);
+  });
+
+  it("does not pass when pipeline condition is false", async () => {
+    if (platform() === "win32") {
+      return;
+    } // skip on Windows
+    const result = await runGate({ command: "echo 'hello' | grep -q world" }, log);
+    expect(result.passed).toBe(false);
+  });
+});

--- a/src/cron/gate.ts
+++ b/src/cron/gate.ts
@@ -1,0 +1,96 @@
+/**
+ * Gate script evaluation for cron jobs.
+ *
+ * A gate is a short-lived shell command that runs before the agent turn.
+ * The agent fires only when the gate exits with the configured `triggerExitCode`
+ * (default 0). Any other exit code silently skips the job for that tick.
+ *
+ * Design goals:
+ *  - Zero cost when the condition is not met (no LLM call at all).
+ *  - Hard time-bounded: a hung script cannot block the cron lane indefinitely.
+ *  - Portable: uses Node's built-in `child_process.execFile` routed through the
+ *    OS shell (`/bin/sh -c` on POSIX, `cmd /c` on Windows).
+ */
+
+import { execFile } from "node:child_process";
+import { platform } from "node:os";
+import type { Logger } from "./service/state.js";
+import type { CronGate } from "./types.js";
+
+/** Default gate timeout in milliseconds. */
+const DEFAULT_GATE_TIMEOUT_MS = 30_000;
+
+/** Default exit code that allows the agent turn to proceed. */
+const DEFAULT_TRIGGER_EXIT_CODE = 0;
+
+export type GateResult =
+  | { passed: true }
+  | { passed: false; exitCode: number | null; stderr: string; timedOut: boolean };
+
+/**
+ * Run the gate script and return whether the agent turn should proceed.
+ *
+ * - Resolves with `{ passed: true }` when the process exits with `triggerExitCode`.
+ * - Resolves with `{ passed: false, ... }` for any other exit code, timeout, or error.
+ * - Never rejects — all errors are surfaced as `passed: false`.
+ */
+export async function runGate(gate: CronGate, log: Logger): Promise<GateResult> {
+  const triggerExitCode = gate.triggerExitCode ?? DEFAULT_TRIGGER_EXIT_CODE;
+  const timeoutMs = gate.timeoutMs ?? DEFAULT_GATE_TIMEOUT_MS;
+  const command = gate.command.trim();
+
+  if (!command) {
+    log.warn({}, "cron:gate: empty gate command — skipping job");
+    return { passed: false, exitCode: null, stderr: "empty gate command", timedOut: false };
+  }
+
+  // Route through the OS shell so the full shell syntax is available
+  // (pipes, &&, environment variable expansion, etc.).
+  const isWindows = platform() === "win32";
+  const [bin, ...args] = isWindows ? ["cmd", "/c", command] : ["/bin/sh", "-c", command];
+
+  log.debug({ command, timeoutMs, triggerExitCode }, "cron:gate: running gate script");
+
+  return new Promise<GateResult>((resolve) => {
+    let settled = false;
+
+    const settle = (result: GateResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(result);
+    };
+
+    const child = execFile(
+      bin,
+      args,
+      { timeout: 0 /* we handle timeout ourselves */ },
+      (err, _stdout, stderr) => {
+        const exitCode = err && "code" in err ? (err.code as number | null) : 0;
+        const normalizedCode = typeof exitCode === "number" ? exitCode : null;
+        const passed = normalizedCode === triggerExitCode;
+
+        log.debug(
+          { command, exitCode: normalizedCode, triggerExitCode, passed },
+          "cron:gate: gate script completed",
+        );
+
+        settle({ passed, exitCode: normalizedCode, stderr: stderr.trim(), timedOut: false });
+      },
+    );
+
+    const timer = setTimeout(() => {
+      log.warn({ command }, "cron:gate: gate script timed out");
+      settle({ passed: false, exitCode: null, stderr: "", timedOut: true });
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* ignore — process may have already exited */
+      }
+    }, timeoutMs);
+
+    // Clean up the timer once the child exits so it doesn't hold the event loop.
+    child.on("exit", () => clearTimeout(timer));
+  });
+}


### PR DESCRIPTION
## Summary

Adds an optional `gate` field to cron jobs that runs a shell script before the agent turn. The agent fires only when the gate exits with `triggerExitCode` (default 0). Any other exit code or timeout silently skips the job at **zero LLM cost**.

## Motivation

A common pattern in cron-driven agents is "check if there is anything to do, then do it". Today, even when there is nothing to do, the job still spins up an isolated agent session or wakes the heartbeat — burning tokens and time. A gate lets you express the condition in a short shell script and skip the expensive part entirely.

Real-world examples:

```bash
# Only run PR-review agent when open PRs exist
openclaw cron add \
  --name "PR review" \
  --cron "0 */2 * * *" \
  --session isolated \
  --message "Review open PRs and summarise findings." \
  --gate "gh pr list --repo myorg/myrepo --state open --json number --jq 'length > 0'" \
  --announce

# Only alert when disk usage is above 80 %
openclaw cron add \
  --name "Disk alert" \
  --cron "0 * * * *" \
  --session main \
  --system-event "Disk usage is critical — investigate and report." \
  --gate "bash -c '[ \ -ge 80 ]'"

# Custom exit code: trigger only when script finds work (exits 1)
openclaw cron add \
  --name "Queue drain" \
  --cron "*/5 * * * *" \
  --session isolated \
  --message "Process the pending task queue." \
  --gate "~/scripts/has-pending-tasks.sh" \
  --gate-exit-code 1
```

## Schema changes

```ts
// New type
type CronGate = {
  command: string;          // shell command (full shell syntax via /bin/sh -c)
  triggerExitCode?: number; // exit code that allows the agent; defaults to 0
  timeoutMs?: number;       // gate killed after this many ms; defaults to 30 000
};

// New optional field on CronJob
gate?: CronGate;
```

`CronJobPatch.gate` accepts `CronGate | null` — null removes an existing gate.

## New CLI flags

```
cron add / cron edit:
  --gate <cmd>            Shell command to run as the gate
  --gate-exit-code <n>    Exit code that lets the agent proceed (default 0)
  --gate-timeout-ms <n>   Max ms before the gate is killed (default 30000)

cron edit only:
  --clear-gate            Remove the gate from an existing job
```

## Implementation

| File | Change |
|---|---|
| `src/cron/types.ts` | `CronGate` type; `CronJob.gate` field; `CronJobPatch.gate` |
| `src/cron/gate.ts` | New gate runner — `child_process.execFile` via `/bin/sh -c` / `cmd /c`, resolves immediately on timeout (SIGKILL sent async) |
| `src/cron/service/timer.ts` | Gate check at the top of `executeJobCore`, before any agent or heartbeat work |
| `src/cron/service/jobs.ts` | Gate normalisation and validation in `createJob` and `applyJobPatch` |
| `src/cli/cron-cli/register.cron-add.ts` | `--gate`, `--gate-exit-code`, `--gate-timeout-ms` |
| `src/cli/cron-cli/register.cron-edit.ts` | Same flags + `--clear-gate` |

## Tests

- **8 unit tests** in `src/cron/gate.test.ts`: exit code pass/fail, custom `triggerExitCode`, timeout, shell pipeline syntax, empty command
- **7 tests** appended to `src/cron/service.jobs.test.ts`: `applyJobPatch` gate set, replace, null-remove, and validation errors

All 25 new + existing tests pass.

## Backward compatibility

Fully additive — existing jobs without a `gate` field are unaffected. The `gate` field is optional throughout the type hierarchy and stored only when explicitly set.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional `gate` field to cron jobs — a shell script that runs before the agent turn to conditionally skip job execution at zero LLM cost. The gate passes when the script exits with the configured `triggerExitCode` (default 0).

**Changes:**
- Added `CronGate` type with `command`, `triggerExitCode`, and `timeoutMs` fields
- Implemented gate runner in `src/cron/gate.ts` using `execFile` via `/bin/sh -c` (POSIX) or `cmd /c` (Windows)
- Integrated gate check at the top of `executeJobCore` in timer service
- Added CLI flags: `--gate`, `--gate-exit-code`, `--gate-timeout-ms`, `--clear-gate`
- Gate validation and normalization in job creation/patching
- 8 unit tests for gate runner, 7 tests for service integration

**Issues found:**
- Timer cleanup logic in `src/cron/gate.ts:65-94` needs refinement to prevent potential memory leak

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor timer cleanup issue that should be addressed
- The implementation is well-designed with proper validation, error handling, platform compatibility, and comprehensive test coverage. However, there's a timer cleanup issue in the gate runner that could cause a memory leak in edge cases. The feature is additive and backward compatible, with no impact on existing jobs.
- src/cron/gate.ts needs timer cleanup fix in the execFile callback

<sub>Last reviewed commit: aa43b8f</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->