### PR TITLE
fix(signal): forward replyTo as quoteTimestamp/quoteAuthor for native threading

### DIFF
--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from "node:http";
+import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Duplex } from "node:stream";
-import { createServer } from "node:http";
 import WebSocket, { WebSocketServer } from "ws";
 import { loadConfig } from "../config/config.js";
 import { isLoopbackAddress, isLoopbackHost } from "../gateway/net.js";

--- a/src/channels/plugins/outbound/signal.ts
+++ b/src/channels/plugins/outbound/signal.ts
@@ -1,7 +1,7 @@
+import type { ChannelOutboundAdapter } from "../types.js";
 import { chunkText } from "../../../auto-reply/chunk.js";
 import { sendMessageSignal } from "../../../signal/send.js";
 import { resolveChannelMediaMaxBytes } from "../media-limits.js";
-import type { ChannelOutboundAdapter } from "../types.js";
 
 function resolveSignalMaxBytes(params: {
   cfg: Parameters<typeof resolveChannelMediaMaxBytes>[0]["cfg"];
@@ -15,21 +15,41 @@ function resolveSignalMaxBytes(params: {
   });
 }
 
+function parseQuoteTimestamp(replyToId?: string | null): number | undefined {
+  if (!replyToId) {
+    return undefined;
+  }
+  const ts = Number.parseInt(replyToId, 10);
+  return Number.isFinite(ts) && ts > 0 ? ts : undefined;
+}
+
 export const signalOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: chunkText,
   chunkerMode: "text",
   textChunkLimit: 4000,
-  sendText: async ({ cfg, to, text, accountId, deps }) => {
+  sendText: async ({ cfg, to, text, accountId, replyToId, replyToAuthor, deps }) => {
     const send = deps?.sendSignal ?? sendMessageSignal;
     const maxBytes = resolveSignalMaxBytes({ cfg, accountId });
     const result = await send(to, text, {
       maxBytes,
       accountId: accountId ?? undefined,
+      quoteTimestamp: parseQuoteTimestamp(replyToId),
+      quoteAuthor: replyToAuthor?.trim() || undefined,
     });
     return { channel: "signal", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps }) => {
+  sendMedia: async ({
+    cfg,
+    to,
+    text,
+    mediaUrl,
+    mediaLocalRoots,
+    accountId,
+    replyToId,
+    replyToAuthor,
+    deps,
+  }) => {
     const send = deps?.sendSignal ?? sendMessageSignal;
     const maxBytes = resolveSignalMaxBytes({ cfg, accountId });
     const result = await send(to, text, {
@@ -37,6 +57,8 @@ export const signalOutbound: ChannelOutboundAdapter = {
       maxBytes,
       accountId: accountId ?? undefined,
       mediaLocalRoots,
+      quoteTimestamp: parseQuoteTimestamp(replyToId),
+      quoteAuthor: replyToAuthor?.trim() || undefined,
     });
     return { channel: "signal", ...result };
   },

--- a/src/channels/plugins/outbound/signal.ts
+++ b/src/channels/plugins/outbound/signal.ts
@@ -1,7 +1,7 @@
-import type { ChannelOutboundAdapter } from "../types.js";
 import { chunkText } from "../../../auto-reply/chunk.js";
 import { sendMessageSignal } from "../../../signal/send.js";
 import { resolveChannelMediaMaxBytes } from "../media-limits.js";
+import type { ChannelOutboundAdapter } from "../types.js";
 
 function resolveSignalMaxBytes(params: {
   cfg: Parameters<typeof resolveChannelMediaMaxBytes>[0]["cfg"];
@@ -31,11 +31,13 @@ export const signalOutbound: ChannelOutboundAdapter = {
   sendText: async ({ cfg, to, text, accountId, replyToId, replyToAuthor, deps }) => {
     const send = deps?.sendSignal ?? sendMessageSignal;
     const maxBytes = resolveSignalMaxBytes({ cfg, accountId });
+    const quoteAuthor = replyToAuthor?.trim();
+    const quoteTimestamp = quoteAuthor ? parseQuoteTimestamp(replyToId) : undefined;
     const result = await send(to, text, {
       maxBytes,
       accountId: accountId ?? undefined,
-      quoteTimestamp: parseQuoteTimestamp(replyToId),
-      quoteAuthor: replyToAuthor?.trim() || undefined,
+      quoteTimestamp,
+      quoteAuthor: quoteAuthor || undefined,
     });
     return { channel: "signal", ...result };
   },
@@ -52,13 +54,15 @@ export const signalOutbound: ChannelOutboundAdapter = {
   }) => {
     const send = deps?.sendSignal ?? sendMessageSignal;
     const maxBytes = resolveSignalMaxBytes({ cfg, accountId });
+    const quoteAuthor = replyToAuthor?.trim();
+    const quoteTimestamp = quoteAuthor ? parseQuoteTimestamp(replyToId) : undefined;
     const result = await send(to, text, {
       mediaUrl,
       maxBytes,
       accountId: accountId ?? undefined,
       mediaLocalRoots,
-      quoteTimestamp: parseQuoteTimestamp(replyToId),
-      quoteAuthor: replyToAuthor?.trim() || undefined,
+      quoteTimestamp,
+      quoteAuthor: quoteAuthor || undefined,
     });
     return { channel: "signal", ...result };
   },

--- a/src/channels/plugins/outbound/signal.ts
+++ b/src/channels/plugins/outbound/signal.ts
@@ -1,5 +1,5 @@
 import { chunkText } from "../../../auto-reply/chunk.js";
-import { sendMessageSignal } from "../../../signal/send.js";
+import { parseQuoteTimestamp, sendMessageSignal } from "../../../signal/send.js";
 import { resolveChannelMediaMaxBytes } from "../media-limits.js";
 import type { ChannelOutboundAdapter } from "../types.js";
 
@@ -13,14 +13,6 @@ function resolveSignalMaxBytes(params: {
       cfg.channels?.signal?.accounts?.[accountId]?.mediaMaxMb ?? cfg.channels?.signal?.mediaMaxMb,
     accountId: params.accountId,
   });
-}
-
-function parseQuoteTimestamp(replyToId?: string | null): number | undefined {
-  if (!replyToId) {
-    return undefined;
-  }
-  const ts = Number.parseInt(replyToId, 10);
-  return Number.isFinite(ts) && ts > 0 ? ts : undefined;
 }
 
 export const signalOutbound: ChannelOutboundAdapter = {

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -79,6 +79,7 @@ export type ChannelOutboundContext = {
   mediaLocalRoots?: readonly string[];
   gifPlayback?: boolean;
   replyToId?: string | null;
+  replyToAuthor?: string | null;
   threadId?: string | number | null;
   accountId?: string | null;
   identity?: OutboundIdentity;

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -738,6 +738,32 @@ describe("deliverOutboundPayloads", () => {
     expect(opts.quoteTimestamp).toBeUndefined();
     expect(opts.quoteAuthor).toBeUndefined();
   });
+
+  it("attaches Signal quote only to first chunk when text is chunked", async () => {
+    const sendSignal = vi.fn().mockResolvedValue({ messageId: "s1", timestamp: 100 });
+    const cfg: OpenClawConfig = { channels: { signal: { textChunkLimit: 20 } } };
+    const text = "A".repeat(30) + "\n\n" + "B".repeat(30);
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "signal",
+      to: "+1555",
+      payloads: [{ text }],
+      replyToId: "1771479242643",
+      replyToAuthor: "6545fc21-4b79-40b7-9b4e-c8fc6f570e59",
+      deps: { sendSignal },
+    });
+
+    expect(sendSignal.mock.calls.length).toBeGreaterThan(1);
+    const firstOpts = sendSignal.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(firstOpts.quoteTimestamp).toBe(1771479242643);
+    expect(firstOpts.quoteAuthor).toBe("6545fc21-4b79-40b7-9b4e-c8fc6f570e59");
+    for (let i = 1; i < sendSignal.mock.calls.length; i++) {
+      const opts = sendSignal.mock.calls[i]?.[2] as Record<string, unknown>;
+      expect(opts.quoteTimestamp).toBeUndefined();
+      expect(opts.quoteAuthor).toBeUndefined();
+    }
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1,9 +1,9 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import { signalOutbound } from "../../channels/plugins/outbound/signal.js";
 import { telegramOutbound } from "../../channels/plugins/outbound/telegram.js";
 import { whatsappOutbound } from "../../channels/plugins/outbound/whatsapp.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import { STATE_DIR } from "../../config/paths.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { markdownToSignalTextChunks } from "../../signal/format.js";
@@ -680,6 +680,46 @@ describe("deliverOutboundPayloads", () => {
       }),
       expect.objectContaining({ channelId: "whatsapp" }),
     );
+  });
+
+  it("forwards replyToId and replyToAuthor as quoteTimestamp/quoteAuthor for Signal", async () => {
+    const sendSignal = vi.fn().mockResolvedValue({ messageId: "s1", timestamp: 100 });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "signal",
+      to: "+1555",
+      payloads: [{ text: "exactly" }],
+      replyToId: "1771479242643",
+      replyToAuthor: "6545fc21-4b79-40b7-9b4e-c8fc6f570e59",
+      deps: { sendSignal },
+    });
+
+    expect(sendSignal).toHaveBeenCalledWith(
+      "+1555",
+      "exactly",
+      expect.objectContaining({
+        quoteTimestamp: 1771479242643,
+        quoteAuthor: "6545fc21-4b79-40b7-9b4e-c8fc6f570e59",
+      }),
+    );
+  });
+
+  it("omits quoteTimestamp when replyToId is not a valid timestamp", async () => {
+    const sendSignal = vi.fn().mockResolvedValue({ messageId: "s1", timestamp: 100 });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "signal",
+      to: "+1555",
+      payloads: [{ text: "reply" }],
+      replyToId: "not-a-number",
+      deps: { sendSignal },
+    });
+
+    const opts = sendSignal.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(opts.quoteTimestamp).toBeUndefined();
+    expect(opts.quoteAuthor).toBeUndefined();
   });
 });
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1,38 +1,38 @@
-import type { ReplyPayload } from "../../auto-reply/types.js";
-import type {
-  ChannelOutboundAdapter,
-  ChannelOutboundContext,
-} from "../../channels/plugins/types.js";
-import type { OpenClawConfig } from "../../config/config.js";
-import type { sendMessageDiscord } from "../../discord/send.js";
-import type { sendMessageIMessage } from "../../imessage/send.js";
-import type { sendMessageSlack } from "../../slack/send.js";
-import type { sendMessageTelegram } from "../../telegram/send.js";
-import type { sendMessageWhatsApp } from "../../web/outbound.js";
-import type { OutboundIdentity } from "./identity.js";
-import type { NormalizedOutboundPayload } from "./payloads.js";
-import type { OutboundChannel } from "./targets.js";
 import {
   chunkByParagraph,
   chunkMarkdownTextWithMode,
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "../../auto-reply/chunk.js";
+import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveChannelMediaMaxBytes } from "../../channels/plugins/media-limits.js";
 import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.js";
