### PR TITLE
docs: add /export-session command to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -925,6 +925,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Anthropic: add opt-in 1M context beta header support for Opus/Sonnet via model `params.context1m: true` (maps to `anthropic-beta: context-1m-2025-08-07`).
 - Agents/Models: support Anthropic Sonnet 4.6 (`anthropic/claude-sonnet-4-6`) across aliases/defaults with forward-compat fallback when upstream catalogs still only expose Sonnet 4.5.
 - Commands/Subagents: add `/subagents spawn` for deterministic subagent activation from chat commands. (#18218) Thanks @JoshuaLelon.
+- Commands/CLI: add `/export-session` command to export session history with full system prompt as HTML. (#18010) Thanks @boris721.
 - Agents/Subagents: add an accepted response note for `sessions_spawn` explaining polling subagents are disabled for one-off calls. Thanks @tyler6204.
 - Agents/Subagents: prefix spawned subagent task messages with context to preserve source information in downstream handling. Thanks @tyler6204.
 - iOS/Share: add an iOS share extension that forwards shared URL/text/image content directly to gateway `agent.request`, with delivery-route fallback and optional receipt acknowledgements. (#19424) Thanks @mbelinky.


### PR DESCRIPTION
## Summary

Adds missing changelog entry for PR #18010 which introduced the `/export-session` command.

## Change Type

- [x] Documentation

## Details

PR #18010 (merged 2026-02-16) added the `/export-session` command to export session history with the full system prompt as HTML, but the changelog entry was missing.

This PR adds the entry to the 2026.2.17 section under Commands/CLI.

---

Thanks for the great project! 🦞

— Boris 🤖

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds missing changelog entry for the `/export-session` command feature to the 2026.2.17 release section. The entry follows the established changelog format with proper categorization under Commands/CLI, includes the PR reference (#18010), and credits the author (`@boris721`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a documentation-only change that adds a single line to the changelog. The entry format matches existing patterns perfectly, is placed in the correct section (2026.2.17), and follows all established conventions (category prefix, description, PR reference, author credit). No code changes, no functional impact.
- No files require special attention

<sub>Last reviewed commit: f9a80bf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->