### PR TITLE
fix(memory): handle ENOENT gracefully in readFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 - CLI/Config: add canonical `--strict-json` parsing for `config set` and keep `--json` as a legacy alias to reduce help/behavior drift. (#21332) thanks @adhitShet.
 - CLI: keep `openclaw -v` as a root-only version alias so subcommand `-v, --verbose` flags (for example ACP/hooks/skills) are no longer intercepted globally. (#21303) thanks @adhitShet.
 - Config/Memory: restore schema help/label metadata for hybrid `mmr` and `temporalDecay` settings so configuration surfaces show correct names and guidance. (#18786) Thanks @rodrigouroz.
+- Memory: return empty snippets when `memory_get`/QMD read files that have not been created yet, and harden memory indexing/session helpers against ENOENT races so missing Markdown no longer crashes tools. (#20680) Thanks @pahdo.
 - Tools/web_search: handle xAI Responses API payloads that emit top-level `output_text` blocks (without a `message` wrapper) so Grok web_search no longer returns `No response` for those results. (#20508) Thanks @echoVic.
 - Telegram/Streaming: always clean up draft previews even when dispatch throws before fallback handling, preventing orphaned preview messages during failed runs. (#19041) thanks @mudrii.
 - Telegram/Streaming: split reasoning and answer draft preview lanes to prevent cross-lane overwrites, and ignore literal `<think>` tags inside inline/fenced code snippets so sample markup is not misrouted as reasoning. (#20774) Thanks @obviyus.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -28,6 +28,19 @@ The default workspace layout uses two memory layers:
 These files live under the workspace (`agents.defaults.workspace`, default
 `~/.openclaw/workspace`). See [Agent workspace](/concepts/agent-workspace) for the full layout.
 
+## Memory tools
+
+OpenClaw exposes two agent-facing tools for these Markdown files:
+
+- `memory_search` — semantic recall over indexed snippets.
+- `memory_get` — targeted read of a specific Markdown file/line range.
+
+`memory_get` now **degrades gracefully when a file doesn't exist** (for example,
+today's daily log before the first write). Both the builtin manager and the QMD
+backend return `{ text: "", path }` instead of throwing `ENOENT`, so agents can
+handle "nothing recorded yet" and continue their workflow without wrapping the
+tool call in try/catch logic.
+
 ## When to write memory
 
 - Decisions, preferences, and durable facts go to `MEMORY.md`.

--- a/src/agents/tools/memory-tool.e2e.test.ts
+++ b/src/agents/tools/memory-tool.e2e.test.ts
@@ -12,11 +12,16 @@ let searchImpl: () => Promise<unknown[]> = async () => [
     source: "memory" as const,
   },
 ];
-let readFileImpl: () => Promise<unknown> = async () => "";
+type MemoryReadParams = { relPath: string; from?: number; lines?: number };
+type MemoryReadResult = { text: string; path: string };
+let readFileImpl: (params: MemoryReadParams) => Promise<MemoryReadResult> = async (params) => ({
+  text: "",
+  path: params.relPath,
+});
 
 const stubManager = {
   search: vi.fn(async () => await searchImpl()),
-  readFile: vi.fn(async () => await readFileImpl()),
+  readFile: vi.fn(async (params: MemoryReadParams) => await readFileImpl(params)),
   status: () => ({
     backend,
     files: 1,
@@ -59,7 +64,7 @@ beforeEach(() => {
       source: "memory" as const,
     },
   ];
-  readFileImpl = async () => ""; // default: return empty string
+  readFileImpl = async (params: MemoryReadParams) => ({ text: "", path: params.relPath });
   vi.clearAllMocks();
 });
 
@@ -170,7 +175,7 @@ describe("memory tools", () => {
   });
 
   it("does not throw when memory_get fails", async () => {
-    readFileImpl = async () => {
+    readFileImpl = async (_params: MemoryReadParams) => {
       throw new Error("path required");
     };
 
@@ -191,7 +196,7 @@ describe("memory tools", () => {
   });
 
   it("returns empty text without error when file does not exist (ENOENT)", async () => {
-    readFileImpl = async () => {
+    readFileImpl = async (_params: MemoryReadParams) => {
       return { text: "", path: "memory/2026-02-19.md" };
     };
 

--- a/src/agents/tools/memory-tool.e2e.test.ts
+++ b/src/agents/tools/memory-tool.e2e.test.ts
@@ -12,7 +12,7 @@ let searchImpl: () => Promise<unknown[]> = async () => [
     source: "memory" as const,
   },
 ];
-let readFileImpl: () => Promise<string> = async () => "";
+let readFileImpl: () => Promise<unknown> = async () => "";
 
 const stubManager = {
   search: vi.fn(async () => await searchImpl()),
@@ -59,7 +59,7 @@ beforeEach(() => {
       source: "memory" as const,
     },
   ];
-  readFileImpl = async () => "";
+  readFileImpl = async () => ""; // default: return empty string
   vi.clearAllMocks();
 });
 
@@ -187,6 +187,25 @@ describe("memory tools", () => {
       text: "",
       disabled: true,
       error: "path required",
+    });
+  });
+
+  it("returns empty text without error when file does not exist (ENOENT)", async () => {
+    readFileImpl = async () => {
+      return { text: "", path: "memory/2026-02-19.md" };
+    };
+
+    const cfg = { agents: { list: [{ id: "main", default: true }] } };
+    const tool = createMemoryGetTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    const result = await tool.execute("call_enoent", { path: "memory/2026-02-19.md" });
+    expect(result.details).toEqual({
+      text: "",
+      path: "memory/2026-02-19.md",
     });
   });
 });

--- a/src/memory/fs-utils.ts
+++ b/src/memory/fs-utils.ts
@@ -1,0 +1,31 @@
+import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
+
+export type RegularFileStatResult = { missing: true } | { missing: false; stat: Stats };
+
+export function isFileMissingError(
+  err: unknown,
+): err is NodeJS.ErrnoException & { code: "ENOENT" } {
+  return Boolean(
+    err &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as Partial<NodeJS.ErrnoException>).code === "ENOENT",
+  );
+}
+
+export async function statRegularFile(absPath: string): Promise<RegularFileStatResult> {
+  let stat: Stats;
+  try {
+    stat = await fs.lstat(absPath);
+  } catch (err) {
+    if (isFileMissingError(err)) {
+      return { missing: true };
+    }
+    throw err;
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error("path required");
+  }
+  return { missing: false, stat };
+}

--- a/src/memory/manager.read-file.test.ts
+++ b/src/memory/manager.read-file.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { MemoryIndexManager } from "./index.js";
+import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
+import { getRequiredMemoryIndexManager } from "./test-manager-helpers.js";
+
+function createMemorySearchCfg(options: {
+  workspaceDir: string;
+  indexPath: string;
+}): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        workspace: options.workspaceDir,
+        memorySearch: {
+          provider: "openai",
+          model: "mock-embed",
+          store: { path: options.indexPath, vector: { enabled: false } },
+          cache: { enabled: false },
+          query: { minScore: 0, hybrid: { enabled: false } },
+          sync: { watch: false, onSessionStart: false, onSearch: false },
+        },
+      },
+      list: [{ id: "main", default: true }],
+    },
+  } as OpenClawConfig;
+}
+
+describe("MemoryIndexManager.readFile", () => {
+  let workspaceDir: string;
+  let indexPath: string;
+  let manager: MemoryIndexManager | null = null;
+
+  beforeEach(async () => {
+    resetEmbeddingMocks();
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-read-"));
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("returns empty text when the requested file does not exist", async () => {
+    manager = await getRequiredMemoryIndexManager({
+      cfg: createMemorySearchCfg({ workspaceDir, indexPath }),
+      agentId: "main",
+    });
+
+    const relPath = "memory/2099-01-01.md";
+    const result = await manager.readFile({ relPath });
+    expect(result).toEqual({ text: "", path: relPath });
+  });
+
+  it("returns content slices when the file exists", async () => {
+    const relPath = "memory/2026-02-20.md";
+    const absPath = path.join(workspaceDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, ["line 1", "line 2", "line 3"].join("\n"), "utf-8");
+
+    manager = await getRequiredMemoryIndexManager({
+      cfg: createMemorySearchCfg({ workspaceDir, indexPath }),
+      agentId: "main",
+    });
+
+    const result = await manager.readFile({ relPath, from: 2, lines: 1 });
+    expect(result).toEqual({ text: "line 2", path: relPath });
+  });
+});

--- a/src/memory/manager.read-file.test.ts
+++ b/src/memory/manager.read-file.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
 import type { MemoryIndexManager } from "./index.js";
@@ -73,5 +73,52 @@ describe("MemoryIndexManager.readFile", () => {
 
     const result = await manager.readFile({ relPath, from: 2, lines: 1 });
     expect(result).toEqual({ text: "line 2", path: relPath });
+  });
+
+  it("returns empty text when the requested slice is past EOF", async () => {
+    const relPath = "memory/window.md";
+    const absPath = path.join(workspaceDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, ["alpha", "beta"].join("\n"), "utf-8");
+
+    manager = await getRequiredMemoryIndexManager({
+      cfg: createMemorySearchCfg({ workspaceDir, indexPath }),
+      agentId: "main",
+    });
+
+    const result = await manager.readFile({ relPath, from: 10, lines: 5 });
+    expect(result).toEqual({ text: "", path: relPath });
+  });
+
+  it("returns empty text when the file disappears after stat", async () => {
+    const relPath = "memory/transient.md";
+    const absPath = path.join(workspaceDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, "first\nsecond", "utf-8");
+
+    manager = await getRequiredMemoryIndexManager({
+      cfg: createMemorySearchCfg({ workspaceDir, indexPath }),
+      agentId: "main",
+    });
+
+    const realReadFile = fs.readFile;
+    let injected = false;
+    const readSpy = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(async (...args: Parameters<typeof realReadFile>) => {
+        const [target, options] = args;
+        if (!injected && typeof target === "string" && path.resolve(target) === absPath) {
+          injected = true;
+          const err = new Error("missing") as NodeJS.ErrnoException;
+          err.code = "ENOENT";
+          throw err;
+        }
+        return realReadFile(target, options);
+      });
+
+    const result = await manager.readFile({ relPath });
+    expect(result).toEqual({ text: "", path: relPath });
+
+    readSpy.mockRestore();
   });
 });

--- a/src/memory/manager.read-file.test.ts
+++ b/src/memory/manager.read-file.test.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import type { MemoryIndexManager } from "./index.js";
 import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
+import type { MemoryIndexManager } from "./index.js";
 import { getRequiredMemoryIndexManager } from "./test-manager-helpers.js";
 
 function createMemorySearchCfg(options: {

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -1,20 +1,12 @@
 import type { Stats } from "node:fs";
-import type { DatabaseSync } from "node:sqlite";
-import { type FSWatcher } from "chokidar";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { ResolvedMemorySearchConfig } from "../agents/memory-search.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type {
-  MemoryEmbeddingProbeResult,
-  MemoryProviderStatus,
-  MemorySearchManager,
-  MemorySearchResult,
-  MemorySource,
-  MemorySyncProgressUpdate,
-} from "./types.js";
+import type { DatabaseSync } from "node:sqlite";
+import { type FSWatcher } from "chokidar";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import type { ResolvedMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   createEmbeddingProvider,
@@ -29,6 +21,14 @@ import { isMemoryPath, normalizeExtraMemoryPaths } from "./internal.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
 import { searchKeyword, searchVector } from "./manager-search.js";
 import { extractKeywords } from "./query-expansion.js";
+import type {
+  MemoryEmbeddingProbeResult,
+  MemoryProviderStatus,
+  MemorySearchManager,
+  MemorySearchResult,
+  MemorySource,
+  MemorySyncProgressUpdate,
+} from "./types.js";
 const SNIPPET_MAX_CHARS = 700;
 const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -437,7 +437,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (!absPath.endsWith(".md")) {
       throw new Error("path required");
     }
-    const stat = await fs.lstat(absPath);
+    let stat;
+    try {
+      stat = await fs.lstat(absPath);
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        return { text: "", path: relPath };
+      }
+      throw err;
+    }
     if (stat.isSymbolicLink() || !stat.isFile()) {
       throw new Error("path required");
     }

--- a/src/memory/manager.vector-dedupe.test.ts
+++ b/src/memory/manager.vector-dedupe.test.ts
@@ -81,6 +81,9 @@ describe("memory vector dedupe", () => {
     ).ensureVectorReady = async () => true;
 
     const entry = await buildFileEntry(path.join(workspaceDir, "MEMORY.md"), workspaceDir);
+    if (!entry) {
+      throw new Error("entry missing");
+    }
     await (
       manager as unknown as {
         indexFile: (entry: unknown, options: { source: "memory" }) => Promise<void>;

--- a/src/memory/sync-memory-files.ts
+++ b/src/memory/sync-memory-files.ts
@@ -25,9 +25,9 @@ export async function syncMemoryFiles(params: {
   model: string;
 }) {
   const files = await listMemoryFiles(params.workspaceDir, params.extraPaths);
-  const fileEntries = await Promise.all(
-    files.map(async (file) => buildFileEntry(file, params.workspaceDir)),
-  );
+  const fileEntries = (
+    await Promise.all(files.map(async (file) => buildFileEntry(file, params.workspaceDir)))
+  ).filter((entry): entry is MemoryFileEntry => entry !== null);
 
   log.debug("memory sync: indexing memory files", {
     files: fileEntries.length,


### PR DESCRIPTION
## Summary
- `MemoryIndexManager.readFile` now catches `ENOENT` and returns `{ text: "", path }` instead of throwing, so the memory read tool degrades gracefully when a file doesn't exist yet (e.g. a daily log that hasn't been created).
- Adds an e2e test covering the ENOENT → empty-text path.

Closes #9307

## Test plan
- [ ] Existing `memory-tool.e2e.test.ts` suite passes
- [ ] New "returns empty text without error when file does not exist (ENOENT)" test passes
- [ ] Manual: delete a daily memory log, invoke the read tool — should return empty text, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `MemoryIndexManager.readFile` to catch `ENOENT` errors and return `{ text: "", path }` instead of throwing, allowing the memory read tool to degrade gracefully when files don't exist yet (e.g., daily logs that haven't been created)

- Added try-catch block around `fs.lstat` call in `manager.ts:440-452`
- Returns empty text with path when file is not found, instead of throwing error
- Added e2e test case to verify ENOENT handling returns empty text without error
- Existing error handling for other file system errors (permissions, invalid paths) remains unchanged

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused error handling improvement with proper test coverage. It follows established ENOENT handling patterns in the codebase, degrades gracefully by returning empty text rather than throwing, and includes an e2e test that validates the new behavior. The modification is minimal and well-contained.
- No files require special attention

<sub>Last reviewed commit: d15ea24</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->