### PR TITLE
fix: auto-select enabled account when only one is available

### DIFF
--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { listEnabledAccountIds, resolveMessageAccountSelection } from "./channel-selection.js";
+
+// Mock the channel plugins
+vi.mock("../../channels/plugins/index.js", () => ({
+  listChannelPlugins: () => [
+    {
+      id: "whatsapp",
+      config: {
+        listAccountIds: (cfg: OpenClawConfig) => {
+          const accounts = (cfg.channels?.whatsapp as Record<string, unknown>)?.accounts;
+          if (!accounts || typeof accounts !== "object") {
+            return ["default"];
+          }
+          return Object.keys(accounts as Record<string, unknown>);
+        },
+        resolveAccount: (cfg: OpenClawConfig, accountId: string) => {
+          const accounts = (cfg.channels?.whatsapp as Record<string, unknown>)?.accounts as
+            | Record<string, unknown>
+            | undefined;
+          return accounts?.[accountId] ?? {};
+        },
+        isEnabled: undefined,
+      },
+    },
+  ],
+}));
+
+describe("listEnabledAccountIds", () => {
+  it("returns enabled accounts only", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: { enabled: false },
+            xiaomi: { enabled: true },
+            backup: {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = listEnabledAccountIds({ cfg, channel: "whatsapp" });
+    expect(result).toEqual(["xiaomi", "backup"]);
+  });
+
+  it("returns all accounts when none explicitly disabled", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: {},
+            other: {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = listEnabledAccountIds({ cfg, channel: "whatsapp" });
+    expect(result).toEqual(["default", "other"]);
+  });
+});
+
+describe("resolveMessageAccountSelection", () => {
+  it("uses provided accountId directly", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: { enabled: false },
+            xiaomi: { enabled: true },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveMessageAccountSelection({
+      cfg,
+      channel: "whatsapp",
+      accountId: "custom",
+    });
+    expect(result).toBe("custom");
+  });
+
+  it("uses default account when enabled", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: { enabled: true },
+            other: { enabled: true },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveMessageAccountSelection({
+      cfg,
+      channel: "whatsapp",
+    });
+    expect(result).toBe("default");
+  });
+
+  it("auto-selects single enabled account when default is disabled", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: { enabled: false },
+            xiaomi: { enabled: true },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveMessageAccountSelection({
+      cfg,
+      channel: "whatsapp",
+    });
+    expect(result).toBe("xiaomi");
+  });
+
+  it("throws when multiple accounts enabled and no explicit selection", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: { enabled: false },
+            xiaomi: { enabled: true },
+            backup: { enabled: true },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(() =>
+      resolveMessageAccountSelection({
+        cfg,
+        channel: "whatsapp",
+      }),
+    ).toThrow(/Multiple accounts enabled.*xiaomi.*backup/);
+  });
+
+  it("throws when no accounts are enabled", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: { enabled: false },
+            other: { enabled: false },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(() =>
+      resolveMessageAccountSelection({
+        cfg,
+        channel: "whatsapp",
+      }),
+    ).toThrow(/No enabled accounts/);
+  });
+});

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -60,6 +60,12 @@ describe("listEnabledAccountIds", () => {
     const result = listEnabledAccountIds({ cfg, channel: "whatsapp" });
     expect(result).toEqual(["default", "other"]);
   });
+
+  it("returns null for unknown channels", () => {
+    const cfg = {} as OpenClawConfig;
+    const result = listEnabledAccountIds({ cfg, channel: "unknown" as never });
+    expect(result).toBeNull();
+  });
 });
 
 describe("resolveMessageAccountSelection", () => {
@@ -160,5 +166,24 @@ describe("resolveMessageAccountSelection", () => {
         channel: "whatsapp",
       }),
     ).toThrow(/No enabled accounts/);
+  });
+
+  it("falls back to default when plugin not found", () => {
+    const cfg = {} as OpenClawConfig;
+    const result = resolveMessageAccountSelection({
+      cfg,
+      channel: "unknown" as never,
+    });
+    expect(result).toBe("default");
+  });
+
+  it("falls back to defaultAccountId when plugin not found", () => {
+    const cfg = {} as OpenClawConfig;
+    const result = resolveMessageAccountSelection({
+      cfg,
+      channel: "unknown" as never,
+      defaultAccountId: "custom",
+    });
+    expect(result).toBe("custom");
   });
 });

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -90,3 +90,75 @@ export async function resolveMessageChannelSelection(params: {
     `Channel is required when multiple channels are configured: ${configured.join(", ")}`,
   );
 }
