### PR TITLE
fix: register poll action gate for Telegram adapter (#17528)

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -20,6 +20,8 @@ export type TelegramActionConfig = {
   sticker?: boolean;
   /** Enable forum topic creation. */
   createForumTopic?: boolean;
+  /** Enable poll actions. */
+  polls?: boolean;
 };
 
 export type TelegramNetworkConfig = {


### PR DESCRIPTION
The Telegram message action adapter was missing the poll action gate and handler. Users with polls enabled in their Telegram action config could not create polls through the agent.

- Add `polls` field to `TelegramActionConfig` type
- Register `poll` in `listActions` when `gate("polls")` is true
- Add poll action handler using `sendPollTelegram`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added the missing `polls` field to `TelegramActionConfig` and registered the poll action gate in the Telegram message adapter, enabling users to create polls when configured. The implementation follows the same pattern used for other Telegram actions like `sticker` and `createForumTopic`, and correctly uses the existing `sendPollTelegram` function.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal and follow established patterns in the codebase. The implementation correctly adds the missing poll action gate registration, uses existing infrastructure (`sendPollTelegram`), and matches the implementation pattern used for other Telegram actions like stickers and forum topics. The type definition is consistent with Discord's `DiscordActionConfig`.
- No files require special attention

<sub>Last reviewed commit: d402679</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->