### PR TITLE
feat: Add official Email channel plugin

### DIFF
--- a/packages/email-channel/.gitignore
+++ b/packages/email-channel/.gitignore
@@ -1,0 +1,36 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# State files (should not be committed)
+state.json
+*.log
+
+# Editor directories and files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# Environment variables
+.env
+.env.local

--- a/packages/email-channel/CHANGELOG.md
+++ b/packages/email-channel/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to the Email Channel plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial release of Email Channel plugin for Clawdbot
+- IMAP email receiving with automatic polling (configurable interval)
+- SMTP email sending for AI responses
+- Sender whitelist functionality for security
+- Persistent state management with:
+  - Timestamp-based email search (SINCE)
+  - Message-ID deduplication
+  - Automatic cleanup (max 1000 Message-IDs)
+- Session history integration with Clawdbot Dashboard
+- Support for multiple email providers (Gmail, QQ, 163, Outlook, etc.)
+- Comprehensive error handling and logging
+- Support for both read and unread email processing
+
+### Security
+- No hardcoded credentials in source code
+- Sender whitelist recommended for production use
+- App-specific password support
+
+## [1.0.0] - 2026-02-07
+
+### Added
+- Initial release
+- Core IMAP/SMTP functionality
+- State persistence system
+- Message-ID deduplication
+- Session history tracking
+- Documentation and examples

