### PR TITLE
fix(feishu): pass mediaLocalRoots through sendMedia to loadWebMedia

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -421,8 +421,10 @@ export async function sendMediaFeishu(params: {
   fileName?: string;
   replyToMessageId?: string;
   accountId?: string;
+  mediaLocalRoots?: readonly string[];
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, mediaLocalRoots } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -439,6 +441,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
+      localRoots: mediaLocalRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
@@ -26,6 +26,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           mediaUrl,
           accountId: accountId ?? undefined,
+          mediaLocalRoots: mediaLocalRoots as string[] | undefined,
         });
         return { channel: "feishu", ...result };
       } catch (err) {


### PR DESCRIPTION
## Problem

The Feishu outbound adapter's `sendMedia` handler does not destructure or forward the `mediaLocalRoots` parameter from the channel outbound context. This causes `loadWebMedia` to fall back to default local roots, which reject agent workspace paths (e.g. `workspace-*`). As a result, local file media sends silently degrade to a plain-text URL fallback (`📎 /path/to/file`).

Other channel adapters (Discord, Signal, etc.) already correctly forward `mediaLocalRoots`.

## Fix

1. **`outbound.ts`**: Destructure `mediaLocalRoots` from the context and pass it to `sendMediaFeishu`.
2. **`media.ts`**: Accept `mediaLocalRoots` in `sendMediaFeishu` params and forward it as `localRoots` to `loadWebMedia`.

## Related

- #20029 (same issue in Telegram adapter)
- #11780 (Feishu EPIPE)
- #17334

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed missing `mediaLocalRoots` forwarding in Feishu adapter's `sendMedia` handler, which caused local workspace file sends to fall back to plain-text URLs instead of uploading actual media. The fix threads the parameter through `outbound.ts` → `sendMediaFeishu` → `loadWebMedia`, matching the pattern already implemented in Discord, Signal, and other channel adapters.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward parameter forwarding fix with no behavioral changes
- The changes are minimal, focused, and follow established patterns from other channel adapters. The fix addresses a clear bug where local workspace files weren't being properly uploaded due to missing parameter forwarding. Type signatures are correct, and the implementation is consistent with Discord, Signal, and Telegram adapters.
- No files require special attention

<sub>Last reviewed commit: 33ddd45</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->