### PR TITLE
Infra: add two-node ops docs and env templates

### DIFF
--- a/.env.mac
+++ b/.env.mac
@@ -1,3 +1,4 @@
+# PLACEHOLDER ONLY. Do not put real tokens here. Use .env.local (gitignored).
 # OpenClaw Docker env (Mac node: dev + portable)
 
 # Image and gateway

--- a/.env.mac
+++ b/.env.mac
@@ -1,0 +1,26 @@
+# OpenClaw Docker env (Mac node: dev + portable)
+
+# Image and gateway
+OPENCLAW_IMAGE=openclaw:local
+OPENCLAW_GATEWAY_BIND=lan
+OPENCLAW_GATEWAY_PORT=9798
+OPENCLAW_BRIDGE_PORT=18790
+OPENCLAW_GATEWAY_TOKEN=replace-with-long-random-token
+
+# Host data paths (Mac)
+OPENCLAW_CONFIG_DIR=./.openclaw/mac/config
+OPENCLAW_WORKSPACE_DIR=./.openclaw/mac/workspace
+
+# Optional provider keys
+OPENAI_API_KEY=replace-with-openai-key
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+OPENROUTER_API_KEY=
+
+# Optional local LLM fallback (Mac only, if used)
+OLLAMA_API_KEY=
+
+# Optional web provider session values
+CLAUDE_AI_SESSION_KEY=
+CLAUDE_WEB_SESSION_KEY=
+CLAUDE_WEB_COOKIE=

--- a/.env.win
+++ b/.env.win
@@ -1,3 +1,4 @@
+# PLACEHOLDER ONLY. Do not put real tokens here. Use .env.local (gitignored).
 # OpenClaw Docker env (Windows node: always-on production-like)
 
 # Image and gateway

--- a/.env.win
+++ b/.env.win
@@ -1,0 +1,29 @@
+# OpenClaw Docker env (Windows node: always-on production-like)
+
+# Image and gateway
+OPENCLAW_IMAGE=openclaw:local
+OPENCLAW_GATEWAY_BIND=lan
+OPENCLAW_GATEWAY_PORT=9797
+OPENCLAW_BRIDGE_PORT=18790
+OPENCLAW_GATEWAY_TOKEN=replace-with-long-random-token
+
+# Host data paths (Windows Docker)
+# Use absolute Windows paths in your local copy, for example:
+# C:/openclaw/data/config
+# C:/openclaw/data/workspace
+OPENCLAW_CONFIG_DIR=./.openclaw/win/config
+OPENCLAW_WORKSPACE_DIR=./.openclaw/win/workspace
+
+# Provider policy for this node: OpenAI cloud only
+OPENAI_API_KEY=replace-with-openai-key
+
+# Keep non-OpenAI providers empty on Windows node
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+OPENROUTER_API_KEY=
+OLLAMA_API_KEY=
+
+# Optional web provider session values
+CLAUDE_AI_SESSION_KEY=
+CLAUDE_WEB_SESSION_KEY=
+CLAUDE_WEB_COOKIE=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 node_modules
 **/node_modules/
 .env
+.env.local
+.env.*.local
+.env.override
+.env.*.override
 .openclaw/
 **/.openclaw/
 docker-compose.extra.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 **/node_modules/
 .env
+.openclaw/
+**/.openclaw/
 docker-compose.extra.yml
 dist
 pnpm-lock.yaml

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ logs:
 	$(COMPOSE) logs --tail=80 openclaw-gateway
 
 health:
-	$(COMPOSE) exec openclaw-gateway sh -lc 'node dist/index.js health --token "$$OPENCLAW_GATEWAY_TOKEN"'
+	curl -fsS http://127.0.0.1:18789/health && echo

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Docker Compose helpers using local gitignored env values.
+ENV_FILE ?= .env.local
+COMPOSE := docker compose --env-file $(ENV_FILE)
+
+.PHONY: up down ps logs health
+
+up:
+	$(COMPOSE) up -d
+
+down:
+	$(COMPOSE) down
+
+ps:
+	$(COMPOSE) ps
+
+logs:
+	$(COMPOSE) logs --tail=80 openclaw-gateway
+
+health:
+	$(COMPOSE) exec openclaw-gateway sh -lc 'node dist/index.js health --token "$$OPENCLAW_GATEWAY_TOKEN"'