--- a/packages/email-channel/CONFIG_EXAMPLES.md
+++ b/packages/email-channel/CONFIG_EXAMPLES.md
@@ -1,0 +1,65 @@
+# Email Channel Configuration Examples
+
+This directory contains example configurations for various email providers.
+
+## Security Notice
+
+**IMPORTANT**: Never commit actual credentials to version control!
+Always use placeholder values in example configurations.
+
+## Configuration Examples
+
+### Gmail
+- Requires App-Specific Password: https://support.google.com/accounts/answer/185833
+- IMAP: imap.gmail.com:993 (SSL)
+- SMTP: smtp.gmail.com:587 (STARTTLS)
+
+### QQ Mail
+- Requires authorization code (not QQ password)
+- IMAP: imap.qq.com:993 (SSL)
+- SMTP: smtp.qq.com:587 (STARTTLS)
+
+### 163 Mail
+- Requires authorization code
+- IMAP: imap.163.com:993 (SSL)
+- SMTP: smtp.163.com:465 (SSL)
+
+### Outlook
+- IMAP: outlook.office365.com:993 (SSL)
+- SMTP: smtp-mail.outlook.com:587 (STARTTLS)
+
+## Quick Start Template
+
+```json
+{
+  "channels": {
+    "email": {
+      "accounts": {
+        "default": {
+          "enabled": true,
+          "imap": {
+            "host": "imap.example.com",
+            "port": 993,
+            "secure": true,
+            "user": "your-email@example.com",
+            "password": "your-password-or-token"
+          },
+          "smtp": {
+            "host": "smtp.example.com",
+            "port": 587,
+            "secure": false,
+            "user": "your-email@example.com",
+            "password": "your-password-or-token"
+          },
+          "checkInterval": 30,
+          "allowedSenders": [
+            "trusted@example.com"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Replace placeholder values with your actual email server configuration.

--- a/packages/email-channel/CONTRIBUTING.md
+++ b/packages/email-channel/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing to Email Channel
+
+Thank you for your interest in contributing to the Email Channel plugin for Clawdbot!
+
+## Development Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/openclaw/clawdbot.git
+   cd clawdbot/packages/email-channel
+   ```
+
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+
+3. **Build the plugin**
+   ```bash
+   npm run build
+   ```
+
+## Testing
+
+### Manual Testing
+
+1. Create a test configuration in `~/.clawdbot/clawdbot.json`
+2. Use a test email account (not your personal email)
+3. Configure the email channel with your test account
+4. Start Clawdbot Gateway: `clawdbot gateway`
+5. Send test emails and verify:
+   - Email reception
+   - AI response delivery
+   - State persistence
+   - Dashboard session history
+
+### Testing Checklist
+
+- [ ] IMAP connection established successfully
+- [ ] SMTP sending works correctly
+- [ ] Sender whitelist filtering works
+- [ ] State file persists across restarts
+- [ ] Duplicate emails are skipped
+- [ ] Dashboard sessions are created
+- [ ] Both read and unread emails are processed
+
+## Code Style
+
+- Use TypeScript for all source files
+- Follow existing code formatting
+- Add JSDoc comments for public APIs
+- Use meaningful variable and function names
+
+## Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/my-feature`
+3. Commit your changes: `git commit -m 'feat: Add my feature'`
+4. Push to the branch: `git push origin feature/my-feature`
+5. Open a Pull Request
+
+## Commit Message Format
+
+Follow conventional commits:
+
+- `feat:` New features
+- `fix:` Bug fixes
+- `docs:` Documentation changes
+- `refactor:` Code refactoring
+- `test:` Test additions or changes
+- `chore:` Maintenance tasks
+
+Example:
+```
+feat: Add support for OAuth2 authentication
+
+- Implement OAuth2 flow for Gmail
+- Add token refresh mechanism
+- Update documentation
+```
+
+## Reporting Issues
+
+When reporting issues, please include:
+
+1. **Clawdbot version**: `clawdbot --version`
+2. **Node.js version**: `node --version`
+3. **Operating system**: macOS, Linux, Windows
+4. **Email provider**: Gmail, QQ, 163, Outlook, etc.
+5. **Error messages**: Complete error logs from `/tmp/clawdbot/`
+6. **Steps to reproduce**: Detailed reproduction steps
+7. **Expected behavior**: What you expected to happen
+8. **Actual behavior**: What actually happened
+
+## Feature Requests
+
+We welcome feature requests! Please:
+
+1. Check existing issues first
+2. Describe the use case clearly
+3. Explain why the feature would be useful
+4. Consider if it fits the plugin's scope
+
+## Security
+
+**Important**: Never commit credentials or sensitive information!
+
+- Use placeholder values in examples
+- Test with dedicated test accounts
+- Report security vulnerabilities privately
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/packages/email-channel/LICENSE
+++ b/packages/email-channel/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Clawdbot Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/email-channel/README.md
+++ b/packages/email-channel/README.md
@@ -1,0 +1,486 @@
+# Email Channel for Clawdbot
+
+A powerful email channel plugin for Clawdbot that enables bidirectional communication via IMAP/SMTP servers.
+
+## Features
+
+### ✨ Core Capabilities
+
+- **IMAP Email Receiving**: Connects to any standard IMAP server to receive emails
+- **SMTP Email Sending**: Sends AI responses directly to the sender's email
+- **Sender Whitelist**: Optional security feature to restrict which email addresses can send commands
+- **Session History**: Maintains conversation history per sender, viewable in Clawdbot Dashboard
+- **Duplicate Prevention**: Uses Message-ID tracking to prevent processing the same email multiple times
+- **Persistent State**: Robust state management survives Gateway restarts
+
+### 🔄 Smart State Management
+
+The email channel uses intelligent state tracking:
+
+- **Time-based Search**: Searches for emails since the last processed timestamp (not reliant on UNSEEN flags)
+- **Message-ID Deduplication**: Tracks processed emails to prevent duplicates
+- **Persistent Storage**: State saved to `~/.clawdbot/extensions/email/state.json`
+- **Auto Cleanup**: Maintains only the last 1000 Message-IDs to prevent file bloat
+
+### 📅 Persistent State File
+
+```json
+{
+  "lastProcessedTimestamp": "2026-02-07T03:04:51.614Z",
+  "processedMessageIds": [
+    "<message-id-1>",
+    "<message-id-2>"
+  ]
+}
+```
+
+**Benefits**:
+- ✅ Processes both read and unread emails (works even if you check email in other clients)
+- ✅ No duplicate processing (Message-ID tracking)
+- ✅ Survives restarts (state persistence)
+- ✅ Time window protection (1-minute buffer for timing edge cases)
+
+## Installation
+
+### Prerequisites
+
+- Clawdbot installed and running
+- Node.js >= 18.0.0
+- An email account with IMAP/SMTP access
+
+### Setup
+
+1. **Install the Plugin**
+
+The email channel is included in Clawdbot. Ensure it's enabled in your configuration.
+
+2. **Configure Email Settings**
+
+Edit `~/.clawdbot/clawdbot.json`:
+
+```json
+{
+  "channels": {
+    "email": {
+      "accounts": {
+        "default": {
+          "enabled": true,
+          "imap": {
+            "host": "imap.example.com",
+            "port": 993,
+            "secure": true,
+            "user": "your-email@example.com",
+            "password": "your-password-or-app-token"
+          },
+          "smtp": {
+            "host": "smtp.example.com",
+            "port": 587,
+            "secure": false,
+            "user": "your-email@example.com",
+            "password": "your-password-or-app-token"
+          },
+          "checkInterval": 30,
+          "allowedSenders": [
+            "trusted@example.com",
+            "admin@yourdomain.com"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+3. **Restart Gateway**
+
+```bash
+clawdbot gateway restart
+```
+
+## Configuration
+
+### IMAP Settings (Receiving Emails)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `host` | string | IMAP server address |
+| `port` | number | IMAP port (993 for SSL, 143 for non-encrypted) |
+| `secure` | boolean | Use SSL/TLS connection |
+| `user` | string | Email username |
+| `password` | string | Email password or app-specific token |
+
+### SMTP Settings (Sending Emails)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `host` | string | SMTP server address |
+| `port` | number | SMTP port (465 for SSL, 587 for STARTTLS) |
+| `secure` | boolean | Use SSL (typically false for port 587) |
+| `user` | string | Email username |
+| `password` | string | Email password or app-specific token |
+
+### Optional Settings
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `checkInterval` | number | 30 | Email check interval in seconds |
+| `allowedSenders` | string[] | [] | Whitelist of authorized sender email addresses |
+
+### Security: Sender Whitelist
+
+**Important**: Configure `allowedSenders` to restrict which email addresses can send commands to your bot.
+
+- If set (non-empty array): Only emails from addresses in the list will be processed
+- If empty or omitted: All senders are accepted (not recommended for production)
+
+**Example**:
+```json
+"allowedSenders": [
+  "personal@example.com",
+  "admin@company.com"
+]
+```
+
+AI responses are always sent to the original sender, regardless of whitelist settings.
+
+## Common Email Server Configurations
+
+### Gmail
+
+```json
+{
+  "imap": {
+    "host": "imap.gmail.com",
+    "port": 993,
+    "secure": true,
+    "user": "your@gmail.com",
+    "password": "app-specific-password"
+  },
+  "smtp": {
+    "host": "smtp.gmail.com",
+    "port": 587,
+    "secure": false,
+    "user": "your@gmail.com",
+    "password": "app-specific-password"
+  }
+}
+```
+
+**Note**: Gmail requires [App-Specific Passwords](https://support.google.com/accounts/answer/185833).
+
+### QQ Mail
+
+```json
+{
+  "imap": {
+    "host": "imap.qq.com",
+    "port": 993,
+    "secure": true,
+    "user": "your@qq.com",
+    "password": "authorization-code"
+  },
+  "smtp": {
+    "host": "smtp.qq.com",
+    "port": 587,
+    "secure": false,
+    "user": "your@qq.com",
+    "password": "authorization-code"
+  }
+}
+```
+
+**Note**: QQ Mail requires authorization code (not QQ password).
+
+### 163 Mail
+
+```json
+{
+  "imap": {
+    "host": "imap.163.com",
+    "port": 993,
+    "secure": true,
+    "user": "your@163.com",
+    "password": "authorization-code"
+  },
+  "smtp": {
+    "host": "smtp.163.com",
+    "port": 465,
+    "secure": true,
+    "user": "your@163.com",
+    "password": "authorization-code"
+  }
+}
+```
+
+### Outlook / Office365
+
+```json
+{
+  "imap": {
+    "host": "outlook.office365.com",
+    "port": 993,
+    "secure": true,
+    "user": "your@outlook.com",
+    "password": "your-password"
+  },
+  "smtp": {
+    "host": "smtp-mail.outlook.com",
+    "port": 587,
+    "secure": false,
+    "user": "your@outlook.com",
+    "password": "your-password"
+  }
+}
+```
+
+## Usage
+
+1. **Configure your email server** and optional sender whitelist
+2. **Restart the Gateway**: `clawdbot gateway restart`
+3. **Send an email** from a whitelisted address to your configured email account
+4. **Receive AI response** directly in your inbox
+
+## Workflow
+
+1. **Load State**: Read `state.json` to get last processed time and Message-ID list
+2. **Search Emails**: Use IMAP `SINCE` search to find emails after last processed time
+3. **Verify Sender**: Check if sender is in `allowedSenders` whitelist
+4. **Check Duplicates**: Verify Message-ID hasn't been processed
+5. **Process Command**: Send email content to AI agent
+6. **Update State**: Save timestamp and Message-ID to state file
+7. **Send Reply**: AI response automatically sent to original sender
+8. **Record History**: Interaction saved to session file for Dashboard viewing
+
+## Viewing History in Dashboard
+
+### Start Dashboard
+
+```bash
+clawdbot dashboard
+```
+
+### View Sessions
+
+Email conversations appear in the session list with format:
+- **Title**: `📧 {sender-email} - {subject}`
+- **Aggregation**: All emails from same sender are in one conversation
+- **Session Key**: `email:{sender-email}`
+
+### View Conversation
+
+Click any email session to see:
+- Complete email content
+- AI responses
+- Timestamps and metadata
+- Thread history
+
+**Session Storage**: `~/.clawdbot/agents/main/sessions/{sessionId}.jsonl`
+
+## Log Output
+
+### Startup
+
+```
+[EMAIL PLUGIN] Loaded state: lastProcessed=2026-02-07T03:04:51.614Z, processedCount=17
+[EMAIL PLUGIN] Restricting to 2 allowed sender(s): trusted@example.com, admin@yourdomain.com
+[EMAIL PLUGIN] Connecting to IMAP server imap.example.com:993
+[EMAIL PLUGIN] IMAP connection ready!
+```
+
+### Email Received
+
+```
+[EMAIL PLUGIN] Searching for emails since 07-Feb-2026
+[EMAIL PLUGIN] Found 1 email(s) since 07-Feb-2026
+[EMAIL PLUGIN] Checking: from=trusted@example.com, subject="Test email"
+[EMAIL PLUGIN] ✓ ACCEPTED email from: trusted@example.com
+[EMAIL PLUGIN] Subject: Test email
+[default] Processing email from trusted@example.com: "Test email" (UID: 12345)
+[EMAIL PLUGIN] ✓ Marked UID 12345 as seen
+[default] Sending reply to trusted@example.com
+Email sent to trusted@example.com
+[default] Email processed successfully
+```
+
+### Unauthorized Sender
+
+```
+[EMAIL PLUGIN] ✗ Ignoring email from unauthorized sender: unknown@spam.com
+[EMAIL PLUGIN] Allowed senders: trusted@example.com, admin@yourdomain.com
+```
+
+## Troubleshooting
+
+### Email Not Processed
+
+**Possible causes**:
+1. Sender not in whitelist
+2. IMAP connection lost
+3. Email already processed (check logs for "Skipping already processed")
+
+**Solutions**:
+1. Verify whitelist configuration
+2. Check logs: `tail -f /tmp/clawdbot/clawdbot-*.log | grep EMAIL`
+3. Check state file: `cat ~/.clawdbot/extensions/email/state.json`
+
+### Read Emails Not Processed
+
+**Resolved in current version!**
+
+The email channel now:
+- ✅ Processes all emails regardless of read/unread status
+- ✅ Uses time-based search instead of UNSEEN flag
+- ✅ Prevents duplicates via Message-ID tracking
+- ✅ Maintains persistent state across restarts
+
+### Cannot See Session History
+
+**Possible causes**:
+1. No emails successfully processed yet
+2. Dashboard needs refresh
+
+**Solutions**:
+1. Verify at least one email was processed (check logs)
+2. Refresh Dashboard page
+3. Check session files exist: `ls ~/.clawdbot/agents/main/sessions/`
+
+### Reprocess an Email
+
+**Method 1: Remove Message-ID from state**
+
+```bash
+# Edit state file
+vim ~/.clawdbot/extensions/email/state.json
+# Remove the Message-ID from processedMessageIds array
+
+# Restart Gateway
+clawdbot gateway restart
+```
+
+**Method 2: Reset timestamp**
+
+Edit `state.json` and set `lastProcessedTimestamp` to an earlier time.
+
+### Reset All State
+
+To completely start fresh:
+
+```bash
+# Remove state file
+rm ~/.clawdbot/extensions/email/state.json
+
+# Restart Gateway
+clawdbot gateway restart
+```
+
+## Security Best Practices
+
+1. **Always configure `allowedSenders` whitelist** in production
+2. **Use a dedicated email account** for your bot (not your personal email)
+3. **Use app-specific passwords** (Gmail, QQ, 163, etc.)
+4. **Never commit credentials** to version control
+5. **Rotate passwords periodically**
+6. **Monitor logs** for unauthorized access attempts
+
+## How It Works: Technical Details
+
+### State Persistence
+
+The email channel maintains a persistent state file that tracks:
+- **lastProcessedTimestamp**: ISO 8601 timestamp of last successful email processing
+- **processedMessageIds**: Array of Message-IDs that have been processed (max 1000)
+
+This enables:
+- Recovery from Gateway restarts
+- Prevention of duplicate processing
+- Time-based email search (independent of read/unread flags)
+
+### Processing Flow
+
+```
+┌─────────────────┐
+│  IMAP Search    │ SINCE lastProcessedTimestamp - 1min buffer
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  Filter Emails │ By Message-ID (skip duplicates)
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  Check Sender   │ In allowedSenders whitelist?
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  Process Email  │ Send to AI agent
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  Update State   │ Save timestamp + Message-ID
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  Send Reply     │ Via SMTP to original sender
+└─────────────────┘
+```
+
+### Session Management
+
+- **Session Key**: `email:{sender-email}`
+- **Title Format**: `📧 {sender} - {subject}`
+- **Continuity**: All emails from same sender in one session
+
+## Architecture
+
+The email channel consists of three main components:
+
+### `src/runtime.ts`
+- IMAP connection management
+- Email receiving and parsing
+- SMTP email sending
+- State persistence (load/save)
+- Duplicate detection
+
+### `src/channel.ts`
+- Clawdbot ChannelPlugin interface implementation
+- Dynamic import of Clawdbot core functions
+- Message dispatching to AI agent
+- Session history integration
+
+### `index.ts`
+- Plugin entry point
+- Plugin registration with Clawdbot
+
+## Development
+
+### Building
+
+```bash
+npm install
+npm run build
+```
+
+### Testing
+
+Create a test configuration with your email credentials and run:
+
+```bash
+clawdbot gateway
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.
+
+## License
+
+MIT License - see LICENSE file for details
+
+## Support
+
+- **Issues**: https://github.com/openclaw/clawdbot/issues
+- **Documentation**: https://github.com/openclaw/clawdbot/wiki

