### PR TITLE
fix(signal): use correct JSON-RPC param names for sendReaction

### DIFF
--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from "node:http";
+import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Duplex } from "node:stream";
-import { createServer } from "node:http";
 import WebSocket, { WebSocketServer } from "ws";
 import { loadConfig } from "../config/config.js";
 import { isLoopbackAddress, isLoopbackHost } from "../gateway/net.js";

--- a/src/signal/send-reactions.test.ts
+++ b/src/signal/send-reactions.test.ts
@@ -30,12 +30,12 @@ describe("sendReactionSignal", () => {
     rpcMock.mockReset().mockResolvedValue({ timestamp: 123 });
   });
 
-  it("sends recipient as string for DM reactions", async () => {
+  it("sends recipient as array for DM reactions", async () => {
     await sendReactionSignal("uuid:123e4567-e89b-12d3-a456-426614174000", 123, "🔥");
 
     const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(rpcMock).toHaveBeenCalledWith("sendReaction", expect.any(Object), expect.any(Object));
-    expect(params.recipient).toBe("123e4567-e89b-12d3-a456-426614174000");
+    expect(params.recipient).toEqual(["123e4567-e89b-12d3-a456-426614174000"]);
     expect(params.targetAuthor).toBe("123e4567-e89b-12d3-a456-426614174000");
     expect(params).not.toHaveProperty("recipients");
     expect(params).not.toHaveProperty("groupId");
@@ -56,13 +56,13 @@ describe("sendReactionSignal", () => {
     expect(params.targetAuthor).toBe("123e4567-e89b-12d3-a456-426614174000");
   });
 
-  it("sends isRemove for reaction removal", async () => {
+  it("sends remove for reaction removal", async () => {
     await removeReactionSignal("+15551230000", 456, "❌");
 
     const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
-    expect(params.recipient).toBe("+15551230000");
+    expect(params.recipient).toEqual(["+15551230000"]);
     expect(params.targetAuthor).toBe("+15551230000");
-    expect(params.isRemove).toBe(true);
-    expect(params).not.toHaveProperty("remove");
+    expect(params.remove).toBe(true);
+    expect(params).not.toHaveProperty("isRemove");
   });
 });

--- a/src/signal/send-reactions.test.ts
+++ b/src/signal/send-reactions.test.ts
@@ -30,36 +30,39 @@ describe("sendReactionSignal", () => {
     rpcMock.mockReset().mockResolvedValue({ timestamp: 123 });
   });
 
-  it("uses recipients array and targetAuthor for uuid dms", async () => {
+  it("sends recipient as string for DM reactions", async () => {
     await sendReactionSignal("uuid:123e4567-e89b-12d3-a456-426614174000", 123, "🔥");
 
     const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(rpcMock).toHaveBeenCalledWith("sendReaction", expect.any(Object), expect.any(Object));
-    expect(params.recipients).toEqual(["123e4567-e89b-12d3-a456-426614174000"]);
-    expect(params.groupIds).toBeUndefined();
+    expect(params.recipient).toBe("123e4567-e89b-12d3-a456-426614174000");
     expect(params.targetAuthor).toBe("123e4567-e89b-12d3-a456-426614174000");
-    expect(params).not.toHaveProperty("recipient");
+    expect(params).not.toHaveProperty("recipients");
     expect(params).not.toHaveProperty("groupId");
+    expect(params).not.toHaveProperty("groupIds");
   });
 
-  it("uses groupIds array and maps targetAuthorUuid", async () => {
+  it("sends groupId as string for group reactions", async () => {
     await sendReactionSignal("", 123, "✅", {
       groupId: "group-id",
       targetAuthorUuid: "uuid:123e4567-e89b-12d3-a456-426614174000",
     });
 
     const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
-    expect(params.recipients).toBeUndefined();
-    expect(params.groupIds).toEqual(["group-id"]);
+    expect(params).not.toHaveProperty("recipient");
+    expect(params).not.toHaveProperty("recipients");
+    expect(params).not.toHaveProperty("groupIds");
+    expect(params.groupId).toBe("group-id");
     expect(params.targetAuthor).toBe("123e4567-e89b-12d3-a456-426614174000");
   });
 
-  it("defaults targetAuthor to recipient for removals", async () => {
+  it("sends isRemove for reaction removal", async () => {
     await removeReactionSignal("+15551230000", 456, "❌");
 
     const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
-    expect(params.recipients).toEqual(["+15551230000"]);
+    expect(params.recipient).toBe("+15551230000");
     expect(params.targetAuthor).toBe("+15551230000");
-    expect(params.remove).toBe(true);
+    expect(params.isRemove).toBe(true);
+    expect(params).not.toHaveProperty("remove");
   });
 });

--- a/src/signal/send-reactions.ts
+++ b/src/signal/send-reactions.ts
@@ -106,11 +106,11 @@ async function sendReactionSignalCore(params: {
   const requestParams: Record<string, unknown> = {
     emoji: normalizedEmoji,
     targetTimestamp: params.targetTimestamp,
-    ...(params.remove ? { isRemove: true } : {}),
+    ...(params.remove ? { remove: true } : {}),
     ...targetAuthorParams,
   };
   if (normalizedRecipient) {
-    requestParams.recipient = normalizedRecipient;
+    requestParams.recipient = [normalizedRecipient];
   }
   if (groupId) {
     requestParams.groupId = groupId;

--- a/src/signal/send-reactions.ts
+++ b/src/signal/send-reactions.ts
@@ -106,14 +106,14 @@ async function sendReactionSignalCore(params: {
   const requestParams: Record<string, unknown> = {
     emoji: normalizedEmoji,
     targetTimestamp: params.targetTimestamp,
-    ...(params.remove ? { remove: true } : {}),
+    ...(params.remove ? { isRemove: true } : {}),
     ...targetAuthorParams,
   };
   if (normalizedRecipient) {
-    requestParams.recipients = [normalizedRecipient];
+    requestParams.recipient = normalizedRecipient;
   }
   if (groupId) {
-    requestParams.groupIds = [groupId];
+    requestParams.groupId = groupId;
   }
   if (account) {
     requestParams.account = account;


### PR DESCRIPTION
## Summary

- Problem: Signal reactions via `message action=react` can be dropped because OpenClaw sends the wrong JSON-RPC parameter names to the signal-cli daemon.
- Why it matters: reactions are a primary low-noise interaction mode; drops look like the agent ignored the message.
- What changed: align `sendReaction` RPC params to signal-cli JSON-RPC (`recipient` / `groupId` / `remove`).
- What did NOT change: no config defaults, no new endpoints, no behavior changes for non-Signal channels.

## Root cause

OpenClaw talks to signal-cli’s JSON-RPC daemon over HTTP (`POST /api/v1/rpc`). The daemon maps CLI args to JSON-RPC params in camelCase; for `sendReaction`, the target args are:

- positional `recipient` (multi-value)
- `--group-id` (multi-value)
- `--remove` (flag)

So the JSON-RPC params are `recipient`, `groupId`, and `remove`.

OpenClaw was sending `recipients` / `groupIds` (plural), so the daemon didn’t receive a recipient/group target and the reaction never delivered.

References:
- signal-cli JSON-RPC HTTP endpoints: https://github.com/AsamK/signal-cli/blob/master/man/signal-cli-jsonrpc.5.adoc
- sendReaction command args: https://github.com/AsamK/signal-cli/blob/master/src/main/java/org/asamk/signal/commands/SendReactionCommand.java

## Changes

- `recipient: [<uuid|e164>]` instead of `recipients: [...]`
- `groupId: "<base64>"` instead of `groupIds: [...]`
- keep `remove: true` for reaction removal (matches `--remove`)
- update unit tests to assert the exact param shape
- formatting-only: reorder one import in `src/browser/extension-relay.ts` to satisfy `pnpm format:check` with the repo’s pinned oxfmt

## Test plan

- `pnpm check`
- `npx vitest run src/signal/send-reactions.test.ts`

## Manual verification (not in CI)

Not run against a live Signal daemon in this PR.

Suggested quick check:
1. DM: `message action=react channel=signal target=uuid:<peer> messageId=<ts> emoji=🔥`
2. Group: `message action=react channel=signal target=signal:group:<id> targetAuthor=uuid:<sender> messageId=<ts> emoji=✅`
3. Removal: same call with `remove=true`

## AI assistance

AI-assisted (Cursor). I reviewed the code paths and updated targeted unit tests.