### PR TITLE
fix(security): block plaintext WebSocket connections to non-loopback addresses

### DIFF
--- a/src/commands/gateway-status.e2e.test.ts
+++ b/src/commands/gateway-status.e2e.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 const loadConfig = vi.fn(() => ({
   gateway: {
     mode: "remote",
-    remote: { url: "ws://remote.example:18789", token: "rtok" },
+    remote: { url: "wss://remote.example:18789", token: "rtok" },
     auth: { token: "ltok" },
   },
 }));
@@ -272,7 +272,7 @@ describe("gateway-status command", () => {
       loadConfig.mockReturnValueOnce({
         gateway: {
           mode: "remote",
-          remote: { url: "ws://studio.example:18789", token: "rtok" },
+          remote: { url: "wss://studio.example:18789", token: "rtok" },
           auth: { token: "ltok" },
         },
       });
@@ -298,7 +298,7 @@ describe("gateway-status command", () => {
     loadConfig.mockReturnValueOnce({
       gateway: {
         mode: "remote",
-        remote: { url: "ws://studio.example:18789", token: "rtok" },
+        remote: { url: "wss://studio.example:18789", token: "rtok" },
         auth: { token: "ltok" },
       },
     });

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -31,9 +31,13 @@ vi.mock("../infra/tailnet.js", () => ({
   pickPrimaryTailnetIPv4,
 }));
 
-vi.mock("./net.js", () => ({
-  pickPrimaryLanIPv4,
-}));
+vi.mock("./net.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./net.js")>();
+  return {
+    ...actual,
+    pickPrimaryLanIPv4,
+  };
+});
 
 vi.mock("./client.js", () => ({
   describeGatewayCloseCode: (code: number) => {
@@ -91,7 +95,7 @@ function makeRemotePasswordGatewayConfig(remotePassword: string, localPassword =
   return {
     gateway: {
       mode: "remote",
-      remote: { url: "ws://remote.example:18789", password: remotePassword },
+      remote: { url: "wss://remote.example:18789", password: remotePassword },
       auth: { password: localPassword },
     },
   };
@@ -122,25 +126,46 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
   });
 
-  it("uses tailnet IP when local bind is tailnet and tailnet is present", async () => {
-    loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "tailnet" } });
+  it("uses tailnet IP with TLS when local bind is tailnet", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "tailnet", tls: { enabled: true } },
+    });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue("100.64.0.1");
 
     await callGateway({ method: "health" });
 
-    expect(lastClientOptions?.url).toBe("ws://100.64.0.1:18800");
+    expect(lastClientOptions?.url).toBe("wss://100.64.0.1:18800");
   });
 
-  it("uses LAN IP when bind is lan and LAN IP is available", async () => {
-    loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
+  it("blocks ws:// to tailnet IP without TLS (CWE-319)", async () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "tailnet" } });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue("100.64.0.1");
+
+    await expect(callGateway({ method: "health" })).rejects.toThrow("SECURITY ERROR");
+  });
+
+  it("uses LAN IP with TLS when bind is lan", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "lan", tls: { enabled: true } },
+    });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
     pickPrimaryLanIPv4.mockReturnValue("192.168.1.42");
 
     await callGateway({ method: "health" });
 
-    expect(lastClientOptions?.url).toBe("ws://192.168.1.42:18800");
+    expect(lastClientOptions?.url).toBe("wss://192.168.1.42:18800");
+  });
+
+  it("blocks ws:// to LAN IP without TLS (CWE-319)", async () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue("192.168.1.42");
+
+    await expect(callGateway({ method: "health" })).rejects.toThrow("SECURITY ERROR");
   });
 
   it("falls back to loopback when bind is lan but no LAN IP found", async () => {
@@ -214,9 +239,9 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.message).toContain("Gateway target: ws://127.0.0.1:18789");
   });
 
-  it("uses LAN IP and reports lan source when bind is lan", () => {
+  it("uses LAN IP with TLS and reports lan source when bind is lan", () => {
     loadConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "lan" },
+      gateway: { mode: "local", bind: "lan", tls: { enabled: true } },
     });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
@@ -224,9 +249,20 @@ describe("buildGatewayConnectionDetails", () => {
 
     const details = buildGatewayConnectionDetails();
 
-    expect(details.url).toBe("ws://10.0.0.5:18800");
+    expect(details.url).toBe("wss://10.0.0.5:18800");
     expect(details.urlSource).toBe("local lan 10.0.0.5");
     expect(details.bindDetail).toBe("Bind: lan");
+  });
+
+  it("throws for ws:// to LAN IP without TLS (CWE-319)", () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "lan" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue("10.0.0.5");
+
+    expect(() => buildGatewayConnectionDetails()).toThrow("SECURITY ERROR");
   });
 
   it("prefers remote url when configured", () => {
@@ -246,6 +282,34 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.urlSource).toBe("config gateway.remote.url");
     expect(details.bindDetail).toBeUndefined();
     expect(details.remoteFallbackNote).toBeUndefined();
+  });
+
+  it("throws for insecure ws:// remote URLs (CWE-319)", () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: { url: "ws://remote.example.com:18789" },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+
+    expect(() => buildGatewayConnectionDetails()).toThrow("SECURITY ERROR");
+    expect(() => buildGatewayConnectionDetails()).toThrow("plaintext ws://");
+    expect(() => buildGatewayConnectionDetails()).toThrow("wss://");
+  });
+
+  it("allows ws:// for loopback addresses in local mode", () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback" },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://127.0.0.1:18789");
   });
 });
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -396,3 +396,33 @@ export function isLoopbackHost(host: string): boolean {
   const unbracket = h.startsWith("[") && h.endsWith("]") ? h.slice(1, -1) : h;
   return isLoopbackAddress(unbracket);
 }