--- a/packages/email-channel/SUBMIT_GUIDE.md
+++ b/packages/email-channel/SUBMIT_GUIDE.md
@@ -1,0 +1,216 @@
+# Submitting Email Channel to Openclaw
+
+## Overview
+
+The Email Channel plugin has been prepared as a clean, professional open-source package ready for submission to the Openclaw project.
+
+## What's Included
+
+### ✅ Source Code
+- `src/channel.ts` - Channel plugin implementation with dynamic imports
+- `src/runtime.ts` - IMAP/SMTP runtime with state management
+- `index.ts` - Plugin entry point
+
+### ✅ Documentation
+- `README.md` - Comprehensive usage guide (English)
+- `CHANGELOG.md` - Version history following Keep a Changelog format
+- `CONTRIBUTING.md` - Contribution guidelines
+- `CONFIG_EXAMPLES.md` - Configuration examples for various email providers
+
+### ✅ Meta Files
+- `package.json` - NPM package configuration
+- `tsconfig.json` - TypeScript configuration
+- `LICENSE` - MIT License
+- `.gitignore` - Git ignore patterns
+
+### ✅ Security
+- **No hardcoded credentials** in source code
+- Only placeholder values in examples
+- Whitelist functionality documented
+
+## Next Steps
+
+### Option 1: Create Pull Request (Recommended)
+
+```bash
+cd /Users/guxiaobo/Documents/GitHub/openclaw
+
+# Create a new branch
+git checkout -b feature/email-channel
+
+# Add the email-channel package
+git add packages/email-channel
+
+# Commit the changes
+git commit -m "feat: Add official Email channel plugin
+
+Add comprehensive IMAP/SMTP email channel support to Clawdbot:
+- IMAP email receiving with automatic polling
+- SMTP email sending for AI responses
+- Sender whitelist for security
+- Persistent state management with timestamp tracking
+- Message-ID deduplication to prevent reprocessing
+- Session history integration with Dashboard
+- Support for all standard IMAP/SMTP servers
+
+See packages/email-channel/README.md for details."
+
+# Push to your fork
+git push origin feature/email-channel
+```
+
+Then create a Pull Request on GitHub:
+1. Go to https://github.com/openclaw/clawdbot
+2. Click "Compare & pull request"
+3. Select your feature branch
+4. Title: "feat: Add official Email channel plugin"
+5. Include the summary from below
+
+### Option 2: Submit as Issue
+
+If you don't have write access, create an issue:
+1. Go to https://github.com/openclaw/clawdbot/issues
+2. Title: "Feature Request: Official Email Channel Plugin"
+3. Include the summary from below
+
+## PR/Issue Description Template
+
+```markdown
+## Summary
+
+I've developed a comprehensive Email Channel plugin for Clawdbot that enables bidirectional communication via IMAP/SMTP servers.
+
+## Features
+
+- **IMAP Email Receiving**: Connects to any standard IMAP server
+- **SMTP Email Sending**: Sends AI responses directly to sender
+- **Sender Whitelist**: Optional security feature to restrict command senders
+- **Session History**: Maintains conversation history per sender
+- **Smart State Management**:
+  - Time-based email search (SINCE) instead of UNSEEN flag dependency
+  - Message-ID deduplication prevents reprocessing
+  - Persistent state survives Gateway restarts
+  - Automatic cleanup prevents file bloat
+- **Multi-Provider Support**: Gmail, QQ, 163, Outlook, and more
+
+## Architecture
+
+The plugin consists of three components:
+
+1. **runtime.ts** - IMAP/SMTP operations and state management
+2. **channel.ts** - Clawdbot ChannelPlugin interface with dynamic imports
+3. **index.ts** - Plugin registration
+
+## Key Innovations
+
+### 1. Time-Based Search vs UNSEEN Flag
+Most email plugins rely on the UNSEEN flag, which fails if users check email in other clients. This plugin uses timestamp-based search, processing all emails since `lastProcessedTimestamp`, regardless of read/unread status.
+
+### 2. Message-ID Deduplication
+Tracks processed emails by Message-ID to prevent duplicates while supporting time-based search.
+
+### 3. State Persistence
+State file (`~/.clawdbot/extensions/email/state.json`) tracks:
+- `lastProcessedTimestamp`: When last email was processed
+- `processedMessageIds`: List of processed Message-IDs (max 1000)
+
+### 4. External Plugin Compatibility
+Uses dynamic imports to load Clawdbot core functions, solving the limitation where `api.runtime` only provides basic methods for external plugins.
+
+## Documentation
+
+Comprehensive documentation included:
+- **README.md**: User guide with configuration examples
+- **CHANGELOG.md**: Version history
+- **CONTRIBUTING.md**: Developer guide
+- **CONFIG_EXAMPLES.md**: Provider-specific configurations
+
+## Testing
+
+Tested with:
+- ✅ QQ Mail (imap.qq.com)
+- ✅ Multiple senders (whitelist feature)
+- ✅ State persistence across restarts
+- ✅ Dashboard session history
+- ✅ Both read and unread email processing
+
+## Security
+
+- No hardcoded credentials in source code
+- Sender whitelist recommended for production
+- App-specific password support
+- MIT License
+
+## Files
+
+Located at: `/packages/email-channel/`
+
+```
+packages/email-channel/
+├── src/
+│   ├── channel.ts      # Channel plugin implementation
+│   └── runtime.ts      # IMAP/SMTP runtime
+├── index.ts             # Plugin entry point
+├── package.json         # NPM configuration
+├── tsconfig.json        # TypeScript config
+├── README.md            # User documentation
+├── CHANGELOG.md         # Version history
+├── CONTRIBUTING.md      # Contribution guide
+├── CONFIG_EXAMPLES.md   # Configuration examples
+├── LICENSE              # MIT License
+└── .gitignore          # Git ignore patterns
+```
+
+## Suggested Integration Path
+
+1. **Review**: Review the code at `packages/email-channel/`
+2. **Test**: Install and test with a test email account
+3. **Feedback**: Provide feedback or request changes
+4. **Merge**: Merge into main Clawdbot repository
+
+## Next Steps for Reviewers
+
+1. Check source code for any concerns
+2. Test with your own email provider
+3. Verify security implications
+4. Suggest improvements if needed
+
+I'm happy to make any adjustments or answer questions!
+```
+
+## Verification Checklist
+
+Before submitting, verify:
+
+- [x] No sensitive information (emails, passwords) in source code
+- [x] README.md is comprehensive and clear
+- [x] LICENSE file included (MIT)
+- [x] CONTRIBUTING.md included
+- [x] CHANGELOG.md included
+- [x] Code follows TypeScript best practices
+- [x] Package.json properly configured
+- [x] Git repository initialized
+- [x] Initial commits created with clear messages
+
+## Current Git Status
+
+```bash
+cd /Users/guxiaobo/Documents/GitHub/openclaw/packages/email-channel
+
+# View commits
+git log --oneline --decorate
+
+# Current status
+git status
+```
+
+## Repository Information
+
+- **Location**: `/Users/guxiaobo/Documents/GitHub/openclaw/packages/email-channel`
+- **Branch**: `main`
+- **Commits**: 2 (initial feature + documentation)
+- **License**: MIT
+
+## Contact
+
+If you have questions or need clarification, please reach out through GitHub issues.

