### PR TITLE
feat: add exec-passthrough extension for direct output delivery

### DIFF
--- a/extensions/exec-passthrough/index.ts
+++ b/extensions/exec-passthrough/index.ts
@@ -1,0 +1,6 @@
+import type { OpenClawPluginApi } from "../../src/plugins/types.js";
+import { registerExecPassthrough } from "./src/passthrough.js";
+
+export default function register(api: OpenClawPluginApi) {
+  registerExecPassthrough(api);
+}

--- a/extensions/exec-passthrough/openclaw.plugin.json
+++ b/extensions/exec-passthrough/openclaw.plugin.json
@@ -1,0 +1,16 @@
+{
+  "id": "exec-passthrough",
+  "name": "Exec Passthrough",
+  "description": "Intercept __PASSTHROUGH__ markers in exec tool results and send content directly to the user, bypassing LLM re-summarization.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "type": "string",
+        "description": "Channel to send passthrough content to. Currently supports: telegram.",
+        "enum": ["telegram"]
+      }
+    }
+  }
+}

--- a/extensions/exec-passthrough/package.json
+++ b/extensions/exec-passthrough/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/exec-passthrough",
+  "version": "2026.2.18",
+  "private": true,
+  "description": "OpenClaw plugin to send exec output directly to the user, bypassing LLM",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/exec-passthrough/src/passthrough.ts
+++ b/extensions/exec-passthrough/src/passthrough.ts
@@ -124,7 +124,7 @@ export function registerExecPassthrough(api: OpenClawPluginApi) {
     (event) => {
       const msg = event.message;
       if (!msg || msg.role !== "toolResult") return;
-      if ((msg as any).toolName !== "exec") return;
+      if (event.toolName !== "exec") return;
 
       const contents = (msg as any).content;
       if (!Array.isArray(contents)) return;
@@ -138,7 +138,11 @@ export function registerExecPassthrough(api: OpenClawPluginApi) {
         found = true;
 
         if (sender) {
-          sender.send(result.passthrough).catch(() => {});
+          sender.send(result.passthrough).catch((err) => {
+            api.logger.error(
+              `exec-passthrough: send failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
           api.logger.info(
             `exec-passthrough: sent ${result.passthrough.length} chars directly, slim for LLM`,
           );

--- a/extensions/exec-passthrough/src/passthrough.ts
+++ b/extensions/exec-passthrough/src/passthrough.ts
@@ -1,0 +1,162 @@
+/**
+ * exec-passthrough — send exec output directly to the user
+ *
+ * CLI scripts can wrap output in __PASSTHROUGH__...__END_PASSTHROUGH__
+ * markers.  This plugin intercepts the tool result, sends the marked
+ * content directly to the user's channel, and replaces it with a slim
+ * placeholder so the LLM doesn't re-summarize it.
+ *
+ * Currently supports Telegram via the runtime channel API.
+ * Other channels can be added by extending the ChannelSender interface.
+ */
+
+import type { OpenClawPluginApi, PluginLogger } from "../../../src/plugins/types.js";
+
+const MARKER_START = "__PASSTHROUGH__";
+const MARKER_END = "__END_PASSTHROUGH__";
+
+// ── Marker parsing (channel-agnostic) ──────────────────────────────
+
+type ExtractResult = {
+  /** Content to send directly to the user. */
+  passthrough: string;
+  /** Slim replacement for the LLM. */
+  slim: string;
+};
+
+function extractPassthrough(text: string): ExtractResult | null {
+  const startIdx = text.indexOf(MARKER_START);
+  if (startIdx === -1) return null;
+
+  const afterStart = startIdx + MARKER_START.length;
+  const endIdx = text.indexOf(MARKER_END, afterStart);
+
+  let passthrough: string;
+  let remaining: string;
+  if (endIdx !== -1) {
+    passthrough = text.slice(afterStart, endIdx).trim();
+    remaining = (text.slice(0, startIdx) + text.slice(endIdx + MARKER_END.length)).trim();
+  } else {
+    passthrough = text.slice(afterStart).trim();
+    remaining = text.slice(0, startIdx).trim();
+  }
+
+  if (!passthrough) return null;
+
+  let slim = "[output sent directly to user — no reply needed]";
+  if (remaining) {
+    slim = `${remaining}\n${slim}`;
+  }
+
+  return { passthrough, slim };
+}
+
+// ── Channel sender ─────────────────────────────────────────────────
+
+interface ChannelSender {
+  send(text: string): Promise<void>;
+}
+
+const TG_MSG_LIMIT = 4000; // Telegram limit is 4096, leave margin
+
+function createTelegramSender(api: OpenClawPluginApi): ChannelSender | null {
+  const config = api.config as Record<string, unknown>;
+  const channels = config?.channels as Record<string, unknown> | undefined;
+  const tg = channels?.telegram as Record<string, unknown> | undefined;
+
+  const botToken = tg?.botToken as string | undefined;
+  const allowFrom = tg?.allowFrom as string[] | undefined;
+
+  let chatId: string | undefined;
+  if (Array.isArray(allowFrom) && allowFrom.length > 0) {
+    chatId = allowFrom.find((id: string) => /^\d+$/.test(id));
+    if (!chatId) {
+      const prefixed = allowFrom.find((id: string) => id.startsWith("tg:"));
+      if (prefixed) chatId = prefixed.replace(/^tg:/, "");
+    }
+  }
+
+  if (!botToken || !chatId) {
+    api.logger.info("exec-passthrough: telegram config incomplete, direct send disabled");
+    return null;
+  }
+
+  api.logger.info(`exec-passthrough: telegram sender ready (chatId=${chatId})`);
+
+  return {
+    async send(text: string) {
+      const chunks: string[] = [];
+      for (let i = 0; i < text.length; i += TG_MSG_LIMIT) {
+        chunks.push(text.slice(i, i + TG_MSG_LIMIT));
+      }
+      for (const chunk of chunks) {
+        try {
+          await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ chat_id: chatId, text: chunk }),
+          });
+        } catch (err) {
+          api.logger.error(
+            `exec-passthrough: telegram send failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    },
+  };
+}
+
+// ── Plugin registration ────────────────────────────────────────────
+
+export function registerExecPassthrough(api: OpenClawPluginApi) {
+  const pluginCfg = (api.pluginConfig ?? {}) as { channel?: string };
+  const channelName = pluginCfg.channel ?? "telegram";
+
+  let sender: ChannelSender | null = null;
+  if (channelName === "telegram") {
+    sender = createTelegramSender(api);
+  } else {
+    api.logger.warn(`exec-passthrough: unsupported channel "${channelName}"`);
+  }
+
+  api.on(
+    "tool_result_persist",
+    (event) => {
+      const msg = event.message;
+      if (!msg || msg.role !== "toolResult") return;
+      if ((msg as any).toolName !== "exec") return;
+
+      const contents = (msg as any).content;
+      if (!Array.isArray(contents)) return;
+
+      let found = false;
+      const newContents = contents.map((c: any) => {
+        if (c.type !== "text" || !c.text) return c;
+        const result = extractPassthrough(c.text);
+        if (!result) return c;
+
+        found = true;
+
+        if (sender) {
+          sender.send(result.passthrough).catch(() => {});
+          api.logger.info(
+            `exec-passthrough: sent ${result.passthrough.length} chars directly, slim for LLM`,
+          );
+        } else {
+          api.logger.info("exec-passthrough: no sender configured, passthrough content dropped");
+        }
+
+        return { ...c, text: result.slim };
+      });
+
+      if (found) {
+        return { message: { ...msg, content: newContents } };
+      }
+    },
+    { priority: 100 },
+  );
+
+  api.logger.info(
+    `exec-passthrough: plugin loaded (channel=${channelName}, sender=${sender ? "active" : "none"})`,
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/exec-passthrough:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/feishu:
     dependencies:
       '@larksuiteoapi/node-sdk':
@@ -6912,7 +6918,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6928,7 +6934,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7132,7 +7138,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8079,7 +8085,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8125,7 +8131,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -9013,14 +9019,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9599,8 +9597,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Adds an extension that intercepts `__PASSTHROUGH__` markers in exec tool results and sends content directly to the user's channel
- Bypasses LLM re-summarization — the LLM sees only a slim placeholder
- Currently supports Telegram as delivery channel, with a `ChannelSender` interface for extensibility

## Motivation

When CLI tools produce formatted output (reports, tables, summaries), the LLM often re-summarizes or reformats it unnecessarily. This is wasteful for both tokens and user experience.

With exec-passthrough, CLI scripts can wrap output in markers:

```bash
echo "__PASSTHROUGH__"
cat formatted-report.txt
echo "__END_PASSTHROUGH__"
```

The plugin:
1. Detects the markers in the `tool_result_persist` hook
2. Sends the marked content directly to the user's channel (e.g. Telegram)
3. Replaces the tool result with `[output sent directly to user — no reply needed]`
4. The LLM sees only the slim result and generates minimal confirmation

## Architecture

```
CLI script → exec tool → tool_result_persist hook
                              ↓
                    extractPassthrough()
                      ↓              ↓
              ChannelSender       Slim for LLM
              (Telegram API)    (replaces tool result)
```

The `ChannelSender` interface allows adding support for other channels (Slack, Discord, etc.) without changing the core marker parsing logic.

## Files

| File | Description |
|------|-------------|
| `extensions/exec-passthrough/index.ts` | Plugin entry point |
| `extensions/exec-passthrough/openclaw.plugin.json` | Plugin manifest |
| `extensions/exec-passthrough/package.json` | Package metadata |
| `extensions/exec-passthrough/src/passthrough.ts` | Marker parsing + Telegram sender |

## Configuration

```json
{
  "plugins": {
    "exec-passthrough": {
      "channel": "telegram"
    }
  }
}
```

Reads Telegram bot token and chat ID from the main OpenClaw config (`channels.telegram.botToken` / `channels.telegram.allowFrom`).

## Test plan

- [x] `tsgo --noEmit` passes
- [ ] Manual test: exec a script that outputs `__PASSTHROUGH__` markers
- [ ] Verify Telegram receives the content directly
- [ ] Verify LLM sees only the slim placeholder

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `exec-passthrough` plugin that intercepts `__PASSTHROUGH__` markers in exec tool output and sends content directly to Telegram, bypassing LLM re-summarization. The plugin hooks into `tool_result_persist` to detect markers, extract content, and deliver it via Telegram API.

**Key changes:**
- New plugin structure under `extensions/exec-passthrough/`
- Marker parsing logic extracts content between `__PASSTHROUGH__` and `__END_PASSTHROUGH__`
- Telegram sender chunks messages at 4000 char limit
- Replaces marked content with slim placeholder for LLM

**Issues found:**
- Critical: `toolName` accessed incorrectly from message instead of event context (line 127)
- The plugin correctly registers on the `tool_result_persist` hook with appropriate priority

<h3>Confidence Score: 3/5</h3>

- This PR contains a critical bug that will prevent the plugin from working correctly
- The plugin won't function due to accessing `toolName` from the wrong location (message vs context). Once fixed, the implementation is straightforward and follows established patterns.
- passthrough.ts requires a fix on line 127 to access toolName from event context

<sub>Last reviewed commit: 4e88d36</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->