### PR TITLE
fix(ollama): cover remaining completeSimple gaps and add transcript policy

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -34,6 +34,11 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
 import { getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
+import {
+  createOllamaStreamFn,
+  ensureOllamaApiRegistered,
+  OLLAMA_NATIVE_BASE_URL,
+} from "../ollama-stream.js";
 import { resolveOwnerDisplaySetting } from "../owner-display.js";
 import {
   ensureSessionHeader,
@@ -583,6 +588,19 @@ export async function compactEmbeddedPiSessionDirect(
         resourceLoader,
       });
       applySystemPromptOverrideToSession(session, systemPromptOverride());
+
+      // Ollama native API: register "ollama" in the SDK's API provider
+      // registry so that completeSimple() (used by session.compact()) can
+      // reach the native /api/chat endpoint (#20652, #11828).
+      if (model.api === "ollama") {
+        ensureOllamaApiRegistered();
+        const providerConfig = params.config?.models?.providers?.[model.provider];
+        const modelBaseUrl = typeof model.baseUrl === "string" ? model.baseUrl.trim() : "";
+        const providerBaseUrl =
+          typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
+        const ollamaBaseUrl = modelBaseUrl || providerBaseUrl || OLLAMA_NATIVE_BASE_URL;
+        session.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl);
+      }
 
       try {
         const prior = await sanitizeSessionHistory({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -42,7 +42,11 @@ import { isTimeoutError } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
-import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-stream.js";
+import {
+  createOllamaStreamFn,
+  ensureOllamaApiRegistered,
+  OLLAMA_NATIVE_BASE_URL,
+} from "../../ollama-stream.js";
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import {
   isCloudCodeAssistFormatError,
@@ -717,9 +721,10 @@ export async function runEmbeddedAttempt(
         workspaceDir: params.workspaceDir,
       });
 
-      // Ollama native API: bypass SDK's streamSimple and use direct /api/chat calls
-      // for reliable streaming + tool calling support (#11828).
+      // Ollama native API: register "ollama" in the SDK's API provider registry
+      // and bypass SDK's streamSimple with direct /api/chat calls (#11828, #20652).
       if (params.model.api === "ollama") {
+        ensureOllamaApiRegistered();
         // Use the resolved model baseUrl first so custom provider aliases work.
         const providerConfig = params.config?.models?.providers?.[params.model.provider];
         const modelBaseUrl =

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -90,6 +90,7 @@ export function resolveTranscriptPolicy(params: {
     !isOpenAi &&
     !OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS.has(provider);
   const isMistral = isMistralModel({ provider, modelId });
+  const isOllama = params.modelApi === "ollama";
   const isOpenRouterGemini =
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&
     modelId.toLowerCase().includes("gemini");
@@ -100,9 +101,10 @@ export function resolveTranscriptPolicy(params: {
   // Drop these blocks at send-time to keep sessions usable.
   const dropThinkingBlocks = isCopilotClaude;
 
-  const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
+  const needsNonImageSanitize =
+    isGoogle || isAnthropic || isMistral || isOpenRouterGemini || isOllama;
 
-  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
+  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic || isOllama;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
     : sanitizeToolCallIds
@@ -127,6 +129,6 @@ export function resolveTranscriptPolicy(params: {
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && (isAnthropic || isStrictOpenAiCompatible),
-    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic || isOllama),
   };
 }

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -8,6 +8,7 @@ import {
   resolveModelRefFromString,
   type ModelRef,
 } from "../agents/model-selection.js";
+import { ensureOllamaApiRegistered } from "../agents/ollama-stream.js";
 import { resolveModel } from "../agents/pi-embedded-runner/model.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type {
@@ -439,6 +440,10 @@ export async function summarizeText(params: {
     await getApiKeyForModel({ model: resolved.model, cfg }),
     ref.provider,
   );
+
+  if (resolved.model.api === "ollama") {
+    ensureOllamaApiRegistered();
+  }
 
   try {
     const controller = new AbortController();


### PR DESCRIPTION
## Summary

- Register `"ollama"` in the SDK's global API provider registry via `ensureOllamaApiRegistered()` for all `completeSimple()` call sites
- Add Ollama API provider registration in TTS text summarization path
- Add `"ollama"` case to `transcript-policy.ts` for proper transcript handling

## Changes

| File | Change |
|------|--------|
| `src/agents/ollama-stream.ts` | Add `ensureOllamaApiRegistered()` using `registerApiProvider()` |
| `src/tts/tts-core.ts` | Call `ensureOllamaApiRegistered()` before `completeSimple()` when summary model is Ollama |
| `src/agents/transcript-policy.ts` | Add `isOllama` flag: enable full sanitization, tool-call ID normalization, tool-use/result pairing repair, synthetic tool results |

## Detail

### 1. TTS summarization (HIGH)

`tts-core.ts:summarizeText()` calls `completeSimple()` directly to summarize long text before speech synthesis. If the TTS summary model is configured as an Ollama model, the SDK's API provider registry doesn't know about `"ollama"` and throws "No API provider registered for api: ollama".

### 2. Branch summarization (MEDIUM)

The SDK's internal `branch-summarization.js` also uses `completeSimple()`. By adding `ensureOllamaApiRegistered()` to `ollama-stream.ts` (same module), any code path that imports from `ollama-stream` will have the function available. The TTS fix also ensures early registration.

### 3. Transcript policy (LOW)

`resolveTranscriptPolicy()` had no branch for `model.api === "ollama"`. All flags defaulted to `false`. Now Ollama models get:
- `sanitizeMode: "full"` — full transcript sanitization
- `sanitizeToolCallIds: true` — normalize tool-call IDs
- `repairToolUseResultPairing: true` — repair mismatched tool-use/result pairs
- `allowSyntheticToolResults: true` — allow synthetic tool results

## Test plan

- [x] oxlint: 0 warnings, 0 errors
- [x] oxfmt: formatting passes
- [ ] Manual: TTS with Ollama summary model
- [x] Manual: Ollama model with tool calling (transcript policy) — verified with `devstral-small-2:24b` via combined testing with #20665

Closes #20699
Depends on #20665