### PR TITLE
feat(auto-reply): add model fallback lifecycle visibility in status, verbose logs, and WebUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - iOS/Gateway: stabilize background wake and reconnect behavior with background reconnect suppression/lease windows, BGAppRefresh wake fallback, location wake hook throttling, and APNs wake retry+nudge instrumentation. (#21226) thanks @mbelinky.
-- Auto-reply/UI: add model fallback lifecycle visibility in verbose logs, /status active-model context with fallback reason, and cohesive WebUI fallback indicators. Thanks @joshavant.
+- Auto-reply/UI: add model fallback lifecycle visibility in verbose logs, /status active-model context with fallback reason, and cohesive WebUI fallback indicators. (#20704) Thanks @joshavant.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - iOS/Gateway: stabilize background wake and reconnect behavior with background reconnect suppression/lease windows, BGAppRefresh wake fallback, location wake hook throttling, and APNs wake retry+nudge instrumentation. (#21226) thanks @mbelinky.
+- Auto-reply/UI: add model fallback lifecycle visibility in verbose logs, /status active-model context with fallback reason, and cohesive WebUI fallback indicators. Thanks @joshavant.
 
 ### Fixes
 
@@ -27,7 +28,6 @@ Docs: https://docs.openclaw.ai
 - Security/Audit: add `gateway.http.no_auth` findings when `gateway.auth.mode="none"` leaves Gateway HTTP APIs reachable, with loopback warning and remote-exposure critical severity, plus regression coverage and docs updates.
 - Skills: harden coding-agent skill guidance by removing shell-command examples that interpolate untrusted issue text directly into command strings.
 - Dev tooling: align `oxfmt` local/CI formatting behavior. (#12579) Thanks @vincentkoc.
-- Auto-reply/UI: add model fallback lifecycle visibility in verbose logs, /status active-model context with fallback reason, and cohesive WebUI fallback indicators. Thanks @joshavant.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Security/Audit: add `gateway.http.no_auth` findings when `gateway.auth.mode="none"` leaves Gateway HTTP APIs reachable, with loopback warning and remote-exposure critical severity, plus regression coverage and docs updates.
 - Skills: harden coding-agent skill guidance by removing shell-command examples that interpolate untrusted issue text directly into command strings.
 - Dev tooling: align `oxfmt` local/CI formatting behavior. (#12579) Thanks @vincentkoc.
+- Auto-reply/UI: add model fallback lifecycle visibility in verbose logs, /status active-model context with fallback reason, and cohesive WebUI fallback indicators. Thanks @joshavant.
 
 ### Fixes
 

--- a/src/auto-reply/fallback-state.test.ts
+++ b/src/auto-reply/fallback-state.test.ts
@@ -66,6 +66,19 @@ describe("fallback-state", () => {
     expect(resolved.nextState.activeModel).toBe("deepinfra/moonshotai/Kimi-K2.5");
   });
 
+  it("normalizes fallback reason whitespace for summaries", () => {
+    const resolved = resolveFallbackTransition({
+      selectedProvider: "fireworks",
+      selectedModel: "fireworks/minimax-m2p5",
+      activeProvider: "deepinfra",
+      activeModel: "moonshotai/Kimi-K2.5",
+      attempts: [{ ...baseAttempt, reason: "rate_limit\n\tburst" }],
+      state: {},
+    });
+
+    expect(resolved.reasonSummary).toBe("rate limit burst");
+  });
+
   it("refreshes reason when fallback remains active with same model pair", () => {
     const resolved = resolveFallbackTransition({
       selectedProvider: "fireworks",

--- a/src/auto-reply/fallback-state.test.ts
+++ b/src/auto-reply/fallback-state.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveActiveFallbackState,
+  resolveFallbackTransition,
+  type FallbackNoticeState,
+} from "./fallback-state.js";
+
+const baseAttempt = {
+  provider: "fireworks",
+  model: "fireworks/minimax-m2p5",
+  error: "Provider fireworks is in cooldown (all profiles unavailable)",
+  reason: "rate_limit" as const,
+};
+
+describe("fallback-state", () => {
+  it("treats fallback as active only when state matches selected and active refs", () => {
+    const state: FallbackNoticeState = {
+      fallbackNoticeSelectedModel: "fireworks/fireworks/minimax-m2p5",
+      fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
+      fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+    };
+
+    const resolved = resolveActiveFallbackState({
+      selectedModelRef: "fireworks/fireworks/minimax-m2p5",
+      activeModelRef: "deepinfra/moonshotai/Kimi-K2.5",
+      state,
+    });
+
+    expect(resolved.active).toBe(true);
+    expect(resolved.reason).toBe("fireworks/fireworks/minimax-m2p5 rate limit");
+  });
+
+  it("does not treat runtime drift as fallback when persisted state does not match", () => {
+    const state: FallbackNoticeState = {
+      fallbackNoticeSelectedModel: "anthropic/claude",
+      fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
+      fallbackNoticeReason: "anthropic/claude rate limit",
+    };
+
+    const resolved = resolveActiveFallbackState({
+      selectedModelRef: "fireworks/fireworks/minimax-m2p5",
+      activeModelRef: "deepinfra/moonshotai/Kimi-K2.5",
+      state,
+    });
+
+    expect(resolved.active).toBe(false);
+    expect(resolved.reason).toBeUndefined();
+  });
+
+  it("marks fallback transition when selected->active pair changes", () => {
+    const resolved = resolveFallbackTransition({
+      selectedProvider: "fireworks",
+      selectedModel: "fireworks/minimax-m2p5",
+      activeProvider: "deepinfra",
+      activeModel: "moonshotai/Kimi-K2.5",
+      attempts: [baseAttempt],
+      state: {},
+    });
+
+    expect(resolved.fallbackActive).toBe(true);
+    expect(resolved.fallbackTransitioned).toBe(true);
+    expect(resolved.fallbackCleared).toBe(false);
+    expect(resolved.stateChanged).toBe(true);
+    expect(resolved.reasonSummary).toBe("fireworks/fireworks/minimax-m2p5 rate limit");
+    expect(resolved.nextState.selectedModel).toBe("fireworks/fireworks/minimax-m2p5");
+    expect(resolved.nextState.activeModel).toBe("deepinfra/moonshotai/Kimi-K2.5");
+  });
+
+  it("refreshes reason when fallback remains active with same model pair", () => {
+    const resolved = resolveFallbackTransition({
+      selectedProvider: "fireworks",
+      selectedModel: "fireworks/minimax-m2p5",
+      activeProvider: "deepinfra",
+      activeModel: "moonshotai/Kimi-K2.5",
+      attempts: [{ ...baseAttempt, reason: "timeout" }],
+      state: {
+        fallbackNoticeSelectedModel: "fireworks/fireworks/minimax-m2p5",
+        fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
+        fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+      },
+    });
+
+    expect(resolved.fallbackTransitioned).toBe(false);
+    expect(resolved.stateChanged).toBe(true);
+    expect(resolved.nextState.reason).toBe("fireworks/fireworks/minimax-m2p5 timeout");
+  });
+
+  it("marks fallback as cleared when runtime returns to selected model", () => {
+    const resolved = resolveFallbackTransition({
+      selectedProvider: "fireworks",
+      selectedModel: "fireworks/minimax-m2p5",
+      activeProvider: "fireworks",
+      activeModel: "fireworks/minimax-m2p5",
+      attempts: [],
+      state: {
+        fallbackNoticeSelectedModel: "fireworks/fireworks/minimax-m2p5",
+        fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
+        fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+      },
+    });
+
+    expect(resolved.fallbackActive).toBe(false);
+    expect(resolved.fallbackCleared).toBe(true);
+    expect(resolved.fallbackTransitioned).toBe(false);
+    expect(resolved.stateChanged).toBe(true);
+    expect(resolved.nextState.selectedModel).toBeUndefined();
+    expect(resolved.nextState.activeModel).toBeUndefined();
+    expect(resolved.nextState.reason).toBeUndefined();
+  });
+});

--- a/src/auto-reply/fallback-state.test.ts
+++ b/src/auto-reply/fallback-state.test.ts
@@ -15,30 +15,30 @@ const baseAttempt = {
 describe("fallback-state", () => {
   it("treats fallback as active only when state matches selected and active refs", () => {
     const state: FallbackNoticeState = {
-      fallbackNoticeSelectedModel: "fireworks/fireworks/minimax-m2p5",
+      fallbackNoticeSelectedModel: "fireworks/minimax-m2p5",
       fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
-      fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+      fallbackNoticeReason: "rate limit",
     };
 
     const resolved = resolveActiveFallbackState({
-      selectedModelRef: "fireworks/fireworks/minimax-m2p5",
+      selectedModelRef: "fireworks/minimax-m2p5",
       activeModelRef: "deepinfra/moonshotai/Kimi-K2.5",
       state,
     });
 
     expect(resolved.active).toBe(true);
-    expect(resolved.reason).toBe("fireworks/fireworks/minimax-m2p5 rate limit");
+    expect(resolved.reason).toBe("rate limit");
   });
 
   it("does not treat runtime drift as fallback when persisted state does not match", () => {
     const state: FallbackNoticeState = {
       fallbackNoticeSelectedModel: "anthropic/claude",
       fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
-      fallbackNoticeReason: "anthropic/claude rate limit",
+      fallbackNoticeReason: "rate limit",
     };
 
     const resolved = resolveActiveFallbackState({
-      selectedModelRef: "fireworks/fireworks/minimax-m2p5",
+      selectedModelRef: "fireworks/minimax-m2p5",
       activeModelRef: "deepinfra/moonshotai/Kimi-K2.5",
       state,
     });
@@ -61,8 +61,8 @@ describe("fallback-state", () => {
     expect(resolved.fallbackTransitioned).toBe(true);
     expect(resolved.fallbackCleared).toBe(false);
     expect(resolved.stateChanged).toBe(true);
-    expect(resolved.reasonSummary).toBe("fireworks/fireworks/minimax-m2p5 rate limit");
-    expect(resolved.nextState.selectedModel).toBe("fireworks/fireworks/minimax-m2p5");
+    expect(resolved.reasonSummary).toBe("rate limit");
+    expect(resolved.nextState.selectedModel).toBe("fireworks/minimax-m2p5");
     expect(resolved.nextState.activeModel).toBe("deepinfra/moonshotai/Kimi-K2.5");
   });
 
@@ -74,15 +74,15 @@ describe("fallback-state", () => {
       activeModel: "moonshotai/Kimi-K2.5",
       attempts: [{ ...baseAttempt, reason: "timeout" }],
       state: {
-        fallbackNoticeSelectedModel: "fireworks/fireworks/minimax-m2p5",
+        fallbackNoticeSelectedModel: "fireworks/minimax-m2p5",
         fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
-        fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+        fallbackNoticeReason: "rate limit",
       },
     });
 
     expect(resolved.fallbackTransitioned).toBe(false);
     expect(resolved.stateChanged).toBe(true);
-    expect(resolved.nextState.reason).toBe("fireworks/fireworks/minimax-m2p5 timeout");
+    expect(resolved.nextState.reason).toBe("timeout");
   });
 
   it("marks fallback as cleared when runtime returns to selected model", () => {
@@ -93,9 +93,9 @@ describe("fallback-state", () => {
       activeModel: "fireworks/minimax-m2p5",
       attempts: [],
       state: {
-        fallbackNoticeSelectedModel: "fireworks/fireworks/minimax-m2p5",
+        fallbackNoticeSelectedModel: "fireworks/minimax-m2p5",
         fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
-        fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+        fallbackNoticeReason: "rate limit",
       },
     });
 

--- a/src/auto-reply/fallback-state.ts
+++ b/src/auto-reply/fallback-state.ts
@@ -1,0 +1,177 @@
+import type { SessionEntry } from "../config/sessions.js";
+import type { RuntimeFallbackAttempt } from "./reply/agent-runner-execution.js";
+
+const FALLBACK_REASON_PART_MAX = 80;
+
+export type FallbackNoticeState = Pick<
+  SessionEntry,
+  "fallbackNoticeSelectedModel" | "fallbackNoticeActiveModel" | "fallbackNoticeReason"
+>;
+
+export function normalizeFallbackModelRef(value?: string): string | undefined {
+  const trimmed = String(value ?? "").trim();
+  return trimmed || undefined;
+}
+
+function truncateFallbackReasonPart(value: string, max = FALLBACK_REASON_PART_MAX): string {
+  const text = String(value ?? "").trim();
+  if (text.length <= max) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+export function formatFallbackAttemptReason(attempt: RuntimeFallbackAttempt): string {
+  const reason = attempt.reason?.trim();
+  if (reason) {
+    return reason.replace(/_/g, " ");
+  }
+  const code = attempt.code?.trim();
+  if (code) {
+    return code;
+  }
+  if (typeof attempt.status === "number") {
+    return `HTTP ${attempt.status}`;
+  }
+  return truncateFallbackReasonPart(attempt.error || "error");
+}
+
+function formatFallbackAttemptSummary(attempt: RuntimeFallbackAttempt): string {
+  return `${attempt.provider}/${attempt.model} ${formatFallbackAttemptReason(attempt)}`;
+}
+
+export function buildFallbackReasonSummary(attempts: RuntimeFallbackAttempt[]): string {
+  const firstAttempt = attempts[0];
+  const firstReason = firstAttempt
+    ? formatFallbackAttemptSummary(firstAttempt)
+    : "selected model unavailable";
+  const moreAttempts = attempts.length > 1 ? ` (+${attempts.length - 1} more attempts)` : "";
+  return `${truncateFallbackReasonPart(firstReason)}${moreAttempts}`;
+}
+
+export function buildFallbackAttemptSummaries(attempts: RuntimeFallbackAttempt[]): string[] {
+  return attempts.map((attempt) =>
+    truncateFallbackReasonPart(formatFallbackAttemptSummary(attempt)),
+  );
+}
+
+export function buildFallbackNotice(params: {
+  selectedProvider: string;
+  selectedModel: string;
+  activeProvider: string;
+  activeModel: string;
+  attempts: RuntimeFallbackAttempt[];
+}): string | null {
+  const selected = `${params.selectedProvider}/${params.selectedModel}`;
+  const active = `${params.activeProvider}/${params.activeModel}`;
+  if (selected === active) {
+    return null;
+  }
+  const reasonSummary = buildFallbackReasonSummary(params.attempts);
+  return `↪️ Model Fallback: ${active} (selected ${selected}; ${reasonSummary})`;
+}
+
+export function buildFallbackClearedNotice(params: {
+  selectedProvider: string;
+  selectedModel: string;
+  previousActiveModel?: string;
+}): string {
+  const selected = `${params.selectedProvider}/${params.selectedModel}`;
+  const previous = normalizeFallbackModelRef(params.previousActiveModel);
+  if (previous && previous !== selected) {
+    return `↪️ Model Fallback cleared: ${selected} (was ${previous})`;
+  }
+  return `↪️ Model Fallback cleared: ${selected}`;
+}
+
+export function resolveActiveFallbackState(params: {
+  selectedModelRef: string;
+  activeModelRef: string;
+  state?: FallbackNoticeState;
+}): { active: boolean; reason?: string } {
+  const selected = normalizeFallbackModelRef(params.state?.fallbackNoticeSelectedModel);
+  const active = normalizeFallbackModelRef(params.state?.fallbackNoticeActiveModel);
+  const reason = normalizeFallbackModelRef(params.state?.fallbackNoticeReason);
+  const fallbackActive =
+    params.selectedModelRef !== params.activeModelRef &&
+    selected === params.selectedModelRef &&
+    active === params.activeModelRef;
+  return {
+    active: fallbackActive,
+    reason: fallbackActive ? reason : undefined,
+  };
+}
+
+export type ResolvedFallbackTransition = {
+  selectedModelRef: string;
+  activeModelRef: string;
+  fallbackActive: boolean;
+  fallbackTransitioned: boolean;
+  fallbackCleared: boolean;
+  reasonSummary: string;
+  attemptSummaries: string[];
+  previousState: {
+    selectedModel?: string;
+    activeModel?: string;
+    reason?: string;
+  };
+  nextState: {
+    selectedModel?: string;
+    activeModel?: string;
+    reason?: string;
+  };
+  stateChanged: boolean;
+};
+
+export function resolveFallbackTransition(params: {
+  selectedProvider: string;
+  selectedModel: string;
+  activeProvider: string;
+  activeModel: string;
+  attempts: RuntimeFallbackAttempt[];
+  state?: FallbackNoticeState;
+}): ResolvedFallbackTransition {
+  const selectedModelRef = `${params.selectedProvider}/${params.selectedModel}`;
+  const activeModelRef = `${params.activeProvider}/${params.activeModel}`;
+  const previousState = {
+    selectedModel: normalizeFallbackModelRef(params.state?.fallbackNoticeSelectedModel),
+    activeModel: normalizeFallbackModelRef(params.state?.fallbackNoticeActiveModel),
+    reason: normalizeFallbackModelRef(params.state?.fallbackNoticeReason),
+  };
+  const fallbackActive = selectedModelRef !== activeModelRef;
+  const fallbackTransitioned =
+    fallbackActive &&
+    (previousState.selectedModel !== selectedModelRef ||
+      previousState.activeModel !== activeModelRef);
+  const fallbackCleared =
+    !fallbackActive && Boolean(previousState.selectedModel || previousState.activeModel);
+  const reasonSummary = buildFallbackReasonSummary(params.attempts);
+  const attemptSummaries = buildFallbackAttemptSummaries(params.attempts);
+  const nextState = fallbackActive
+    ? {
+        selectedModel: selectedModelRef,
+        activeModel: activeModelRef,
+        reason: reasonSummary,
+      }
+    : {
+        selectedModel: undefined,
+        activeModel: undefined,
+        reason: undefined,
+      };
+  const stateChanged =
+    previousState.selectedModel !== nextState.selectedModel ||
+    previousState.activeModel !== nextState.activeModel ||
+    previousState.reason !== nextState.reason;
+  return {
+    selectedModelRef,
+    activeModelRef,
+    fallbackActive,
+    fallbackTransitioned,
+    fallbackCleared,
+    reasonSummary,
+    attemptSummaries,
+    previousState,
+    nextState,
+    stateChanged,
+  };
+}

--- a/src/auto-reply/fallback-state.ts
+++ b/src/auto-reply/fallback-state.ts
@@ -15,7 +15,9 @@ export function normalizeFallbackModelRef(value?: string): string | undefined {
 }
 
 function truncateFallbackReasonPart(value: string, max = FALLBACK_REASON_PART_MAX): string {
-  const text = String(value ?? "").trim();
+  const text = String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
   if (text.length <= max) {
     return text;
   }

--- a/src/auto-reply/fallback-state.ts
+++ b/src/auto-reply/fallback-state.ts
@@ -1,4 +1,5 @@
 import type { SessionEntry } from "../config/sessions.js";
+import { formatProviderModelRef } from "./model-runtime.js";
 import type { RuntimeFallbackAttempt } from "./reply/agent-runner-execution.js";
 
 const FALLBACK_REASON_PART_MAX = 80;
@@ -37,13 +38,13 @@ export function formatFallbackAttemptReason(attempt: RuntimeFallbackAttempt): st
 }
 
 function formatFallbackAttemptSummary(attempt: RuntimeFallbackAttempt): string {
-  return `${attempt.provider}/${attempt.model} ${formatFallbackAttemptReason(attempt)}`;
+  return `${formatProviderModelRef(attempt.provider, attempt.model)} ${formatFallbackAttemptReason(attempt)}`;
 }
 
 export function buildFallbackReasonSummary(attempts: RuntimeFallbackAttempt[]): string {
   const firstAttempt = attempts[0];
   const firstReason = firstAttempt
-    ? formatFallbackAttemptSummary(firstAttempt)
+    ? formatFallbackAttemptReason(firstAttempt)
     : "selected model unavailable";
   const moreAttempts = attempts.length > 1 ? ` (+${attempts.length - 1} more attempts)` : "";
   return `${truncateFallbackReasonPart(firstReason)}${moreAttempts}`;
@@ -62,8 +63,8 @@ export function buildFallbackNotice(params: {
   activeModel: string;
   attempts: RuntimeFallbackAttempt[];
 }): string | null {
-  const selected = `${params.selectedProvider}/${params.selectedModel}`;
-  const active = `${params.activeProvider}/${params.activeModel}`;
+  const selected = formatProviderModelRef(params.selectedProvider, params.selectedModel);
+  const active = formatProviderModelRef(params.activeProvider, params.activeModel);
   if (selected === active) {
     return null;
   }
@@ -76,7 +77,7 @@ export function buildFallbackClearedNotice(params: {
   selectedModel: string;
   previousActiveModel?: string;
 }): string {
-  const selected = `${params.selectedProvider}/${params.selectedModel}`;
+  const selected = formatProviderModelRef(params.selectedProvider, params.selectedModel);
   const previous = normalizeFallbackModelRef(params.previousActiveModel);
   if (previous && previous !== selected) {
     return `↪️ Model Fallback cleared: ${selected} (was ${previous})`;
@@ -131,8 +132,8 @@ export function resolveFallbackTransition(params: {
   attempts: RuntimeFallbackAttempt[];
   state?: FallbackNoticeState;
 }): ResolvedFallbackTransition {
-  const selectedModelRef = `${params.selectedProvider}/${params.selectedModel}`;
-  const activeModelRef = `${params.activeProvider}/${params.activeModel}`;
+  const selectedModelRef = formatProviderModelRef(params.selectedProvider, params.selectedModel);
+  const activeModelRef = formatProviderModelRef(params.activeProvider, params.activeModel);
   const previousState = {
     selectedModel: normalizeFallbackModelRef(params.state?.fallbackNoticeSelectedModel),
     activeModel: normalizeFallbackModelRef(params.state?.fallbackNoticeActiveModel),

--- a/src/auto-reply/model-runtime.ts
+++ b/src/auto-reply/model-runtime.ts
@@ -1,10 +1,44 @@
 import type { SessionEntry } from "../config/sessions.js";
 
+export function formatProviderModelRef(providerRaw: string, modelRaw: string): string {
+  const provider = String(providerRaw ?? "").trim();
+  const model = String(modelRaw ?? "").trim();
+  if (!provider) {
+    return model;
+  }
+  if (!model) {
+    return provider;
+  }
+  const prefix = `${provider}/`;
+  if (model.toLowerCase().startsWith(prefix.toLowerCase())) {
+    const normalizedModel = model.slice(prefix.length).trim();
+    if (normalizedModel) {
+      return `${provider}/${normalizedModel}`;
+    }
+  }
+  return `${provider}/${model}`;
+}
+
 type ModelRef = {
   provider: string;
   model: string;
   label: string;
 };
+
+function normalizeModelWithinProvider(provider: string, modelRaw: string): string {
+  const model = String(modelRaw ?? "").trim();
+  if (!provider || !model) {
+    return model;
+  }
+  const prefix = `${provider}/`;
+  if (model.toLowerCase().startsWith(prefix.toLowerCase())) {
+    const withoutPrefix = model.slice(prefix.length).trim();
+    if (withoutPrefix) {
+      return withoutPrefix;
+    }
+  }
+  return model;
+}
 
 function normalizeModelRef(
   rawModel: string,
@@ -25,10 +59,11 @@ function normalizeModelRef(
     }
   }
   const provider = String(fallbackProvider ?? "").trim();
+  const dedupedModel = normalizeModelWithinProvider(provider, trimmed);
   return {
     provider,
-    model: trimmed,
-    label: provider ? `${provider}/${trimmed}` : trimmed,
+    model: dedupedModel || trimmed,
+    label: provider ? formatProviderModelRef(provider, dedupedModel || trimmed) : trimmed,
   };
 }
 

--- a/src/auto-reply/model-runtime.ts
+++ b/src/auto-reply/model-runtime.ts
@@ -1,0 +1,58 @@
+import type { SessionEntry } from "../config/sessions.js";
+
+type ModelRef = {
+  provider: string;
+  model: string;
+  label: string;
+};
+
+function normalizeModelRef(
+  rawModel: string,
+  fallbackProvider: string,
+  parseEmbeddedProvider = false,
+): ModelRef {
+  const trimmed = String(rawModel ?? "").trim();
+  const slashIndex = parseEmbeddedProvider ? trimmed.indexOf("/") : -1;
+  if (slashIndex > 0) {
+    const provider = trimmed.slice(0, slashIndex).trim();
+    const model = trimmed.slice(slashIndex + 1).trim();
+    if (provider && model) {
+      return {
+        provider,
+        model,
+        label: `${provider}/${model}`,
+      };
+    }
+  }
+  const provider = String(fallbackProvider ?? "").trim();
+  return {
+    provider,
+    model: trimmed,
+    label: provider ? `${provider}/${trimmed}` : trimmed,
+  };
+}
+
+export function resolveSelectedAndActiveModel(params: {
+  selectedProvider: string;
+  selectedModel: string;
+  sessionEntry?: Pick<SessionEntry, "modelProvider" | "model">;
+}): {
+  selected: ModelRef;
+  active: ModelRef;
+  activeDiffers: boolean;
+} {
+  const selected = normalizeModelRef(params.selectedModel, params.selectedProvider);
+  const runtimeModel = params.sessionEntry?.model?.trim();
+  const runtimeProvider = params.sessionEntry?.modelProvider?.trim();
+
+  const active = runtimeModel
+    ? normalizeModelRef(runtimeModel, runtimeProvider || selected.provider, !runtimeProvider)
+    : selected;
+  const activeDiffers = active.provider !== selected.provider || active.model !== selected.model;
+
+  return {
+    selected,
+    active,
+    activeDiffers,
+  };
+}

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -54,6 +54,7 @@ vi.mock("../../agents/model-fallback.js", () => ({
     result: await run(provider, model),
     provider,
     model,
+    attempts: [],
   }),
 }));
 
@@ -538,12 +539,393 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("announces model fallback in verbose mode", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({ payloads: [{ text: "final" }], meta: {} });
+    const modelFallback = await import("../../agents/model-fallback.js");
+    vi.spyOn(modelFallback, "runWithModelFallback").mockImplementationOnce(
+      async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+        provider: "deepinfra",
+        model: "moonshotai/Kimi-K2.5",
+        attempts: [
+          {
+            provider: "fireworks",
+            model: "fireworks/minimax-m2p5",
+            error: "Provider fireworks is in cooldown (all profiles unavailable)",
+            reason: "rate_limit",
+          },
+        ],
+      }),
+    );
+
+    const { run } = createMinimalRun({
+      resolvedVerboseLevel: "on",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+    });
+    const res = await run();
+    expect(Array.isArray(res)).toBe(true);
+    const payloads = res as { text?: string }[];
+    expect(payloads[0]?.text).toContain("Model Fallback:");
+    expect(payloads[0]?.text).toContain("deepinfra/moonshotai/Kimi-K2.5");
+    expect(sessionEntry.fallbackNoticeReason).toBe("fireworks/fireworks/minimax-m2p5 rate limit");
+  });
+
+  it("does not announce model fallback when verbose is off", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({ payloads: [{ text: "final" }], meta: {} });
+    const modelFallback = await import("../../agents/model-fallback.js");
+    vi.spyOn(modelFallback, "runWithModelFallback").mockImplementationOnce(
+      async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+        provider: "deepinfra",
+        model: "moonshotai/Kimi-K2.5",
+        attempts: [
+          {
+            provider: "fireworks",
+            model: "fireworks/minimax-m2p5",
+            error: "Provider fireworks is in cooldown (all profiles unavailable)",
+            reason: "rate_limit",
+          },
+        ],
+      }),
+    );
+
+    const { run } = createMinimalRun({
+      resolvedVerboseLevel: "off",
+    });
+    const res = await run();
+    const payload = Array.isArray(res) ? (res[0] as { text?: string }) : (res as { text?: string });
+    expect(payload.text).not.toContain("Model Fallback:");
+  });
+
+  it("announces model fallback only once per active fallback state", async () => {
+    const { onAgentEvent } = await import("../../infra/agent-events.js");
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+    const modelFallback = await import("../../agents/model-fallback.js");
+    const fallbackSpy = vi
+      .spyOn(modelFallback, "runWithModelFallback")
+      .mockImplementation(
+        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+          provider: "deepinfra",
+          model: "moonshotai/Kimi-K2.5",
+          attempts: [
+            {
+              provider: "fireworks",
+              model: "fireworks/minimax-m2p5",
+              error: "Provider fireworks is in cooldown (all profiles unavailable)",
+              reason: "rate_limit",
+            },
+          ],
+        }),
+      );
+    try {
+      const { run } = createMinimalRun({
+        resolvedVerboseLevel: "on",
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+      });
+      const fallbackEvents: Array<Record<string, unknown>> = [];
+      const off = onAgentEvent((evt) => {
+        if (evt.stream === "lifecycle" && evt.data?.phase === "fallback") {
+          fallbackEvents.push(evt.data);
+        }
+      });
+      const first = await run();
+      const second = await run();
+      off();
+
+      const firstText = Array.isArray(first) ? first[0]?.text : first?.text;
+      const secondText = Array.isArray(second) ? second[0]?.text : second?.text;
+      expect(firstText).toContain("Model Fallback:");
+      expect(secondText).not.toContain("Model Fallback:");
+      expect(fallbackEvents).toHaveLength(1);
+    } finally {
+      fallbackSpy.mockRestore();
+    }
+  });
+
+  it("re-announces model fallback after returning to selected model", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+    let callCount = 0;
+
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+    const modelFallback = await import("../../agents/model-fallback.js");
+    const fallbackSpy = vi
+      .spyOn(modelFallback, "runWithModelFallback")
+      .mockImplementation(
+        async ({
+          provider,
+          model,
+          run,
+        }: {
+          provider: string;
+          model: string;
+          run: (provider: string, model: string) => Promise<unknown>;
+        }) => {
+          callCount += 1;
+          if (callCount === 2) {
+            return {
+              result: await run(provider, model),
+              provider,
+              model,
+              attempts: [],
+            };
+          }
+          return {
+            result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+            provider: "deepinfra",
+            model: "moonshotai/Kimi-K2.5",
+            attempts: [
+              {
+                provider: "fireworks",
+                model: "fireworks/minimax-m2p5",
+                error: "Provider fireworks is in cooldown (all profiles unavailable)",
+                reason: "rate_limit",
+              },
+            ],
+          };
+        },
+      );
+    try {
+      const { run } = createMinimalRun({
+        resolvedVerboseLevel: "on",
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+      });
+      const first = await run();
+      const second = await run();
+      const third = await run();
+
+      const firstText = Array.isArray(first) ? first[0]?.text : first?.text;
+      const secondText = Array.isArray(second) ? second[0]?.text : second?.text;
+      const thirdText = Array.isArray(third) ? third[0]?.text : third?.text;
+      expect(firstText).toContain("Model Fallback:");
+      expect(secondText).not.toContain("Model Fallback:");
+      expect(thirdText).toContain("Model Fallback:");
+    } finally {
+      fallbackSpy.mockRestore();
+    }
+  });
+
+  it("announces fallback-cleared once when runtime returns to selected model", async () => {
+    const { onAgentEvent } = await import("../../infra/agent-events.js");
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+    let callCount = 0;
+
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+    const modelFallback = await import("../../agents/model-fallback.js");
+    const fallbackSpy = vi
+      .spyOn(modelFallback, "runWithModelFallback")
+      .mockImplementation(
+        async ({
+          provider,
+          model,
+          run,
+        }: {
+          provider: string;
+          model: string;
+          run: (provider: string, model: string) => Promise<unknown>;
+        }) => {
+          callCount += 1;
+          if (callCount === 1) {
+            return {
+              result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+              provider: "deepinfra",
+              model: "moonshotai/Kimi-K2.5",
+              attempts: [
+                {
+                  provider: "fireworks",
+                  model: "fireworks/minimax-m2p5",
+                  error: "Provider fireworks is in cooldown (all profiles unavailable)",
+                  reason: "rate_limit",
+                },
+              ],
+            };
+          }
+          return {
+            result: await run(provider, model),
+            provider,
+            model,
+            attempts: [],
+          };
+        },
+      );
+    try {
+      const { run } = createMinimalRun({
+        resolvedVerboseLevel: "on",
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+      });
+      const phases: string[] = [];
+      const off = onAgentEvent((evt) => {
+        const phase = typeof evt.data?.phase === "string" ? evt.data.phase : null;
+        if (evt.stream === "lifecycle" && phase) {
+          phases.push(phase);
+        }
+      });
+      const first = await run();
+      const second = await run();
+      const third = await run();
+      off();
+
+      const firstText = Array.isArray(first) ? first[0]?.text : first?.text;
+      const secondText = Array.isArray(second) ? second[0]?.text : second?.text;
+      const thirdText = Array.isArray(third) ? third[0]?.text : third?.text;
+      expect(firstText).toContain("Model Fallback:");
+      expect(secondText).toContain("Model Fallback cleared:");
+      expect(thirdText).not.toContain("Model Fallback cleared:");
+      expect(phases.filter((phase) => phase === "fallback")).toHaveLength(1);
+      expect(phases.filter((phase) => phase === "fallback_cleared")).toHaveLength(1);
+    } finally {
+      fallbackSpy.mockRestore();
+    }
+  });
+
+  it("backfills fallback reason when fallback is already active", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      fallbackNoticeSelectedModel: "anthropic/claude",
+      fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
+      modelProvider: "deepinfra",
+      model: "moonshotai/Kimi-K2.5",
+    };
+    const sessionStore = { main: sessionEntry };
+
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+    const modelFallback = await import("../../agents/model-fallback.js");
+    const fallbackSpy = vi
+      .spyOn(modelFallback, "runWithModelFallback")
+      .mockImplementation(
+        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+          provider: "deepinfra",
+          model: "moonshotai/Kimi-K2.5",
+          attempts: [
+            {
+              provider: "anthropic",
+              model: "claude",
+              error: "Provider anthropic is in cooldown (all profiles unavailable)",
+              reason: "rate_limit",
+            },
+          ],
+        }),
+      );
+    try {
+      const { run } = createMinimalRun({
+        resolvedVerboseLevel: "on",
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+      });
+      const res = await run();
+      const firstText = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(firstText).not.toContain("Model Fallback:");
+      expect(sessionEntry.fallbackNoticeReason).toBe("anthropic/claude rate limit");
+    } finally {
+      fallbackSpy.mockRestore();
+    }
+  });
+
+  it("refreshes fallback reason summary while fallback stays active", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      fallbackNoticeSelectedModel: "anthropic/claude",
+      fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
+      fallbackNoticeReason: "anthropic/claude rate limit",
+      modelProvider: "deepinfra",
+      model: "moonshotai/Kimi-K2.5",
+    };
+    const sessionStore = { main: sessionEntry };
+
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+    const modelFallback = await import("../../agents/model-fallback.js");
+    const fallbackSpy = vi
+      .spyOn(modelFallback, "runWithModelFallback")
+      .mockImplementation(
+        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+          provider: "deepinfra",
+          model: "moonshotai/Kimi-K2.5",
+          attempts: [
+            {
+              provider: "anthropic",
+              model: "claude",
+              error: "Provider anthropic is in cooldown (all profiles unavailable)",
+              reason: "timeout",
+            },
+          ],
+        }),
+      );
+    try {
+      const { run } = createMinimalRun({
+        resolvedVerboseLevel: "on",
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+      });
+      const res = await run();
+      const firstText = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(firstText).not.toContain("Model Fallback:");
+      expect(sessionEntry.fallbackNoticeReason).toBe("anthropic/claude timeout");
+    } finally {
+      fallbackSpy.mockRestore();
+    }
+  });
+
   it("retries after compaction failure by resetting the session", async () => {
     await withTempStateDir(async (stateDir) => {
       const sessionId = "session";
       const storePath = path.join(stateDir, "sessions", "sessions.json");
       const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
-      const sessionEntry = { sessionId, updatedAt: Date.now(), sessionFile: transcriptPath };
+      const sessionEntry = {
+        sessionId,
+        updatedAt: Date.now(),
+        sessionFile: transcriptPath,
+        fallbackNoticeSelectedModel: "fireworks/fireworks/minimax-m2p5",
+        fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
+        fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+      };
       const sessionStore = { main: sessionEntry };
 
       await fs.mkdir(path.dirname(storePath), { recursive: true });
@@ -575,9 +957,15 @@ describe("runReplyAgent typing (heartbeat)", () => {
       }
       expect(payload.text?.toLowerCase()).toContain("reset");
       expect(sessionStore.main.sessionId).not.toBe(sessionId);
+      expect(sessionStore.main.fallbackNoticeSelectedModel).toBeUndefined();
+      expect(sessionStore.main.fallbackNoticeActiveModel).toBeUndefined();
+      expect(sessionStore.main.fallbackNoticeReason).toBeUndefined();
 
       const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
       expect(persisted.main.sessionId).toBe(sessionStore.main.sessionId);
+      expect(persisted.main.fallbackNoticeSelectedModel).toBeUndefined();
+      expect(persisted.main.fallbackNoticeActiveModel).toBeUndefined();
+      expect(persisted.main.fallbackNoticeReason).toBeUndefined();
     });
   });
 

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -574,7 +574,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     const payloads = res as { text?: string }[];
     expect(payloads[0]?.text).toContain("Model Fallback:");
     expect(payloads[0]?.text).toContain("deepinfra/moonshotai/Kimi-K2.5");
-    expect(sessionEntry.fallbackNoticeReason).toBe("fireworks/fireworks/minimax-m2p5 rate limit");
+    expect(sessionEntry.fallbackNoticeReason).toBe("rate limit");
   });
 
   it("does not announce model fallback when verbose is off", async () => {
@@ -946,7 +946,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const res = await run();
       const firstText = Array.isArray(res) ? res[0]?.text : res?.text;
       expect(firstText).not.toContain("Model Fallback:");
-      expect(sessionEntry.fallbackNoticeReason).toBe("anthropic/claude rate limit");
+      expect(sessionEntry.fallbackNoticeReason).toBe("rate limit");
     } finally {
       fallbackSpy.mockRestore();
     }
@@ -958,7 +958,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       updatedAt: Date.now(),
       fallbackNoticeSelectedModel: "anthropic/claude",
       fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
-      fallbackNoticeReason: "anthropic/claude rate limit",
+      fallbackNoticeReason: "rate limit",
       modelProvider: "deepinfra",
       model: "moonshotai/Kimi-K2.5",
     };
