### PR TITLE
feat(ui): add update warning banner to control dashboard

### DIFF
--- a/src/gateway/protocol/schema/snapshot.ts
+++ b/src/gateway/protocol/schema/snapshot.ts
@@ -60,6 +60,13 @@ export const SnapshotSchema = Type.Object(
         Type.Literal("trusted-proxy"),
       ]),
     ),
+    updateAvailable: Type.Optional(
+      Type.Object({
+        currentVersion: NonEmptyString,
+        latestVersion: NonEmptyString,
+        channel: NonEmptyString,
+      }),
+    ),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -2,6 +2,7 @@ import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { getHealthSnapshot, type HealthSummary } from "../../commands/health.js";
 import { CONFIG_PATH, STATE_DIR, loadConfig } from "../../config/config.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
+import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { listSystemPresence } from "../../infra/system-presence.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolveGatewayAuth } from "../auth.js";
@@ -22,6 +23,7 @@ export function buildGatewaySnapshot(): Snapshot {
   const presence = listSystemPresence();
   const uptimeMs = Math.round(process.uptime() * 1000);
   const auth = resolveGatewayAuth({ authConfig: cfg.gateway?.auth, env: process.env });
+  const updateAvailable = getUpdateAvailable() ?? undefined;
   // Health is async; caller should await getHealthSnapshot and replace later if needed.
   const emptyHealth: unknown = {};
   return {
@@ -39,6 +41,7 @@ export function buildGatewaySnapshot(): Snapshot {
       scope,
     },
     authMode: auth.mode,
+    updateAvailable,
   };
 }
 

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -14,6 +14,18 @@ type UpdateCheckState = {
   lastNotifiedTag?: string;
 };
 
+type UpdateAvailable = {
+  currentVersion: string;
+  latestVersion: string;
+  channel: string;
+};
+
+let updateAvailableCache: UpdateAvailable | null = null;
+
+export function getUpdateAvailable(): UpdateAvailable | null {
+  return updateAvailableCache;
+}
+
 const UPDATE_CHECK_FILENAME = "update-check.json";
 const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
