### PR TITLE
Security: warn when gateway auth mode is none

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -292,6 +292,13 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.exit(1);
     return;
   }
+  if (resolvedAuthMode === "none") {
+    const log = createSubsystemLogger("gateway");
+    log.warn(
+      "Gateway auth mode is 'none' — all connections are unauthenticated. " +
+        "Set gateway.auth.token or gateway.auth.password to secure the gateway.",
+    );
+  }
   if (bind !== "loopback" && !hasSharedSecret && resolvedAuthMode !== "trusted-proxy") {
     defaultRuntime.error(
       [


### PR DESCRIPTION
## Summary
- Log a warning at gateway startup when auth mode resolves to `"none"` (no authentication configured)
- Alerts operators who may have forgotten to set `gateway.auth.token` or `gateway.auth.password`
- Non-breaking: does not change behavior, only adds a visible warning

Note: the existing check at line 295 already blocks non-loopback binding without auth. This warning covers the loopback case where the gateway is technically reachable but unauthenticated.

## Test plan
- [ ] Start gateway without auth configured, verify warning appears in logs
- [ ] Start gateway with token/password configured, verify no warning
- [ ] Existing gateway tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a warning log when gateway auth mode resolves to `"none"` to alert operators about unauthenticated gateway access. The warning is non-breaking and only provides visibility into a potentially insecure configuration, particularly for loopback bindings where the existing check (line 302) doesn't block startup.

- Warns when `resolvedAuthMode === "none"` regardless of bind mode
- Complements existing security check at line 302 that blocks non-loopback bindings without auth
- Message provides clear guidance to set `gateway.auth.token` or `gateway.auth.password`

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- The change only adds a non-breaking warning log with no behavioral changes. The code is straightforward, correctly placed in the validation flow, and improves security awareness for operators. The only minor improvement is reusing the existing logger instance instead of creating a new one.
- No files require special attention

<sub>Last reviewed commit: 7caef16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->