### PR TITLE
fix: run BOOT.md for each configured agent at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Hooks: run BOOT.md startup checks per configured agent scope, including per-agent session-key resolution, startup-hook regression coverage, and non-success boot outcome logging for diagnosability. (#20569) thanks @mcaxtr.
 - Telegram: unify message-like inbound handling so `message` and `channel_post` share the same dedupe/access/media pipeline and remain behaviorally consistent. (#20591) Thanks @obviyus.
 - Telegram/Agents: gate exec/bash tool-failure warnings behind verbose mode so default Telegram replies stay clean while verbose sessions still surface diagnostics. (#20560) Thanks @obviyus.
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.

--- a/src/gateway/boot.test.ts
+++ b/src/gateway/boot.test.ts
@@ -9,7 +9,7 @@ const agentCommand = vi.fn();
 vi.mock("../commands/agent.js", () => ({ agentCommand }));
 
 const { runBootOnce } = await import("./boot.js");
-const { resolveAgentIdFromSessionKey, resolveMainSessionKey } =
+const { resolveAgentIdFromSessionKey, resolveAgentMainSessionKey, resolveMainSessionKey } =
   await import("../config/sessions/main-session.js");
 const { resolveStorePath } = await import("../config/sessions/paths.js");
 const { loadSessionStore, saveSessionStore } = await import("../config/sessions/store.js");
@@ -95,6 +95,24 @@ describe("runBootOnce", () => {
     expect(call?.message).toContain("BOOT.md:");
     expect(call?.message).toContain(content);
     expect(call?.message).toContain("NO_REPLY");
+
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("uses per-agent session key when agentId is provided", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-boot-"));
+    await fs.writeFile(path.join(workspaceDir, "BOOT.md"), "Check status.", "utf-8");
+
+    agentCommand.mockResolvedValue(undefined);
+    const cfg = {};
+    const agentId = "ops";
+    await expect(runBootOnce({ cfg, deps: makeDeps(), workspaceDir, agentId })).resolves.toEqual({
+      status: "ran",
+    });
+
+    expect(agentCommand).toHaveBeenCalledTimes(1);
+    const perAgentCall = agentCommand.mock.calls[0]?.[0];
+    expect(perAgentCall?.sessionKey).toBe(resolveAgentMainSessionKey({ cfg, agentId }));
 
     await fs.rm(workspaceDir, { recursive: true, force: true });
   });

--- a/src/gateway/boot.ts
+++ b/src/gateway/boot.ts
@@ -1,11 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { CliDeps } from "../cli/deps.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type { SessionEntry } from "../config/sessions/types.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import type { CliDeps } from "../cli/deps.js";
 import { agentCommand } from "../commands/agent.js";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveAgentMainSessionKey,
@@ -13,6 +12,7 @@ import {
 } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore, updateSessionStore } from "../config/sessions/store.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { type RuntimeEnv, defaultRuntime } from "../runtime.js";
 

--- a/src/gateway/boot.ts
+++ b/src/gateway/boot.ts
@@ -1,17 +1,18 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { CliDeps } from "../cli/deps.js";
-import { agentCommand } from "../commands/agent.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { agentCommand } from "../commands/agent.js";
 import {
   resolveAgentIdFromSessionKey,
+  resolveAgentMainSessionKey,
   resolveMainSessionKey,
 } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore, updateSessionStore } from "../config/sessions/store.js";
-import type { SessionEntry } from "../config/sessions/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { type RuntimeEnv, defaultRuntime } from "../runtime.js";
 
@@ -138,6 +139,7 @@ export async function runBootOnce(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;
   workspaceDir: string;
+  agentId?: string;
 }): Promise<BootRunResult> {
   const bootRuntime: RuntimeEnv = {
     log: () => {},
@@ -157,7 +159,9 @@ export async function runBootOnce(params: {
     return { status: "skipped", reason: result.status };
   }
 
-  const sessionKey = resolveMainSessionKey(params.cfg);
+  const sessionKey = params.agentId
+    ? resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.agentId })
+    : resolveMainSessionKey(params.cfg);
   const message = buildBootPrompt(result.content ?? "");
   const sessionId = generateBootSessionId();
   const mappingSnapshot = snapshotMainSessionMapping({

--- a/src/hooks/bundled/boot-md/HOOK.md
+++ b/src/hooks/bundled/boot-md/HOOK.md
@@ -16,4 +16,5 @@ metadata:
 
 # Boot Checklist Hook
 
-Runs `BOOT.md` every time the gateway starts, if the file exists in the workspace.
+Runs `BOOT.md` at gateway startup for each configured agent scope, if the file exists in that
+agent's resolved workspace.

--- a/src/hooks/bundled/boot-md/handler.gateway-startup.integration.test.ts
+++ b/src/hooks/bundled/boot-md/handler.gateway-startup.integration.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../../../cli/deps.js";
+import type { OpenClawConfig } from "../../../config/config.js";
+
+const runBootOnce = vi.fn();
+
+vi.mock("../../../gateway/boot.js", () => ({ runBootOnce }));
+vi.mock("../../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const { default: runBootChecklist } = await import("./handler.js");
+const { clearInternalHooks, createInternalHookEvent, registerInternalHook, triggerInternalHook } =
+  await import("../../internal-hooks.js");
+
+describe("boot-md startup hook integration", () => {
+  beforeEach(() => {
+    runBootOnce.mockReset();
+    clearInternalHooks();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+  });
+
+  it("dispatches gateway:startup through internal hooks and runs BOOT for each configured agent scope", async () => {
+    const cfg = {
+      hooks: { internal: { enabled: true } },
+      agents: {
+        list: [
+          { id: "main", default: true, workspace: "/ws/main" },
+          { id: "ops", workspace: "/ws/ops" },
+        ],
+      },
+    } as OpenClawConfig;
+    const deps = {} as CliDeps;
+    runBootOnce.mockResolvedValue({ status: "ran" });
+
+    registerInternalHook("gateway:startup", runBootChecklist);
+    const event = createInternalHookEvent("gateway", "startup", "gateway:startup", { cfg, deps });
+    await triggerInternalHook(event);
+
+    expect(runBootOnce).toHaveBeenCalledTimes(2);
+    expect(runBootOnce).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ cfg, deps, workspaceDir: "/ws/main", agentId: "main" }),
+    );
+    expect(runBootOnce).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ cfg, deps, workspaceDir: "/ws/ops", agentId: "ops" }),
+    );
+  });
+});

