### PR TITLE
fix: skip default HEARTBEAT_OK instructions when custom prompt is set

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -618,15 +618,18 @@ export function buildAgentSystemPrompt(params: {
 
   // Skip heartbeats for subagent/none modes
   if (!isMinimal) {
-    lines.push(
-      "## Heartbeats",
-      heartbeatPromptLine,
-      "If you receive a heartbeat poll (a user message matching the heartbeat prompt above), and there is nothing that needs attention, reply exactly:",
-      "HEARTBEAT_OK",
-      'OpenClaw treats a leading/trailing "HEARTBEAT_OK" as a heartbeat ack (and may discard it).',
-      'If something needs attention, do NOT include "HEARTBEAT_OK"; reply with the alert text instead.',
-      "",
-    );
+    lines.push("## Heartbeats", heartbeatPromptLine);
+    // Only add default HEARTBEAT_OK instructions if no custom prompt is configured.
+    // Custom prompts define their own heartbeat behavior (e.g., Free Mind Protocol for autonomous agents).
+    if (!heartbeatPrompt) {
+      lines.push(
+        "If you receive a heartbeat poll (a user message matching the heartbeat prompt above), and there is nothing that needs attention, reply exactly:",
+        "HEARTBEAT_OK",
+        'OpenClaw treats a leading/trailing "HEARTBEAT_OK" as a heartbeat ack (and may discard it).',
+        'If something needs attention, do NOT include "HEARTBEAT_OK"; reply with the alert text instead.',
+        "",
+      );
+    }
   }
 
   lines.push(


### PR DESCRIPTION
## Problem

When a custom heartbeat prompt is configured via `agents.defaults.heartbeat.prompt`, the system prompt still includes hardcoded HEARTBEAT_OK instructions after the custom prompt. This causes conflicting guidance.

**Before (with custom prompt):**
```
## Heartbeats
Heartbeat prompt: <CUSTOM PROMPT>
If you receive a heartbeat poll... and there is nothing that needs attention, reply exactly:
HEARTBEAT_OK  <-- CONFLICTS with custom prompt!
```

## Solution

Only add the default HEARTBEAT_OK instructions when NO custom prompt is configured. Custom prompts should fully define their own heartbeat behavior.

**After (with custom prompt):**
```
## Heartbeats
Heartbeat prompt: <CUSTOM PROMPT>
```

**After (without custom prompt - default behavior):**
```
## Heartbeats
Heartbeat prompt: (configured)
If you receive a heartbeat poll... and there is nothing that needs attention, reply exactly:
HEARTBEAT_OK
```

## Use Case

This enables the "Free Mind Protocol" pattern where agents define custom heartbeat behavior that doesn't require HEARTBEAT_OK responses, allowing for more autonomous agent operation.

## Changes

- Modified `src/agents/system-prompt.ts` to conditionally add default HEARTBEAT_OK instructions only when no custom heartbeat prompt is set

## Testing

- Backward compatible: default behavior unchanged
- Custom prompts now work as expected without conflicting instructions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Conditionally adds default HEARTBEAT_OK instructions only when no custom heartbeat prompt is configured. When `agents.defaults.heartbeat.prompt` is set, the system prompt now excludes the default HEARTBEAT_OK instructions, allowing custom prompts to define their own heartbeat behavior without conflicting guidance.

- Modified `src/agents/system-prompt.ts:620-633` to wrap HEARTBEAT_OK instructions in `if (!heartbeatPrompt)` check
- The `heartbeatPrompt` variable is already trimmed at line 345, so the check correctly identifies when a custom prompt is set
- Maintains backward compatibility: default behavior unchanged when no custom prompt is configured
- Enables custom heartbeat patterns like "Free Mind Protocol" for autonomous agent operation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal, well-contained, and logically correct. It adds a simple conditional check that preserves existing behavior when no custom prompt is set, while fixing the conflicting instructions issue when a custom prompt is configured. The variable `heartbeatPrompt` is already properly trimmed at line 345, ensuring the boolean check works correctly for empty strings, undefined, and actual custom prompts.
- No files require special attention

<sub>Last reviewed commit: 8447d89</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->