### PR TITLE
fix: handle malformed tool call JSON parse errors gracefully

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
@@ -156,35 +156,25 @@ describe("isMalformedToolCallError", () => {
   it("detects Anthropic tool_use JSON parse errors", () => {
     expect(
       isMalformedToolCallError(
-        'tool_use block had invalid JSON in "input": Unexpected token \'}\' at position 42',
+        "tool_use block had invalid JSON in \"input\": Unexpected token '}' at position 42",
       ),
     ).toBe(true);
   });
 
   it("detects tool_call with SyntaxError", () => {
-    expect(
-      isMalformedToolCallError(
-        "SyntaxError: JSON parse error in tool_call input",
-      ),
-    ).toBe(true);
+    expect(isMalformedToolCallError("SyntaxError: JSON parse error in tool_call input")).toBe(true);
   });
 
   it("detects tool_input with unterminated string", () => {
-    expect(
-      isMalformedToolCallError(
-        "tool_input: unterminated string in JSON at position 15",
-      ),
-    ).toBe(true);
+    expect(isMalformedToolCallError("tool_input: unterminated string in JSON at position 15")).toBe(
+      true,
+    );
   });
 
   it("does NOT match generic JSON errors without tool context", () => {
     expect(isMalformedToolCallError("Unexpected token in JSON")).toBe(false);
-    expect(isMalformedToolCallError("SyntaxError: JSON parse error")).toBe(
-      false,
-    );
-    expect(
-      isMalformedToolCallError("The user sent an unexpected token"),
-    ).toBe(false);
+    expect(isMalformedToolCallError("SyntaxError: JSON parse error")).toBe(false);
+    expect(isMalformedToolCallError("The user sent an unexpected token")).toBe(false);
   });
 
   it("returns false for empty/null input", () => {

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
@@ -5,6 +5,7 @@ import {
   formatBillingErrorMessage,
   formatAssistantErrorText,
   formatRawAssistantErrorForUi,
+  isMalformedToolCallError,
 } from "./pi-embedded-helpers.js";
 
 describe("formatAssistantErrorText", () => {
@@ -148,5 +149,45 @@ describe("formatRawAssistantErrorForUi", () => {
     expect(formatRawAssistantErrorForUi(htmlError)).toBe(
       "The AI service is temporarily unavailable (HTTP 521). Please try again in a moment.",
     );
+  });
+});
+
+describe("isMalformedToolCallError", () => {
+  it("detects Anthropic tool_use JSON parse errors", () => {
+    expect(
+      isMalformedToolCallError(
+        'tool_use block had invalid JSON in "input": Unexpected token \'}\' at position 42',
+      ),
+    ).toBe(true);
+  });
+
+  it("detects tool_call with SyntaxError", () => {
+    expect(
+      isMalformedToolCallError(
+        "SyntaxError: JSON parse error in tool_call input",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects tool_input with unterminated string", () => {
+    expect(
+      isMalformedToolCallError(
+        "tool_input: unterminated string in JSON at position 15",
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT match generic JSON errors without tool context", () => {
+    expect(isMalformedToolCallError("Unexpected token in JSON")).toBe(false);
+    expect(isMalformedToolCallError("SyntaxError: JSON parse error")).toBe(
+      false,
+    );
+    expect(
+      isMalformedToolCallError("The user sent an unexpected token"),
+    ).toBe(false);
+  });
+
+  it("returns false for empty/null input", () => {
+    expect(isMalformedToolCallError("")).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -29,6 +29,8 @@ export {
   isFailoverErrorMessage,
   isImageDimensionErrorMessage,
   isImageSizeError,
+  isMissingToolCallInputError,
+  isMalformedToolCallError,
   isOverloadedErrorMessage,
   isRawApiErrorPayload,
   isRateLimitAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -691,10 +691,20 @@ export function isMissingToolCallInputError(raw: string): boolean {
 }
 
 const MALFORMED_JSON_RE =
-  /unexpected (?:token|non-whitespace|character|end of json|number)|unterminated string|bad control character|expected (?:property name|'[,}]'|double-quoted)|json (?:parse|syntax)|syntaxerror.*json/i;
+  /(?:tool_use|tool.call|tool_input|input.*json|parse.*tool|tool.*parse).*(?:unexpected (?:token|non-whitespace|character|end of json|number)|unterminated string|bad control character|expected (?:property name|'[,}]'|double-quoted)|json (?:parse|syntax)|syntaxerror)|(?:unexpected (?:token|non-whitespace|character|end of json)|unterminated string|expected (?:property name|'[,}]'|double-quoted)|json (?:parse|syntax)|syntaxerror).*(?:tool_use|tool.call|tool_input)/i;
 
 export function isMalformedToolCallError(raw: string): boolean {
   if (!raw) {
+    return false;
+  }
+  // Fast path: must mention both JSON-parse-like errors AND tool context
+  const lower = raw.toLowerCase();
+  const hasToolContext =
+    lower.includes("tool_use") ||
+    lower.includes("tool_call") ||
+    lower.includes("tool_input") ||
+    lower.includes("tool call");
+  if (!hasToolContext) {
     return false;
   }
   return MALFORMED_JSON_RE.test(raw);


### PR DESCRIPTION
## Problem

Fixes #7867

When a model (e.g. Venice.ai Kimi K2.5) produces malformed tool call arguments — such as concatenated JSON `{}{"path":...}` — the JSON parse `SyntaxError` is surfaced verbatim to the user via the messaging channel:

> Unexpected non-whitespace character after JSON at position 2 (line 1 column 3)

This is confusing and leaks internal implementation details.

## Solution

Add `isMalformedToolCallError()` in `formatAssistantErrorText()` to detect common JSON `SyntaxError` patterns (unexpected token, unterminated string, etc.) and rewrite them to a user-friendly message:

> The model produced a malformed tool call that couldn't be parsed. Please try again — if this persists, switch to a different model or use /new to start a fresh session.

## Related

- #16673 (centralized outbound sanitization gate)
- #9951 (context overflow errors leak)
- #18937 (API error messages leak)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added detection and user-friendly formatting for malformed tool call JSON parse errors. When models like Venice.ai Kimi K2.5 produce invalid JSON (e.g., concatenated objects `{}{"path":...}`), the system now shows a helpful message instead of exposing raw `SyntaxError` details to users.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it adds defensive error handling for a specific edge case
- The change is small, focused, and defensive in nature. It improves user experience by sanitizing internal error messages. The regex pattern could theoretically have false positives, but given the context (error messages from LLM APIs), this is unlikely to cause issues in practice. The only concern is the lack of tests for the new functionality.
- No files require special attention

<sub>Last reviewed commit: 04d2107</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->