### PR TITLE
Fix LaunchAgent missing TMPDIR causing SQLITE_CANTOPEN on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - Gateway/TUI: honor `agents.defaults.blockStreamingDefault` for `chat.send` by removing the hardcoded block-streaming disable override, so replies can use configured block-mode delivery. (#19693) Thanks @neipor.
 - Protocol/Apple: regenerate Swift gateway models for `push.test` so `pnpm protocol:check` stays green on main. Thanks @mbelinky.

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -151,6 +151,26 @@ describe("launchd install", () => {
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
     expect(enableIndex).toBeLessThan(bootstrapIndex);
   });
+
+  it("writes TMPDIR to LaunchAgent environment when provided", async () => {
+    const env: Record<string, string | undefined> = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+    const tmpDir = "/var/folders/xy/abc123/T/";
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: ["node", "-e", "process.exit(0)"],
+      environment: { TMPDIR: tmpDir },
+    });
+
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const plist = state.files.get(plistPath) ?? "";
+    expect(plist).toContain("<key>EnvironmentVariables</key>");
+    expect(plist).toContain("<key>TMPDIR</key>");
+    expect(plist).toContain(`<string>${tmpDir}</string>`);
+  });
 });
 
 describe("resolveLaunchAgentPlistPath", () => {

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -282,6 +282,31 @@ describe("buildServiceEnvironment", () => {
     }
   });
 
+  it("forwards TMPDIR from the host environment", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user", TMPDIR: "/var/folders/xw/abc123/T/" },
+      port: 18789,
+    });
+    expect(env.TMPDIR).toBe("/var/folders/xw/abc123/T/");
+  });
+
+  it("forwards LANG from the host environment", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user", LANG: "en_US.UTF-8" },
+      port: 18789,
+    });
+    expect(env.LANG).toBe("en_US.UTF-8");
+  });
+
+  it("omits TMPDIR and LANG when not set in host environment", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+    });
+    expect(env.TMPDIR).toBeUndefined();
+    expect(env.LANG).toBeUndefined();
+  });
+
   it("uses profile-specific unit and label", () => {
     const env = buildServiceEnvironment({
       env: { HOME: "/home/user", OPENCLAW_PROFILE: "work" },
@@ -300,6 +325,14 @@ describe("buildNodeServiceEnvironment", () => {
       env: { HOME: "/home/user" },
     });
     expect(env.HOME).toBe("/home/user");
+  });
+
+  it("forwards TMPDIR and LANG for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", TMPDIR: "/tmp/custom", LANG: "en_US.UTF-8" },
+    });
+    expect(env.TMPDIR).toBe("/tmp/custom");
+    expect(env.LANG).toBe("en_US.UTF-8");
   });
 });
 

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -290,21 +290,12 @@ describe("buildServiceEnvironment", () => {
     expect(env.TMPDIR).toBe("/var/folders/xw/abc123/T/");
   });
 
