### PR TITLE
feat: add Astrai as implicit provider (intelligent inference router)

### DIFF
--- a/docs/providers/astrai.md
+++ b/docs/providers/astrai.md
@@ -25,11 +25,11 @@ Instead of locking into a single provider, Astrai routes across OpenAI, Anthropi
 
 Astrai supports three routing strategies:
 
-| Strategy     | Description                                    |
-| ------------ | ---------------------------------------------- |
-| `balanced`   | Balance cost and quality (default)             |
-| `cheapest`   | Minimize cost while maintaining quality        |
-| `fastest`    | Minimize latency                               |
+| Strategy   | Description                             |
+| ---------- | --------------------------------------- |
+| `balanced` | Balance cost and quality (default)      |
+| `cheapest` | Minimize cost while maintaining quality |
+| `fastest`  | Minimize latency                        |
 
 ## Setup
 
@@ -63,11 +63,11 @@ openclaw chat --model astrai/auto "Hello, are you working?"
 
 ## Model Selection
 
-| Model ID           | Description                                              |
-| ------------------ | -------------------------------------------------------- |
-| `auto`             | Let Astrai pick the best model per request (recommended) |
-| `gpt-4o`           | Route to GPT-4o via cheapest available provider          |
-| `claude-sonnet-4`  | Route to Claude Sonnet 4 via cheapest provider           |
+| Model ID          | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `auto`            | Let Astrai pick the best model per request (recommended) |
+| `gpt-4o`          | Route to GPT-4o via cheapest available provider          |
+| `claude-sonnet-4` | Route to Claude Sonnet 4 via cheapest provider           |
 
 With `auto`, Astrai classifies each prompt's complexity and routes accordingly:
 
@@ -84,12 +84,12 @@ openclaw models set astrai/gpt-4o
 
 ## Features
 
-| Feature              | Support                        |
-| -------------------- | ------------------------------ |
-| **Streaming**        | Supported                      |
-| **Function calling** | Supported (model-dependent)    |
+| Feature              | Support                            |
+| -------------------- | ---------------------------------- |
+| **Streaming**        | Supported                          |
+| **Function calling** | Supported (model-dependent)        |
 | **Vision/Images**    | Supported on vision-capable models |
-| **JSON mode**        | Supported via `response_format` |
+| **JSON mode**        | Supported via `response_format`    |
 
 ## Config File Example
 

