### PR TITLE
fix(security): OC-14 add role authorization checks to Discord admin operations

### DIFF
--- a/src/agents/tools/discord-actions-moderation.authz.test.ts
+++ b/src/agents/tools/discord-actions-moderation.authz.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it, vi } from "vitest";
+import { PermissionFlagsBits } from "discord-api-types/v10";
+import type { DiscordActionConfig } from "../../config/config.js";
+import { handleDiscordModerationAction } from "./discord-actions-moderation.js";
+
+const discordSendMocks = vi.hoisted(() => ({
+  banMemberDiscord: vi.fn(async () => ({})),
+  kickMemberDiscord: vi.fn(async () => ({})),
+  timeoutMemberDiscord: vi.fn(async () => ({ id: "user123" })),
+  hasGuildPermissionDiscord: vi.fn(async () => false),
+}));
+
+const { banMemberDiscord, kickMemberDiscord, timeoutMemberDiscord, hasGuildPermissionDiscord } =
+  discordSendMocks;
+
+vi.mock("../../discord/send.js", () => ({
+  ...discordSendMocks,
+}));
+
+const enableAllActions = () => true;
+
+describe("Discord Moderation Action Authorization", () => {
+  describe("ban action", () => {
+    it("rejects when sender lacks BAN_MEMBERS permission", async () => {
+      hasGuildPermissionDiscord.mockResolvedValueOnce(false);
+
+      await expect(
+        handleDiscordModerationAction(
+          "ban",
+          {
+            guildId: "guild123",
+            userId: "user456",
+            senderUserId: "sender789",
+            reason: "test ban",
+          },
+          enableAllActions,
+        ),
+      ).rejects.toThrow("does not have required permissions");
+
+      expect(hasGuildPermissionDiscord).toHaveBeenCalledWith(
+        "guild123",
+        "sender789",
+        [PermissionFlagsBits.BanMembers],
+        undefined,
+      );
+      expect(banMemberDiscord).not.toHaveBeenCalled();
+    });
+
+    it("rejects with 'missing sender user ID' error when senderUserId is not provided", async () => {
+      await expect(
+        handleDiscordModerationAction(
+          "ban",
+          {
+            guildId: "guild123",
+            userId: "user456",
+            reason: "test ban",
+          },
+          enableAllActions,
+        ),
+      ).rejects.toThrow("Sender user ID required");
+    });
+
+    it("executes ban when sender has BAN_MEMBERS permission", async () => {
+      hasGuildPermissionDiscord.mockResolvedValueOnce(true);
+      banMemberDiscord.mockResolvedValueOnce({ ok: true });
+
+      const result = await handleDiscordModerationAction(
+        "ban",
+        {
+          guildId: "guild123",
+          userId: "user456",
+          senderUserId: "sender789",
+          reason: "test ban",
+          deleteMessageDays: 7,
+        },
+        enableAllActions,
+      );
+
+      expect(result.content).toEqual({ ok: true });
+      expect(hasGuildPermissionDiscord).toHaveBeenCalledWith(
+        "guild123",
+        "sender789",
+        [PermissionFlagsBits.BanMembers],
+        undefined,
+      );
+      expect(banMemberDiscord).toHaveBeenCalledWith(
+        {
+          guildId: "guild123",
+          userId: "user456",
+          reason: "test ban",
+          deleteMessageDays: 7,
+        },
+        undefined,
+      );
+    });
+
+    it("executes ban with accountId when sender has BAN_MEMBERS permission", async () => {
+      hasGuildPermissionDiscord.mockResolvedValueOnce(true);
+      banMemberDiscord.mockResolvedValueOnce({ ok: true });
+
+      const result = await handleDiscordModerationAction(
+        "ban",
+        {
+          guildId: "guild123",
+          userId: "user456",
+          senderUserId: "sender789",
+          accountId: "account999",
+          reason: "test ban",
+        },
+        enableAllActions,
+      );
+
+      expect(result.content).toEqual({ ok: true });
+      expect(hasGuildPermissionDiscord).toHaveBeenCalledWith(
+        "guild123",
+        "sender789",
+        [PermissionFlagsBits.BanMembers],
+        { accountId: "account999" },
+      );
+      expect(banMemberDiscord).toHaveBeenCalledWith(
+        {
+          guildId: "guild123",
+          userId: "user456",
+          reason: "test ban",
+          deleteMessageDays: undefined,
+        },
+        { accountId: "account999" },
+      );
+    });
+  });
+
+  describe("kick action", () => {
+    it("rejects when sender lacks KICK_MEMBERS permission", async () => {
+      hasGuildPermissionDiscord.mockResolvedValueOnce(false);
+
+      await expect(
+        handleDiscordModerationAction(
+          "kick",
+          {
+            guildId: "guild123",
+            userId: "user456",
+            senderUserId: "sender789",
+            reason: "test kick",
+          },
+          enableAllActions,
+        ),
+      ).rejects.toThrow("does not have required permissions");
+
+      expect(hasGuildPermissionDiscord).toHaveBeenCalledWith(
+        "guild123",
+        "sender789",
+        [PermissionFlagsBits.KickMembers],
+        undefined,
+      );
+      expect(kickMemberDiscord).not.toHaveBeenCalled();
+    });
+
+    it("executes kick when sender has KICK_MEMBERS permission", async () => {
+      hasGuildPermissionDiscord.mockResolvedValueOnce(true);
+      kickMemberDiscord.mockResolvedValueOnce({ ok: true });
+
+      const result = await handleDiscordModerationAction(
+        "kick",
+        {
+          guildId: "guild123",
+          userId: "user456",
+          senderUserId: "sender789",
+          reason: "test kick",
+        },
+        enableAllActions,
+      );
+
+      expect(result.content).toEqual({ ok: true });
+      expect(hasGuildPermissionDiscord).toHaveBeenCalledWith(
+        "guild123",
+        "sender789",
+        [PermissionFlagsBits.KickMembers],
+        undefined,
+      );
+      expect(kickMemberDiscord).toHaveBeenCalledWith(
+        { guildId: "guild123", userId: "user456", reason: "test kick" },
+        undefined,
+      );
+    });
+  });
+
+  describe("timeout action", () => {
+    it("rejects when sender lacks MODERATE_MEMBERS permission", async () => {
+      hasGuildPermissionDiscord.mockResolvedValueOnce(false);
+
+      await expect(
+        handleDiscordModerationAction(
+          "timeout",
+          {
+            guildId: "guild123",
+            userId: "user456",
+            senderUserId: "sender789",
+            durationMinutes: 60,
+          },
+          enableAllActions,
+        ),
+      ).rejects.toThrow("does not have required permissions");
+
+      expect(hasGuildPermissionDiscord).toHaveBeenCalledWith(
+        "guild123",
+        "sender789",
+        [PermissionFlagsBits.ModerateMembers],
+        undefined,
+      );
+      expect(timeoutMemberDiscord).not.toHaveBeenCalled();
+    });
+
+    it("executes timeout when sender has MODERATE_MEMBERS permission", async () => {
+      hasGuildPermissionDiscord.mockResolvedValueOnce(true);
+      timeoutMemberDiscord.mockResolvedValueOnce({ id: "user456" });
+
+      const result = await handleDiscordModerationAction(
+        "timeout",
+        {
+          guildId: "guild123",
+          userId: "user456",
+          senderUserId: "sender789",
+          durationMinutes: 60,
+          reason: "test timeout",
+        },
+        enableAllActions,
+      );
+
+      expect(result.content).toEqual({ ok: true, member: { id: "user456" } });
+      expect(hasGuildPermissionDiscord).toHaveBeenCalledWith(
+        "guild123",
+        "sender789",
+        [PermissionFlagsBits.ModerateMembers],
+        undefined,
+      );
+      expect(timeoutMemberDiscord).toHaveBeenCalledWith(
+        {
+          guildId: "guild123",
+          userId: "user456",
+          durationMinutes: 60,
+          until: undefined,
+          reason: "test timeout",
+        },
+        undefined,
+      );
+    });
+
+    it("allows timeout with until instead of durationMinutes", async () => {
+      hasGuildPermissionDiscord.mockResolvedValueOnce(true);
+      timeoutMemberDiscord.mockResolvedValueOnce({ id: "user456" });
+
+      const result = await handleDiscordModerationAction(
+        "timeout",
+        {
+          guildId: "guild123",
+          userId: "user456",
+          senderUserId: "sender789",
+          until: "2024-12-31T23:59:59Z",
+        },
+        enableAllActions,
+      );
+
+      expect(result.content).toEqual({ ok: true, member: { id: "user456" } });
+      expect(timeoutMemberDiscord).toHaveBeenCalledWith(
+        {
+          guildId: "guild123",
+          userId: "user456",
+          durationMinutes: undefined,
+          until: "2024-12-31T23:59:59Z",
+          reason: undefined,
+        },
+        undefined,
+      );
+    });
+  });
+
+  describe("disabled moderation", () => {
+    const moderationDisabled = (key: keyof DiscordActionConfig) => key !== "moderation";
+
+    it("rejects ban when moderation is disabled", async () => {
+      await expect(
+        handleDiscordModerationAction(
+          "ban",
+          {
+            guildId: "guild123",
+            userId: "user456",
+            senderUserId: "sender789",
+          },
+          moderationDisabled,
+        ),
+      ).rejects.toThrow("Discord moderation is disabled");
+
+      expect(hasGuildPermissionDiscord).not.toHaveBeenCalled();
+      expect(banMemberDiscord).not.toHaveBeenCalled();
+    });
+
+    it("rejects kick when moderation is disabled", async () => {
+      await expect(
+        handleDiscordModerationAction(
+          "kick",
+          {
+            guildId: "guild123",
+            userId: "user456",
+            senderUserId: "sender789",
+          },
+          moderationDisabled,
+        ),
+      ).rejects.toThrow("Discord moderation is disabled");
+
+      expect(kickMemberDiscord).not.toHaveBeenCalled();
+    });
+
+    it("rejects timeout when moderation is disabled", async () => {
+      await expect(
+        handleDiscordModerationAction(
+          "timeout",
+          {
+            guildId: "guild123",
+            userId: "user456",
+            senderUserId: "sender789",
+          },
+          moderationDisabled,
+        ),
+      ).rejects.toThrow("Discord moderation is disabled");
+
+      expect(timeoutMemberDiscord).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -355,6 +355,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const deleteMessageDays = readNumberParam(actionParams, "deleteDays", {
       integer: true,
     });
+    const senderUserId = readStringParam(actionParams, "senderUserId");
     const discordAction = action;
     return await handleDiscordAction(
       {
@@ -366,6 +367,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         until,
         reason,
         deleteMessageDays,
+        senderUserId,
       },
       cfg,
     );

--- a/src/discord/send.permissions.authz.test.ts
+++ b/src/discord/send.permissions.authz.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+import { PermissionFlagsBits, Routes } from "discord-api-types/v10";
+import type { RequestClient } from "@buape/carbon";
+import { fetchMemberGuildPermissionsDiscord, hasGuildPermissionDiscord } from "./send.permissions.js";
+
+const mockRest = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock("./client.js", () => ({
+  resolveDiscordRest: () => mockRest as RequestClient,
+}));
+
+describe("Discord Guild Permissions Authorization", () => {
+  describe("fetchMemberGuildPermissionsDiscord", () => {
+    it("returns null when member is not in guild", async () => {
+      mockRest.get.mockRejectedValueOnce(new Error("404 Member not found"));
+
+      const result = await fetchMemberGuildPermissionsDiscord("guild123", "user456");
+
+      expect(result).toBeNull();
+    });
+
+    it("calculates permissions from guild @everyone role and member roles", async () => {
+      const guildId = "guild123";
+      const userId = "user456";
+      const everyoneRoleId = guildId; // @everyone role has same ID as guild
+
+      mockRest.get
+        .mockResolvedValueOnce({
+          id: guildId,
+          roles: [
+            {
+              id: everyoneRoleId,
+              name: "@everyone",
+              permissions: PermissionFlagsBits.ViewChannel.toString(),
+            },
+            {
+              id: "role-moderator",
+              name: "Moderator",
+              permissions: PermissionFlagsBits.KickMembers.toString(),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: userId,
+          roles: ["role-moderator"],
+        });
+
+      const result = await fetchMemberGuildPermissionsDiscord(guildId, userId);
+
+      expect(result).toBeDefined();
+      expect(result).not.toBeNull();
+      // Should have both ViewChannel and KickMembers permissions
+      const hasViewChannel = (result! & PermissionFlagsBits.ViewChannel) === PermissionFlagsBits.ViewChannel;
+      const hasKickMembers = (result! & PermissionFlagsBits.KickMembers) === PermissionFlagsBits.KickMembers;
+      expect(hasViewChannel).toBe(true);
+      expect(hasKickMembers).toBe(true);
+    });
+
+    it("handles user with ADMINISTRATOR permission", async () => {
+      const guildId = "guild123";
+      const userId = "user456";
+
+      mockRest.get
+        .mockResolvedValueOnce({
+          id: guildId,
+          roles: [
+            {
+              id: guildId,
+              permissions: PermissionFlagsBits.ViewChannel.toString(),
+            },
+            {
+              id: "role-admin",
+              name: "Admin",
+              permissions: PermissionFlagsBits.Administrator.toString(),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: userId,
+          roles: ["role-admin"],
+        });
+
+      const result = await fetchMemberGuildPermissionsDiscord(guildId, userId);
+
+      expect(result).toBeDefined();
+      expect(result).not.toBeNull();
+      const hasAdmin = (result! & PermissionFlagsBits.Administrator) === PermissionFlagsBits.Administrator;
+      expect(hasAdmin).toBe(true);
+    });
+  });
+
+  describe("hasGuildPermissionDiscord", () => {
+    it("returns false when user is not a guild member", async () => {
+      mockRest.get.mockRejectedValueOnce(new Error("404 Member not found"));
+
+      const result = await hasGuildPermissionDiscord("guild123", "user456", [PermissionFlagsBits.KickMembers]);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when user has required permission", async () => {
+      const guildId = "guild123";
+      const userId = "user456";
+
+      mockRest.get
+        .mockResolvedValueOnce({
+          id: guildId,
+          roles: [
+            {
+              id: guildId,
+              permissions: "0",
+            },
+            {
+              id: "role-moderator",
+              permissions: PermissionFlagsBits.KickMembers.toString(),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: userId,
+          roles: ["role-moderator"],
+        });
+
+      const result = await hasGuildPermissionDiscord(guildId, userId, [PermissionFlagsBits.KickMembers]);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns true when user has ADMINISTRATOR permission", async () => {
+      const guildId = "guild123";
+      const userId = "user456";
+
+      mockRest.get
+        .mockResolvedValueOnce({
+          id: guildId,
+          roles: [
+            {
+              id: guildId,
+              permissions: "0",
+            },
+            {
+              id: "role-admin",
+              permissions: PermissionFlagsBits.Administrator.toString(),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: userId,
+          roles: ["role-admin"],
+        });
+
+      const result = await hasGuildPermissionDiscord(guildId, userId, [
+        PermissionFlagsBits.KickMembers,
+        PermissionFlagsBits.BanMembers,
+      ]);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when user lacks required permission", async () => {
+      const guildId = "guild123";
+      const userId = "user456";
+
+      mockRest.get
+        .mockResolvedValueOnce({
+          id: guildId,
+          roles: [
+            {
+              id: guildId,
+              permissions: PermissionFlagsBits.ViewChannel.toString(),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: userId,
+          roles: [],
+        });
+
+      const result = await hasGuildPermissionDiscord(guildId, userId, [PermissionFlagsBits.KickMembers]);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when user has any of multiple required permissions", async () => {
+      const guildId = "guild123";
+      const userId = "user456";
+
+      mockRest.get
+        .mockResolvedValueOnce({
+          id: guildId,
+          roles: [
+            {
+              id: guildId,
+              permissions: "0",
+            },
+            {
+              id: "role-moderator",
+              permissions: PermissionFlagsBits.KickMembers.toString(),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: userId,
+          roles: ["role-moderator"],
+        });
+
+      const result = await hasGuildPermissionDiscord(guildId, userId, [
+        PermissionFlagsBits.BanMembers,
+        PermissionFlagsBits.KickMembers,
+      ]);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when user lacks all required permissions", async () => {
+      const guildId = "guild123";
+      const userId = "user456";
+
+      mockRest.get
+        .mockResolvedValueOnce({
+          id: guildId,
+          roles: [
+            {
+              id: guildId,
+              permissions: PermissionFlagsBits.ViewChannel.toString(),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: userId,
+          roles: [],
+        });
+
+      const result = await hasGuildPermissionDiscord(guildId, userId, [
+        PermissionFlagsBits.BanMembers,
+        PermissionFlagsBits.KickMembers,
+      ]);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -46,6 +46,10 @@ export {
 export { sendDiscordComponentMessage } from "./send.components.js";
 export {
   fetchChannelPermissionsDiscord,
+  fetchMemberGuildPermissionsDiscord,
+  hasGuildPermissionDiscord,
+} from "./send.permissions.js";
+export {
   fetchReactionsDiscord,
   reactMessageDiscord,
   removeOwnReactionsDiscord,


### PR DESCRIPTION
## Summary

- Check sender's guild permissions before executing admin operations
- Reject ban/kick/timeout commands from non-admin users

## Security Impact

**OC-14 high (CWE-862, CVSS 7.8)** — Attack vectors remediated:
1. Non-admin user triggers admin operation via bot without authorization check

## Changes

| File | Change |
|------|--------|
| `src/discord/send.permissions.ts` | Add permission check functions |
| `src/agents/tools/discord-actions-moderation.ts` | Add sender authorization checks |

## Test plan

- [x] Non-admin cannot ban users
- [x] Non-admin cannot kick users
- [x] Admin users can execute operations

---
*Created by [Aether AI Agent](https://tryaether.ai) — AI security research and remediation agent.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Discord role-based authorization checks to ban, kick, and timeout moderation operations, preventing non-admin users from executing privileged actions via the bot. The implementation checks `senderUserId` permissions against Discord guild roles before executing any moderation action.

**Key changes:**
- Added `fetchMemberGuildPermissionsDiscord()` and `hasGuildPermissionDiscord()` functions in `src/discord/send.permissions.ts` to query Discord API for user guild permissions
- Added `verifySenderModerationPermission()` in `src/agents/tools/discord-actions-moderation.ts` that enforces permission checks before ban/kick/timeout operations
- Modified `handle-action.guild-admin.ts` to pass through `senderUserId` parameter from action params
- Added comprehensive unit tests for permission checking and authorization logic

**Issues found:**
- Existing e2e tests in `src/agents/tools/discord-actions.e2e.test.ts` were not updated to include required `senderUserId` parameter and will fail
- Tests need additional mocks for `hasGuildPermissionDiscord` function introduced by this PR
- No clear mechanism shown for how `senderUserId` gets populated in actual runtime usage (must be explicitly provided by caller)

<h3>Confidence Score: 3/5</h3>

- This PR fixes a critical security vulnerability but breaks existing e2e tests
- Score reflects strong security improvement (authorization checks are properly implemented with good test coverage for the new code) but significant integration issues (existing e2e tests not updated, unclear runtime parameter flow). The security fix is correct but the PR is incomplete - existing tests will fail and there's no documentation of how `senderUserId` should be populated by callers.
- Pay close attention to `src/agents/tools/discord-actions.e2e.test.ts` which has failing tests

<sub>Last reviewed commit: 61a4a5b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->