### PR TITLE
feat(gateway): Cloudflare Tunnel & Access integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -624,6 +624,10 @@
       "destination": "/gateway/tailscale"
     },
     {
+      "source": "/cloudflare",
+      "destination": "/gateway/cloudflare"
+    },
+    {
       "source": "/talk",
       "destination": "/nodes/talk"
     },
@@ -1163,7 +1167,12 @@
               },
               {
                 "group": "Remote access",
-                "pages": ["gateway/remote", "gateway/remote-gateway-readme", "gateway/tailscale"]
+                "pages": [
+                  "gateway/remote",
+                  "gateway/remote-gateway-readme",
+                  "gateway/tailscale",
+                  "gateway/cloudflare"
+                ]
               },
               {
                 "group": "Security",

--- a/docs/gateway/cloudflare.md
+++ b/docs/gateway/cloudflare.md
@@ -1,0 +1,230 @@
+---
+summary: "Expose the Gateway via Cloudflare Tunnel with Cloudflare Access authentication"
+read_when:
+  - setting up Cloudflare Tunnel for remote access
+  - configuring Cloudflare Access authentication
+  - running openclaw behind cloudflared
+title: "Cloudflare"
+---
+
+# Cloudflare Tunnel & Access
+
+OpenClaw can integrate with Cloudflare Tunnel and Cloudflare Access to expose the
+Gateway securely over the internet with identity-aware authentication.
+
+## Modes
+
+- `managed`: OpenClaw spawns and manages a `cloudflared tunnel run` process using a
+  tunnel token. Also verifies Cloudflare Access JWTs for authentication.
+- `access-only`: You run `cloudflared` externally (e.g. via systemd, Docker sidecar,
+  or Cloudflare's managed connector). OpenClaw only verifies incoming Cloudflare Access
+  JWT headers.
+- `off`: Default (no Cloudflare integration).
+
+## Setup: Managed mode
+
+Use managed mode when OpenClaw and `cloudflared` run on the same machine and you want
+OpenClaw to manage the tunnel lifecycle.
+
+### 1. Create a Cloudflare Tunnel
+
+1. Go to the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/)
+2. Navigate to **Networks** > **Tunnels** > **Create a tunnel**
+3. Choose **Cloudflared** as the connector type
+4. Give your tunnel a name (e.g. `openclaw`)
+5. On the **Install and run connectors** step, copy the tunnel token from the install
+   command — it's the long `eyJ...` string after `--token`
+
+### 2. Add a public hostname
+
+Still in the tunnel configuration:
+
+1. Go to the **Public Hostnames** tab
+2. Click **Add a public hostname**
+3. Set:
+   - **Subdomain**: e.g. `openclaw`
+   - **Domain**: pick one of your Cloudflare domains
+   - **Service type**: `HTTP`
+   - **URL**: `localhost:18789` (the default Gateway port)
+4. Save the hostname
+
+### 3. (Optional) Create a Cloudflare Access application
+
+To require identity verification via Cloudflare Access:
+
+1. In Zero Trust, go to **Access** > **Applications** > **Add an application**
+2. Choose **Self-hosted**
+3. Set the application domain to match the public hostname from step 2
+4. Configure an access policy (e.g. allow specific email addresses)
+5. Note your **team domain** (visible in **Settings** > **Custom Pages**, or from
+   your `<team>.cloudflareaccess.com` URL)
+6. Optionally copy the **Application Audience (AUD) tag** from the application's
+   overview page
+
+### 4. Configure OpenClaw
+
+```json5
+{
+  gateway: {
+    bind: "loopback",
+    cloudflare: {
+      mode: "managed",
+      tunnelToken: "eyJ...", // or use OPENCLAW_CLOUDFLARE_TUNNEL_TOKEN env var
+      teamDomain: "myteam",
+      audience: "abc123...", // optional Application Audience tag
+    },
+  },
+}
+```
+
+OpenClaw will spawn `cloudflared tunnel run`, which connects to the Cloudflare edge
+and routes traffic to your local Gateway port.
+
+### 5. Install cloudflared
+
+The `cloudflared` binary must be available on the machine. Install it from
+[Cloudflare's docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/).
+
+## Setup: Access-only mode (Docker / external cloudflared)
+
+Use this when you manage `cloudflared` yourself — e.g. as a Docker sidecar, a systemd
+service, or Cloudflare's managed connector. This is the recommended approach for
+Docker deployments.
+
+### 1. Create a tunnel and public hostname
+
+Follow steps 1-3 from the managed mode setup above, but set the **Service URL** to
+point to the OpenClaw container by its Docker Compose service name:
+
+- **Service type**: `HTTP`
+- **URL**: `openclaw-gateway:18789` (Docker Compose) or `localhost:18789` (same host)
+
+### 2. Run cloudflared externally
+
+**Docker Compose example:**
+
+```yaml
+services:
+  openclaw-gateway:
+    image: openclaw:latest
+    command:
+      [
+        "node",
+        "openclaw.mjs",
+        "gateway",
+        "--allow-unconfigured",
+        "--bind",
+        "lan",
+        "--cloudflare",
+        "access-only",
+        "--cloudflare-team-domain",
+        "myteam",
+      ]
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel run
+    environment:
+      TUNNEL_TOKEN: "eyJ..." # your tunnel token
+    depends_on:
+      - openclaw-gateway
+```
+
+**Systemd / bare-metal:** run `cloudflared tunnel run --token <TOKEN>` as a service,
+pointing to `http://localhost:18789`.
+
+### 3. Configure OpenClaw
+
+```json5
+{
+  gateway: {
+    bind: "lan", // "lan" when cloudflared runs in a separate container
+    cloudflare: {
+      mode: "access-only",
+      teamDomain: "myteam",
+      audience: "abc123...", // optional
+    },
+  },
+}
+```
+
+## Authentication
+
+When cloudflare mode is active, OpenClaw verifies the `Cf-Access-Jwt-Assertion`
+header on incoming requests. The JWT is validated against the JWKS endpoint at
+`https://<teamDomain>.cloudflareaccess.com/cdn-cgi/access/certs`.
+
+Verification checks:
+
+- JWT signature (RS256/ES256 via JWKS)
+- Expiry (`exp` claim)
+- Issuer (`iss` must match `https://<teamDomain>.cloudflareaccess.com`)
+- Audience (`aud` must match configured audience, if set)
+
+On success, the user's email from the JWT `email` claim is used as the authenticated
+identity (auth method: `cloudflare-access`).
+
+### Auth interaction
+
+By default, `allowCloudflareAccess` is `true` when cloudflare mode is `managed` or
+`access-only` (unless auth mode is `trusted-proxy`). Cloudflare Access JWT
+verification runs after Tailscale identity checks and before token/password auth.
+
+The gateway still generates a pairing token on first start. You can use either the
+Cloudflare Access identity (automatic via the JWT header) or the pairing token to
+authenticate.
+
+To disable Cloudflare Access identity and require explicit credentials:
+
+```json5
+{
+  gateway: {
+    cloudflare: { mode: "managed" /* ... */ },
+    auth: { allowCloudflareAccess: false },
+  },
+}
+```
+
+## CLI examples
+
+```bash
+# Managed mode
+openclaw gateway --cloudflare managed \
+  --cloudflare-tunnel-token "eyJ..." \
+  --cloudflare-team-domain myteam
+
+# Access-only mode
+openclaw gateway --cloudflare access-only \
+  --cloudflare-team-domain myteam \
+  --cloudflare-audience "abc123..."
+```
+
+## Environment variables
+
+| Variable                           | Description                                               |
+| ---------------------------------- | --------------------------------------------------------- |
+| `OPENCLAW_CLOUDFLARE_TUNNEL_TOKEN` | Tunnel token for managed mode (alternative to config/CLI) |
+
+## Configuration reference
+
+| Field                                | Type                                      | Required              | Description                              |
+| ------------------------------------ | ----------------------------------------- | --------------------- | ---------------------------------------- |
+| `gateway.cloudflare.mode`            | `"off"` \| `"managed"` \| `"access-only"` | No                    | Cloudflare mode (default: `off`)         |
+| `gateway.cloudflare.tunnelToken`     | string                                    | Managed only          | Tunnel token from Zero Trust dashboard   |
+| `gateway.cloudflare.teamDomain`      | string                                    | Managed + Access-only | Team domain for JWKS endpoint            |
+| `gateway.cloudflare.audience`        | string                                    | No                    | Application Audience (AUD) tag           |
+| `gateway.auth.allowCloudflareAccess` | boolean                                   | No                    | Allow CF Access JWT auth (default: auto) |
+
+## Validation rules
+
+| Mode          | Requires                     | Bind     | Notes                            |
+| ------------- | ---------------------------- | -------- | -------------------------------- |
+| `off`         | nothing                      | any      | Default                          |
+| `managed`     | `tunnelToken` + `teamDomain` | loopback | cloudflared proxies to localhost |
+| `access-only` | `teamDomain`                 | any      | External cloudflared expected    |
+
+## Learn more
+
+- [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+- [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/)
+- [Zero Trust dashboard](https://one.dash.cloudflare.com/)

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -112,6 +112,8 @@ export type GatewayAuthConfig = {
   password?: string;
   /** Allow Tailscale identity headers when serve mode is enabled. */
   allowTailscale?: boolean;
+  /** Allow Cloudflare Access JWT identity when cloudflare mode is active. */
+  allowCloudflareAccess?: boolean;
   /** Rate-limit configuration for failed authentication attempts. */
   rateLimit?: GatewayAuthRateLimitConfig;
   /**
@@ -139,6 +141,19 @@ export type GatewayTailscaleConfig = {
   mode?: GatewayTailscaleMode;
   /** Reset serve/funnel configuration on shutdown. */
   resetOnExit?: boolean;
+};
+
+export type GatewayCloudflareMode = "off" | "managed" | "access-only";
+
+export type GatewayCloudflareConfig = {
+  /** Cloudflare tunnel/access mode. */
+  mode?: GatewayCloudflareMode;
+  /** Tunnel token from Cloudflare Zero Trust dashboard (managed mode). */
+  tunnelToken?: string;
+  /** Cloudflare Access team domain (e.g. "myteam" for myteam.cloudflareaccess.com). Required for JWT verification. */
+  teamDomain?: string;
+  /** Optional Cloudflare Access Application Audience (AUD) tag for stricter JWT validation. */
+  audience?: string;
 };
 
 export type GatewayRemoteConfig = {
@@ -299,6 +314,7 @@ export type GatewayConfig = {
   controlUi?: GatewayControlUiConfig;
   auth?: GatewayAuthConfig;
   tailscale?: GatewayTailscaleConfig;
+  cloudflare?: GatewayCloudflareConfig;
   remote?: GatewayRemoteConfig;
   reload?: GatewayReloadConfig;
   tls?: GatewayTlsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -428,6 +428,7 @@ export const OpenClawSchema = z
             token: z.string().optional().register(sensitive),
             password: z.string().optional().register(sensitive),
             allowTailscale: z.boolean().optional(),
+            allowCloudflareAccess: z.boolean().optional(),
             rateLimit: z
               .object({
                 maxAttempts: z.number().optional(),
@@ -461,6 +462,17 @@ export const OpenClawSchema = z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),
             resetOnExit: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
+        cloudflare: z
+          .object({
+            mode: z
+              .union([z.literal("off"), z.literal("managed"), z.literal("access-only")])
+              .optional(),
+            tunnelToken: z.string().optional().register(sensitive),
+            teamDomain: z.string().optional(),
+            audience: z.string().optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -5,10 +5,12 @@ import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
+import { setCloudflareAccessVerifier } from "./auth.js";
 
 export function createGatewayCloseHandler(params: {
   bonjourStop: (() => Promise<void>) | null;
   tailscaleCleanup: (() => Promise<void>) | null;
+  cloudflareCleanup: (() => Promise<void>) | null;
   canvasHost: CanvasHostHandler | null;
   canvasHostServer: CanvasHostServer | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
@@ -47,6 +49,14 @@ export function createGatewayCloseHandler(params: {
     if (params.tailscaleCleanup) {
       await params.tailscaleCleanup();
     }
+    if (params.cloudflareCleanup) {
+      try {
+        await params.cloudflareCleanup();
+      } catch {
+        /* ignore */
+      }
+    }
+    setCloudflareAccessVerifier(null);
     if (params.canvasHost) {
       try {
         await params.canvasHost.close();

--- a/src/gateway/server-cloudflare.ts
+++ b/src/gateway/server-cloudflare.ts
@@ -1,0 +1,45 @@
+import { startCloudflaredTunnel } from "../infra/cloudflared.js";
+
+export async function startGatewayCloudflareExposure(params: {
+  cloudflareMode: "off" | "managed" | "access-only";
+  tunnelToken?: string;
+  controlUiBasePath?: string;
+  logCloudflare: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}): Promise<(() => Promise<void>) | null> {
+  if (params.cloudflareMode === "off") {
+    return null;
+  }
+
+  if (params.cloudflareMode === "access-only") {
+    params.logCloudflare.info(
+      "access-only mode: Cloudflare Access JWT verification active (external cloudflared expected)",
+    );
+    return null;
+  }
+
+  // managed mode — spawn cloudflared tunnel run
+  if (!params.tunnelToken) {
+    params.logCloudflare.error("managed mode: no tunnel token provided, skipping tunnel start");
+    return null;
+  }
+
+  try {
+    const tunnel = await startCloudflaredTunnel({
+      token: params.tunnelToken,
+      timeoutMs: 30_000,
+    });
+    params.logCloudflare.info(
+      `managed tunnel running (connectorId=${tunnel.connectorId ?? "unknown"}, pid=${tunnel.pid ?? "unknown"})`,
+    );
+    return tunnel.stop;
+  } catch (err) {
+    params.logCloudflare.error(
+      `managed tunnel failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -1,6 +1,7 @@
 import type {
   GatewayAuthConfig,
   GatewayBindMode,
+  GatewayCloudflareConfig,
   GatewayTailscaleConfig,
   loadConfig,
 } from "../config/config.js";
@@ -26,6 +27,8 @@ export type GatewayRuntimeConfig = {
   authMode: ResolvedGatewayAuth["mode"];
   tailscaleConfig: GatewayTailscaleConfig;
   tailscaleMode: "off" | "serve" | "funnel";
+  cloudflareConfig: GatewayCloudflareConfig;
+  cloudflareMode: "off" | "managed" | "access-only";
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
   canvasHostEnabled: boolean;
 };
@@ -40,6 +43,7 @@ export async function resolveGatewayRuntimeConfig(params: {
   openResponsesEnabled?: boolean;
   auth?: GatewayAuthConfig;
   tailscale?: GatewayTailscaleConfig;
+  cloudflare?: GatewayCloudflareConfig;
 }): Promise<GatewayRuntimeConfig> {
   const bindMode = params.bind ?? params.cfg.gateway?.bind ?? "loopback";
   const customBindHost = params.cfg.gateway?.customBindHost;
@@ -83,11 +87,19 @@ export async function resolveGatewayRuntimeConfig(params: {
   const tailscaleOverrides = params.tailscale ?? {};
   const tailscaleConfig = mergeGatewayTailscaleConfig(tailscaleBase, tailscaleOverrides);
   const tailscaleMode = tailscaleConfig.mode ?? "off";
+  const cloudflareBase = params.cfg.gateway?.cloudflare ?? {};
+  const cloudflareOverrides = params.cloudflare ?? {};
+  const cloudflareConfig: GatewayCloudflareConfig = {
+    ...cloudflareBase,
+    ...cloudflareOverrides,
+  };
+  const cloudflareMode = cloudflareConfig.mode ?? "off";
   const resolvedAuth = resolveGatewayAuth({
     authConfig: params.cfg.gateway?.auth,
     authOverride: params.auth,
     env: process.env,
     tailscaleMode,
+    cloudflareMode,
   });
   const authMode: ResolvedGatewayAuth["mode"] = resolvedAuth.mode;
   const hasToken = typeof resolvedAuth.token === "string" && resolvedAuth.token.trim().length > 0;
@@ -110,7 +122,12 @@ export async function resolveGatewayRuntimeConfig(params: {
   if (tailscaleMode !== "off" && !isLoopbackHost(bindHost)) {
     throw new Error("tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)");
   }
-  if (!isLoopbackHost(bindHost) && !hasSharedSecret && authMode !== "trusted-proxy") {
+  if (
+    !isLoopbackHost(bindHost) &&
+    !hasSharedSecret &&
+    authMode !== "trusted-proxy" &&
+    !resolvedAuth.allowCloudflareAccess
+  ) {
     throw new Error(
       `refusing to bind gateway to ${bindHost}:${params.port} without auth (set gateway.auth.token/password, or set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD)`,
     );
@@ -129,6 +146,33 @@ export async function resolveGatewayRuntimeConfig(params: {
     }
   }
 
+  if (cloudflareMode === "managed") {
+    const tunnelToken =
+      cloudflareConfig.tunnelToken ?? process.env.OPENCLAW_CLOUDFLARE_TUNNEL_TOKEN;
+    if (!tunnelToken) {
+      throw new Error(
+        "cloudflare managed mode requires a tunnel token (set gateway.cloudflare.tunnelToken or OPENCLAW_CLOUDFLARE_TUNNEL_TOKEN)",
+      );
+    }
+    if (!cloudflareConfig.teamDomain) {
+      throw new Error(
+        "cloudflare managed mode requires a team domain for JWT verification (set gateway.cloudflare.teamDomain)",
+      );
+    }
+    if (!isLoopbackHost(bindHost)) {
+      throw new Error(
+        "cloudflare managed mode requires gateway bind=loopback (cloudflared proxies to localhost)",
+      );
+    }
+  }
+  if (cloudflareMode === "access-only") {
+    if (!cloudflareConfig.teamDomain) {
+      throw new Error(
+        "cloudflare access-only mode requires a team domain for JWT verification (set gateway.cloudflare.teamDomain)",
+      );
+    }
+  }
+
   return {
     bindHost,
     controlUiEnabled,
@@ -143,6 +187,8 @@ export async function resolveGatewayRuntimeConfig(params: {
     authMode,
     tailscaleConfig,
     tailscaleMode,
+    cloudflareConfig,
+    cloudflareMode,
     hooksConfig,
     canvasHostEnabled,
   };

--- a/src/gateway/server.canvas-auth.e2e.test.ts
+++ b/src/gateway/server.canvas-auth.e2e.test.ts
@@ -160,6 +160,7 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      allowCloudflareAccess: false,
     };
 
     await withTempConfig({
@@ -274,6 +275,7 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      allowCloudflareAccess: false,
     };
 
     await withTempConfig({
@@ -314,6 +316,7 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      allowCloudflareAccess: false,
     };
 
     await withTempConfig({
@@ -391,6 +394,7 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      allowCloudflareAccess: false,
     };
 
     await withTempConfig({

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -72,6 +72,7 @@ describe("gateway plugin HTTP auth boundary", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      allowCloudflareAccess: false,
     };
 
     await withTempConfig({

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -224,6 +224,7 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
           modeSource: "config",
           token: "shared-gateway-token-1234567890",
           allowTailscale: false,
+          allowCloudflareAccess: false,
         },
       }),
     ).toThrow(/hooks\.token must not match gateway auth token/i);
@@ -243,6 +244,7 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
           modeSource: "config",
           password: "pw",
           allowTailscale: false,
+          allowCloudflareAccess: false,
         },
       }),
     ).not.toThrow();
@@ -262,6 +264,7 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
           modeSource: "config",
           token: "shared-gateway-token-1234567890",
           allowTailscale: false,
+          allowCloudflareAccess: false,
         },
       }),
     ).not.toThrow();

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -125,7 +125,12 @@ beforeAll(async () => {
   sharedServer = createServer((req, res) => {
     void (async () => {
       const handled = await handleToolsInvokeHttpRequest(req, res, {
-        auth: { mode: "token", token: TEST_GATEWAY_TOKEN, allowTailscale: false },
+        auth: {
+          mode: "token",
+          token: TEST_GATEWAY_TOKEN,
+          allowTailscale: false,
+          allowCloudflareAccess: false,
+        },
       });
       if (handled) {
         return;

--- a/src/infra/cloudflare-access.test.ts
+++ b/src/infra/cloudflare-access.test.ts
@@ -1,0 +1,229 @@
+import crypto from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { createCloudflareAccessVerifier } from "./cloudflare-access.js";
+
+// Generate a test RSA keypair for signing JWTs
+const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+// Export as JWK for the mock JWKS endpoint
+const publicJwk = crypto.createPublicKey(publicKey).export({ format: "jwk" }) as {
+  kty: string;
+  n: string;
+  e: string;
+};
+
+const TEST_KID = "test-key-1";
+const TEST_TEAM_DOMAIN = "myteam";
+const TEST_ISSUER = `https://${TEST_TEAM_DOMAIN}.cloudflareaccess.com`;
+const TEST_AUDIENCE = "test-aud-tag";
+
+function base64UrlEncode(data: Buffer | string): string {
+  const buf = typeof data === "string" ? Buffer.from(data) : data;
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function createTestJwt(opts: {
+  email?: string;
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  kid?: string;
+}): Promise<string> {
+  const header = {
+    alg: "RS256",
+    typ: "JWT",
+    kid: opts.kid ?? TEST_KID,
+  };
+
+  const payload = {
+    email: opts.email ?? "user@example.com",
+    sub: "user-123",
+    iss: opts.iss ?? TEST_ISSUER,
+    aud: opts.aud ?? TEST_AUDIENCE,
+    exp: opts.exp ?? Math.floor(Date.now() / 1000) + 3600,
+    iat: Math.floor(Date.now() / 1000),
+  };
+
+  const headerB64 = base64UrlEncode(JSON.stringify(header));
+  const payloadB64 = base64UrlEncode(JSON.stringify(payload));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const sign = crypto.createSign("RSA-SHA256");
+  sign.update(signingInput);
+  const signature = sign.sign(privateKey);
+
+  return `${signingInput}.${base64UrlEncode(signature)}`;
+}
+
+function createMockFetch(): typeof globalThis.fetch {
+  return vi.fn(async (url: string | URL | Request) => {
+    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+    if (urlStr.includes("/cdn-cgi/access/certs")) {
+      return new Response(
+        JSON.stringify({
+          keys: [
+            {
+              kty: publicJwk.kty,
+              kid: TEST_KID,
+              alg: "RS256",
+              use: "sig",
+              n: publicJwk.n,
+              e: publicJwk.e,
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response("Not Found", { status: 404 });
+  }) as typeof globalThis.fetch;
+}
+
+describe("cloudflare-access verifier", () => {
+  it("verifies a valid JWT and returns user email", async () => {
+    const verifier = createCloudflareAccessVerifier({
+      teamDomain: TEST_TEAM_DOMAIN,
+      audience: TEST_AUDIENCE,
+      fetchFn: createMockFetch(),
+    });
+
+    const token = await createTestJwt({});
+    const result = await verifier.verify(token);
+
+    expect(result).not.toBeNull();
+    expect(result!.email).toBe("user@example.com");
+  });
+
+  it("rejects expired JWT", async () => {
+    const verifier = createCloudflareAccessVerifier({
+      teamDomain: TEST_TEAM_DOMAIN,
+      audience: TEST_AUDIENCE,
+      fetchFn: createMockFetch(),
+    });
+
+    const token = await createTestJwt({
+      exp: Math.floor(Date.now() / 1000) - 3600,
+    });
+    const result = await verifier.verify(token);
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects JWT with wrong issuer", async () => {
+    const verifier = createCloudflareAccessVerifier({
+      teamDomain: TEST_TEAM_DOMAIN,
+      audience: TEST_AUDIENCE,
+      fetchFn: createMockFetch(),
+    });
+
+    const token = await createTestJwt({
+      iss: "https://evil.cloudflareaccess.com",
+    });
+    const result = await verifier.verify(token);
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects JWT with wrong audience when audience is configured", async () => {
+    const verifier = createCloudflareAccessVerifier({
+      teamDomain: TEST_TEAM_DOMAIN,
+      audience: TEST_AUDIENCE,
+      fetchFn: createMockFetch(),
+    });
+
+    const token = await createTestJwt({
+      aud: "wrong-audience",
+    });
+    const result = await verifier.verify(token);
+
+    expect(result).toBeNull();
+  });
+
+  it("accepts any audience when audience is not configured", async () => {
+    const verifier = createCloudflareAccessVerifier({
+      teamDomain: TEST_TEAM_DOMAIN,
+      fetchFn: createMockFetch(),
+    });
+
+    const token = await createTestJwt({
+      aud: "any-audience",
+    });
+    const result = await verifier.verify(token);
+
+    expect(result).not.toBeNull();
+    expect(result!.email).toBe("user@example.com");
+  });
+
+  it("rejects malformed token", async () => {
+    const verifier = createCloudflareAccessVerifier({
+      teamDomain: TEST_TEAM_DOMAIN,
+      fetchFn: createMockFetch(),
+    });
+
+    const result = await verifier.verify("not.a.valid.jwt");
+    expect(result).toBeNull();
+  });
+
+  it("rejects token with unknown kid", async () => {
+    const verifier = createCloudflareAccessVerifier({
+      teamDomain: TEST_TEAM_DOMAIN,
+      fetchFn: createMockFetch(),
+    });
+
+    const token = await createTestJwt({ kid: "unknown-key-id" });
+    const result = await verifier.verify(token);
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects JWT with tampered signature", async () => {
+    const verifier = createCloudflareAccessVerifier({
+      teamDomain: TEST_TEAM_DOMAIN,
+      audience: TEST_AUDIENCE,
+      fetchFn: createMockFetch(),
+    });
+
+    const token = await createTestJwt({});
+    // Tamper with the signature
+    const parts = token.split(".");
+    parts[2] = base64UrlEncode(crypto.randomBytes(256));
+    const tampered = parts.join(".");
+
+    const result = await verifier.verify(tampered);
+    expect(result).toBeNull();
+  });
+
+  it("rejects JWT with no email claim", async () => {
+    const verifier = createCloudflareAccessVerifier({
+      teamDomain: TEST_TEAM_DOMAIN,
+      fetchFn: createMockFetch(),
+    });
+
+    // Create a token with no email
+    const header = {
+      alg: "RS256",
+      typ: "JWT",
+      kid: TEST_KID,
+    };
+    const payload = {
+      sub: "service-token",
+      iss: TEST_ISSUER,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      iat: Math.floor(Date.now() / 1000),
+    };
+    const headerB64 = base64UrlEncode(JSON.stringify(header));
+    const payloadB64 = base64UrlEncode(JSON.stringify(payload));
+    const signingInput = `${headerB64}.${payloadB64}`;
+    const sign = crypto.createSign("RSA-SHA256");
+    sign.update(signingInput);
+    const signature = sign.sign(privateKey);
+    const token = `${signingInput}.${base64UrlEncode(signature)}`;
+
+    const result = await verifier.verify(token);
+    expect(result).toBeNull();
+  });
+});

--- a/src/infra/cloudflare-access.ts
+++ b/src/infra/cloudflare-access.ts
@@ -1,0 +1,198 @@
+import crypto from "node:crypto";
+
+export type CloudflareAccessUser = {
+  email: string;
+};
+
+export type CloudflareAccessVerifier = {
+  verify(token: string): Promise<CloudflareAccessUser | null>;
+};
+
+type JwksKey = {
+  kty: string;
+  kid: string;
+  alg?: string;
+  n?: string;
+  e?: string;
+  crv?: string;
+  x?: string;
+  y?: string;
+  use?: string;
+};
+
+type JwksResponse = {
+  keys: JwksKey[];
+};
+
+type JwtHeader = {
+  alg: string;
+  kid?: string;
+  typ?: string;
+};
+
+type JwtPayload = {
+  email?: string;
+  sub?: string;
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  iat?: number;
+  [key: string]: unknown;
+};
+
+const JWKS_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+function base64UrlDecode(input: string): Buffer {
+  // Replace URL-safe chars and add padding
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const paddedLength = padded.length + ((4 - (padded.length % 4)) % 4);
+  return Buffer.from(padded.padEnd(paddedLength, "="), "base64");
+}
+
+function decodeJwtPart<T>(part: string): T {
+  return JSON.parse(base64UrlDecode(part).toString("utf8")) as T;
+}
+
+function jwkToCryptoKeyAlgorithm(jwk: JwksKey): RsaHashedImportParams | EcKeyImportParams {
+  if (jwk.kty === "RSA") {
+    return { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" };
+  }
+  if (jwk.kty === "EC") {
+    const namedCurve = jwk.crv ?? "P-256";
+    return { name: "ECDSA", namedCurve };
+  }
+  throw new Error(`Unsupported JWK key type: ${jwk.kty}`);
+}
+
+function verifyAlgorithmForKey(jwk: JwksKey): AlgorithmIdentifier | RsaPssParams | EcdsaParams {
+  if (jwk.kty === "RSA") {
+    return { name: "RSASSA-PKCS1-v1_5" };
+  }
+  if (jwk.kty === "EC") {
+    return { name: "ECDSA", hash: "SHA-256" };
+  }
+  throw new Error(`Unsupported JWK key type: ${jwk.kty}`);
+}
+
+async function importJwk(jwk: JwksKey): Promise<crypto.webcrypto.CryptoKey> {
+  const algorithm = jwkToCryptoKeyAlgorithm(jwk);
+  // Only pass the fields relevant for key import
+  const keyData = {
+    kty: jwk.kty,
+    alg: jwk.alg,
+    use: jwk.use,
+    ...(jwk.kty === "RSA" ? { n: jwk.n, e: jwk.e } : {}),
+    ...(jwk.kty === "EC" ? { crv: jwk.crv, x: jwk.x, y: jwk.y } : {}),
+  };
+  return await crypto.subtle.importKey("jwk", keyData, algorithm, false, ["verify"]);
+}
+
+/**
+ * Create a Cloudflare Access JWT verifier.
+ *
+ * Fetches JWKS from `https://<teamDomain>.cloudflareaccess.com/cdn-cgi/access/certs`
+ * and verifies JWTs using Node's built-in WebCrypto API.
+ */
+export function createCloudflareAccessVerifier(opts: {
+  teamDomain: string;
+  audience?: string;
+  /** Override fetch for testing. */
+  fetchFn?: typeof globalThis.fetch;
+}): CloudflareAccessVerifier {
+  const issuer = `https://${opts.teamDomain}.cloudflareaccess.com`;
+  const jwksUrl = `${issuer}/cdn-cgi/access/certs`;
+  const audience = opts.audience;
+  const fetchFn = opts.fetchFn ?? globalThis.fetch;
+
+  let cachedKeys: Map<string, JwksKey> | null = null;
+  let cachedAt = 0;
+
+  async function fetchJwks(): Promise<Map<string, JwksKey>> {
+    const now = Date.now();
+    if (cachedKeys && now - cachedAt < JWKS_CACHE_TTL_MS) {
+      return cachedKeys;
+    }
+    const res = await fetchFn(jwksUrl);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch JWKS from ${jwksUrl}: ${res.status}`);
+    }
+    const body = (await res.json()) as JwksResponse;
+    const keyMap = new Map<string, JwksKey>();
+    for (const key of body.keys ?? []) {
+      if (key.kid) {
+        keyMap.set(key.kid, key);
+      }
+    }
+    cachedKeys = keyMap;
+    cachedAt = now;
+    return keyMap;
+  }
+
+  async function verify(token: string): Promise<CloudflareAccessUser | null> {
+    try {
+      const parts = token.split(".");
+      if (parts.length !== 3) {
+        return null;
+      }
+
+      const header = decodeJwtPart<JwtHeader>(parts[0]);
+      const payload = decodeJwtPart<JwtPayload>(parts[1]);
+
+      // Validate issuer
+      if (payload.iss !== issuer) {
+        return null;
+      }
+
+      // Validate expiry
+      if (typeof payload.exp === "number" && payload.exp < Date.now() / 1000) {
+        return null;
+      }
+
+      // Validate audience (if configured)
+      if (audience) {
+        const aud = payload.aud;
+        const audMatch = Array.isArray(aud) ? aud.includes(audience) : aud === audience;
+        if (!audMatch) {
+          return null;
+        }
+      }
+
+      // Find the signing key
+      let keys = await fetchJwks();
+      let jwk = header.kid ? keys.get(header.kid) : undefined;
+
+      // If key not found, refresh JWKS (key rotation)
+      if (!jwk && header.kid) {
+        cachedKeys = null;
+        keys = await fetchJwks();
+        jwk = keys.get(header.kid);
+      }
+      if (!jwk) {
+        return null;
+      }
+
+      // Verify signature using WebCrypto
+      const cryptoKey = await importJwk(jwk);
+      const signatureInput = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
+      const signature = new Uint8Array(base64UrlDecode(parts[2]));
+      const algorithm = verifyAlgorithmForKey(jwk);
+
+      const valid = await crypto.subtle.verify(algorithm, cryptoKey, signature, signatureInput);
+
+      if (!valid) {
+        return null;
+      }
+
+      const email = typeof payload.email === "string" ? payload.email : undefined;
+      if (!email) {
+        return null;
+      }
+
+      return { email };
+    } catch {
+      return null;
+    }
+  }
+
+  return { verify };
+}

--- a/src/infra/cloudflared.test.ts
+++ b/src/infra/cloudflared.test.ts
@@ -1,0 +1,181 @@
+import type { ChildProcess } from "node:child_process";
+import type { Readable } from "node:stream";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock spawn
+const spawnMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+// Mock runExec
+const execMock = vi.fn();
+vi.mock("../process/exec.js", () => ({
+  runExec: (...args: unknown[]) => execMock(...args),
+}));
+
+// Mock existsSync
+const existsSyncMock = vi.fn<(p: string) => boolean>(() => true);
+vi.mock("node:fs", () => ({
+  existsSync: (p: string) => existsSyncMock(p),
+}));
+
+describe("findCloudflaredBinary", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    delete process.env.OPENCLAW_TEST_CLOUDFLARED_BINARY;
+  });
+
+  it("returns environment override when set", async () => {
+    process.env.OPENCLAW_TEST_CLOUDFLARED_BINARY = "/custom/cloudflared";
+    const { findCloudflaredBinary } = await import("./cloudflared.js");
+    const result = await findCloudflaredBinary(execMock);
+    expect(result).toBe("/custom/cloudflared");
+  });
+
+  it("finds cloudflared via which", async () => {
+    execMock.mockImplementation((cmd: string, _args: string[]) => {
+      if (cmd === "which") {
+        return Promise.resolve({ stdout: "/usr/local/bin/cloudflared\n", stderr: "" });
+      }
+      // --version check
+      return Promise.resolve({ stdout: "cloudflared version 2024.1.0\n", stderr: "" });
+    });
+    existsSyncMock.mockReturnValue(true);
+
+    const { findCloudflaredBinary } = await import("./cloudflared.js");
+    const result = await findCloudflaredBinary(execMock);
+    expect(result).toBe("/usr/local/bin/cloudflared");
+  });
+
+  it("falls back to known paths when which fails", async () => {
+    execMock.mockImplementation((cmd: string, _args: string[]) => {
+      if (cmd === "which") {
+        return Promise.reject(new Error("not found"));
+      }
+      // --version check for known path
+      return Promise.resolve({ stdout: "cloudflared version 2024.1.0\n", stderr: "" });
+    });
+    existsSyncMock.mockImplementation((p: string) => p === "/usr/local/bin/cloudflared");
+
+    const { findCloudflaredBinary } = await import("./cloudflared.js");
+    const result = await findCloudflaredBinary(execMock);
+    expect(result).toBe("/usr/local/bin/cloudflared");
+  });
+
+  it("returns null when binary is not found", async () => {
+    execMock.mockRejectedValue(new Error("not found"));
+    existsSyncMock.mockReturnValue(false);
+
+    const { findCloudflaredBinary } = await import("./cloudflared.js");
+    const result = await findCloudflaredBinary(execMock);
+    expect(result).toBeNull();
+  });
+});
+
+describe("startCloudflaredTunnel", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    delete process.env.OPENCLAW_TEST_CLOUDFLARED_BINARY;
+  });
+
+  function createMockProcess(): ChildProcess {
+    const events: Record<string, Array<(...args: unknown[]) => void>> = {};
+    const stdoutEvents: Record<string, Array<(...args: unknown[]) => void>> = {};
+    const stderrEvents: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+    const mockStdout = {
+      setEncoding: vi.fn(),
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        stdoutEvents[event] = stdoutEvents[event] ?? [];
+        stdoutEvents[event].push(cb);
+      }),
+    };
+    const mockStderr = {
+      setEncoding: vi.fn(),
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        stderrEvents[event] = stderrEvents[event] ?? [];
+        stderrEvents[event].push(cb);
+      }),
+    };
+
+    return {
+      pid: 12345,
+      killed: false,
+      stdout: mockStdout as unknown as Readable,
+      stderr: mockStderr as unknown as Readable,
+      kill: vi.fn(),
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        events[event] = events[event] ?? [];
+        events[event].push(cb);
+      }),
+      once: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        events[event] = events[event] ?? [];
+        events[event].push(cb);
+      }),
+      _emit: (event: string, ...args: unknown[]) => {
+        for (const cb of events[event] ?? []) {
+          cb(...args);
+        }
+      },
+      _emitStderr: (data: string) => {
+        for (const cb of stderrEvents.data ?? []) {
+          cb(data);
+        }
+      },
+    } as unknown as ChildProcess & {
+      _emit: (event: string, ...args: unknown[]) => void;
+      _emitStderr: (data: string) => void;
+    };
+  }
+
+  it("starts tunnel and parses connector ID", async () => {
+    const mockChild = createMockProcess() as ChildProcess & {
+      _emit: (event: string, ...args: unknown[]) => void;
+      _emitStderr: (data: string) => void;
+    };
+
+    spawnMock.mockReturnValue(mockChild);
+    process.env.OPENCLAW_TEST_CLOUDFLARED_BINARY = "/usr/local/bin/cloudflared";
+
+    const { startCloudflaredTunnel } = await import("./cloudflared.js");
+
+    const tunnelPromise = startCloudflaredTunnel({
+      token: "test-token",
+      timeoutMs: 5000,
+    });
+
+    // Simulate cloudflared registering a connection
+    await new Promise((r) => setTimeout(r, 50));
+    mockChild._emitStderr("INF Registered tunnel connection connectorID=abc123-def456");
+
+    const tunnel = await tunnelPromise;
+    expect(tunnel.connectorId).toBe("abc123-def456");
+    expect(tunnel.pid).toBe(12345);
+    expect(typeof tunnel.stop).toBe("function");
+  });
+
+  it("throws when tunnel exits before registering", async () => {
+    const mockChild = createMockProcess() as ChildProcess & {
+      _emit: (event: string, ...args: unknown[]) => void;
+      _emitStderr: (data: string) => void;
+    };
+
+    spawnMock.mockReturnValue(mockChild);
+    process.env.OPENCLAW_TEST_CLOUDFLARED_BINARY = "/usr/local/bin/cloudflared";
+
+    const { startCloudflaredTunnel } = await import("./cloudflared.js");
+
+    const tunnelPromise = startCloudflaredTunnel({
+      token: "bad-token",
+      timeoutMs: 5000,
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    mockChild._emit("exit", 1, null);
+
+    await expect(tunnelPromise).rejects.toThrow(/cloudflared exited/);
+  });
+});

--- a/src/infra/cloudflared.ts
+++ b/src/infra/cloudflared.ts
@@ -1,0 +1,194 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { runExec } from "../process/exec.js";
+
+/**
+ * Locate the cloudflared binary using multiple strategies:
+ * 1. Environment override (for testing)
+ * 2. PATH lookup (via `which`)
+ * 3. Known install paths
+ */
+export async function findCloudflaredBinary(
+  exec: typeof runExec = runExec,
+): Promise<string | null> {
+  const forced = process.env.OPENCLAW_TEST_CLOUDFLARED_BINARY?.trim();
+  if (forced) {
+    return forced;
+  }
+
+  const checkBinary = async (path: string): Promise<boolean> => {
+    if (!path || !existsSync(path)) {
+      return false;
+    }
+    try {
+      await Promise.race([
+        exec(path, ["--version"], { timeoutMs: 3000 }),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 3000)),
+      ]);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  // Strategy 1: which command
+  try {
+    const { stdout } = await exec("which", ["cloudflared"]);
+    const fromPath = stdout.trim();
+    if (fromPath && (await checkBinary(fromPath))) {
+      return fromPath;
+    }
+  } catch {
+    // which failed, continue
+  }
+
+  // Strategy 2: Known install paths
+  const knownPaths = [
+    "/usr/local/bin/cloudflared",
+    "/usr/bin/cloudflared",
+    "/opt/homebrew/bin/cloudflared",
+  ];
+  for (const candidate of knownPaths) {
+    if (await checkBinary(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+let cachedCloudflaredBinary: string | null = null;
+
+export async function getCloudflaredBinary(exec: typeof runExec = runExec): Promise<string> {
+  const forced = process.env.OPENCLAW_TEST_CLOUDFLARED_BINARY?.trim();
+  if (forced) {
+    cachedCloudflaredBinary = forced;
+    return forced;
+  }
+  if (cachedCloudflaredBinary) {
+    return cachedCloudflaredBinary;
+  }
+  cachedCloudflaredBinary = await findCloudflaredBinary(exec);
+  return cachedCloudflaredBinary ?? "cloudflared";
+}
+
+export type CloudflaredTunnel = {
+  /** Connector ID parsed from cloudflared output, if available. */
+  connectorId: string | null;
+  pid: number | null;
+  stderr: string[];
+  stop: () => Promise<void>;
+};
+
+/**
+ * Start a cloudflared tunnel process using a pre-configured tunnel token.
+ *
+ * The token encodes the tunnel UUID, account tag, and tunnel secret — cloudflared
+ * connects to the Cloudflare edge and routes traffic to the local origin.
+ */
+export async function startCloudflaredTunnel(opts: {
+  token: string;
+  timeoutMs?: number;
+  exec?: typeof runExec;
+}): Promise<CloudflaredTunnel> {
+  const exec = opts.exec ?? runExec;
+  const bin = await getCloudflaredBinary(exec);
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const stderr: string[] = [];
+
+  // Pass the token via TUNNEL_TOKEN env var rather than --token CLI arg
+  // to avoid leaking the secret in `ps` output.
+  const args = ["tunnel", "run"];
+  const child: ChildProcess = spawn(bin, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, TUNNEL_TOKEN: opts.token },
+  });
+
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+
+  let connectorId: string | null = null;
+
+  const collectOutput = (stream: NodeJS.ReadableStream | null) => {
+    stream?.on("data", (chunk: string) => {
+      const lines = String(chunk)
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+      stderr.push(...lines);
+
+      // Parse connector ID from cloudflared output
+      for (const line of lines) {
+        const match = line.match(/Registered tunnel connection\s+connectorID=([a-f0-9-]+)/i);
+        if (match) {
+          connectorId = match[1];
+        }
+      }
+    });
+  };
+
+  collectOutput(child.stdout);
+  collectOutput(child.stderr);
+
+  const stop = async () => {
+    if (child.killed) {
+      return;
+    }
+    child.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } finally {
+          resolve();
+        }
+      }, 1500);
+      child.once("exit", () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+  };
+
+  // Wait for the tunnel to register at least one connection, or timeout.
+  try {
+    await Promise.race([
+      new Promise<void>((resolve) => {
+        const check = setInterval(() => {
+          if (connectorId) {
+            clearInterval(check);
+            resolve();
+          }
+        }, 100);
+        // Clean up interval on process exit
+        child.once("exit", () => clearInterval(check));
+      }),
+      new Promise<void>((_, reject) => {
+        setTimeout(
+          () => reject(new Error("cloudflared tunnel did not register within timeout")),
+          timeoutMs,
+        );
+      }),
+      new Promise<void>((_, reject) => {
+        child.once("exit", (code, signal) => {
+          reject(
+            new Error(
+              `cloudflared exited before tunnel registered (${code ?? "null"}${signal ? `/${signal}` : ""})`,
+            ),
+          );
+        });
+      }),
+    ]);
+  } catch (err) {
+    await stop();
+    const suffix = stderr.length > 0 ? `\n${stderr.join("\n")}` : "";
+    throw new Error(`${err instanceof Error ? err.message : String(err)}${suffix}`, { cause: err });
+  }
+
+  return {
+    connectorId,
+    pid: typeof child.pid === "number" ? child.pid : null,
+    stderr,
+    stop,
+  };
+}


### PR DESCRIPTION
## Summary

OpenClaw can now integrate with Cloudflare Tunnel and Cloudflare Access to expose the Gateway securely over the internet with identity-aware authentication. Two modes are supported:

- **managed**: OpenClaw spawns and manages a `cloudflared tunnel run` process using a tunnel token. Also verifies Cloudflare Access JWTs for authentication.
- **access-only**: You run `cloudflared` externally. OpenClaw only verifies incoming Cloudflare Access JWT headers.

JWT verification uses Node's built-in `crypto.subtle` WebCrypto API with JWKS fetching/caching from the Cloudflare Access certs endpoint — no external dependencies added. Tunnel token is passed via `TUNNEL_TOKEN` env var to avoid process-list exposure.

## Changes

### New files

| File | Description |
|------|-------------|
| `src/infra/cloudflared.ts` | Binary detection (PATH + known paths) and tunnel process management (spawn, connector ID parsing, SIGTERM→SIGKILL stop) |
| `src/infra/cloudflare-access.ts` | JWT verification using WebCrypto: JWKS fetching with 10-min cache, RS256/ES256 signature validation, key rotation support |
| `src/gateway/server-cloudflare.ts` | Exposure lifecycle (mirrors `server-tailscale.ts` pattern) |
| `docs/gateway/cloudflare.md` | Full documentation: setup for both modes, auth interaction, CLI examples, config reference, validation rules |

### Modified files

| File | Change |
|------|--------|
| `src/config/types.gateway.ts` | Add `GatewayCloudflareMode`, `GatewayCloudflareConfig`, `allowCloudflareAccess` |
| `src/config/zod-schema.ts` | Add cloudflare config schema with mode, tunnelToken (sensitive), teamDomain, audience |
| `src/gateway/auth.ts` | Add Cloudflare Access auth flow (`Cf-Access-Jwt-Assertion` header), module-level verifier setter, `allowCloudflareAccess` resolution |
| `src/gateway/server-runtime-config.ts` | Merge cloudflare config (base + overrides), validation rules (managed requires tunnelToken + teamDomain + loopback) |
| `src/gateway/server.impl.ts` | Create verifier on startup, wire exposure and cleanup |
| `src/gateway/server-close.ts` | Add cloudflare cleanup + clear global verifier |
| `src/cli/gateway-cli/run.ts` | Add `--cloudflare`, `--cloudflare-tunnel-token`, `--cloudflare-team-domain`, `--cloudflare-audience` CLI options |

### Test files

| File | Tests |
|------|-------|
| `src/infra/cloudflared.test.ts` | 6 tests: env override, which lookup, fallback paths, not found, tunnel start, exit before registration |
| `src/infra/cloudflare-access.test.ts` | 9 tests: valid JWT, expired, wrong issuer/audience, malformed, unknown kid, tampered signature, no email — uses real RSA keypairs |
| `src/gateway/auth.test.ts` | 4 new tests + updated existing: CF Access auth flow, fallthrough, mode resolution |
| 3 existing test files | Added `allowCloudflareAccess: false` to inline auth objects |

## Test plan

- [x] `tsc --noEmit` — 0 errors (excluding pre-existing upstream issue in `server.chat.gateway-server-chat-b.e2e.test.ts`)
- [x] 57 tests pass across 5 test files
- [x] ESLint clean via pre-commit hook
- [x] Manual test with a real Cloudflare Tunnel in managed mode
- [x] Manual test with access-only mode behind an external cloudflared

## AI Generated

This pr was mostly ai generated, i did indeed test it locally in a docker container, it was able to successfully manage `cloudflared` and handle traffic via cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds comprehensive Cloudflare Tunnel and Access integration with two operating modes: `managed` (OpenClaw spawns cloudflared) and `access-only` (external cloudflared with JWT-only verification). JWT verification is implemented using Node's built-in WebCrypto API with JWKS caching, RS256/ES256 support, and proper key rotation handling. The tunnel token is passed via environment variable to avoid process list exposure. Implementation follows existing patterns from Tailscale integration and includes extensive test coverage (19 new tests across 3 test suites) with proper validation rules enforced at runtime.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- High confidence due to: (1) comprehensive test coverage with 19 new tests including security-critical JWT verification scenarios, (2) proper security practices (WebCrypto-based JWT verification, token passed via env var, signature validation, expiry/issuer/audience checks), (3) well-structured implementation following existing patterns from Tailscale integration, (4) extensive validation rules at both config and runtime levels, (5) proper cleanup and lifecycle management including verifier reset on shutdown
- No files require special attention

<sub>Last reviewed commit: 390f92b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->