--- a/docs/providers/astrai.md
+++ b/docs/providers/astrai.md
@@ -1,0 +1,140 @@
+---
+summary: "Use Astrai intelligent inference router in OpenClaw"
+read_when:
+  - You want cost-optimized AI inference in OpenClaw
+  - You want automatic model selection across providers
+  - You want Astrai setup guidance
+title: "Astrai"
+---
+
+# Astrai (Intelligent Inference Router)
+
+**Astrai** is an AI inference router that automatically selects the optimal model and provider for each request based on cost, latency, and task complexity.
+
+Instead of locking into a single provider, Astrai routes across OpenAI, Anthropic, Google, Groq, DeepInfra, and more — finding the cheapest equivalent model that meets quality requirements. One API key, all providers.
+
+## Why Astrai in OpenClaw
+
+- **Automatic model selection** — set model to `auto` and Astrai picks the best model per request
+- **Cost optimization** — routes simple tasks to cheap models, complex tasks to frontier models
+- **Multi-provider failover** — automatic retry chain across all providers
+- **OpenAI-compatible API** — standard `/v1/chat/completions` endpoint
+- **Task-aware routing** — detects task type (code, research, chat) and picks optimal models
+
+## Routing Strategies
+
+Astrai supports three routing strategies:
+
+| Strategy     | Description                                    |
+| ------------ | ---------------------------------------------- |
+| `balanced`   | Balance cost and quality (default)             |
+| `cheapest`   | Minimize cost while maintaining quality        |
+| `fastest`    | Minimize latency                               |
+
+## Setup
+
+### 1. Get API Key
+
+1. Sign up at [astrai-compute.fly.dev](https://astrai-compute.fly.dev)
+2. Get your API key (format: `sk-astrai-...`)
+
+### 2. Configure OpenClaw
+
+**Option A: Environment Variable**
+
+```bash
+export ASTRAI_API_KEY="sk-astrai-xxxxxxxxxxxx"
+```
+
+**Option B: Config file**
+
+```json5
+{
+  env: { ASTRAI_API_KEY: "sk-astrai-..." },
+  agents: { defaults: { model: { primary: "astrai/auto" } } },
+}
+```
+
+### 3. Verify Setup
+
+```bash
+openclaw chat --model astrai/auto "Hello, are you working?"
+```
+
+## Model Selection
+
+| Model ID           | Description                                              |
+| ------------------ | -------------------------------------------------------- |
+| `auto`             | Let Astrai pick the best model per request (recommended) |
+| `gpt-4o`           | Route to GPT-4o via cheapest available provider          |
+| `claude-sonnet-4`  | Route to Claude Sonnet 4 via cheapest provider           |
+
+With `auto`, Astrai classifies each prompt's complexity and routes accordingly:
+
+- **Simple chat/summarization** → cheap models (Groq Llama, DeepInfra)
+- **Code generation** → Anthropic Claude or OpenAI Codex
+- **Complex reasoning** → frontier models (GPT-4o, Claude Opus)
+
+Change your default model anytime:
+
+```bash
+openclaw models set astrai/auto
+openclaw models set astrai/gpt-4o
+```
+
+## Features
+
+| Feature              | Support                        |
+| -------------------- | ------------------------------ |
+| **Streaming**        | Supported                      |
+| **Function calling** | Supported (model-dependent)    |
+| **Vision/Images**    | Supported on vision-capable models |
+| **JSON mode**        | Supported via `response_format` |
+
+## Config File Example
+
+```json5
+{
+  env: { ASTRAI_API_KEY: "sk-astrai-..." },
+  agents: { defaults: { model: { primary: "astrai/auto" } } },
+  models: {
+    mode: "merge",
+    providers: {
+      astrai: {
+        baseUrl: "https://astrai-compute.fly.dev/v1",
+        apiKey: "${ASTRAI_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "auto",
+            name: "Astrai Auto (intelligent routing)",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 200000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+## Usage Examples
+
+```bash
+# Automatic model selection (recommended)
+openclaw chat --model astrai/auto
+
+# Route to GPT-4o via cheapest provider
+openclaw chat --model astrai/gpt-4o
+
+# Route to Claude via cheapest provider
+openclaw chat --model astrai/claude-sonnet-4
+```
+
+## Links
+
+- [Astrai GitHub](https://github.com/beee003/astrai-landing)
+- [API Base URL](https://astrai-compute.fly.dev)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -56,6 +56,7 @@ See [Venice AI](/providers/venice).
 - [vLLM (local models)](/providers/vllm)
 - [Qianfan](/providers/qianfan)
 - [NVIDIA](/providers/nvidia)
+- [Astrai (intelligent inference router)](/providers/astrai)
 
 ## Transcription providers
 


### PR DESCRIPTION
## Summary

- Adds **[Astrai](https://github.com/beee003/astrai-landing)** as an auto-detected implicit provider in OpenClaw's model catalog
- When `ASTRAI_API_KEY` is set (or an auth profile exists), Astrai appears as a provider with `astrai/auto`, `astrai/gpt-4o`, and `astrai/claude-sonnet-4` models
- Astrai is an AI inference router that auto-selects the optimal model/provider per request based on **cost, latency, and task complexity**
- Uses `openai-completions` API (OpenAI-compatible `/v1/chat/completions`)

### Why Astrai in OpenClaw

OpenClaw already supports 15+ providers, but each requires its own API key and manual model selection. Astrai adds **intelligent routing** — one API key covers all major providers (OpenAI, Anthropic, Google, Groq, DeepInfra, etc.), and `astrai/auto` automatically picks the best model per request:

- Simple chat → cheap models (Groq Llama, DeepInfra)
- Code generation → Claude or Codex
- Complex reasoning → frontier models (GPT-4o, Claude Opus)

Three routing strategies: `balanced` (default), `cheapest`, `fastest`.

### Changes

| File | Change |
|------|--------|
| `src/agents/models-config.providers.ts` | Add `ASTRAI_*` constants, `buildAstraiProvider()`, wire into `resolveImplicitProviders()` |
| `docs/providers/astrai.md` | Full provider documentation (setup, models, config examples) |
| `docs/providers/index.md` | Add Astrai to provider list |

### Usage

```bash
# Set API key
export ASTRAI_API_KEY="sk-astrai-xxxxxxxxxxxx"

# Use automatic model selection
openclaw chat --model astrai/auto "Hello!"

# Route to specific model via cheapest provider
openclaw chat --model astrai/gpt-4o "Write a function..."
```

### How it integrates

Follows the exact same pattern as other implicit providers (venice, together, nvidia, etc.):
- `resolveEnvApiKeyVarName("astrai")` checks for `ASTRAI_API_KEY` env var
- `resolveApiKeyFromProfiles()` checks auth profile store
- `buildAstraiProvider()` returns a `ProviderConfig` with `api: "openai-completions"`

## Test plan

- [ ] Verify `ASTRAI_API_KEY` env var triggers auto-detection
- [ ] Verify `openclaw models list | grep astrai` shows `astrai/auto`, `astrai/gpt-4o`, `astrai/claude-sonnet-4`
- [ ] Verify `openclaw chat --model astrai/auto` works with a valid key
- [ ] Verify existing providers are unaffected when `ASTRAI_API_KEY` is not set
- [ ] Verify docs render correctly in the provider index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Astrai as an implicit provider for intelligent inference routing across multiple AI providers. The implementation follows existing patterns (similar to NVIDIA, Venice, etc.) with auto-detection via `ASTRAI_API_KEY` env var and auth profiles.

**Critical issue found:** The `ASTRAI_API_KEY` environment variable won't be detected because the required entry is missing from the `envMap` in `src/agents/model-auth.ts`. This means the provider won't auto-enable even when the env var is set.

The documentation is comprehensive and follows existing provider docs patterns. Code structure matches other OpenAI-compatible providers (uses `openai-completions` API, proper cost/context configuration).

<h3>Confidence Score: 1/5</h3>

- This PR cannot be merged safely due to a critical bug that prevents the core functionality from working
- Score of 1 reflects a blocking logical error: the `ASTRAI_API_KEY` env var won't be recognized because it's not registered in the `envMap` in `model-auth.ts`. Without this registration, users cannot use the provider even if they set the env var correctly. The PR description's test plan explicitly requires verifying env var detection, which will fail. All other aspects (code structure, documentation, patterns) are correct.
- `src/agents/model-auth.ts` requires modification (not included in PR) to add `astrai: "ASTRAI_API_KEY"` to the envMap around line 318

<sub>Last reviewed commit: da18bc8</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->