### PR TITLE
Security: add length validation to browser evaluate function

### DIFF
--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -217,6 +217,11 @@ export async function fillFormViaPlaywright(opts: {
   }
 }
 
+// SECURITY: Maximum length for evaluate function bodies.
+// Limits the surface area for code injection via the browser evaluate path.
+// The browser sandbox provides the primary security boundary; this is defense-in-depth.
+const MAX_EVALUATE_FN_LENGTH = 100_000;
+
 export async function evaluateViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
@@ -228,6 +233,11 @@ export async function evaluateViaPlaywright(opts: {
   const fnText = String(opts.fn ?? "").trim();
   if (!fnText) {
     throw new Error("function is required");
+  }
+  if (fnText.length > MAX_EVALUATE_FN_LENGTH) {
+    throw new Error(
+      `evaluate function body too large (${fnText.length} chars, max ${MAX_EVALUATE_FN_LENGTH})`,
+    );
   }
   const page = await getPageForTargetId(opts);
   ensurePageState(page);


### PR DESCRIPTION
## Summary
- Add a 100KB max length check on evaluate function bodies in `pw-tools-core.interactions.ts`
- The browser sandbox is the primary security boundary for `evaluateViaPlaywright`; this is defense-in-depth to limit oversized payloads
- Clear security comment explaining the architecture

## Test plan
- [ ] Run browser-related tests
- [ ] Verify normal evaluate calls (typically <1KB) work as before
- [ ] Verify oversized payloads (>100KB) are rejected with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a 100KB max length check on evaluate function bodies in `evaluateViaPlaywright` to limit oversized payloads as defense-in-depth security measure. The implementation correctly validates before executing the function and provides a clear error message.

**Key changes:**
- Added `MAX_EVALUATE_FN_LENGTH` constant (100,000 bytes)
- Length check with descriptive error message showing actual vs max size
- Clear security comment explaining the defense-in-depth rationale

**Issue found:**
- `waitForViaPlaywright` also accepts function strings via `opts.fn` parameter on line 446 and passes them to `page.waitForFunction` without the same length validation, which is an inconsistency in the security boundary

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one inconsistency to address: `waitForViaPlaywright` lacks the same length validation
- The implementation is solid - correct validation placement, clear error messages, and good security comments. Score of 4 (not 5) due to incomplete coverage: `waitForViaPlaywright` on line 446 also accepts function strings but doesn't have the same length check, creating an inconsistency in the security boundary
- Pay attention to `waitForViaPlaywright` function (line 446) which needs the same length validation for consistency

<sub>Last reviewed commit: 7f52b4f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->