### PR TITLE
fix: Grok web_search extracts output_text blocks at top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - CLI/Config: add canonical `--strict-json` parsing for `config set` and keep `--json` as a legacy alias to reduce help/behavior drift. (#21332) thanks @adhitShet.
 - CLI: keep `openclaw -v` as a root-only version alias so subcommand `-v, --verbose` flags (for example ACP/hooks/skills) are no longer intercepted globally. (#21303) thanks @adhitShet.
 - Config/Memory: restore schema help/label metadata for hybrid `mmr` and `temporalDecay` settings so configuration surfaces show correct names and guidance. (#18786) Thanks @rodrigouroz.
+- Tools/web_search: handle xAI Responses API payloads that emit top-level `output_text` blocks (without a `message` wrapper) so Grok web_search no longer returns `No response` for those results. (#20508) Thanks @echoVic.
 
 - Discord/Gateway: handle close code 4014 (missing privileged gateway intents) without crashing the gateway. Thanks @thewilloftheshadow.
 - Security/Net: strip sensitive headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Cookie2`) on cross-origin redirects in `fetchWithSsrFGuard` to prevent credential forwarding across origin boundaries. (#20313) Thanks @afurm.

--- a/src/agents/tools/web-search.e2e.test.ts
+++ b/src/agents/tools/web-search.e2e.test.ts
@@ -219,4 +219,26 @@ describe("web_search grok response parsing", () => {
     expect(result.text).toBeUndefined();
     expect(result.annotationCitations).toEqual([]);
   });
+
+  it("extracts output_text blocks directly in output array (no message wrapper)", () => {
+    const result = extractGrokContent({
+      output: [
+        { type: "web_search_call" },
+        {
+          type: "output_text",
+          text: "direct output text",
+          annotations: [
+            {
+              type: "url_citation",
+              url: "https://example.com/direct",
+              start_index: 0,
+              end_index: 5,
+            },
+          ],
+        },
+      ],
+    } as Parameters<typeof extractGrokContent>[0]);
+    expect(result.text).toBe("direct output text");
+    expect(result.annotationCitations).toEqual(["https://example.com/direct"]);
+  });
 });


### PR DESCRIPTION
Some xAI Responses API responses place output_text blocks directly in the output array without a message wrapper. The parser only looked for output_text inside message.content blocks, missing these top-level entries entirely.

This adds a fallback path that checks for output_text blocks at the top level of the output array, extracting text and url_citation annotations.

Includes test coverage for the new code path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a parsing bug in the Grok web search tool where xAI API responses with top-level `output_text` blocks (not wrapped in a message) were being ignored. The fix adds a fallback path in `extractGrokContent` that checks for `output_text` blocks directly in the `output` array and extracts both text content and `url_citation` annotations.

- Adds `text` and `annotations` fields to the `GrokSearchResponse` type definition to handle top-level output blocks
- Implements fallback logic in `extractGrokContent` function (lines 163-179 in web-search.ts) that processes unwrapped `output_text` blocks
- Includes comprehensive test coverage for the new code path
- Maintains backward compatibility with existing message-wrapped format and deprecated `output_text` field

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The implementation is clean, well-tested, and maintains backward compatibility. The change is additive (only adds a fallback path), preserves existing behavior, includes appropriate type definitions, and has comprehensive test coverage for the new code path.
- No files require special attention

<sub>Last reviewed commit: 0babd11</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->