--- a/packages/email-channel/index.ts
+++ b/packages/email-channel/index.ts
@@ -1,0 +1,13 @@
+import type { ClawdbotPluginApi } from "clawdbot/plugin-sdk";
+import { emailPlugin } from "./src/channel";
+import { setEmailRuntime } from "./src/channel";
+
+const plugin = {
+  id: "email",
+  register(api: ClawdbotPluginApi) {
+    setEmailRuntime(api.runtime);
+    api.registerChannel({ plugin: emailPlugin });
+  },
+};
+
+export default plugin;

--- a/packages/email-channel/package.json
+++ b/packages/email-channel/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@openclaw/email-channel",
+  "version": "1.0.0",
+  "description": "Email channel for Clawdbot - Send and receive commands via IMAP/SMTP",
+  "type": "module",
+  "main": "index.ts",
+  "keywords": [
+    "clawdbot",
+    "plugin",
+    "channel",
+    "email",
+    "imap",
+    "smtp"
+  ],
+  "author": "Clawdbot Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/clawdbot",
+    "directory": "packages/email-channel"
+  },
+  "bugs": {
+    "url": "https://github.com/openclaw/clawdbot/issues"
+  },
+  "clawdbot": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "email",
+      "label": "Email",
+      "selectionLabel": "Email (IMAP/SMTP)",
+      "docsPath": "/channels/email",
+      "blurb": "Send and receive email via IMAP/SMTP servers.",
+      "order": 100,
+      "aliases": [
+        "mail",
+        "smtp"
+      ]
+    }
+  },
+  "dependencies": {
+    "imap": "^0.8.19",
+    "mailparser": "^3.6.9",
+    "nodemailer": "^6.9.13"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.1",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/email-channel/src/channel.ts
+++ b/packages/email-channel/src/channel.ts
@@ -1,0 +1,255 @@
+import type { ChannelPlugin, PluginRuntime } from "clawdbot/plugin-sdk";
+import { startEmail, stopEmail, sendEmail } from "./runtime";
+import { createRequire } from "module";
+
+// Dynamic imports for clawdbot internals
+const require = createRequire(import.meta.url);
+const clawdbotPath = "/opt/homebrew/lib/node_modules/clawdbot/dist";
+
+let runtime: PluginRuntime | null = null;
+
+// Lazy load dispatch functions
+let dispatchFunctions: any = null;
+
+async function getDispatchFunctions() {
+  if (!dispatchFunctions) {
+    const {
+      dispatchReplyWithBufferedBlockDispatcher,
+    } = await import(`${clawdbotPath}/auto-reply/reply/provider-dispatcher.js`);
+    const { resolveEffectiveMessagesConfig } = await import(`${clawdbotPath}/agents/identity.js`);
+    const { createReplyDispatcherWithTyping } = await import(`${clawdbotPath}/auto-reply/reply/reply-dispatcher.js`);
+    dispatchFunctions = {
+      dispatchReplyWithBufferedBlockDispatcher,
+      resolveEffectiveMessagesConfig,
+      createReplyDispatcherWithTyping,
+    };
+  }
+  return dispatchFunctions;
+}
+
+interface EmailAccount {
+  enabled?: boolean;
+  imap: {
+    host: string;
+    port: number;
+    secure: boolean;
+    user: string;
+    password: string;
+  };
+  smtp: {
+    host: string;
+    port: number;
+    secure: boolean;
+    user: string;
+    password: string;
+  };
+  checkInterval?: number;
+  allowedSenders?: string[];
+}
+
+// Store email context for outbound messaging
+const emailContexts = new Map<string, { fromEmail: string; subject: string; messageId: string }>();
+
+export function setEmailRuntime(r: PluginRuntime): void {
+  runtime = r;
+}
+
+export function getEmailRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("Email runtime not initialized - plugin not registered");
+  }
+  return runtime;
+}
+
+export function getEmailContext(sessionKey: string) {
+  return emailContexts.get(sessionKey);
+}
+
+const emailPlugin: ChannelPlugin<EmailAccount> = {
+  id: "email",
+  meta: {
+    id: "email",
+    label: "Email",
+    selectionLabel: "Email (IMAP/SMTP)",
+    docsPath: "/channels/email",
+    blurb: "Send and receive email via IMAP/SMTP servers.",
+    aliases: ["mail", "smtp"]
+  },
+  capabilities: {
+    chatTypes: ["direct"]
+  },
+  config: {
+    listAccountIds: (cfg) => {
+      const accounts = cfg.channels?.email?.accounts;
+      return accounts ? Object.keys(accounts) : [];
+    },
+    resolveAccount: (cfg, accountId) => {
+      const accounts = cfg.channels?.email?.accounts;
+      const account = accounts?.[accountId || "default"] || accounts?.default || {};
+      return {
+        accountId: accountId || "default",
+        enabled: account.enabled ?? true,
+        ...account
+      } as EmailAccount;
+    },
+    isConfigured: (account) => {
+      return Boolean(
+        account.imap?.host &&
+        account.imap?.port &&
+        account.imap?.user &&
+        account.imap?.password &&
+        account.smtp?.host &&
+        account.smtp?.port &&
+        account.smtp?.user &&
+        account.smtp?.password
+      );
+    }
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      // Store runtime for later use
+      runtime = ctx.runtime as PluginRuntime;
+
+      const account = ctx.account as EmailAccount;
+
+      if (!account || !account.enabled) {
+        ctx.log?.info?.(`[${account.accountId}] Email account disabled`);
+        return;
+      }
+
+      if (!account.imap?.host || !account.imap?.port || !account.imap?.user || !account.imap?.password) {
+        ctx.log?.error?.(`[${account.accountId}] Email IMAP configuration incomplete`);
+        return;
+      }
+
+      if (!account.smtp?.host || !account.smtp?.port || !account.smtp?.user || !account.smtp?.password) {
+        ctx.log?.error?.(`[${account.accountId}] Email SMTP configuration incomplete`);
+        return;
+      }
+
+      ctx.log?.info?.(`[${account.accountId}] Starting email channel`);
+
+      // Log allowed senders configuration
+      if (account.allowedSenders && account.allowedSenders.length > 0) {
+        ctx.log?.info?.(`[${account.accountId}] Only accepting emails from: ${account.allowedSenders.join(", ")}`);
+      } else {
+        ctx.log?.info?.(`[${account.accountId}] Accepting emails from all senders`);
+      }
+
+      startEmail(account, async (from, fromEmail, subject, body, messageId, uid) => {
+        // Build the formatted message envelope
+        const message = `From: ${from}\nSubject: ${subject}\n\n${body}`;
+
+        // Use fromEmail as sessionKey so all emails from the same sender are in one conversation
+        const sessionKey = `email:${fromEmail}`;
+
+        // Create a readable title for the session in Dashboard
+        const title = `📧 ${fromEmail}${subject ? ` - ${subject}` : ''}`;
+
+        ctx.log?.info?.(`[${account.accountId}] Processing email from ${fromEmail}: "${subject}" (UID: ${uid})`);
+
+        try {
+          // Store email context for outbound messaging
+          emailContexts.set(sessionKey, { fromEmail, subject, messageId });
+
+          // Get dispatch functions dynamically loaded from clawdbot core
+          const {
+            dispatchReplyWithBufferedBlockDispatcher,
+            resolveEffectiveMessagesConfig,
+          } = await getDispatchFunctions();
+
+          // Use the dispatch function to process the message
+          const result = await dispatchReplyWithBufferedBlockDispatcher({
+            ctx: {
+              Body: message,
+              RawBody: body,
+              CommandBody: body,
+              From: `email:${fromEmail}`,
+              To: `${fromEmail}|${subject}|${messageId}`, // Format: "email|subject|messageId"
+              SessionKey: sessionKey,
+              AccountId: account.accountId,
+              ChatType: "direct" as const,
+              ConversationLabel: from,
+              SenderName: from,
+              SenderId: fromEmail,
+              Provider: "email",
+              Surface: "email",
+              MessageSid: messageId,
+              Timestamp: Date.now(),
+            },
+            cfg: ctx.cfg,
+            dispatcherOptions: {
+              responsePrefix: undefined,
+              humanDelay: resolveEffectiveMessagesConfig(ctx.cfg, undefined).humanDelay,
+              deliver: async (payload, info) => {
+                // Send the reply via email
+                const replyText = payload.text || '';
+                ctx.log?.info?.(`[${account.accountId}] Sending reply to ${fromEmail}`);
+                await sendEmail(fromEmail, subject, replyText, messageId);
+              },
+              onError: (err, info) => {
+                ctx.log?.error?.(`[${account.accountId}] Email reply failed: ${String(err)}`);
+              },
+            },
+            replyOptions: {
+              disableBlockStreaming: true, // Email doesn't support streaming
+            },
+          });
+
+          ctx.log?.info?.(`[${account.accountId}] Email processed successfully`);
+        } catch (error: any) {
+          // Log detailed error information
+          const errorMsg = error?.message || String(error);
+          const errorStack = error?.stack || '';
+          const errorDetails = error?.toString() || String(error);
+
+          ctx.log?.error?.(`[${account.accountId}] Error processing email from ${fromEmail}:`);
+          ctx.log?.error?.(`[${account.accountId}] Error type: ${error?.constructor?.name || 'Unknown'}`);
+          ctx.log?.error?.(`[${account.accountId}] Error message: ${errorMsg}`);
+          if (errorStack) {
+            ctx.log?.error?.(`[${account.accountId}] Stack trace: ${errorStack.split('\n').slice(0, 5).join(' | ')}`);
+          }
+          ctx.log?.error?.(`[${account.accountId}] Full error: ${errorDetails}`);
+
+          console.error(`[EMAIL CHANNEL ERROR] From: ${fromEmail}, Subject: ${subject}`);
+          console.error(`[EMAIL CHANNEL ERROR] Error:`, error);
+
+          // Send error notification to sender
+          const errorMessage = "Sorry, there was an error processing your request. Please try again later.";
+          await sendEmail(fromEmail, subject, errorMessage, messageId);
+        }
+      });
+
+      // Return a cleanup function
+      return () => {
+        ctx.log?.info?.(`[${account.accountId}] Stopping email channel`);
+        stopEmail();
+      };
+    }
+  },
+  outbound: {
+    deliveryMode: "direct",
+    sendText: async ({ text, to }) => {
+      // Parse the target: format is "recipientEmail|subject|messageId"
+      const match = to.match(/^([^|]+)\|([^|]+)\|(.+)$/);
+      if (!match) {
+        return { ok: false, error: "Invalid email target format" };
+      }
+
+      const [, recipientEmail, subject, messageId] = match;
+
+      const success = await sendEmail(recipientEmail, subject, text, messageId);
+      return { ok: success };
+    }
+  },
+  messaging: {
+    normalizeTarget: ({ to }) => {
+      // Convert email address to target format: "email|subject|messageId"
+      // We store the context in dispatch, so we can retrieve it here
+      // For now, return the email as-is (it will be formatted in dispatch)
+      return to;
+    }
+  }
+};
+
+export { emailPlugin };

