### PR TITLE
fix: replace Math.max/min spread with reduce to prevent stack overflow

### DIFF
--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -317,7 +317,8 @@ function pickAmbiguousMatch(
     entry,
     rank: typeof entry.rank === "number" ? entry.rank : 0,
   }));
-  const bestRank = Math.max(...ranked.map((item) => item.rank));
+  // Use reduce instead of spread to avoid stack overflow on large arrays
+  const bestRank = ranked.reduce((max, item) => (item.rank > max ? item.rank : max), -Infinity);
   const best = ranked.find((item) => item.rank === bestRank)?.entry;
   return best ?? entries[0] ?? null;
 }

--- a/src/memory/mmr.ts
+++ b/src/memory/mmr.ts
@@ -136,8 +136,9 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
   }
 
   // Normalize scores to [0, 1] for fair comparison with similarity
-  const maxScore = Math.max(...items.map((i) => i.score));
-  const minScore = Math.min(...items.map((i) => i.score));
+  // Use reduce instead of spread to avoid stack overflow on large arrays
+  const maxScore = items.reduce((max, i) => (i.score > max ? i.score : max), -Infinity);
+  const minScore = items.reduce((min, i) => (i.score < min ? i.score : min), Infinity);
   const scoreRange = maxScore - minScore;
 
   const normalizeScore = (score: number): number => {


### PR DESCRIPTION
## Summary

Fixes #20789

Replace spread operator usage in `Math.max/Math.min` calls with reduce-based alternatives to prevent `RangeError: Maximum call stack size exceeded` on large arrays (>100k elements).

## Changes

### `src/memory/mmr.ts`
- `mmrRerank`: Score normalization now uses reduce instead of spread

### `src/infra/outbound/target-resolver.ts`  
- `pickAmbiguousMatch`: Rank selection now uses reduce instead of spread

### Not changed: `src/agents/auth-profiles/usage.ts`
The array in `resolveProfileUnusableUntil` is filtered from a 2-element source (`[cooldownUntil, disabledUntil]`), so it will always have at most 2 elements. This is **not** a stack overflow risk and was intentionally left unchanged.

## Testing

- [x] Changes are minimal and focused
- [x] Logic remains identical (same min/max behavior)
- [ ] CI checks

## AI Disclosure
This PR was AI-assisted (Claude). I understand what the code does — it's a straightforward replacement of spread-based Math.max/min with reduce-based equivalents that handle large arrays safely.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces `Math.max(...array)` and `Math.min(...array)` spread operators with `reduce()` implementations to prevent stack overflow on large arrays (>100k elements).

**Changes:**
- `src/memory/mmr.ts:140-141` - Score normalization in `mmrRerank()` now uses reduce for finding max/min scores
- `src/infra/outbound/target-resolver.ts:321` - Rank selection in `pickAmbiguousMatch()` now uses reduce for finding best rank

**Technical correctness:** The logic is identical - reduce-based implementations correctly replicate Math.max/min behavior while avoiding the call stack limit imposed by the spread operator.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused fix with identical logic and no risk
- The changes are minimal, well-documented, and maintain identical behavior while fixing a real stack overflow issue. The reduce implementations correctly handle edge cases (empty arrays, single elements) and the PR author correctly identified that `src/agents/auth-profiles/usage.ts` doesn't need changes since it only operates on 2-element arrays.
- No files require special attention

<sub>Last reviewed commit: 88a9fd2</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->