--- a/OPS/ROLE-SEPARATION.md
+++ b/OPS/ROLE-SEPARATION.md
@@ -1,0 +1,28 @@
+# OpenClaw Two-Node Role Separation
+
+## Node roles
+
+- Mac node: development and portable operations node.
+  - Primary use: local development, testing, and controlled rollouts.
+  - Optional fallback: local LLM provider(s), such as Ollama, when cloud access is unavailable.
+- Windows 11 Docker node: always-on production-like node.
+  - Primary use: stable continuous runtime.
+  - Provider policy: cloud OpenAI only (no local LLM runtime on this node).
+
+## Source of truth
+
+- Single source of truth for code, compose, and docs: this repository.
+- Mac is the authoring node; Windows consumes the same repo state.
+
+## Deployment model
+
+- One `docker-compose.yml` is shared by both nodes.
+- Environment differences are handled only through env files:
+  - Mac: `.env.mac`
+  - Windows: `.env.win`
+- Do not fork compose per host unless there is a hard technical blocker.
+
+## Configuration boundary
+
+- Keep host-specific values in env files only (ports, bind paths, tokens, provider keys).
+- Keep application logic and service definitions host-agnostic in `docker-compose.yml`.

--- a/OPS/RUNBOOK.md
+++ b/OPS/RUNBOOK.md
@@ -1,0 +1,96 @@
+# OpenClaw Two-Node Runbook
+
+## Bring up Mac node
+
+```bash
+cd /Users/kermitv/dev/projects/openclaw-upstream
+docker compose --env-file .env.mac up -d --build openclaw-gateway
+```
+
+Optional CLI tasks from Mac:
+
+```bash
+docker compose --env-file .env.mac run --rm openclaw-cli onboard
+docker compose --env-file .env.mac run --rm openclaw-cli dashboard --no-open
+```
+
+## Bring up Windows node
+
+```bash
+cd <repo-path-on-windows>
+docker compose --env-file .env.win up -d --build openclaw-gateway
+```
+
+Optional CLI tasks from Windows:
+
+```bash
+docker compose --env-file .env.win run --rm openclaw-cli dashboard --no-open
+```
+
+## Health checks
+
+```bash
+docker compose --env-file .env.mac ps
+docker compose --env-file .env.mac logs --tail 120 openclaw-gateway
+docker compose --env-file .env.mac exec openclaw-gateway node dist/index.js health --token "$OPENCLAW_GATEWAY_TOKEN"
+```
+
+Windows version:
+
+```bash
+docker compose --env-file .env.win ps
+docker compose --env-file .env.win logs --tail 120 openclaw-gateway
+docker compose --env-file .env.win exec openclaw-gateway node dist/index.js health --token "$OPENCLAW_GATEWAY_TOKEN"
+```
+
+## Deploy changes from Mac to Windows
+
+```bash
+# On Mac
+git add -A
+git commit -m "infra/docs: update OpenClaw two-node setup"
+git push origin <branch>
+```
+
+```bash
+# On Windows
+cd <repo-path-on-windows>
+git fetch origin
+git checkout <branch>
+git pull --rebase origin <branch>
+docker compose --env-file .env.win up -d --build
+```
+
+## Data volumes and paths
+
+- Container paths:
+  - `/home/node/.openclaw`
+  - `/home/node/.openclaw/workspace`
+- Host paths are defined by env files:
+  - `OPENCLAW_CONFIG_DIR`
+  - `OPENCLAW_WORKSPACE_DIR`
+
+## Restart and recovery
+
+```bash
+# Restart gateway only
+docker compose --env-file .env.mac restart openclaw-gateway
+docker compose --env-file .env.win restart openclaw-gateway
+```
+
+```bash
+# Full recreate (safe default)
+docker compose --env-file .env.mac down
+docker compose --env-file .env.mac up -d --build
+```
+
+```bash
+docker compose --env-file .env.win down
+docker compose --env-file .env.win up -d --build
+```
+
+```bash
+# Inspect recent logs after recovery
+docker compose --env-file .env.mac logs --tail 200 openclaw-gateway
+docker compose --env-file .env.win logs --tail 200 openclaw-gateway
+```

--- a/OPS/RUNBOOK.md
+++ b/OPS/RUNBOOK.md
@@ -3,7 +3,7 @@
 ## Bring up Mac node
 
 ```bash
-cd /Users/kermitv/dev/projects/openclaw-upstream
+cd <repo-path-on-mac>
 docker compose --env-file .env.mac up -d --build openclaw-gateway
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR:-./.openclaw}:/home/node/.openclaw
+      - ${OPENCLAW_WORKSPACE_DIR:-./.openclaw/workspace}:/home/node/.openclaw/workspace
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
@@ -38,9 +38,10 @@ services:
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR:-./.openclaw}:/home/node/.openclaw
+      - ${OPENCLAW_WORKSPACE_DIR:-./.openclaw/workspace}:/home/node/.openclaw/workspace
     stdin_open: true
     tty: true
     init: true
+    restart: unless-stopped
     entrypoint: ["node", "dist/index.js"]

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -99,6 +99,17 @@ Note: run `docker compose ...` from the repo root. If you enabled
 docker compose -f docker-compose.yml -f docker-compose.extra.yml <command>
 ```
 
