### PR TITLE
fix: classify Google 503 UNAVAILABLE as transient failover [AI-assisted]

### DIFF
--- a/src/agents/failover-error.e2e.test.ts
+++ b/src/agents/failover-error.e2e.test.ts
@@ -13,6 +13,13 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
+    expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
+  });
+
+  it("infers timeout from Google AI SDK JSON-wrapped 503 error message", () => {
+    const googleError503 =
+      '{"error":{"message":"This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.","code":503,"status":"Service Unavailable"}}';
+    expect(resolveFailoverReasonFromError({ message: googleError503 })).toBe("timeout");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -161,6 +161,10 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
+  if (status === 503) {
+    // Service Unavailable — treat as transient timeout so failover cascade advances.
+    return "timeout";
+  }
   if (status === 400) {
     return "format";
   }


### PR DESCRIPTION
## Summary
This fixes a failover classification gap where Google AI SDK responses can return JSON-wrapped 503 errors like:

```json
{"error":{"message":"...","code":503,"status":"Service Unavailable"}}
```

These payloads were not reliably classified as transient failover errors, so fallback cascades could stall and return provider error text instead of advancing to next candidates.

### Changes
- Extend transient HTTP detection to parse embedded JSON error codes (`error.code`) in API error payloads.
- Treat `status === 503` as a transient timeout in `resolveFailoverReasonFromError`.
- Add regression tests for Google JSON-wrapped 503 handling.
- Add guard test to ensure JSON-wrapped 429 remains non-transient (rate-limit path, not timeout path).

## Why
OpenClaw failover behavior depends on robust error classification. If JSON-wrapped 503/UNAVAILABLE shapes are missed, model fallback may not advance under temporary provider load spikes.

## Testing
AI-assisted PR: yes (Codex/OpenClaw).

Degree of testing: lightly tested + targeted.

Ran locally:
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts src/agents/failover-error.e2e.test.ts` ✅ (43/43 passed)
- `pnpm check` ✅
- `pnpm build` ✅

## Prompt / Session context
Issue identified from live council-run artifacts where Gemini seat repeatedly returned `code: 503` / `status: UNAVAILABLE` without cascading to fallback candidates. This patch is a minimal classification fix + regression coverage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends transient HTTP error detection to correctly classify Google AI SDK JSON-wrapped 503 errors as transient timeout errors, ensuring failover cascades advance to next candidates instead of stalling.

- Added `status === 503` handling in `resolveFailoverReasonFromError` (src/agents/failover-error.ts:164-167) to treat Service Unavailable as transient timeout
- Implemented `extractEmbeddedHttpCode` helper (src/agents/pi-embedded-helpers/errors.ts:171-188) to parse `error.code` from JSON-wrapped API error payloads
- Extended `isTransientHttpError` (src/agents/pi-embedded-helpers/errors.ts:190-203) to detect embedded HTTP codes when no leading status prefix exists
- Added regression tests for Google AI SDK 503 UNAVAILABLE handling across both error classification paths
- Guard test ensures 429 rate limit errors remain non-transient

The implementation correctly leverages existing `TRANSIENT_HTTP_ERROR_CODES` set which already includes 503, ensuring consistency across both detection paths (leading HTTP status and embedded JSON codes).

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted fix with comprehensive test coverage
- The PR addresses a specific, well-documented failover classification gap with minimal code changes. The logic is sound (503 Service Unavailable is correctly treated as transient), test coverage is thorough (includes both direct status code checks and JSON-wrapped error handling with guard tests for 429), and the implementation follows existing patterns in the codebase. The changes are isolated to error classification logic with no side effects on other systems.
- No files require special attention

<sub>Last reviewed commit: c8aa42b</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->