--- a/packages/email-channel/src/runtime.ts
+++ b/packages/email-channel/src/runtime.ts
@@ -1,0 +1,371 @@
+import Imap from "imap";
+import nodemailer from "nodemailer";
+import { simpleParser } from "mailparser";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+interface EmailConfig {
+  imap: {
+    host: string;
+    port: number;
+    secure: boolean;
+    user: string;
+    password: string;
+  };
+  smtp: {
+    host: string;
+    port: number;
+    secure: boolean;
+    user: string;
+    password: string;
+  };
+  checkInterval?: number;
+  allowedSenders?: string[];
+}
+
+interface EmailProcessorState {
+  lastProcessedTimestamp: string;  // ISO 8601 format
+  processedMessageIds: string[];   // List of Message-IDs that have been processed
+}
+
+const STATE_FILE_PATH = path.join(os.homedir(), ".clawdbot", "extensions", "email", "state.json");
+
+let imapConnection: Imap | null = null;
+let smtpTransporter: nodemailer.Transporter | null = null;
+let checkTimer: NodeJS.Timeout | null = null;
+let messageHandler: ((from: string, fromEmail: string, subject: string, body: string, messageId: string, uid: number) => Promise<void>) | null = null;
+let allowedSenders: string[] = [];
+let currentState: EmailProcessorState = {
+  lastProcessedTimestamp: new Date(0).toISOString(),  // Default to epoch
+  processedMessageIds: []
+};
+
+// Load state from file
+function loadState(): void {
+  try {
+    if (fs.existsSync(STATE_FILE_PATH)) {
+      const data = fs.readFileSync(STATE_FILE_PATH, "utf-8");
+      currentState = JSON.parse(data);
+      console.log(`[EMAIL PLUGIN] Loaded state: lastProcessed=${currentState.lastProcessedTimestamp}, processedCount=${currentState.processedMessageIds.length}`);
+    } else {
+      console.log("[EMAIL PLUGIN] No existing state file, starting fresh");
+    }
+  } catch (error) {
+    console.error("[EMAIL PLUGIN] Error loading state file:", error);
+    console.log("[EMAIL PLUGIN] Starting with empty state");
+  }
+}
+
+// Save state to file
+function saveState(): void {
+  try {
+    const dir = path.dirname(STATE_FILE_PATH);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(STATE_FILE_PATH, JSON.stringify(currentState, null, 2));
+  } catch (error) {
+    console.error("[EMAIL PLUGIN] Error saving state file:", error);
+  }
+}
+
+// Check if a message has been processed
+function isMessageProcessed(messageId: string): boolean {
+  return currentState.processedMessageIds.includes(messageId);
+}
+
+// Mark a message ID as processed (without updating timestamp)
+function markMessageIdAsProcessed(messageId: string): void {
+  if (!currentState.processedMessageIds.includes(messageId)) {
+    currentState.processedMessageIds.push(messageId);
+    saveState();
+  }
+}
+
+// Mark a message as processed and update timestamp
+function markMessageAsProcessed(messageId: string): void {
+  // Always update timestamp when processing completes
+  currentState.lastProcessedTimestamp = new Date().toISOString();
+  if (!currentState.processedMessageIds.includes(messageId)) {
+    currentState.processedMessageIds.push(messageId);
+  }
+  saveState();
+}
+
+// Clean up old Message-IDs (keep only last 1000 to prevent file from growing too large)
+function cleanupOldMessageIds(): void {
+  if (currentState.processedMessageIds.length > 1000) {
+    currentState.processedMessageIds = currentState.processedMessageIds.slice(-1000);
+    saveState();
+  }
+}
+
+function extractEmail(from: string): string {
+  // Extract email from "Name <email>" format
+  const emailMatch = from.match(/<([^>]+)>/);
+  return emailMatch ? emailMatch[1].trim().toLowerCase() : from.trim().toLowerCase();
+}
+
+function isSenderAllowed(fromEmail: string): boolean {
+  if (!allowedSenders || allowedSenders.length === 0) {
+    return true; // No restrictions
+  }
+  return allowedSenders.some(allowed => fromEmail === allowed.toLowerCase());
+}
+
+function createImapConnection(config: EmailConfig): Imap {
+  return new Imap({
+    user: config.imap.user,
+    password: config.imap.password,
+    host: config.imap.host,
+    port: config.imap.port,
+    tls: config.imap.secure,
+    tlsOptions: { rejectUnauthorized: false }
+  });
+}
+
+function createSmtpTransporter(config: EmailConfig): nodemailer.Transporter {
+  return nodemailer.createTransport({
+    host: config.smtp.host,
+    port: config.smtp.port,
+    secure: config.smtp.secure,
+    auth: {
+      user: config.smtp.user,
+      pass: config.smtp.password
+    }
+  });
+}
+
+function openInbox(cb: (err: Error | null, box?: any) => void): void {
+  if (!imapConnection) {
+    cb(new Error("IMAP connection not initialized"));
+    return;
+  }
+  imapConnection.openBox("INBOX", false, cb);
+}
+
+function formatDateForImap(date: Date): string {
+  // IMAP date format: 06-Feb-2026
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  const day = String(date.getDate()).padStart(2, "0");
+  const month = months[date.getMonth()];
+  const year = date.getFullYear();
+  return `${day}-${month}-${year}`;
+}
+
+function checkEmail(): void {
+  if (!imapConnection) return;
+
+  // Search for emails SINCE the last processed timestamp
+  // Add a small buffer (1 minute) to catch any edge cases
+  const lastProcessedDate = new Date(currentState.lastProcessedTimestamp);
+  const searchDate = new Date(lastProcessedDate.getTime() - 60000); // 1 minute buffer
+  const dateStr = formatDateForImap(searchDate);
+
+  console.log(`[EMAIL PLUGIN] Searching for emails since ${dateStr} (last processed: ${currentState.lastProcessedTimestamp})`);
+
+  imapConnection.search([["SINCE", dateStr]], (err, results) => {
+    if (err) {
+      console.error("[EMAIL PLUGIN] Email search error:", err);
+      return;
+    }
+
+    if (!results || results.length === 0) {
+      console.log("[EMAIL PLUGIN] No new emails found");
+      return;
+    }
+
+    console.log(`[EMAIL PLUGIN] Found ${results.length} email(s) since ${dateStr}`);
+
+    const fetch = imapConnection.fetch(results, { bodies: "", markSeen: false });
+
+    fetch.on("message", (msg) => {
+      let uid: number | null = null;
+
+      // Capture the UID from message attributes
+      msg.on("attributes", (attrs) => {
+        uid = attrs.uid;
+      });
+
+      msg.on("body", async (stream) => {
+        try {
+          const parsed = await simpleParser(stream);
+
+          const from = parsed.from?.text || "";
+          const fromEmail = extractEmail(from);
+          const subject = parsed.subject || "";
+          const body = parsed.text || parsed.html || "";
+          const messageId = parsed.messageId || "";
+
+          // Skip if already processed
+          if (isMessageProcessed(messageId)) {
+            console.log(`[EMAIL PLUGIN] Skipping already processed: ${messageId}`);
+            return;
+          }
+
+          console.log(`[EMAIL PLUGIN] Checking: from=${fromEmail}, subject="${subject}"`);
+
+          // Check if sender is allowed
+          if (!isSenderAllowed(fromEmail)) {
+            console.log(`[EMAIL PLUGIN] ✗ Ignoring email from unauthorized sender: ${fromEmail}`);
+            if (allowedSenders.length > 0) {
+              console.log(`[EMAIL PLUGIN] Allowed senders: ${allowedSenders.join(", ")}`);
+            }
+            return;
+          }
+
+          console.log(`[EMAIL PLUGIN] ✓ ACCEPTED email from: ${fromEmail}`);
+          console.log(`[EMAIL PLUGIN] Subject: ${subject}`);
+          console.log(`[EMAIL PLUGIN] Message-ID: ${messageId}`);
+          console.log(`[EMAIL PLUGIN] UID: ${uid}`);
+          console.log(`[EMAIL PLUGIN] Date: ${parsed.date?.toISOString()}`);
+
+          // Mark message ID as processed immediately to prevent duplicate processing
+          markMessageIdAsProcessed(messageId);
+
+          // Call the handler (async)
+          if (messageHandler && uid !== null) {
+            try {
+              await messageHandler(from, fromEmail, subject, body, messageId, uid);
+
+              // Update timestamp after successful processing
+              markMessageAsProcessed(messageId);
+
+              // Mark email as \Seen after successful processing
+              imapConnection!.addFlags(uid, ["\\Seen"], (err) => {
+                if (err) {
+                  console.error(`[EMAIL PLUGIN] Failed to mark email as seen:`, err);
+                } else {
+                  console.log(`[EMAIL PLUGIN] ✓ Marked UID ${uid} as seen`);
+                }
+              });
+
+              // Clean up old Message-IDs periodically
+              cleanupOldMessageIds();
+            } catch (error) {
+              console.error(`[EMAIL PLUGIN] ✗ Error processing email from ${fromEmail}:`, error);
+              // Remove from processed list so it can be retried
+              const index = currentState.processedMessageIds.indexOf(messageId);
+              if (index > -1) {
+                currentState.processedMessageIds.splice(index, 1);
+                saveState();
+              }
+            }
+          }
+        } catch (err) {
+          console.error("[EMAIL PLUGIN] Email parse error:", err);
+        }
+      });
+    });
+
+    fetch.once("error", (err) => {
+      console.error("[EMAIL PLUGIN] Email fetch error:", err);
+    });
+
+    fetch.once("end", () => {
+      console.log("[EMAIL PLUGIN] Email check complete");
+    });
+  });
+}
+
+export function startEmail(config: EmailConfig, handler: (from: string, fromEmail: string, subject: string, body: string, messageId: string, uid: number) => Promise<void>): void {
+  console.error("[EMAIL PLUGIN] startEmail called!");
+
+  // Load persistent state
+  loadState();
+
+  messageHandler = handler;
+  allowedSenders = (config.allowedSenders || []).map(email => email.trim().toLowerCase());
+
+  // Log allowed senders configuration
+  if (allowedSenders.length > 0) {
+    console.error(`[EMAIL PLUGIN] Restricting to ${allowedSenders.length} allowed sender(s): ${allowedSenders.join(", ")}`);
+  } else {
+    console.error(`[EMAIL PLUGIN] Accepting emails from all senders`);
+  }
+
+  imapConnection = createImapConnection(config);
+  smtpTransporter = createSmtpTransporter(config);
+
+  console.error(`[EMAIL PLUGIN] Connecting to IMAP server ${config.imap.host}:${config.imap.port}`);
+
+  imapConnection.once("ready", () => {
+    console.error("[EMAIL PLUGIN] IMAP connection ready!");
+    openInbox((err) => {
+      if (err) {
+        console.error("Error opening inbox:", err);
+        return;
+      }
+
+      // Initial check
+      checkEmail();
+
+      // Set up interval to check for new emails
+      const interval = (config.checkInterval || 30) * 1000;
+      checkTimer = setInterval(checkEmail, interval);
+    });
+  });
+
+  imapConnection.once("error", (err) => {
+    console.error("IMAP connection error:", err);
+  });
+
+  imapConnection.connect();
+}
+
+export async function sendEmail(to: string, subject: string, body: string, inReplyTo?: string): Promise<boolean> {
+  if (!smtpTransporter) {
+    console.error("SMTP transporter not initialized");
+    return false;
+  }
+
+  try {
+    const mailOptions: nodemailer.SendMailOptions = {
+      from: smtpTransporter.options.auth?.user,
+      to: to,
+      subject: subject.startsWith("Re:") ? subject : `Re: ${subject}`,
+      text: body
+    };
+
+    if (inReplyTo) {
+      mailOptions.headers = { "In-Reply-To": inReplyTo, References: inReplyTo };
+    }
+
+    await smtpTransporter.sendMail(mailOptions);
+    console.log(`Email sent to ${to}`);
+    return true;
+  } catch (error) {
+    console.error("Error sending email:", error);
+    return false;
+  }
+}
+
+export function stopEmail(): void {
+  if (checkTimer) {
+    clearInterval(checkTimer);
+    checkTimer = null;
+  }
+
+  if (imapConnection) {
+    imapConnection.end();
+    imapConnection = null;
+  }
+
+  if (smtpTransporter) {
+    smtpTransporter.close();
+    smtpTransporter = null;
+  }
+
+  messageHandler = null;
+  allowedSenders = [];
+  // Don't clear currentState, it should persist
+}
+
+export function getAllowedSenders(): string[] {
+  return [...allowedSenders];
+}
+
+export function getState(): EmailProcessorState {
+  return { ...currentState };
+}

