### PR TITLE
fix: Device Token Scope Escalation via Rotate Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Pairing: prevent device-token rotate scope escalation by enforcing an approved-scope baseline, preserving approved scopes across metadata updates, and rejecting rotate requests that exceed approved role scope implications. (#20703) thanks @coygeek.
 - Gateway/Security: require secure context and paired-device checks for Control UI auth even when `gateway.controlUi.allowInsecureAuth` is set, and align audit messaging with the hardened behavior. (#20684) thanks @coygeek.
 - macOS/Build: default release packaging to `BUNDLE_ID=ai.openclaw.mac` in `scripts/package-mac-dist.sh`, so Sparkle feed URL is retained and auto-update no longer fails with an empty appcast feed. (#19750) thanks @loganprit.
 

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -24,7 +24,7 @@ import type { GatewayRequestHandlers } from "./types.js";
 function redactPairedDevice(
   device: { tokens?: Record<string, DeviceAuthToken> } & Record<string, unknown>,
 ) {
-  const { tokens, ...rest } = device;
+  const { tokens, approvedScopes: _approvedScopes, ...rest } = device;
   return {
     ...rest,
     tokens: summarizeDeviceTokens(tokens),

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -177,6 +177,17 @@ function mergePendingDevicePairingRequest(
   };
 }
 
+function scopesAllow(requested: string[], allowed: string[]): boolean {
+  if (requested.length === 0) {
+    return true;
+  }
+  if (allowed.length === 0) {
+    return false;
+  }
+  const allowedSet = new Set(allowed);
+  return requested.every((scope) => allowedSet.has(scope));
+}
+
 const DEVICE_SCOPE_IMPLICATIONS: Readonly<Record<string, readonly string[]>> = {
   "operator.admin": ["operator.read", "operator.write", "operator.approvals", "operator.pairing"],
   "operator.write": ["operator.read"],

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -56,6 +56,7 @@ export type PairedDevice = {
   role?: string;
   roles?: string[];
   scopes?: string[];
+  approvedScopes?: string[];
   remoteIp?: string;
   tokens?: Record<string, DeviceAuthToken>;
   createdAtMs: number;
@@ -176,6 +177,33 @@ function mergePendingDevicePairingRequest(
   };
 }
 
+const DEVICE_SCOPE_IMPLICATIONS: Readonly<Record<string, readonly string[]>> = {
+  "operator.admin": ["operator.read", "operator.write", "operator.approvals", "operator.pairing"],
+  "operator.write": ["operator.read"],
+};
+
+function expandScopeImplications(scopes: string[]): string[] {
+  const expanded = new Set(scopes);
+  const queue = [...scopes];
+  while (queue.length > 0) {
+    const scope = queue.pop();
+    if (!scope) {
+      continue;
+    }
+    for (const impliedScope of DEVICE_SCOPE_IMPLICATIONS[scope] ?? []) {
+      if (!expanded.has(impliedScope)) {
+        expanded.add(impliedScope);
+        queue.push(impliedScope);
+      }
+    }
+  }
+  return [...expanded];
+}
+
+function scopesAllowWithImplications(requested: string[], allowed: string[]): boolean {
+  return scopesAllow(expandScopeImplications(requested), expandScopeImplications(allowed));
+}
+
 function newToken() {
   return generatePairingToken();
 }
@@ -286,7 +314,10 @@ export async function approveDevicePairing(
     const now = Date.now();
     const existing = state.pairedByDeviceId[pending.deviceId];
     const roles = mergeRoles(existing?.roles, existing?.role, pending.roles, pending.role);
-    const scopes = mergeScopes(existing?.scopes, pending.scopes);
+    const approvedScopes = mergeScopes(
+      existing?.approvedScopes ?? existing?.scopes,
+      pending.scopes,
+    );
     const tokens = existing?.tokens ? { ...existing.tokens } : {};
     const roleForToken = normalizeRole(pending.role);
     if (roleForToken) {
@@ -312,7 +343,8 @@ export async function approveDevicePairing(
       clientMode: pending.clientMode,
       role: pending.role,
       roles,
-      scopes,
+      scopes: approvedScopes,
+      approvedScopes,
       remoteIp: pending.remoteIp,
       tokens,
       createdAtMs: existing?.createdAtMs ?? now,
@@ -359,7 +391,9 @@ export async function removePairedDevice(
 
 export async function updatePairedDeviceMetadata(
   deviceId: string,
-  patch: Partial<Omit<PairedDevice, "deviceId" | "createdAtMs" | "approvedAtMs">>,
+  patch: Partial<
+    Omit<PairedDevice, "deviceId" | "createdAtMs" | "approvedAtMs" | "approvedScopes">
+  >,
   baseDir?: string,
 ): Promise<void> {
   return await withLock(async () => {
@@ -376,6 +410,7 @@ export async function updatePairedDeviceMetadata(
       deviceId: existing.deviceId,
       createdAtMs: existing.createdAtMs,
       approvedAtMs: existing.approvedAtMs,
+      approvedScopes: existing.approvedScopes,
       role: patch.role ?? existing.role,
       roles,
       scopes,
@@ -525,6 +560,12 @@ export async function rotateDeviceToken(params: {
     const requestedScopes = normalizeDeviceAuthScopes(
       params.scopes ?? existing?.scopes ?? device.scopes,
     );
+    const approvedScopes = normalizeDeviceAuthScopes(
+      device.approvedScopes ?? device.scopes ?? existing?.scopes,
+    );
+    if (!scopesAllowWithImplications(requestedScopes, approvedScopes)) {
+      return null;
+    }
     const now = Date.now();
     const next = buildDeviceAuthToken({
       role,
@@ -535,9 +576,6 @@ export async function rotateDeviceToken(params: {
     });
     tokens[role] = next;
     device.tokens = tokens;
-    if (params.scopes !== undefined) {
-      device.scopes = requestedScopes;
-    }
     state.pairedByDeviceId[device.deviceId] = device;
     await persistState(state, params.baseDir);
     return next;


### PR DESCRIPTION
## Fix Summary
The `device.token.rotate` endpoint allows an authenticated device to escalate its own scopes beyond what was originally approved during pairing, enabling privilege escalation from a limited device role to full admin access.

## Issue Linkage
Fixes #20702

## Security Snapshot
- CVSS v3.1: 8.1 (High)
- CVSS v4.0: 8.6 (High)

## Implementation Details
### Files Changed
- `src/gateway/server-methods/devices.ts` (+1/-1)
- `src/infra/device-pairing.test.ts` (+23/-2)
- `src/infra/device-pairing.ts` (+43/-6)

### Technical Analysis
The vulnerability is reachable through a production code path where untrusted input can influence security-sensitive behavior without sufficient invariant enforcement. Current evidence indicates impact consistent with the summary: The `device.token.rotate` endpoint allows an authenticated device to escalate its own scopes beyond what was originally approved during pairing, enabling privilege escalation from a limited device role to full admin access.

## Validation Evidence
- Command: `pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: GPT-5.3-Codex

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Addresses device token scope escalation by introducing an `approvedScopes` field that preserves the originally approved scopes during device pairing and prevents unauthorized privilege escalation during token rotation.

Key changes:
- Added `approvedScopes` field to track scopes approved at pairing time in `src/infra/device-pairing.ts:58`
- Modified `rotateDeviceToken` to validate requested scopes against `approvedScopes` using scope implication logic in `src/infra/device-pairing.ts:542-547`
- Added `expandScopeImplications` and `scopesAllowWithImplications` helpers to handle hierarchical scope relationships (e.g., `operator.admin` implies `operator.read`) in `src/infra/device-pairing.ts:170-190`
- Removed automatic `device.scopes` mutation during rotation that previously allowed escalation in `src/infra/device-pairing.ts:555-558` (removed lines)
- Protected `approvedScopes` from modification via `updatePairedDeviceMetadata` in `src/infra/device-pairing.ts:374` and `src/infra/device-pairing.ts:392`
- Redacted `approvedScopes` from API responses to prevent information disclosure in `src/gateway/server-methods/devices.ts:27`
- Added comprehensive test coverage for both down-scoping (allowed) and escalation (blocked) scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence - it properly fixes a critical security vulnerability without introducing new issues
- The fix correctly implements defense-in-depth by: (1) introducing an immutable `approvedScopes` baseline that cannot be modified after approval, (2) validating all rotation requests against this baseline with proper scope implication handling, (3) returning null instead of throwing on unauthorized escalation attempts to prevent state mutation, (4) protecting the security-sensitive field from external modification, and (5) comprehensive test coverage that validates both the vulnerability fix and legitimate down-scoping scenarios. The implementation follows security best practices by making the validation logic explicit, adding redaction to prevent information disclosure, and ensuring state remains unchanged when attacks are blocked.
- No files require special attention

<sub>Last reviewed commit: 93e73eb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->