### PR TITLE
fix(cron): propagate auth-profile resolution to isolated sessions (#20624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenRouter: preserve stored session provider when model IDs are vendor-prefixed (for example, `anthropic/...`) so follow-up turns do not incorrectly route to direct provider APIs. (#22753) Thanks @dndodson.
 - Providers/OpenRouter: preserve the required `openrouter/` prefix for OpenRouter-native model IDs during model-ref normalization. (#12942) Thanks @omair445.
 - Providers/OpenRouter: pass through provider routing parameters from model params.provider to OpenRouter request payloads for provider selection controls. (#17148) Thanks @carrotRakko.
+- Cron/Auth: propagate auth-profile resolution to isolated cron sessions so provider API keys are resolved the same way as main sessions, fixing 401 errors when using providers configured via auth-profiles. (#20689) Thanks @lailoo.
 - Telegram/Webhook: keep webhook monitors alive until gateway abort signals fire, preventing false channel exits and immediate webhook auto-restart loops.
 - Telegram/Polling: retry recoverable setup-time network failures in monitor startup and await runner teardown before retry to avoid overlapping polling sessions.
 - Telegram/Polling: clear Telegram webhooks (`deleteWebhook`) before starting long-poll `getUpdates`, including retry handling for transient cleanup failures.

--- a/src/cron/isolated-agent.auth-profile-propagation.test.ts
+++ b/src/cron/isolated-agent.auth-profile-propagation.test.ts
@@ -1,0 +1,117 @@
+import "./isolated-agent.mocks.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+import { makeCfg, makeJob, withTempCronHome } from "./isolated-agent.test-harness.js";
+import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
+
+describe("runCronIsolatedAgentTurn auth profile propagation (#20624)", () => {
+  beforeEach(() => {
+    setupIsolatedAgentTurnMocks({ fast: true });
+  });
+
+  it("passes authProfileId to runEmbeddedPiAgent when auth profiles exist", async () => {
+    await withTempCronHome(async (home) => {
+      // 1. Write session store
+      const sessionsDir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const storePath = path.join(sessionsDir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            "agent:main:main": {
+              sessionId: "main-session",
+              updatedAt: Date.now(),
+              lastProvider: "webchat",
+              lastTo: "",
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      // 2. Write auth-profiles.json in the agent directory
+      //    resolveAgentDir returns <stateDir>/agents/main/agent
+      //    stateDir = <home>/.openclaw
+      const agentDir = path.join(home, ".openclaw", "agents", "main", "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "openrouter:default": {
+              type: "api_key",
+              provider: "openrouter",
+              key: "sk-or-test-key-12345",
+            },
+          },
+          order: {
+            openrouter: ["openrouter:default"],
+          },
+        }),
+        "utf-8",
+      );
+
+      // 3. Mock runEmbeddedPiAgent to return ok
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "openrouter", model: "kimi-k2.5" },
+        },
+      });
+
+      // 4. Run cron isolated agent turn with openrouter model
+      const cfg = makeCfg(home, storePath, {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter/moonshotai/kimi-k2.5" },
+            workspace: path.join(home, "openclaw"),
+          },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg,
+        deps: {
+          sendMessageSlack: vi.fn(),
+          sendMessageWhatsApp: vi.fn(),
+          sendMessageTelegram: vi.fn(),
+          sendMessageDiscord: vi.fn(),
+          sendMessageSignal: vi.fn(),
+          sendMessageIMessage: vi.fn(),
+        },
+        job: makeJob({ kind: "agentTurn", message: "check status", deliver: false }),
+        message: "check status",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledTimes(1);
+
+      // 5. Check that authProfileId was passed
+      const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0] as {
+        authProfileId?: string;
+        authProfileIdSource?: string;
+      };
+
+      console.log(`authProfileId passed to runEmbeddedPiAgent: ${callArgs?.authProfileId}`);
+      console.log(`authProfileIdSource passed: ${callArgs?.authProfileIdSource}`);
+
+      if (!callArgs?.authProfileId) {
+        console.log("❌ BUG CONFIRMED: isolated cron session does NOT pass authProfileId");
+        console.log("   This causes 401 errors when using providers that require auth profiles");
+      }
+
+      // This assertion will FAIL on main — proving the bug
+      expect(callArgs?.authProfileId).toBe("openrouter:default");
+    });
+  });
+});

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -32,14 +32,20 @@ vi.mock("../../agents/model-catalog.js", () => ({
   loadModelCatalog: vi.fn().mockResolvedValue({ models: [] }),
 }));
 