+
+/**
+ * List enabled account IDs for a channel.
+ * An account is considered enabled if it exists and has `enabled !== false`.
+ */
+export function listEnabledAccountIds(params: {
+  cfg: OpenClawConfig;
+  channel: MessageChannelId;
+}): string[] {
+  const plugin = listChannelPlugins().find((p) => p.id === params.channel);
+  if (!plugin) {
+    return [];
+  }
+
+  const accountIds = plugin.config.listAccountIds(params.cfg);
+  return accountIds.filter((accountId) => {
+    const account = plugin.config.resolveAccount(params.cfg, accountId);
+    return plugin.config.isEnabled
+      ? plugin.config.isEnabled(account, params.cfg)
+      : isAccountEnabled(account);
+  });
+}
+
+/**
+ * Resolve account ID for a channel, auto-selecting if only one is enabled.
+ *
+ * Behavior:
+ * 1. If accountId is provided, use it as-is
+ * 2. If "default" account is enabled, use "default"
+ * 3. If exactly one account is enabled, use that account
+ * 4. If multiple accounts are enabled, require explicit accountId
+ * 5. If no accounts are enabled, throw an error
+ */
+export function resolveMessageAccountSelection(params: {
+  cfg: OpenClawConfig;
+  channel: MessageChannelId;
+  accountId?: string | null;
+  defaultAccountId?: string;
+}): string {
+  // If explicit accountId provided, use it
+  if (params.accountId) {
+    return params.accountId;
+  }
+
+  const enabledAccounts = listEnabledAccountIds({
+    cfg: params.cfg,
+    channel: params.channel,
+  });
+
+  if (enabledAccounts.length === 0) {
+    throw new Error(
+      `No enabled accounts for channel ${params.channel}. Check your channel configuration.`,
+    );
+  }
+
+  // If default account is enabled, prefer it
+  const defaultId = params.defaultAccountId ?? "default";
+  if (enabledAccounts.includes(defaultId)) {
+    return defaultId;
+  }
+
+  // If exactly one account is enabled, use it
+  if (enabledAccounts.length === 1) {
+    return enabledAccounts[0];
+  }
+
+  // Multiple enabled accounts, require explicit selection
+  throw new Error(
+    `Multiple accounts enabled for ${params.channel}: ${enabledAccounts.join(", ")}. ` +
+      `Please specify accountId explicitly.`,
+  );
+}

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -22,6 +22,7 @@ import {
 import { throwIfAborted } from "./abort.js";
 import {
   listConfiguredMessageChannels,
+  resolveMessageAccountSelection,
   resolveMessageChannelSelection,
 } from "./channel-selection.js";
 import { applyTargetToParams } from "./channel-target.js";
@@ -750,10 +751,14 @@ export async function runMessageAction(
   }
 
   const channel = await resolveChannel(cfg, params);
-  const accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
-  if (accountId) {
-    params.accountId = accountId;
-  }
+  // Auto-select enabled account when only one is available (fixes #20756)
+  const accountId = resolveMessageAccountSelection({
+    cfg,
+    channel,
+    accountId: readStringParam(params, "accountId"),
+    defaultAccountId: input.defaultAccountId,
+  });
+  params.accountId = accountId;
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
 
   await normalizeSandboxMediaParams({


### PR DESCRIPTION
## Summary

Fixes #20756

When using the message tool without specifying `accountId`, the tool now intelligently selects the appropriate account:

1. **If explicit `accountId` provided** → use it (unchanged)
2. **If `default` account is enabled** → use `default` (unchanged)  
3. **If `default` is disabled but exactly one account is enabled** → auto-select it ✨ NEW
4. **If multiple accounts are enabled** → require explicit `accountId` selection
5. **If no accounts are enabled** → throw a clear error

## Problem

Previously, the tool would always fall back to `default` account even when disabled:

```json
{
  "channels": {
    "whatsapp": {
      "accounts": {
        "default": { "enabled": false },
        "xiaomi": { "enabled": true }
      }
    }
  }
}
```

Result: Confusing error `No active WhatsApp Web listener (account: default)`

## Solution

Added `resolveMessageAccountSelection()` and `listEnabledAccountIds()` functions in `channel-selection.ts` that check account enabled state before selection.

## Changes

- `src/infra/outbound/channel-selection.ts`: Added account selection helpers
- `src/infra/outbound/message-action-runner.ts`: Use new account selection
- `src/infra/outbound/channel-selection.test.ts`: Tests for new behavior

## Testing

- [x] Unit tests for `listEnabledAccountIds`
- [x] Unit tests for `resolveMessageAccountSelection`
- [ ] CI checks

## AI Disclosure

This PR was AI-assisted (Claude). I understand the changes — they follow the same pattern as the existing `resolveMessageChannelSelection` function for channels, now applied to accounts.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added intelligent account auto-selection for the message tool when `accountId` is not specified. Previously, the tool would always fall back to the `default` account even when disabled, causing confusing errors. The new logic checks enabled state and auto-selects when exactly one account is available, following the same pattern as the existing `resolveMessageChannelSelection` function.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns in the codebase (`resolveMessageChannelSelection`), has comprehensive unit tests covering all code paths including edge cases, and the logic is straightforward with clear error messages. The change is well-scoped and fixes a specific UX issue without affecting other functionality.
- No files require special attention

<sub>Last reviewed commit: 95e0133</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->