### PR TITLE
fix #20595: skip port check when attachOnly is enabled

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -167,7 +167,9 @@ export async function launchOpenClawChrome(
   if (!profile.cdpIsLoopback) {
     throw new Error(`Profile "${profile.name}" is remote; cannot launch local Chrome.`);
   }
-  await ensurePortAvailable(profile.cdpPort);
+  if (!resolved.attachOnly) {
+    await ensurePortAvailable(profile.cdpPort);
+  }
 
   const exe = resolveBrowserExecutable(resolved);
   if (!exe) {


### PR DESCRIPTION
test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Skipped port availability check when `attachOnly` is enabled in `launchOpenClawChrome` function. When `attachOnly: true`, the system should never launch a new browser instance and only attach to an existing one, so checking port availability is unnecessary and could cause false failures if another process is already using that port legitimately.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - adds defensive check to skip unnecessary port validation
- The change is minimal, well-scoped, and logically correct. When `attachOnly` is true, the system should never launch Chrome and thus shouldn't check port availability. The fix adds a safety guard that prevents spurious port conflicts when attaching to existing browser instances.
- No files require special attention

<sub>Last reviewed commit: f03692e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->