### PR TITLE
feat(whatsapp): add linkPreviewPolicy for URL exfiltration protection

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -100,6 +100,13 @@ export type WhatsAppConfig = {
   debounceMs?: number;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /**
+   * Link preview policy for outbound messages.
+   * - "allow": Send messages as-is, link previews may be generated (default)
+   * - "warn": Log a security warning when URLs are detected in outbound messages
+   * - "mangle": Wrap URLs in angle brackets to suppress link previews
+   */
+  linkPreviewPolicy?: "allow" | "warn" | "mangle";
 };
 
 export type WhatsAppAccountConfig = {
@@ -168,4 +175,11 @@ export type WhatsAppAccountConfig = {
   debounceMs?: number;
   /** Heartbeat visibility settings for this account. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /**
+   * Link preview policy for outbound messages.
+   * - "allow": Send messages as-is, link previews may be generated (default)
+   * - "warn": Log a security warning when URLs are detected in outbound messages
+   * - "mangle": Wrap URLs in angle brackets to suppress link previews
+   */
+  linkPreviewPolicy?: "allow" | "warn" | "mangle";
 };

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -11,6 +11,18 @@ import {
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
+/**
+ * Link preview policy for outbound messages.
+ * - "allow": Send messages as-is, link previews may be generated (default)
+ * - "warn": Log a security warning when URLs are detected in outbound messages
+ * - "mangle": Wrap URLs in angle brackets to suppress link previews
+ *
+ * Security context: Link previews can potentially be exploited for data exfiltration
+ * if an attacker can influence the agent to include a URL pointing to their server.
+ * The preview fetch would include the URL path, which could encode sensitive data.
+ */
+export const LinkPreviewPolicySchema = z.enum(["allow", "warn", "mangle"]).optional();
+
 export const WhatsAppAccountSchema = z
   .object({
     name: z.string().optional(),
@@ -59,6 +71,8 @@ export const WhatsAppAccountSchema = z
       .optional(),
     debounceMs: z.number().int().nonnegative().optional().default(0),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    /** Link preview policy for outbound messages. See LinkPreviewPolicySchema for details. */
+    linkPreviewPolicy: LinkPreviewPolicySchema,
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -129,6 +143,8 @@ export const WhatsAppConfigSchema = z
       .optional(),
     debounceMs: z.number().int().nonnegative().optional().default(0),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    /** Link preview policy for outbound messages. See LinkPreviewPolicySchema for details. */
+    linkPreviewPolicy: LinkPreviewPolicySchema,
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -27,6 +27,7 @@ export type ResolvedWhatsAppAccount = {
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  linkPreviewPolicy?: "allow" | "warn" | "mangle";
 };
 
 function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
@@ -166,6 +167,7 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
+    linkPreviewPolicy: accountCfg?.linkPreviewPolicy ?? rootCfg?.linkPreviewPolicy,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a new config option to control how URLs in outbound WhatsApp messages are handled, providing protection against potential data exfiltration via link previews.

## Security Context

Link previews can be exploited for data exfiltration if an attacker influences the agent to include URLs pointing to their server. The preview fetch reveals the URL path, which could encode sensitive data.

## Configuration

```yaml
channels:
  whatsapp:
    linkPreviewPolicy: allow  # default - previews generated normally
    # linkPreviewPolicy: warn   # log security warning when URLs detected
    # linkPreviewPolicy: mangle # wrap URLs in <brackets> to suppress previews
```

Supports both root-level and per-account configuration.

## Changes

- **Schema**: Added `LinkPreviewPolicySchema` and `linkPreviewPolicy` field to WhatsApp config
- **Types**: Updated `WhatsAppAccountConfig` and `WhatsAppConfig` types
- **Utils**: Added URL detection utilities (`detectUrls`, `containsUrls`, `mangleUrlsForPreview`)
- **Outbound**: Apply policy in `sendMessageWhatsApp()`
- **Tests**: Comprehensive test coverage including edge cases

## Technical Notes

- Uses fresh regex instances per call to avoid global `lastIndex` state bugs
- Uses `offset` parameter in replace callback to correctly handle duplicate URLs
- Follows existing patterns in the codebase

## Testing

- ✅ Build passes
- ✅ All tests pass (40 tests in utils.test.ts)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `linkPreviewPolicy` configuration option to protect against URL exfiltration attacks via WhatsApp link previews. The implementation includes schema changes, utility functions for URL detection/mangling, comprehensive test coverage, and outbound message processing logic. The feature supports three modes: `allow` (default), `warn` (logs security warnings), and `mangle` (wraps URLs in angle brackets to suppress previews). Configuration cascades from root-level WhatsApp config to per-account settings following existing patterns in the codebase.

**Key changes:**
- Added `LinkPreviewPolicySchema` with security context documentation
- Implemented URL detection utilities with fresh regex instances to avoid global state bugs
- Applied policy in `sendMessageWhatsApp()` before sending outbound messages
- Added 40 comprehensive tests covering edge cases (duplicate URLs, already-wrapped URLs, regex state isolation)
- Configuration resolution follows existing account-level override patterns

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations around regex edge cases
- The PR adds a well-designed security feature with comprehensive test coverage and follows existing codebase patterns. The implementation correctly handles global regex state bugs and URL mangling edge cases. The only concern is the URL regex pattern may not handle all edge cases perfectly (e.g., URLs ending with punctuation), but the conservative approach is appropriate for security features.
- No files require special attention - all changes follow established patterns

<sub>Last reviewed commit: feefd6e</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->