### PR TITLE
fix(session-memory): search state-dir sessions path when workspace differs

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -207,6 +207,9 @@ const saveSessionToMemory: HookHandler = async (event) => {
         sessionsDirs.add(path.dirname(currentSessionFile));
       }
       sessionsDirs.add(path.join(workspaceDir, "sessions"));
+      // Also search the actual state-dir sessions path (may differ from workspace)
+      const stateDir = resolveStateDir(process.env, os.homedir);
+      sessionsDirs.add(path.join(stateDir, "agents", agentId, "sessions"));
 
       for (const sessionsDir of sessionsDirs) {
         const recoveredSessionFile = await findPreviousSessionFile({


### PR DESCRIPTION
## Problem

When `workspaceDir` ≠ `stateDir` (common when workspace is a custom directory like `~/clawd` while state lives in `~/.openclaw`), the session-memory hook only searched `workspaceDir/sessions` for previous transcripts after `/new` or `/reset`.

The actual JSONL session files live in `~/.openclaw/agents/<id>/sessions/`, so the hook never found them — resulting in empty memory files with only 5 lines of metadata.

This is the root cause that recent fixes (19ae7a4, d6acd71, 3fff266) were circling around. Those addressed `.reset.` file rotation but missed the fundamental path mismatch.

## Fix

Add `stateDir/agents/<agentId>/sessions` to the search paths in `saveSessionToMemory`. 3 lines, uses the already-imported `resolveStateDir`.

## Testing

- Tested locally: `/new` now generates complete memory files with conversation summaries
- `pnpm build` passes
- AI-assisted (Claude), fully tested locally

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the root cause of incomplete session memory files by adding the actual state directory sessions path (`~/.openclaw/agents/<agentId>/sessions`) to the search locations when `workspaceDir` differs from `stateDir`.

- The session-memory hook now searches three locations: the current session file directory, `workspaceDir/sessions`, and `stateDir/agents/<agentId>/sessions`
- Previously only searched `workspaceDir/sessions`, which caused the hook to miss actual session transcripts living in `~/.openclaw/agents/<id>/sessions/`
- This resulted in empty memory files containing only 5 lines of metadata after `/new` or `/reset` commands
- The fix is minimal (3 lines), uses the already-imported `resolveStateDir` function, and follows the same pattern as other parts of the codebase that need to access per-agent session files

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical, well-tested locally, and addresses a clear path mismatch bug. The implementation uses existing utility functions, follows established patterns throughout the codebase (as seen in 20+ other files that use the same `stateDir/agents/<agentId>/sessions` path pattern), and is covered by the existing test suite that already verifies session file recovery logic
- No files require special attention

<sub>Last reviewed commit: 03bd9a1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->