@@ -100,6 +112,11 @@ export async function runGatewayUpdateCheck(params: {
 
   const cmp = compareSemverStrings(VERSION, resolved.version);
   if (cmp != null && cmp < 0) {
+    updateAvailableCache = {
+      currentVersion: VERSION,
+      latestVersion: resolved.version,
+      channel: tag,
+    };
     const shouldNotify =
       state.lastNotifiedVersion !== resolved.version || state.lastNotifiedTag !== tag;
     if (shouldNotify) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1,6 +1,42 @@
 @import "./chat.css";
 
 /* ===========================================
+   Update Banner
+   =========================================== */
+
+.update-banner {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  margin: 0 calc(-1 * var(--shell-pad)) 0;
+  border-radius: 0;
+  border-left: none;
+  border-right: none;
+  text-align: center;
+  font-weight: 500;
+  padding: 10px 16px;
+}
+
+.update-banner code {
+  background: rgba(239, 68, 68, 0.15);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.update-banner__btn {
+  margin-left: 8px;
+  border-color: var(--danger);
+  color: var(--danger);
+  font-size: 12px;
+  padding: 4px 12px;
+}
+
+.update-banner__btn:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.15);
+}
+
+/* ===========================================
    Cards - Refined with depth
    =========================================== */
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -54,6 +54,7 @@ type GatewayHost = {
   refreshSessionsAfterChat: Set<string>;
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalError: string | null;
+  updateAvailable: { currentVersion: string; latestVersion: string; channel: string } | null;
 };
 
 type SessionDefaultsSnapshot = {
@@ -278,6 +279,7 @@ export function applySnapshot(host: GatewayHost, hello: GatewayHelloOk) {
         presence?: PresenceEntry[];
         health?: HealthSnapshot;
         sessionDefaults?: SessionDefaultsSnapshot;
+        updateAvailable?: { currentVersion: string; latestVersion: string; channel: string };
       }
     | undefined;
   if (snapshot?.presence && Array.isArray(snapshot.presence)) {
@@ -289,4 +291,5 @@ export function applySnapshot(host: GatewayHost, hello: GatewayHelloOk) {
   if (snapshot?.sessionDefaults) {
     applySessionDefaults(host, snapshot.sessionDefaults);
   }
+  host.updateAvailable = snapshot?.updateAvailable ?? null;
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -188,6 +188,17 @@ export function renderApp(state: AppViewState) {
         </div>
       </aside>
       <main class="content ${isChat ? "content--chat" : ""}">
+        ${state.updateAvailable
+          ? html`<div class="update-banner callout danger" role="alert">
+              <strong>Update available:</strong> v${state.updateAvailable.latestVersion}
+              (running v${state.updateAvailable.currentVersion}).
+              <button
+                class="btn btn--sm update-banner__btn"
+                ?disabled=${state.updateRunning || !state.connected}
+                @click=${() => runUpdate(state)}
+              >${state.updateRunning ? "Updating…" : "Update now"}</button>
+            </div>`
+          : nothing}
         <section class="content-header">
           <div>
             ${state.tab === "usage" ? nothing : html`<div class="page-title">${titleForTab(state.tab)}</div>`}

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -221,6 +221,7 @@ export type AppViewState = {
   logsLimit: number;
   logsMaxBytes: number;
   logsAtBottom: boolean;
+  updateAvailable: { currentVersion: string; latestVersion: string; channel: string } | null;
   client: GatewayBrowserClient | null;
   refreshSessionsAfterChat: Set<string>;
   connect: () => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -300,6 +300,12 @@ export class OpenClawApp extends LitElement {
   @state() cronRuns: CronRunLogEntry[] = [];
   @state() cronBusy = false;
 
+  @state() updateAvailable: {
+    currentVersion: string;
+    latestVersion: string;
+    channel: string;
+  } | null = null;
+
   @state() skillsLoading = false;
   @state() skillsReport: SkillStatusReport | null = null;
   @state() skillsError: string | null = null;


### PR DESCRIPTION
## Summary

SecurityScorecard's STRIKE research recently identified over **40,000 exposed OpenClaw gateway instances**, with **35.4% running known-vulnerable versions**. The gateway already performs an npm update check on startup and compares against the registry every 24 hours — but the result is only logged to the server console. The control UI has zero visibility into whether the running version is outdated, which means operators have no idea they're exposed unless they happen to read server logs.

OpenClaw's user base is broadening well beyond developers who live in terminals. Self-hosters, small teams, and non-technical operators are deploying gateways and relying on the control dashboard as their primary management interface. For these users, security has to be surfaced where they already are — not hidden behind CLI output they will never see. Making version awareness frictionless and actionable is a prerequisite for reducing that 35.4% number.

This PR adds a **sticky red warning banner** to the top of the control UI content area whenever the gateway detects it is running behind the latest published version. The banner includes an **"Update now" button** wired to the existing `update.run` RPC (the same mechanism the config page already uses), so operators can act immediately without switching to a terminal.

## Changes

### Server side
- Cache the update check result in a module-level variable with a typed `UpdateAvailable` shape (`currentVersion`, `latestVersion`, `channel`)
- Export a `getUpdateAvailable()` getter for the rest of the process
- Add an optional `updateAvailable` field to `SnapshotSchema` (backward compatible — old clients ignore it, old servers simply omit it)
- Include the cached update status in `buildGatewaySnapshot()` so it is delivered to every UI client on connect and reconnect

### UI side
- Add `updateAvailable` to `GatewayHost`, `AppViewState`, and the app's reactive state so it flows through the standard snapshot pipeline
- Extract `updateAvailable` from the hello snapshot in `applySnapshot()`
- Render a `.update-banner.callout.danger` element with `role="alert"` as the first child of `<main>`, before the content header
- Wire the "Update now" button to `runUpdate(state)`, the same controller function used by the config tab
- Use `position: sticky` and negative margins to pin the banner edge-to-edge at the top of the scrollable content area

## Files modified

| File | Change |
|------|--------|
| `src/infra/update-startup.ts` | Cache update result, export `getUpdateAvailable()` |
| `src/gateway/protocol/schema/snapshot.ts` | Add optional `updateAvailable` to `SnapshotSchema` |
| `src/gateway/server/health-state.ts` | Include `updateAvailable` in `buildGatewaySnapshot()` |
| `ui/src/ui/app-gateway.ts` | Extract `updateAvailable` from snapshot |
| `ui/src/ui/app-view-state.ts` | Add `updateAvailable` to `AppViewState` |
| `ui/src/ui/app.ts` | Initialize `updateAvailable` reactive state |
| `ui/src/ui/app-render.ts` | Render banner with "Update now" button |
| `ui/src/styles/components.css` | Sticky positioning and banner styles |

## Test plan

- [ ] Verify banner does not appear when gateway is up to date (field is `null`/absent)
- [ ] Verify banner appears with correct versions when `updateAvailable` is populated
- [ ] Verify "Update now" button triggers `update.run` RPC
- [ ] Verify banner persists across tab switches and reconnects
- [ ] Verify old UI clients connecting to updated gateway ignore the new field
- [ ] Verify old gateways omitting the field show no banner on updated UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

adds sticky warning banner to control UI when gateway detects outdated version

The gateway already checks for updates every 24 hours and logs results to the console. This PR surfaces that information in the control UI by:
- caching the update check result in `src/infra/update-startup.ts` and exporting a getter
- adding an optional `updateAvailable` field to the gateway snapshot schema (backward compatible)
- including the cached update status in `buildGatewaySnapshot()` so it's delivered to UI clients
- rendering a sticky danger banner at the top of the UI content area with an "Update now" button that triggers the existing `update.run` RPC

**Key issues:**
- the update cache in `update-startup.ts:113-129` is never cleared when the version is up-to-date, which could show stale "update available" state if the gateway is updated without restarting (minor edge case since updates typically require restart)
- unused CSS rule for `.update-banner code` that doesn't match any rendered elements

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor logic issue that should be addressed
- The implementation is clean and follows existing patterns well. The schema change is backward compatible (uses `Type.Optional`), the UI reuses the existing `runUpdate` controller, and the data flow through snapshot → host → app state is consistent with other fields. The main concern is the cache not being cleared when no update is available, which could show stale update banners in edge cases. The unused CSS is cosmetic. Overall architecture and integration are solid.
- Pay close attention to `src/infra/update-startup.ts` to ensure the cache clearing logic is added

<sub>Last reviewed commit: 068c065</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->