### PR TITLE
fix(gateway): scan all agents in usage.cost RPC (#20558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Usage: scan all agents (not just the default "main" agent) in `usage.cost` RPC so multi-agent deployments report accurate token and cost totals. (#20558)
 - Telegram: unify message-like inbound handling so `message` and `channel_post` share the same dedupe/access/media pipeline and remain behaviorally consistent. (#20591) Thanks @obviyus.
 - Telegram/Agents: gate exec/bash tool-failure warnings behind verbose mode so default Telegram replies stay clean while verbose sessions still surface diagnostics. (#20560) Thanks @obviyus.
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.

--- a/src/gateway/server-methods/usage.cost-multi-agent.test.ts
+++ b/src/gateway/server-methods/usage.cost-multi-agent.test.ts
@@ -40,7 +40,7 @@ describe("usage.cost multi-agent (#20558)", () => {
           role: "assistant",
           provider: "openai",
           model: "gpt-5.2",
-          usage: { input: 100, output: 50, totalTokens: 150, cost: { total: 0.10 } },
+          usage: { input: 100, output: 50, totalTokens: 150, cost: { total: 0.1 } },
         },
       }),
       "utf-8",
@@ -57,7 +57,7 @@ describe("usage.cost multi-agent (#20558)", () => {
           role: "assistant",
           provider: "openai",
           model: "gpt-5.2",
-          usage: { input: 200, output: 100, totalTokens: 300, cost: { total: 0.20 } },
+          usage: { input: 200, output: 100, totalTokens: 300, cost: { total: 0.2 } },
         },
       }),
       "utf-8",
@@ -70,13 +70,17 @@ describe("usage.cost multi-agent (#20558)", () => {
     const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
 
     expect(summary.totals.totalTokens).toBe(450);
-    expect(summary.totals.totalCost).toBeCloseTo(0.30, 5);
+    expect(summary.totals.totalCost).toBeCloseTo(0.3, 5);
   });
 
   it("merges daily entries from multiple agents on the same date", async () => {
     const ts = new Date().toISOString();
 
-    for (const [agentId, tokens] of [["main", 100], ["alpha", 200], ["beta", 300]] as const) {
+    for (const [agentId, tokens] of [
+      ["main", 100],
+      ["alpha", 200],
+      ["beta", 300],
+    ] as const) {
       const dir = path.join(root, "agents", agentId, "sessions");
       await fs.mkdir(dir, { recursive: true });
       await fs.writeFile(
@@ -88,7 +92,12 @@ describe("usage.cost multi-agent (#20558)", () => {
             role: "assistant",
             provider: "openai",
             model: "gpt-5.2",
-            usage: { input: tokens, output: 0, totalTokens: tokens, cost: { total: tokens * 0.001 } },
+            usage: {
+              input: tokens,
+              output: 0,
+              totalTokens: tokens,
+              cost: { total: tokens * 0.001 },
+            },
           },
         }),
         "utf-8",
@@ -102,7 +111,7 @@ describe("usage.cost multi-agent (#20558)", () => {
     const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
 
     expect(summary.totals.totalTokens).toBe(600);
-    expect(summary.totals.totalCost).toBeCloseTo(0.60, 5);
+    expect(summary.totals.totalCost).toBeCloseTo(0.6, 5);
     // All three agents report on the same day → single daily entry
     expect(summary.daily).toHaveLength(1);
     expect(summary.daily[0]?.totalTokens).toBe(600);

--- a/src/gateway/server-methods/usage.cost-multi-agent.test.ts
+++ b/src/gateway/server-methods/usage.cost-multi-agent.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { __test } from "./usage.js";
+
+const { loadCostUsageSummaryCached, costUsageCache } = __test;
+
+describe("usage.cost multi-agent (#20558)", () => {
+  let root: string;
+  let originalState: string | undefined;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-multi-agent-"));
+    originalState = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = root;
+    costUsageCache.clear();
+  });
+
+  afterEach(() => {
+    if (originalState === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalState;
+    }
+  });
+
+  it("includes tokens from non-main agents in cost summary", async () => {
+    const ts = new Date().toISOString();
+
+    const mainDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(mainDir, { recursive: true });
+    await fs.writeFile(
+      path.join(mainDir, "sess-main.jsonl"),
+      JSON.stringify({
+        type: "message",
+        timestamp: ts,
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: { input: 100, output: 50, totalTokens: 150, cost: { total: 0.10 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    const workerDir = path.join(root, "agents", "worker", "sessions");
+    await fs.mkdir(workerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(workerDir, "sess-worker.jsonl"),
+      JSON.stringify({
+        type: "message",
+        timestamp: ts,
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: { input: 200, output: 100, totalTokens: 300, cost: { total: 0.20 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    const startMs = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    const endMs = Date.now() + 24 * 60 * 60 * 1000;
+    const config = {} as OpenClawConfig;
+
+    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
+
+    expect(summary.totals.totalTokens).toBe(450);
+    expect(summary.totals.totalCost).toBeCloseTo(0.30, 5);
+  });
+
+  it("merges daily entries from multiple agents on the same date", async () => {
+    const ts = new Date().toISOString();
+
+    for (const [agentId, tokens] of [["main", 100], ["alpha", 200], ["beta", 300]] as const) {
+      const dir = path.join(root, "agents", agentId, "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, `sess-${agentId}.jsonl`),
+        JSON.stringify({
+          type: "message",
+          timestamp: ts,
+          message: {
+            role: "assistant",
+            provider: "openai",
+            model: "gpt-5.2",
+            usage: { input: tokens, output: 0, totalTokens: tokens, cost: { total: tokens * 0.001 } },
+          },
+        }),
+        "utf-8",
+      );
+    }
+
+    const startMs = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    const endMs = Date.now() + 24 * 60 * 60 * 1000;
+    const config = {} as OpenClawConfig;
+
+    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
+
+    expect(summary.totals.totalTokens).toBe(600);
+    expect(summary.totals.totalCost).toBeCloseTo(0.60, 5);
+    // All three agents report on the same day → single daily entry
+    expect(summary.daily).toHaveLength(1);
+    expect(summary.daily[0]?.totalTokens).toBe(600);
+  });
+});

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -257,7 +257,8 @@ async function loadCostUsageSummaryAllAgents(params: {
   }
 
   const daily = Array.from(dailyMap.values()).toSorted((a, b) => a.date.localeCompare(b.date));
-  const days = perAgent[0]?.days ?? Math.ceil((params.endMs - params.startMs) / (24 * 60 * 60 * 1000)) + 1;
+  const days =
+    perAgent[0]?.days ?? Math.ceil((params.endMs - params.startMs) / (24 * 60 * 60 * 1000)) + 1;
 
   return { updatedAt: Date.now(), days, daily, totals };
 }

--- a/src/gateway/server.usage-cost-multi-agent.e2e.test.ts
+++ b/src/gateway/server.usage-cost-multi-agent.e2e.test.ts
@@ -35,7 +35,7 @@ describe("usage.cost multi-agent e2e (#20558)", () => {
           role: "assistant",
           provider: "openai",
           model: "gpt-5.2",
-          usage: { input: 100, output: 50, totalTokens: 150, cost: { total: 0.10 } },
+          usage: { input: 100, output: 50, totalTokens: 150, cost: { total: 0.1 } },
         },
       }),
       "utf-8",
@@ -53,7 +53,7 @@ describe("usage.cost multi-agent e2e (#20558)", () => {
           role: "assistant",
           provider: "openai",
           model: "gpt-5.2",
-          usage: { input: 200, output: 100, totalTokens: 300, cost: { total: 0.20 } },
+          usage: { input: 200, output: 100, totalTokens: 300, cost: { total: 0.2 } },
         },
       }),
       "utf-8",
@@ -81,7 +81,7 @@ describe("usage.cost multi-agent e2e (#20558)", () => {
 
       // Should be 450 (main 150 + worker 300)
       expect(totals.totalTokens).toBeGreaterThanOrEqual(450);
-      expect(totals.totalCost).toBeGreaterThanOrEqual(0.30 - 0.001);
+      expect(totals.totalCost).toBeGreaterThanOrEqual(0.3 - 0.001);
     });
   });
 });

--- a/src/gateway/server.usage-cost-multi-agent.e2e.test.ts
+++ b/src/gateway/server.usage-cost-multi-agent.e2e.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { connectOk, installGatewayTestHooks, rpcReq } from "./test-helpers.js";
+import { withServer } from "./test-with-server.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("usage.cost multi-agent e2e (#20558)", () => {
+  it("should include tokens from all agents, not just main", async () => {
+    const ts = new Date().toISOString();
+    const stateDir = process.env.OPENCLAW_STATE_DIR!;
+
+    // Write multi-agent config
+    const { writeConfigFile } = await import("../config/config.js");
+    await writeConfigFile({
+      session: { mainKey: "main-test" },
+      agents: {
+        list: [
+          { id: "main", name: "Main Agent" },
+          { id: "worker", name: "Worker Agent" },
+        ],
+      },
+    });
+
+    // Create session data for "main" agent (150 tokens, $0.10)
+    const mainDir = path.join(stateDir, "agents", "main", "sessions");
+    await fs.mkdir(mainDir, { recursive: true });
+    await fs.writeFile(
+      path.join(mainDir, "sess-main-e2e.jsonl"),
+      JSON.stringify({
+        type: "message",
+        timestamp: ts,
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: { input: 100, output: 50, totalTokens: 150, cost: { total: 0.10 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    // Create session data for "worker" agent (300 tokens, $0.20)
+    const workerDir = path.join(stateDir, "agents", "worker", "sessions");
+    await fs.mkdir(workerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(workerDir, "sess-worker-e2e.jsonl"),
+      JSON.stringify({
+        type: "message",
+        timestamp: ts,
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: { input: 200, output: 100, totalTokens: 300, cost: { total: 0.20 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    // Start real gateway, connect, call usage.cost RPC
+    await withServer(async (ws) => {
+      await connectOk(ws, { token: "secret", scopes: ["operator.read"] });
+
+      const res = await rpcReq<{
+        totals: { totalTokens: number; totalCost: number };
+        daily: Array<{ date: string; totalTokens: number }>;
+      }>(ws, "usage.cost", { days: 7 });
+
+      expect(res.ok).toBe(true);
+
+      const totals = res.payload!.totals;
+      console.log(`Total tokens from usage.cost RPC: ${totals.totalTokens}`);
+      console.log(`Total cost from usage.cost RPC: ${totals.totalCost}`);
+
+      if (totals.totalTokens < 450) {
+        console.log("❌ BUG CONFIRMED: usage.cost only scans main agent");
+        console.log(`   Expected >= 450 (main 150 + worker 300), got ${totals.totalTokens}`);
+      }
+
+      // Should be 450 (main 150 + worker 300)
+      expect(totals.totalTokens).toBeGreaterThanOrEqual(450);
+      expect(totals.totalCost).toBeGreaterThanOrEqual(0.30 - 0.001);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: `usage.cost` RPC only reports tokens/cost from the default "main" agent, severely under-reporting in multi-agent deployments
- **Root cause**: `loadCostUsageSummaryCached` in `src/gateway/server-methods/usage.ts` called `loadCostUsageSummary` without an `agentId`, which defaults to scanning only the "main" agent's sessions directory
- **Fix**: Iterate all agents via `listAgentsForGateway` and merge per-agent summaries (daily + totals)

Fixes #20558

## Problem

`loadCostUsageSummary()` at `src/infra/session-cost-usage.ts:314` resolves the sessions directory via `resolveSessionTranscriptsDirForAgent(params?.agentId)`. When `agentId` is `undefined`, it defaults to `DEFAULT_AGENT_ID` ("main"), so only `agents/main/sessions/` is scanned.

The `sessions.usage` RPC already handles multi-agent correctly via `discoverAllSessionsForUsage`, but `usage.cost` did not.

**Before fix:**
Input: Multi-agent deployment with main (150 tokens) + worker (300 tokens)
Output: `totalTokens: 150` (only main agent)

## Changes

- `src/gateway/server-methods/usage.ts` — Add `loadCostUsageSummaryAllAgents` that iterates all agents and merges daily/totals; use it in `loadCostUsageSummaryCached`
- `src/gateway/server-methods/usage.cost-multi-agent.test.ts` — Regression tests for multi-agent cost aggregation
- `CHANGELOG.md` — Add fix entry

**After fix:**
Input: Multi-agent deployment with main (150 tokens) + worker (300 tokens)
Output: `totalTokens: 450` (all agents combined)

## Test plan

- [x] New test: multi-agent cost summary includes all agents (2 test cases)
- [x] All 8 existing session-cost-usage tests pass
- [x] All 5 existing usage handler tests pass
- [x] Lint passes

## Effect on User Experience

**Before:** Dashboard shows incomplete token usage and cost — only the default agent's sessions are counted, making multi-agent deployments appear to use far fewer tokens than reality.
**After:** Dashboard accurately reflects total token usage and cost across all configured agents.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `usage.cost` RPC to aggregate token usage and costs across all agents instead of only the default "main" agent. The implementation adds `loadCostUsageSummaryAllAgents` that iterates all agents via `listAgentsForGateway`, loads per-agent summaries, and merges daily breakdowns and totals. The fix ensures multi-agent deployments accurately report complete usage metrics in the dashboard.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-isolated, focused on a specific bug, includes comprehensive test coverage with two test cases validating the aggregation logic, and follows existing patterns in the codebase. The implementation correctly merges daily entries by date and accumulates totals across all cost/token fields.
- No files require special attention

<sub>Last reviewed commit: 9663533</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->