@@ -996,7 +996,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const res = await run();
       const firstText = Array.isArray(res) ? res[0]?.text : res?.text;
       expect(firstText).not.toContain("Model Fallback:");
-      expect(sessionEntry.fallbackNoticeReason).toBe("anthropic/claude timeout");
+      expect(sessionEntry.fallbackNoticeReason).toBe("timeout");
     } finally {
       fallbackSpy.mockRestore();
     }
@@ -1011,9 +1011,9 @@ describe("runReplyAgent typing (heartbeat)", () => {
         sessionId,
         updatedAt: Date.now(),
         sessionFile: transcriptPath,
-        fallbackNoticeSelectedModel: "fireworks/fireworks/minimax-m2p5",
+        fallbackNoticeSelectedModel: "fireworks/minimax-m2p5",
         fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
-        fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+        fallbackNoticeReason: "rate limit",
       };
       const sessionStore = { main: sessionEntry };
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -15,10 +15,16 @@ import {
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
+import {
+  buildFallbackClearedNotice,
+  buildFallbackNotice,
+  resolveFallbackTransition,
+} from "../fallback-state.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -290,6 +296,9 @@ export async function runReplyAgent(params: {
       updatedAt: Date.now(),
       systemSent: false,
       abortedLastRun: false,
+      fallbackNoticeSelectedModel: undefined,
+      fallbackNoticeActiveModel: undefined,
+      fallbackNoticeReason: undefined,
     };
     const agentId = resolveAgentIdFromSessionKey(sessionKey);
     const nextSessionFile = resolveSessionTranscriptPath(
@@ -373,7 +382,14 @@ export async function runReplyAgent(params: {
       return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);
     }
 
-    const { runResult, fallbackProvider, fallbackModel, directlySentBlockKeys } = runOutcome;
+    const {
+      runId,
+      runResult,
+      fallbackProvider,
+      fallbackModel,
+      fallbackAttempts,
+      directlySentBlockKeys,
+    } = runOutcome;
     let { didLogHeartbeatStrip, autoCompactionCompleted } = runOutcome;
 
     if (
@@ -414,6 +430,42 @@ export async function runReplyAgent(params: {
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
     const providerUsed =
       runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
+    const verboseEnabled = resolvedVerboseLevel !== "off";
+    const selectedProvider = followupRun.run.provider;
+    const selectedModel = followupRun.run.model;
+    const fallbackStateEntry =
+      activeSessionEntry ?? (sessionKey ? activeSessionStore?.[sessionKey] : undefined);
+    const fallbackTransition = resolveFallbackTransition({
+      selectedProvider,
+      selectedModel,
+      activeProvider: providerUsed,
+      activeModel: modelUsed,
+      attempts: fallbackAttempts,
+      state: fallbackStateEntry,
+    });
+    if (fallbackTransition.stateChanged) {
+      if (fallbackStateEntry) {
+        fallbackStateEntry.fallbackNoticeSelectedModel = fallbackTransition.nextState.selectedModel;
+        fallbackStateEntry.fallbackNoticeActiveModel = fallbackTransition.nextState.activeModel;
+        fallbackStateEntry.fallbackNoticeReason = fallbackTransition.nextState.reason;
+        fallbackStateEntry.updatedAt = Date.now();
+        activeSessionEntry = fallbackStateEntry;
+      }
+      if (sessionKey && fallbackStateEntry && activeSessionStore) {
+        activeSessionStore[sessionKey] = fallbackStateEntry;
+      }
+      if (sessionKey && storePath) {
+        await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => ({
+            fallbackNoticeSelectedModel: fallbackTransition.nextState.selectedModel,
+            fallbackNoticeActiveModel: fallbackTransition.nextState.activeModel,
+            fallbackNoticeReason: fallbackTransition.nextState.reason,
+          }),
+        });
+      }
+    }
     const cliSessionId = isCliProvider(providerUsed, cfg)
       ? runResult.meta?.agentMeta?.sessionId?.trim()
       : undefined;
@@ -546,9 +598,64 @@ export async function runReplyAgent(params: {
       }
     }
 
-    // If verbose is enabled and this is a new session, prepend a session hint.
+    // If verbose is enabled, prepend operational run notices.
     let finalPayloads = guardedReplyPayloads;
-    const verboseEnabled = resolvedVerboseLevel !== "off";
+    const verboseNotices: ReplyPayload[] = [];
+
+    if (verboseEnabled && activeIsNewSession) {
+      verboseNotices.push({ text: `🧭 New session: ${followupRun.run.sessionId}` });
+    }
+
+    if (verboseEnabled && fallbackTransition.fallbackTransitioned) {
+      emitAgentEvent({
+        runId,
+        sessionKey,
+        stream: "lifecycle",
+        data: {
+          phase: "fallback",
+          selectedProvider,
+          selectedModel,
+          activeProvider: providerUsed,
+          activeModel: modelUsed,
+          reasonSummary: fallbackTransition.reasonSummary,
+          attemptSummaries: fallbackTransition.attemptSummaries,
+          attempts: fallbackAttempts,
+        },
+      });
+      const fallbackNotice = buildFallbackNotice({
+        selectedProvider,
+        selectedModel,
+        activeProvider: providerUsed,
+        activeModel: modelUsed,
+        attempts: fallbackAttempts,
+      });
+      if (fallbackNotice) {
+        verboseNotices.push({ text: fallbackNotice });
+      }
+    }
+    if (verboseEnabled && fallbackTransition.fallbackCleared) {
+      emitAgentEvent({
+        runId,
+        sessionKey,
+        stream: "lifecycle",
+        data: {
+          phase: "fallback_cleared",
+          selectedProvider,
+          selectedModel,
+          activeProvider: providerUsed,
+          activeModel: modelUsed,
+          previousActiveModel: fallbackTransition.previousState.activeModel,
+        },
+      });
+      verboseNotices.push({
+        text: buildFallbackClearedNotice({
+          selectedProvider,
+          selectedModel,
+          previousActiveModel: fallbackTransition.previousState.activeModel,
+        }),
+      });
+    }
+
     if (autoCompactionCompleted) {
       const count = await incrementRunCompactionCount({
         sessionEntry: activeSessionEntry,
@@ -578,11 +685,11 @@ export async function runReplyAgent(params: {
 
       if (verboseEnabled) {
         const suffix = typeof count === "number" ? ` (count ${count})` : "";
-        finalPayloads = [{ text: `🧹 Auto-compaction complete${suffix}.` }, ...finalPayloads];
+        verboseNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
       }
     }
-    if (verboseEnabled && activeIsNewSession) {
-      finalPayloads = [{ text: `🧭 New session: ${followupRun.run.sessionId}` }, ...finalPayloads];
+    if (verboseNotices.length > 0) {
+      finalPayloads = [...verboseNotices, ...finalPayloads];
     }
     if (responseUsageLine) {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -606,7 +606,7 @@ export async function runReplyAgent(params: {
       verboseNotices.push({ text: `🧭 New session: ${followupRun.run.sessionId}` });
     }
 
-    if (verboseEnabled && fallbackTransition.fallbackTransitioned) {
+    if (fallbackTransition.fallbackTransitioned) {
       emitAgentEvent({
         runId,
         sessionKey,
@@ -622,18 +622,20 @@ export async function runReplyAgent(params: {
           attempts: fallbackAttempts,
         },
       });
-      const fallbackNotice = buildFallbackNotice({
-        selectedProvider,
-        selectedModel,
-        activeProvider: providerUsed,
-        activeModel: modelUsed,
-        attempts: fallbackAttempts,
-      });
-      if (fallbackNotice) {
-        verboseNotices.push({ text: fallbackNotice });
+      if (verboseEnabled) {
+        const fallbackNotice = buildFallbackNotice({
+          selectedProvider,
+          selectedModel,
+          activeProvider: providerUsed,
+          activeModel: modelUsed,
+          attempts: fallbackAttempts,
+        });
+        if (fallbackNotice) {
+          verboseNotices.push({ text: fallbackNotice });
+        }
       }
     }
-    if (verboseEnabled && fallbackTransition.fallbackCleared) {
+    if (fallbackTransition.fallbackCleared) {
       emitAgentEvent({
         runId,
         sessionKey,
@@ -647,13 +649,15 @@ export async function runReplyAgent(params: {
           previousActiveModel: fallbackTransition.previousState.activeModel,
         },
       });
-      verboseNotices.push({
-        text: buildFallbackClearedNotice({
-          selectedProvider,
-          selectedModel,
-          previousActiveModel: fallbackTransition.previousState.activeModel,
-        }),
-      });
+      if (verboseEnabled) {
+        verboseNotices.push({
+          text: buildFallbackClearedNotice({
+            selectedProvider,
+            selectedModel,
+            previousActiveModel: fallbackTransition.previousState.activeModel,
+          }),
+        });
+      }
     }
 
     if (autoCompactionCompleted) {

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -19,6 +19,7 @@ import {
 } from "../../infra/provider-usage.js";
 import type { MediaUnderstandingDecision } from "../../media-understanding/types.js";
 import { normalizeGroupActivation } from "../group-activation.js";
+import { resolveSelectedAndActiveModel } from "../model-runtime.js";
 import { buildStatusMessage } from "../status.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
@@ -136,6 +137,25 @@ export async function buildStatusReply(params: {
   const groupActivation = isGroup
     ? (normalizeGroupActivation(sessionEntry?.groupActivation) ?? defaultGroupActivation())
     : undefined;
+  const modelRefs = resolveSelectedAndActiveModel({
+    selectedProvider: provider,
+    selectedModel: model,
+    sessionEntry,
+  });
+  const selectedModelAuth = resolveModelAuthLabel({
+    provider,
+    cfg,
+    sessionEntry,
+    agentDir: statusAgentDir,
+  });
+  const activeModelAuth = modelRefs.activeDiffers
+    ? resolveModelAuthLabel({
+        provider: modelRefs.active.provider,
+        cfg,
+        sessionEntry,
+        agentDir: statusAgentDir,
+      })
+    : selectedModelAuth;
   const agentDefaults = cfg.agents?.defaults ?? {};
   const statusText = buildStatusMessage({
     config: cfg,
@@ -160,12 +180,8 @@ export async function buildStatusReply(params: {
     resolvedVerbose: resolvedVerboseLevel,
     resolvedReasoning: resolvedReasoningLevel,
     resolvedElevated: resolvedElevatedLevel,
-    modelAuth: resolveModelAuthLabel({
-      provider,
-      cfg,
-      sessionEntry,
-      agentDir: statusAgentDir,
-    }),
+    modelAuth: selectedModelAuth,
+    activeModelAuth,
     usageLine: usageLine ?? undefined,
     queue: {
       mode: queueSettings.mode,

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -106,6 +106,7 @@ export async function handleDirectiveOnly(
     allowedModelCatalog,
     resetModelOverride,
     surface: params.surface,
+    sessionEntry,
   });
   if (modelInfo) {
     return modelInfo;

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -63,6 +63,32 @@ describe("/model chat UX", () => {
     expect(reply?.text).toContain("Switch: /model <provider/model>");
   });
 
+  it("shows active runtime model when different from selected model", async () => {
+    const directives = parseInlineDirectives("/model");
+    const cfg = { commands: { text: true } } as unknown as OpenClawConfig;
+
+    const reply = await maybeHandleModelDirectiveInfo({
+      directives,
+      cfg,
+      agentDir: "/tmp/agent",
+      activeAgentId: "main",
+      provider: "fireworks",
+      model: "fireworks/minimax-m2p5",
+      defaultProvider: "fireworks",
+      defaultModel: "fireworks/minimax-m2p5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelCatalog: [],
+      resetModelOverride: false,
+      sessionEntry: {
+        modelProvider: "deepinfra",
+        model: "moonshotai/Kimi-K2.5",
+      },
+    });
+
+    expect(reply?.text).toContain("Current: fireworks/fireworks/minimax-m2p5 (selected)");
+    expect(reply?.text).toContain("Active: deepinfra/moonshotai/Kimi-K2.5 (runtime)");
+  });
+
   it("auto-applies closest match for typos", () => {
     const directives = parseInlineDirectives("/model anthropic/claud-opus-4-5");
     const cfg = { commands: { text: true } } as unknown as OpenClawConfig;

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -85,7 +85,7 @@ describe("/model chat UX", () => {
       },
     });
 
-    expect(reply?.text).toContain("Current: fireworks/fireworks/minimax-m2p5 (selected)");
+    expect(reply?.text).toContain("Current: fireworks/minimax-m2p5 (selected)");
     expect(reply?.text).toContain("Active: deepinfra/moonshotai/Kimi-K2.5 (runtime)");
   });
 

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -205,7 +205,7 @@ describe("buildStatusMessage", () => {
         model: "claude-haiku-4-5",
         fallbackNoticeSelectedModel: "openai/gpt-4.1-mini",
         fallbackNoticeActiveModel: "anthropic/claude-haiku-4-5",
-        fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+        fallbackNoticeReason: "rate limit",
         contextTokens: 32_000,
       },
       sessionKey: "agent:main:main",
@@ -217,11 +217,10 @@ describe("buildStatusMessage", () => {
 
     const normalized = normalizeTestText(text);
     expect(normalized).toContain("Model: openai/gpt-4.1-mini");
-    expect(normalized).toContain("(selected)");
-    expect(normalized).toContain("Active: anthropic/claude-haiku-4-5");
-    expect(normalized).toContain("(Reason: fireworks/fireworks/minimax-m2p5 rate limit)");
+    expect(normalized).toContain("Fallback: anthropic/claude-haiku-4-5");
+    expect(normalized).toContain("(rate limit)");
     expect(normalized).not.toContain(" - Reason:");
-    expect(normalized).not.toContain("Active Reason:");
+    expect(normalized).not.toContain("Active:");
     expect(normalized).toContain("di_123...abc");
   });
 
@@ -236,9 +235,9 @@ describe("buildStatusMessage", () => {
         updatedAt: 0,
         modelProvider: "anthropic",
         model: "claude-haiku-4-5",
-        fallbackNoticeSelectedModel: "fireworks/fireworks/minimax-m2p5",
+        fallbackNoticeSelectedModel: "fireworks/minimax-m2p5",
         fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
-        fallbackNoticeReason: "fireworks/fireworks/minimax-m2p5 rate limit",
+        fallbackNoticeReason: "rate limit",
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -249,9 +248,8 @@ describe("buildStatusMessage", () => {
 
     const normalized = normalizeTestText(text);
     expect(normalized).toContain("Model: openai/gpt-4.1-mini");
-    expect(normalized).not.toContain("(selected)");
-    expect(normalized).not.toContain("Active:");
-    expect(normalized).not.toContain("Reason:");
+    expect(normalized).not.toContain("Fallback:");
+    expect(normalized).not.toContain("(rate limit)");
   });
 
   it("omits active lines when runtime matches selected model", () => {
@@ -265,7 +263,7 @@ describe("buildStatusMessage", () => {
         updatedAt: 0,
         modelProvider: "openai",
         model: "gpt-4.1-mini",
-        fallbackNoticeReason: "openai/gpt-4.1-mini unknown",
+        fallbackNoticeReason: "unknown",
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -274,8 +272,7 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).not.toContain("Active:");
-    expect(normalized).not.toContain("Active Reason:");
+    expect(normalized).not.toContain("Fallback:");
   });
 
   it("keeps provider prefix from configured model", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -41,7 +41,7 @@ import {
 } from "./commands-registry.js";
 import type { CommandCategory } from "./commands-registry.types.js";
 import { resolveActiveFallbackState } from "./fallback-state.js";
-import { resolveSelectedAndActiveModel } from "./model-runtime.js";
+import { formatProviderModelRef, resolveSelectedAndActiveModel } from "./model-runtime.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
 
 type AgentDefaults = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>;
@@ -492,19 +492,19 @@ export function buildStatusMessage(args: StatusArgs): string {
   const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
 
   const selectedModelLabel = modelRefs.selected.label || "unknown";
+  const activeModelLabel = formatProviderModelRef(activeProvider, activeModel) || "unknown";
   const fallbackState = resolveActiveFallbackState({
-    selectedModelRef: `${selectedProvider}/${selectedModel}`,
-    activeModelRef: `${activeProvider}/${activeModel}`,
+    selectedModelRef: selectedModelLabel,
+    activeModelRef: activeModelLabel,
     state: entry,
   });
   const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
-  const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${
-    fallbackState.active ? " (selected)" : ""
-  }`;
-  const activeModelLine = fallbackState.active
-    ? `🧠 Active: ${activeProvider}/${activeModel}${
-        activeAuthLabelValue ? ` · 🔑 ${activeAuthLabelValue}` : ""
-      } (Reason: ${fallbackState.reason ?? "selected model unavailable"})`
+  const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}`;
+  const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
+  const fallbackLine = fallbackState.active
+    ? `↪️ Fallback: ${activeModelLabel}${
+        showFallbackAuth ? ` · 🔑 ${activeAuthLabelValue}` : ""
+      } (${fallbackState.reason ?? "selected model unavailable"})`
     : null;
   const commit = resolveCommitHash();
   const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
@@ -519,7 +519,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     versionLine,
     args.timeLine,
     modelLine,
-    activeModelLine,
+    fallbackLine,
     usageCostLine,
     `📚 ${contextLine}`,
     mediaLine,

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -40,6 +40,8 @@ import {
   type ChatCommandDefinition,
 } from "./commands-registry.js";
 import type { CommandCategory } from "./commands-registry.types.js";
+import { resolveActiveFallbackState } from "./fallback-state.js";
+import { resolveSelectedAndActiveModel } from "./model-runtime.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
 
 type AgentDefaults = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>;
@@ -72,6 +74,7 @@ type StatusArgs = {
   resolvedReasoning?: ReasoningLevel;
   resolvedElevated?: ElevatedLevel;
   modelAuth?: string;
+  activeModelAuth?: string;
   usageLine?: string;
   timeLine?: string;
   queue?: QueueStatus;
@@ -339,12 +342,19 @@ export function buildStatusMessage(args: StatusArgs): string {
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const provider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
-  let model = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
+  const selectedProvider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
+  const selectedModel = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
+  const modelRefs = resolveSelectedAndActiveModel({
+    selectedProvider,
+    selectedModel,
+    sessionEntry: entry,
+  });
+  let activeProvider = modelRefs.active.provider;
+  let activeModel = modelRefs.active.model;
   let contextTokens =
     entry?.contextTokens ??
     args.agent?.contextTokens ??
-    lookupContextTokens(model) ??
+    lookupContextTokens(activeModel) ??
     DEFAULT_CONTEXT_TOKENS;
 
   let inputTokens = entry?.inputTokens;
@@ -366,8 +376,18 @@ export function buildStatusMessage(args: StatusArgs): string {
       if (!totalTokens || totalTokens === 0 || candidate > totalTokens) {
         totalTokens = candidate;
       }
-      if (!model) {
-        model = logUsage.model ?? model;
+      if (!entry?.model && logUsage.model) {
+        const slashIndex = logUsage.model.indexOf("/");
+        if (slashIndex > 0) {
+          const provider = logUsage.model.slice(0, slashIndex).trim();
+          const model = logUsage.model.slice(slashIndex + 1).trim();
+          if (provider && model) {
+            activeProvider = provider;
+            activeModel = model;
+          }
+        } else {
+          activeModel = logUsage.model;
+        }
       }
       if (!contextTokens && logUsage.model) {
         contextTokens = lookupContextTokens(logUsage.model) ?? contextTokens;
@@ -440,14 +460,21 @@ export function buildStatusMessage(args: StatusArgs): string {
   ];
   const activationLine = activationParts.filter(Boolean).join(" · ");
 
-  const authMode = resolveModelAuthMode(provider, args.config);
-  const authLabelValue =
-    args.modelAuth ?? (authMode && authMode !== "unknown" ? authMode : undefined);
-  const showCost = authLabelValue === "api-key" || authLabelValue === "mixed";
+  const activeAuthMode = resolveModelAuthMode(activeProvider, args.config);
+  const selectedAuthLabelValue =
+    args.modelAuth ??
+    (() => {
+      const selectedAuthMode = resolveModelAuthMode(selectedProvider, args.config);
+      return selectedAuthMode && selectedAuthMode !== "unknown" ? selectedAuthMode : undefined;
+    })();
+  const activeAuthLabelValue =
+    args.activeModelAuth ??
+    (activeAuthMode && activeAuthMode !== "unknown" ? activeAuthMode : undefined);
+  const showCost = activeAuthLabelValue === "api-key" || activeAuthLabelValue === "mixed";
   const costConfig = showCost
     ? resolveModelCostConfig({
-        provider,
-        model,
+        provider: activeProvider,
+        model: activeModel,
         config: args.config,
       })
     : undefined;
@@ -464,9 +491,21 @@ export function buildStatusMessage(args: StatusArgs): string {
       : undefined;
   const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
 
-  const modelLabel = model ? `${provider}/${model}` : "unknown";
-  const authLabel = authLabelValue ? ` · 🔑 ${authLabelValue}` : "";
-  const modelLine = `🧠 Model: ${modelLabel}${authLabel}`;
+  const selectedModelLabel = modelRefs.selected.label || "unknown";
+  const fallbackState = resolveActiveFallbackState({
+    selectedModelRef: `${selectedProvider}/${selectedModel}`,
+    activeModelRef: `${activeProvider}/${activeModel}`,
+    state: entry,
+  });
+  const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
+  const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${
+    fallbackState.active ? " (selected)" : ""
+  }`;
+  const activeModelLine = fallbackState.active
+    ? `🧠 Active: ${activeProvider}/${activeModel}${
+        activeAuthLabelValue ? ` · 🔑 ${activeAuthLabelValue}` : ""
+      } (Reason: ${fallbackState.reason ?? "selected model unavailable"})`
+    : null;
   const commit = resolveCommitHash();
   const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
   const usagePair = formatUsagePair(inputTokens, outputTokens);
@@ -480,6 +519,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     versionLine,
     args.timeLine,
     modelLine,
+    activeModelLine,
     usageCostLine,
     `📚 ${contextLine}`,
     mediaLine,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -80,6 +80,13 @@ export type SessionEntry = {
   totalTokensFresh?: boolean;
   modelProvider?: string;
   model?: string;
+  /**
+   * Last selected/runtime model pair for which a fallback notice was emitted.
+   * Used to avoid repeating the same fallback notice every turn.
+   */
+  fallbackNoticeSelectedModel?: string;
+  fallbackNoticeActiveModel?: string;
+  fallbackNoticeReason?: string;
   contextTokens?: number;
   compactionCount?: number;
   memoryFlushAt?: number;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -635,6 +635,16 @@
   border-color: rgba(34, 197, 94, 0.35);
 }
 
+.compaction-indicator--fallback {
+  color: #d97706;
+  border-color: rgba(217, 119, 6, 0.35);
+}
+
+.compaction-indicator--fallback-cleared {
+  color: var(--ok);
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
 @keyframes compaction-spin {
   to {
     transform: rotate(360deg);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -824,6 +824,7 @@ export function renderApp(state: AppViewState) {
                 loading: state.chatLoading,
                 sending: state.chatSending,
                 compactionStatus: state.compactionStatus,
+                fallbackStatus: state.fallbackStatus,
                 assistantAvatarUrl: chatAvatarUrl,
                 messages: state.chatMessages,
                 toolMessages: state.chatToolMessages,

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -51,13 +51,13 @@ describe("app-tool-stream fallback lifecycle handling", () => {
         selectedModel: "fireworks/minimax-m2p5",
         activeProvider: "deepinfra",
         activeModel: "moonshotai/Kimi-K2.5",
-        reasonSummary: "fireworks/fireworks/minimax-m2p5 rate limit",
+        reasonSummary: "rate limit",
       },
     });
 
-    expect(host.fallbackStatus?.selected).toBe("fireworks/fireworks/minimax-m2p5");
+    expect(host.fallbackStatus?.selected).toBe("fireworks/minimax-m2p5");
     expect(host.fallbackStatus?.active).toBe("deepinfra/moonshotai/Kimi-K2.5");
-    expect(host.fallbackStatus?.reason).toBe("fireworks/fireworks/minimax-m2p5 rate limit");
+    expect(host.fallbackStatus?.reason).toBe("rate limit");
     vi.useRealTimers();
   });
 

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { handleAgentEvent, type FallbackStatus, type ToolStreamEntry } from "./app-tool-stream.ts";
+
+type ToolStreamHost = Parameters<typeof handleAgentEvent>[0];
+type MutableHost = ToolStreamHost & {
+  compactionStatus?: unknown;
+  compactionClearTimer?: number | null;
+  fallbackStatus?: FallbackStatus | null;
+  fallbackClearTimer?: number | null;
+};
+
+function createHost(overrides?: Partial<MutableHost>): MutableHost {
+  return {
+    sessionKey: "main",
+    chatRunId: null,
+    toolStreamById: new Map<string, ToolStreamEntry>(),
+    toolStreamOrder: [],
+    chatToolMessages: [],
+    toolStreamSyncTimer: null,
+    compactionStatus: null,
+    compactionClearTimer: null,
+    fallbackStatus: null,
+    fallbackClearTimer: null,
+    ...overrides,
+  };
+}
+
+describe("app-tool-stream fallback lifecycle handling", () => {
+  beforeAll(() => {
+    const globalWithWindow = globalThis as typeof globalThis & {
+      window?: Window & typeof globalThis;
+    };
+    if (!globalWithWindow.window) {
+      globalWithWindow.window = globalThis as unknown as Window & typeof globalThis;
+    }
+  });
+
+  it("accepts session-scoped fallback lifecycle events when no run is active", () => {
+    vi.useFakeTimers();
+    const host = createHost();
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "fallback",
+        selectedProvider: "fireworks",
+        selectedModel: "fireworks/minimax-m2p5",
+        activeProvider: "deepinfra",
+        activeModel: "moonshotai/Kimi-K2.5",
+        reasonSummary: "fireworks/fireworks/minimax-m2p5 rate limit",
+      },
+    });
+
+    expect(host.fallbackStatus?.selected).toBe("fireworks/fireworks/minimax-m2p5");
+    expect(host.fallbackStatus?.active).toBe("deepinfra/moonshotai/Kimi-K2.5");
+    expect(host.fallbackStatus?.reason).toBe("fireworks/fireworks/minimax-m2p5 rate limit");
+    vi.useRealTimers();
+  });
+
+  it("rejects idle fallback lifecycle events for other sessions", () => {
+    vi.useFakeTimers();
+    const host = createHost();
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      sessionKey: "agent:other:main",
+      data: {
+        phase: "fallback",
+        selectedProvider: "fireworks",
+        selectedModel: "fireworks/minimax-m2p5",
+        activeProvider: "deepinfra",
+        activeModel: "moonshotai/Kimi-K2.5",
+      },
+    });
+
+    expect(host.fallbackStatus).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -49,6 +49,13 @@ function resolveModelLabel(provider: unknown, model: unknown): string | null {
   }
   const providerValue = toTrimmedString(provider);
   if (providerValue) {
+    const prefix = `${providerValue}/`;
+    if (modelValue.toLowerCase().startsWith(prefix.toLowerCase())) {
+      const trimmedModel = modelValue.slice(prefix.length).trim();
+      if (trimmedModel) {
+        return `${providerValue}/${trimmedModel}`;
+      }
+    }
     return `${providerValue}/${modelValue}`;
   }
   const slashIndex = modelValue.indexOf("/");
@@ -347,9 +354,10 @@ function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventP
     if (summaries.length > 0) {
       return summaries;
     }
-    return parseFallbackAttempts(data.attempts).map(
-      (attempt) => `${attempt.provider}/${attempt.model}: ${attempt.reason}`,
-    );
+    return parseFallbackAttempts(data.attempts).map((attempt) => {
+      const modelRef = resolveModelLabel(attempt.provider, attempt.model);
+      return `${modelRef ?? `${attempt.provider}/${attempt.model}`}: ${attempt.reason}`;
+    });
   })();
 
   if (host.fallbackClearTimer != null) {

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -34,6 +34,75 @@ type ToolStreamHost = {
   toolStreamSyncTimer: number | null;
 };
 
+function toTrimmedString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function resolveModelLabel(provider: unknown, model: unknown): string | null {
+  const modelValue = toTrimmedString(model);
+  if (!modelValue) {
+    return null;
+  }
+  const providerValue = toTrimmedString(provider);
+  if (providerValue) {
+    return `${providerValue}/${modelValue}`;
+  }
+  const slashIndex = modelValue.indexOf("/");
+  if (slashIndex > 0) {
+    const p = modelValue.slice(0, slashIndex).trim();
+    const m = modelValue.slice(slashIndex + 1).trim();
+    if (p && m) {
+      return `${p}/${m}`;
+    }
+  }
+  return modelValue;
+}
+
+type FallbackAttempt = {
+  provider: string;
+  model: string;
+  reason: string;
+};
+
+function parseFallbackAttemptSummaries(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => toTrimmedString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+}
+
+function parseFallbackAttempts(value: unknown): FallbackAttempt[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const out: FallbackAttempt[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const item = entry as Record<string, unknown>;
+    const provider = toTrimmedString(item.provider);
+    const model = toTrimmedString(item.model);
+    if (!provider || !model) {
+      continue;
+    }
+    const reason =
+      toTrimmedString(item.reason)?.replace(/_/g, " ") ??
+      toTrimmedString(item.code) ??
+      (typeof item.status === "number" ? `HTTP ${item.status}` : null) ??
+      toTrimmedString(item.error) ??
+      "error";
+    out.push({ provider, model, reason });
+  }
+  return out;
+}
+
 function extractToolOutputText(value: unknown): string | null {
   if (!value || typeof value !== "object") {
     return null;
@@ -167,12 +236,25 @@ export type CompactionStatus = {
   completedAt: number | null;
 };
 
+export type FallbackStatus = {
+  phase?: "active" | "cleared";
+  selected: string;
+  active: string;
+  previous?: string;
+  reason?: string;
+  attempts: string[];
+  occurredAt: number;
+};
+
 type CompactionHost = ToolStreamHost & {
   compactionStatus?: CompactionStatus | null;
   compactionClearTimer?: number | null;
+  fallbackStatus?: FallbackStatus | null;
+  fallbackClearTimer?: number | null;
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
+const FALLBACK_TOAST_DURATION_MS = 8000;
 
 export function handleCompactionEvent(host: CompactionHost, payload: AgentEventPayload) {
   const data = payload.data ?? {};
@@ -204,6 +286,94 @@ export function handleCompactionEvent(host: CompactionHost, payload: AgentEventP
   }
 }
 
+function resolveAcceptedSession(
+  host: ToolStreamHost,
+  payload: AgentEventPayload,
+  options?: {
+    allowSessionScopedWhenIdle?: boolean;
+  },
+): { accepted: boolean; sessionKey?: string } {
+  const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
+  if (sessionKey && sessionKey !== host.sessionKey) {
+    return { accepted: false };
+  }
+  if (!host.chatRunId && options?.allowSessionScopedWhenIdle && sessionKey) {
+    return { accepted: true, sessionKey };
+  }
+  // Fallback: only accept session-less events for the active run.
+  if (!sessionKey && host.chatRunId && payload.runId !== host.chatRunId) {
+    return { accepted: false };
+  }
+  if (host.chatRunId && payload.runId !== host.chatRunId) {
+    return { accepted: false };
+  }
+  if (!host.chatRunId) {
+    return { accepted: false };
+  }
+  return { accepted: true, sessionKey };
+}
+
+function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventPayload) {
+  const data = payload.data ?? {};
+  const phase = payload.stream === "fallback" ? "fallback" : toTrimmedString(data.phase);
+  if (payload.stream === "lifecycle" && phase !== "fallback" && phase !== "fallback_cleared") {
+    return;
+  }
+
+  const accepted = resolveAcceptedSession(host, payload, { allowSessionScopedWhenIdle: true });
+  if (!accepted.accepted) {
+    return;
+  }
+
+  const selected =
+    resolveModelLabel(data.selectedProvider, data.selectedModel) ??
+    resolveModelLabel(data.fromProvider, data.fromModel);
+  const active =
+    resolveModelLabel(data.activeProvider, data.activeModel) ??
+    resolveModelLabel(data.toProvider, data.toModel);
+  const previous =
+    toTrimmedString(data.previousActiveModel) ??
+    resolveModelLabel(data.previousActiveProvider, data.previousActiveModel);
+  if (!selected || !active) {
+    return;
+  }
+  if (phase === "fallback" && selected === active) {
+    return;
+  }
+
+  const reason = toTrimmedString(data.reasonSummary) ?? toTrimmedString(data.reason);
+  const attempts = (() => {
+    const summaries = parseFallbackAttemptSummaries(data.attemptSummaries);
+    if (summaries.length > 0) {
+      return summaries;
+    }
+    return parseFallbackAttempts(data.attempts).map(
+      (attempt) => `${attempt.provider}/${attempt.model}: ${attempt.reason}`,
+    );
+  })();
+
+  if (host.fallbackClearTimer != null) {
+    window.clearTimeout(host.fallbackClearTimer);
+    host.fallbackClearTimer = null;
+  }
+  host.fallbackStatus = {
+    phase: phase === "fallback_cleared" ? "cleared" : "active",
+    selected,
+    active: phase === "fallback_cleared" ? selected : active,
+    previous:
+      phase === "fallback_cleared"
+        ? (previous ?? (active !== selected ? active : undefined))
+        : undefined,
+    reason: reason ?? undefined,
+    attempts,
+    occurredAt: Date.now(),
+  };
+  host.fallbackClearTimer = window.setTimeout(() => {
+    host.fallbackStatus = null;
+    host.fallbackClearTimer = null;
+  }, FALLBACK_TOAST_DURATION_MS);
+}
+
 export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPayload) {
   if (!payload) {
     return;
@@ -215,23 +385,19 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
+  if (payload.stream === "lifecycle" || payload.stream === "fallback") {
+    handleLifecycleFallbackEvent(host as CompactionHost, payload);
+    return;
+  }
+
   if (payload.stream !== "tool") {
     return;
   }
-  const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
-  if (sessionKey && sessionKey !== host.sessionKey) {
+  const accepted = resolveAcceptedSession(host, payload);
+  if (!accepted.accepted) {
     return;
   }
-  // Fallback: only accept session-less events for the active run.
-  if (!sessionKey && host.chatRunId && payload.runId !== host.chatRunId) {
-    return;
-  }
-  if (host.chatRunId && payload.runId !== host.chatRunId) {
-    return;
-  }
-  if (!host.chatRunId) {
-    return;
-  }
+  const sessionKey = accepted.sessionKey;
 
   const data = payload.data ?? {};
   const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : "";

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -339,8 +339,8 @@ function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventP
     resolveModelLabel(data.activeProvider, data.activeModel) ??
     resolveModelLabel(data.toProvider, data.toModel);
   const previous =
-    toTrimmedString(data.previousActiveModel) ??
-    resolveModelLabel(data.previousActiveProvider, data.previousActiveModel);
+    resolveModelLabel(data.previousActiveProvider, data.previousActiveModel) ??
+    toTrimmedString(data.previousActiveModel);
   if (!selected || !active) {
     return;
   }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -1,5 +1,5 @@
 import type { EventLogEntry } from "./app-events.ts";
-import type { CompactionStatus } from "./app-tool-stream.ts";
+import type { CompactionStatus, FallbackStatus } from "./app-tool-stream.ts";
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
@@ -61,6 +61,7 @@ export type AppViewState = {
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
   compactionStatus: CompactionStatus | null;
+  fallbackStatus: FallbackStatus | null;
   chatAvatarUrl: string | null;
   chatThinkingLevel: string | null;
   chatQueue: ChatQueueItem[];

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -48,6 +48,7 @@ import {
   resetToolStream as resetToolStreamInternal,
   type ToolStreamEntry,
   type CompactionStatus,
+  type FallbackStatus,
 } from "./app-tool-stream.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { normalizeAssistantIdentity } from "./assistant-identity.ts";
@@ -140,6 +141,7 @@ export class OpenClawApp extends LitElement {
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
+  @state() fallbackStatus: FallbackStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
   @state() chatQueue: ChatQueueItem[] = [];

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -23,6 +23,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     sending: false,
     canAbort: false,
     compactionStatus: null,
+    fallbackStatus: null,
     messages: [],
     toolMessages: [],
     stream: null,
@@ -108,6 +109,75 @@ describe("chat view", () => {
     );
 
     expect(container.querySelector(".compaction-indicator")).toBeNull();
+    nowSpy.mockRestore();
+  });
+
+  it("renders fallback indicator shortly after fallback event", () => {
+    const container = document.createElement("div");
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    render(
+      renderChat(
+        createProps({
+          fallbackStatus: {
+            selected: "fireworks/fireworks/minimax-m2p5",
+            active: "deepinfra/moonshotai/Kimi-K2.5",
+            attempts: ["fireworks/fireworks/minimax-m2p5: rate limit"],
+            occurredAt: 900,
+          },
+        }),
+      ),
+      container,
+    );
+
+    const indicator = container.querySelector(".compaction-indicator--fallback");
+    expect(indicator).not.toBeNull();
+    expect(indicator?.textContent).toContain("Fallback active: deepinfra/moonshotai/Kimi-K2.5");
+    nowSpy.mockRestore();
+  });
+
+  it("hides stale fallback indicator", () => {
+    const container = document.createElement("div");
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(20_000);
+    render(
+      renderChat(
+        createProps({
+          fallbackStatus: {
+            selected: "fireworks/fireworks/minimax-m2p5",
+            active: "deepinfra/moonshotai/Kimi-K2.5",
+            attempts: [],
+            occurredAt: 0,
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".compaction-indicator--fallback")).toBeNull();
+    nowSpy.mockRestore();
+  });
+
+  it("renders fallback-cleared indicator shortly after transition", () => {
+    const container = document.createElement("div");
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    render(
+      renderChat(
+        createProps({
+          fallbackStatus: {
+            phase: "cleared",
+            selected: "fireworks/fireworks/minimax-m2p5",
+            active: "fireworks/fireworks/minimax-m2p5",
+            previous: "deepinfra/moonshotai/Kimi-K2.5",
+            attempts: [],
+            occurredAt: 900,
+          },
+        }),
+      ),
+      container,
+    );
+
+    const indicator = container.querySelector(".compaction-indicator--fallback-cleared");
+    expect(indicator).not.toBeNull();
+    expect(indicator?.textContent).toContain("Fallback cleared: fireworks/fireworks/minimax-m2p5");
     nowSpy.mockRestore();
   });
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -119,9 +119,9 @@ describe("chat view", () => {
       renderChat(
         createProps({
           fallbackStatus: {
-            selected: "fireworks/fireworks/minimax-m2p5",
+            selected: "fireworks/minimax-m2p5",
             active: "deepinfra/moonshotai/Kimi-K2.5",
-            attempts: ["fireworks/fireworks/minimax-m2p5: rate limit"],
+            attempts: ["fireworks/minimax-m2p5: rate limit"],
             occurredAt: 900,
           },
         }),
@@ -142,7 +142,7 @@ describe("chat view", () => {
       renderChat(
         createProps({
           fallbackStatus: {
-            selected: "fireworks/fireworks/minimax-m2p5",
+            selected: "fireworks/minimax-m2p5",
             active: "deepinfra/moonshotai/Kimi-K2.5",
             attempts: [],
             occurredAt: 0,
@@ -164,8 +164,8 @@ describe("chat view", () => {
         createProps({
           fallbackStatus: {
             phase: "cleared",
-            selected: "fireworks/fireworks/minimax-m2p5",
-            active: "fireworks/fireworks/minimax-m2p5",
+            selected: "fireworks/minimax-m2p5",
+            active: "fireworks/minimax-m2p5",
             previous: "deepinfra/moonshotai/Kimi-K2.5",
             attempts: [],
             occurredAt: 900,
@@ -177,7 +177,7 @@ describe("chat view", () => {
 
     const indicator = container.querySelector(".compaction-indicator--fallback-cleared");
     expect(indicator).not.toBeNull();
-    expect(indicator?.textContent).toContain("Fallback cleared: fireworks/fireworks/minimax-m2p5");
+    expect(indicator?.textContent).toContain("Fallback cleared: fireworks/minimax-m2p5");
     nowSpy.mockRestore();
   });
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -21,6 +21,16 @@ export type CompactionIndicatorStatus = {
   completedAt: number | null;
 };
 
+export type FallbackIndicatorStatus = {
+  phase?: "active" | "cleared";
+  selected: string;
+  active: string;
+  previous?: string;
+  reason?: string;
+  attempts: string[];
+  occurredAt: number;
+};
+
 export type ChatProps = {
   sessionKey: string;
   onSessionKeyChange: (next: string) => void;
@@ -30,6 +40,7 @@ export type ChatProps = {
   sending: boolean;
   canAbort?: boolean;
   compactionStatus?: CompactionIndicatorStatus | null;
+  fallbackStatus?: FallbackIndicatorStatus | null;
   messages: unknown[];
   toolMessages: unknown[];
   stream: string | null;
@@ -72,6 +83,7 @@ export type ChatProps = {
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
+const FALLBACK_TOAST_DURATION_MS = 8000;
 
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
   el.style.height = "auto";
@@ -105,6 +117,45 @@ function renderCompactionIndicator(status: CompactionIndicatorStatus | null | un
   }
 
   return nothing;
+}
+
+function renderFallbackIndicator(status: FallbackIndicatorStatus | null | undefined) {
+  if (!status) {
+    return nothing;
+  }
+  const phase = status.phase ?? "active";
+  const elapsed = Date.now() - status.occurredAt;
+  if (elapsed >= FALLBACK_TOAST_DURATION_MS) {
+    return nothing;
+  }
+  const details = [
+    `Selected: ${status.selected}`,
+    phase === "cleared" ? `Active: ${status.selected}` : `Active: ${status.active}`,
+    phase === "cleared" && status.previous ? `Previous fallback: ${status.previous}` : null,
+    status.reason ? `Reason: ${status.reason}` : null,
+    status.attempts.length > 0 ? `Attempts: ${status.attempts.slice(0, 3).join(" | ")}` : null,
+  ]
+    .filter(Boolean)
+    .join(" • ");
+  const message =
+    phase === "cleared"
+      ? `Fallback cleared: ${status.selected}`
+      : `Fallback active: ${status.active}`;
+  const className =
+    phase === "cleared"
+      ? "compaction-indicator compaction-indicator--fallback-cleared"
+      : "compaction-indicator compaction-indicator--fallback";
+  const icon = phase === "cleared" ? icons.check : icons.brain;
+  return html`
+    <div
+      class=${className}
+      role="status"
+      aria-live="polite"
+      title=${details}
+    >
+      ${icon} ${message}
+    </div>
+  `;
 }
 
 function generateAttachmentId(): string {
@@ -352,6 +403,7 @@ export function renderChat(props: ChatProps) {
           : nothing
       }
 
+      ${renderFallbackIndicator(props.fallbackStatus)}
       ${renderCompactionIndicator(props.compactionStatus)}
 
       ${


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: model fallback activation/clear transitions were not clearly surfaced to users in a cohesive way across chat verbosity, /status, and WebUI.
- Why it matters: users could see a selected model but not easily understand when runtime had switched to fallback, why it switched, or when fallback
cleared.
- What changed: added one-time fallback lifecycle notices, unified fallback reason summaries, and aligned /status + WebUI presentation for selected-vs-
active model context.
- What did NOT change (scope boundary): fallback routing decision logic/provider behavior itself was not redesigned; this PR focuses on observability and
UX consistency.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #9550
- Related #None

## User-visible / Behavior Changes

- Verbose mode now emits one-time lifecycle messages for fallback activation and fallback clear transitions.
- Fallback notices use consistent wording (Model Fallback:) and reason summaries.
- /status now shows Active: only when fallback is active, includes selected-model-like credential context, and appends reason as (Reason: <summary>).
- WebUI fallback indicators now align with existing tool/event stream UX patterns for cohesive visibility.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: None

## Repro + Verification

### Environment

- OS: macOS host + VM (clawbox-1)
- Runtime/container: OpenClaw gateway in VM, hot-reload via pnpm:gateway watch
- Model/provider: primary fireworks/fireworks/minimax-m2p5, fallback deepinfra/moonshotai/Kimi-K2.5
- Integration/channel (if any): WebUI chat + /status
- Relevant config (redacted): Fireworks cooldown set/cleared in ~/.openclaw/auth-profiles.json to deterministically force fallback transitions

### Steps

1. Configure primary + fallback and force primary cooldown.
2. Send message in WebUI with verbose enabled and observe fallback lifecycle message + indicator behavior.
3. Clear cooldown and send again; confirm one-time fallback-cleared transition and /status updates.

### Expected

- One-time fallback activation message appears when fallback begins.
- One-time fallback-cleared message appears when fallback ends.
- /status shows Active: only while fallback is active and includes reason summary consistently.

### Actual

- Matches expected behavior in manual VM/WebUI validation.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

The chat channel validation loop was:
- Set agent's primary model to a cooldown state
- Send a new message to the agent, triggering a model fallback
Observe: Verbose-mode message, /status shows new 'Active:' line
- Send another message to the agent
Observe: No second verbose-mode message, /status still shows 'Active:' line

- Remove agent's primary model cooldown state
- Send a new message to the agent, triggering a model fallback (to primary)
Observe: Verbose-mode 'clear' message, /status no longer shows 'Active:' line
- Send another message to the agent
Observe: No second verbose-mode message, /status still no longer shows 'Active:' line

The WebUI validation loop was the same, except looking for the 'compaction toast'-type UI.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: None

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: disable verbose output for runtime notices and/or revert this feature commit.
- Files/config to restore: auto-reply fallback observability paths and WebUI fallback indicator rendering paths from previous commit.
- Known bad symptoms reviewers should watch for: repeated fallback notices every turn, missing fallback-clear notice, /status showing stale Active: line
when fallback is not active.

## Risks and Mitigations

- Risk: lifecycle notice spam if transition state tracking regresses.
- Mitigation: explicit transition-state helper with one-time emission tests.
- Risk: reason text drift between backend and UI.
- Mitigation: backend canonical summary reuse and parser simplification in UI path.

## Screenshots
<img width="603" height="2985" alt="chat_model_fallback" src="https://github.com/user-attachments/assets/ce9b3240-7601-4d7b-8e48-cd8b8227f83f" />
<img width="1319" height="126" alt="webui_model_clear" src="https://github.com/user-attachments/assets/8b70bc59-14ee-4637-a385-38122d8316f6" />
<img width="1323" height="128" alt="webui_model_fallback" src="https://github.com/user-attachments/assets/450c5889-aefd-424c-8634-42aa565862c2" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added model fallback lifecycle visibility across CLI, WebUI, and verbose logs. When the runtime switches from a selected model to a fallback model (e.g., due to rate limits or provider cooldowns), users now see one-time transition notices and consistent status indicators.

- Introduced `fallback-state.ts` with transition detection logic that tracks selected vs active model pairs and emits one-time notices for fallback activation and clearing transitions
- Extended `SessionEntry` with `fallbackNoticeSelectedModel`, `fallbackNoticeActiveModel`, and `fallbackNoticeReason` fields to persist transition state across runs
- Enhanced `runReplyAgent` to emit lifecycle agent events (`phase: "fallback"` and `phase: "fallback_cleared"`) with verbose notices prepended to reply payloads
- Updated `/status` command to display both selected model and active runtime model when fallback is active, including reason summary
- Added WebUI fallback indicators (toast-style notifications) that appear for 8 seconds during transitions and align with existing compaction indicator UX patterns
- Comprehensive test coverage includes unit tests for state transitions, integration tests for one-time emission guarantees, and WebUI event handling tests

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The implementation is well-architected with clear separation of concerns: state management in `fallback-state.ts`, runtime integration in `agent-runner.ts`, status display in `status.ts`, and UI rendering in WebUI components. The PR includes comprehensive test coverage (110 lines in `fallback-state.test.ts`, 390+ lines added to `agent-runner.runreplyagent.test.ts`, 137 lines in `server-chat.agent-events.test.ts`, and 86 lines in `app-tool-stream.node.test.ts`) that validates transition logic, one-time emission guarantees, and session-scoped event handling. The changes are purely additive for observability and do not modify fallback routing decision logic itself, minimizing risk to existing behavior. Type safety is maintained throughout, and the implementation follows existing patterns (agent events, session state persistence, WebUI toast indicators).
- No files require special attention

<sub>Last reviewed commit: 0e1e23e</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->