### PR TITLE
feat: add configurable typingTtlSeconds to config schema

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,3 +1,5 @@
+import type { MsgContext } from "../templating.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -12,9 +14,7 @@ import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
-import type { MsgContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveDefaultModel } from "./directive-handling.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
 import { handleInlineActions } from "./get-reply-inline-actions.js";

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -112,8 +112,12 @@ export async function getReplyFromConfig(
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
   const configuredTtlSeconds =
     agentCfg?.typingTtlSeconds ?? sessionCfg?.typingTtlSeconds;
+  // Clamp to Node.js setTimeout max (~24.8 days) to prevent 32-bit overflow
+  const MAX_TTL_SECONDS = 2_147_483;
   const typingTtlMs =
-    typeof configuredTtlSeconds === "number" ? configuredTtlSeconds * 1000 : undefined;
+    typeof configuredTtlSeconds === "number"
+      ? Math.min(configuredTtlSeconds, MAX_TTL_SECONDS) * 1000
+      : undefined;
   const typing = createTypingController({
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,5 +1,3 @@
-import type { MsgContext } from "../templating.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -14,7 +12,9 @@ import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
+import type { MsgContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveDefaultModel } from "./directive-handling.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
 import { handleInlineActions } from "./get-reply-inline-actions.js";
@@ -110,8 +110,7 @@ export async function getReplyFromConfig(
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
-  const configuredTtlSeconds =
-    agentCfg?.typingTtlSeconds ?? sessionCfg?.typingTtlSeconds;
+  const configuredTtlSeconds = agentCfg?.typingTtlSeconds ?? sessionCfg?.typingTtlSeconds;
   // Clamp to Node.js setTimeout max (~24.8 days) to prevent 32-bit overflow
   const MAX_TTL_SECONDS = 2_147_483;
   const typingTtlMs =

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -110,10 +110,15 @@ export async function getReplyFromConfig(
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
+  const configuredTtlSeconds =
+    agentCfg?.typingTtlSeconds ?? sessionCfg?.typingTtlSeconds;
+  const typingTtlMs =
+    typeof configuredTtlSeconds === "number" ? configuredTtlSeconds * 1000 : undefined;
   const typing = createTypingController({
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,
     typingIntervalSeconds,
+    ...(typingTtlMs !== undefined && { typingTtlMs }),
     silentToken: SILENT_REPLY_TOKEN,
     log: defaultRuntime.log,
   });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -191,6 +191,8 @@ export type AgentDefaultsConfig = {
   /** Max inbound media size in MB for agent-visible attachments (text note or future image attach). */
   mediaMaxMb?: number;
   typingIntervalSeconds?: number;
+  /** Typing indicator TTL in seconds. 0 = disabled (stays active until processing completes). */
+  typingTtlSeconds?: number;
   /** Typing indicator start mode (never|instant|thinking|message). */
   typingMode?: TypingMode;
   /** Periodic background heartbeat runs. */

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -98,6 +98,8 @@ export type SessionConfig = {
   resetByChannel?: Record<string, SessionResetConfig>;
   store?: string;
   typingIntervalSeconds?: number;
+  /** Typing indicator TTL in seconds. 0 = disabled (stays active until processing completes). */
+  typingTtlSeconds?: number;
   typingMode?: TypingMode;
   mainKey?: string;
   sendPolicy?: SessionSendPolicyConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -127,6 +127,7 @@ export const AgentDefaultsSchema = z
     timeoutSeconds: z.number().int().positive().optional(),
     mediaMaxMb: z.number().positive().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
+    typingTtlSeconds: z.number().int().nonnegative().optional(),
     typingMode: z
       .union([
         z.literal("never"),

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -49,6 +49,7 @@ export const SessionSchema = z
     resetByChannel: z.record(z.string(), SessionResetConfigSchema).optional(),
     store: z.string().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
+    typingTtlSeconds: z.number().int().nonnegative().optional(),
     typingMode: z
       .union([
         z.literal("never"),


### PR DESCRIPTION
## Summary

Adds `typingTtlSeconds` to both agent-level and session-level config schemas, and passes it through to `createTypingController()` in `get-reply.ts`.

## Problem

The typing indicator has a hardcoded 2-minute TTL (`typingTtlMs = 2 * 60_000`). For extended thinking models (e.g. Claude Opus 4.6 with `effort:max`), tool-heavy workflows, or complex multi-step replies, processing regularly exceeds 2 minutes — causing the typing indicator to disappear while the model is still actively working. This confuses users into thinking the bot has stalled.

`typingIntervalSeconds` is already configurable in the schema, but there is no config path for the TTL.

## Change

**5 files, 11 insertions:**

| File | Change |
|---|---|
| `src/config/types.agent-defaults.ts` | Add `typingTtlSeconds?: number` |
| `src/config/types.base.ts` | Add `typingTtlSeconds?: number` |
| `src/config/zod-schema.agent-defaults.ts` | Add `typingTtlSeconds: z.number().int().nonnegative().optional()` |
| `src/config/zod-schema.session.ts` | Add `typingTtlSeconds: z.number().int().nonnegative().optional()` |
| `src/auto-reply/reply/get-reply.ts` | Read from config, pass to `createTypingController()` |

## Behavior

| `typingTtlSeconds` | Behavior |
|---|---|
| not set / undefined | Default 2-minute TTL (backward compatible) |
| `0` | Disabled — typing stays active until run completes |
| `> 0` | Custom TTL in seconds |

The `0` case works because `createTypingController()` already has the guard:
```ts
if (typingTtlMs <= 0) return; // skip TTL timer entirely
```

## Config Example

```yaml
# Disable TTL (typing stays active for full processing duration)
agents:
  defaults:
    typingTtlSeconds: 0

# Extend to 5 minutes
agents:
  defaults:
    typingTtlSeconds: 300
```

## Design Decisions

- **`.nonnegative()` not `.positive()`** — because `0` is a valid value meaning "disabled"
- **Seconds not milliseconds** — matches existing `typingIntervalSeconds` convention
- **Spread with undefined check** — only passes `typingTtlMs` when explicitly configured, preserving the existing default for unset values
- **Agent cascades to session** — `agentCfg?.typingTtlSeconds ?? sessionCfg?.typingTtlSeconds` follows the same pattern as `typingIntervalSeconds`

Closes #13673

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds configurable `typingTtlSeconds` to agent and session config schemas, allowing users to control how long the typing indicator stays active. The implementation follows the existing `typingIntervalSeconds` pattern and correctly:

- Adds schema validation with `.nonnegative()` (allowing `0` to disable TTL)
- Cascades from agent to session config
- Converts seconds to milliseconds before passing to `createTypingController()`
- Only passes the parameter when explicitly set (preserving the 2-minute default)
- Supports `0` value to disable TTL entirely (typing stays active until processing completes)

The change solves a real problem for extended thinking models and tool-heavy workflows where processing exceeds the hardcoded 2-minute TTL.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, follows established patterns in the codebase (mirrors `typingIntervalSeconds`), and makes only additive changes. The type checking, schema validation, and conditional spreading ensure backward compatibility. The existing `createTypingController()` logic already handles all edge cases including `0` and negative values.
- No files require special attention

<sub>Last reviewed commit: 0514a1b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->