### PR TITLE
Docs: update MiniMax from M2.5/Lightning to M2.5/Highspeed

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -303,7 +303,7 @@ Options:
 - `--non-interactive`
 - `--mode <local|remote>`
 - `--flow <quickstart|advanced|manual>` (manual is an alias for advanced)
-- `--auth-choice <setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip>`
+- `--auth-choice <setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-highspeed|opencode-zen|custom-api-key|skip>`
 - `--token-provider <id>` (non-interactive; used with `--auth-choice token`)
 - `--token <token>` (non-interactive; used with `--auth-choice token`)
 - `--token-profile-id <id>` (non-interactive; default: `<provider>:manual`)

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -143,7 +143,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [How do I switch models on the fly (without restarting)?](#how-do-i-switch-models-on-the-fly-without-restarting)
   - [Can I use GPT 5.2 for daily tasks and Codex 5.3 for coding](#can-i-use-gpt-52-for-daily-tasks-and-codex-53-for-coding)
   - [Why do I see "Model … is not allowed" and then no reply?](#why-do-i-see-model-is-not-allowed-and-then-no-reply)
-  - [Why do I see "Unknown model: minimax/MiniMax-M2.1"?](#why-do-i-see-unknown-model-minimaxminimaxm21)
+  - [Why do I see "Unknown model: minimax/MiniMax-M2.5"?](#why-do-i-see-unknown-model-minimaxminimaxm21)
   - [Can I use MiniMax as my default and OpenAI for complex tasks?](#can-i-use-minimax-as-my-default-and-openai-for-complex-tasks)
   - [Are opus / sonnet / gpt built-in shortcuts?](#are-opus-sonnet-gpt-builtin-shortcuts)
   - [How do I define/override model shortcuts (aliases)?](#how-do-i-defineoverride-model-shortcuts-aliases)
@@ -742,7 +742,7 @@ This stores OAuth tokens in auth profiles on the gateway host. Details: [Model p
 
 ### Is a local model OK for casual chats
 
-Usually no. OpenClaw needs large context + strong safety; small cards truncate and leak. If you must, run the **largest** MiniMax M2.1 build you can locally (LM Studio) and see [/gateway/local-models](/gateway/local-models). Smaller/quantized models increase prompt-injection risk - see [Security](/gateway/security).
+Usually no. OpenClaw needs large context + strong safety; small cards truncate and leak. If you must, run the **largest** MiniMax M2.5 build you can locally (LM Studio) and see [/gateway/local-models](/gateway/local-models). Smaller/quantized models increase prompt-injection risk - see [Security](/gateway/security).
 
 ### How do I keep hosted model traffic in a specific region
 
@@ -1971,7 +1971,7 @@ Models are referenced as `provider/model` (example: `anthropic/claude-opus-4-6`)
 **Reliable (less character):** `openai/gpt-5.2` - nearly as good as Opus, just less personality.
 **Budget:** `zai/glm-4.7`.
 
-MiniMax M2.1 has its own docs: [MiniMax](/providers/minimax) and
+MiniMax M2.5 has its own docs: [MiniMax](/providers/minimax) and
 [Local models](/gateway/local-models).
 
 Rule of thumb: use the **best model you can afford** for high-stakes work, and a cheaper
@@ -2016,7 +2016,7 @@ Docs: [Models](/concepts/models), [Configure](/cli/configure), [Config](/cli/con
 ### What do OpenClaw, Flawd, and Krill use for models
 
 - **OpenClaw + Flawd:** Anthropic Opus (`anthropic/claude-opus-4-6`) - see [Anthropic](/providers/anthropic).
-- **Krill:** MiniMax M2.1 (`minimax/MiniMax-M2.1`) - see [MiniMax](/providers/minimax).
+- **Krill:** MiniMax M2.5 (`minimax/MiniMax-M2.5`) - see [MiniMax](/providers/minimax).
 
 ### How do I switch models on the fly without restarting
 
@@ -2083,7 +2083,7 @@ Model "provider/model" is not allowed. Use /model to list available models.
 That error is returned **instead of** a normal reply. Fix: add the model to
 `agents.defaults.models`, remove the allowlist, or pick a model from `/model list`.
 
-### Why do I see Unknown model minimaxMiniMaxM21
+### Why do I see Unknown model minimaxMiniMaxM25
 
 This means the **provider isn't configured** (no MiniMax provider config or auth
 profile was found), so the model can't be resolved. A fix for this detection is
@@ -2094,8 +2094,8 @@ Fix checklist:
 1. Upgrade to **2026.1.12** (or run from source `main`), then restart the gateway.
 2. Make sure MiniMax is configured (wizard or JSON), or that a MiniMax API key
    exists in env/auth profiles so the provider can be injected.
-3. Use the exact model id (case-sensitive): `minimax/MiniMax-M2.1` or
-   `minimax/MiniMax-M2.1-lightning`.
+3. Use the exact model id (case-sensitive): `minimax/MiniMax-M2.5` or
+   `minimax/MiniMax-M2.5-highspeed`.
 4. Run:
 
    ```bash
@@ -2118,9 +2118,9 @@ Fallbacks are for **errors**, not "hard tasks," so use `/model` or a separate ag
   env: { MINIMAX_API_KEY: "sk-...", OPENAI_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "minimax/MiniMax-M2.1" },
+      model: { primary: "minimax/MiniMax-M2.5" },
       models: {
-        "minimax/MiniMax-M2.1": { alias: "minimax" },
+        "minimax/MiniMax-M2.5": { alias: "minimax" },
         "openai/gpt-5.2": { alias: "gpt" },
       },
     },

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -1,5 +1,5 @@
 ---
-summary: "Use MiniMax M2.1 in OpenClaw"
+summary: "Use MiniMax M2.5 in OpenClaw"
 read_when:
   - You want MiniMax models in OpenClaw
   - You need MiniMax setup guidance
@@ -8,15 +8,14 @@ title: "MiniMax"
 
 # MiniMax
 
-MiniMax is an AI company that builds the **M2/M2.1** model family. The current
-coding-focused release is **MiniMax M2.1** (December 23, 2025), built for
-real-world complex tasks.
+MiniMax is an AI company that builds the **M2/M2.5** model family. The current
+coding-focused release is **MiniMax M2.5**, built for real-world complex tasks.
 
-Source: [MiniMax M2.1 release note](https://www.minimax.io/news/minimax-m21)
+Source: [MiniMax M2.5 release note](https://www.minimax.io/news/MiniMax-M2-5)
 
-## Model overview (M2.1)
+## Model overview (M2.5)
 
-MiniMax highlights these improvements in M2.1:
+MiniMax highlights these improvements in M2.5:
 
 - Stronger **multi-language coding** (Rust, Java, Go, C++, Kotlin, Objective-C, TS/JS).
 - Better **web/app development** and aesthetic output quality (including native mobile).
@@ -27,13 +26,12 @@ MiniMax highlights these improvements in M2.1:
   Droid/Factory AI, Cline, Kilo Code, Roo Code, BlackBox).
 - Higher-quality **dialogue and technical writing** outputs.
 
-## MiniMax M2.1 vs MiniMax M2.1 Lightning
+## MiniMax M2.5 vs MiniMax M2.5 Highspeed
 
-- **Speed:** Lightning is the “fast” variant in MiniMax’s pricing docs.
-- **Cost:** Pricing shows the same input cost, but Lightning has higher output cost.
-- **Coding plan routing:** The Lightning back-end isn’t directly available on the MiniMax
-  coding plan. MiniMax auto-routes most requests to Lightning, but falls back to the
-  regular M2.1 back-end during traffic spikes.
+- **Speed:** Highspeed is the “fast” variant in MiniMax’s model lineup.
+- **Cost:** Same input cost; Highspeed has higher output cost.
+- **Coding plan:** MiniMax now offers a [Highspeed coding plan](https://platform.minimax.io/subscribe/coding-plan)
+  that gives direct access to the M2.5 Highspeed back-end.
 
 ## Choose a setup
 
@@ -56,7 +54,7 @@ You will be prompted to select an endpoint:
 
 See [MiniMax OAuth plugin README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth) for details.
 
-### MiniMax M2.1 (API key)
+### MiniMax M2.5 (API key)
 
 **Best for:** hosted MiniMax with Anthropic-compatible API.
 
@@ -64,12 +62,12 @@ Configure via CLI:
 
 - Run `openclaw configure`
 - Select **Model/auth**
-- Choose **MiniMax M2.1**
+- Choose **MiniMax M2.5**
 
 ```json5
 {
   env: { MINIMAX_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.1" } } },
+  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.5" } } },
   models: {
     mode: "merge",
     providers: {
@@ -79,9 +77,9 @@ Configure via CLI:
         api: "anthropic-messages",
         models: [
           {
-            id: "MiniMax-M2.1",
-            name: "MiniMax M2.1",
-            reasoning: false,
+            id: "MiniMax-M2.5",
+            name: "MiniMax M2.5",
+            reasoning: true,
             input: ["text"],
             cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 },
             contextWindow: 200000,
@@ -94,9 +92,9 @@ Configure via CLI:
 }
 ```
 
-### MiniMax M2.1 as fallback (Opus primary)
+### MiniMax M2.5 as fallback (Opus primary)
 
-**Best for:** keep Opus 4.6 as primary, fail over to MiniMax M2.1.
+**Best for:** keep Opus 4.6 as primary, fail over to MiniMax M2.5.
 
 ```json5
 {
@@ -105,11 +103,11 @@ Configure via CLI:
     defaults: {
       models: {
         "anthropic/claude-opus-4-6": { alias: "opus" },
-        "minimax/MiniMax-M2.1": { alias: "minimax" },
+        "minimax/MiniMax-M2.5": { alias: "minimax" },
       },
       model: {
         primary: "anthropic/claude-opus-4-6",
-        fallbacks: ["minimax/MiniMax-M2.1"],
+        fallbacks: ["minimax/MiniMax-M2.5"],
       },
     },
   },
@@ -119,7 +117,7 @@ Configure via CLI:
 ### Optional: Local via LM Studio (manual)
 
 **Best for:** local inference with LM Studio.
-We have seen strong results with MiniMax M2.1 on powerful hardware (e.g. a
+We have seen strong results with MiniMax M2.5 on powerful hardware (e.g. a
 desktop/server) using LM Studio's local server.
 
 Configure manually via `openclaw.json`:
@@ -128,8 +126,8 @@ Configure manually via `openclaw.json`:
 {
   agents: {
     defaults: {
-      model: { primary: "lmstudio/minimax-m2.1-gs32" },
-      models: { "lmstudio/minimax-m2.1-gs32": { alias: "Minimax" } },
+      model: { primary: "lmstudio/minimax-m2.5-gs32" },
+      models: { "lmstudio/minimax-m2.5-gs32": { alias: "Minimax" } },
     },
   },
   models: {
@@ -141,9 +139,9 @@ Configure manually via `openclaw.json`:
         api: "openai-responses",
         models: [
           {
-            id: "minimax-m2.1-gs32",
-            name: "MiniMax M2.1 GS32",
-            reasoning: false,
+            id: "minimax-m2.5-gs32",
+            name: "MiniMax M2.5 GS32",
+            reasoning: true,
             input: ["text"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             contextWindow: 196608,
@@ -162,7 +160,7 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 
 1. Run `openclaw configure`.
 2. Select **Model/auth**.
-3. Choose **MiniMax M2.1**.
+3. Choose **MiniMax M2.5**.
 4. Pick your default model when prompted.
 
 ## Configuration options
@@ -181,25 +179,25 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 - Update pricing values in `models.json` if you need exact cost tracking.
 - Referral link for MiniMax Coding Plan (10% off): [https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link](https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link)
 - See [/concepts/model-providers](/concepts/model-providers) for provider rules.
-- Use `openclaw models list` and `openclaw models set minimax/MiniMax-M2.1` to switch.
+- Use `openclaw models list` and `openclaw models set minimax/MiniMax-M2.5` to switch.
 
 ## Troubleshooting
 
-### “Unknown model: minimax/MiniMax-M2.1”
+### “Unknown model: minimax/MiniMax-M2.5”
 
 This usually means the **MiniMax provider isn’t configured** (no provider entry
 and no MiniMax auth profile/env key found). A fix for this detection is in
 **2026.1.12** (unreleased at the time of writing). Fix by:
 
 - Upgrading to **2026.1.12** (or run from source `main`), then restarting the gateway.
-- Running `openclaw configure` and selecting **MiniMax M2.1**, or
+- Running `openclaw configure` and selecting **MiniMax M2.5**, or
 - Adding the `models.providers.minimax` block manually, or
 - Setting `MINIMAX_API_KEY` (or a MiniMax auth profile) so the provider can be injected.
 
 Make sure the model id is **case‑sensitive**:
 
-- `minimax/MiniMax-M2.1`
-- `minimax/MiniMax-M2.1-lightning`
+- `minimax/MiniMax-M2.5`
+- `minimax/MiniMax-M2.5-highspeed`
 
 Then recheck with:
 

--- a/docs/zh-CN/cli/index.md
+++ b/docs/zh-CN/cli/index.md
@@ -310,7 +310,7 @@ openclaw [--dev] [--profile <name>] <command>
 - `--non-interactive`
 - `--mode <local|remote>`
 - `--flow <quickstart|advanced|manual>`（manual 是 advanced 的别名）
-- `--auth-choice <setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip>`
+- `--auth-choice <setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-highspeed|opencode-zen|skip>`
 - `--token-provider <id>`（非交互式；与 `--auth-choice token` 配合使用）
 - `--token <token>`（非交互式；与 `--auth-choice token` 配合使用）
 - `--token-profile-id <id>`（非交互式；默认：`<provider>:manual`）

--- a/docs/zh-CN/help/faq.md
+++ b/docs/zh-CN/help/faq.md
@@ -150,7 +150,7 @@ x-i18n:
   - [如何在运行中切换模型（无需重启）？](#how-do-i-switch-models-on-the-fly-without-restarting)
   - [能否日常任务用 GPT 5.2，编程用 Codex 5.2？](#can-i-use-gpt-52-for-daily-tasks-and-codex-52-for-coding)
   - [为什么我看到"Model … is not allowed"然后没有回复？](#why-do-i-see-model-is-not-allowed-and-then-no-reply)
-  - [为什么我看到"Unknown model: minimax/MiniMax-M2.1"？](#why-do-i-see-unknown-model-minimaxminimaxm21)
+  - [为什么我看到"Unknown model: minimax/MiniMax-M2.5"？](#why-do-i-see-unknown-model-minimaxminimaxm21)
   - [能否将 MiniMax 设为默认，复杂任务用 OpenAI？](#can-i-use-minimax-as-my-default-and-openai-for-complex-tasks)
   - [opus / sonnet / gpt 是内置快捷方式吗？](#are-opus-sonnet-gpt-builtin-shortcuts)
   - [如何定义/覆盖模型快捷方式（别名）？](#how-do-i-defineoverride-model-shortcuts-aliases)
@@ -694,7 +694,7 @@ Gemini CLI 使用**插件认证流程**，而不是 `openclaw.json` 中的 clien
 
 ### 本地模型适合日常聊天吗
 
-通常不适合。OpenClaw 需要大上下文 + 强安全性；小显卡会截断且泄漏。如果必须使用，请在本地运行你能运行的**最大** MiniMax M2.1 版本（LM Studio），参阅 [/gateway/local-models](/gateway/local-models)。较小/量化的模型会增加提示注入风险——参阅[安全](/gateway/security)。
+通常不适合。OpenClaw 需要大上下文 + 强安全性；小显卡会截断且泄漏。如果必须使用，请在本地运行你能运行的**最大** MiniMax M2.5 版本（LM Studio），参阅 [/gateway/local-models](/gateway/local-models)。较小/量化的模型会增加提示注入风险——参阅[安全](/gateway/security)。
 
 ### 如何将托管模型流量限制在特定区域
 
@@ -1786,7 +1786,7 @@ agents.defaults.model.primary
 **可靠（个性较少）：** `openai/gpt-5.2`——几乎和 Opus 一样好，只是个性较少。
 **经济：** `zai/glm-4.7`。
 
-MiniMax M2.1 有自己的文档：[MiniMax](/providers/minimax) 和
+MiniMax M2.5 有自己的文档：[MiniMax](/providers/minimax) 和
 [本地模型](/gateway/local-models)。
 
 经验法则：高风险工作使用你能负担的**最好的模型**，日常聊天或摘要使用更便宜的模型。你可以按智能体路由模型并使用子智能体并行处理长任务（每个子智能体消耗令牌）。参阅[模型](/concepts/models)和[子智能体](/tools/subagents)。
@@ -1823,7 +1823,7 @@ MiniMax M2.1 有自己的文档：[MiniMax](/providers/minimax) 和
 ### OpenClaw、Flawd 和 Krill 使用什么模型
 
 - **OpenClaw + Flawd：** Anthropic Opus（`anthropic/claude-opus-4-5`）——参阅 [Anthropic](/providers/anthropic)。
-- **Krill：** MiniMax M2.1（`minimax/MiniMax-M2.1`）——参阅 [MiniMax](/providers/minimax)。
+- **Krill：** MiniMax M2.5（`minimax/MiniMax-M2.5`）——参阅 [MiniMax](/providers/minimax)。
 
 ### 如何在运行中切换模型（无需重启）
 
@@ -1888,7 +1888,7 @@ Model "provider/model" is not allowed. Use /model to list available models.
 
 该错误**代替**正常回复返回。修复：将模型添加到 `agents.defaults.models`，移除允许列表，或从 `/model list` 中选择一个模型。
 
-### 为什么我看到"Unknown model: minimax/MiniMax-M2.1"
+### 为什么我看到"Unknown model: minimax/MiniMax-M2.5"
 
 这意味着**提供商未配置**（未找到 MiniMax 提供商配置或认证配置文件），因此模型无法解析。此检测的修复在 **2026.1.12**（撰写本文时尚未发布）中。
 
@@ -1896,7 +1896,7 @@ Model "provider/model" is not allowed. Use /model to list available models.
 
 1. 升级到 **2026.1.12**（或从源码 `main` 运行），然后重启 Gateway 网关。
 2. 确保 MiniMax 已配置（向导或 JSON），或者 MiniMax API 密钥存在于环境/认证配置文件中以便提供商可以被注入。
-3. 使用精确的模型 ID（区分大小写）：`minimax/MiniMax-M2.1` 或 `minimax/MiniMax-M2.1-lightning`。
+3. 使用精确的模型 ID（区分大小写）：`minimax/MiniMax-M2.5` 或 `minimax/MiniMax-M2.5-highspeed`。
 4. 运行：
    ```bash
    openclaw models list
@@ -1916,9 +1916,9 @@ Model "provider/model" is not allowed. Use /model to list available models.
   env: { MINIMAX_API_KEY: "sk-...", OPENAI_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "minimax/MiniMax-M2.1" },
+      model: { primary: "minimax/MiniMax-M2.5" },
       models: {
-        "minimax/MiniMax-M2.1": { alias: "minimax" },
+        "minimax/MiniMax-M2.5": { alias: "minimax" },
         "openai/gpt-5.2": { alias: "gpt" },
       },
     },

--- a/docs/zh-CN/providers/minimax.md
+++ b/docs/zh-CN/providers/minimax.md
@@ -2,7 +2,7 @@
 read_when:
   - 你想在 OpenClaw 中使用 MiniMax 模型
   - 你需要 MiniMax 设置指南
-summary: 在 OpenClaw 中使用 MiniMax M2.1
+summary: 在 OpenClaw 中使用 MiniMax M2.5
 title: MiniMax
 x-i18n:
   generated_at: "2026-02-03T10:08:52Z"
@@ -15,13 +15,13 @@ x-i18n:
 
 # MiniMax
 
-MiniMax 是一家构建 **M2/M2.1** 模型系列的 AI 公司。当前面向编程的版本是 **MiniMax M2.1**（2025 年 12 月 23 日），专为现实世界的复杂任务而构建。
+MiniMax 是一家构建 **M2/M2.5** 模型系列的 AI 公司。当前面向编程的版本是 **MiniMax M2.5**，专为现实世界的复杂任务而构建。
 
-来源：[MiniMax M2.1 发布说明](https://www.minimax.io/news/minimax-m21)
+来源：[MiniMax M2.5 发布说明](https://www.minimax.io/news/MiniMax-M2-5)
 
-## 模型概述（M2.1）
+## 模型概述（M2.5）
 
-MiniMax 强调 M2.1 的以下改进：
+MiniMax 强调 M2.5 的以下改进：
 
 - 更强的**多语言编程**能力（Rust、Java、Go、C++、Kotlin、Objective-C、TS/JS）。
 - 更好的 **Web/应用开发**和美观输出质量（包括原生移动端）。
@@ -30,11 +30,11 @@ MiniMax 强调 M2.1 的以下改进：
 - 更强的**工具/智能体框架**兼容性和上下文管理（Claude Code、Droid/Factory AI、Cline、Kilo Code、Roo Code、BlackBox）。
 - 更高质量的**对话和技术写作**输出。
 
-## MiniMax M2.1 vs MiniMax M2.1 Lightning
+## MiniMax M2.5 vs MiniMax M2.5 Highspeed
 
-- **速度：** Lightning 是 MiniMax 定价文档中的"快速"变体。
-- **成本：** 定价显示相同的输入成本，但 Lightning 的输出成本更高。
-- **编程计划路由：** Lightning 后端在 MiniMax 编程计划中不能直接使用。MiniMax 自动将大多数请求路由到 Lightning，但在流量高峰期会回退到常规 M2.1 后端。
+- **速度：** Highspeed 是 MiniMax 模型产品线中的"快速"变体。
+- **成本：** 输入成本相同；Highspeed 的输出成本更高。
+- **编程计划：** MiniMax 现已推出 [Highspeed 编程计划](https://platform.minimax.io/subscribe/coding-plan)，可直接使用 M2.5 Highspeed 后端。
 
 ## 选择设置方式
 
@@ -57,7 +57,7 @@ openclaw onboard --auth-choice minimax-portal
 
 详情参见 [MiniMax OAuth 插件 README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth)。
 
-### MiniMax M2.1（API 密钥）
+### MiniMax M2.5（API 密钥）
 
 **适用于：** 使用 Anthropic 兼容 API 的托管 MiniMax。
 
@@ -65,12 +65,12 @@ openclaw onboard --auth-choice minimax-portal
 
 - 运行 `openclaw configure`
 - 选择 **Model/auth**
-- 选择 **MiniMax M2.1**
+- 选择 **MiniMax M2.5**
 
 ```json5
 {
   env: { MINIMAX_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.1" } } },
+  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.5" } } },
   models: {
     mode: "merge",
     providers: {
@@ -80,9 +80,9 @@ openclaw onboard --auth-choice minimax-portal
         api: "anthropic-messages",
         models: [
           {
-            id: "MiniMax-M2.1",
-            name: "MiniMax M2.1",
-            reasoning: false,
+            id: "MiniMax-M2.5",
+            name: "MiniMax M2.5",
+            reasoning: true,
             input: ["text"],
             cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 },
             contextWindow: 200000,
@@ -95,9 +95,9 @@ openclaw onboard --auth-choice minimax-portal
 }
 ```
 
-### MiniMax M2.1 作为备用（Opus 为主）
+### MiniMax M2.5 作为备用（Opus 为主）
 
-**适用于：** 保持 Opus 4.5 为主模型，故障时切换到 MiniMax M2.1。
+**适用于：** 保持 Opus 4.5 为主模型，故障时切换到 MiniMax M2.5。
 
 ```json5
 {
@@ -106,11 +106,11 @@ openclaw onboard --auth-choice minimax-portal
     defaults: {
       models: {
         "anthropic/claude-opus-4-5": { alias: "opus" },
-        "minimax/MiniMax-M2.1": { alias: "minimax" },
+        "minimax/MiniMax-M2.5": { alias: "minimax" },
       },
       model: {
         primary: "anthropic/claude-opus-4-5",
-        fallbacks: ["minimax/MiniMax-M2.1"],
+        fallbacks: ["minimax/MiniMax-M2.5"],
       },
     },
   },
@@ -120,7 +120,7 @@ openclaw onboard --auth-choice minimax-portal
 ### 可选：通过 LM Studio 本地运行（手动）
 
 **适用于：** 使用 LM Studio 进行本地推理。
-我们在强大硬件（例如台式机/服务器）上使用 LM Studio 的本地服务器运行 MiniMax M2.1 时看到了出色的效果。
+我们在强大硬件（例如台式机/服务器）上使用 LM Studio 的本地服务器运行 MiniMax M2.5 时看到了出色的效果。
 
 通过 `openclaw.json` 手动配置：
 
@@ -128,8 +128,8 @@ openclaw onboard --auth-choice minimax-portal
 {
   agents: {
     defaults: {
-      model: { primary: "lmstudio/minimax-m2.1-gs32" },
-      models: { "lmstudio/minimax-m2.1-gs32": { alias: "Minimax" } },
+      model: { primary: "lmstudio/minimax-m2.5-gs32" },
+      models: { "lmstudio/minimax-m2.5-gs32": { alias: "Minimax" } },
     },
   },
   models: {
@@ -141,9 +141,9 @@ openclaw onboard --auth-choice minimax-portal
         api: "openai-responses",
         models: [
           {
-            id: "minimax-m2.1-gs32",
-            name: "MiniMax M2.1 GS32",
-            reasoning: false,
+            id: "minimax-m2.5-gs32",
+            name: "MiniMax M2.5 GS32",
+            reasoning: true,
             input: ["text"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             contextWindow: 196608,
@@ -162,7 +162,7 @@ openclaw onboard --auth-choice minimax-portal
 
 1. 运行 `openclaw configure`。
 2. 选择 **Model/auth**。
-3. 选择 **MiniMax M2.1**。
+3. 选择 **MiniMax M2.5**。
 4. 在提示时选择你的默认模型。
 
 ## 配置选项
@@ -181,23 +181,23 @@ openclaw onboard --auth-choice minimax-portal
 - 如果需要精确的成本跟踪，请更新 `models.json` 中的定价值。
 - MiniMax 编程计划推荐链接（9 折优惠）：https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link
 - 参见 [/concepts/model-providers](/concepts/model-providers) 了解提供商规则。
-- 使用 `openclaw models list` 和 `openclaw models set minimax/MiniMax-M2.1` 切换模型。
+- 使用 `openclaw models list` 和 `openclaw models set minimax/MiniMax-M2.5` 切换模型。
 
 ## 故障排除
 
-### "Unknown model: minimax/MiniMax-M2.1"
+### "Unknown model: minimax/MiniMax-M2.5"
 
 这通常意味着 **MiniMax 提供商未配置**（没有提供商条目，也没有找到 MiniMax 认证配置文件/环境变量密钥）。此检测的修复在 **2026.1.12** 中（撰写本文时尚未发布）。修复方法：
 
 - 升级到 **2026.1.12**（或从源码 `main` 分支运行），然后重启 Gateway 网关。
-- 运行 `openclaw configure` 并选择 **MiniMax M2.1**，或
+- 运行 `openclaw configure` 并选择 **MiniMax M2.5**，或
 - 手动添加 `models.providers.minimax` 块，或
 - 设置 `MINIMAX_API_KEY`（或 MiniMax 认证配置文件）以便注入提供商。
 
 确保模型 id **区分大小写**：
 
-- `minimax/MiniMax-M2.1`
-- `minimax/MiniMax-M2.1-lightning`
+- `minimax/MiniMax-M2.5`
+- `minimax/MiniMax-M2.5-highspeed`
 
 然后重新检查：
 

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -438,8 +438,8 @@ function buildMinimaxProvider(): ProviderConfig {
         reasoning: true,
       }),
       buildMinimaxTextModel({
-        id: "MiniMax-M2.5-Lightning",
-        name: "MiniMax M2.5 Lightning",
+        id: "MiniMax-M2.5-highspeed",
+        name: "MiniMax M2.5 Highspeed",
         reasoning: true,
       }),
     ],

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -37,6 +37,7 @@ type ModelSelectionState = {
 
 const FUZZY_VARIANT_TOKENS = [
   "lightning",
+  "highspeed",
   "preview",
   "mini",
   "fast",

--- a/src/commands/auth-choice-options.e2e.test.ts
+++ b/src/commands/auth-choice-options.e2e.test.ts
@@ -31,7 +31,7 @@ describe("buildAuthChoiceOptions", () => {
   it.each([
     ["Z.AI (GLM) auth choice", ["zai-api-key"]],
     ["Xiaomi auth choice", ["xiaomi-api-key"]],
-    ["MiniMax auth choice", ["minimax-api", "minimax-api-key-cn", "minimax-api-lightning"]],
+    ["MiniMax auth choice", ["minimax-api", "minimax-api-key-cn", "minimax-api-highspeed"]],
     [
       "Moonshot auth choice",
       ["moonshot-api-key", "moonshot-api-key-cn", "kimi-code-api-key", "together-api-key"],

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -50,7 +50,7 @@ const AUTH_CHOICE_GROUP_DEFS: {
     value: "minimax",
     label: "MiniMax",
     hint: "M2.5 (recommended)",
-    choices: ["minimax-portal", "minimax-api", "minimax-api-key-cn", "minimax-api-lightning"],
+    choices: ["minimax-portal", "minimax-api", "minimax-api-key-cn", "minimax-api-highspeed"],
   },
   {
     value: "moonshot",
@@ -292,8 +292,8 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     hint: "China endpoint (api.minimaxi.com)",
   },
   {
-    value: "minimax-api-lightning",
-    label: "MiniMax M2.5 Lightning",
+    value: "minimax-api-highspeed",
+    label: "MiniMax M2.5 Highspeed",
     hint: "Faster, higher output cost",
   },
   { value: "custom-api-key", label: "Custom Provider" },

--- a/src/commands/auth-choice.apply.minimax.ts
+++ b/src/commands/auth-choice.apply.minimax.ts
@@ -78,10 +78,10 @@ export async function applyAuthChoiceMiniMax(
   if (
     params.authChoice === "minimax-cloud" ||
     params.authChoice === "minimax-api" ||
-    params.authChoice === "minimax-api-lightning"
+    params.authChoice === "minimax-api-highspeed"
   ) {
     const modelId =
-      params.authChoice === "minimax-api-lightning" ? "MiniMax-M2.5-Lightning" : "MiniMax-M2.5";
+      params.authChoice === "minimax-api-highspeed" ? "MiniMax-M2.5-highspeed" : "MiniMax-M2.5";
     await ensureMinimaxApiKey({
       profileId: "minimax:default",
       promptMessage: "Enter MiniMax API key",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -35,7 +35,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "minimax-cloud": "minimax",
   "minimax-api": "minimax",
   "minimax-api-key-cn": "minimax-cn",
-  "minimax-api-lightning": "minimax",
+  "minimax-api-highspeed": "minimax",
   minimax: "lmstudio",
   "opencode-zen": "opencode",
   "xai-api-key": "xai",

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -82,7 +82,7 @@ const MINIMAX_MODEL_CATALOG = {
     reasoning: false,
   },
   "MiniMax-M2.5": { name: "MiniMax M2.5", reasoning: true },
-  "MiniMax-M2.5-Lightning": { name: "MiniMax M2.5 Lightning", reasoning: true },
+  "MiniMax-M2.5-highspeed": { name: "MiniMax M2.5 Highspeed", reasoning: true },
 } as const;
 
 type MinimaxCatalogId = keyof typeof MINIMAX_MODEL_CATALOG;

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -559,7 +559,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     authChoice === "minimax-cloud" ||
     authChoice === "minimax-api" ||
     authChoice === "minimax-api-key-cn" ||
-    authChoice === "minimax-api-lightning"
+    authChoice === "minimax-api-highspeed"
   ) {
     const isCn = authChoice === "minimax-api-key-cn";
     const providerId = isCn ? "minimax-cn" : "minimax";
@@ -584,7 +584,7 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     const modelId =
-      authChoice === "minimax-api-lightning" ? "MiniMax-M2.5-Lightning" : "MiniMax-M2.5";
+      authChoice === "minimax-api-highspeed" ? "MiniMax-M2.5-highspeed" : "MiniMax-M2.5";
     return isCn
       ? applyMinimaxApiConfigCn(nextConfig, modelId)
       : applyMinimaxApiConfig(nextConfig, modelId);

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -38,7 +38,7 @@ export type AuthChoice =
   | "minimax"
   | "minimax-api"
   | "minimax-api-key-cn"
-  | "minimax-api-lightning"
+  | "minimax-api-highspeed"
   | "minimax-portal"
   | "opencode-zen"
   | "github-copilot"


### PR DESCRIPTION
## Summary

- Rename MiniMax M2.5 Lightning to M2.5 Highspeed across docs and code
- Update coding plan section: MiniMax now offers a Highspeed coding plan with direct M2.5 Highspeed access
- Update all M2.1 references to M2.5 in MiniMax provider docs
- Add `highspeed` to fuzzy model variant tokens

## Test plan

- [ ] `pnpm test` passes
- [ ] `pnpm check` passes
- [ ] Verify docs render correctly on Mintlify

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames MiniMax model references from M2.1/Lightning to M2.5/Highspeed across documentation and code. The changes correctly update CLI docs, provider docs (English and Chinese), and core TypeScript files including auth choice options, model selection, and onboarding flows.

**Key changes:**
- Updated model IDs: `MiniMax-M2.1-lightning` → `MiniMax-M2.5-highspeed`
- Updated auth choice: `minimax-api-lightning` → `minimax-api-highspeed`
- Added `highspeed` to fuzzy model variant tokens
- Updated documentation to reflect MiniMax's new Highspeed coding plan

**Issues found:**
- Several test files still reference old M2.1/Lightning models and need updates
- `src/agents/models-config.providers.ts` contains old M2.1 model definitions (lines 420-428)
- `src/commands/onboard-auth.models.ts` has M2.1 entries in the catalog (lines 79-83)
- Multiple e2e test files use old model names in test data
- Two anchor link mismatches in FAQ docs where links point to `m21` but should point to `m25`

<h3>Confidence Score: 2/5</h3>

- This PR has incomplete migration that will cause test failures and inconsistent behavior
- The PR successfully updates many files but leaves critical M2.1/Lightning references in production code (`models-config.providers.ts`, `onboard-auth.models.ts`) and test files. These omissions will cause tests to fail and create inconsistent model availability. The old model definitions in `models-config.providers.ts` mean the deprecated models are still being registered. This is a systematic rename that requires complete coverage.
- `src/agents/models-config.providers.ts`, `src/commands/onboard-auth.models.ts`, `src/commands/onboard-auth.e2e.test.ts`, and `src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts` need immediate attention

<sub>Last reviewed commit: cb9c958</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->