### PR TITLE
Security: use crypto.randomBytes for temp file names

### DIFF
--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -36,7 +36,8 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
     .map((l) => l.trim())
     .filter(Boolean);
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
-  const tmp = `${filePath}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`;
+  const { randomBytes } = await import("node:crypto");
+  const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
   await fs.rename(tmp, filePath);
 }

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -49,7 +49,8 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
 
 export async function saveCronStore(storePath: string, store: CronStoreFile) {
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
-  const tmp = `${storePath}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`;
+  const { randomBytes } = await import("node:crypto");
+  const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   const json = JSON.stringify(store, null, 2);
   await fs.promises.writeFile(tmp, json, "utf-8");
   await fs.promises.rename(tmp, storePath);

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -382,8 +383,8 @@ function readPrefs(prefsPath: string): TtsUserPrefs {
 }
 
 function atomicWriteFileSync(filePath: string, content: string): void {
-  const tmpPath = `${filePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
-  writeFileSync(tmpPath, content);
+  const tmpPath = `${filePath}.tmp.${Date.now()}.${randomBytes(8).toString("hex")}`;
+  writeFileSync(tmpPath, content, { mode: 0o600 });
   try {
     renameSync(tmpPath, filePath);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Replace `Math.random()` with `crypto.randomBytes()` for temp file name generation in `tts.ts`, `run-log.ts`, and `store.ts`
- `Math.random()` is predictable and can enable TOCTOU race conditions on temp files
- Set `mode: 0o600` on TTS temp files to restrict access to owner only

## Test plan
- [ ] Run `vitest src/tts/tts.test.ts` to verify TTS tests pass
- [ ] Run `vitest src/cron/run-log.test.ts` and `vitest src/cron/store.test.ts`
- [ ] Verify temp files are created with correct permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `Math.random()` with `crypto.randomBytes()` for temp file generation in three files (`tts.ts`, `run-log.ts`, `store.ts`), eliminating predictable file names that could enable TOCTOU race conditions. Added `mode: 0o600` to TTS temp files to restrict access to owner only.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The changes are straightforward security improvements that replace predictable random number generation with cryptographically secure alternatives. The implementation is correct and consistent across all three files, with proper error handling preserved. The addition of restrictive file permissions (0o600) on TTS temp files is an appropriate security hardening measure.
- No files require special attention

<sub>Last reviewed commit: fe8bba3</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->