### PR TITLE
fix(subagents): prioritize agent runtime default model over global defaults on spawn

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -343,7 +343,6 @@ export function resolveSubagentSpawnModelSelection(params: {
       cfg: params.cfg,
       agentId: params.agentId,
     }) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.model?.primary) ??
     `${runtimeDefault.provider}/${runtimeDefault.model}`
   );
 }

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.e2e.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.e2e.test.ts
@@ -236,7 +236,7 @@ describe("openclaw-tools: subagents (sessions_spawn model + thinking)", () => {
     });
   });
 
-  it("sessions_spawn prefers target agent primary model over global default", async () => {
+  it("sessions_spawn prefers target agent runtime default model over global defaults.model.primary", async () => {
     await expectSpawnUsesConfiguredModel({
       config: {
         session: { mainKey: "main", scope: "per-sender" },


### PR DESCRIPTION
## Summary

   Fix subagent model resolution so `sessions_spawn` prefers the target agent’s runtime default model before falling
 back to `agents.defaults.model.primary`.

   ## Root Cause

   `resolveSubagentSpawnModelSelect ion` used this order:

   1. explicit `sessions_spawn.model`
   2. subagent model config (`subagents.model` / per-agent subagents / agent model)
   3. `agents.defaults.model.primary`
   4. runtime default from `resolveDefaultModelForAgent`

   Because global `agents.defaults.model.primary` was checked before runtime default, agent-specific runtime defaults
 could be incorrectly overridden during subagent spawn.

   ## Fix

   Updated `resolveSubagentSpawnModelSelect ion` in `src/agents/model-selection.ts`:

   - removed the direct fallback to `agents.defaults.model.primary`
   - now falls back directly to runtime default (`resolveDefaultModelForAgent`), which already resolves agent-specific
 primary model correctly

   Effective precedence is now:

   1. explicit `sessions_spawn.model`
   2. subagent-specific configured model
   3. target agent runtime default model

   ## Test Plan

   Ran:

   ```bash
   corepack pnpm vitest run --config vitest.e2e.config.ts
 src/agents/openclaw-tools.subagents.sessions-spawn.model.e2e.test.ts
 ```

 Result:
 - 1 test file passed
 - 9 tests passed

 Includes the repro scenario:
 - target agent has custom primary model
 - spawn called without model override
 - expected: child session uses agent model, not global defaults primary

 Backward Compatibility

 - No API/schema changes
 - Explicit sessions_spawn.model behavior unchanged
 - Existing subagent-specific model configs remain highest-priority after explicit override
 - Only fallback precedence is corrected to match intended behavior
 
Fixes #20002

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed subagent model resolution to correctly prioritize agent-specific runtime default models over global `agents.defaults.model.primary`. The change removes a premature fallback to the global default, allowing `resolveDefaultModelForAgent` to properly apply agent-specific model configuration before falling back to global defaults. This ensures that when spawning a subagent for an agent with a custom primary model, the agent's model is used instead of being incorrectly overridden by the global default.

**Key changes:**
- Removed direct fallback to `agents.defaults.model.primary` in `resolveSubagentSpawnModelSelection` (src/agents/model-selection.ts:346)
- Updated test description to clarify the expected behavior
- All existing tests pass, including the new test validating the fix

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple one-line removal that corrects the model resolution precedence order. The logic is sound: `resolveDefaultModelForAgent` already handles agent-specific model overrides correctly by temporarily patching the config before calling `resolveConfiguredModelRef`. The removed line was causing premature fallback to global defaults, bypassing agent-specific configuration. All tests pass, including a specific test validating the corrected behavior. No API or schema changes, backward compatible.
- No files require special attention

<sub>Last reviewed commit: f19023d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->