--- a/packages/email-channel/submit.sh
+++ b/packages/email-channel/submit.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -e
+
+echo "==============================================="
+echo "  Email Channel 提交脚本"
+echo "==============================================="
+echo ""
+
+# 配置
+GITHUB_USER="guxiaobo"
+REPO="openclaw"
+EMAIL_CHANNEL_DIR="$HOME/Documents/GitHub/openclaw/packages/email-channel"
+WORK_DIR="$HOME/temp-openclaw-submit"
+
+echo "📋 配置信息："
+echo "  GitHub 用户: $GITHUB_USER"
+echo "  仓库名称: $REPO"
+echo ""
+
+# 创建工作目录
+echo "📁 步骤 1/6: 创建工作目录..."
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+echo "✅ 工作目录创建完成: $WORK_DIR"
+echo ""
+
+# 克隆 fork 的仓库（使用 HTTPS）
+echo "📥 步骤 2/6: 克隆你的 fork..."
+cd "$WORK_DIR"
+git clone "https://github.com/$GITHUB_USER/$REPO.git" .
+echo "✅ 克隆完成"
+echo ""
+
+# 创建 packages 目录并复制 email-channel
+echo "📦 步骤 3/6: 添加 Email Channel 包..."
+mkdir -p packages
+cp -r "$EMAIL_CHANNEL_DIR" packages/
+echo "✅ Email Channel 包已复制"
+echo ""
+
+# 配置 git
+echo "⚙️  步骤 4/6: 配置 Git..."
+git config user.name "Gu XiaoBo"
+git config user.email "guxiaobo@users.noreply.github.com"
+echo "✅ Git 配置完成"
+echo ""
+
+# 创建功能分支
+echo "🌿 步骤 5/6: 创建功能分支并提交..."
+BRANCH_NAME="feature/email-channel-$(date +%Y%m%d)"
+git checkout -b "$BRANCH_NAME"
+
+# 添加所有文件
+git add .
+
+# 提交
+git commit -m "feat: Add official Email channel plugin
+
+Add comprehensive IMAP/SMTP email channel support to Clawdbot:
+
+Features:
+- IMAP email receiving with automatic polling
+- SMTP email sending for AI responses
+- Sender whitelist for security
+- Persistent state management with timestamp tracking
+- Message-ID deduplication to prevent reprocessing
+- Session history integration with Dashboard
+- Support for all standard IMAP/SMTP servers
+
+Technical highlights:
+- Time-based email search (SINCE) instead of UNSEEN flag
+- Processes both read and unread emails correctly
+- State persistence survives Gateway restarts
+- Automatic cleanup of old Message-IDs
+- Session aggregation by sender
+
+Documentation:
+- Comprehensive README with configuration examples
+- CHANGELOG, CONTRIBUTING, and CONFIG_EXAMPLES guides
+- MIT License
+
+See packages/email-channel/README.md for details."
+
+echo "✅ 提交完成"
+echo ""
+
+# 推送到 GitHub
+echo "🚀 步骤 6/6: 推送到 GitHub..."
+git push -u origin "$BRANCH_NAME"
+echo "✅ 推送完成"
+echo ""
+
+echo "==============================================="
+echo "  ✅ 所有步骤完成！"
+echo "==============================================="
+echo ""
+
+# 显示 PR 创建链接
+MAIN_BRANCH=$(git remote show origin | grep "HEAD branch" | sed 's/.*: //' || echo "main")
+echo "📊 下一步：创建 Pull Request"
+echo ""
+echo "1. 在浏览器中打开以下链接："
+echo ""
+echo "   https://github.com/$GITHUB_USER/$REPO/compare/$MAIN_BRANCH...$BRANCH_NAME"
+echo ""
+echo "2. PR 标题："
+echo "   feat: Add official Email channel plugin"
+echo ""
+echo "3. PR 描述："
+echo "   复制 packages/email-channel/SUBMIT_GUIDE.md 中的模板内容"
+echo ""
+
+# 尝试使用 gh CLI 创建 PR（如果可用）
+if command -v gh &> /dev/null; then
+    echo "或者尝试使用 GitHub CLI 自动创建 PR："
+    echo "  gh pr create --title 'feat: Add official Email channel plugin' --file packages/email-channel/SUBMIT_GUIDE.md"
+fi

