### PR TITLE
feat: centralized outbound message sanitization gate

### DIFF
--- a/src/infra/outbound/sanitize-outbound.ts
+++ b/src/infra/outbound/sanitize-outbound.ts
@@ -145,7 +145,7 @@ function looksLikeLeakedContent(text: string): boolean {
     lower.includes("[openclaw]") ||
     lower.includes("untrusted metadata") ||
     lower.includes("inbound_meta") ||
-    text.startsWith("{") ||
+    lower.startsWith("{") ||
     text.includes("at ") ||
     lower.includes("<!doctype") ||
     lower.includes("<html")

--- a/src/infra/outbound/sanitize-outbound.ts
+++ b/src/infra/outbound/sanitize-outbound.ts
@@ -23,9 +23,6 @@ import {
 
 // ── Patterns that indicate leaked internal content ──────────────────
 
-/** Raw JSON error payloads (e.g. `{"type":"error","error":{...}}`) */
-const RAW_JSON_ERROR_RE = /^\s*\{[\s\S]*"(?:error|type|message|status)"[\s\S]*\}\s*$/;
-
 /** Internal [openclaw] prefixed system messages that should never reach users */
 const INTERNAL_PREFIX_RE = /^\[openclaw\]\s*⚠️?\s*🛠️?\s*(?:Exec|Tool|Command)/i;
 

--- a/src/infra/outbound/sanitize-outbound.ts
+++ b/src/infra/outbound/sanitize-outbound.ts
@@ -1,0 +1,156 @@
+/**
+ * Centralized outbound text sanitization gate.
+ *
+ * Every message leaving the gateway passes through `sanitizeOutboundText()`
+ * before hitting any channel send function.  This is the single point of
+ * control that prevents internal errors, raw API payloads, and metadata
+ * from leaking to end-users.
+ *
+ * Related issues: #7867, #9951, #11038, #16673, #18937, #20004, #20279
+ */
+
+import {
+  isRawApiErrorPayload,
+  isContextOverflowError,
+  isRateLimitErrorMessage,
+  isBillingErrorMessage,
+  isTimeoutErrorMessage,
+  isOverloadedErrorMessage,
+  isCloudflareOrHtmlErrorPage,
+  formatRawAssistantErrorForUi,
+  formatBillingErrorMessage,
+} from "../../agents/pi-embedded-helpers/errors.js";
+
+// ── Patterns that indicate leaked internal content ──────────────────
+
+/** Raw JSON error payloads (e.g. `{"type":"error","error":{...}}`) */
+const RAW_JSON_ERROR_RE = /^\s*\{[\s\S]*"(?:error|type|message|status)"[\s\S]*\}\s*$/;
+
+/** Internal [openclaw] prefixed system messages that should never reach users */
+const INTERNAL_PREFIX_RE = /^\[openclaw\]\s*⚠️?\s*🛠️?\s*(?:Exec|Tool|Command)/i;
+
+/** Stack traces */
+const STACK_TRACE_RE = /^\s*at\s+[\w$.]+\s+\(.*:\d+:\d+\)/m;
+
+/** Conversation metadata leak (untrusted metadata headers from inbound context) */
+const METADATA_LEAK_RE =
+  /Conversation info \(untrusted metadata\)|Sender \(untrusted metadata\)|"schema"\s*:\s*"openclaw\.inbound_meta/;
+
+/** HTTP status code prefix with raw body */
+const HTTP_ERROR_BODY_RE = /^(?:HTTP\s*)?\d{3}\s+\{[\s\S]*\}\s*$/;
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/**
+ * Sanitize text before it is sent to any outbound channel.
+ *
+ * Returns the original text unchanged when it looks safe, or a
+ * rewritten user-friendly message when it matches a known leak pattern.
+ */
+export function sanitizeOutboundText(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return text;
+  }
+
+  // ── Fast path: most messages are normal assistant text ──────────
+  // Only run expensive checks when the text looks suspicious.
+  if (!looksLikeLeakedContent(trimmed)) {
+    return text;
+  }
+
+  // ── Context overflow ───────────────────────────────────────────
+  if (isContextOverflowError(trimmed)) {
+    return (
+      "Context overflow: prompt too large for the model. " +
+      "Try /reset (or /new) to start a fresh session, or use a larger-context model."
+    );
+  }
+
+  // ── Rate limit / overloaded ────────────────────────────────────
+  if (isRateLimitErrorMessage(trimmed)) {
+    return "⚠️ API rate limit reached. Please try again later.";
+  }
+  if (isOverloadedErrorMessage(trimmed)) {
+    return "The AI service is temporarily overloaded. Please try again in a moment.";
+  }
+
+  // ── Billing ────────────────────────────────────────────────────
+  if (isBillingErrorMessage(trimmed)) {
+    return formatBillingErrorMessage();
+  }
+
+  // ── Timeout ────────────────────────────────────────────────────
+  if (isTimeoutErrorMessage(trimmed)) {
+    return "LLM request timed out.";
+  }
+
+  // ── Cloudflare / HTML error pages ──────────────────────────────
+  if (isCloudflareOrHtmlErrorPage(trimmed)) {
+    return "The AI service is temporarily unavailable. Please try again in a moment.";
+  }
+
+  // ── Raw API JSON error payloads ────────────────────────────────
+  if (isRawApiErrorPayload(trimmed)) {
+    return formatRawAssistantErrorForUi(trimmed);
+  }
+
+  // ── Internal [openclaw] system messages ────────────────────────
+  if (INTERNAL_PREFIX_RE.test(trimmed)) {
+    return "⚠️ An internal error occurred. Please try again.";
+  }
+
+  // ── Conversation metadata / PII leak ───────────────────────────
+  if (METADATA_LEAK_RE.test(trimmed)) {
+    return "⚠️ An internal error occurred. Please try again.";
+  }
+
+  // ── Stack traces ───────────────────────────────────────────────
+  if (STACK_TRACE_RE.test(trimmed)) {
+    return "⚠️ An internal error occurred. Please try again.";
+  }
+
+  // ── HTTP error with raw JSON body ──────────────────────────────
+  if (HTTP_ERROR_BODY_RE.test(trimmed)) {
+    return formatRawAssistantErrorForUi(trimmed);
+  }
+
+  return text;
+}
+
+// ── Heuristic pre-filter ────────────────────────────────────────────
+
+/**
+ * Quick check to decide whether the text *might* contain leaked content.
+ * Avoids running all the regex checks on normal assistant messages.
+ */
+function looksLikeLeakedContent(text: string): boolean {
+  // Short texts are unlikely to be leaked payloads
+  if (text.length < 20) {
+    return false;
+  }
+
+  const lower = text.toLowerCase();
+  return (
+    lower.includes("error") ||
+    lower.includes("rate limit") ||
+    lower.includes("context") ||
+    lower.includes("overflow") ||
+    lower.includes("timeout") ||
+    lower.includes("timed out") ||
+    lower.includes("overloaded") ||
+    lower.includes("billing") ||
+    lower.includes("credits") ||
+    lower.includes("[openclaw]") ||
+    lower.includes("untrusted metadata") ||
+    lower.includes("inbound_meta") ||
+    text.startsWith("{") ||
+    text.includes("at ") ||
+    lower.includes("<!doctype") ||
+    lower.includes("<html")
+  );
+}


### PR DESCRIPTION
## Problem

Fixes #16673

The current error sanitization is scattered across multiple per-tool and per-error-type handlers. Each new tool or API integration can introduce new leak vectors that require patching individually. This has led to multiple related issues:

- #7867 — Malformed tool call errors leaked verbatim
- #9951 — Context overflow errors leak to user
- #11038 — Context corruption exposes raw API errors
- #18937 — API error messages (401) leaked to user channel
- #20004 — Internal error messages leaking to WhatsApp contacts
- #20279 — PII exposed in "Media failed" error messages

## Solution

Add a single `sanitizeOutboundText()` gate in `deliver.ts` at the `deliverOutboundPayloadsCore()` boundary — every `payload.text` gets sanitized before hitting any channel send function, regardless of source.

### Architecture

```
Before: Tool errors → payloads.ts (per-tool sanitization) → deliver.ts → channels
After:  Tool errors → payloads.ts (raw) → deliver.ts (central sanitizer) → channels
```

### What it catches

- Raw API JSON error payloads (`{"type":"error",...}`)
- Context overflow / rate limit / billing / timeout errors
- Cloudflare/HTML error pages
- Internal `[openclaw]` system messages
- Conversation metadata / PII leaks
- Stack traces
- HTTP errors with raw JSON bodies

### Performance

A fast-path heuristic (`looksLikeLeakedContent()`) avoids running expensive regex checks on normal assistant messages — only suspicious text triggers the full sanitization pipeline.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added centralized sanitization gate in `deliverOutboundPayloadsCore()` at deliver.ts:529. Every outbound message now passes through `sanitizeOutboundText()` before hitting any channel send function, catching leaked API errors, raw JSON payloads, internal metadata, and stack traces regardless of source.

Key implementation details:
- Fast-path heuristic (`looksLikeLeakedContent()`) avoids expensive regex checks on normal assistant messages
- Reuses existing error detection helpers from `pi-embedded-helpers/errors.ts`
- Sanitization runs after `message_sending` hook but before actual channel delivery
- Replaces leaked content with user-friendly error messages

Found one inconsistency in the fast-path heuristic where one check operates on the untrimmed original text while others use the lowercased trimmed version.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor syntax fix
- The implementation follows sound architectural principles with a single sanitization gate, reuses well-tested error detection helpers, and includes a performance optimization via fast-path heuristic. One minor inconsistency exists in the heuristic that should be fixed, but it's unlikely to cause issues in practice since trimmed text would still be caught by downstream regex checks
- src/infra/outbound/sanitize-outbound.ts requires a one-line fix for the fast-path heuristic inconsistency

<sub>Last reviewed commit: 64481fe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->