### PR TITLE
Security: use execFileSync instead of execSync with shell

### DIFF
--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 export type TimeFormatPreference = "auto" | "12" | "24";
 export type ResolvedTimeFormat = "12" | "24";
@@ -96,9 +96,10 @@ export function withNormalizedTimestamp<T extends Record<string, unknown>>(
 function detectSystemTimeFormat(): boolean {
   if (process.platform === "darwin") {
     try {
-      const result = execSync("defaults read -g AppleICUForce24HourTime 2>/dev/null", {
+      const result = execFileSync("defaults", ["read", "-g", "AppleICUForce24HourTime"], {
         encoding: "utf8",
         timeout: 500,
+        stdio: ["pipe", "pipe", "pipe"],
       }).trim();
       if (result === "1") {
         return true;
@@ -113,8 +114,9 @@ function detectSystemTimeFormat(): boolean {
 
   if (process.platform === "win32") {
     try {
-      const result = execSync(
-        'powershell -Command "(Get-Culture).DateTimeFormat.ShortTimePattern"',
+      const result = execFileSync(
+        "powershell",
+        ["-Command", "(Get-Culture).DateTimeFormat.ShortTimePattern"],
         { encoding: "utf8", timeout: 1000 },
       ).trim();
       if (result.startsWith("H")) {

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -148,10 +148,10 @@ async function resolveNodePath(): Promise<string> {
 }
 
 async function resolveBinaryPath(binary: string): Promise<string> {
-  const { execSync } = await import("node:child_process");
+  const { execFileSync } = await import("node:child_process");
   const cmd = process.platform === "win32" ? "where" : "which";
   try {
-    const output = execSync(`${cmd} ${binary}`, { encoding: "utf8" }).trim();
+    const output = execFileSync(cmd, [binary], { encoding: "utf8" }).trim();
     const resolved = output.split(/\r?\n/)[0]?.trim();
     if (!resolved) {
       throw new Error("empty");


### PR DESCRIPTION
## Summary
- Replace `execSync` (shell string interpolation) with `execFileSync` (argv array) in `program-args.ts` and `date-time.ts`
- `execSync` spawns a shell and is vulnerable to command injection when arguments are interpolated
- `execFileSync` invokes binaries directly with an explicit argument array, eliminating shell interpretation

## Test plan
- [ ] Run `vitest src/daemon/program-args.test.ts`
- [ ] Verify `which`/`where` binary resolution still works on macOS/Linux/Windows
- [ ] Verify `defaults read` time format detection works on macOS
- [ ] Verify PowerShell time format detection works on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `execSync` with `execFileSync` in `src/agents/date-time.ts` and `src/daemon/program-args.ts` to eliminate shell command injection vulnerabilities. The changes convert shell string interpolation to explicit argv arrays, preventing malicious input from being interpreted as shell commands.

Key changes:
- `date-time.ts`: macOS `defaults read` and Windows PowerShell time format detection now use `execFileSync` with argument arrays
- `program-args.ts`: `which`/`where` binary resolution now uses `execFileSync` with argument arrays
- All error handling remains intact with try-catch blocks preserving existing behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a straightforward security hardening change
- The changes correctly migrate from shell-based command execution to direct binary invocation, eliminating command injection attack vectors. All error handling is preserved, timeout configurations remain in place, and the migration follows established patterns already used elsewhere in the codebase (e.g., `cli-credentials.ts`). The test plan appropriately covers the affected platforms.
- No files require special attention - both changes are security improvements with preserved functionality

<sub>Last reviewed commit: 86a1f9c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->