### PR TITLE
fix: strip resolvedSkills from session store to prevent snapshot bloat

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -333,7 +333,10 @@ export async function compactEmbeddedPiSessionDirect(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
-    const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+    const shouldLoadSkillEntries =
+      !params.skillsSnapshot ||
+      (!params.skillsSnapshot.resolvedSkills &&
+        (!params.skillsSnapshot.skills || params.skillsSnapshot.skills.length === 0));
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -248,7 +248,10 @@ export async function runEmbeddedAttempt(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
-    const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+    const shouldLoadSkillEntries =
+      !params.skillsSnapshot ||
+      (!params.skillsSnapshot.resolvedSkills &&
+        (!params.skillsSnapshot.skills || params.skillsSnapshot.skills.length === 0));
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -121,7 +121,7 @@ function normalizeSessionStore(store: Record<string, SessionEntry>): void {
     // built-in skills are present.  The field is only needed at runtime; the
     // lightweight `skills` array (name + primaryEnv) is sufficient on disk.
     if (store[key]?.skillsSnapshot?.resolvedSkills) {
-      const { resolvedSkills: _, ...rest } = store[key].skillsSnapshot!;
+      const { resolvedSkills: _, ...rest } = store[key].skillsSnapshot;
       store[key] = { ...store[key], skillsSnapshot: rest };
     }
   }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -115,6 +115,15 @@ function normalizeSessionStore(store: Record<string, SessionEntry>): void {
     if (normalized !== entry) {
       store[key] = normalized;
     }
+    // Strip resolvedSkills from the snapshot before persisting — it contains
+    // full Skill objects (name, description, filePath, …) for every loaded
+    // skill and can bloat sessions.json by several MB per entry when many
+    // built-in skills are present.  The field is only needed at runtime; the
+    // lightweight `skills` array (name + primaryEnv) is sufficient on disk.
+    if (store[key]?.skillsSnapshot?.resolvedSkills) {
+      const { resolvedSkills: _, ...rest } = store[key].skillsSnapshot!;
+      store[key] = { ...store[key], skillsSnapshot: rest };
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Fixes #20528

`buildWorkspaceSkillSnapshot()` stores full `Skill` objects (name, description, filePath, etc.) in `resolvedSkills`, which gets serialized to `sessions.json`. With 3,138 built-in skills this adds ~2.9 MB per session entry, causing `sessions.json` to grow to hundreds of MB/day with frequent cron jobs.

## Solution

1. **`normalizeSessionStore()`** now strips `resolvedSkills` from each session's `skillsSnapshot` before persisting to disk. The lightweight `skills` array (`name` + `primaryEnv`) remains — sufficient for cache-hit checks.

2. **`shouldLoadSkillEntries`** in both `attempt.ts` and `compact.ts` now checks `skills.length > 0` as a fallback when `resolvedSkills` is absent (i.e. session restored from disk), so skill env overrides still work correctly without re-scanning the filesystem.

## Impact

- Session snapshots go from ~2.9 MB → ~18 KB per entry
- No behavioral change for in-memory runtime (resolvedSkills still populated during the session)
- Existing bloated sessions.json files are cleaned up on next write

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Strips the heavy `resolvedSkills` field (full Skill objects with name, description, filePath) from session snapshots before persisting to disk, reducing session storage from ~2.9 MB to ~18 KB per entry. The lightweight `skills` array (name + primaryEnv) remains sufficient for cache-hit checks and environment overrides.

**Key changes:**
- `normalizeSessionStore()` now removes `resolvedSkills` before disk persistence
- Updated fallback logic in `attempt.ts` and `compact.ts` to check `skills.length > 0` when `resolvedSkills` is absent
- No behavioral changes for runtime (resolvedSkills still populated during active sessions)
- Existing bloated sessions.json files automatically cleaned on next write

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are surgical, well-scoped, and address a clear performance issue. The logic correctly preserves the lightweight `skills` array for cache checks and env overrides while removing only the redundant heavy `resolvedSkills` field. The fallback condition properly handles all three scenarios: fresh sessions, in-memory sessions with resolvedSkills, and restored sessions with only the lightweight skills array.
- No files require special attention

<sub>Last reviewed commit: dba2024</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->