--- a/src/hooks/bundled/boot-md/handler.test.ts
+++ b/src/hooks/bundled/boot-md/handler.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InternalHookEvent } from "../../internal-hooks.js";
+
+const runBootOnce = vi.fn();
+const listAgentIds = vi.fn();
+const resolveAgentWorkspaceDir = vi.fn();
+
+vi.mock("../../../gateway/boot.js", () => ({ runBootOnce }));
+vi.mock("../../../agents/agent-scope.js", () => ({
+  listAgentIds,
+  resolveAgentWorkspaceDir,
+}));
+
+const { default: runBootChecklist } = await import("./handler.js");
+
+function makeEvent(overrides?: Partial<InternalHookEvent>): InternalHookEvent {
+  return {
+    type: "gateway",
+    action: "startup",
+    sessionKey: "test",
+    context: {},
+    timestamp: new Date(),
+    messages: [],
+    ...overrides,
+  };
+}
+
+describe("boot-md handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips non-gateway events", async () => {
+    await runBootChecklist(makeEvent({ type: "command", action: "new" }));
+    expect(runBootOnce).not.toHaveBeenCalled();
+  });
+
+  it("skips non-startup actions", async () => {
+    await runBootChecklist(makeEvent({ action: "shutdown" }));
+    expect(runBootOnce).not.toHaveBeenCalled();
+  });
+
+  it("skips when cfg is missing from context", async () => {
+    await runBootChecklist(makeEvent({ context: { workspaceDir: "/tmp" } }));
+    expect(runBootOnce).not.toHaveBeenCalled();
+  });
+
+  it("runs boot for each agent", async () => {
+    const cfg = { agents: { list: [{ id: "main" }, { id: "ops" }] } };
+    listAgentIds.mockReturnValue(["main", "ops"]);
+    resolveAgentWorkspaceDir.mockImplementation((_cfg: unknown, id: string) => `/ws/${id}`);
+    runBootOnce.mockResolvedValue({ status: "ran" });
+
+    await runBootChecklist(makeEvent({ context: { cfg } }));
+
+    expect(listAgentIds).toHaveBeenCalledWith(cfg);
+    expect(runBootOnce).toHaveBeenCalledTimes(2);
+    expect(runBootOnce).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg, workspaceDir: "/ws/main", agentId: "main" }),
+    );
+    expect(runBootOnce).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg, workspaceDir: "/ws/ops", agentId: "ops" }),
+    );
+  });
+
+  it("runs boot for single default agent when no agents configured", async () => {
+    const cfg = {};
+    listAgentIds.mockReturnValue(["main"]);
+    resolveAgentWorkspaceDir.mockReturnValue("/ws/main");
+    runBootOnce.mockResolvedValue({ status: "skipped", reason: "missing" });
+
+    await runBootChecklist(makeEvent({ context: { cfg } }));
+
+    expect(runBootOnce).toHaveBeenCalledTimes(1);
+    expect(runBootOnce).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg, workspaceDir: "/ws/main", agentId: "main" }),
+    );
+  });
+});

