### PR TITLE
fix(discord): replace any with DiscordGuildMemberLike 

### DIFF
--- a/src/discord/monitor/sender-identity.ts
+++ b/src/discord/monitor/sender-identity.ts
@@ -21,6 +21,16 @@ type DiscordWebhookMessageLike = {
   webhook_id?: string | null;
 };
 
+/**
+ * Minimal guild member type for sender identity resolution.
+ * Supports both `nick` (raw Discord API) and `nickname` (Carbon library) fields.
+ * Only includes the nickname field which is used for display name resolution.
+ */
+type DiscordGuildMemberLike = {
+  nick?: string | null;
+  nickname?: string | null;
+};
+
 export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): string | null {
   const candidate = message.webhookId ?? message.webhook_id;
   return typeof candidate === "string" && candidate.trim() ? candidate.trim() : null;
@@ -28,8 +38,7 @@ export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): str
 
 export function resolveDiscordSenderIdentity(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordGuildMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): DiscordSenderIdentity {
   const pkInfo = params.pluralkitInfo ?? null;
@@ -74,8 +83,7 @@ export function resolveDiscordSenderIdentity(params: {
 
 export function resolveDiscordSenderLabel(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordGuildMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): string {
   return resolveDiscordSenderIdentity(params).label;


### PR DESCRIPTION
## Summary
Describe the problem and fix in 2–5 bullets:
- Problem: `member` parameter in Discord sender identity functions uses `any` type, requiring lint suppression
- Why it matters: Reduces type safety and hides the actual API contract
- What changed: Added `DiscordGuildMemberLike` type with `nick`/`nickname` fields, updated function signatures
- What did NOT change (scope boundary): No runtime behavior changes, same logic, just type annotations

## Change Type (select all)
- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes # N/A
- Related # N/A (general type safety improvement)

## User-visible / Behavior Changes
None

## Security Impact (required)
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: N/A (type-only change)
- Runtime/container: Node.js 22+
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): N/A

### Steps
1. Run `pnpm build && pnpm check`
2. Verify no TypeScript errors
3. Run `pnpm test src/discord/`

### Expected
- Build succeeds
- Type check passes
- Tests pass

### Actual
- (To be verified by CI)

## Evidence
Attach at least one:
- [x] Failing test/log before + passing after (CI will verify)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
What you personally verified (not just CI), and how:
- Verified scenarios: Code review of all usages of `resolveDiscordSenderIdentity` and `resolveDiscordSenderLabel`
- Edge cases checked: Verified `nickname` field access matches new type definition
- What you did **not** verify: Local test execution (no pnpm environment)

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: Revert commit
- Files/config to restore: `src/discord/monitor/sender-identity.ts`
- Known bad symptoms reviewers should watch for: TypeScript errors in Discord integration callers

## Risks and Mitigations
None - pure type annotation change with no runtime impact.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `any` type for Discord guild member parameter with a proper `DiscordGuildMemberLike` type definition. The new type supports both `nick` (raw Discord API) and `nickname` (Carbon library) fields, improving type safety without changing runtime behavior. All call sites pass `params.data.member` or `null`, which are compatible with the new optional `DiscordGuildMemberLike | null` signature.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a pure type annotation change with zero runtime impact. The new `DiscordGuildMemberLike` type correctly captures the actual API contract (supporting both `nick` and `nickname` fields), removes unsafe `any` usage, and eliminates lint suppressions. All call sites are compatible with the new signature.
- No files require special attention

<sub>Last reviewed commit: 81bcf7c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->