### PR TITLE
feat(agents): add compaction model override for compaction runs

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -753,6 +753,7 @@ Periodic heartbeat runs.
     defaults: {
       compaction: {
         mode: "safeguard", // default | safeguard
+        model: "anthropic/claude-sonnet-4-6",
         reserveTokensFloor: 24000,
         memoryFlush: {
           enabled: true,
@@ -767,6 +768,7 @@ Periodic heartbeat runs.
 ```
 
 - `mode`: `default` or `safeguard` (chunked summarization for long histories). See [Compaction](/concepts/compaction).
+- `model`: optional compaction model override (`provider/model` or a configured alias from `agents.defaults.models`).
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Skipped when workspace is read-only.
 
 ### `agents.defaults.contextPruning`

--- a/src/agents/pi-embedded-runner/compact-model-selection.test.ts
+++ b/src/agents/pi-embedded-runner/compact-model-selection.test.ts
@@ -1,0 +1,441 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { getApiKeyForModel } from "../model-auth.js";
+import {
+  resolveCompactionModelForRun,
+  resolveCompactionOverrideModelRef,
+} from "./compact-model-selection.js";
+import { resolveModel } from "./model.js";
+
+type ResolveModelFn = typeof resolveModel;
+type ResolveModelResult = ReturnType<ResolveModelFn>;
+type RuntimeModel = NonNullable<ResolveModelResult["model"]>;
+
+function makeConfig(rawModels: Record<string, { alias?: string }>): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        models: rawModels,
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function makeConfigWithDefaults(params: {
+  modelPrimary?: string;
+  rawModels: Record<string, { alias?: string }>;
+}): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        ...(params.modelPrimary ? { model: { primary: params.modelPrimary } } : {}),
+        models: params.rawModels,
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function makeRuntimeModel(provider: string, id: string): RuntimeModel {
+  return {
+    id,
+    name: id,
+    provider,
+    api: "messages",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  } as RuntimeModel;
+}
+
+function makeResolveSuccess(provider: string, id: string): ResolveModelResult {
+  return {
+    model: makeRuntimeModel(provider, id),
+    authStorage: {
+      setRuntimeApiKey: vi.fn(),
+    } as unknown as ResolveModelResult["authStorage"],
+    modelRegistry: {} as ResolveModelResult["modelRegistry"],
+  };
+}
+
+describe("resolveCompactionOverrideModelRef", () => {
+  it("resolves configured aliases", () => {
+    const cfg = makeConfig({
+      "anthropic/claude-sonnet-4-6": { alias: "cheap-sonnet" },
+    });
+    const resolved = resolveCompactionOverrideModelRef({
+      raw: "cheap-sonnet",
+      cfg,
+      defaultProvider: "anthropic",
+    });
+    expect("error" in resolved).toBe(false);
+    if ("error" in resolved) {
+      return;
+    }
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.modelId).toBe("claude-sonnet-4-6");
+    expect(resolved.source).toBe("alias");
+  });
+
+  it("resolves explicit provider/model references", () => {
+    const cfg = makeConfig({
+      "openai/gpt-4.1-mini": {},
+    });
+    const resolved = resolveCompactionOverrideModelRef({
+      raw: "openai/gpt-4.1-mini",
+      cfg,
+      defaultProvider: "anthropic",
+    });
+    expect("error" in resolved).toBe(false);
+    if ("error" in resolved) {
+      return;
+    }
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.modelId).toBe("gpt-4.1-mini");
+    expect(resolved.source).toBe("provider/model");
+  });
+
+  it("rejects models missing from agents.defaults.models", () => {
+    const cfg = makeConfig({
+      "anthropic/claude-opus-4-6": {},
+    });
+    const resolved = resolveCompactionOverrideModelRef({
+      raw: "anthropic/claude-sonnet-4-6",
+      cfg,
+      defaultProvider: "anthropic",
+    });
+    expect("error" in resolved).toBe(true);
+    if (!("error" in resolved)) {
+      return;
+    }
+    expect(resolved.error).toContain("model not configured in agents.defaults.models");
+  });
+
+  it("rejects bare non-alias model ids", () => {
+    const cfg = makeConfig({
+      "anthropic/claude-sonnet-4-6": {},
+    });
+    const resolved = resolveCompactionOverrideModelRef({
+      raw: "claude-sonnet-4-6",
+      cfg,
+      defaultProvider: "anthropic",
+    });
+    expect("error" in resolved).toBe(true);
+    if (!("error" in resolved)) {
+      return;
+    }
+    expect(resolved.error).toContain("expected provider/model or configured alias");
+  });
+});
+
+describe("resolveCompactionModelForRun", () => {
+  it("uses the session model when no override is configured", async () => {
+    const resolveModelFn = vi.fn((provider: string, modelId: string) => {
+      expect(provider).toBe("anthropic");
+      expect(modelId).toBe("claude-opus-4-6");
+      return makeResolveSuccess(provider, modelId);
+    });
+    const getApiKeyForModelFn = vi.fn(async () => ({
+      apiKey: "session-key",
+      source: "test",
+      mode: "api-key" as const,
+    }));
+    const resolved = await resolveCompactionModelForRun({
+      sessionProvider: "anthropic",
+      sessionModelId: "claude-opus-4-6",
+      cfg: makeConfig({
+        "anthropic/claude-opus-4-6": {},
+      }),
+      agentDir: "/tmp/agent",
+      authProfileId: "session-profile",
+      resolveModelFn: resolveModelFn as ResolveModelFn,
+      getApiKeyForModelFn: getApiKeyForModelFn as typeof getApiKeyForModel,
+    });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      return;
+    }
+    expect(resolved.value.overrideUsed).toBe(false);
+    expect(resolved.value.provider).toBe("anthropic");
+    expect(resolved.value.modelId).toBe("claude-opus-4-6");
+    expect(resolveModelFn).toHaveBeenCalledTimes(1);
+    expect(getApiKeyForModelFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "session-profile",
+      }),
+    );
+  });
+
+  it("uses a configured alias override and logs the selected model", async () => {
+    const infos: string[] = [];
+    const warns: string[] = [];
+    const resolveModelFn = vi.fn((provider: string, modelId: string) =>
+      makeResolveSuccess(provider, modelId),
+    );
+    const getApiKeyForModelFn = vi.fn(async () => ({
+      apiKey: "override-key",
+      source: "test",
+      mode: "api-key" as const,
+    }));
+    const resolved = await resolveCompactionModelForRun({
+      sessionProvider: "anthropic",
+      sessionModelId: "claude-opus-4-6",
+      overrideRaw: "cheap-sonnet",
+      cfg: makeConfig({
+        "anthropic/claude-opus-4-6": {},
+        "anthropic/claude-sonnet-4-6": { alias: "cheap-sonnet" },
+      }),
+      agentDir: "/tmp/agent",
+      authProfileId: "session-profile",
+      logInfo: (message) => infos.push(message),
+      logWarn: (message) => warns.push(message),
+      resolveModelFn: resolveModelFn as ResolveModelFn,
+      getApiKeyForModelFn: getApiKeyForModelFn as typeof getApiKeyForModel,
+    });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      return;
+    }
+    expect(resolved.value.overrideUsed).toBe(true);
+    expect(resolved.value.provider).toBe("anthropic");
+    expect(resolved.value.modelId).toBe("claude-sonnet-4-6");
+    expect(infos).toContain(
+      "[compaction] using override model anthropic/claude-sonnet-4-6 (session model: anthropic/claude-opus-4-6)",
+    );
+    expect(warns).toEqual([]);
+    expect(getApiKeyForModelFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "session-profile",
+      }),
+    );
+  });
+
+  it("uses explicit provider/model override when configured", async () => {
+    const resolveModelFn = vi.fn((provider: string, modelId: string) =>
+      makeResolveSuccess(provider, modelId),
+    );
+    const getApiKeyForModelFn = vi.fn(async () => ({
+      apiKey: "override-key",
+      source: "test",
+      mode: "api-key" as const,
+    }));
+    const resolved = await resolveCompactionModelForRun({
+      sessionProvider: "anthropic",
+      sessionModelId: "claude-opus-4-6",
+      overrideRaw: "anthropic/claude-sonnet-4-6",
+      cfg: makeConfig({
+        "anthropic/claude-opus-4-6": {},
+        "anthropic/claude-sonnet-4-6": {},
+      }),
+      agentDir: "/tmp/agent",
+      authProfileId: "session-profile",
+      resolveModelFn: resolveModelFn as ResolveModelFn,
+      getApiKeyForModelFn: getApiKeyForModelFn as typeof getApiKeyForModel,
+    });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      return;
+    }
+    expect(resolved.value.overrideUsed).toBe(true);
+    expect(resolved.value.provider).toBe("anthropic");
+    expect(resolved.value.modelId).toBe("claude-sonnet-4-6");
+  });
+
+  it("falls back to the session model when override is not in configured catalog", async () => {
+    const warns: string[] = [];
+    const resolveModelFn = vi.fn((provider: string, modelId: string) =>
+      makeResolveSuccess(provider, modelId),
+    );
+    const getApiKeyForModelFn = vi.fn(async () => ({
+      apiKey: "session-key",
+      source: "test",
+      mode: "api-key" as const,
+    }));
+    const resolved = await resolveCompactionModelForRun({
+      sessionProvider: "anthropic",
+      sessionModelId: "claude-opus-4-6",
+      overrideRaw: "anthropic/claude-sonnet-4-6",
+      cfg: makeConfig({
+        "anthropic/claude-opus-4-6": {},
+      }),
+      agentDir: "/tmp/agent",
+      authProfileId: "session-profile",
+      logWarn: (message) => warns.push(message),
+      resolveModelFn: resolveModelFn as ResolveModelFn,
+      getApiKeyForModelFn: getApiKeyForModelFn as typeof getApiKeyForModel,
+    });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      return;
+    }
+    expect(resolved.value.overrideUsed).toBe(false);
+    expect(resolveModelFn).toHaveBeenCalledTimes(1);
+    expect(warns[0]).toContain("using session model anthropic/claude-opus-4-6");
+  });
+
+  it("falls back when override model resolution fails", async () => {
+    const warns: string[] = [];
+    const resolveModelFn = vi.fn((provider: string, modelId: string) => {
+      if (provider === "anthropic" && modelId === "claude-sonnet-4-6") {
+        return {
+          error: "Unknown model: anthropic/claude-sonnet-4-6",
+          authStorage: {
+            setRuntimeApiKey: vi.fn(),
+          } as unknown as ResolveModelResult["authStorage"],
+          modelRegistry: {} as ResolveModelResult["modelRegistry"],
+        } as ResolveModelResult;
+      }
+      return makeResolveSuccess(provider, modelId);
+    });
+    const getApiKeyForModelFn = vi.fn(async () => ({
+      apiKey: "session-key",
+      source: "test",
+      mode: "api-key" as const,
+    }));
+    const resolved = await resolveCompactionModelForRun({
+      sessionProvider: "anthropic",
+      sessionModelId: "claude-opus-4-6",
+      overrideRaw: "anthropic/claude-sonnet-4-6",
+      cfg: makeConfig({
+        "anthropic/claude-opus-4-6": {},
+        "anthropic/claude-sonnet-4-6": {},
+      }),
+      agentDir: "/tmp/agent",
+      authProfileId: "session-profile",
+      logWarn: (message) => warns.push(message),
+      resolveModelFn: resolveModelFn as ResolveModelFn,
+      getApiKeyForModelFn: getApiKeyForModelFn as typeof getApiKeyForModel,
+    });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      return;
+    }
+    expect(resolved.value.overrideUsed).toBe(false);
+    expect(resolveModelFn).toHaveBeenCalledTimes(2);
+    expect(warns.some((entry) => entry.includes("unavailable"))).toBe(true);
+  });
+
+  it("falls back when override authentication fails", async () => {
+    const warns: string[] = [];
+    const resolveModelFn = vi.fn((provider: string, modelId: string) =>
+      makeResolveSuccess(provider, modelId),
+    );
+    const getApiKeyForModelFn = vi.fn(async (params: { model: { id: string } }) => {
+      if (params.model.id === "claude-sonnet-4-6") {
+        throw new Error("Invalid override API key");
+      }
+      return {
+        apiKey: "session-key",
+        source: "test",
+        mode: "api-key" as const,
+      };
+    });
+    const resolved = await resolveCompactionModelForRun({
+      sessionProvider: "anthropic",
+      sessionModelId: "claude-opus-4-6",
+      overrideRaw: "anthropic/claude-sonnet-4-6",
+      cfg: makeConfig({
+        "anthropic/claude-opus-4-6": {},
+        "anthropic/claude-sonnet-4-6": {},
+      }),
+      agentDir: "/tmp/agent",
+      authProfileId: "session-profile",
+      logWarn: (message) => warns.push(message),
+      resolveModelFn: resolveModelFn as ResolveModelFn,
+      getApiKeyForModelFn: getApiKeyForModelFn as typeof getApiKeyForModel,
+    });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      return;
+    }
+    expect(resolved.value.overrideUsed).toBe(false);
+    expect(warns.some((entry) => entry.includes("Invalid override API key"))).toBe(true);
+  });
+
+  it("does not lock override auth profile when provider differs from the session", async () => {
+    const resolveModelFn = vi.fn((provider: string, modelId: string) =>
+      makeResolveSuccess(provider, modelId),
+    );
+    const getApiKeyForModelFn = vi.fn(async () => ({
+      apiKey: "override-key",
+      source: "test",
+      mode: "api-key" as const,
+    }));
+    const resolved = await resolveCompactionModelForRun({
+      sessionProvider: "anthropic",
+      sessionModelId: "claude-opus-4-6",
+      overrideRaw: "openai/gpt-4.1-mini",
+      cfg: makeConfig({
+        "anthropic/claude-opus-4-6": {},
+        "openai/gpt-4.1-mini": {},
+      }),
+      agentDir: "/tmp/agent",
+      authProfileId: "anthropic-profile",
+      resolveModelFn: resolveModelFn as ResolveModelFn,
+      getApiKeyForModelFn: getApiKeyForModelFn as typeof getApiKeyForModel,
+    });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      return;
+    }
+    expect(resolved.value.overrideUsed).toBe(true);
+    expect(resolved.value.provider).toBe("openai");
+    expect(getApiKeyForModelFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: undefined,
+      }),
+    );
+  });
+
+  it("resolves providerless aliases with config default provider (not session provider)", async () => {
+    const infos: string[] = [];
+    const resolveModelFn = vi.fn((provider: string, modelId: string) => {
+      if (provider === "openai" && modelId === "claude-sonnet-4-6") {
+        return {
+          error: "Unknown model: openai/claude-sonnet-4-6",
+          authStorage: {
+            setRuntimeApiKey: vi.fn(),
+          } as unknown as ResolveModelResult["authStorage"],
+          modelRegistry: {} as ResolveModelResult["modelRegistry"],
+        } as ResolveModelResult;
+      }
+      return makeResolveSuccess(provider, modelId);
+    });
+    const getApiKeyForModelFn = vi.fn(async () => ({
+      apiKey: "key",
+      source: "test",
+      mode: "api-key" as const,
+    }));
+
+    const resolved = await resolveCompactionModelForRun({
+      sessionProvider: "openai",
+      sessionModelId: "gpt-4.1-mini",
+      overrideRaw: "cheap-sonnet",
+      cfg: makeConfigWithDefaults({
+        modelPrimary: "anthropic/claude-opus-4-6",
+        rawModels: {
+          "claude-opus-4-6": { alias: "opus" },
+          "claude-sonnet-4-6": { alias: "cheap-sonnet" },
+          "openai/gpt-4.1-mini": {},
+        },
+      }),
+      agentDir: "/tmp/agent",
+      authProfileId: "openai-profile",
+      logInfo: (message) => infos.push(message),
+      resolveModelFn: resolveModelFn as ResolveModelFn,
+      getApiKeyForModelFn: getApiKeyForModelFn as typeof getApiKeyForModel,
+    });
+
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      return;
+    }
+    expect(resolved.value.overrideUsed).toBe(true);
+    expect(resolved.value.provider).toBe("anthropic");
+    expect(resolved.value.modelId).toBe("claude-sonnet-4-6");
+    expect(infos).toContain(
+      "[compaction] using override model anthropic/claude-sonnet-4-6 (session model: openai/gpt-4.1-mini)",
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/compact-model-selection.ts
+++ b/src/agents/pi-embedded-runner/compact-model-selection.ts
@@ -1,0 +1,233 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
+import { getApiKeyForModel } from "../model-auth.js";
+import {
+  buildConfiguredAllowlistKeys,
+  buildModelAliasIndex,
+  modelKey,
+  normalizeProviderId,
+  resolveConfiguredModelRef,
+  resolveModelRefFromString,
+} from "../model-selection.js";
+import { resolveModel } from "./model.js";
+import { describeUnknownError } from "./utils.js";
+
+type ResolveModelFn = typeof resolveModel;
+type ResolveModelResult = ReturnType<ResolveModelFn>;
+type ResolvedRuntimeModel = NonNullable<ResolveModelResult["model"]>;
+
+export type ResolvedCompactionModel = {
+  provider: string;
+  modelId: string;
+  model: ResolvedRuntimeModel;
+  authStorage: ResolveModelResult["authStorage"];
+  modelRegistry: ResolveModelResult["modelRegistry"];
+  overrideUsed: boolean;
+};
+
+export function resolveCompactionOverrideModelRef(params: {
+  raw: string;
+  cfg?: OpenClawConfig;
+  defaultProvider: string;
+}):
+  | {
+      provider: string;
+      modelId: string;
+      key: string;
+      source: "alias" | "provider/model";
+    }
+  | { error: string } {
+  const raw = params.raw.trim();
+  if (!raw) {
+    return { error: "compaction.model is empty" };
+  }
+  const cfg = params.cfg;
+  if (!cfg) {
+    return { error: "config unavailable" };
+  }
+  const aliasIndex = buildModelAliasIndex({
+    cfg,
+    defaultProvider: params.defaultProvider,
+  });
+  const resolved = resolveModelRefFromString({
+    raw,
+    defaultProvider: params.defaultProvider,
+    aliasIndex,
+  });
+  if (!resolved) {
+    return { error: `invalid model reference: ${raw}` };
+  }
+  if (!raw.includes("/") && !resolved.alias) {
+    return {
+      error: `invalid model reference: ${raw} (expected provider/model or configured alias)`,
+    };
+  }
+
+  const configuredKeys = buildConfiguredAllowlistKeys({
+    cfg,
+    defaultProvider: params.defaultProvider,
+  });
+  if (!configuredKeys || configuredKeys.size === 0) {
+    return {
+      error: "agents.defaults.models is empty; compaction.model requires a configured model",
+    };
+  }
+
+  const key = modelKey(resolved.ref.provider, resolved.ref.model);
+  if (!configuredKeys.has(key)) {
+    return { error: `model not configured in agents.defaults.models: ${key}` };
+  }
+  return {
+    provider: resolved.ref.provider,
+    modelId: resolved.ref.model,
+    key,
+    source: resolved.alias ? "alias" : "provider/model",
+  };
+}
+
+async function resolveAndAuthenticateCompactionModel(params: {
+  provider: string;
+  modelId: string;
+  cfg?: OpenClawConfig;
+  agentDir: string;
+  authProfileId?: string;
+  resolveModelFn: ResolveModelFn;
+  getApiKeyForModelFn: typeof getApiKeyForModel;
+}): Promise<
+  { ok: true; value: Omit<ResolvedCompactionModel, "overrideUsed"> } | { ok: false; reason: string }
+> {
+  const { model, error, authStorage, modelRegistry } = params.resolveModelFn(
+    params.provider,
+    params.modelId,
+    params.agentDir,
+    params.cfg,
+  );
+  if (!model) {
+    return {
+      ok: false,
+      reason: error ?? `Unknown model: ${params.provider}/${params.modelId}`,
+    };
+  }
+  try {
+    const apiKeyInfo = await params.getApiKeyForModelFn({
+      model,
+      cfg: params.cfg,
+      profileId: params.authProfileId,
+      agentDir: params.agentDir,
+    });
+    if (!apiKeyInfo.apiKey) {
+      if (apiKeyInfo.mode !== "aws-sdk") {
+        throw new Error(
+          `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
+        );
+      }
+    } else if (model.provider === "github-copilot") {
+      const { resolveCopilotApiToken } = await import("../../providers/github-copilot-token.js");
+      const copilotToken = await resolveCopilotApiToken({
+        githubToken: apiKeyInfo.apiKey,
+      });
+      authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+    } else {
+      authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
+    }
+  } catch (err) {
+    return { ok: false, reason: describeUnknownError(err) };
+  }
+  return {
+    ok: true,
+    value: {
+      provider: params.provider,
+      modelId: params.modelId,
+      model,
+      authStorage,
+      modelRegistry,
+    },
+  };
+}
+
+export async function resolveCompactionModelForRun(params: {
+  sessionProvider: string;
+  sessionModelId: string;
+  overrideRaw?: string;
+  cfg?: OpenClawConfig;
+  agentDir: string;
+  authProfileId?: string;
+  logInfo?: (message: string) => void;
+  logWarn?: (message: string) => void;
+  resolveModelFn?: ResolveModelFn;
+  getApiKeyForModelFn?: typeof getApiKeyForModel;
+}): Promise<{ ok: true; value: ResolvedCompactionModel } | { ok: false; reason: string }> {
+  const resolveModelFn = params.resolveModelFn ?? resolveModel;
+  const getApiKeyForModelFn = params.getApiKeyForModelFn ?? getApiKeyForModel;
+  const sessionRef = `${params.sessionProvider}/${params.sessionModelId}`;
+  const rawOverride = params.overrideRaw?.trim() ?? "";
+  const selectionDefaultProvider = params.cfg
+    ? resolveConfiguredModelRef({
+        cfg: params.cfg,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      }).provider
+    : params.sessionProvider;
+
+  if (rawOverride) {
+    const overrideRef = resolveCompactionOverrideModelRef({
+      raw: rawOverride,
+      cfg: params.cfg,
+      defaultProvider: selectionDefaultProvider,
+    });
+    if ("error" in overrideRef) {
+      params.logWarn?.(
+        `[compaction] override model "${rawOverride}" ignored (${overrideRef.error}); using session model ${sessionRef}`,
+      );
+    } else {
+      const sameProvider =
+        normalizeProviderId(overrideRef.provider) === normalizeProviderId(params.sessionProvider);
+      const overrideAuthProfileId = sameProvider ? params.authProfileId : undefined;
+      const overrideResolved = await resolveAndAuthenticateCompactionModel({
+        provider: overrideRef.provider,
+        modelId: overrideRef.modelId,
+        cfg: params.cfg,
+        agentDir: params.agentDir,
+        authProfileId: overrideAuthProfileId,
+        resolveModelFn,
+        getApiKeyForModelFn,
+      });
+      if (overrideResolved.ok) {
+        const overrideRefText = `${overrideRef.provider}/${overrideRef.modelId}`;
+        params.logInfo?.(
+          `[compaction] using override model ${overrideRefText} (session model: ${sessionRef})`,
+        );
+        return {
+          ok: true,
+          value: {
+            ...overrideResolved.value,
+            overrideUsed: true,
+          },
+        };
+      }
+      params.logWarn?.(
+        `[compaction] override model ${overrideRef.provider}/${overrideRef.modelId} unavailable (${overrideResolved.reason}); using session model ${sessionRef}`,
+      );
+    }
+  }
+
+  const sessionResolved = await resolveAndAuthenticateCompactionModel({
+    provider: params.sessionProvider,
+    modelId: params.sessionModelId,
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    authProfileId: params.authProfileId,
+    resolveModelFn,
+    getApiKeyForModelFn,
+  });
+  if (!sessionResolved.ok) {
+    return { ok: false, reason: sessionResolved.reason };
+  }
+  return {
+    ok: true,
+    value: {
+      ...sessionResolved.value,
+      overrideUsed: false,
+    },
+  };
+}

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -17,6 +17,7 @@ describe("config compaction settings", () => {
               defaults: {
                 compaction: {
                   mode: "safeguard",
+                  model: "anthropic/claude-sonnet-4-6",
                   reserveTokensFloor: 12_345,
                   memoryFlush: {
                     enabled: false,
@@ -36,6 +37,7 @@ describe("config compaction settings", () => {
 
       const cfg = loadConfig();
 
+      expect(cfg.agents?.defaults?.compaction?.model).toBe("anthropic/claude-sonnet-4-6");
       expect(cfg.agents?.defaults?.compaction?.reserveTokensFloor).toBe(12_345);
       expect(cfg.agents?.defaults?.compaction?.mode).toBe("safeguard");
       expect(cfg.agents?.defaults?.compaction?.memoryFlush?.enabled).toBe(false);

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -289,6 +289,8 @@ export type AgentCompactionMode = "default" | "safeguard";
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
+  /** Compaction model override (provider/model or configured alias). */
+  model?: string;
   /** Minimum reserve tokens enforced for Pi compaction (0 disables the floor). */
   reserveTokensFloor?: number;
   /** Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -91,6 +91,7 @@ export const AgentDefaultsSchema = z
     compaction: z
       .object({
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+        model: z.string().optional(),
         reserveTokensFloor: z.number().int().nonnegative().optional(),
         maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
         memoryFlush: z


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: compaction always used the session model, so users could not route compaction to a cheaper configured model.
- Why it matters: auto/manual compaction can add avoidable cost on premium session models.
- What changed: added `agents.defaults.compaction.model` config + validation, added compaction model selection/auth fallback helper, wired compaction runtime to use selected effective model, and documented the new field.
- What did NOT change (scope boundary): compaction prompt content/flow/threshold logic and the existing hard-fail behavior when the session model itself cannot resolve/authenticate.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes openclaw/openclaw#7926
- Closes openclaw/openclaw#15826
- Closes openclaw/openclaw#17461
- Closes openclaw/openclaw#19501
- Related openclaw/openclaw#15927

## User-visible / Behavior Changes

- New optional config: `agents.defaults.compaction.model`.
- Accepted format: `provider/model` or configured alias from `agents.defaults.models`.
- If override resolves + authenticates, compaction runs on override model and logs:
  - `[compaction] using override model <provider/model> (session model: <provider/model>)`
- If override is invalid/unconfigured/unresolvable/unauthenticated, compaction logs warning and falls back to session model.
- If `compaction.model` is unset, behavior is unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No (reuses existing `getApiKeyForModel()` path)
- New/changed network calls? (`Yes/No`) No new external surfaces; uses existing provider auth/model calls
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3 (Build 25D125)
- Runtime/container: Node v25.6.0, pnpm 10.23.0, Bun 1.3.9
- Model/provider: compaction selection tests cover alias/provider-model/session-provider combinations
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - `agents.defaults.models` includes target model key/alias
  - `agents.defaults.compaction.model` set to alias or `provider/model`

### Steps

1. Configure `agents.defaults.compaction.model` to a configured alias or `provider/model` in `agents.defaults.models`.
2. Trigger compaction path (`/compact` or auto-compaction overflow).
3. Observe compaction model-selection logs and resulting compaction behavior.

### Expected

- Override model used when valid + authenticated.
- Session model fallback when override fails selection/auth.

### Actual

- Matches expected; override and fallback paths verified with focused tests and local checks.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace/log snippet covered by tests:

- `[compaction] using override model anthropic/claude-sonnet-4-6 (session model: anthropic/claude-opus-4-6)`
- Fallback warnings include reason and session target.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm check`
  - `pnpm protocol:check`
  - `pnpm build`
  - `pnpm check:docs`
  - `pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts`
  - `CLAWDBOT_INSTALL_URL=https://openclaw.ai/install.sh CLAWDBOT_INSTALL_CLI_URL=https://openclaw.ai/install-cli.sh CLAWDBOT_NO_ONBOARD=1 CLAWDBOT_INSTALL_SMOKE_SKIP_CLI=1 CLAWDBOT_INSTALL_SMOKE_SKIP_NONROOT=1 CLAWDBOT_INSTALL_SMOKE_SKIP_PREVIOUS=1 pnpm test:install:smoke`
- Edge cases checked:
  - unset override
  - alias override
  - explicit provider/model override
  - override not in configured catalog
  - override resolve failure
  - override auth failure
  - different-provider override auth-profile behavior
- What you did **not** verify:
  - Windows CI lane execution in local Windows environment

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes (new optional config key)
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove/unset `agents.defaults.compaction.model` to restore session-model compaction behavior.
- Files/config to restore:
  - Config: remove `agents.defaults.compaction.model`
- Known bad symptoms reviewers should watch for:
  - Override configured but always warning/falling back due to model catalog mismatch or auth mismatch.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: misconfigured/providerless override strings unexpectedly ignored.
  - Mitigation: strict validation + explicit warning logs + fallback to session model.
- Risk: cross-provider override could accidentally force wrong auth profile.
  - Mitigation: same-provider keeps session profile; different-provider resolves auth without locking to session profile.

## Original Prompt (verbatim)

```text
Implement a compaction.model config override for OpenClaw so auto-compaction can use a different (cheaper) model than the session's primary model.

## What to change

1. **Config schema** (types.ts or wherever CompactionConfig is defined):
   - Add optional model?: string field to the compaction config (format: "provider/model" or alias)
   - Example: agents.defaults.compaction.model: "anthropic/claude-sonnet-4-6"

2. **Compaction runner** (compact.ts):
   - In compactEmbeddedPiSessionDirect(), check if config.agents.defaults.compaction.model is set
   - If set, resolve that model (using the existing resolveModel() helper) instead of using the session's params.provider/params.model
   - The resolved model needs a valid API key — use the same getApiKeyForModel() path
   - Fall back to the session model if the compaction model fails to resolve or authenticate

3. **Config reference docs** (configuration-reference.md):
   - Document the new compaction.model field under agents.defaults.compaction
   - Note: format is "provider/model" or a configured alias

4. **Logging**: Log which model is being used for compaction so users can verify it's working:
   [compaction] using override model anthropic/claude-sonnet-4-6 (session model: anthropic/claude-opus-4-6)

## Key files
- compact.ts — main compaction logic
- model.ts — resolveModel()
- src/config/ — config types and validation
- configuration-reference.md — docs

## Constraints
- When compaction.model is unset, behavior is unchanged (use session model)
- The compaction model must be in the configured model catalog (agents.defaults.models)
- Auth resolution should use the same profile as the session unless the model requires a different provider
- Don't change the compaction prompt/logic itself, only which model runs it

Closes openclaw/openclaw#7926, #15826, #17461, #19501
```

## Original Codex Plan (verbatim)

```text
## Compaction model override (`agents.defaults.compaction.model`)

### Summary
Add a new optional config field so compaction can run on a cheaper model, while preserving current behavior when unset. The compaction runner will try the override model first, require it to map to configured catalog entries, authenticate via existing auth resolution, and gracefully fall back to the session model if override resolution/auth fails.

### Public interface/type changes
1. Update `/Users/pasta/workspace/openclaw/src/config/types.agent-defaults.ts`:
- Add `model?: string` to `AgentCompactionConfig`.
- Docstring: accepts `provider/model` or configured alias.

2. Update `/Users/pasta/workspace/openclaw/src/config/zod-schema.agent-defaults.ts`:
- Add `model: z.string().optional()` under `agents.defaults.compaction`.

3. Update docs in `/Users/pasta/workspace/openclaw/docs/gateway/configuration-reference.md`:
- Add `model` in the `agents.defaults.compaction` example.
- Add bullet describing accepted format (`provider/model` or alias from configured models).

### Runtime implementation plan
1. In `/Users/pasta/workspace/openclaw/src/agents/pi-embedded-runner/compact.ts`, introduce a small model-selection/auth block before the existing compaction session setup:
- Keep `sessionProvider/sessionModel` from `params.provider` + `params.model`.
- Read `compaction.model` override from config.
- Resolve override model ref using existing model-selection helpers (alias support + normalized provider/model).
- Enforce “must be in `agents.defaults.models`” by checking resolved key against configured model keys.
- If override passes validation:
  - Call existing `resolveModel()` for override provider/model.
  - Authenticate via existing `getApiKeyForModel()` path.
  - Profile behavior:
    - Same provider as session: reuse `params.authProfileId`.
    - Different provider: use provider-specific auth resolution (no locked session profile).
  - On success, use this override model/provider/modelId for the rest of compaction run.
- On any override resolve/auth failure, log fallback reason and continue with session model path.
- If session model resolution/auth fails, preserve current hard-fail behavior.

2. Ensure all downstream compaction runtime uses the selected effective model variables:
- Tool creation metadata (`modelProvider`, `modelId`, auth mode).
- Runtime info/system prompt metadata.
- Transcript policy and sanitization provider/model arguments.
- Extension/runtime guards relying on provider/model.

3. Keep compaction prompt logic unchanged:
- No changes to compaction instructions, summarization flow, or thresholds.

### Logging changes
1. Add explicit success log when override is active:
- `[compaction] using override model <provider/model> (session model: <provider/model>)`

2. Add fallback warning logs when override is configured but unusable:
- Include reason and fallback target session model.

### Tests
1. Update `/Users/pasta/workspace/openclaw/src/config/config.compaction-settings.test.ts`:
- Verify `compaction.model` is preserved through config load.

2. Add focused compaction override tests (new unit test file near compact runner, likely with helper extraction for testability):
- Unset override: unchanged behavior (session model used).
- Override by alias (catalog-backed): override model used.
- Override by explicit `provider/model` in catalog: override model used.
- Override not in configured catalog: fallback to session model.
- Override resolveModel failure: fallback to session model.
- Override auth failure: fallback to session model.
- Different-provider override uses provider-specific auth path (not locked to session profile).
- Verify override success log string and fallback warning log emission.

### Assumptions/defaults
1. Override applies to all runs through `compactEmbeddedPiSessionDirect` (overflow and manual), since that is the shared compaction execution path.
2. If override is invalid/unresolvable/unauthenticated, compaction must continue with session model instead of failing.
3. `compaction.model` accepts aliases from configured model catalog and explicit `provider/model`; non-alias bare model IDs are treated as invalid input for this field.
4. No changes to `schema.help`/`schema.labels` are required in this patch (compaction fields currently are not listed there).

### Tracking issues
- https://github.com/openclaw/openclaw/issues/7926
- https://github.com/openclaw/openclaw/issues/15826
- https://github.com/openclaw/openclaw/issues/17461
- https://github.com/openclaw/openclaw/issues/19501
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added optional `agents.defaults.compaction.model` config to allow compaction runs to use a different (typically cheaper) model than the session model. The implementation extracts model selection/auth logic into a dedicated module (`compact-model-selection.ts`) with proper fallback behavior when the override fails. When configured, compaction tries the override model first and falls back to the session model on any resolution or auth failure. All changes are backward compatible (unset override preserves existing behavior) and include comprehensive unit tests covering alias resolution, explicit provider/model refs, catalog validation, auth failures, and cross-provider scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-architected with proper separation of concerns, comprehensive test coverage (11 test cases covering all edge cases), graceful fallback behavior, backward compatibility, and no breaking changes. The code reuses existing auth/model resolution helpers and includes appropriate logging for debugging.
- No files require special attention

<sub>Last reviewed commit: ed571bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->