-  it("forwards LANG from the host environment", () => {
-    const env = buildServiceEnvironment({
-      env: { HOME: "/home/user", LANG: "en_US.UTF-8" },
-      port: 18789,
-    });
-    expect(env.LANG).toBe("en_US.UTF-8");
-  });
-
-  it("omits TMPDIR and LANG when not set in host environment", () => {
+  it("omits TMPDIR when not set in host environment", () => {
     const env = buildServiceEnvironment({
       env: { HOME: "/home/user" },
       port: 18789,
     });
     expect(env.TMPDIR).toBeUndefined();
-    expect(env.LANG).toBeUndefined();
   });
 
   it("uses profile-specific unit and label", () => {
@@ -327,12 +318,11 @@ describe("buildNodeServiceEnvironment", () => {
     expect(env.HOME).toBe("/home/user");
   });
 
-  it("forwards TMPDIR and LANG for node services", () => {
+  it("forwards TMPDIR for node services", () => {
     const env = buildNodeServiceEnvironment({
-      env: { HOME: "/home/user", TMPDIR: "/tmp/custom", LANG: "en_US.UTF-8" },
+      env: { HOME: "/home/user", TMPDIR: "/tmp/custom" },
     });
     expect(env.TMPDIR).toBe("/tmp/custom");
-    expect(env.LANG).toBe("en_US.UTF-8");
   });
 });
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -215,7 +215,6 @@ export function buildServiceEnvironment(params: {
   return {
     HOME: env.HOME,
     TMPDIR: env.TMPDIR,
-    LANG: env.LANG,
     PATH: buildMinimalServicePath({ env }),
     OPENCLAW_PROFILE: profile,
     OPENCLAW_STATE_DIR: stateDir,
@@ -239,7 +238,6 @@ export function buildNodeServiceEnvironment(params: {
   return {
     HOME: env.HOME,
     TMPDIR: env.TMPDIR,
-    LANG: env.LANG,
     PATH: buildMinimalServicePath({ env }),
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -214,6 +214,8 @@ export function buildServiceEnvironment(params: {
   const configPath = env.OPENCLAW_CONFIG_PATH;
   return {
     HOME: env.HOME,
+    TMPDIR: env.TMPDIR,
+    LANG: env.LANG,
     PATH: buildMinimalServicePath({ env }),
     OPENCLAW_PROFILE: profile,
     OPENCLAW_STATE_DIR: stateDir,
@@ -236,6 +238,8 @@ export function buildNodeServiceEnvironment(params: {
   const configPath = env.OPENCLAW_CONFIG_PATH;
   return {
     HOME: env.HOME,
+    TMPDIR: env.TMPDIR,
+    LANG: env.LANG,
     PATH: buildMinimalServicePath({ env }),
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { VERSION } from "../version.js";
 import {
@@ -212,8 +213,8 @@ export function buildServiceEnvironment(params: {
   const systemdUnit = `${resolveGatewaySystemdServiceName(profile)}.service`;
   const stateDir = env.OPENCLAW_STATE_DIR;
   const configPath = env.OPENCLAW_CONFIG_PATH;
-  // launchd on macOS does not inherit shell TMPDIR by default; forward it explicitly there.
-  const tmpDir = process.platform === "darwin" ? env.TMPDIR : undefined;
+  // Keep a usable temp directory for supervised services even when the host env omits TMPDIR.
+  const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,
@@ -237,8 +238,7 @@ export function buildNodeServiceEnvironment(params: {
   const { env } = params;
   const stateDir = env.OPENCLAW_STATE_DIR;
   const configPath = env.OPENCLAW_CONFIG_PATH;
-  // Keep TMPDIR propagation scoped to macOS launchd installs.
-  const tmpDir = process.platform === "darwin" ? env.TMPDIR : undefined;
+  const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -212,9 +212,11 @@ export function buildServiceEnvironment(params: {
   const systemdUnit = `${resolveGatewaySystemdServiceName(profile)}.service`;
   const stateDir = env.OPENCLAW_STATE_DIR;
   const configPath = env.OPENCLAW_CONFIG_PATH;
+  // launchd on macOS does not inherit shell TMPDIR by default; forward it explicitly there.
+  const tmpDir = process.platform === "darwin" ? env.TMPDIR : undefined;
   return {
     HOME: env.HOME,
-    TMPDIR: env.TMPDIR,
+    TMPDIR: tmpDir,
     PATH: buildMinimalServicePath({ env }),
     OPENCLAW_PROFILE: profile,
     OPENCLAW_STATE_DIR: stateDir,
@@ -235,9 +237,11 @@ export function buildNodeServiceEnvironment(params: {
   const { env } = params;
   const stateDir = env.OPENCLAW_STATE_DIR;
   const configPath = env.OPENCLAW_CONFIG_PATH;
+  // Keep TMPDIR propagation scoped to macOS launchd installs.
+  const tmpDir = process.platform === "darwin" ? env.TMPDIR : undefined;
   return {
     HOME: env.HOME,
-    TMPDIR: env.TMPDIR,
+    TMPDIR: tmpDir,
     PATH: buildMinimalServicePath({ env }),
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,


### PR DESCRIPTION
## Problem

When the gateway runs as a macOS LaunchAgent (installed via `openclaw gateway install`), SQLite fails with `SQLITE_CANTOPEN: unable to open database file` on every startup.

macOS launchd does not inherit shell environment variables. The generated plist includes `HOME` and `PATH` but omits `TMPDIR`. Without `TMPDIR`, SQLite cannot locate the per-user temp directory (`/var/folders/…`) needed for journal and WAL files.

Running the gateway from an interactive shell works because `TMPDIR` is set by the shell.

## Fix

Forward `TMPDIR` and `LANG` from the host environment into the service environment for both gateway and node LaunchAgents.

- `TMPDIR`: required by SQLite for temp file creation on macOS
- `LANG`: ensures consistent locale for string collation and file encoding

Both are omitted from the plist when unset in the host environment (the existing `renderEnvDict` filter handles this).

## Tests

4 new test cases covering TMPDIR/LANG forwarding for both gateway and node service environments.

Fixes #20489

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Forwards `TMPDIR` and `LANG` environment variables from the host environment to both gateway and node LaunchAgent services on macOS. This fixes SQLite's `SQLITE_CANTOPEN` error that occurs when the gateway runs as a LaunchAgent, where `TMPDIR` is needed for SQLite journal and WAL files. The `renderEnvDict` filter ensures these variables are omitted from the plist when unset in the host environment.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-tested, and directly addresses the root cause. The implementation correctly forwards environment variables through existing infrastructure that already handles undefined values appropriately. The changes are limited to two straightforward additions per function with comprehensive test coverage.
- No files require special attention

<sub>Last reviewed commit: 296d5ed</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->