### PR TITLE
fix(providers): rename MiniMax M2.5 Lightning to M2.5 highspeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -623,7 +623,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Reminders: guard reminder promises by appending a note when no `cron.add` succeeded in the turn, so users know nothing was scheduled. (#18588) Thanks @vignesh07.
 - Discord: omit empty content fields for media-only messages while preserving caption whitespace. (#9507) Thanks @leszekszpunar.
 - Onboarding/Providers: add Z.AI endpoint-specific auth choices (`zai-coding-global`, `zai-coding-cn`, `zai-global`, `zai-cn`) and expand default Z.AI model wiring. (#13456) Thanks @tomsun28.
-- Onboarding/Providers: update MiniMax API default/recommended models from M2.1 to M2.5, add M2.5/M2.5-Lightning model entries, and include `minimax-m2.5` in modern model filtering. (#14865) Thanks @adao-max.
+- Onboarding/Providers: update MiniMax API default/recommended models from M2.1 to M2.5, add M2.5/M2.5-highspeed model entries, and include `minimax-m2.5` in modern model filtering. (#14865) Thanks @adao-max.
 - Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.
 - Voice Call: pass Twilio stream auth token via `<Parameter>` instead of query string. (#14029) Thanks @mcwigglesmcgee.
 - Config/Models: allow full `models.providers.*.models[*].compat` keys used by `openai-completions` (`thinkingFormat`, `supportsStrictMode`, and streaming/tool-result compatibility flags) so valid provider overrides no longer fail strict config validation. (#11063) Thanks @ikari-pl.

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -438,8 +438,8 @@ function buildMinimaxProvider(): ProviderConfig {
         reasoning: true,
       }),
       buildMinimaxTextModel({
-        id: "MiniMax-M2.5-Lightning",
-        name: "MiniMax M2.5 Lightning",
+        id: "MiniMax-M2.5-highspeed",
+        name: "MiniMax M2.5 highspeed",
         reasoning: true,
       }),
     ],

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -293,7 +293,7 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
   },
   {
     value: "minimax-api-lightning",
-    label: "MiniMax M2.5 Lightning",
+    label: "MiniMax M2.5 highspeed",
     hint: "Faster, higher output cost",
   },
   { value: "custom-api-key", label: "Custom Provider" },

--- a/src/commands/auth-choice.apply.minimax.ts
+++ b/src/commands/auth-choice.apply.minimax.ts
@@ -74,7 +74,7 @@ export async function applyAuthChoiceMiniMax(
     params.authChoice === "minimax-api-lightning"
   ) {
     const modelId =
-      params.authChoice === "minimax-api-lightning" ? "MiniMax-M2.5-Lightning" : "MiniMax-M2.5";
+      params.authChoice === "minimax-api-lightning" ? "MiniMax-M2.5-highspeed" : "MiniMax-M2.5";
     await ensureMinimaxApiKey({
       profileId: "minimax:default",
       promptMessage: "Enter MiniMax API key",

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -82,7 +82,7 @@ const MINIMAX_MODEL_CATALOG = {
     reasoning: false,
   },
   "MiniMax-M2.5": { name: "MiniMax M2.5", reasoning: true },
-  "MiniMax-M2.5-Lightning": { name: "MiniMax M2.5 Lightning", reasoning: true },
+  "MiniMax-M2.5-highspeed": { name: "MiniMax M2.5 highspeed", reasoning: true },
 } as const;
 
 type MinimaxCatalogId = keyof typeof MINIMAX_MODEL_CATALOG;

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -584,7 +584,7 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     const modelId =
-      authChoice === "minimax-api-lightning" ? "MiniMax-M2.5-Lightning" : "MiniMax-M2.5";
+      authChoice === "minimax-api-lightning" ? "MiniMax-M2.5-highspeed" : "MiniMax-M2.5";
     return isCn
       ? applyMinimaxApiConfigCn(nextConfig, modelId)
       : applyMinimaxApiConfig(nextConfig, modelId);


### PR DESCRIPTION
## Summary

- Problem: MiniMax has renamed the M2.5 Lightning model to M2.5 highspeed, but the codebase still references the old name.
- Why it matters: Model IDs and display names should match the provider's official naming to avoid confusion.
- What changed: Renamed all occurrences of `MiniMax-M2.5-Lightning` / `MiniMax M2.5 Lightning` to `MiniMax-M2.5-highspeed` / `MiniMax M2.5 highspeed` across model config, auth choice options, onboarding, and changelog.
- What did NOT change (scope boundary): No logic changes; only string renames. The `minimax-api-lightning` auth choice value is kept as-is since it is a stable internal identifier.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #14865

## User-visible / Behavior Changes

- The MiniMax Lightning model option now displays as "MiniMax M2.5 highspeed" in onboarding and auth choice prompts.
- The model ID sent to the MiniMax API changes from `MiniMax-M2.5-Lightning` to `MiniMax-M2.5-highspeed`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Users with existing config referencing the old `MiniMax-M2.5-Lightning` model ID may need to update their config.
  - Mitigation: This is a provider-driven rename; the old ID would stop working on MiniMax's side regardless.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renamed MiniMax M2.5 Lightning model to MiniMax M2.5 highspeed across model configurations, auth choice options, and onboarding flows to match MiniMax's official naming update.

- Updated model ID from `MiniMax-M2.5-Lightning` to `MiniMax-M2.5-highspeed` in models config (`models-config.providers.ts:441-442`)
- Updated display name from "MiniMax M2.5 Lightning" to "MiniMax M2.5 highspeed" in auth choice options (`auth-choice-options.ts:296`)
- Updated model catalog entry in onboarding models (`onboard-auth.models.ts:85`)
- Updated model ID mapping in auth choice handlers (`auth-choice.apply.minimax.ts:77`, `auth-choice.ts:587`)
- Updated changelog reference to reflect the new naming (`CHANGELOG.md:626`)
- The internal auth choice value `minimax-api-lightning` remains unchanged as a stable identifier

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a straightforward string rename that updates model IDs and display names to match MiniMax's official naming convention. All occurrences have been consistently updated across the codebase (model config, auth options, onboarding, changelog). No logic changes were made, only string replacements. The internal identifier `minimax-api-lightning` was correctly preserved as a stable internal value.
- No files require special attention

<sub>Last reviewed commit: c933ed1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->