+Canonical local env workflow:
+
+```bash
+cp .env.example .env.local
+$EDITOR .env.local
+docker compose --env-file .env.local up -d
+docker compose --env-file .env.local logs --tail=80 openclaw-gateway
+```
+
+Prefer `--env-file .env.local` over shell exports. Shell environment variables can drift between terminals and produce inconsistent Compose behavior.
+
 ### Control UI token + pairing (Docker)
 
 If you see “unauthorized” or “disconnected (1008): pairing required”, fetch a

--- a/docs/runbook/telegram-disable-command-auto-registration.md
+++ b/docs/runbook/telegram-disable-command-auto-registration.md
@@ -1,0 +1,28 @@
+---
+title: "Disable Telegram Command Auto Registration"
+summary: "Stop Telegram setMyCommands attempts that can fail with BOT_COMMAND_INVALID."
+---
+
+If Telegram startup logs show `setMyCommands failed` or `BOT_COMMAND_INVALID`, disable native command menu registration in `~/.openclaw/openclaw.json`.
+
+Use boolean `false` values (the config convention is `true`/`false` or `"auto"`):
+
+```json5
+{
+  commands: {
+    native: false,
+    nativeSkills: false,
+  },
+}
+```
+
+This does **not** disable Telegram messaging. It only stops OpenClaw from attempting Telegram `setMyCommands` registration.
+
+Verification:
+
+```bash
+docker compose --env-file .env.local restart openclaw-gateway
+docker compose --env-file .env.local logs --since=5m openclaw-gateway | grep -i telegram
+```
+
+Expected result: logs no longer include `setMyCommands failed` or `BOT_COMMAND_INVALID`.

--- a/docs/runbook/telegram-disable-command-auto-registration.md
+++ b/docs/runbook/telegram-disable-command-auto-registration.md
@@ -3,26 +3,40 @@ title: "Disable Telegram Command Auto Registration"
 summary: "Stop Telegram setMyCommands attempts that can fail with BOT_COMMAND_INVALID."
 ---
 
-If Telegram startup logs show `setMyCommands failed` or `BOT_COMMAND_INVALID`, disable native command menu registration in `~/.openclaw/openclaw.json`.
+## Symptoms
 
-Use boolean `false` values (the config convention is `true`/`false` or `"auto"`):
+- Logs show: `setMyCommands failed (400: Bad Request: BOT_COMMAND_INVALID)`
+
+## Cause
+
+- Telegram bot commands must match regex `^[a-z0-9_]{1,32}$`
+- Auto-generated commands (for example, hyphenated or mixed-case skill names) can violate this.
+
+## Workaround (No Code Change)
+
+- Disable native command auto-registration in `~/.openclaw/openclaw.json`:
 
 ```json5
 {
   commands: {
-    native: false,
-    nativeSkills: false,
+    native: "off",
+    nativeSkills: "off",
   },
 }
 ```
 
-This does **not** disable Telegram messaging. It only stops OpenClaw from attempting Telegram `setMyCommands` registration.
-
-Verification:
+- Restart gateway:
 
 ```bash
 docker compose --env-file .env.local restart openclaw-gateway
+```
+
+This does **not** disable Telegram messaging. It only stops OpenClaw from attempting Telegram `setMyCommands`.
+
+## Verify
+
+```bash
 docker compose --env-file .env.local logs --since=5m openclaw-gateway | grep -i telegram
 ```
 
-Expected result: logs no longer include `setMyCommands failed` or `BOT_COMMAND_INVALID`.
+- Confirm no `BOT_COMMAND_INVALID` entries.


### PR DESCRIPTION
## Summary
- add OPS docs for two-node architecture (role separation + command runbook)
- add .env.mac and .env.win templates with placeholders
- keep compose host-agnostic and env-file driven for node differences
- ignore local runstate directory (.openclaw/) and keep .env ignored

## Scope
- infrastructure docs and repo plumbing only
- no application logic changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes infrastructure for a two-node OpenClaw deployment with clear role separation between Mac (dev/portable) and Windows (always-on production) nodes.

**Key additions:**
- `.env.mac` and `.env.win` template files with placeholders for node-specific configuration
- `OPS/ROLE-SEPARATION.md` documenting the architectural split and deployment model
- `OPS/RUNBOOK.md` with operational commands for both nodes
- `Makefile` providing convenient Docker Compose shortcuts
- `.gitignore` entries for local env overrides and runtime state directory (`.openclaw/`)
- `docker-compose.yml` updated with default volume paths and `restart: unless-stopped` policy
- `docs/install/docker.md` updated with canonical local env workflow
- `docs/runbook/telegram-disable-command-auto-registration.md` workaround for `BOT_COMMAND_INVALID` errors

The changes follow repository guidelines by using placeholders instead of hardcoded paths and keeping host-specific configuration in environment files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Infrastructure and documentation only changes with no application logic modifications. All files follow repository guidelines for generic placeholders, proper gitignore patterns, and environment-driven configuration. The changes enable better operational management of multi-node deployments.
- No files require special attention

<sub>Last reviewed commit: 039d7f0</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->