### PR TITLE
feat(browser): add proxy configuration option

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -101,6 +101,61 @@ Notes:
 - Auto-detect order: system default browser if Chromium-based; otherwise Chrome → Brave → Edge → Chromium → Chrome Canary.
 - Local `openclaw` profiles auto-assign `cdpPort`/`cdpUrl` — set those only for remote CDP.
 
+## Proxy
+
+Route all browser traffic through a proxy server:
+
+```json5
+{
+  browser: {
+    proxy: "http://127.0.0.1:7890",
+  },
+}
+```
+
+Supported schemes: `http://`, `https://`, `socks5://`.
+
+### Authenticated proxies
+
+Include credentials directly in the URL:
+
+```json5
+{
+  browser: {
+    proxy: "http://username:password@proxy.example.com:8080",
+  },
+}
+```
+
+Credentials are stripped from the URL before passing `--proxy-server` to Chrome
+(Chrome does not support inline proxy credentials). OpenClaw handles
+authentication automatically via CDP by intercepting the proxy's 407 challenge
+and responding with the configured credentials.
+
+### Per-profile proxy overrides
+
+```json5
+{
+  browser: {
+    proxy: "http://default-proxy:8080",
+    profiles: {
+      work: { cdpPort: 18801, color: "#0066CC", proxy: "socks5://work-proxy:1080" },
+    },
+  },
+}
+```
+
+Per-profile proxies inherit credentials from the global proxy unless the
+profile's own URL contains credentials.
+
+### Notes
+
+- The proxy is passed to Chrome as `--proxy-server`.
+- System-level `HTTP_PROXY` environment variables do not affect the
+  OpenClaw-managed browser.
+- Proxy credentials are sensitive; prefer environment variable substitution
+  or a secrets manager over committing them to config files.
+
 ## Use Brave (or another Chromium-based browser)
 
 If your **system default** browser is Chromium-based (Chrome/Brave/Edge/etc),

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -145,8 +145,10 @@ and responding with the configured credentials.
 }
 ```
 
-Per-profile proxies inherit credentials from the global proxy unless the
-profile's own URL contains credentials.
+When a profile sets its own `proxy`, credentials come only from that URL.
+Global proxy credentials are inherited only when no profile-level proxy is set.
+A profile proxy without credentials means no authentication — global credentials
+are never forwarded to a different proxy server.
 
 ### Notes
 

--- a/src/browser/chrome.auth-challenge.test.ts
+++ b/src/browser/chrome.auth-challenge.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveProxyAuthChallengeResponse } from "./chrome.js";
+
+describe("browser chrome proxy auth challenge handling", () => {
+  const proxyCredentials = {
+    username: "proxy-user",
+    password: "proxy-pass",
+  };
+
+  it("provides credentials for proxy challenges", () => {
+    expect(resolveProxyAuthChallengeResponse("Proxy", proxyCredentials)).toEqual({
+      response: "ProvideCredentials",
+      username: "proxy-user",
+      password: "proxy-pass",
+    });
+  });
+
+  it("treats proxy source case-insensitively", () => {
+    expect(resolveProxyAuthChallengeResponse("pRoXy", proxyCredentials)).toEqual({
+      response: "ProvideCredentials",
+      username: "proxy-user",
+      password: "proxy-pass",
+    });
+  });
+
+  it("does not send proxy credentials for origin server auth challenges", () => {
+    expect(resolveProxyAuthChallengeResponse("Server", proxyCredentials)).toEqual({
+      response: "Default",
+    });
+  });
+
+  it("defaults safely when auth challenge source is missing", () => {
+    expect(resolveProxyAuthChallengeResponse(undefined, proxyCredentials)).toEqual({
+      response: "Default",
+    });
+  });
+});

--- a/src/browser/chrome.proxy-launch.test.ts
+++ b/src/browser/chrome.proxy-launch.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const existsSync = vi.fn(() => true);
+  const mkdirSync = vi.fn();
+  return {
+    ...actual,
+    existsSync,
+    mkdirSync,
+    default: { ...actual.default, existsSync, mkdirSync },
+  };
+});
+
+vi.mock("../infra/ports.js", () => ({
+  ensurePortAvailable: vi.fn(async () => {}),
+}));
+
+vi.mock("./chrome.executables.js", () => ({
+  resolveBrowserExecutableForPlatform: vi.fn(() => ({
+    kind: "chrome",
+    path: "/tmp/fake-chrome",
+  })),
+}));
+
+vi.mock("./chrome.profile-decoration.js", () => ({
+  decorateOpenClawProfile: vi.fn(),
+  ensureProfileCleanExit: vi.fn(),
+  isProfileDecorated: vi.fn(() => true),
+}));
+
+vi.mock("./cdp.js", () => ({
+  getHeadersWithAuth: vi.fn(() => ({})),
+  normalizeCdpWsUrl: vi.fn((wsUrl: string) => wsUrl),
+}));
+
+import { spawn } from "node:child_process";
+import { launchOpenClawChrome } from "./chrome.js";
+import { resolveBrowserConfig, resolveProfile } from "./config.js";
+
+type MockProc = {
+  pid: number;
+  killed: boolean;
+  exitCode: number | null;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+function createMockProc(): MockProc {
+  return {
+    pid: 4321,
+    killed: false,
+    exitCode: null,
+    kill: vi.fn(),
+  };
+}
+
+describe("browser chrome proxy launch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      } as unknown as Response),
+    );
+    vi.mocked(spawn).mockImplementation(() => createMockProc() as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("passes profile proxy via --proxy-server (profile overrides global)", async () => {
+    const resolved = resolveBrowserConfig({
+      proxy: "http://global-proxy:8080",
+      profiles: {
+        work: {
+          cdpPort: 18801,
+          color: "#0066CC",
+          proxy: "http://profile-proxy:9090",
+        },
+      },
+    });
+    const profile = resolveProfile(resolved, "work");
+    expect(profile).not.toBeNull();
+
+    await launchOpenClawChrome(resolved, profile!);
+
+    const args = vi.mocked(spawn).mock.calls.at(-1)?.[1] as string[] | undefined;
+    expect(args).toBeDefined();
+    expect(args).toContain("--proxy-server=http://profile-proxy:9090");
+    expect(args).not.toContain("--proxy-server=http://global-proxy:8080");
+  });
+
+  it("passes sanitized proxy URL without credentials to --proxy-server", async () => {
+    const resolved = resolveBrowserConfig({
+      proxy: "http://username:p%40ss@proxy.example.com:8080",
+    });
+    const profile = resolveProfile(resolved, "openclaw");
+    expect(profile).not.toBeNull();
+
+    // Keep this launch test focused on arg injection; auth wiring is covered elsewhere.
+    const profileWithoutAuth = {
+      ...profile!,
+      proxyCredentials: undefined,
+    };
+
+    await launchOpenClawChrome(resolved, profileWithoutAuth);
+
+    const args = vi.mocked(spawn).mock.calls.at(-1)?.[1] as string[] | undefined;
+    expect(args).toBeDefined();
+    expect(args).toContain("--proxy-server=http://proxy.example.com:8080");
+    const argLine = args?.join(" ") ?? "";
+    expect(argLine).not.toContain("username");
+    expect(argLine).not.toContain("p@ss");
+  });
+});

--- a/src/browser/chrome.proxy-launch.test.ts
+++ b/src/browser/chrome.proxy-launch.test.ts
@@ -8,15 +8,13 @@ vi.mock("node:child_process", async (importOriginal) => {
   };
 });
 
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
+vi.mock("node:fs", () => {
   const existsSync = vi.fn(() => true);
   const mkdirSync = vi.fn();
   return {
-    ...actual,
     existsSync,
     mkdirSync,
-    default: { ...actual.default, existsSync, mkdirSync },
+    default: { existsSync, mkdirSync },
   };
 });
 

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -239,9 +239,7 @@ async function setupCdpProxyAuth(
   }
 
   const cdpBase = `http://127.0.0.1:${cdpPort}`;
