### PR TITLE
fix: gate Telegram exec tool warnings behind verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/Agents: gate exec/bash tool-failure warnings behind verbose mode so default Telegram replies stay clean while verbose sessions still surface diagnostics. (#20560) Thanks @obviyus.
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
 - Agents/Billing: include the active model that produced a billing error in user-facing billing messages (for example, `OpenAI (gpt-5.3)`) across payload, failover, and lifecycle error paths, so users can identify exactly which key needs credits. (#20510) Thanks @echoVic.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.

--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -163,7 +163,7 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toBe("All good");
   });
 
-  it("adds tool error fallback when the assistant only invoked tools", () => {
+  it("adds tool error fallback when the assistant only invoked tools and verbose mode is on", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({
         stopReason: "toolUse",
@@ -178,6 +178,7 @@ describe("buildEmbeddedRunPayloads", () => {
         ],
       }),
       lastToolError: { toolName: "exec", error: "Command exited with code 1" },
+      verboseLevel: "on",
     });
 
     expect(payloads).toHaveLength(1);

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildEmbeddedRunPayloads } from "./payloads.js";
+
+type BuildPayloadParams = Parameters<typeof buildEmbeddedRunPayloads>[0];
+
+function buildPayloads(overrides: Partial<BuildPayloadParams> = {}) {
+  return buildEmbeddedRunPayloads({
+    assistantTexts: [],
+    toolMetas: [],
+    lastAssistant: undefined,
+    sessionKey: "session:telegram",
+    inlineToolResultsAllowed: false,
+    verboseLevel: "off",
+    reasoningLevel: "off",
+    toolResultFormat: "plain",
+    ...overrides,
+  });
+}
+
+describe("buildEmbeddedRunPayloads tool-error warnings", () => {
+  it("suppresses exec tool errors when verbose mode is off", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "exec", error: "command failed" },
+      verboseLevel: "off",
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("shows exec tool errors when verbose mode is on", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "exec", error: "command failed" },
+      verboseLevel: "on",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("Exec");
+    expect(payloads[0]?.text).toContain("command failed");
+  });
+
+  it("keeps non-exec mutating tool failures visible", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "write", error: "permission denied" },
+      verboseLevel: "off",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("Write");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -49,8 +49,14 @@ function shouldShowToolErrorWarning(params: {
   hasUserFacingReply: boolean;
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean;
+  verboseLevel?: VerboseLevel;
 }): boolean {
   if (params.suppressToolErrorWarnings) {
+    return false;
+  }
+  const normalizedToolName = params.lastToolError.toolName.trim().toLowerCase();
+  const verboseEnabled = params.verboseLevel === "on" || params.verboseLevel === "full";
+  if ((normalizedToolName === "exec" || normalizedToolName === "bash") && !verboseEnabled) {
     return false;
   }
   const isMutatingToolError =
@@ -255,6 +261,7 @@ export function buildEmbeddedRunPayloads(params: {
       hasUserFacingReply: hasUserFacingAssistantReply,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+      verboseLevel: params.verboseLevel,
     });
 
     // Always surface mutating tool failures so we do not silently confirm actions that did not happen.

--- a/src/agents/pi-embedded-subscribe.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { extractToolErrorMessage } from "./pi-embedded-subscribe.tools.js";
+
+describe("extractToolErrorMessage", () => {
+  it("ignores non-error status values", () => {
+    expect(extractToolErrorMessage({ details: { status: "0" } })).toBeUndefined();
+    expect(extractToolErrorMessage({ details: { status: "completed" } })).toBeUndefined();
+    expect(extractToolErrorMessage({ details: { status: "ok" } })).toBeUndefined();
+  });
+
+  it("keeps error-like status values", () => {
+    expect(extractToolErrorMessage({ details: { status: "failed" } })).toBe("failed");
+    expect(extractToolErrorMessage({ details: { status: "timeout" } })).toBe("timeout");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -29,6 +29,23 @@ function normalizeToolErrorText(text: string): string | undefined {
     : firstLine;
 }
 
+function isErrorLikeStatus(status: string): boolean {
+  const normalized = status.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (
+    normalized === "0" ||
+    normalized === "ok" ||
+    normalized === "success" ||
+    normalized === "completed" ||
+    normalized === "running"
+  ) {
+    return false;
+  }
+  return /error|fail|timeout|timed[_\s-]?out|denied|cancel|invalid|forbidden/.test(normalized);
+}
+
 function readErrorCandidate(value: unknown): string | undefined {
   if (typeof value === "string") {
     return normalizeToolErrorText(value);
@@ -59,7 +76,10 @@ function extractErrorField(value: unknown): string | undefined {
     return direct;
   }
   const status = typeof record.status === "string" ? record.status.trim() : "";
-  return status ? normalizeToolErrorText(status) : undefined;
+  if (!status || !isErrorLikeStatus(status)) {
+    return undefined;
+  }
+  return normalizeToolErrorText(status);
 }
 
 export function sanitizeToolResult(result: unknown): unknown {


### PR DESCRIPTION
## Summary

- Problem: Telegram users can see raw exec tool failure warnings (including command context) during normal runs.
- Why it matters: leaks internal tool details into end-user chats; noisy and unsafe by default.
- What changed: gate `exec`/`bash` tool-error warnings behind verbose mode (`on|full`) and ignore non-error status values like `0/ok/completed/running` when extracting tool error text.
- What did NOT change (scope boundary): non-exec mutating warnings (e.g. `write`) still surface as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #19912
- Related #19894

## User-visible / Behavior Changes

- Default (`verbose=off`): `exec`/`bash` failure warnings are suppressed from user-visible payloads.
- Verbose (`verbose=on|full`): `exec`/`bash` failure warnings remain visible.
- Tool error extraction no longer treats success-like status values (`0`, `ok`, `completed`, `running`) as error text.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: n/a (unit tests)
- Integration/channel (if any): Telegram dispatch path covered by tests
- Relevant config (redacted): verbose mode `off` vs `on`

### Steps

1. Build payloads with `lastToolError.toolName="exec"`, verbose `off`.
2. Build payloads with same error, verbose `on`.
3. Extract error message from `{ details: { status: "0" } }` and from `{ details: { status: "failed" } }`.

### Expected

- Step 1: no user-facing warning payload.
- Step 2: warning payload exists.
- Step 3: `"0"` ignored, `"failed"` preserved.

### Actual

- Matches expected in added tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: new unit tests + existing Telegram dispatch test.
- Edge cases checked: non-exec mutating warning (`write`) still visible; status-based false-positive error text removed.
- What you did **not** verify: live Telegram end-to-end against a real bot token.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/pi-embedded-runner/run/payloads.ts`, `src/agents/pi-embedded-subscribe.tools.ts`.
- Known bad symptoms reviewers should watch for: missing exec warnings in verbose mode (regression), or `failed: 0` style warnings returning.

## Risks and Mitigations

- Risk: users may miss exec failures in non-verbose mode if assistant text is empty.
  - Mitigation: behavior remains explicit in verbose mode; non-exec mutating tool warnings unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Gated `exec`/`bash` tool warnings behind verbose mode to prevent leaking internal command details to Telegram users, while filtering out false-positive error statuses like `0` or `completed`.

Key changes:
- `exec` and `bash` tool errors now suppressed in default mode, visible only when `verbose=on|full`
- Non-exec mutating tools (e.g. `write`) continue showing warnings regardless of verbose mode
- Status values like `0`, `ok`, `success`, `completed`, `running` no longer treated as errors
- Comprehensive test coverage added for both gating logic and status filtering

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no significant risks
- Well-scoped bug fix with thorough test coverage, clear behavioral boundaries, and no breaking changes. Logic correctly distinguishes between exec/bash tools (gated) and other mutating tools (always visible), with proper status filtering to avoid false positives.
- No files require special attention

<sub>Last reviewed commit: a68b696</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->