### PR TITLE
LINE/Security: harden inbound media temp-file naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Security/Feishu: prevent path traversal in Feishu inbound media temp-file writes by replacing key-derived temp filenames with UUID-based names. Thanks @allsmog for reporting.
+- LINE/Security: harden inbound media temp-file naming by using UUID-based temp paths for downloaded media instead of external message IDs. (#20792) Thanks @mbelinky.
 - Security/Media: harden local media ingestion against TOCTOU/symlink swap attacks by pinning reads to a single file descriptor with symlink rejection and inode/device verification in `saveMediaSource`. Thanks @dorjoos for reporting.
 - Security/Lobster (Windows): for the next npm release, remove shell-based fallback when launching Lobster wrappers (`.cmd`/`.bat`) and switch to explicit argv execution with wrapper entrypoint resolution, preventing command injection while preserving Windows wrapper compatibility. Thanks @tdjackey for reporting.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.

--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -45,6 +45,9 @@ describe("downloadLineMedia", () => {
     expect(result.size).toBe(jpeg.length);
     expect(result.contentType).toBe("image/jpeg");
     expect(typeof writtenPath).toBe("string");
+    if (typeof writtenPath !== "string") {
+      throw new Error("expected string temp file path");
+    }
     expect(result.path).toBe(writtenPath);
     expect(writtenPath).toContain("line-media-");
     expect(writtenPath).toMatch(/\.jpg$/);

--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMessageContentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@line/bot-sdk", () => ({
+  messagingApi: {
+    MessagingApiBlobClient: class {
+      getMessageContent(messageId: string) {
+        return getMessageContentMock(messageId);
+      }
+    },
+  },
+}));
+
+vi.mock("../globals.js", () => ({
+  logVerbose: () => {},
+}));
+
+import { downloadLineMedia } from "./download.js";
+
+async function* chunks(parts: Buffer[]): AsyncGenerator<Buffer> {
+  for (const part of parts) {
+    yield part;
+  }
+}
+
+describe("downloadLineMedia", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not derive temp file path from external messageId", async () => {
+    const messageId = "a/../../../../etc/passwd";
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([jpeg]));
+
+    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
+
+    const result = await downloadLineMedia(messageId, "token");
+    const writtenPath = writeSpy.mock.calls[0]?.[0];
+
+    expect(result.size).toBe(jpeg.length);
+    expect(result.contentType).toBe("image/jpeg");
+    expect(typeof writtenPath).toBe("string");
+    expect(result.path).toBe(writtenPath);
+    expect(writtenPath).toContain("line-media-");
+    expect(writtenPath).toMatch(/\.jpg$/);
+    expect(writtenPath).not.toContain(messageId);
+    expect(writtenPath).not.toContain("..");
+
+    const tmpRoot = path.resolve(os.tmpdir());
+    const rel = path.relative(tmpRoot, path.resolve(writtenPath));
+    expect(rel === ".." || rel.startsWith(`..${path.sep}`)).toBe(false);
+  });
+
+  it("rejects oversized media before writing to disk", async () => {
+    getMessageContentMock.mockResolvedValueOnce(chunks([Buffer.alloc(4), Buffer.alloc(4)]));
+    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValue(undefined);
+
+    await expect(downloadLineMedia("mid", "token", 7)).rejects.toThrow(/Media exceeds/i);
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +9,10 @@ interface DownloadResult {
   path: string;
   contentType?: string;
   size: number;
+}
+
+function buildLineTempMediaPath(extension: string): string {
+  return path.join(os.tmpdir(), `line-media-${Date.now()}-${crypto.randomUUID()}${extension}`);
 }
 
 export async function downloadLineMedia(
@@ -39,10 +44,8 @@ export async function downloadLineMedia(
   const contentType = detectContentType(buffer);
   const ext = getExtensionForContentType(contentType);
 
-  // Write to temp file
-  const tempDir = os.tmpdir();
-  const fileName = `line-media-${messageId}-${Date.now()}${ext}`;
-  const filePath = path.join(tempDir, fileName);
+  // Use random temp names; never derive paths from external message identifiers.
+  const filePath = buildLineTempMediaPath(ext);
 
   await fs.promises.writeFile(filePath, buffer);
 


### PR DESCRIPTION
## Summary\n- harden LINE media download temp path generation to avoid deriving filenames from external message IDs\n- add regression tests proving traversal-style message IDs cannot influence the write path\n\n## Motivation\n- follow-up hardening after GHSA-vj3g-5px3-gr46 (Feishu traversal fix), scoped as proactive defense-in-depth\n\n## Testing\n- pnpm exec vitest run src/line/download.test.ts\n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens LINE media download against path traversal vulnerabilities by replacing external message IDs with cryptographically random UUIDs in temp file paths. The fix introduces `buildLineTempMediaPath()` that combines `Date.now()` and `crypto.randomUUID()` to generate safe temp filenames, preventing attackers from using crafted message IDs like `../../../../etc/passwd` to write files outside the temp directory. This follows the same defense-in-depth approach applied to Feishu in commit c8210991.

Key changes:
- Replaced `line-media-${messageId}-${Date.now()}` pattern with `line-media-${Date.now()}-${crypto.randomUUID()}`
- Added comprehensive regression tests verifying traversal-style message IDs cannot escape temp directory
- Maintained all existing functionality while eliminating the security risk

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security hardening fix with comprehensive test coverage
- The fix directly addresses a path traversal vulnerability using industry-standard mitigation (crypto.randomUUID). The implementation is simple, well-tested with edge cases including traversal attempts, and follows the same pattern already proven effective in the Feishu fix. The change is minimal and surgical, affecting only the temp path generation logic without touching business logic or data flow.
- No files require special attention

<sub>Last reviewed commit: 0f30c21</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->