### PR TITLE
feat(openai-compat): Open WebUI support — CORS, OPTIONS, GET /v1/models, streaming errors

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -426,7 +426,11 @@ export async function agentCommand(
         ) {
           const { updated } = applyModelOverrideToSessionEntry({
             entry,
-            selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
+            selection: {
+              provider: defaultProvider,
+              model: defaultModel,
+              isDefault: true,
+            },
           });
           if (updated) {
             await persistSessionEntry({
@@ -441,7 +445,7 @@ export async function agentCommand(
     }
 
     const storedProviderOverride = sessionEntry?.providerOverride?.trim();
-    const storedModelOverride = sessionEntry?.modelOverride?.trim();
+    const storedModelOverride = sessionEntry?.modelOverride?.trim() || opts.modelOverride?.trim();
     if (storedModelOverride) {
       const candidateProvider = storedProviderOverride || defaultProvider;
       const normalizedStored = normalizeModelRef(candidateProvider, storedModelOverride);

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -76,4 +76,6 @@ export type AgentCommandOpts = {
   inputProvenance?: InputProvenance;
   /** Per-call stream param overrides (best-effort). */
   streamParams?: AgentStreamParams;
+  /** Override the LLM model for this request (e.g. "claude-sonnet-4-6"). Takes lower priority than a session-stored model override. */
+  modelOverride?: string;
 };

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -117,6 +117,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.controlUi.allowInsecureAuth": "Allow Insecure Control UI Auth",
   "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
   "gateway.http.endpoints.chatCompletions.enabled": "OpenAI Chat Completions Endpoint",
+  "gateway.http.endpoints.chatCompletions.allowedOrigins": "Chat Completions CORS Origins",
   "gateway.reload.mode": "Config Reload Mode",
   "gateway.reload.debounceMs": "Config Reload Debounce (ms)",
   "gateway.nodes.browser.mode": "Gateway Node Browser Mode",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -173,6 +173,14 @@ export type GatewayHttpChatCompletionsConfig = {
    * Default: false when absent.
    */
   enabled?: boolean;
+  /**
+   * CORS origins allowed to access OpenAI-compatible endpoints.
+   * Supports exact origins (e.g. "http://localhost:3000") and wildcards ("*").
+   * When absent, requests without an Origin header are allowed; cross-origin
+   * browser requests must list the origin explicitly.
+   * Example: ["http://localhost:3000", "https://chat.example.com"]
+   */
+  allowedOrigins?: string[];
 };
 
 export type GatewayHttpResponsesConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -493,6 +493,7 @@ export const OpenClawSchema = z
                 chatCompletions: z
                   .object({
                     enabled: z.boolean().optional(),
+                    allowedOrigins: z.array(z.string()).optional(),
                   })
                   .strict()
                   .optional(),

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommand } from "../commands/agent.js";
 import { loadConfig } from "../config/config.js";
-import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import { onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
@@ -468,11 +468,6 @@ export async function handleOpenAiHttpRequest(
             finish_reason: "stop",
           },
         ],
-      });
-      emitAgentEvent({
-        runId,
-        stream: "lifecycle",
-        data: { phase: "error" },
       });
     } finally {
       if (!closed) {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -222,8 +222,22 @@ async function handleOpenAiModelsRequest(
   });
   const activeProvider = configuredRef.provider || DEFAULT_PROVIDER;
 
+  const defaultModel = configuredRef.model || "claude-opus-4-6";
+
   const catalog = await loadModelCatalog({ config: cfg }).catch(() => []);
   const filtered = catalog.filter((entry) => entry.provider === activeProvider);
+
+  // Sort: configured default model first so clients select it automatically.
+  filtered.sort((a, b) => {
+    if (a.id === defaultModel) {
+      return -1;
+    }
+    if (b.id === defaultModel) {
+      return 1;
+    }
+    return 0;
+  });
+
   const models =
     filtered.length > 0
       ? filtered.map((entry) => ({
@@ -234,7 +248,7 @@ async function handleOpenAiModelsRequest(
         }))
       : [
           {
-            id: "claude-opus-4-6",
+            id: defaultModel,
             object: "model",
             created,
             owned_by: activeProvider,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -229,7 +229,10 @@ export function createHooksRequestHandler(
     const expired = !current || nowMs - current.windowStartedAtMs >= HOOK_AUTH_FAILURE_WINDOW_MS;
     const next: HookAuthFailure = expired
       ? { count: 1, windowStartedAtMs: nowMs }
-      : { count: current.count + 1, windowStartedAtMs: current.windowStartedAtMs };
+      : {
+          count: current.count + 1,
+          windowStartedAtMs: current.windowStartedAtMs,
+        };
     // Delete-before-set refreshes Map insertion order so recently-active
     // clients are not evicted before dormant ones during oldest-half eviction.
     if (hookAuthFailures.has(clientKey)) {
@@ -533,11 +536,14 @@ export function createGatewayHttpServer(opts: {
         }
       }
       if (openAiChatCompletionsEnabled) {
+        const openAiAllowedOrigins =
+          configSnapshot.gateway?.http?.endpoints?.chatCompletions?.allowedOrigins;
         if (
           await handleOpenAiHttpRequest(req, res, {
             auth: resolvedAuth,
             trustedProxies,
             rateLimiter,
+            allowedOrigins: openAiAllowedOrigins,
           })
         ) {
           return;


### PR DESCRIPTION
## Summary

Enables browser-based OpenAI-compatible clients (Open WebUI, LibreChat, etc.) to connect directly to the OpenClaw gateway without a reverse-proxy workaround.

- **CORS support** — new `gateway.http.endpoints.chatCompletions.allowedOrigins` config field; gateway reflects the request origin in `Access-Control-Allow-Origin` when it matches the allowlist
- **OPTIONS preflight** — `204` response with full CORS headers for all `/v1/*` paths, replacing the previous `405`
- **`GET /v1/models`** — returns real LLM model IDs from the configured provider's catalog (sorted with default model first) instead of internal agent names; bare LLM model IDs in `POST /v1/chat/completions` are detected and passed as per-request `modelOverride` to the agent
- **Streaming error visibility** — `phase=error` lifecycle events no longer prematurely close the SSE stream; agent errors are now forwarded as a content chunk instead of producing a silent blank response
- **Zod schema + labels** — `allowedOrigins` registered in the config schema and doctor labels

## Config example

```yaml
gateway:
  http:
    endpoints:
      chatCompletions:
        enabled: true
        allowedOrigins:
          - "http://localhost:3000"   # Open WebUI
```

Then point Open WebUI (or any OpenAI-compatible client) at `http://<gateway-host>:<port>/v1` with your gateway bearer token as the API key.

## Test plan

- [x] `GET /v1/models` returns LLM catalog models (not agent IDs), filtered to configured provider
- [x] `GET /v1/models` sorts configured default model first
- [x] Selecting a specific LLM model in Open WebUI routes that model via `modelOverride`
- [x] `OPTIONS /v1/chat/completions` with matching `Origin` → `204` + CORS headers
- [x] `OPTIONS /v1/chat/completions` with non-matching `Origin` → `204`, no CORS headers
- [x] `POST /v1/chat/completions` streaming with agent error → error text visible in client, not blank
- [x] `openclaw doctor` accepts `allowedOrigins` without warnings
- [x] Existing non-CORS clients (curl, server-to-server) unaffected

## Review Fixes

- Removed redundant `emitAgentEvent({ phase: "error" })` from streaming catch block — `agentCommand` already emits this event before throwing (flagged by Greptile, confirmed via `src/commands/agent.ts:602`)

## Additional Changes (latest push)

- `/v1/models` now loads real LLM model IDs from `loadModelCatalog()`, filtered to the configured provider (`anthropic`, `openai`, etc.), so Open WebUI model picker shows meaningful model names
- Added `modelOverride?: string` to `AgentCommandOpts` for per-request LLM model override (lower priority than session-stored override)
- Completions handler detects bare LLM model IDs (not `openclaw`/`agent:` prefixed) and passes them as `modelOverride`
- Default model sorted first in `/v1/models` so Open WebUI pre-selects it automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)