### PR TITLE
fix: use AnyExport for createMockWebListener return type

### DIFF
--- a/src/web/auto-reply.test-harness.ts
+++ b/src/web/auto-reply.test-harness.ts
@@ -171,7 +171,7 @@ export function createWebListenerFactoryCapture(): AnyExport {
   };
 }
 
-export function createMockWebListener(): MockWebListener {
+export function createMockWebListener(): AnyExport {
   return {
     close: vi.fn(async () => undefined),
     onClose: new Promise<WebListenerCloseReason>(() => {}),


### PR DESCRIPTION
Fixes TS2742 error in d.ts emission where createMockWebListener's inferred type referenced internal vitest types. Using AnyExport aligns with other mock factories in this file.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes `createMockWebListener` return type from `MockWebListener` to `AnyExport` to fix TS2742 error during `.d.ts` emission. This aligns the function with other mock factories in the file (`createWebListenerFactoryCapture` and `createWebInboundDeliverySpies`) that already use `AnyExport` to avoid leaking internal vitest mock types into declaration files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward type-only fix that resolves a TypeScript compilation issue without affecting runtime behavior. It follows the existing pattern used by other mock factories in the same file, and usage sites don't rely on the specific type annotation
- No files require special attention

<sub>Last reviewed commit: 0f31ae4</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->