### PR TITLE
feat: add bypass-model support for skill commands

### DIFF
--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -54,6 +54,10 @@ export type SkillCommandSpec = {
   description: string;
   /** Optional deterministic dispatch behavior for this command. */
   dispatch?: SkillCommandDispatchSpec;
+  /** If true, execute exec-command directly without AI model invocation. */
+  bypassModel?: boolean;
+  /** Shell command to execute when bypassModel is true. */
+  execCommand?: string;
 };
 
 export type SkillsInstallPreferences = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -768,11 +768,23 @@ export function buildWorkspaceSkillCommandSpecs(
       return { kind: "tool", toolName, argMode: "raw" } as const;
     })();
 
+    // Parse bypass-model and exec-command for direct command execution
+    const bypassModelRaw =
+      entry.frontmatter?.["bypass-model"] ?? entry.frontmatter?.["bypass_model"] ?? "";
+    const bypassModel = String(bypassModelRaw).toLowerCase() === "true";
+
+    const execCommand = (
+      entry.frontmatter?.["exec-command"] ??
+      entry.frontmatter?.["exec_command"] ??
+      ""
+    ).trim();
+
     specs.push({
       name: unique,
       skillName: rawName,
       description,
       ...(dispatch ? { dispatch } : {}),
+      ...(bypassModel && execCommand ? { bypassModel, execCommand } : {}),
     });
   }
   return specs;

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -180,16 +180,15 @@ export async function resolveReplyDirectives(params: {
     .filter((alias): alias is string => Boolean(alias))
     .filter((alias) => !reservedCommands.has(alias.toLowerCase()));
 
-  // Only load workspace skill commands when we actually need them to filter aliases.
-  // This avoids scanning skills for messages that only use inline directives like /think:/verbose:.
-  const skillCommands =
-    allowTextCommands && rawAliases.length > 0
-      ? listSkillCommandsForWorkspace({
-          workspaceDir,
-          cfg,
-          skillFilter,
-        })
-      : [];
+  // Load workspace skill commands when text commands are allowed.
+  // This is needed for both alias filtering and skill command invocation.
+  const skillCommands = allowTextCommands
+    ? listSkillCommandsForWorkspace({
+        workspaceDir,
+        cfg,
+        skillFilter,
+      })
+    : [];
   for (const command of skillCommands) {
     reservedCommands.add(command.name.toLowerCase());
   }

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -184,10 +184,7 @@ export async function handleInlineActions(params: {
     }
 
     // Handle bypass-model: execute command directly without AI
-    const { bypassModel, execCommand } = skillInvocation.command as {
-      bypassModel?: boolean;
-      execCommand?: string;
-    };
+    const { bypassModel, execCommand } = skillInvocation.command;
     if (bypassModel && execCommand) {
       try {
         const { execSync } = await import("node:child_process");

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -183,6 +183,28 @@ export async function handleInlineActions(params: {
       return { kind: "reply", reply: undefined };
     }
 
+    // Handle bypass-model: execute command directly without AI
+    const { bypassModel, execCommand } = skillInvocation.command as {
+      bypassModel?: boolean;
+      execCommand?: string;
+    };
+    if (bypassModel && execCommand) {
+      try {
+        const { execSync } = await import("node:child_process");
+        const output = execSync(execCommand, {
+          encoding: "utf-8",
+          timeout: 30000,
+          maxBuffer: 1024 * 1024,
+        });
+        typing.cleanup();
+        return { kind: "reply", reply: { text: output.trim() || "✅ Done" } };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        typing.cleanup();
+        return { kind: "reply", reply: { text: `❌ ${message}` } };
+      }
+    }
+
     const dispatch = skillInvocation.command.dispatch;
     if (dispatch?.kind === "tool") {
       const rawArgs = (skillInvocation.args ?? "").trim();

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -191,7 +191,9 @@ export async function handleInlineActions(params: {
     if (bypassModel && execCommand) {
       try {
         const { execSync } = await import("node:child_process");
-        const output = execSync(execCommand, {
+        const args = skillInvocation.args?.trim() || "";
+        const fullCommand = args ? `${execCommand} ${args}` : execCommand;
+        const output = execSync(fullCommand, {
           encoding: "utf-8",
           timeout: 30000,
           maxBuffer: 1024 * 1024,


### PR DESCRIPTION
## Summary

Add `bypass-model: true` and `exec-command: "..."` frontmatter support for skills, allowing slash commands to execute shell commands directly without AI model invocation.

## Why This Matters

**With bypass-model, OpenClaw becomes a true Intelligent Assistant — not just an AI Assistant.**

- 🧠 **Uses AI when AI is needed** — complex reasoning, creative tasks, conversations
- ⚡ **Uses direct commands when commands are enough** — system queries, scripts, utilities
- 💰 **Zero tokens wasted** on deterministic operations
- 🎯 **100% accuracy** for command-based tasks (no hallucination possible)
- 🚀 **Instant response** — no model latency for simple commands

This is the difference between a smart tool that knows when to think vs. one that overthinks everything.

## Usage

```yaml
# ~/.openclaw/skills/ip/SKILL.md
---
name: ip
description: Get public IP address
user-invocable: true
bypass-model: true
exec-command: "curl -s ipinfo.io/ip"
---
```

Arguments pass through automatically:
- `/git status` → executes `git status`
- `/note list` → executes `note list`
- `/docker ps` → executes `docker ps`

## Changes

| File | Change |
|------|--------|
| `src/agents/skills/workspace.ts` | Parse `bypass-model` and `exec-command` from frontmatter |
| `src/auto-reply/reply/get-reply-inline-actions.ts` | Execute bypass logic before normal dispatch |
| `src/auto-reply/reply/get-reply-directives.ts` | Fix bug: skill commands now load without model aliases |

## Testing

1. Create a bypass-model skill as shown above
2. Invoke via `/ip` in any channel
3. Verify instant response without model usage

## Backwards Compatibility

- ✅ No breaking changes
- ✅ Existing skills work exactly as before
- ✅ Opt-in via explicit `bypass-model: true`

---

**Fixes:** #7985
**Also addresses:** #10366

cc @ShenWang96 @twobotass @5hanth