### PR TITLE
fix(ollama): register API provider for completeSimple/compaction

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -34,6 +34,11 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
 import { getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
+import {
+  createOllamaStreamFn,
+  ensureOllamaApiRegistered,
+  OLLAMA_NATIVE_BASE_URL,
+} from "../ollama-stream.js";
 import { resolveOwnerDisplaySetting } from "../owner-display.js";
 import {
   ensureSessionHeader,
@@ -583,6 +588,19 @@ export async function compactEmbeddedPiSessionDirect(
         resourceLoader,
       });
       applySystemPromptOverrideToSession(session, systemPromptOverride());
+
+      // Ollama native API: register "ollama" in the SDK's API provider
+      // registry so that completeSimple() (used by session.compact()) can
+      // reach the native /api/chat endpoint (#20652, #11828).
+      if (model.api === "ollama") {
+        ensureOllamaApiRegistered();
+        const providerConfig = params.config?.models?.providers?.[model.provider];
+        const modelBaseUrl = typeof model.baseUrl === "string" ? model.baseUrl.trim() : "";
+        const providerBaseUrl =
+          typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
+        const ollamaBaseUrl = modelBaseUrl || providerBaseUrl || OLLAMA_NATIVE_BASE_URL;
+        session.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl);
+      }
 
       try {
         const prior = await sanitizeSessionHistory({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -42,7 +42,11 @@ import { isTimeoutError } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
-import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-stream.js";
+import {
+  createOllamaStreamFn,
+  ensureOllamaApiRegistered,
+  OLLAMA_NATIVE_BASE_URL,
+} from "../../ollama-stream.js";
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import {
   isCloudCodeAssistFormatError,
@@ -717,9 +721,10 @@ export async function runEmbeddedAttempt(
         workspaceDir: params.workspaceDir,
       });
 
-      // Ollama native API: bypass SDK's streamSimple and use direct /api/chat calls
-      // for reliable streaming + tool calling support (#11828).
+      // Ollama native API: register "ollama" in the SDK's API provider registry
+      // and bypass SDK's streamSimple with direct /api/chat calls (#11828, #20652).
       if (params.model.api === "ollama") {
+        ensureOllamaApiRegistered();
         // Use the resolved model baseUrl first so custom provider aliases work.
         const providerConfig = params.config?.models?.providers?.[params.model.provider];
         const modelBaseUrl =


### PR DESCRIPTION
## Summary

- Register `"ollama"` in the SDK's **global API provider registry** via `registerApiProvider()`, so that `completeSimple()` (used by `session.compact()`) can resolve the Ollama API type
- Adds `ensureOllamaApiRegistered()` to `ollama-stream.ts` — idempotent, called from both `compact.ts` and `attempt.ts`
- Fixes "No API provider registered for api: ollama" error during compaction with Ollama models

## Root Cause

The initial analysis (commit `5e4d7fb`) was incomplete. Overriding `session.agent.streamFn` only covers the SDK's **agent run loop**. However, `session.compact()` internally calls:

```
session.compact() → SDK compact() → completeSimple() → resolveApiProvider(model.api)
```

`completeSimple()` resolves providers through a **global API registry** (`apiProviderRegistry` Map), NOT through `streamFn`. Since `"ollama"` is not a built-in API type in `@mariozechner/pi-ai`, the registry lookup fails with the reported error.

## Fix

1. **`ollama-stream.ts`**: Added `ensureOllamaApiRegistered()` that calls `registerApiProvider()` to register `"ollama"` in the SDK's global API provider registry. Uses `model.baseUrl` at call time for flexibility. Idempotent — safe to call multiple times.

2. **`compact.ts`**: Call `ensureOllamaApiRegistered()` before `session.compact()` so `completeSimple()` can find the `"ollama"` provider.

3. **`attempt.ts`**: Call `ensureOllamaApiRegistered()` alongside the existing `streamFn` override, ensuring both the agent run loop AND any internal `completeSimple()` calls (e.g., branch summarization) work correctly.

## Changes

| File | Change |
|------|--------|
| `src/agents/ollama-stream.ts` | Add `ensureOllamaApiRegistered()` using `registerApiProvider()` |
| `src/agents/pi-embedded-runner/compact.ts` | Call `ensureOllamaApiRegistered()` in compaction path |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Call `ensureOllamaApiRegistered()` in run path |

## Test plan

- [x] Existing `ollama-stream.test.ts` passes (16 tests)
- [x] oxfmt formatting check passes
- [x] oxlint check passes (0 warnings, 0 errors)
- [x] Manual verification: Ollama model compaction works correctly after fix

Closes #20652