### PR TITLE
fix(auto-reply): restore prompt cache stability by moving per-turn ids to user context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.
 - Agents/Billing: include the active model that produced a billing error in user-facing billing messages (for example, `OpenAI (gpt-5.3)`) across payload, failover, and lifecycle error paths, so users can identify exactly which key needs credits. (#20510) Thanks @echoVic.
 - Gateway/TUI: honor `agents.defaults.blockStreamingDefault` for `chat.send` by removing the hardcoded block-streaming disable override, so replies can use configured block-mode delivery. (#19693) Thanks @neipor.
+- Auto-reply/Prompt caching: restore prefix-cache stability by keeping inbound system metadata session-stable and moving per-message IDs (`message_id`, `message_id_full`, `reply_to_id`, `sender_id`) into untrusted conversation context. (#20597) Thanks @anisoptera.
 - UI/Sessions: accept the canonical main session-key alias in Chat UI flows so main-session routing stays consistent. (#20311) Thanks @mbelinky.
 - OpenClawKit/Protocol: preserve JSON boolean literals (`true`/`false`) when bridging through `AnyCodable` so Apple client RPC params no longer re-encode booleans as `1`/`0`. Thanks @mbelinky.
 - Commands/Doctor: skip embedding-provider warnings when `memory.backend` is `qmd`, because QMD manages embeddings internally and does not require `memorySearch` providers. (#17263) Thanks @miloudbelarebia.

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -19,7 +19,7 @@ function parseConversationInfoPayload(text: string): Record<string, unknown> {
 }
 
 describe("buildInboundMetaSystemPrompt", () => {
-  it("includes trusted message and routing ids for tool actions", () => {
+  it("includes session-stable routing fields", () => {
     const prompt = buildInboundMetaSystemPrompt({
       MessageSid: "123",
       MessageSidFull: "123",
@@ -33,41 +33,28 @@ describe("buildInboundMetaSystemPrompt", () => {
 
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["schema"]).toBe("openclaw.inbound_meta.v1");
-    expect(payload["message_id"]).toBe("123");
-    expect(payload["message_id_full"]).toBeUndefined();
-    expect(payload["reply_to_id"]).toBe("99");
     expect(payload["chat_id"]).toBe("telegram:5494292670");
     expect(payload["channel"]).toBe("telegram");
   });
 
-  it("includes sender_id when provided", () => {
+  it("does not include per-turn message identifiers (cache stability)", () => {
     const prompt = buildInboundMetaSystemPrompt({
-      MessageSid: "456",
+      MessageSid: "123",
+      MessageSidFull: "123",
+      ReplyToId: "99",
       SenderId: "289522496",
-      OriginatingTo: "telegram:-1001249586642",
+      OriginatingTo: "telegram:5494292670",
       OriginatingChannel: "telegram",
       Provider: "telegram",
       Surface: "telegram",
-      ChatType: "group",
+      ChatType: "direct",
     } as TemplateContext);
 
     const payload = parseInboundMetaPayload(prompt);
-    expect(payload["sender_id"]).toBe("289522496");
-  });
-
-  it("trims sender_id before storing", () => {
-    const prompt = buildInboundMetaSystemPrompt({
-      MessageSid: "457",
-      SenderId: "  289522496  ",
-      OriginatingTo: "telegram:-1001249586642",
-      OriginatingChannel: "telegram",
-      Provider: "telegram",
-      Surface: "telegram",
-      ChatType: "group",
-    } as TemplateContext);
-
-    const payload = parseInboundMetaPayload(prompt);
-    expect(payload["sender_id"]).toBe("289522496");
+    expect(payload["message_id"]).toBeUndefined();
+    expect(payload["message_id_full"]).toBeUndefined();
+    expect(payload["reply_to_id"]).toBeUndefined();
+    expect(payload["sender_id"]).toBeUndefined();
   });
 
   it("omits sender_id when blank", () => {
@@ -83,36 +70,6 @@ describe("buildInboundMetaSystemPrompt", () => {
 
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["sender_id"]).toBeUndefined();
-  });
-
-  it("omits sender_id when not provided", () => {
-    const prompt = buildInboundMetaSystemPrompt({
-      MessageSid: "789",
-      OriginatingTo: "telegram:5494292670",
-      OriginatingChannel: "telegram",
-      Provider: "telegram",
-      Surface: "telegram",
-      ChatType: "direct",
-    } as TemplateContext);
-
-    const payload = parseInboundMetaPayload(prompt);
-    expect(payload["sender_id"]).toBeUndefined();
-  });
-
-  it("keeps message_id_full only when it differs from message_id", () => {
-    const prompt = buildInboundMetaSystemPrompt({
-      MessageSid: "short-id",
-      MessageSidFull: "full-provider-message-id",
-      OriginatingTo: "channel:C1",
-      OriginatingChannel: "slack",
-      Provider: "slack",
-      Surface: "slack",
-      ChatType: "group",
-    } as TemplateContext);
-
-    const payload = parseInboundMetaPayload(prompt);
-    expect(payload["message_id"]).toBe("short-id");
-    expect(payload["message_id_full"]).toBe("full-provider-message-id");
   });
 });
 
@@ -154,6 +111,63 @@ describe("buildInboundUserContextPrefix", () => {
 
     const conversationInfo = parseConversationInfoPayload(text);
     expect(conversationInfo["message_id"]).toBe("msg-123");
+  });
+
+  it("includes message_id_full when it differs from message_id", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      MessageSid: "short-id",
+      MessageSidFull: "full-provider-message-id",
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["message_id"]).toBe("short-id");
+    expect(conversationInfo["message_id_full"]).toBe("full-provider-message-id");
+  });
+
+  it("omits message_id_full when it matches message_id", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      MessageSid: "same-id",
+      MessageSidFull: "same-id",
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["message_id"]).toBe("same-id");
+    expect(conversationInfo["message_id_full"]).toBeUndefined();
+  });
+
+  it("includes reply_to_id in conversation info", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      MessageSid: "msg-200",
+      ReplyToId: "msg-199",
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["reply_to_id"]).toBe("msg-199");
+  });
+
+  it("includes sender_id in conversation info", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      MessageSid: "msg-456",
+      SenderId: "289522496",
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["sender_id"]).toBe("289522496");
+  });
+
+  it("trims sender_id in conversation info", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      MessageSid: "msg-457",
+      SenderId: "  289522496  ",
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["sender_id"]).toBe("289522496");
   });
 
   it("falls back to SenderId when sender phone is missing", () => {


### PR DESCRIPTION
## Summary

• Problem: Commit bed8e7abe added message_id, message_id_full, reply_to_id, and sender_id to buildInboundMetaSystemPrompt(), injecting them into the system prompt on every turn. Since message_id is unique per message, this caused the system prompt to differ on every turn, busting prefix-based prompt caches on local model providers (llama-server, LM Studio/MLX) and causing full cache rebuilds on every conversation turn.
• Why it matters: Cache invalidation on every turn increases latency, costs, and reduces efficiency for local models.
• What changed: Moved per-message identifiers from buildInboundMetaSystemPrompt() (system prompt) to buildInboundUserContextPrefix() (user context prefix). System prompt now contains only session-stable routing fields.
• What did NOT change (scope boundary): Other metadata fields (sender info, thread starter, forwarded message, chat history) remain unchanged. The buildInboundMetaSystemPrompt() trusted metadata schema remains the same.

Change Type

• [x] Bug fix

## Scope (select all touched areas)

- [X] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #19892 , #19989
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)
* New permissions/capabilities? No
• Secrets/tokens handling changed? No
• New/changed network calls? No
• Command/tool execution surface changed? No
• Data access scope changed? No

## Repro + Verification

### Environment
• OS: Linux (Debian)
• Runtime/container: Node.js v22.22.0
• Model/provider: glm-4.7-flash, llama.cpp
• Integration/channel: General
• Relevant config: Default OpenClaw config

### Steps

1. Configure OpenClaw to use a local model provider (e.g., llama-server, LM Studio)
2. Send multiple messages in a conversation
3. Observe prompt cache behavior via logs or diagnostics

###Expected

• Prompt cache should remain stable across turns when workspace files don't change
• Cache should only rebuild when actual workspace changes occur

###Actual

• Before fix: Cache invalidation on every turn
• After fix: Cache remains stable across turns

## Evidence

Attach at least one:

- [x] Trace/log snippets
Here's it actually being able to use the prefix cache:
```Feb 18 19:54:43 megami launch_models.sh[497507]: slot get_availabl: id  0 | task -1 | selected slot by LCP similarity, sim_best = 0.206 (> 0.100 thold), f_keep = 0.070
Feb 18 19:54:43 megami launch_models.sh[497507]: srv  get_availabl: updating prompt cache
Feb 18 19:54:43 megami launch_models.sh[497507]: srv   prompt_save:  - saving prompt with length 18201, total state size = 940.031 MiB
Feb 18 19:54:43 megami launch_models.sh[497507]: srv          load:  - looking for better prompt, base f_keep = 0.070, sim = 0.206
Feb 18 19:54:43 megami launch_models.sh[497507]: srv          load:  - found better prompt with f_keep = 0.578, sim = 0.813
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran this for some time, my agent is so much faster now it's wild. Even with more sessions going than I have slots to hold.
- Edge cases checked:
I did consider splitting the conversation info block a few different ways but didn't see the point in the end.
- What you did **not** verify:
Lots I'm sure. But I've been running it for a while with no issues!

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
Just revert it and restart.
- Files/config to restore:
none
- Known bad symptoms reviewers should watch for:
You're probably already experiencing them.

## Risks and Mitigations
None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Relocated per-turn message identifiers (`message_id`, `message_id_full`, `reply_to_id`, `sender_id`) from system prompt to user context prefix to prevent prompt cache invalidation on every conversation turn. The system prompt now contains only session-stable routing fields (`chat_id`, `channel`, `provider`, `surface`, `chat_type`, `flags`), while per-turn identifiers are included in the conversation info block within user context. This optimization enables efficient prefix-based caching for local model providers (llama-server, LM Studio, MLX).

- Moved per-turn identifiers from `buildInboundMetaSystemPrompt()` to `buildInboundUserContextPrefix()`
- Added clear inline documentation explaining cache stability rationale
- Updated tests to verify system prompt excludes per-turn identifiers
- Added comprehensive test coverage for user context prefix including all relocated fields
- Preserved metadata schema (`openclaw.inbound_meta.v1`) unchanged

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a straightforward refactoring that moves metadata fields between two string-building functions without altering logic or behavior. Comprehensive test coverage verifies both the exclusion from system prompt and inclusion in user context. The implementation includes clear documentation explaining the cache stability rationale. No security implications, backwards compatibility issues, or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 607c922</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->