-vi.mock("../../agents/model-selection.js", () => ({
-  getModelRefStatus: vi.fn().mockReturnValue({ allowed: false }),
-  isCliProvider: vi.fn().mockReturnValue(false),
-  resolveAllowedModelRef: vi.fn().mockReturnValue({ ref: { provider: "openai", model: "gpt-4" } }),
-  resolveConfiguredModelRef: vi.fn().mockReturnValue({ provider: "openai", model: "gpt-4" }),
-  resolveHooksGmailModel: vi.fn().mockReturnValue(null),
-  resolveThinkingDefault: vi.fn().mockReturnValue(undefined),
-}));
+vi.mock("../../agents/model-selection.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/model-selection.js")>();
+  return {
+    ...actual,
+    getModelRefStatus: vi.fn().mockReturnValue({ allowed: false }),
+    isCliProvider: vi.fn().mockReturnValue(false),
+    resolveAllowedModelRef: vi
+      .fn()
+      .mockReturnValue({ ref: { provider: "openai", model: "gpt-4" } }),
+    resolveConfiguredModelRef: vi.fn().mockReturnValue({ provider: "openai", model: "gpt-4" }),
+    resolveHooksGmailModel: vi.fn().mockReturnValue(null),
+    resolveThinkingDefault: vi.fn().mockReturnValue(undefined),
+  };
+});
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary

- **Bug**: Isolated cron sessions fail with HTTP 401 when using providers configured via auth-profiles (e.g. OpenRouter)
- **Root cause**: `runCronIsolatedAgentTurn` in `src/cron/isolated-agent/run.ts` calls `runEmbeddedPiAgent` without passing `authProfileId`/`authProfileIdSource`, so the agent falls back to env-var auth resolution instead of using configured auth-profiles
- **Fix**: Call `resolveSessionAuthProfileOverride()` before the run and pass the resolved profile to `runEmbeddedPiAgent`, mirroring the main session path in `get-reply-run.ts`

Fixes #20624

## Problem

When an isolated cron session (`sessionTarget: "isolated"`, `payload.kind: "agentTurn"`) runs, it calls `runEmbeddedPiAgent` without `authProfileId` or `authProfileIdSource`. The main session path in `get-reply-run.ts:375-419` calls `resolveSessionAuthProfileOverride()` and passes both parameters, but the isolated cron path at `run.ts:475-495` omits them entirely.

This causes the agent to fall back to environment variable auth resolution, which may not match the configured auth-profiles. For providers like OpenRouter where the API key is stored in auth-profiles rather than env vars, this results in `HTTP 401: User not found`.

**Before fix:**
```
authProfileId passed to runEmbeddedPiAgent: undefined
❌ BUG CONFIRMED: isolated cron session does NOT pass authProfileId
```

## Changes

- `src/cron/isolated-agent/run.ts` — Import `resolveSessionAuthProfileOverride`, call it before the model fallback run, and pass `authProfileId`/`authProfileIdSource` to `runEmbeddedPiAgent`
- `src/cron/isolated-agent/run.skill-filter.test.ts` — Update `model-selection.js` mock to use `importOriginal` so `normalizeProviderId` and `findNormalizedProviderValue` (used by the new auth profile resolution path) are available
- `src/cron/isolated-agent.auth-profile-propagation.test.ts` — New regression test that sets up auth-profiles on disk and verifies `authProfileId` is passed to `runEmbeddedPiAgent`

**After fix:**
```
authProfileId passed to runEmbeddedPiAgent: openrouter:default
authProfileIdSource passed: auto
✅ PASS
```

## Test plan

- [x] New test: auth profile propagation to isolated cron sessions
- [x] All 174 existing cron tests pass
- [x] All 25 auth-profiles tests pass
- [x] Lint passes
- [x] Format passes

## Effect on User Experience

**Before:** Isolated cron sessions using providers configured via auth-profiles (e.g. OpenRouter) fail with `HTTP 401: User not found`, while main sessions using the same API key work fine.
**After:** Isolated cron sessions resolve auth-profiles the same way as main sessions, so provider API keys are correctly propagated.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where isolated cron sessions failed with HTTP 401 errors when using providers configured via auth-profiles (e.g., OpenRouter). The root cause was that `runCronIsolatedAgentTurn` did not pass `authProfileId` and `authProfileIdSource` to `runEmbeddedPiAgent`, causing the agent to fall back to environment variable auth resolution instead of using the configured auth-profiles.

The fix correctly mirrors the pattern from `get-reply-run.ts:375-385` by calling `resolveSessionAuthProfileOverride()` before the model fallback run and passing both auth parameters to `runEmbeddedPiAgent`. This ensures isolated cron sessions resolve auth-profiles consistently with main sessions.

Key changes:
- Added auth profile resolution in `src/cron/isolated-agent/run.ts:435-448` before the agent run
- Updated test mock to use `importOriginal` so `normalizeProviderId` and `findNormalizedProviderValue` are available (required by auth profile resolution)
- Added comprehensive regression test that verifies `authProfileId` is correctly propagated
- Updated changelog with clear user-facing description

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward and correctly mirrors the established pattern from the main session path. The implementation adds auth profile resolution by calling the same `resolveSessionAuthProfileOverride()` function used in the reference implementation, with identical parameters. The change is well-tested with a new regression test that verifies the fix, and the existing test mock was properly updated to support the new code path. All tests pass (174 cron tests, 25 auth-profile tests), and the fix is minimal and focused on the specific issue.
- No files require special attention

<sub>Last reviewed commit: 7ab3a87</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->