### PR TITLE
feat: add file-writer extension for shell-safe text passing

### DIFF
--- a/extensions/file-writer/index.ts
+++ b/extensions/file-writer/index.ts
@@ -1,0 +1,6 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "../../src/plugins/types.js";
+import { createFileWriterTool } from "./src/file-writer-tool.js";
+
+export default function register(api: OpenClawPluginApi) {
+  api.registerTool(createFileWriterTool(api) as unknown as AnyAgentTool, { optional: true });
+}

--- a/extensions/file-writer/openclaw.plugin.json
+++ b/extensions/file-writer/openclaw.plugin.json
@@ -1,0 +1,16 @@
+{
+  "id": "file-writer",
+  "name": "File Writer",
+  "description": "Write text content to temporary files, bypassing shell escaping issues when passing long text to CLI tools.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "allowedDirs": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Additional directories to allow writes to (beyond /tmp and ~/.cache)."
+      }
+    }
+  }
+}

--- a/extensions/file-writer/package.json
+++ b/extensions/file-writer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/file-writer",
+  "version": "2026.2.18",
+  "private": true,
+  "description": "OpenClaw plugin to write text content to temporary files",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/file-writer/src/file-writer-tool.ts
+++ b/extensions/file-writer/src/file-writer-tool.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+
+/**
+ * Default directories where file writes are allowed.
+ * macOS `os.tmpdir()` returns `/var/folders/.../`, not `/tmp/`.
+ * `/tmp` is a symlink to `/private/tmp` on macOS — allow both.
+ */
+const DEFAULT_ALLOWED_DIRS = [
+  os.tmpdir(),
+  "/tmp",
+  "/private/tmp",
+  path.join(os.homedir(), ".cache"),
+];
+
+type PluginCfg = {
+  allowedDirs?: string[];
+};
+
+function isPathAllowed(filePath: string, allowedDirs: string[]): boolean {
+  const resolved = path.resolve(filePath);
+  return allowedDirs.some((dir) => resolved.startsWith(dir + path.sep) || resolved === dir);
+}
+
+export function createFileWriterTool(api: OpenClawPluginApi) {
+  const pluginCfg = (api.pluginConfig ?? {}) as PluginCfg;
+  const allowedDirs = [...DEFAULT_ALLOWED_DIRS, ...(pluginCfg.allowedDirs ?? [])];
+
+  api.logger.info(`file-writer: allowed dirs: ${allowedDirs.join(", ")}`);
+
+  return {
+    name: "write_file",
+    label: "Write File",
+    description:
+      "Write text content to a temporary file. Use this when you need to pass long text " +
+      "to a command-line tool via exec (e.g. pass a memo body with --file /tmp/memo.txt). " +
+      "The content is written as-is with no shell escaping issues. " +
+      "Allowed paths: /tmp/*, ~/.cache/*, and any directories configured in allowedDirs.",
+    parameters: Type.Object({
+      file_path: Type.String({
+        description:
+          "Absolute path to write to. Must be under /tmp/ or ~/.cache/. Example: /tmp/memo-content.txt",
+      }),
+      content: Type.String({
+        description: "The text content to write to the file.",
+      }),
+    }),
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = params.file_path;
+      const content = params.content;
+
+      if (typeof filePath !== "string" || !filePath) {
+        return { content: [{ type: "text", text: "Error: file_path is required" }] };
+      }
+
+      if (typeof content !== "string") {
+        return { content: [{ type: "text", text: "Error: content is required" }] };
+      }
+
+      // Expand ~ to home directory
+      const expandedPath = filePath.startsWith("~/")
+        ? path.join(os.homedir(), filePath.slice(2))
+        : filePath;
+      const resolvedPath = path.resolve(expandedPath);
+
+      if (!isPathAllowed(resolvedPath, allowedDirs)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error: Path not allowed. Must be under one of: ${allowedDirs.join(", ")}. Got: ${resolvedPath}`,
+            },
+          ],
+        };
+      }
+
+      try {
+        const dir = path.dirname(resolvedPath);
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, { recursive: true });
+        }
+
+        fs.writeFileSync(resolvedPath, content, "utf-8");
+        const stats = fs.statSync(resolvedPath);
+
+        return {
+          content: [{ type: "text", text: `Written ${stats.size} bytes to ${resolvedPath}` }],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error writing file: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    },
+  };
+}

--- a/extensions/file-writer/src/file-writer-tool.ts
+++ b/extensions/file-writer/src/file-writer-tool.ts
@@ -27,7 +27,10 @@ function isPathAllowed(filePath: string, allowedDirs: string[]): boolean {
 
 export function createFileWriterTool(api: OpenClawPluginApi) {
   const pluginCfg = (api.pluginConfig ?? {}) as PluginCfg;
-  const allowedDirs = [...DEFAULT_ALLOWED_DIRS, ...(pluginCfg.allowedDirs ?? [])];
+  const allowedDirs = [
+    ...DEFAULT_ALLOWED_DIRS,
+    ...(pluginCfg.allowedDirs ?? []).map((d) => path.resolve(d)),
+  ];
 
   api.logger.info(`file-writer: allowed dirs: ${allowedDirs.join(", ")}`);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/file-writer:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/google-antigravity-auth:
     devDependencies:
       openclaw:
@@ -6912,7 +6918,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6928,7 +6934,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7132,7 +7138,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8079,7 +8085,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8125,7 +8131,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -9013,14 +9019,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9599,8 +9597,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Adds a `write_file` tool extension that writes text content to temporary files using structured JSON parameters, completely bypassing shell escaping
- Solves the fundamental problem that the `exec` tool passes commands as shell strings, causing long text with quotes, parentheses, URLs, and non-ASCII characters to break
- Security: writes restricted to `/tmp/`, `~/.cache/`, and optionally configured directories

## Motivation

When the LLM needs to pass long text to a CLI tool via `exec`, shell quoting is fragile:

```
exec("web-save memo --body 'This has "quotes" and (parens) and https://example.com/page?id=1'")
```

This inevitably breaks. The `write_file` tool lets the LLM write the content to a temp file first:

```
write_file({ file_path: "/tmp/memo.txt", content: "..." })
exec("web-save memo --file /tmp/memo.txt")
```

## Files

| File | Description |
|------|-------------|
| `extensions/file-writer/index.ts` | Plugin entry point |
| `extensions/file-writer/openclaw.plugin.json` | Plugin manifest with `allowedDirs` config |
| `extensions/file-writer/package.json` | Package metadata |
| `extensions/file-writer/src/file-writer-tool.ts` | Tool implementation |

## Configuration

Optional `allowedDirs` config to extend the default allowed directories:

```json
{
  "plugins": {
    "file-writer": {
      "allowedDirs": ["/home/user/data"]
    }
  }
}
```

## Test plan

- [x] `tsgo --noEmit` passes
- [ ] Manual test: write a file to `/tmp/test.txt` via the tool, verify content
- [ ] Manual test: write to a disallowed path, verify rejection

Related #19496

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `write_file` tool extension that enables LLMs to write text content to temporary files using structured JSON parameters, solving shell escaping issues when passing long text with special characters to CLI tools via `exec`.

- New plugin at `extensions/file-writer/` with standard structure
- Security: restricts writes to `/tmp/`, `/private/tmp/`, `~/.cache/`, and optionally configured directories
- Path validation logic resolves paths and checks they're under allowed directories
- Follows existing tool patterns from `llm-task` extension

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the path normalization issue for user-configured directories
- The implementation follows existing patterns and has good path validation, but user-configured `allowedDirs` must be normalized to prevent security bypass. The single logic issue is straightforward to fix.
- Review `extensions/file-writer/src/file-writer-tool.ts:30` for the path normalization fix

<sub>Last reviewed commit: b6695f9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->