### PR TITLE
fix(gateway): detect launchd supervision via OPENCLAW_LAUNCHD_LABEL and XPC_SERVICE_NAME

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -23,6 +23,9 @@ afterEach(() => {
 function clearSupervisorHints() {
   delete process.env.LAUNCH_JOB_LABEL;
   delete process.env.LAUNCH_JOB_NAME;
+  delete process.env.XPC_SERVICE_NAME;
+  delete process.env.OPENCLAW_LAUNCHD_LABEL;
+  delete process.env.OPENCLAW_SYSTEMD_UNIT;
   delete process.env.INVOCATION_ID;
   delete process.env.SYSTEMD_EXEC_PID;
   delete process.env.JOURNAL_STREAM;
@@ -38,6 +41,30 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when launchd/systemd hints are present", () => {
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns supervised when OPENCLAW_LAUNCHD_LABEL is set", () => {
+    clearSupervisorHints();
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns supervised when OPENCLAW_SYSTEMD_UNIT is set", () => {
+    clearSupervisorHints();
+    process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns supervised when XPC_SERVICE_NAME is set", () => {
+    clearSupervisorHints();
+    process.env.XPC_SERVICE_NAME = "ai.openclaw.gateway";
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
     expect(spawnMock).not.toHaveBeenCalled();

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -9,8 +9,15 @@ export type GatewayRespawnResult = {
 };
 
 const SUPERVISOR_HINT_ENV_VARS = [
+  // macOS launchd (legacy, not reliably set by modern macOS)
   "LAUNCH_JOB_LABEL",
   "LAUNCH_JOB_NAME",
+  // macOS launchd (set by launchd on modern macOS)
+  "XPC_SERVICE_NAME",
+  // OpenClaw's own service env vars (set by generated plist/unit files)
+  "OPENCLAW_LAUNCHD_LABEL",
+  "OPENCLAW_SYSTEMD_UNIT",
+  // Linux systemd
   "INVOCATION_ID",
   "SYSTEMD_EXEC_PID",
   "JOURNAL_STREAM",


### PR DESCRIPTION
## Summary

- **Problem:** `isLikelySupervisedProcess()` only checks legacy macOS env vars (`LAUNCH_JOB_LABEL`, `LAUNCH_JOB_NAME`) and systemd-specific vars. Modern macOS doesn't reliably set these, and OpenClaw's own generated plist uses `OPENCLAW_LAUNCHD_LABEL` instead. When detection fails, the gateway forks a detached child and exits — orphaning the child under launchd, causing a crash loop.
- **Why it matters:** On macOS with `KeepAlive: true`, the orphaned child holds the port while launchd respawns a new process that can't bind it → exit code 1 → launchd retries → infinite crash loop. Requires manual `launchctl bootout` + `kill` to recover.
- **What changed:** Added `OPENCLAW_LAUNCHD_LABEL`, `OPENCLAW_SYSTEMD_UNIT`, and `XPC_SERVICE_NAME` to the `SUPERVISOR_HINT_ENV_VARS` list in `process-respawn.ts`. Updated tests to clear and validate all new hints.
- **What did NOT change (scope boundary):** No changes to the restart flow, spawn logic, drain/shutdown orchestration, or plist generation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #20536
- Fixes #19521
- Related #14161

## User-visible / Behavior Changes

- Gateway config changes that trigger SIGUSR1 restarts no longer cause orphaned processes or crash loops under launchd on macOS.
- The gateway now correctly exits with code 0 and lets launchd handle the restart, maintaining proper PID tracking.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.5 (Apple Silicon)
- Runtime/container: Node.js 25.6.1
- Model/provider: N/A (infrastructure fix)
- Integration/channel: N/A
- Relevant config: `KeepAlive: true` in launchd plist, `commands.restart: true` in openclaw.json

### Steps

1. Install OpenClaw via Homebrew, configure as a launchd service
2. Start the gateway via `launchctl bootstrap`
3. Make a config change that triggers a restart (e.g., modify `memory.qmd.paths`)
4. Observe the gateway logs:
   - **Before fix:** `restart mode: full process restart (spawned pid XXXX)` → orphan + crash loop
   - **After fix:** `restart mode: full process restart (supervisor restart)` → clean launchd restart

### Expected

- Gateway exits cleanly, launchd restarts it with a new PID
- New process binds port successfully

### Actual (before fix)

- Gateway spawns a detached child, exits
- Launchd detects exit, starts new instance
- New instance fails to bind port (orphan holds it) → exit code 1 → crash loop

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

**Before fix** (from gateway.log):
```
[gateway] restart mode: full process restart (spawned pid 19520)
```
Then crash loop with exit code 1 as new launchd-managed process can't bind port 18789.

**After fix** — `isLikelySupervisedProcess()` detects `OPENCLAW_LAUNCHD_LABEL=ai.openclaw.gateway` in the environment and returns `{ mode: "supervised" }`. The gateway exits cleanly; launchd restarts it.

**New test cases pass:**
```
✓ returns supervised when OPENCLAW_LAUNCHD_LABEL is set
✓ returns supervised when OPENCLAW_SYSTEMD_UNIT is set
✓ returns supervised when XPC_SERVICE_NAME is set
```

## Human Verification (required)

- Verified scenarios:
  - Gateway restarts cleanly under launchd after config change (no orphaned processes)
  - No crash loop after restart — new PID binds port successfully
  - `lsof -i :18789` shows the launchd-managed PID matches the listening process
- Edge cases checked:
  - Legacy `LAUNCH_JOB_LABEL` still works (existing test preserved)
  - All new env vars individually trigger supervised mode
  - `clearSupervisorHints()` in tests clears all vars including new ones
- What I did **not** verify:
  - systemd behavior on Linux (no Linux test environment, but `OPENCLAW_SYSTEMD_UNIT` follows same pattern)
  - Docker/containerized environments

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` — uses env vars already set by generated plist/unit files
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `OPENCLAW_NO_RESPAWN=1` in the plist to force in-process restart mode
- Files/config to restore: `src/infra/process-respawn.ts`
- Known bad symptoms reviewers should watch for: If `XPC_SERVICE_NAME` is set in non-launchd contexts (unlikely), the gateway would exit instead of spawning — harmless, as in-process restart is the fallback for failed spawns anyway

## Risks and Mitigations

- Risk: `XPC_SERVICE_NAME` could theoretically be set in non-supervisor contexts.
  - Mitigation: This var is set by macOS's XPC system only for managed services. Even if incorrectly triggered, the result is a clean exit + supervisor restart, which is safer than the current orphaned-process behavior.

---

🤖 AI-assisted (Claude Opus 4.6 via Claude Code). Fully tested locally on macOS with real launchd service.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three new environment variables (`OPENCLAW_LAUNCHD_LABEL`, `OPENCLAW_SYSTEMD_UNIT`, `XPC_SERVICE_NAME`) to the supervisor detection list in `process-respawn.ts`. This prevents the gateway from spawning orphaned child processes under launchd/systemd supervision, which was causing crash loops when config changes triggered restarts.

The fix is well-targeted and backward compatible:
- All three env vars are already set by OpenClaw's generated service files or by the system (XPC)
- Test coverage includes individual tests for each new variable
- `clearSupervisorHints()` helper properly updated to clean all new vars

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted bug fix that adds three environment variables to an existing detection list. The logic is straightforward (checking if env vars are set), test coverage is comprehensive with individual tests for each new variable, and the change is backward compatible since it only adds new detection cases without removing existing ones. The fix directly addresses the root cause of the crash loop issue described in the PR
- No files require special attention

<sub>Last reviewed commit: b661433</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->