### PR TITLE
fix: preserve assistant partial stream during reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - Gateway/Auth: default unresolved gateway auth to token mode with startup auto-generation/persistence of `gateway.auth.token`, while allowing explicit `gateway.auth.mode: "none"` for intentional open loopback setups. (#20686) thanks @gumadeiras.
 - Browser/Relay: require gateway-token auth on both `/extension` and `/cdp`, and align Chrome extension setup to use a single `gateway.auth.token` input for relay authentication. Thanks @tdjackey for reporting.
 - Gateway/Hooks: run BOOT.md startup checks per configured agent scope, including per-agent session-key resolution, startup-hook regression coverage, and non-success boot outcome logging for diagnosability. (#20569) thanks @mcaxtr.

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -52,6 +52,7 @@ export type EmbeddedPiSubscribeState = {
   emittedAssistantUpdate: boolean;
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
+  reasoningStreamOpen: boolean;
   assistantMessageIndex: number;
   lastAssistantTextMessageIndex: number;
   lastAssistantTextNormalized?: string;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
@@ -251,6 +251,59 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
   });
 
+  it("emits reasoning end once when native and tagged reasoning end overlap", () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const onReasoningEnd = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run",
+      reasoningMode: "stream",
+      onReasoningStream: vi.fn(),
+      onReasoningEnd,
+    });
+
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "<think>Checking",
+      },
+    });
+
+    handler?.({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Checking" }],
+      },
+      assistantMessageEvent: {
+        type: "thinking_end",
+      },
+    });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: " files</think>\nFinal answer",
+      },
+    });
+
+    expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+  });
+
   it("emits delta chunks in agent events for streaming assistant text", () => {
     const { emit, onAgentEvent } = createAgentEventHarness();
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -55,6 +55,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     emittedAssistantUpdate: false,
     lastStreamedReasoning: undefined,
     lastBlockReplyText: undefined,
+    reasoningStreamOpen: false,
     assistantMessageIndex: 0,
     lastAssistantTextMessageIndex: -1,
     lastAssistantTextNormalized: undefined,
@@ -117,6 +118,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastBlockReplyText = undefined;
     state.lastStreamedReasoning = undefined;
     state.lastReasoningSent = undefined;
+    state.reasoningStreamOpen = false;
     state.suppressBlockChunks = false;
     state.assistantMessageIndex += 1;
     state.lastAssistantTextMessageIndex = -1;

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -27,7 +27,11 @@ describe("tool mutation helpers", () => {
     expect(writeFingerprint).toContain("tool=write");
     expect(writeFingerprint).toContain("path=/tmp/demo.txt");
     expect(writeFingerprint).toContain("id=42");
-    expect(writeFingerprint).toContain("meta=write /tmp/demo.txt");
+    expect(writeFingerprint).not.toContain("meta=write /tmp/demo.txt");
+
+    const metaOnlyFingerprint = buildToolActionFingerprint("exec", { command: "ls -la" }, "ls -la");
+    expect(metaOnlyFingerprint).toContain("tool=exec");
+    expect(metaOnlyFingerprint).toContain("meta=ls -la");
 
     const readFingerprint = buildToolActionFingerprint("read", { path: "/tmp/demo.txt" });
     expect(readFingerprint).toBeUndefined();

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -151,6 +151,7 @@ export function buildToolActionFingerprint(
   if (action) {
     parts.push(`action=${action}`);
   }
+  let hasStableTarget = false;
   for (const key of [
     "path",
     "filePath",
@@ -167,10 +168,14 @@ export function buildToolActionFingerprint(
     const value = normalizeFingerprintValue(record?.[key]);
     if (value) {
       parts.push(`${key.toLowerCase()}=${value}`);
+      hasStableTarget = true;
     }
   }
   const normalizedMeta = meta?.trim().replace(/\s+/g, " ").toLowerCase();
-  if (normalizedMeta) {
+  // Meta text often carries volatile details (for example "N chars").
+  // Prefer stable arg-derived keys for matching; only fall back to meta
+  // when no stable target key is available.
+  if (normalizedMeta && !hasStableTarget) {
     parts.push(`meta=${normalizedMeta}`);
   }
   return parts.join("|");


### PR DESCRIPTION
## Before
When reasoning stream was enabled and a reasoning callback existed, core runner suppressed assistant partial streaming.

## What this broke
Channels that rely on partial callbacks could show reasoning, but assistant answer updates stopped streaming and appeared only as a final message.

## Fix
- Keep assistant `onPartialReply` active even when reasoning stream is enabled.
- Handle native `thinking_start`/`thinking_delta`/`thinking_end` events in embedded subscribe handlers so reasoning streaming and reasoning end signals are emitted consistently.
- Add regression tests covering both behaviors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a regression where assistant partial streaming (`onPartialReply`) was suppressed when reasoning stream mode was enabled. Channels relying on partial callbacks can now show both reasoning updates and assistant answer streaming simultaneously.

- Removed `allowPartialStream` guard that was incorrectly skipping assistant text deltas during reasoning
- Added explicit handling for native `thinking_start`/`thinking_delta`/`thinking_end` events in embedded subscribe handlers
- Included regression tests for both concurrent behaviors

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly removes an overly restrictive guard that was blocking legitimate streaming behavior. The changes are narrowly scoped, well-tested with regression tests covering both reasoning and assistant streaming, and follow existing patterns in the codebase. The logic change makes semantic sense: reasoning and assistant streaming are independent concerns and should not block each other.
- No files require special attention

<sub>Last reviewed commit: 18e0922</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->