### PR TITLE
feat(discord): auto-resolve user mentions in message content

### DIFF
--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -156,6 +156,29 @@ describe("resolveDiscordMessageText", () => {
     expect(text).toContain("[Forwarded message from @Bob]");
     expect(text).toContain("forwarded hello");
   });
+
+  it("resolves user mentions in content", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "Hello <@123> and <@456>!",
+        mentions: [
+          { id: "123", username: "alice", global_name: "Alice Wonderland", discriminator: "0" },
+          { id: "456", username: "bob", discriminator: "0" },
+        ],
+      }),
+    );
+    expect(text).toBe("Hello @Alice Wonderland and @bob!");
+  });
+
+  it("leaves content unchanged if no mentions present", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "Hello world",
+        mentions: [],
+      }),
+    );
+    expect(text).toBe("Hello world");
+  });
 });
 
 describe("resolveDiscordChannelInfo", () => {


### PR DESCRIPTION
## Summary
Resolves Discord user mentions (e.g., `<@123>`) in incoming message content to human-readable names (e.g., `@Alice`) using the message's `mentions` metadata.

Fixes #20617.

## Implementation
- Added `resolveDiscordMentions` helper in `message-utils.ts`
- Maps ID to `global_name` (priority) or `username`
- Handles both `<@id>` and `<@!id>` formats
- Added unit tests covering resolution and no-op cases

## Impact
- Agents now see `@Alice hello` instead of `<@12345> hello`
- Improves context understanding for multi-user conversations

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds user mention resolution to Discord message content, converting `<@id>` format to readable names like `@Alice`. The implementation correctly prioritizes `global_name` over `username` and handles both `<@id>` and `<@!id>` formats. The change is scoped to the message text resolution flow and includes appropriate test coverage for basic cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, focused, and follows existing patterns in the codebase. The change is scoped to message text resolution with appropriate guards. Test coverage validates the core functionality. No breaking changes or security concerns identified.
- No files require special attention

<sub>Last reviewed commit: 0cb7e10</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->