-  const versionRes = await fetch(appendCdpPath(cdpBase, "/json/version"));
-  const version = (await versionRes.json()) as { webSocketDebuggerUrl?: string };
-  const browserWsUrl = version.webSocketDebuggerUrl?.trim();
+  const browserWsUrl = await getChromeWebSocketUrl(cdpBase);
   if (!browserWsUrl) {
     throw new Error("no browser WebSocket URL for proxy auth setup");
   }

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -171,6 +171,148 @@ export async function isChromeCdpReady(
   return await canOpenWebSocket(wsUrl, handshakeTimeoutMs);
 }
 
+/**
+ * Enable Fetch-based proxy auth on a single CDP session.
+ *
+ * Sends Fetch.enable with handleAuthRequests, then listens for authRequired
+ * events and responds with stored credentials. Also continues paused requests
+ * so normal traffic is not blocked.
+ */
+function enableFetchAuthOnSession(
+  ws: WebSocket,
+  sessionId: string,
+  idCounter: { value: number },
+): void {
+  const send = (method: string, params: Record<string, unknown> = {}) => {
+    const msg: Record<string, unknown> = {
+      id: ++idCounter.value,
+      method,
+      params,
+    };
+    if (sessionId) {
+      msg.sessionId = sessionId;
+    }
+    ws.send(JSON.stringify(msg));
+  };
+
+  send("Fetch.enable", {
+    handleAuthRequests: true,
+    patterns: [{ urlPattern: "*" }],
+  });
+}
+
+/**
+ * Set up CDP Fetch-based proxy authentication for all page targets.
+ *
+ * Chrome does not support proxy credentials via --proxy-server. When it hits a
+ * 407 Proxy Authentication Required, the Fetch domain fires authRequired and we
+ * respond with the configured credentials via Fetch.continueWithAuth.
+ *
+ * Fetch is a page-level CDP domain, so we connect to the browser WebSocket,
+ * use Target.setDiscoverTargets to watch for new pages, attach to each one,
+ * and enable Fetch on every page session. This ensures proxy auth works across
+ * all tabs, not just the initial about:blank.
+ */
+async function setupCdpProxyAuth(profile: ResolvedBrowserProfile): Promise<void> {
+  const { proxyCredentials, cdpPort } = profile;
+  if (!proxyCredentials) {
+    return;
+  }
+
+  const cdpBase = `http://127.0.0.1:${cdpPort}`;
+  const versionRes = await fetch(appendCdpPath(cdpBase, "/json/version"));
+  const version = (await versionRes.json()) as { webSocketDebuggerUrl?: string };
+  const browserWsUrl = version.webSocketDebuggerUrl?.trim();
+  if (!browserWsUrl) {
+    throw new Error("no browser WebSocket URL for proxy auth setup");
+  }
+
+  const ws = new WebSocket(browserWsUrl);
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+
+  const idCounter = { value: 0 };
+  const enabledSessions = new Set<string>();
+
+  const sendBrowser = (method: string, params: Record<string, unknown> = {}) => {
+    ws.send(JSON.stringify({ id: ++idCounter.value, method, params }));
+  };
+
+  const sendSession = (sessionId: string, method: string, params: Record<string, unknown> = {}) => {
+    ws.send(JSON.stringify({ id: ++idCounter.value, sessionId, method, params }));
+  };
+
+  // Handle all CDP messages from browser + forwarded session events.
+  ws.on("message", (data: Buffer) => {
+    let msg: {
+      method?: string;
+      params?: Record<string, unknown>;
+      sessionId?: string;
+    };
+    try {
+      msg = JSON.parse(data.toString());
+    } catch {
+      return;
+    }
+
+    // New target discovered — attach to page targets.
+    if (msg.method === "Target.targetCreated") {
+      const info = msg.params?.targetInfo as { targetId?: string; type?: string } | undefined;
+      if (info?.type === "page" && info.targetId) {
+        sendBrowser("Target.attachToTarget", {
+          targetId: info.targetId,
+          flatten: true,
+        });
+      }
+      return;
+    }
+
+    // Attached to a target — enable Fetch on the new session.
+    if (msg.method === "Target.attachedToTarget") {
+      const sessionId = msg.params?.sessionId as string | undefined;
+      if (sessionId && !enabledSessions.has(sessionId)) {
+        enabledSessions.add(sessionId);
+        enableFetchAuthOnSession(ws, sessionId, idCounter);
+      }
+      return;
+    }
+
+    // Session-scoped events (Fetch.authRequired / Fetch.requestPaused).
+    const sessionId = msg.sessionId;
+    if (!sessionId) {
+      return;
+    }
+
+    if (msg.method === "Fetch.authRequired") {
+      const requestId = msg.params?.requestId as string;
+      sendSession(sessionId, "Fetch.continueWithAuth", {
+        requestId,
+        authChallengeResponse: {
+          response: "ProvideCredentials",
+          username: proxyCredentials.username,
+          password: proxyCredentials.password,
+        },
+      });
+    } else if (msg.method === "Fetch.requestPaused") {
+      const requestId = msg.params?.requestId as string;
+      sendSession(sessionId, "Fetch.continueRequest", { requestId });
+    }
+  });
+
+  // Auto-attach to existing and future targets.
+  sendBrowser("Target.setDiscoverTargets", { discover: true });
+  // Also attach to targets that already exist (the initial about:blank page).
+  sendBrowser("Target.setAutoAttach", {
+    autoAttach: true,
+    waitForDebuggerOnStart: false,
+    flatten: true,
+  });
+
+  log.info(`🔑 proxy auth handler installed for profile "${profile.name}"`);
+}
+
 export async function launchOpenClawChrome(
   resolved: ResolvedBrowserConfig,
   profile: ResolvedBrowserProfile,
@@ -231,6 +373,11 @@ export async function launchOpenClawChrome(
     // Append user-configured extra arguments (e.g., stealth flags, window size)
     if (resolved.extraArgs.length > 0) {
       args.push(...resolved.extraArgs);
+    }
+
+    // Proxy: use profile-level proxy (falls back to global in resolveProfile)
+    if (profile.proxy) {
+      args.push(`--proxy-server=${profile.proxy}`);
     }
 
     // Always open a blank tab to ensure a target exists.
@@ -337,6 +484,17 @@ export async function launchOpenClawChrome(
   // Chrome started successfully — detach the stderr listener and release the buffer.
   proc.stderr?.off("data", onStderr);
   stderrChunks.length = 0;
+
+  // Set up proxy authentication via CDP if credentials are configured.
+  // Chrome's --proxy-server does not support inline credentials, so we intercept
+  // the 407 auth challenge via the Fetch domain and respond programmatically.
+  if (profile.proxyCredentials) {
+    try {
+      await setupCdpProxyAuth(profile);
+    } catch (err) {
+      log.warn(`proxy auth setup failed for profile "${profile.name}": ${String(err)}`);
+    }
+  }
 
   const pid = proc.pid ?? -1;
   log.info(

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -382,11 +382,17 @@ async function setupCdpProxyAuth(
     // Attached to a target — enable Fetch on the new session.
     if (msg.method === "Target.attachedToTarget") {
       const sessionId = msg.params?.sessionId as string | undefined;
+      const targetType = (msg.params?.targetInfo as { type?: string } | undefined)?.type;
       if (sessionId && !enabledSessions.has(sessionId)) {
         enabledSessions.add(sessionId);
         void enableFetchAuthOnSession(sendSessionAwait, sessionId)
           .then(() => {
-            resolveFirstFetchEnabled();
+            // Only gate launch readiness on page targets — a worker or
+            // service-worker resolving first would leave the initial page
+            // without Fetch.enable, racing into a 407.
+            if (targetType === "page") {
+              resolveFirstFetchEnabled();
+            }
           })
           .catch((err) => {
             rejectFirstFetchEnabled(err instanceof Error ? err : new Error(String(err)));

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -179,23 +179,14 @@ export async function isChromeCdpReady(
  * so normal traffic is not blocked.
  */
 function enableFetchAuthOnSession(
-  ws: WebSocket,
+  sendSessionAwait: (
+    sessionId: string,
+    method: string,
+    params?: Record<string, unknown>,
+  ) => Promise<void>,
   sessionId: string,
-  idCounter: { value: number },
-): void {
-  const send = (method: string, params: Record<string, unknown> = {}) => {
-    const msg: Record<string, unknown> = {
-      id: ++idCounter.value,
-      method,
-      params,
-    };
-    if (sessionId) {
-      msg.sessionId = sessionId;
-    }
-    ws.send(JSON.stringify(msg));
-  };
-
-  send("Fetch.enable", {
+): Promise<void> {
+  return sendSessionAwait(sessionId, "Fetch.enable", {
     handleAuthRequests: true,
     patterns: [{ urlPattern: "*" }],
   });
@@ -213,7 +204,10 @@ function enableFetchAuthOnSession(
  * and enable Fetch on every page session. This ensures proxy auth works across
  * all tabs, not just the initial about:blank.
  */
-async function setupCdpProxyAuth(profile: ResolvedBrowserProfile): Promise<void> {
+async function setupCdpProxyAuth(
+  profile: ResolvedBrowserProfile,
+  proc: ChildProcessWithoutNullStreams,
+): Promise<void> {
   const { proxyCredentials, cdpPort } = profile;
   if (!proxyCredentials) {
     return;
@@ -233,8 +227,44 @@ async function setupCdpProxyAuth(profile: ResolvedBrowserProfile): Promise<void>
     ws.once("error", reject);
   });
 
+  ws.on("error", (err) => {
+    log.warn(`proxy auth WebSocket error for profile "${profile.name}": ${String(err)}`);
+  });
+
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    try {
+      ws.close();
+    } catch {
+      // ignore
+    }
+    if (ws.readyState !== WebSocket.CLOSED) {
+      try {
+        ws.terminate();
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  proc.once("exit", cleanup);
+  proc.once("close", cleanup);
+  proc.once("error", cleanup);
+
   const idCounter = { value: 0 };
   const enabledSessions = new Set<string>();
+  const pendingAcks = new Map<
+    number,
+    {
+      method: string;
+      resolve: () => void;
+      reject: (err: Error) => void;
+    }
+  >();
 
   const sendBrowser = (method: string, params: Record<string, unknown> = {}) => {
     ws.send(JSON.stringify({ id: ++idCounter.value, method, params }));
@@ -244,16 +274,96 @@ async function setupCdpProxyAuth(profile: ResolvedBrowserProfile): Promise<void>
     ws.send(JSON.stringify({ id: ++idCounter.value, sessionId, method, params }));
   };
 
+  const sendBrowserAwait = async (method: string, params: Record<string, unknown> = {}) => {
+    const id = ++idCounter.value;
+    await new Promise<void>((resolve, reject) => {
+      pendingAcks.set(id, { method, resolve, reject });
+      ws.send(JSON.stringify({ id, method, params }));
+    });
+  };
+
+  const sendSessionAwait = async (
+    sessionId: string,
+    method: string,
+    params: Record<string, unknown> = {},
+  ) => {
+    const id = ++idCounter.value;
+    await new Promise<void>((resolve, reject) => {
+      pendingAcks.set(id, { method: `${sessionId}:${method}`, resolve, reject });
+      ws.send(JSON.stringify({ id, sessionId, method, params }));
+    });
+  };
+
+  let firstFetchEnabledSettled = false;
+  let resolveFirstFetchEnabled: () => void = () => {};
+  let rejectFirstFetchEnabled: (err: Error) => void = () => {};
+  const firstFetchEnabled = new Promise<void>((resolve, reject) => {
+    resolveFirstFetchEnabled = () => {
+      if (firstFetchEnabledSettled) {
+        return;
+      }
+      firstFetchEnabledSettled = true;
+      resolve();
+    };
+    rejectFirstFetchEnabled = (err: Error) => {
+      if (firstFetchEnabledSettled) {
+        return;
+      }
+      firstFetchEnabledSettled = true;
+      reject(err);
+    };
+  });
+
+  const firstFetchEnabledTimeout = setTimeout(() => {
+    rejectFirstFetchEnabled(
+      new Error(`timed out waiting for proxy auth hooks for profile "${profile.name}"`),
+    );
+  }, 1_500);
+
+  const rejectPendingAcks = (reason: string) => {
+    for (const [id, pending] of pendingAcks) {
+      pendingAcks.delete(id);
+      pending.reject(new Error(reason));
+    }
+  };
+
+  ws.on("close", () => {
+    rejectPendingAcks(`proxy auth WebSocket closed for profile "${profile.name}"`);
+    rejectFirstFetchEnabled(
+      new Error(
+        `proxy auth WebSocket closed before hooks were ready for profile "${profile.name}"`,
+      ),
+    );
+  });
+
   // Handle all CDP messages from browser + forwarded session events.
   ws.on("message", (data: Buffer) => {
     let msg: {
+      id?: number;
       method?: string;
       params?: Record<string, unknown>;
       sessionId?: string;
+      error?: { message?: string };
     };
     try {
       msg = JSON.parse(data.toString());
     } catch {
+      return;
+    }
+
+    if (typeof msg.id === "number") {
+      const pending = pendingAcks.get(msg.id);
+      if (!pending) {
+        return;
+      }
+      pendingAcks.delete(msg.id);
+      if (msg.error) {
+        pending.reject(
+          new Error(`CDP ${pending.method} failed: ${msg.error.message ?? "unknown"}`),
+        );
+      } else {
+        pending.resolve();
+      }
       return;
     }
 
@@ -274,7 +384,13 @@ async function setupCdpProxyAuth(profile: ResolvedBrowserProfile): Promise<void>
       const sessionId = msg.params?.sessionId as string | undefined;
       if (sessionId && !enabledSessions.has(sessionId)) {
         enabledSessions.add(sessionId);
-        enableFetchAuthOnSession(ws, sessionId, idCounter);
+        void enableFetchAuthOnSession(sendSessionAwait, sessionId)
+          .then(() => {
+            resolveFirstFetchEnabled();
+          })
+          .catch((err) => {
+            rejectFirstFetchEnabled(err instanceof Error ? err : new Error(String(err)));
+          });
       }
       return;
     }
@@ -301,14 +417,20 @@ async function setupCdpProxyAuth(profile: ResolvedBrowserProfile): Promise<void>
     }
   });
 
-  // Auto-attach to existing and future targets.
-  sendBrowser("Target.setDiscoverTargets", { discover: true });
-  // Also attach to targets that already exist (the initial about:blank page).
-  sendBrowser("Target.setAutoAttach", {
-    autoAttach: true,
-    waitForDebuggerOnStart: false,
-    flatten: true,
-  });
+  try {
+    // Auto-attach to existing and future targets.
+    await sendBrowserAwait("Target.setDiscoverTargets", { discover: true });
+    // Also attach to targets that already exist (the initial about:blank page).
+    await sendBrowserAwait("Target.setAutoAttach", {
+      autoAttach: true,
+      waitForDebuggerOnStart: false,
+      flatten: true,
+    });
+
+    await firstFetchEnabled;
+  } finally {
+    clearTimeout(firstFetchEnabledTimeout);
+  }
 
   log.info(`🔑 proxy auth handler installed for profile "${profile.name}"`);
 }
@@ -490,7 +612,7 @@ export async function launchOpenClawChrome(
   // the 407 auth challenge via the Fetch domain and respond programmatically.
   if (profile.proxyCredentials) {
     try {
-      await setupCdpProxyAuth(profile);
+      await setupCdpProxyAuth(profile, proc);
     } catch (err) {
       log.warn(`proxy auth setup failed for profile "${profile.name}": ${String(err)}`);
     }

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -192,6 +192,31 @@ function enableFetchAuthOnSession(
   });
 }
 
+type CdpAuthChallengeResponse =
+  | {
+      response: "ProvideCredentials";
+      username: string;
+      password: string;
+    }
+  | {
+      response: "Default";
+    };
+
+export function resolveProxyAuthChallengeResponse(
+  challengeSource: unknown,
+  proxyCredentials: { username: string; password: string },
+): CdpAuthChallengeResponse {
+  const source = typeof challengeSource === "string" ? challengeSource.toLowerCase() : "";
+  if (source !== "proxy") {
+    return { response: "Default" };
+  }
+  return {
+    response: "ProvideCredentials",
+    username: proxyCredentials.username,
+    password: proxyCredentials.password,
+  };
+}
+
 /**
  * Set up CDP Fetch-based proxy authentication for all page targets.
  *
@@ -221,7 +246,7 @@ async function setupCdpProxyAuth(
     throw new Error("no browser WebSocket URL for proxy auth setup");
   }
 
-  const ws = new WebSocket(browserWsUrl);
+  const ws = openCdpWebSocket(browserWsUrl);
   await new Promise<void>((resolve, reject) => {
     ws.once("open", resolve);
     ws.once("error", reject);
@@ -409,13 +434,13 @@ async function setupCdpProxyAuth(
 
     if (msg.method === "Fetch.authRequired") {
       const requestId = msg.params?.requestId as string;
+      const challengeSource = (msg.params?.authChallenge as { source?: string } | undefined)
+        ?.source;
+      // Only answer proxy (407) challenges with proxy credentials.
+      // For origin server auth (401), fall back to browser default handling.
       sendSession(sessionId, "Fetch.continueWithAuth", {
         requestId,
-        authChallengeResponse: {
-          response: "ProvideCredentials",
-          username: proxyCredentials.username,
-          password: proxyCredentials.password,
-        },
+        authChallengeResponse: resolveProxyAuthChallengeResponse(challengeSource, proxyCredentials),
       });
     } else if (msg.method === "Fetch.requestPaused") {
       const requestId = msg.params?.requestId as string;

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -440,4 +440,24 @@ describe("browser config", () => {
     const openclaw = resolveProfile(resolved, "openclaw");
     expect(openclaw?.proxyCredentials).toEqual({ username: "globaluser", password: "globalpass" });
   });
+
+  it("profile proxy without credentials does not inherit global credentials", () => {
+    const resolved = resolveBrowserConfig({
+      proxy: "http://user:pass@global-proxy:8080",
+      profiles: {
+        work: {
+          proxy: "socks5://work-proxy:1080",
+          cdpPort: 9223,
+        },
+      },
+    });
+    const work = resolveProfile(resolved, "work");
+    expect(work?.proxy).toBe("socks5://work-proxy:1080");
+    expect(work?.proxyCredentials).toBeUndefined();
+
+    // Global profile should still retain its own credentials
+    const openclaw = resolveProfile(resolved, "openclaw");
+    expect(openclaw?.proxy).toBe("http://global-proxy:8080");
+    expect(openclaw?.proxyCredentials).toEqual({ username: "user", password: "pass" });
+  });
 });

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -298,4 +298,146 @@ describe("browser config", () => {
       expect(resolved.defaultProfile).toBe("custom");
     });
   });
+
+  // Proxy tests
+  it("defaults proxy to undefined when not provided", () => {
+    const resolved = resolveBrowserConfig(undefined);
+    expect(resolved.proxy).toBeUndefined();
+    expect(resolved.proxyCredentials).toBeUndefined();
+  });
+
+  it("resolves a valid http proxy URL", () => {
+    const resolved = resolveBrowserConfig({ proxy: "http://127.0.0.1:7890" });
+    expect(resolved.proxy).toBe("http://127.0.0.1:7890");
+    expect(resolved.proxyCredentials).toBeUndefined();
+  });
+
+  it("resolves a valid https proxy URL", () => {
+    const resolved = resolveBrowserConfig({ proxy: "https://proxy.example.com:8443" });
+    expect(resolved.proxy).toBe("https://proxy.example.com:8443");
+    expect(resolved.proxyCredentials).toBeUndefined();
+  });
+
+  it("resolves a valid socks5 proxy URL", () => {
+    const resolved = resolveBrowserConfig({ proxy: "socks5://proxy.example.com:1080" });
+    expect(resolved.proxy).toBe("socks5://proxy.example.com:1080");
+    expect(resolved.proxyCredentials).toBeUndefined();
+  });
+
+  it("trims whitespace from proxy URL", () => {
+    const resolved = resolveBrowserConfig({ proxy: "  http://127.0.0.1:7890  " });
+    expect(resolved.proxy).toBe("http://127.0.0.1:7890");
+  });
+
+  it("treats empty proxy string as unset", () => {
+    const resolved = resolveBrowserConfig({ proxy: "" });
+    expect(resolved.proxy).toBeUndefined();
+    expect(resolved.proxyCredentials).toBeUndefined();
+  });
+
+  it("treats whitespace-only proxy string as unset", () => {
+    const resolved = resolveBrowserConfig({ proxy: "   " });
+    expect(resolved.proxy).toBeUndefined();
+    expect(resolved.proxyCredentials).toBeUndefined();
+  });
+
+  it("rejects proxy URL with unsupported scheme", () => {
+    expect(() => resolveBrowserConfig({ proxy: "ftp://proxy.example.com:21" })).toThrow(
+      /must start with http/i,
+    );
+  });
+
+  it("rejects proxy URL with invalid format", () => {
+    expect(() => resolveBrowserConfig({ proxy: "not-a-url" })).toThrow();
+  });
+
+  it("rejects proxy URL with path, query, or hash", () => {
+    expect(() => resolveBrowserConfig({ proxy: "http://proxy.example.com:8080/path" })).toThrow(
+      /must not include path, query, or hash/i,
+    );
+    expect(() =>
+      resolveBrowserConfig({ proxy: "http://proxy.example.com:8080?token=abc" }),
+    ).toThrow(/must not include path, query, or hash/i);
+    expect(() => resolveBrowserConfig({ proxy: "http://proxy.example.com:8080#frag" })).toThrow(
+      /must not include path, query, or hash/i,
+    );
+  });
+
+  it("extracts credentials from proxy URL and strips them from server", () => {
+    const resolved = resolveBrowserConfig({ proxy: "http://user:p%40ss@proxy.example.com:8080" });
+    expect(resolved.proxy).toBe("http://proxy.example.com:8080");
+    expect(resolved.proxyCredentials).toEqual({ username: "user", password: "p@ss" });
+  });
+
+  it("extracts credentials from socks5 proxy URL", () => {
+    const resolved = resolveBrowserConfig({ proxy: "socks5://myuser:mypass@proxy:1080" });
+    expect(resolved.proxy).toBe("socks5://proxy:1080");
+    expect(resolved.proxyCredentials).toEqual({ username: "myuser", password: "mypass" });
+  });
+
+  it("supports unicode credentials in proxy URL", () => {
+    const resolved = resolveBrowserConfig({
+      proxy: "http://%E2%9C%93:%F0%9F%94%91@proxy.example.com:8080",
+    });
+    expect(resolved.proxy).toBe("http://proxy.example.com:8080");
+    expect(resolved.proxyCredentials).toEqual({ username: "✓", password: "🔑" });
+  });
+
+  it("rejects malformed percent-encoding in proxy credentials", () => {
+    expect(() =>
+      resolveBrowserConfig({ proxy: "http://user:%ZZ@proxy.example.com:8080" }),
+    ).toThrow();
+  });
+
+  it("profile proxy overrides global proxy", () => {
+    const resolved = resolveBrowserConfig({
+      proxy: "http://global:8080",
+      profiles: {
+        work: { cdpPort: 18801, color: "#0066CC", proxy: "socks5://work:1080" },
+      },
+    });
+    const work = resolveProfile(resolved, "work");
+    expect(work?.proxy).toBe("socks5://work:1080");
+
+    const openclaw = resolveProfile(resolved, "openclaw");
+    expect(openclaw?.proxy).toBe("http://global:8080");
+  });
+
+  it("profile inherits global proxy when not set", () => {
+    const resolved = resolveBrowserConfig({
+      proxy: "http://global:8080",
+      profiles: {
+        work: { cdpPort: 18801, color: "#0066CC" },
+      },
+    });
+    const work = resolveProfile(resolved, "work");
+    expect(work?.proxy).toBe("http://global:8080");
+  });
+
+  it("profile inherits global proxy credentials when not set", () => {
+    const resolved = resolveBrowserConfig({
+      proxy: "http://user:pass@global:8080",
+      profiles: {
+        work: { cdpPort: 18801, color: "#0066CC" },
+      },
+    });
+    const work = resolveProfile(resolved, "work");
+    expect(work?.proxy).toBe("http://global:8080");
+    expect(work?.proxyCredentials).toEqual({ username: "user", password: "pass" });
+  });
+
+  it("profile proxy credentials override global credentials", () => {
+    const resolved = resolveBrowserConfig({
+      proxy: "http://globaluser:globalpass@global:8080",
+      profiles: {
+        work: { cdpPort: 18801, color: "#0066CC", proxy: "http://workuser:workpass@work:9090" },
+      },
+    });
+    const work = resolveProfile(resolved, "work");
+    expect(work?.proxy).toBe("http://work:9090");
+    expect(work?.proxyCredentials).toEqual({ username: "workuser", password: "workpass" });
+
+    const openclaw = resolveProfile(resolved, "openclaw");
+    expect(openclaw?.proxyCredentials).toEqual({ username: "globaluser", password: "globalpass" });
+  });
 });

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -448,6 +448,7 @@ describe("browser config", () => {
         work: {
           proxy: "socks5://work-proxy:1080",
           cdpPort: 9223,
+          color: "#0066CC",
         },
       },
     });

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -391,7 +391,11 @@ export function resolveProfile(
 
   const parsedProfileProxy = profile.proxy?.trim() ? parseProxyUrl(profile.proxy) : undefined;
   const proxy = parsedProfileProxy?.server ?? resolved.proxy;
-  const proxyCredentials = parsedProfileProxy?.credentials ?? resolved.proxyCredentials;
+  // Only inherit global credentials when the profile doesn't specify its own proxy.
+  // A profile proxy without credentials means no auth — don't leak global credentials.
+  const proxyCredentials = parsedProfileProxy
+    ? parsedProfileProxy.credentials
+    : resolved.proxyCredentials;
 
   return {
     name: profileName,

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -16,6 +16,11 @@ import {
 } from "./constants.js";
 import { CDP_PORT_RANGE_START, getUsedPorts } from "./profiles.js";
 
+export type ProxyCredentials = {
+  username: string;
+  password: string;
+};
+
 export type ResolvedBrowserConfig = {
   enabled: boolean;
   evaluateEnabled: boolean;
@@ -36,6 +41,8 @@ export type ResolvedBrowserConfig = {
   profiles: Record<string, BrowserProfileConfig>;
   ssrfPolicy?: SsrFPolicy;
   extraArgs: string[];
+  proxy?: string;
+  proxyCredentials?: ProxyCredentials;
 };
 
 export type ResolvedBrowserProfile = {
@@ -47,6 +54,8 @@ export type ResolvedBrowserProfile = {
   color: string;
   driver: "openclaw" | "extension";
   attachOnly: boolean;
+  proxy?: string;
+  proxyCredentials?: ProxyCredentials;
 };
 
 function normalizeHexColor(raw: string | undefined) {
@@ -149,6 +158,48 @@ export function parseHttpUrl(raw: string, label: string) {
     port,
     normalized: parsed.toString().replace(/\/$/, ""),
   };
+}
+
+const PROXY_SCHEME_RE = /^(https?|socks5):\/\//i;
+
+export type ParsedProxyUrl = {
+  /** URL without credentials, suitable for --proxy-server. */
+  server: string;
+  /** Credentials extracted from the URL, if present. */
+  credentials?: ProxyCredentials;
+};
+
+export function parseProxyUrl(raw: string): ParsedProxyUrl {
+  const trimmed = raw.trim();
+  if (!PROXY_SCHEME_RE.test(trimmed)) {
+    throw new Error(
+      `Proxy URL must start with http://, https://, or socks5:// — got: ${trimmed.split("://")[0] || "(empty)"}`,
+    );
+  }
+  // Validate it parses as a URL (handles host:port validation)
+  const parsed = new URL(trimmed);
+  const port = parsed.port ? Number.parseInt(parsed.port, 10) : undefined;
+  if (port !== undefined && (Number.isNaN(port) || port <= 0 || port > 65535)) {
+    throw new Error(`Proxy URL has invalid port: ${parsed.port}`);
+  }
+
+  const hasPath = parsed.pathname !== "" && parsed.pathname !== "/";
+  if (hasPath || parsed.search || parsed.hash) {
+    throw new Error("Proxy URL must not include path, query, or hash");
+  }
+
+  // Extract credentials before stripping them from the URL.
+  // Chrome's --proxy-server does not support inline credentials.
+  const username = decodeURIComponent(parsed.username);
+  const password = decodeURIComponent(parsed.password);
+  const credentials = username || password ? { username, password } : undefined;
+
+  // Build a clean URL without credentials for --proxy-server.
+  parsed.username = "";
+  parsed.password = "";
+  const server = parsed.toString().replace(/\/$/, "");
+
+  return { server, credentials };
 }
 
 /**
@@ -281,6 +332,8 @@ export function resolveBrowserConfig(
     : [];
   const ssrfPolicy = resolveBrowserSsrFPolicy(cfg);
 
+  const parsedProxy = cfg?.proxy?.trim() ? parseProxyUrl(cfg.proxy) : undefined;
+
   return {
     enabled,
     evaluateEnabled,
@@ -301,6 +354,8 @@ export function resolveBrowserConfig(
     profiles,
     ssrfPolicy,
     extraArgs,
+    proxy: parsedProxy?.server,
+    proxyCredentials: parsedProxy?.credentials,
   };
 }
 
@@ -334,6 +389,10 @@ export function resolveProfile(
     throw new Error(`Profile "${profileName}" must define cdpPort or cdpUrl.`);
   }
 
+  const parsedProfileProxy = profile.proxy?.trim() ? parseProxyUrl(profile.proxy) : undefined;
+  const proxy = parsedProfileProxy?.server ?? resolved.proxy;
+  const proxyCredentials = parsedProfileProxy?.credentials ?? resolved.proxyCredentials;
+
   return {
     name: profileName,
     cdpPort,
@@ -343,6 +402,8 @@ export function resolveProfile(
     color: profile.color,
     driver,
     attachOnly: profile.attachOnly ?? resolved.attachOnly,
+    proxy,
+    proxyCredentials,
   };
 }
 

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -9,6 +9,8 @@ export type BrowserProfileConfig = {
   attachOnly?: boolean;
   /** Profile color (hex). Auto-assigned at creation. */
   color: string;
+  /** Per-profile proxy override. Same format as browser.proxy. */
+  proxy?: string;
 };
 export type BrowserSnapshotDefaults = {
   /** Default snapshot mode (applies when mode is not provided). */
@@ -66,4 +68,11 @@ export type BrowserConfig = {
    * Example: ["--window-size=1920,1080", "--disable-infobars"]
    */
   extraArgs?: string[];
+  /**
+   * Proxy server for browser traffic.
+   * Passed as Chrome's --proxy-server launch argument.
+   * Supports http, https, and socks5 schemes.
+   * Example: "http://127.0.0.1:7890" or "socks5://proxy.example.com:1080"
+   */
+  proxy?: string;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -252,6 +252,8 @@ export const OpenClawSchema = z
         attachOnly: z.boolean().optional(),
         cdpPortRangeStart: z.number().int().min(1).max(65535).optional(),
         defaultProfile: z.string().optional(),
+        extraArgs: z.array(z.string()).optional(),
+        proxy: z.string().optional(),
         snapshotDefaults: BrowserSnapshotDefaultsSchema,
         ssrfPolicy: z
           .object({
@@ -274,6 +276,7 @@ export const OpenClawSchema = z
                 driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
                 attachOnly: z.boolean().optional(),
                 color: HexColorSchema,
+                proxy: z.string().optional(),
               })
               .strict()
               .refine((value) => value.cdpPort || value.cdpUrl, {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -284,7 +284,6 @@ export const OpenClawSchema = z
               }),
           )
           .optional(),
-        extraArgs: z.array(z.string()).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## `feat(browser): add proxy configuration option`

### Summary

Adds native proxy support to the browser tool. Users can route all browser traffic through HTTP, HTTPS, or SOCKS5 proxy servers via config.

### What changed

**Config** (`browser.proxy`):
```json5
{
  browser: {
    proxy: "http://127.0.0.1:7890",
    profiles: {
      work: { proxy: "socks5://work-proxy:1080" }
    }
  }
}
```

**Authenticated proxies** — credentials in the URL are stripped before `--proxy-server` and injected via CDP `Fetch.authRequired`:
```json5
{ browser: { proxy: "http://user:pass@proxy.example.com:8080" } }
```

**Per-profile overrides** — profile proxy falls back to global when not set.

### Files changed (7)

| File | Change |
|---|---|
| `src/config/types.browser.ts` | `proxy?: string` on `BrowserConfig` + `BrowserProfileConfig` |
| `src/config/zod-schema.ts` | `proxy` + `extraArgs` added to Zod schema (extraArgs was in TS type but missing from schema — `.strict()` rejected it; required for proxy to pass validation) |
| `src/browser/config.ts` | `parseProxyUrl()` with scheme validation, credential extraction, port check. Per-profile fallback to global. |
| `src/browser/chrome.ts` | `--proxy-server` arg injection + `setupCdpProxyAuth()` for authenticated proxies via browser-level CDP |
| `src/browser/config.test.ts` | Proxy config resolution tests: scheme validation, credential extraction, profile inheritance, edge cases |
| `src/browser/chrome.proxy-launch.test.ts` | Launch-layer tests: `--proxy-server` arg injection, credential stripping, profile override |
| `docs/tools/browser.md` | Proxy configuration docs with auth and per-profile examples |

### Why CDP for auth?

Chrome's `--proxy-server` silently ignores inline credentials (`user:pass@host`). When a proxy returns 407, we intercept it via CDP `Fetch.authRequired` and respond with the configured credentials. This is the same underlying mechanism Puppeteer uses for `page.authenticate()`, extended to the browser level via `Target.setAutoAttach` so it covers all tabs automatically.

### Testing

- `pnpm build && pnpm check && pnpm test` — all pass
- Unit tests for proxy config resolution (scheme validation, credential extraction, profile inheritance, edge cases)
- Launch-layer tests for `--proxy-server` arg injection and credential stripping
- Manually verified with HTTP (no-auth), HTTP (auth), and SOCKS5 (auth) proxies

### AI disclosure

- **AI-assisted:** Claude + Codex
- **Testing degree:** fully tested (`pnpm build && pnpm check && pnpm test` + targeted proxy unit/launch tests + manual proxy verification)
- **Prompts/session logs:** available on request
- **Human review:** I reviewed all changes and understand the implementation

Closes #8079

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds native proxy support to the browser tool with HTTP, HTTPS, and SOCKS5 protocol support. Proxy credentials are extracted from URLs and injected via CDP's Fetch domain to handle 407 authentication challenges, since Chrome's `--proxy-server` doesn't support inline credentials. The implementation includes per-profile proxy overrides with proper fallback to global config, comprehensive test coverage for config resolution and launch behavior, and clear documentation with security notes.

**Key changes:**
- Config validation via `parseProxyUrl()` with scheme validation, credential extraction, and port checking
- CDP-based proxy authentication via `setupCdpProxyAuth()` that attaches to all page targets
- Per-profile proxy inheritance with credential override support
- Full test coverage: 17 config tests + 2 launch tests covering schemes, credentials, inheritance, and edge cases

**Issue found:**
- CDP WebSocket in `setupCdpProxyAuth` lacks error handling and is never cleaned up (see inline comment)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one WebSocket cleanup issue that should be addressed
- Implementation is well-designed with proper credential handling, comprehensive tests (19 total), and good documentation. The CDP-based auth approach correctly handles Chrome's limitation with inline proxy credentials. However, the WebSocket connection in setupCdpProxyAuth lacks error handling and cleanup, which could cause resource leaks during long browser sessions. This is a minor issue that doesn't affect core functionality but should be fixed.
- Pay attention to src/browser/chrome.ts (WebSocket lifecycle management)

<sub>Last reviewed commit: 78eccb7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->