+
+/**
+ * Security check for WebSocket URLs (CWE-319: Cleartext Transmission of Sensitive Information).
+ *
+ * Returns true if the URL is secure for transmitting data:
+ * - wss:// (TLS) is always secure
+ * - ws:// is only secure for loopback addresses (localhost, 127.x.x.x, ::1)
+ *
+ * All other ws:// URLs are considered insecure because both credentials
+ * AND chat/conversation data would be exposed to network interception.
+ */
+export function isSecureWebSocketUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol === "wss:") {
+    return true;
+  }
+
+  if (parsed.protocol !== "ws:") {
+    return false;
+  }
+
+  // ws:// is only secure for loopback addresses
+  return isLoopbackHost(parsed.hostname);
+}

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -2015,7 +2015,7 @@ description: test skill
           mode: "remote",
           auth: { token: "local-token-should-not-use" },
           remote: {
-            url: "ws://remote.example.com:18789",
+            url: "wss://remote.example.com:18789",
             token: "remote-token-xyz789",
           },
         },
@@ -2054,7 +2054,7 @@ description: test skill
           mode: "remote",
           auth: { token: "local-token-should-not-use" },
           remote: {
-            url: "ws://remote.example.com:18789",
+            url: "wss://remote.example.com:18789",
             token: "remote-token",
           },
         },
@@ -2091,7 +2091,7 @@ description: test skill
         gateway: {
           mode: "remote",
           remote: {
-            url: "ws://remote.example.com:18789",
+            url: "wss://remote.example.com:18789",
             password: "remote-pass",
           },
         },
@@ -2129,7 +2129,7 @@ description: test skill
         gateway: {
           mode: "remote",
           remote: {
-            url: "ws://remote.example.com:18789",
+            url: "wss://remote.example.com:18789",
             password: "remote-pass",
           },
         },

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -21,9 +21,15 @@ vi.mock("../infra/tailnet.js", () => ({
   pickPrimaryTailnetIPv4,
 }));
 
-vi.mock("../gateway/net.js", () => ({
-  pickPrimaryLanIPv4,
-}));
+vi.mock("../gateway/net.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../gateway/net.js")>();
+  return {
+    ...actual,
+    pickPrimaryLanIPv4,
+    // Allow all URLs in tests - security validation is tested separately
+    isSecureWebSocketUrl: () => true,
+  };
+});
 
 const { resolveGatewayConnection } = await import("./gateway-chat.js");
 


### PR DESCRIPTION
## Summary

Fixes #12519 - CWE-319: Cleartext Transmission of Sensitive Information (CVSS 9.8)

This PR blocks ALL plaintext `ws://` WebSocket connections to non-loopback addresses, protecting both credentials and chat data from network interception.

### Security Policy

| URL Type | Result |
|----------|--------|
| `wss://` any host | ✅ Allowed |
| `ws://127.0.0.1`, `ws://localhost`, `ws://[::1]` | ✅ Allowed |
| `ws://` LAN/tailnet/remote | ❌ **Blocked** |

### Key Changes

- **`src/gateway/net.ts`**: Added `isSecureWebSocketUrl()` to validate WebSocket URL security
- **`src/gateway/client.ts`**: Block insecure connections at connection time (catches device tokens loaded dynamically)
- **`src/gateway/call.ts`**: Block insecure URLs during config/URL resolution (all code paths)
- Malformed URLs handled gracefully without crashing

### Why Block Without Checking Credentials?

1. **Device tokens bypass**: Credentials can be loaded from persistent storage after initial validation
2. **Chat data exposure**: Issue #12519 highlights MITM risk for conversation data, not just credentials
3. **Defense in depth**: Block at the transport layer regardless of auth state

## Test plan

- [x] New tests for `GatewayClient` security checks (4 tests)
- [x] New tests for `buildGatewayConnectionDetails` blocking (5 tests)
- [x] Updated existing tests to use `wss://` for non-loopback URLs
- [x] Malformed URL handling test
- [x] All 450 gateway/security tests passing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses a critical security vulnerability (CWE-319: Cleartext Transmission of Sensitive Information, CVSS 9.8) by blocking plaintext WebSocket connections to non-loopback addresses. The implementation adds `isSecureWebSocketUrl()` validation that allows `wss://` to any host and `ws://` only to loopback addresses (localhost, 127.x.x.x, ::1).

**Key changes:**
- Added `isSecureWebSocketUrl()` function in `src/gateway/net.ts` with proper URL parsing and error handling
- Enforced security checks at two critical points: `GatewayClient.start()` and `buildGatewayConnectionDetails()` to catch all code paths
- Updated test suite comprehensively (9 new security tests across net, client, and call modules)
- Updated existing tests to use `wss://` for non-loopback URLs and enable TLS in config where needed
- All security checks provide clear, actionable error messages directing users to use `wss://` or SSH tunneling

The fix correctly implements defense in depth by blocking at both connection initialization and URL resolution, handles malformed URLs gracefully, and protects both credentials and chat data from interception.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The implementation is well-designed with comprehensive test coverage (9 new security tests), handles edge cases properly (malformed URLs, multiple code paths), and follows security best practices. The fix addresses a critical vulnerability (CVSS 9.8) correctly by implementing defense in depth at multiple layers. Error messages are clear and actionable. All existing tests were updated appropriately to maintain compatibility.
- No files require special attention

<sub>Last reviewed commit: 9952d0e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->