### PR TITLE
fix: use KillMode=mixed to prevent orphaned child processes

### DIFF
--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -49,10 +49,13 @@ export function buildSystemdUnit({
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
-    // KillMode=process ensures systemd only waits for the main process to exit.
-    // Without this, podman's conmon (container monitor) processes block shutdown
-    // since they run as children of the gateway and stay in the same cgroup.
-    "KillMode=process",
+    // KillMode=mixed sends SIGTERM to the main process first, then SIGKILL to
+    // any remaining children after TimeoutStopSec. This prevents orphaned child
+    // processes (health checks, plugins, doctor) from accumulating across restarts
+    // while still allowing graceful shutdown of the main gateway process.
+    // Note: the previous KillMode=process left children alive in the cgroup,
+    // which leaked hundreds of MB on long-running instances.
+    "KillMode=mixed",
     workingDirLine,
     ...envLines,
     "",


### PR DESCRIPTION
## Summary

- Changes the systemd unit's `KillMode` from `process` to `mixed` to prevent orphaned child processes from accumulating across gateway restarts

## Problem

When the gateway service restarts, `KillMode=process` only sends SIGTERM to the main process. Child processes (health checks, plugins, doctor) survive in the cgroup and continue running indefinitely. On long-running instances, this leaks hundreds of MB of RAM.

**Observed on a t3.medium (4 GB) instance after 2 days:**

| Process | RSS |
|---------|-----|
| clawdbot (health check) | 197 MB |
| clawdbot-plugins | 182 MB |
| clawdbot-doctor | 134 MB |
| clawdbot-plugins (2nd) | 106 MB |
| **Total orphans** | **618 MB** |

## Fix

`KillMode=mixed` sends SIGTERM to the main process first (allowing graceful shutdown), then SIGKILL to any remaining children after `TimeoutStopSec`. This:

- Prevents orphaned child processes from accumulating
- Still allows the main gateway process to shut down gracefully
- Is the recommended mode for services that spawn children that should not outlive the parent

The original `KillMode=process` was added to avoid killing podman's `conmon` process, but `mixed` achieves the same goal — `conmon` (as a direct child of `ExecStart`) would receive SIGTERM and can handle it gracefully, while truly orphaned processes get cleaned up.

## Test plan

- [ ] Verify gateway starts normally with `KillMode=mixed`
- [ ] Restart the gateway service and confirm child processes are terminated
- [ ] Confirm no orphaned health-check/plugin/doctor processes after multiple restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes systemd `KillMode` from `process` to `mixed` to prevent orphaned child processes (health checks, plugins, doctor) from accumulating across gateway restarts, addressing a memory leak issue.

- Prevents orphaned child processes from surviving gateway restarts
- Allows graceful shutdown of main process via SIGTERM before SIGKILL cleanup
- Addresses memory leak where orphaned processes accumulated hundreds of MB over time
- Comment mentions `TimeoutStopSec` but the directive isn't actually configured (defaults to 90s)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The change from `KillMode=process` to `KillMode=mixed` is technically sound and addresses a real memory leak issue. The approach is standard for systemd services that spawn child processes. However, `TimeoutStopSec` is referenced in comments but not configured, relying on the default 90-second timeout. Adding an explicit timeout value would make the behavior more predictable.
- No files require special attention

<sub>Last reviewed commit: 499790a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->