### PR TITLE
fix: include channel message timestamp in inbound_meta for agent context

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -75,6 +75,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const messageId = safeTrim(ctx.MessageSid);
   const messageIdFull = safeTrim(ctx.MessageSidFull);
   const conversationInfo = {
+    timestamp_ms: ctx.Timestamp,
     message_id: messageId,
     message_id_full: messageIdFull && messageIdFull !== messageId ? messageIdFull : undefined,
     reply_to_id: safeTrim(ctx.ReplyToId),


### PR DESCRIPTION
**Closing in favor of #19716**, which takes a better approach: it formats the timestamp into a human-readable string with timezone support (matching the existing `injectTimestamp()` pattern for TUI/web), rather than injecting a raw `timestamp_ms` number.

---

*This PR was authored by an AI agent and reviewed by @hyf0 before submission.*

## Original Problem

Channel messages (Telegram, Discord, etc.) lack timestamps in the agent prompt. The agent receives `inbound_meta` JSON but no time information, even though `ctx.Timestamp` is available.

See #19716 for the proper fix.