### PR TITLE
docs(bedrock): add cross-region inference prefix documentation

### DIFF
--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -162,6 +162,31 @@ source ~/.bashrc
 openclaw models list
 ```
 
+## Cross-Region Inference
+
+When using AWS Bedrock, model IDs may require a **region prefix** (`us.`, `eu.`, `ap.`) to access models in different regions from your default. This is required for **cross-region inference**.
+
+### When to Use Prefixes
+
+- If your default region (e.g., `us-east-1`) doesn't host the model you want
+- To explicitly use a model in a specific region (e.g., `eu.` for Europe, `ap.` for Asia)
+
+### Prefix Examples
+
+| Model ID | Region | Use Case |
+|----------|--------|----------|
+| `anthropic.claude-opus-4-5-20251101-v1:0` | Local (us-east-1) | Default, no prefix needed |
+| `us.anthropic.claude-opus-4-5-20251101-v1:0` | US (explicit) | Force US region |
+| `eu.anthropic.claude-opus-4-5-20251101-v1:0` | Europe | Access EU-hosted models |
+| `ap.anthropic.claude-opus-4-5-20251101-v1:0` | Asia Pacific | Access APAC-hosted models |
+
+### Troubleshooting
+
+If you get a "model not found" error:
+1. Check that model access is enabled in your AWS account for that region
+2. Add the appropriate prefix (`us.`, `eu.`, or `ap.`) to your model ID
+3. Ensure your `AWS_REGION` matches or is set to allow cross-region access
+
 ## Notes
 
 - Bedrock requires **model access** enabled in your AWS account/region.


### PR DESCRIPTION
## Summary
Adds documentation explaining AWS Bedrock cross-region inference prefixes (`us.`, `eu.`, `ap.`) and when to use them.

## Changes
- Added "Cross-Region Inference" section to `docs/providers/bedrock.md`
- Explains prefix usage and when they're needed
- Adds troubleshooting section for "model not found" errors

## Issue
Fixes #20507

## Testing
- Verified docs render correctly
- Checked prefix table formatting

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added documentation for AWS Bedrock cross-region inference prefixes (`us.`, `eu.`, `ap.`). Explains when prefixes are needed and provides a clear table with examples for different regions, plus troubleshooting tips for "model not found" errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only change that adds helpful clarification about AWS Bedrock cross-region inference. No code changes, clear formatting, and accurate technical information
- No files require special attention

<sub>Last reviewed commit: 16c978d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->