+import type {
+  ChannelOutboundAdapter,
+  ChannelOutboundContext,
+} from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import {
   appendAssistantMessageToSessionTranscript,
   resolveMirroredTranscriptText,
 } from "../../config/sessions.js";
+import type { sendMessageDiscord } from "../../discord/send.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import type { sendMessageIMessage } from "../../imessage/send.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { markdownToSignalTextChunks, type SignalTextStyleRange } from "../../signal/format.js";
 import { sendMessageSignal } from "../../signal/send.js";
+import type { sendMessageSlack } from "../../slack/send.js";
+import type { sendMessageTelegram } from "../../telegram/send.js";
+import type { sendMessageWhatsApp } from "../../web/outbound.js";
 import { throwIfAborted } from "./abort.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
+import type { OutboundIdentity } from "./identity.js";
+import type { NormalizedOutboundPayload } from "./payloads.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
+import type { OutboundChannel } from "./targets.js";
 
 export type { NormalizedOutboundPayload } from "./payloads.js";
 export { normalizeOutboundPayloads } from "./payloads.js";
@@ -553,9 +553,13 @@ async function deliverOutboundPayloadsCore(
         if (!Number.isFinite(ts) || ts <= 0) {
           return undefined;
         }
+        const quoteAuthor = params.replyToAuthor?.trim();
+        if (!quoteAuthor) {
+          return undefined;
+        }
         return {
           quoteTimestamp: ts,
-          quoteAuthor: params.replyToAuthor?.trim() || undefined,
+          quoteAuthor,
         };
       })();
       if (handler.sendPayload && effectivePayload.channelData) {

--- a/src/infra/outbound/delivery-queue-reply-author.test.ts
+++ b/src/infra/outbound/delivery-queue-reply-author.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ackDelivery,
+  enqueueDelivery,
+  loadPendingDeliveries,
+  recoverPendingDeliveries,
+} from "./delivery-queue.js";
+
+describe("delivery-queue replyToAuthor persistence", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "oc-queue-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("persists replyToAuthor and replays it on recovery", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "signal",
+        to: "+1555",
+        payloads: [{ text: "quoted reply" }],
+        replyToId: "1771479242643",
+        replyToAuthor: "6545fc21-4b79-40b7-9b4e-c8fc6f570e59",
+      },
+      tmpDir,
+    );
+
+    const pending = await loadPendingDeliveries(tmpDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.replyToAuthor).toBe("6545fc21-4b79-40b7-9b4e-c8fc6f570e59");
+    expect(pending[0]?.replyToId).toBe("1771479242643");
+
+    const deliverFn = vi.fn(async () => {});
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    await recoverPendingDeliveries({
+      deliver: deliverFn,
+      log,
+      cfg: {},
+      stateDir: tmpDir,
+      delay: async () => {},
+    });
+
+    expect(deliverFn).toHaveBeenCalledTimes(1);
+    expect(deliverFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToAuthor: "6545fc21-4b79-40b7-9b4e-c8fc6f570e59",
+        replyToId: "1771479242643",
+      }),
+    );
+
+    await ackDelivery(id, tmpDir);
+    const afterAck = await loadPendingDeliveries(tmpDir);
+    expect(afterAck).toHaveLength(0);
+  });
+});

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -39,6 +39,7 @@ export interface QueuedDelivery {
   payloads: ReplyPayload[];
   threadId?: string | number | null;
   replyToId?: string | null;
+  replyToAuthor?: string | null;
   bestEffort?: boolean;
   gifPlayback?: boolean;
   silent?: boolean;
@@ -72,6 +73,7 @@ type QueuedDeliveryParams = {
   payloads: ReplyPayload[];
   threadId?: string | number | null;
   replyToId?: string | null;
+  replyToAuthor?: string | null;
   bestEffort?: boolean;
   gifPlayback?: boolean;
   silent?: boolean;
@@ -93,6 +95,7 @@ export async function enqueueDelivery(
     payloads: params.payloads,
     threadId: params.threadId,
     replyToId: params.replyToId,
+    replyToAuthor: params.replyToAuthor,
     bestEffort: params.bestEffort,
     gifPlayback: params.gifPlayback,
     silent: params.silent,
@@ -280,6 +283,7 @@ export async function recoverPendingDeliveries(opts: {
         payloads: entry.payloads,
         threadId: entry.threadId,
         replyToId: entry.replyToId,
+        replyToAuthor: entry.replyToAuthor,
         bestEffort: entry.bestEffort,
         gifPlayback: entry.gifPlayback,
         silent: entry.silent,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1,12 +1,4 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import type {
-  ChannelId,
-  ChannelMessageActionName,
-  ChannelThreadingToolContext,
-} from "../../channels/plugins/types.js";
-import type { OpenClawConfig } from "../../config/config.js";
-import type { OutboundSendDeps } from "./deliver.js";
-import type { MessagePollResult, MessageSendResult } from "./message.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import {
   readNumberParam,
@@ -15,6 +7,12 @@ import {
 } from "../../agents/tools/common.js";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
+import type {
+  ChannelId,
+  ChannelMessageActionName,
+  ChannelThreadingToolContext,
+} from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -27,6 +25,7 @@ import {
   resolveMessageChannelSelection,
 } from "./channel-selection.js";
 import { applyTargetToParams } from "./channel-target.js";
+import type { OutboundSendDeps } from "./deliver.js";
 import {
   hydrateSendAttachmentParams,
   hydrateSetGroupIconParams,
@@ -40,6 +39,7 @@ import {
   resolveTelegramAutoThreadId,
 } from "./message-action-params.js";
 import { actionHasTarget, actionRequiresTarget } from "./message-action-spec.js";
+import type { MessagePollResult, MessageSendResult } from "./message.js";
 import {
   applyCrossContextDecoration,
   buildCrossContextDecoration,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1,4 +1,12 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import type {
+  ChannelId,
+  ChannelMessageActionName,
+  ChannelThreadingToolContext,
+} from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { OutboundSendDeps } from "./deliver.js";
+import type { MessagePollResult, MessageSendResult } from "./message.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import {
   readNumberParam,
@@ -7,12 +15,6 @@ import {
 } from "../../agents/tools/common.js";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
-import type {
-  ChannelId,
-  ChannelMessageActionName,
-  ChannelThreadingToolContext,
-} from "../../channels/plugins/types.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -25,7 +27,6 @@ import {
   resolveMessageChannelSelection,
 } from "./channel-selection.js";
 import { applyTargetToParams } from "./channel-target.js";
-import type { OutboundSendDeps } from "./deliver.js";
 import {
   hydrateSendAttachmentParams,
   hydrateSetGroupIconParams,
@@ -39,7 +40,6 @@ import {
   resolveTelegramAutoThreadId,
 } from "./message-action-params.js";
 import { actionHasTarget, actionRequiresTarget } from "./message-action-spec.js";
-import type { MessagePollResult, MessageSendResult } from "./message.js";
 import {
   applyCrossContextDecoration,
   buildCrossContextDecoration,
@@ -475,6 +475,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   const silent = readBooleanParam(params, "silent");
 
   const replyToId = readStringParam(params, "replyTo");
+  const replyToAuthor =
+    readStringParam(params, "replyToAuthor") ?? readStringParam(params, "quoteAuthor");
   const resolvedThreadId = resolveAndApplyOutboundThreadId(params, {
     channel,
     to,
@@ -542,6 +544,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     gifPlayback,
     bestEffort: bestEffort ?? undefined,
     replyToId: replyToId ?? undefined,
+    replyToAuthor: replyToAuthor ?? undefined,
     threadId: resolvedThreadId ?? undefined,
   });
 

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -1,8 +1,8 @@
-import type { OpenClawConfig } from "../../config/config.js";
-import type { PollInput } from "../../polls.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { callGateway, randomIdempotencyKey } from "../../gateway/call.js";
+import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
 import {
   GATEWAY_CLIENT_MODES,

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -1,8 +1,8 @@
-import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { PollInput } from "../../polls.js";
+import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { loadConfig } from "../../config/config.js";
 import { callGateway, randomIdempotencyKey } from "../../gateway/call.js";
-import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
 import {
   GATEWAY_CLIENT_MODES,
@@ -39,6 +39,7 @@ type MessageSendParams = {
   gifPlayback?: boolean;
   accountId?: string;
   replyToId?: string;
+  replyToAuthor?: string;
   threadId?: string | number;
   dryRun?: boolean;
   bestEffort?: boolean;
@@ -216,6 +217,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       accountId: params.accountId,
       payloads: normalizedPayloads,
       replyToId: params.replyToId,
+      replyToAuthor: params.replyToAuthor,
       threadId: params.threadId,
       gifPlayback: params.gifPlayback,
       deps: params.deps,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -1,12 +1,12 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
+import { throwIfAborted } from "./abort.js";
 import type { OutboundSendDeps } from "./deliver.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
-import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
-import { throwIfAborted } from "./abort.js";
 import { sendMessage, sendPoll } from "./message.js";
 import { extractToolPayload } from "./tool-payload.js";
 

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -1,12 +1,12 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
-import { throwIfAborted } from "./abort.js";
 import type { OutboundSendDeps } from "./deliver.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
+import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
+import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
+import { throwIfAborted } from "./abort.js";
 import { sendMessage, sendPoll } from "./message.js";
 import { extractToolPayload } from "./tool-payload.js";
 
@@ -84,6 +84,7 @@ export async function executeSendAction(params: {
   gifPlayback?: boolean;
   bestEffort?: boolean;
   replyToId?: string;
+  replyToAuthor?: string;
   threadId?: string | number;
 }): Promise<{
   handledBy: "plugin" | "core";
@@ -127,6 +128,7 @@ export async function executeSendAction(params: {
     channel: params.ctx.channel || undefined,
     accountId: params.ctx.accountId ?? undefined,
     replyToId: params.replyToId,
+    replyToAuthor: params.replyToAuthor,
     threadId: params.threadId,
     gifPlayback: params.gifPlayback,
     dryRun: params.ctx.dryRun,

--- a/src/signal/parse-quote-timestamp.test.ts
+++ b/src/signal/parse-quote-timestamp.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { parseQuoteTimestamp } from "./send.js";
+
+describe("parseQuoteTimestamp", () => {
+  it("parses a valid numeric timestamp string", () => {
+    expect(parseQuoteTimestamp("1771479242643")).toBe(1771479242643);
+  });
+
+  it("returns undefined for null/undefined/empty", () => {
+    expect(parseQuoteTimestamp(null)).toBeUndefined();
+    expect(parseQuoteTimestamp(undefined)).toBeUndefined();
+    expect(parseQuoteTimestamp("")).toBeUndefined();
+  });
+
+  it("returns undefined for non-numeric strings", () => {
+    expect(parseQuoteTimestamp("not-a-number")).toBeUndefined();
+    expect(parseQuoteTimestamp("abc123")).toBeUndefined();
+  });
+
+  it("returns undefined for zero or negative values", () => {
+    expect(parseQuoteTimestamp("0")).toBeUndefined();
+    expect(parseQuoteTimestamp("-100")).toBeUndefined();
+  });
+
+  it("parses a string with trailing non-numeric chars (parseInt behavior)", () => {
+    expect(parseQuoteTimestamp("12345abc")).toBe(12345);
+  });
+});

--- a/src/signal/send.ts
+++ b/src/signal/send.ts
@@ -28,6 +28,14 @@ export type SignalSendResult = {
 
 export type SignalRpcOpts = Pick<SignalSendOpts, "baseUrl" | "account" | "accountId" | "timeoutMs">;
 
+export function parseQuoteTimestamp(replyToId?: string | null): number | undefined {
+  if (!replyToId) {
+    return undefined;
+  }
+  const ts = Number.parseInt(replyToId, 10);
+  return Number.isFinite(ts) && ts > 0 ? ts : undefined;
+}
+
 export type SignalReceiptType = "read" | "viewed";
 
 type SignalTarget =

--- a/src/signal/send.ts
+++ b/src/signal/send.ts
@@ -17,6 +17,8 @@ export type SignalSendOpts = {
   timeoutMs?: number;
   textMode?: "markdown" | "plain";
   textStyles?: SignalTextStyleRange[];
+  quoteTimestamp?: number;
+  quoteAuthor?: string;
 };
 
 export type SignalSendResult = {
@@ -179,6 +181,13 @@ export async function sendMessageSignal(
     throw new Error("Signal recipient is required");
   }
   Object.assign(params, targetParams);
+
+  if (opts.quoteTimestamp && opts.quoteTimestamp > 0) {
+    params.quoteTimestamp = opts.quoteTimestamp;
+    if (opts.quoteAuthor?.trim()) {
+      params.quoteAuthor = opts.quoteAuthor.trim();
+    }
+  }
 
   const result = await signalRpcRequest<{ timestamp?: number }>("send", params, {
     baseUrl,

--- a/src/signal/send.ts
+++ b/src/signal/send.ts
@@ -182,11 +182,10 @@ export async function sendMessageSignal(
   }
   Object.assign(params, targetParams);
 
-  if (opts.quoteTimestamp && opts.quoteTimestamp > 0) {
+  const quoteAuthor = opts.quoteAuthor?.trim();
+  if (opts.quoteTimestamp && opts.quoteTimestamp > 0 && quoteAuthor) {
     params.quoteTimestamp = opts.quoteTimestamp;
-    if (opts.quoteAuthor?.trim()) {
-      params.quoteAuthor = opts.quoteAuthor.trim();
-    }
+    params.quoteAuthor = quoteAuthor;
   }
 
   const result = await signalRpcRequest<{ timestamp?: number }>("send", params, {


### PR DESCRIPTION
## Summary

- Problem: Signal reply threading (quote bubbles) doesn’t work because `replyToId` is never mapped to signal-cli’s `quoteTimestamp`/`quoteAuthor` JSON-RPC fields.
- Why it matters: without native quote bubbles, replies in busy threads are ambiguous and the UX regresses to plain-text quoting.
- What changed: thread `replyToId` + new `replyToAuthor` through the outbound pipeline and forward them as `quoteTimestamp`/`quoteAuthor` for Signal.
- What did NOT change: no config defaults, no gateway routing changes, no behavior changes for other channels.

## Root cause

The outbound pipeline already carries `replyToId`, but Signal didn’t implement any mapping.

- Telegram/Discord/Slack map `replyToId` in their outbound adapters.
- Signal’s outbound adapter ignored `replyToId`.
- Additionally, Signal’s primary send path in `deliver.ts` bypasses the outbound adapter for markdown→Signal styled-text formatting, so fixing only the adapter is insufficient.

Signal also requires the quoted message author (`quoteAuthor`) in addition to the quoted message timestamp (`quoteTimestamp`). The pipeline didn’t carry this, so this PR adds `replyToAuthor` as an additive optional field.

## Behavior details

- Quote params are only included when both are present:
  - `replyToId` parses as a positive integer timestamp
  - `replyToAuthor` is provided (non-empty)
- If `replyToAuthor` is missing, we send a normal message (no partial quote payload).
- For chunked Signal sends, the quote bubble is attached only to the first chunk.

## Changes

- Add `quoteTimestamp`/`quoteAuthor` to `SignalSendOpts` and include them in the Signal `send` JSON-RPC call
- Add `replyToAuthor` to `ChannelOutboundContext` and thread it through:
  - message-action-runner → outbound-send-service → message → deliver
- Update Signal’s inline send path in `deliver.ts` to forward quote params
- Update Signal outbound adapter to map `replyToId`/`replyToAuthor` → `quoteTimestamp`/`quoteAuthor`
- Accept `replyToAuthor` or `quoteAuthor` as the message tool param name (alias)

## Usage

```
message action=send channel=signal target=<recipient> message="exactly" replyTo=<message_timestamp> replyToAuthor=<sender_uuid>
```

## Test plan

- `pnpm check`
- `npx vitest run src/infra/outbound/deliver.test.ts src/infra/outbound/outbound-send-service.test.ts src/infra/outbound/message.test.ts`

## Manual verification (not in CI)

Not run against a live Signal account/daemon in this PR.

Suggested quick check:
1. Send a Signal DM or group message.
2. Reply with `replyTo=<ts>` + `replyToAuthor=<uuid>`.
3. Confirm the recipient UI shows a native quote bubble.
4. Send a multi-paragraph reply that chunks and confirm only the first chunk is quoted.

## Security impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same signal-cli daemon)
- Command/tool execution surface changed? Yes (additive `replyToAuthor` param for Signal quote bubbles)

## AI assistance

AI-assisted (Cursor). I reviewed the full outbound pipeline and added unit tests to lock the parameter forwarding behavior.