### PR TITLE
fix #20566: allow unknown fields in provider config

### DIFF
--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -49,6 +49,7 @@ export type ModelProviderConfig = {
   headers?: Record<string, string>;
   authHeader?: boolean;
   models: ModelDefinitionConfig[];
+  [key: string]: unknown;
 };
 
 export type BedrockDiscoveryConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -67,7 +67,7 @@ export const ModelProviderSchema = z
     authHeader: z.boolean().optional(),
     models: z.array(ModelDefinitionSchema),
   })
-  .strict();
+  .catchall(z.unknown());
 
 export const BedrockDiscoverySchema = z
   .object({


### PR DESCRIPTION
## Summary

When configuring a custom provider like claude-max with a proxy, OpenClaw was showing "[object Object]" connection error due to provider config serialization issues.

## Changes

- `src/config/zod-schema.core.ts`: Changed `.strict()` to `.catchall(z.unknown())` in `ModelProviderSchema` to preserve unknown fields during config parsing.

## Testing

- [x] Code compiles and passes format check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `ModelProviderSchema` from `.strict()` to `.catchall(z.unknown())` to allow custom provider configurations (like claude-max with proxy) to preserve unknown fields during parsing. Previously, `.strict()` would reject any fields not explicitly defined in the schema, causing serialization issues that manifested as "[object Object]" connection errors.

The change is minimal and follows existing patterns in the codebase where other schemas use `.catchall()` for similar flexibility (`src/config/zod-schema.ts:126`, `src/config/zod-schema.agents.ts:52`).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The change is simple, well-targeted, and follows existing patterns in the codebase. The only minor concern is that the TypeScript type definition doesn't fully reflect the schema change (missing index signature), but this won't cause runtime issues - just potential type-checking mismatches if code tries to access unknown fields
- No files require special attention - the change is straightforward and localized

<sub>Last reviewed commit: 370166c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->