### PR TITLE
feat: add anthropic/claude-opus-4-6 to XHIGH_MODEL_REFS

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
@@ -105,7 +105,7 @@ describe("directive behavior", () => {
 
       const texts = (Array.isArray(res) ? res : [res]).map((entry) => entry?.text).filter(Boolean);
       expect(texts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
+        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex, github-copilot/gpt-5.2 or anthropic/claude-opus-4-6.',
       );
     });
   });

--- a/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
@@ -105,7 +105,7 @@ describe("directive behavior", () => {
 
       const texts = (Array.isArray(res) ? res : [res]).map((entry) => entry?.text).filter(Boolean);
       expect(texts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex, github-copilot/gpt-5.2 or anthropic/claude-opus-4-6.',
+        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex, github-copilot/gpt-5.2, anthropic/claude-opus-4-6 or anthropic/claude-opus-4.6.',
       );
     });
   });

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -29,6 +29,7 @@ export const XHIGH_MODEL_REFS = [
   "openai-codex/gpt-5.1-codex",
   "github-copilot/gpt-5.2-codex",
   "github-copilot/gpt-5.2",
+  "anthropic/claude-opus-4-6",
 ] as const;
 
 const XHIGH_MODEL_SET = new Set(XHIGH_MODEL_REFS.map((entry) => entry.toLowerCase()));

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -30,6 +30,7 @@ export const XHIGH_MODEL_REFS = [
   "github-copilot/gpt-5.2-codex",
   "github-copilot/gpt-5.2",
   "anthropic/claude-opus-4-6",
+  "anthropic/claude-opus-4.6",
 ] as const;
 
 const XHIGH_MODEL_SET = new Set(XHIGH_MODEL_REFS.map((entry) => entry.toLowerCase()));


### PR DESCRIPTION
## Summary

Adds `anthropic/claude-opus-4-6` to `XHIGH_MODEL_REFS` in `src/auto-reply/thinking.ts`.

## Problem

`XHIGH_MODEL_REFS` only contains OpenAI/Codex/Copilot models. When `thinkingDefault` is set to `xhigh`, Anthropic models silently downgrade to `high` because `supportsXHighThinking()` returns `false`.

However, the Anthropic provider (`pi-ai`) **already supports xhigh natively**:
- `supportsAdaptiveThinking()` returns `true` for Opus 4.6+
- `mapThinkingLevelToEffort("xhigh")` → `"max"`
- API call: `thinking: {type: "adaptive"}` + `output_config: {effort: "max"}`

The **only** blocker is the allowlist gate in `thinking.ts`.

## Change

One line — add `"anthropic/claude-opus-4-6"` to the array.

## Why Only Opus 4.6?

The pi-ai Anthropic provider gates adaptive thinking on `supportsAdaptiveThinking()`, which checks for `opus-4-6` / `opus-4.6` in the model ID. Only Opus 4.6+ uses the `output_config: { effort }` API path. Older models use budget-based thinking where xhigh has no distinct behavior beyond high.

## End-to-End Flow After Patch

```
config: thinkingDefault: "xhigh"
  → normalizeThinkLevel("xhigh") → "xhigh"
  → supportsXHighThinking("anthropic", "claude-opus-4-6") → true  ← THIS PR
  → no downgrade
  → pi-ai anthropic provider:
    → supportsAdaptiveThinking("claude-opus-4-6") → true
    → mapThinkingLevelToEffort("xhigh") → "max"
    → API: thinking: {type: "adaptive"}, output_config: {effort: "max"}
```

## Testing

1. Set `thinkingDefault: "xhigh"` with `anthropic/claude-opus-4-6` as default model
2. Send a message → should NOT see "downgrading to high" in logs
3. Verify API request includes `output_config: { effort: "max" }`
4. Non-Opus Anthropic models should still correctly downgrade

Closes #6820

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `anthropic/claude-opus-4-6` to the `XHIGH_MODEL_REFS` allowlist in `src/auto-reply/thinking.ts`. This enables the "xhigh" thinking level for Claude Opus 4.6 models when `thinkingDefault: "xhigh"` is configured, preventing the silent downgrade to "high" that previously occurred.

**Key changes:**
- Single line addition to `XHIGH_MODEL_REFS` array to include `"anthropic/claude-opus-4-6"`
- Enables `supportsXHighThinking()` to return `true` for this model
- Allows the model to use adaptive thinking with `effort: "max"` via the Anthropic provider

**Issue found:**
- The test at `src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts:108` hardcodes the expected error message listing all xhigh-supported models. This test will fail because the actual error message (generated dynamically by `formatXHighModelHint()`) will now include the new Anthropic model.

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge after fixing the test failure
- The change itself is minimal and correct - just adding a model reference to an allowlist. However, the PR introduces a test failure that must be fixed before merging. The hardcoded test expectation at line 108 of the xhigh codex test file will fail because the error message now includes the Anthropic model.
- The test file `src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts` needs updating at line 108 to include `anthropic/claude-opus-4-6` in the expected error message

<sub>Last reviewed commit: 7df2e85</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->