### PR TITLE
fix(gateway): include deleted/reset sessions in usage.cost RPC (#20599)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Usage: include deleted and reset session transcripts in `usage.cost` RPC so the dashboard reports accurate totals instead of undercounting when sessions have been deleted or reset. (#20599)
 - Telegram: unify message-like inbound handling so `message` and `channel_post` share the same dedupe/access/media pipeline and remain behaviorally consistent. (#20591) Thanks @obviyus.
 - Telegram/Agents: gate exec/bash tool-failure warnings behind verbose mode so default Telegram replies stay clean while verbose sessions still surface diagnostics. (#20560) Thanks @obviyus.
 - Gateway/Daemon: forward `TMPDIR` into installed service environments so macOS LaunchAgent gateway runs can open SQLite temp/journal files reliably instead of failing with `SQLITE_CANTOPEN`. (#20512) Thanks @Clawborn.

--- a/src/gateway/server.usage-cost-deleted-sessions.e2e.test.ts
+++ b/src/gateway/server.usage-cost-deleted-sessions.e2e.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { connectOk, installGatewayTestHooks, rpcReq } from "./test-helpers.js";
+import { withServer } from "./test-with-server.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("usage.cost deleted/reset sessions e2e (#20599)", () => {
+  it("should include tokens from deleted and reset sessions, not just active", async () => {
+    const ts = new Date().toISOString();
+    const stateDir = process.env.OPENCLAW_STATE_DIR!;
+
+    const { writeConfigFile } = await import("../config/config.js");
+    await writeConfigFile({
+      session: { mainKey: "main-test" },
+    });
+
+    const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // Active session: 100 tokens, $0.10
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-active.jsonl"),
+      JSON.stringify({
+        type: "message",
+        timestamp: ts,
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: { input: 60, output: 40, totalTokens: 100, cost: { total: 0.1 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    // Deleted session: 200 tokens, $0.20
+    const deletedTs = new Date().toISOString().replaceAll(":", "-");
+    await fs.writeFile(
+      path.join(sessionsDir, `sess-deleted.jsonl.deleted.${deletedTs}`),
+      JSON.stringify({
+        type: "message",
+        timestamp: ts,
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: { input: 120, output: 80, totalTokens: 200, cost: { total: 0.2 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    // Reset session: 300 tokens, $0.30
+    const resetTs = new Date().toISOString().replaceAll(":", "-");
+    await fs.writeFile(
+      path.join(sessionsDir, `sess-reset.jsonl.reset.${resetTs}`),
+      JSON.stringify({
+        type: "message",
+        timestamp: ts,
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: { input: 180, output: 120, totalTokens: 300, cost: { total: 0.3 } },
+        },
+      }),
+      "utf-8",
+    );
+
+    // Start real gateway, connect, call usage.cost RPC
+    await withServer(async (ws) => {
+      await connectOk(ws, { token: "secret", scopes: ["operator.read"] });
+
+      const res = await rpcReq<{
+        totals: { totalTokens: number; totalCost: number };
+        daily: Array<{ date: string; totalTokens: number }>;
+      }>(ws, "usage.cost", { days: 7 });
+
+      expect(res.ok).toBe(true);
+
+      const totals = res.payload!.totals;
+      console.log(`Total tokens from usage.cost RPC: ${totals.totalTokens}`);
+      console.log(`Total cost from usage.cost RPC: ${totals.totalCost}`);
+
+      if (totals.totalTokens < 600) {
+        console.log("❌ BUG CONFIRMED: usage.cost ignores deleted/reset sessions");
+        console.log(
+          `   Expected >= 600 (active 100 + deleted 200 + reset 300), got ${totals.totalTokens}`,
+        );
+      }
+
+      // Should be 600 (active 100 + deleted 200 + reset 300)
+      expect(totals.totalTokens).toBeGreaterThanOrEqual(600);
+      expect(totals.totalCost).toBeGreaterThanOrEqual(0.6 - 0.001);
+    });
+  });
+});

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -51,6 +51,16 @@ export type {
   SessionUsageTimeSeries,
 } from "./session-cost-usage.types.js";
 
+/**
+ * Returns true if the filename is a session transcript file — active, deleted, or reset.
+ * Matches: `*.jsonl`, `*.jsonl.deleted.<ts>`, `*.jsonl.reset.<ts>`.
+ */
+function isSessionTranscriptFile(name: string): boolean {
+  return (
+    name.endsWith(".jsonl") || name.includes(".jsonl.deleted.") || name.includes(".jsonl.reset.")
+  );
+}
+
 const emptyTotals = (): CostUsageTotals => ({
   input: 0,
   output: 0,
@@ -316,7 +326,7 @@ export async function loadCostUsageSummary(params?: {
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter((entry) => entry.isFile() && isSessionTranscriptFile(entry.name))
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);


### PR DESCRIPTION
## Summary

- **Bug**: `usage.cost` RPC undercounts tokens and cost by ignoring deleted/reset session transcripts
- **Root cause**: `loadCostUsageSummary` in `src/infra/session-cost-usage.ts` filters files with `.endsWith(".jsonl")`, excluding `*.jsonl.deleted.*` and `*.jsonl.reset.*` archives
- **Fix**: Widen the file filter to include archived session transcripts

Fixes #20599

## Problem

When sessions are deleted or reset, their transcript files are renamed from `foo.jsonl` to `foo.jsonl.deleted.<timestamp>` or `foo.jsonl.reset.<timestamp>` (via `archiveFileOnDisk` in `session-utils.fs.ts`). These files remain on disk with full usage data intact.

However, `loadCostUsageSummary` only scans files ending in `.jsonl`:

```typescript
.filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
```

This means all usage from deleted/reset sessions is invisible to the dashboard. In the reporter's deployment, this resulted in 85% of actual cost being hidden.

**Before fix:**
- Active sessions: 100 tokens, $0.10
- Deleted session (on disk as `*.jsonl.deleted.*`): 200 tokens, $0.20
- Reset session (on disk as `*.jsonl.reset.*`): 300 tokens, $0.30
- `usage.cost` RPC returns: 100 tokens, $0.10

## Changes

- `src/infra/session-cost-usage.ts` — Add `isSessionTranscriptFile()` helper that matches `*.jsonl`, `*.jsonl.deleted.*`, and `*.jsonl.reset.*`; use it in `loadCostUsageSummary` file filter
- `src/gateway/server.usage-cost-deleted-sessions.e2e.test.ts` — E2E test: starts real gateway, creates active + deleted + reset session files, calls `usage.cost` RPC, verifies all tokens are counted
- `CHANGELOG.md` — Add fix entry

**After fix:**
- `usage.cost` RPC returns: 600 tokens, $0.60 (all sessions counted)

## Test plan

- [x] New e2e test: real gateway with active + deleted + reset sessions, verifies totalTokens >= 600
- [x] All 8 existing session-cost-usage tests pass
- [x] All 5 existing usage handler tests pass
- [x] Format check passes
- [x] Lint passes

## Effect on User Experience

**Before:** Usage dashboard shows only active session costs. Deleted/reset sessions (which can represent 85%+ of actual spend) are invisible, giving users a false sense of low usage.

**After:** Dashboard accurately reports total cost across all sessions, including those that have been deleted or reset.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where the `usage.cost` RPC undercounted tokens and costs by ignoring deleted and reset session transcripts.

**Root cause:** The file filter in `loadCostUsageSummary` (line 329) only matched `*.jsonl` files, excluding archived sessions (`*.jsonl.deleted.*` and `*.jsonl.reset.*`) that are created when sessions are deleted or reset via `archiveFileOnDisk`.

**Changes:**
- Added `isSessionTranscriptFile()` helper function that matches all three file patterns: active (`*.jsonl`), deleted (`*.jsonl.deleted.*`), and reset (`*.jsonl.reset.*`) sessions
- Updated the file filter in `loadCostUsageSummary` to use this new helper
- Added comprehensive E2E test verifying all session types are counted
- Updated CHANGELOG with user-facing fix description

**Impact:** Users previously saw only active session costs in their dashboard. This bug could hide 85%+ of actual usage if many sessions were deleted/reset. After this fix, the dashboard accurately reflects total cost across all sessions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical, well-tested, and addresses a clearly-defined bug. The new helper function correctly matches the exact naming patterns used by `archiveFileOnDisk`, the E2E test provides comprehensive coverage with all three file types, and the change is backward-compatible (active `.jsonl` files continue to work). The fix is isolated to the cost calculation path and doesn't affect session discovery/listing functionality.
- No files require special attention

<sub>Last reviewed commit: cf74cd1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->