### PR TITLE
fix(agents): always strip orphaned OpenAI reasoning items, not only on model change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: always strip orphaned OpenAI reasoning items from session history, not only on model changes — prevents persistent 400 errors after a gateway restart or interrupted call when using reasoning models (e.g. gpt-5.2).
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -366,10 +366,12 @@ export async function sanitizeSessionHistory(params: {
         modelId: params.modelId,
       })
     : false;
-  const sanitizedOpenAI =
-    isOpenAIResponsesApi && modelChanged
-      ? downgradeOpenAIReasoningBlocks(repairedTools)
-      : repairedTools;
+  // Always downgrade orphaned reasoning blocks for OpenAI Responses API — not just on model
+  // changes. A gateway restart or interrupted call can leave dangling reasoning items in history
+  // even when the model hasn't changed, causing 400 errors on subsequent calls.
+  const sanitizedOpenAI = isOpenAIResponsesApi
+    ? downgradeOpenAIReasoningBlocks(repairedTools)
+    : repairedTools;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {


### PR DESCRIPTION
## Summary

- `sanitizeSessionHistory()` was only calling `downgradeOpenAIReasoningBlocks()` when the model changed (`isOpenAIResponsesApi && modelChanged`), but orphaned reasoning items can appear **without** a model change — a gateway restart or interrupted API call leaves a dangling `reasoning` item in the session JSONL that causes every subsequent call to fail with:
  ```
  400 Item 'rs_...' of type 'reasoning' was provided without its required following item.
  ```
- Fix: always apply `downgradeOpenAIReasoningBlocks()` when using the OpenAI Responses API. The function already safely preserves valid reasoning+content pairs and only strips orphans, so applying it unconditionally is safe.

## Test plan

- [ ] Existing tests pass: `src/agents/pi-embedded-helpers.downgradeopenai-reasoning.test.ts` (4 tests) and `src/agents/openai-responses.reasoning-replay.test.ts` (2 tests) — all green
- [ ] Full test suite passes
- [ ] `pnpm build` and `pnpm check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed the `modelChanged` condition from `downgradeOpenAIReasoningBlocks()` call in `sanitizeSessionHistory()`, ensuring orphaned OpenAI reasoning items are always stripped when using the OpenAI Responses API. This prevents persistent 400 errors that occur after gateway restarts or interrupted API calls, where dangling reasoning items remain in session history even without model changes. The function safely preserves valid reasoning+content pairs and only removes orphans, making unconditional application both safe and necessary for reliability.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted fix that removes a restrictive condition causing bugs. The `downgradeOpenAIReasoningBlocks()` function is idempotent and designed to be safe when called unconditionally - it only removes orphaned reasoning blocks that would cause API errors, while preserving valid reasoning+content pairs. The fix is well-tested (6 existing tests), properly documented in the changelog, and addresses a real production issue where gateway restarts or interrupted calls leave dangling reasoning items that break subsequent API calls.
- No files require special attention

<sub>Last reviewed commit: 8107ad1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->