### PR TITLE
Auto-reply: preserve Telegram DM newlines

### DIFF
--- a/src/auto-reply/reply.telegram-newline-to-llm.e2e.test.ts
+++ b/src/auto-reply/reply.telegram-newline-to-llm.e2e.test.ts
@@ -1,0 +1,128 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { normalizeCommandBody } from "./commands-registry.js";
+import { getReplyFromConfig } from "./reply.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(
+    async (home) => {
+      return await fn(home);
+    },
+    {
+      env: {
+        OPENCLAW_AGENT_DIR: (home) => path.join(home, ".openclaw", "agent"),
+        PI_CODING_AGENT_DIR: (home) => path.join(home, ".openclaw", "agent"),
+      },
+      prefix: "openclaw-telegram-newline-",
+    },
+  );
+}
+
+function makeTelegramConfig(home: string): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: { primary: "anthropic/claude-opus-4-5" },
+        workspace: path.join(home, "openclaw"),
+      },
+    },
+    channels: { telegram: { allowFrom: ["*"], dmPolicy: "open" } },
+    session: { store: path.join(home, "sessions.json") },
+  };
+}
+
+function makeTelegramDirectCtx(body: string) {
+  return {
+    Body: body,
+    BodyForAgent: body,
+    RawBody: body,
+    CommandBody: normalizeCommandBody(body),
+    From: "telegram:1001",
+    To: "telegram:1001",
+    Provider: "telegram",
+    Surface: "telegram",
+    ChatType: "direct",
+    CommandAuthorized: true,
+  } as const;
+}
+
+describe("telegram multiline delivery to embedded llm", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([
+      { id: "claude-opus-4-5", name: "Opus 4.5", provider: "anthropic" },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("preserves user newlines for plain multiline DMs", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "ok" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const body = "line one\nline two\nline three";
+      const res = await getReplyFromConfig(
+        makeTelegramDirectCtx(body),
+        {},
+        makeTelegramConfig(home),
+      );
+
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toBe("ok");
+      expect(runEmbeddedPiAgent).toHaveBeenCalledOnce();
+
+      const prompt = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0]?.prompt ?? "";
+      expect(prompt).toContain("line one\nline two\nline three");
+    });
+  });
+
+  it("preserves newlines even when body contains unknown slash tokens", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "ok" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const body = "line one\n/unknown\nline two";
+      const res = await getReplyFromConfig(
+        makeTelegramDirectCtx(body),
+        {},
+        makeTelegramConfig(home),
+      );
+
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toBe("ok");
+      expect(runEmbeddedPiAgent).toHaveBeenCalledOnce();
+
+      const prompt = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0]?.prompt ?? "";
+      expect(prompt).toContain("line one\n/unknown\nline two");
+    });
+  });
+});

--- a/src/auto-reply/reply/reply-inline.ts
+++ b/src/auto-reply/reply/reply-inline.ts
@@ -38,8 +38,15 @@ export function stripInlineStatus(body: string): {
   if (!trimmed) {
     return { cleaned: "", didStrip: false };
   }
-  // Use [^\S\n]+ instead of \s+ to only collapse horizontal whitespace,
-  // preserving newlines so multi-line messages keep their paragraph structure.
-  const cleaned = collapseInlineHorizontalWhitespace(trimmed.replace(INLINE_STATUS_RE, " ")).trim();
-  return { cleaned, didStrip: cleaned !== trimmed };
+  let didStrip = false;
+  const removed = trimmed.replace(INLINE_STATUS_RE, () => {
+    didStrip = true;
+    return " ";
+  });
+  if (!didStrip) {
+    return { cleaned: trimmed, didStrip: false };
+  }
+  // Collapse only horizontal whitespace so multi-line messages keep paragraph breaks.
+  const cleaned = collapseInlineHorizontalWhitespace(removed).trim();
+  return { cleaned, didStrip: true };
 }

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+const probeGateway = vi.fn<
+  (opts: {
+    url: string;
+    auth?: { token?: string; password?: string };
+    timeoutMs: number;
+  }) => Promise<{
+    ok: boolean;
+    configSnapshot: unknown;
+  }>
+>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 


### PR DESCRIPTION
## Summary

- Fix newline loss in user input before prompt delivery to embedded LLM.
- Preserve existing `/status` stripping behavior only when `/status` is actually present.
- Add e2e regression coverage for Telegram direct-message multiline input.

### Why
- User multiline DM content was flattened into a single line in normal conversation paths.
- Flattening removed user-intended line boundaries and harmed downstream LLM interpretation.

## Root Cause
- `stripInlineStatus()` normalized whitespace via `replace(/\s+/g, " ")` even when no `/status` existed.
- That behavior converted user `\n` line breaks into spaces.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

- New permissions/capabilities?  `NO`
- Secrets/tokens handling changed? `NO`
- New/changed network calls? `NO`
- Command/tool execution surface changed? `NO`
- Data access scope changed? `NO`

## Human Verification (required)
Author understanding: I reviewed and understand the implemented changes and their runtime behavior.

### Testing
- Degree: fully tested.
- Commands run:
  - `pnpm build`
  - `pnpm check`
  - `pnpm test`
- Result: all passed.

### Deployment Validation
- Deployed to personal production environment.
- Runtime behavior validated as normal after deployment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)


## Risks and Mitigations

None
