### PR TITLE
fix: skip auto-attaching tool MEDIA: paths already sent via message t…

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -381,7 +381,9 @@ export async function handleToolExecutionEnd(
   // When shouldEmitToolOutput() is true, emitToolOutput already delivers media
   // via parseReplyDirectives (MEDIA: text extraction), so skip to avoid duplicates.
   if (ctx.params.onToolResult && !isToolError && !ctx.shouldEmitToolOutput()) {
-    const mediaPaths = extractToolResultMediaPaths(result);
+    const mediaPaths = extractToolResultMediaPaths(result).filter(
+      (p) => !ctx.state.messagingToolSentMediaUrls.includes(p),
+    );
     if (mediaPaths.length > 0) {
       try {
         void ctx.params.onToolResult({ mediaUrls: mediaPaths });

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -342,7 +342,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       markdown: useMarkdown,
     });
     const message = `${agg}\n${formatToolOutputBlock(output)}`;
-    const { text: cleanedText, mediaUrls } = parseReplyDirectives(message);
+
+    const { text: cleanedText, mediaUrls: rawMediaUrls } = parseReplyDirectives(message);
+    const mediaUrls = rawMediaUrls?.filter((url) => !messagingToolSentMediaUrls.includes(url));
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0)) {
       return;
     }


### PR DESCRIPTION
Fixes #20153

When a tool returns MEDIA:/path/image.png and the agent also sends the
same file via the message tool with a caption, Telegram received the
image twice.

messagingToolSentMediaUrls already tracked explicitly-sent paths but
was never used to filter the onToolResult auto-attach paths.

Fixes both delivery paths:
- emitToolOutput in pi-embedded-subscribe.ts (shouldEmitToolOutput path)
- extractToolResultMediaPaths in handlers.tools.ts (!shouldEmitToolOutput path)

## Summary
- Problem: Tool-returned MEDIA: paths auto-attach to reply AND get sent explicitly via message tool, causing duplicate images on Telegram
- Why it matters: Users receive the same image twice in the same turn
- What changed: Filter mediaUrls against messagingToolSentMediaUrls in both onToolResult delivery paths
- What did NOT change: Tracking logic, state structure, any other delivery behavior

## Change Type
- [x] Bug fix

## Scope
- [x] Skills / tool execution

## Linked Issue
Closes #20153

## User-visible / Behavior Changes
Users on Telegram will no longer receive duplicate images when the agent uses a tool that returns a MEDIA: path and also sends that same file explicitly via the message tool.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
1. Use browser screenshot tool — returns MEDIA:/tmp/screenshot.png
2. Agent sends same file via message tool with caption
3. Before fix: image received twice on Telegram
4. After fix: image received once

## Evidence
- [x] All 9 existing tests in pi-embedded-subscribe.handlers.tools.test.ts pass
- Note: 2 pre-existing TS errors in server.chat.gateway-server-chat-b.e2e.test.ts are unrelated

## Human Verification
- Verified: Code logic traced through both delivery paths
- Edge cases checked: Tool error case (media not committed on failure — unchanged)
- Not verified: Live Telegram end-to-end test

## Compatibility
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- Revert: src/agents/pi-embedded-subscribe.ts and src/agents/pi-embedded-subscribe.handlers.tools.ts
- Risk: None — filter only suppresses paths confirmed already delivered

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes duplicate image delivery on Telegram by filtering `MEDIA:` paths already sent via the message tool. The fix adds filtering in both delivery paths: `emitToolOutput` (when `shouldEmitToolOutput` is true) and `extractToolResultMediaPaths` (when it's false). This prevents the same media file from being auto-attached when it was already explicitly sent with a caption.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-scoped, and uses an existing tracking mechanism (`messagingToolSentMediaUrls`) that was already in place but not being utilized for filtering. Both delivery paths are correctly handled, and the filtering logic is straightforward. Existing tests pass, and the change only affects the deduplication logic without altering state management or tracking behavior.
- No files require special attention

<sub>Last reviewed commit: 303d431</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->