--- a/src/hooks/bundled/boot-md/handler.ts
+++ b/src/hooks/bundled/boot-md/handler.ts
@@ -1,15 +1,18 @@
-import type { CliDeps } from "../../../cli/deps.js";
-import type { OpenClawConfig } from "../../../config/config.js";
-import type { HookHandler } from "../../hooks.js";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import type { CliDeps } from "../../../cli/deps.js";
 import { createDefaultDeps } from "../../../cli/deps.js";
+import type { OpenClawConfig } from "../../../config/config.js";
 import { runBootOnce } from "../../../gateway/boot.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { HookHandler } from "../../hooks.js";
 
 type BootHookContext = {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   deps?: CliDeps;
 };
+
+const log = createSubsystemLogger("hooks/boot-md");
 
 const runBootChecklist: HookHandler = async (event) => {
   if (event.type !== "gateway" || event.action !== "startup") {
@@ -26,7 +29,22 @@ const runBootChecklist: HookHandler = async (event) => {
 
   for (const agentId of agentIds) {
     const workspaceDir = resolveAgentWorkspaceDir(context.cfg, agentId);
-    await runBootOnce({ cfg: context.cfg, deps, workspaceDir, agentId });
+    const result = await runBootOnce({ cfg: context.cfg, deps, workspaceDir, agentId });
+    if (result.status === "failed") {
+      log.warn("boot-md failed for agent startup run", {
+        agentId,
+        workspaceDir,
+        reason: result.reason,
+      });
+      continue;
+    }
+    if (result.status === "skipped") {
+      log.debug("boot-md skipped for agent startup run", {
+        agentId,
+        workspaceDir,
+        reason: result.reason,
+      });
+    }
   }
 };
 

--- a/src/hooks/bundled/boot-md/handler.ts
+++ b/src/hooks/bundled/boot-md/handler.ts
@@ -1,8 +1,9 @@
 import type { CliDeps } from "../../../cli/deps.js";
-import { createDefaultDeps } from "../../../cli/deps.js";
 import type { OpenClawConfig } from "../../../config/config.js";
-import { runBootOnce } from "../../../gateway/boot.js";
 import type { HookHandler } from "../../hooks.js";
+import { listAgentIds, resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import { createDefaultDeps } from "../../../cli/deps.js";
+import { runBootOnce } from "../../../gateway/boot.js";
 
 type BootHookContext = {
   cfg?: OpenClawConfig;
@@ -16,12 +17,17 @@ const runBootChecklist: HookHandler = async (event) => {
   }
 
   const context = (event.context ?? {}) as BootHookContext;
-  if (!context.cfg || !context.workspaceDir) {
+  if (!context.cfg) {
     return;
   }
 
   const deps = context.deps ?? createDefaultDeps();
-  await runBootOnce({ cfg: context.cfg, deps, workspaceDir: context.workspaceDir });
+  const agentIds = listAgentIds(context.cfg);
+
+  for (const agentId of agentIds) {
+    const workspaceDir = resolveAgentWorkspaceDir(context.cfg, agentId);
+    await runBootOnce({ cfg: context.cfg, deps, workspaceDir, agentId });
+  }
 };
 
 export default runBootChecklist;

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -4,12 +4,14 @@ import {
   createInternalHookEvent,
   getRegisteredEventKeys,
   isAgentBootstrapEvent,
+  isGatewayStartupEvent,
   isMessageReceivedEvent,
   isMessageSentEvent,
   registerInternalHook,
   triggerInternalHook,
   unregisterInternalHook,
   type AgentBootstrapHookContext,
+  type GatewayStartupHookContext,
   type MessageReceivedHookContext,
   type MessageSentHookContext,
 } from "./internal-hooks.js";
@@ -182,6 +184,21 @@ describe("hooks", () => {
     it("returns false for non-bootstrap events", () => {
       const event = createInternalHookEvent("command", "new", "test-session");
       expect(isAgentBootstrapEvent(event)).toBe(false);
+    });
+  });
+
+  describe("isGatewayStartupEvent", () => {
+    it("returns true for gateway:startup events with expected context", () => {
+      const context: GatewayStartupHookContext = {
+        cfg: {},
+      };
+      const event = createInternalHookEvent("gateway", "startup", "gateway:startup", context);
+      expect(isGatewayStartupEvent(event)).toBe(true);
+    });
+
+    it("returns false for non-startup gateway events", () => {
+      const event = createInternalHookEvent("gateway", "shutdown", "gateway:shutdown", {});
+      expect(isGatewayStartupEvent(event)).toBe(false);
     });
   });
 

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -6,6 +6,7 @@
  */
 
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
+import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 
 export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
@@ -23,6 +24,18 @@ export type AgentBootstrapHookEvent = InternalHookEvent & {
   type: "agent";
   action: "bootstrap";
   context: AgentBootstrapHookContext;
+};
+
+export type GatewayStartupHookContext = {
+  cfg?: OpenClawConfig;
+  deps?: CliDeps;
+  workspaceDir?: string;
+};
+
+export type GatewayStartupHookEvent = InternalHookEvent & {
+  type: "gateway";
+  action: "startup";
+  context: GatewayStartupHookContext;
 };
 
 // ============================================================================
@@ -232,6 +245,14 @@ export function isAgentBootstrapEvent(event: InternalHookEvent): event is AgentB
     return false;
   }
   return Array.isArray(context.bootstrapFiles);
+}
+
+export function isGatewayStartupEvent(event: InternalHookEvent): event is GatewayStartupHookEvent {
+  if (event.type !== "gateway" || event.action !== "startup") {
+    return false;
+  }
+  const context = event.context as GatewayStartupHookContext | null;
+  return Boolean(context && typeof context === "object");
 }
 
 export function isMessageReceivedEvent(


### PR DESCRIPTION
## Summary

Fixes #13000

- The boot-md hook now iterates over all configured agents (via `listAgentIds`) instead of running `BOOT.md` only for the default agent's workspace.
- `runBootOnce()` accepts an optional `agentId` parameter and resolves the per-agent session key when provided.
- Each agent's workspace directory is resolved via `resolveAgentWorkspaceDir`, so each agent loads its own `BOOT.md` independently.

## Test plan

- [x] New unit test in `boot.test.ts` verifies per-agent session key resolution (`resolveAgentMainSessionKey`)
- [x] New test file `handler.test.ts` verifies the handler iterates over all agents and passes correct `workspaceDir` + `agentId` to `runBootOnce`
- [x] Handler correctly skips non-gateway and non-startup events
- [x] Handler gracefully handles missing `cfg` in context
- [x] Single-agent (default) configuration still works as before

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated the boot-md hook handler to run `BOOT.md` for each configured agent at gateway startup instead of only for the default agent. The handler now iterates through all agent IDs via `listAgentIds()` and resolves each agent's workspace directory independently using `resolveAgentWorkspaceDir()`. The `runBootOnce()` function was extended to accept an optional `agentId` parameter that determines the correct per-agent session key via `resolveAgentMainSessionKey()`.

- Handler now uses `listAgentIds()` and `resolveAgentWorkspaceDir()` to iterate over all agents
- `runBootOnce()` accepts optional `agentId` parameter for per-agent session key resolution  
- Per-agent session key resolution logic properly integrated with existing session management
- Tests verify both multi-agent and single-agent (default) configurations work correctly
- Handler correctly skips execution when `cfg` is missing from context

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-tested with comprehensive unit tests covering both the new per-agent session key resolution and the handler's iteration logic. The changes are focused and backward-compatible (single-agent configurations continue to work). The handler correctly validates required context and gracefully handles missing configuration.
- No files require special attention

<sub>Last reviewed commit: ecaff9c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->