### PR TITLE
fix: prevent zsh glob expansion errors in exec commands

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -28,7 +28,7 @@ import {
   readEnvInt,
 } from "./bash-tools.shared.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
-import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
+import { getShellConfig, sanitizeBinaryOutput, wrapCommandForShell } from "./shell-utils.js";
 
 // Sanitize inherited host env before merge so dangerous variables from process.env
 // are not propagated into non-sandboxed executions.
@@ -402,11 +402,12 @@ export async function runExecProcess(opts: {
       };
     }
     const { shell, args: shellArgs } = getShellConfig();
-    const childArgv = [shell, ...shellArgs, execCommand];
+    const wrappedCommand = wrapCommandForShell(shell, execCommand);
+    const childArgv = [shell, ...shellArgs, wrappedCommand];
     if (opts.usePty) {
       return {
         mode: "pty" as const,
-        ptyCommand: execCommand,
+        ptyCommand: wrappedCommand,
         childFallbackArgv: childArgv,
         env: shellRuntimeEnv,
         stdinMode: "pipe-open" as const,

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -39,6 +39,22 @@ export function resolvePowerShellPath(): string {
   return "powershell.exe";
 }
 
+/**
+ * Wraps a command string for safe execution under the resolved shell.
+ *
+ * zsh's `nomatch` option (enabled by default) causes "no matches found" errors
+ * when commands contain unquoted glob characters like `?` or `[]` (common in
+ * URLs).  Prefixing with `setopt nonomatch` lets unmatched globs pass through
+ * as literal strings.
+ */
+export function wrapCommandForShell(shell: string, command: string): string {
+  const name = path.basename(shell);
+  if (name === "zsh") {
+    return `setopt nonomatch; ${command}`;
+  }
+  return command;
+}
+
 export function getShellConfig(): { shell: string; args: string[] } {
   if (process.platform === "win32") {
     // Use PowerShell instead of cmd.exe on Windows.

--- a/src/process/supervisor/supervisor.pty-command.test.ts
+++ b/src/process/supervisor/supervisor.pty-command.test.ts
@@ -6,6 +6,7 @@ const { createPtyAdapterMock } = vi.hoisted(() => ({
 
 vi.mock("../../agents/shell-utils.js", () => ({
   getShellConfig: () => ({ shell: "sh", args: ["-c"] }),
+  wrapCommandForShell: (_shell: string, command: string) => command,
 }));
 
 vi.mock("./adapters/pty.js", () => ({

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { getShellConfig } from "../../agents/shell-utils.js";
+import { getShellConfig, wrapCommandForShell } from "../../agents/shell-utils.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createChildAdapter } from "./adapters/child.js";
 import { createPtyAdapter } from "./adapters/pty.js";
@@ -130,7 +130,7 @@ export function createProcessSupervisor(): ProcessSupervisor {
               }
               return await createPtyAdapter({
                 shell,
-                args: [...shellArgs, ptyCommand],
+                args: [...shellArgs, wrapCommandForShell(shell, ptyCommand)],
                 cwd: input.cwd,
                 env: input.env,
               });


### PR DESCRIPTION
## Summary

- zsh's `nomatch` option (enabled by default) causes `no matches found` errors when exec commands contain unquoted glob characters like `?` or `[]`, which are common in URLs (e.g. `https://example.com/page?si=abc`)
- Adds `wrapCommandForShell()` helper in `shell-utils.ts` that prefixes commands with `setopt nonomatch;` when the resolved shell is zsh, letting unmatched globs pass through as literal strings
- Applied to both PTY and child-process execution paths

## Motivation

When OpenClaw runs on macOS with zsh as the default shell, commands like:
```
yt-summary add https://www.youtube.com/watch?v=xxxxx
```
fail with `zsh: no matches found: https://www.youtube.com/watch?v=xxxxx` because zsh interprets `?v=xxxxx` as a glob pattern.

The `setopt nonomatch` builtin tells zsh to pass unmatched glob patterns through as literal strings (matching bash's default behavior), without affecting any other shell behavior.

## Changes

| File | Change |
|------|--------|
| `src/agents/shell-utils.ts` | Add `wrapCommandForShell()` — prefixes with `setopt nonomatch;` for zsh, no-op for other shells |
| `src/agents/bash-tools.exec-runtime.ts` | Wrap `execCommand` before passing to child argv and PTY |
| `src/process/supervisor/supervisor.ts` | Wrap `ptyCommand` in the PTY adapter path |
| `src/process/supervisor/supervisor.pty-command.test.ts` | Add `wrapCommandForShell` to the shell-utils mock |

## Test plan

- [x] `tsgo --noEmit` passes (no type errors in modified files)
- [x] Existing `supervisor.pty-command.test.ts` passes (mock updated)
- [ ] Manual test: run `exec` with a URL containing `?` on zsh — should no longer error

Fixes #19496
Related #12727

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes zsh glob expansion errors by prefixing commands with `setopt nonomatch;` when the resolved shell is zsh. This prevents `no matches found` errors for unquoted glob characters (like `?` in URLs). The fix is applied consistently across both PTY and child-process execution paths in `bash-tools.exec-runtime.ts` and `supervisor.ts`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after addressing the test assertion issue
- The fix correctly addresses the zsh glob expansion issue with a minimal, targeted change. The implementation is sound and applied consistently across all execution paths. However, there's a test assertion that assumes commands are passed verbatim, which will fail when the actual shell is zsh since `wrapCommandForShell` will modify the command.
- src/process/supervisor/supervisor.pty-command.test.ts - test assertion needs adjustment

<sub>Last reviewed commit: d1076ad</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->