--- a/packages/email-channel/tsconfig.json
+++ b/packages/email-channel/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "index.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
Add comprehensive IMAP/SMTP email channel support to Clawdbot.

This PR adds a full-featured email channel plugin that allows Clawdbot to send and receive emails via standard IMAP/SMTP servers.

**Features:**
- IMAP email receiving with automatic polling
- SMTP email sending for AI responses
- Sender whitelist for security
- Persistent state management with timestamp tracking
- Message-ID deduplication to prevent reprocessing
- Session history integration with Dashboard
- Support for all standard IMAP/SMTP servers

**Technical highlights:**
- Time-based email search (SINCE) instead of UNSEEN flag
- Processes both read and unread emails correctly
- State persistence survives Gateway restarts
- Automatic cleanup of old Message-IDs
- Session aggregation by sender

**Documentation:**
- Comprehensive README with configuration examples
- CHANGELOG, CONTRIBUTING, and CONFIG_EXAMPLES guides
- MIT License

See `packages/email-channel/README.md` for details.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a comprehensive email channel plugin with IMAP/SMTP support, state persistence, and message deduplication. However, there are several critical issues that must be resolved before merging:

**Critical Issues:**
- **Hardcoded macOS path** (`/opt/homebrew/lib/node_modules/clawdbot/dist`) breaks plugin on non-macOS systems and non-Homebrew installations
- **Security vulnerability**: TLS certificate validation disabled (`rejectUnauthorized: false`) allows MITM attacks
- **Wrong import paths**: Uses `clawdbot/plugin-sdk` instead of `openclaw/plugin-sdk` (legacy naming)
- **Wrong repository URLs**: Points to non-existent `openclaw/clawdbot` repo instead of `openclaw/openclaw`

**Additional Issues:**
- Uses `clawdbot` metadata key instead of `openclaw` in package.json
- Dynamic imports from hardcoded paths instead of using `runtime.channel.reply.*` methods (see `extensions/irc/src/inbound.ts:302` for correct pattern)
- State file uses legacy `~/.clawdbot` directory path

**Positive Aspects:**
- Well-structured state management with timestamp tracking and Message-ID deduplication
- Comprehensive documentation with examples
- Proper session aggregation by sender email
- Whitelist security feature for sender filtering

<h3>Confidence Score: 1/5</h3>

- This PR has critical bugs that will cause runtime failures on most systems and a security vulnerability
- Score of 1 reflects multiple critical issues: hardcoded macOS-specific path breaks cross-platform compatibility, disabled TLS validation creates security vulnerability, wrong import paths will cause import errors, and incorrect repo URLs in package metadata. The plugin will not work correctly without fixes.
- Pay close attention to `packages/email-channel/src/channel.ts` (hardcoded paths and security), `packages/email-channel/index.ts` (import paths), and `packages/email-channel/package.json` (metadata corrections)

<sub>Last reviewed commit: 0aa51e3</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->