### PR TITLE
fix(minimax): enable tool-use/result repair and drop malformed assistant turns

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -30,6 +30,7 @@ const MISTRAL_MODEL_HINTS = [
   "ministral",
   "mistralai",
 ];
+const MINIMAX_MODEL_HINTS = ["minimax"];
 const OPENAI_MODEL_APIS = new Set([
   "openai",
   "openai-completions",
@@ -73,6 +74,18 @@ function isMistralModel(params: { provider?: string | null; modelId?: string | n
   return MISTRAL_MODEL_HINTS.some((hint) => modelId.includes(hint));
 }
 
+function isMiniMaxModel(params: { provider?: string | null; modelId?: string | null }): boolean {
+  const provider = normalizeProviderId(params.provider ?? "");
+  if (provider === "minimax") {
+    return true;
+  }
+  const modelId = (params.modelId ?? "").toLowerCase();
+  if (!modelId) {
+    return false;
+  }
+  return MINIMAX_MODEL_HINTS.some((hint) => modelId.includes(hint));
+}
+
 export function resolveTranscriptPolicy(params: {
   modelApi?: string | null;
   provider?: string | null;
@@ -84,6 +97,7 @@ export function resolveTranscriptPolicy(params: {
   const isAnthropic = isAnthropicApi(params.modelApi, provider);
   const isOpenAi = isOpenAiProvider(provider) || (!provider && isOpenAiApi(params.modelApi));
   const isMistral = isMistralModel({ provider, modelId });
+  const isMiniMax = isMiniMaxModel({ provider, modelId });
   const isOpenRouterGemini =
     (provider === "openrouter" || provider === "opencode") &&
     modelId.toLowerCase().includes("gemini");
@@ -101,7 +115,7 @@ export function resolveTranscriptPolicy(params: {
     : sanitizeToolCallIds
       ? "strict"
       : undefined;
-  const repairToolUseResultPairing = isGoogle || isAnthropic;
+  const repairToolUseResultPairing = isGoogle || isAnthropic || isMiniMax;
   const sanitizeThoughtSignatures = isOpenRouterGemini
     ? { allowBase64Only: true, includeCamelCase: true }
     : undefined;
@@ -118,6 +132,6 @@ export function resolveTranscriptPolicy(params: {
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && isAnthropic,
-    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic || isMiniMax),
   };
 }


### PR DESCRIPTION
## Problem

MiniMax has the same strict `tool_call`/`tool_result` pairing requirement as Anthropic and Google, but `repairToolUseResultPairing` and `allowSyntheticToolResults` were never enabled for it in `resolveTranscriptPolicy`.

This caused sessions to fail with:

> **Jinja template rendering failed: Message has tool role, but there was no previous assistant message with a tool call!**

Two root causes compound the issue:

1. **Missing repair flag** — orphaned/displaced `toolResult` messages are never moved or synthetically filled, so MiniMax sees a tool-result turn with no preceding tool-call turn.

2. **MiniMax API bug** — MiniMax sometimes returns `finish_reason: "tool_calls"` (`stopReason=toolUse`) with no actual function-call blocks in the content. These text-only turns end up immediately before a real tool-calling assistant turn, creating consecutive assistant messages. MiniMax's Jinja2 template then misattributes the subsequent tool results to the wrong turn.

The comment in `session-transcript-repair.ts` already named MiniMax explicitly as a strict provider — the flag just wasn't set.

## Changes

**`src/agents/transcript-policy.ts`**
- Add `MINIMAX_MODEL_HINTS` constant and `isMiniMaxModel()` helper (mirrors existing `isMistralModel()` pattern)
- Enable `repairToolUseResultPairing` for MiniMax
- Enable `allowSyntheticToolResults` for MiniMax

**`src/agents/session-transcript-repair.ts`** (in `repairToolCallInputs`)
- Drop assistant messages with `content.length === 0` — these are always error artifacts from failed/interrupted API calls and create consecutive assistant turns that strict providers reject
- Drop assistant messages where `stopReason === "toolUse"` but no tool-call blocks are present — handles the MiniMax API bug where it signals tool intent but emits no function calls

## Testing

- [x] Verified locally against a corrupted MiniMax session that was producing the Jinja error — MiniMax replies successfully after the fix
- [x] Linter clean (`pnpm check`)
- [ ] Unit tests (the repair logic is covered by existing tests; no new test cases added — happy to add if maintainers prefer)

## AI-assisted

Built with Claude (Sonnet 4.6). I understand what the code does and verified it locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enables transcript repair for MiniMax provider to handle strict tool-call/tool-result pairing requirements. After MiniMax switched to `anthropic-messages` API (PR #15297), it inherited Anthropic's strict turn ordering constraints but repair mechanisms were never enabled.

The fix adds:
- MiniMax detection helper in `transcript-policy.ts` (mirrors existing `isMistralModel()` pattern)
- Enables `repairToolUseResultPairing` and `allowSyntheticToolResults` for MiniMax
- Drops malformed assistant messages (empty content arrays or `stopReason=toolUse` with no actual tool calls) to prevent consecutive assistant turns that trigger Jinja validation errors

Changes follow established patterns for Anthropic/Google providers and address documented MiniMax API bugs where `finish_reason: "tool_calls"` is returned without function-call content.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - addresses a documented bug with defensive repair logic
- The implementation follows established patterns for Anthropic/Google strict providers and addresses a real failure mode (Jinja template errors). The defensive repair logic is sound but lacks test coverage for MiniMax-specific scenarios. The changes are scoped and well-documented, though comprehensive unit tests would strengthen confidence.
- No files require special attention - both changes are straightforward and follow existing patterns

<sub>Last reviewed commit: 3b58ee6</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->