### PR TITLE
feat(heartbeat): inject active cron job summary into heartbeat prompt

### DIFF
--- a/src/infra/heartbeat-cron-summary.test.ts
+++ b/src/infra/heartbeat-cron-summary.test.ts
@@ -1,0 +1,156 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { buildHeartbeatCronSummary } from "./heartbeat-cron-summary.js";
+
+describe("buildHeartbeatCronSummary", () => {
+  const tmpDirs: string[] = [];
+
+  async function createTmpCronStore(jobs: unknown[]) {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-summary-"));
+    tmpDirs.push(dir);
+    const storePath = path.join(dir, "jobs.json");
+    await fs.writeFile(storePath, JSON.stringify({ version: 1, jobs }));
+    return storePath;
+  }
+
+  afterEach(async () => {
+    for (const dir of tmpDirs) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+    tmpDirs.length = 0;
+  });
+
+  it("returns undefined when no cron jobs exist", async () => {
+    const storePath = await createTmpCronStore([]);
+    const result = await buildHeartbeatCronSummary({
+      cfg: { cron: { store: storePath } } as OpenClawConfig,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when all jobs are disabled", async () => {
+    const storePath = await createTmpCronStore([
+      {
+        id: "1",
+        name: "disabled-job",
+        enabled: false,
+        schedule: { kind: "cron", expr: "0 * * * *" },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "test" },
+        state: {},
+      },
+    ]);
+    const result = await buildHeartbeatCronSummary({
+      cfg: { cron: { store: storePath } } as OpenClawConfig,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("includes enabled jobs with schedule and target info", async () => {
+    const storePath = await createTmpCronStore([
+      {
+        id: "1",
+        name: "ai-news-daily",
+        enabled: true,
+        schedule: { kind: "cron", expr: "0 22 * * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "send news" },
+        state: {},
+      },
+      {
+        id: "2",
+        name: "morning-report",
+        enabled: true,
+        schedule: { kind: "cron", expr: "30 22 * * *" },
+        sessionTarget: "main",
+        payload: { kind: "systemEvent", text: "check report" },
+        state: {},
+      },
+    ]);
+    const result = await buildHeartbeatCronSummary({
+      cfg: { cron: { store: storePath } } as OpenClawConfig,
+    });
+    expect(result).toBeDefined();
+    expect(result).toContain("Active cron jobs");
+    expect(result).toContain("do NOT duplicate");
+    expect(result).toContain("ai-news-daily");
+    expect(result).toContain('cron "0 22 * * *" (UTC)');
+    expect(result).toContain("isolated, agentTurn");
+    expect(result).toContain("morning-report");
+    expect(result).toContain("main, systemEvent");
+  });
+
+  it("handles every-style schedules", async () => {
+    const storePath = await createTmpCronStore([
+      {
+        id: "1",
+        name: "backup",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 21600000 },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "backup" },
+        state: {},
+      },
+    ]);
+    const result = await buildHeartbeatCronSummary({
+      cfg: { cron: { store: storePath } } as OpenClawConfig,
+    });
+    expect(result).toContain("every 360m");
+  });
+
+  it("handles at-style schedules", async () => {
+    const storePath = await createTmpCronStore([
+      {
+        id: "1",
+        name: "one-shot",
+        enabled: true,
+        schedule: { kind: "at", at: "2026-02-20T10:00:00Z" },
+        sessionTarget: "main",
+        payload: { kind: "systemEvent", text: "reminder" },
+        state: {},
+      },
+    ]);
+    const result = await buildHeartbeatCronSummary({
+      cfg: { cron: { store: storePath } } as OpenClawConfig,
+    });
+    expect(result).toContain("once at 2026-02-20T10:00:00Z");
+  });
+
+  it("returns undefined when cron store path does not exist", async () => {
+    const result = await buildHeartbeatCronSummary({
+      cfg: { cron: { store: "/tmp/nonexistent-cron-store-12345/jobs.json" } } as OpenClawConfig,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("filters out disabled jobs from summary", async () => {
+    const storePath = await createTmpCronStore([
+      {
+        id: "1",
+        name: "enabled-job",
+        enabled: true,
+        schedule: { kind: "cron", expr: "0 * * * *" },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "test" },
+        state: {},
+      },
+      {
+        id: "2",
+        name: "disabled-job",
+        enabled: false,
+        schedule: { kind: "cron", expr: "0 * * * *" },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "test" },
+        state: {},
+      },
+    ]);
+    const result = await buildHeartbeatCronSummary({
+      cfg: { cron: { store: storePath } } as OpenClawConfig,
+    });
+    expect(result).toContain("enabled-job");
+    expect(result).not.toContain("disabled-job");
+  });
+});

--- a/src/infra/heartbeat-cron-summary.ts
+++ b/src/infra/heartbeat-cron-summary.ts
@@ -1,0 +1,52 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { CronJob, CronSchedule } from "../cron/types.js";
+import { loadCronStore, resolveCronStorePath } from "../cron/store.js";
+
+/** Maximum number of cron jobs to include in the heartbeat summary. */
+const MAX_JOBS = 15;
+
+function formatSchedule(schedule: CronSchedule): string {
+  switch (schedule.kind) {
+    case "at":
+      return `once at ${schedule.at}`;
+    case "every":
+      return `every ${Math.round(schedule.everyMs / 1000 / 60)}m`;
+    case "cron":
+      return schedule.tz ? `cron "${schedule.expr}" (${schedule.tz})` : `cron "${schedule.expr}"`;
+  }
+}
+
+function summarizeJob(job: CronJob): string {
+  const schedule = formatSchedule(job.schedule);
+  const target = job.sessionTarget === "isolated" ? "isolated" : "main";
+  const payloadKind = job.payload.kind === "agentTurn" ? "agentTurn" : "systemEvent";
+  return `- ${job.name}: ${schedule} [${target}, ${payloadKind}]`;
+}
+
+/**
+ * Build a compact summary of enabled cron jobs for injection into the heartbeat prompt.
+ * Returns `undefined` when no enabled jobs exist or the cron store cannot be read.
+ */
+export async function buildHeartbeatCronSummary(params: {
+  cfg: OpenClawConfig;
+}): Promise<string | undefined> {
+  try {
+    const storePath = resolveCronStorePath(params.cfg.cron?.store);
+    const store = await loadCronStore(storePath);
+    const enabledJobs = store.jobs.filter((j) => j.enabled);
+    if (enabledJobs.length === 0) {
+      return undefined;
+    }
+    const lines = enabledJobs.slice(0, MAX_JOBS).map(summarizeJob);
+    if (enabledJobs.length > MAX_JOBS) {
+      lines.push(`... and ${enabledJobs.length - MAX_JOBS} more`);
+    }
+    return [
+      "Active cron jobs (do NOT duplicate these in heartbeat — they run automatically):",
+      ...lines,
+    ].join("\n");
+  } catch {
+    // Cron store unreadable — skip summary silently.
+    return undefined;
+  }
+}

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import type { ChannelHeartbeatDeps } from "../channels/plugins/types.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
+import type { OutboundSendDeps } from "./outbound/deliver.js";
 import {
   resolveAgentConfig,
   resolveAgentWorkspaceDir,
@@ -18,11 +23,8 @@ import {
 } from "../auto-reply/heartbeat.js";
 import { getReplyFromConfig } from "../auto-reply/reply.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
-import type { ReplyPayload } from "../auto-reply/types.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
-import type { ChannelHeartbeatDeps } from "../channels/plugins/types.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
-import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
   canonicalizeMainSessionAlias,
@@ -34,7 +36,6 @@ import {
   saveSessionStore,
   updateSessionStore,
 } from "../config/sessions.js";
-import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
@@ -43,6 +44,7 @@ import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { escapeRegExp } from "../utils.js";
 import { formatErrorMessage } from "./errors.js";
 import { isWithinActiveHours } from "./heartbeat-active-hours.js";
+import { buildHeartbeatCronSummary } from "./heartbeat-cron-summary.js";
 import {
   buildCronEventPrompt,
   isCronSystemEvent,
@@ -56,7 +58,6 @@ import {
   requestHeartbeatNow,
   setHeartbeatWakeHandler,
 } from "./heartbeat-wake.js";
-import type { OutboundSendDeps } from "./outbound/deliver.js";
 import { deliverOutboundPayloads } from "./outbound/deliver.js";
 import {
   resolveHeartbeatDeliveryTarget,
@@ -590,11 +591,23 @@ export async function runHeartbeatOnce(opts: {
     .map((event) => event.text);
   const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);
   const hasCronEvents = cronEvents.length > 0;
-  const prompt = hasExecCompletion
+  const isRegularHeartbeat = !hasExecCompletion && !hasCronEvents;
+  const basePrompt = hasExecCompletion
     ? EXEC_EVENT_PROMPT
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents)
       : resolveHeartbeatPrompt(cfg, heartbeat);
+
+  // For regular heartbeat polls, append a summary of active cron jobs so the
+  // agent knows what is already automated and avoids duplicating that work.
+  let prompt = basePrompt;
+  if (isRegularHeartbeat) {
+    const cronSummary = await buildHeartbeatCronSummary({ cfg });
+    if (cronSummary) {
+      prompt = `${basePrompt}\n\n${cronSummary}`;
+    }
+  }
+
   const ctx = {
     Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
     From: sender,


### PR DESCRIPTION
## Problem

After context compaction, the LLM agent loses memory of which tasks are already automated via cron jobs. This causes duplicate work — e.g., the agent manually sends an AI news briefing during heartbeat even though a `ai-news-daily` cron job already handles it.

This is a general problem for any user running both heartbeat and cron: compaction erases the agent's knowledge of scheduled jobs, leading to redundant API calls, duplicate messages, and wasted tokens.

## Solution

During regular heartbeat polls, read the cron store and append a compact summary of enabled cron jobs to the heartbeat prompt:

```
Active cron jobs (do NOT duplicate these in heartbeat — they run automatically):
- ai-news-daily: cron "0 22 * * *" (UTC) [isolated, agentTurn]
- openclaw-backup: every 360m [isolated, agentTurn]
- morning-report: cron "30 22 * * *" [main, systemEvent]
```

Each job entry includes: name, schedule (cron/every/at), session target, and payload type. Capped at 15 jobs to bound token usage.

## Design decisions

- **Only injected for regular heartbeat polls** — exec-event and cron-event runs use specialized prompts and don't need the summary
- **Graceful fallback** — if the cron store is missing or unreadable, the summary is silently skipped
- **Read-only** — uses the existing `loadCronStore` from `src/cron/store.ts`, no new persistence layer
- **Minimal footprint** — new file `src/infra/heartbeat-cron-summary.ts` (~50 lines) + 1-line integration in `heartbeat-runner.ts`

## Files changed

- `src/infra/heartbeat-cron-summary.ts` — new helper to build compact cron summary
- `src/infra/heartbeat-cron-summary.test.ts` — 7 test cases covering all schedule types, disabled jobs, empty stores, and missing files
- `src/infra/heartbeat-runner.ts` — inject summary into regular heartbeat prompt

## Testing

All existing heartbeat tests pass (36 + 2 + 12 = 50 tests), plus 7 new tests for the summary builder.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds active cron job awareness to the heartbeat system by injecting a summary of enabled cron jobs into the heartbeat prompt. This prevents duplicate work after context compaction by reminding the agent which tasks are already automated.

Key changes:
- New helper function `buildHeartbeatCronSummary` reads the cron store and generates a compact text summary of enabled jobs (max 15 jobs)
- Summary includes job name, schedule (cron/every/at), session target (isolated/main), and payload type (agentTurn/systemEvent)
- Only injected during regular heartbeat polls, not for exec-event or cron-event runs
- Gracefully handles missing or unreadable cron stores by returning `undefined`
- Comprehensive test coverage (7 test cases) covering all schedule types, disabled jobs filtering, and edge cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with clear boundaries: it only reads from the cron store (no mutations), has comprehensive test coverage (7 test cases), gracefully handles all error conditions, and is narrowly scoped to regular heartbeat polls only. The code follows repository conventions for TypeScript, testing patterns, and error handling.
- No files require special attention

<sub>Last reviewed commit: cbb5cad</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->