### PR TITLE
Pr clean-feat(skills,plugins): add allowedAgents config for agent-based access control

### DIFF
--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig, SkillConfig } from "../../config/config.js";
+import type { SkillEligibilityContext, SkillEntry } from "./types.js";
 import {
   evaluateRuntimeRequires,
   hasBinary,
@@ -7,7 +8,6 @@ import {
   resolveRuntimePlatform,
 } from "../../shared/config-eval.js";
 import { resolveSkillKey } from "./frontmatter.js";
-import type { SkillEligibilityContext, SkillEntry } from "./types.js";
 
 const DEFAULT_CONFIG_VALUES: Record<string, boolean> = {
   "browser.enabled": true,
@@ -81,6 +81,14 @@ export function shouldIncludeSkill(params: {
 
   if (skillConfig?.enabled === false) {
     return false;
+  }
+  // Check agent-level allowlist
+  const allowedAgents = normalizeAllowlist(skillConfig?.allowedAgents);
+  if (allowedAgents && allowedAgents.length > 0) {
+    const agentId = eligibility?.agentId;
+    if (!agentId || !allowedAgents.includes(agentId)) {
+      return false;
+    }
   }
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -71,6 +71,8 @@ export type SkillEntry = {
 };
 
 export type SkillEligibilityContext = {
+  /** The agent ID for which skills are being filtered. */
+  agentId?: string;
   remote?: {
     platforms: string[];
     hasBin: (bin: string) => boolean;

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -1,8 +1,10 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
+import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
+import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
+import type { HandleCommandsParams } from "./commands-types.js";
 import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
-import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
 import { createOpenClawCodingTools } from "../../agents/pi-tools.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
@@ -10,10 +12,9 @@ import { getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import { buildSystemPromptParams } from "../../agents/system-prompt-params.js";
 import { buildAgentSystemPrompt } from "../../agents/system-prompt.js";
 import { buildToolSummaryMap } from "../../agents/tool-summaries.js";
-import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
-import type { HandleCommandsParams } from "./commands-types.js";
 
 export type CommandsSystemPromptBundle = {
   systemPrompt: string;
@@ -36,9 +37,12 @@ export async function resolveCommandsSystemPromptBundle(
   });
   const skillsSnapshot = (() => {
     try {
+      const agentId = params.sessionKey
+        ? resolveAgentIdFromSessionKey(params.sessionKey)
+        : undefined;
       return buildWorkspaceSkillSnapshot(workspaceDir, {
         config: params.cfg,
-        eligibility: { remote: getRemoteSkillEligibility() },
+        eligibility: { agentId, remote: getRemoteSkillEligibility() },
         snapshotVersion: getSkillsSnapshotVersion(workspaceDir),
       });
     } catch {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,3 +1,4 @@
+import type { AgentCommandOpts } from "./agent/types.js";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -61,7 +62,6 @@ import { deliverAgentCommandResult } from "./agent/delivery.js";
 import { resolveAgentRunContext } from "./agent/run-context.js";
 import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
 import { resolveSession } from "./agent/session.js";
-import type { AgentCommandOpts } from "./agent/types.js";
 
 type PersistSessionEntryParams = {
   sessionStore: Record<string, SessionEntry>;
@@ -318,7 +318,7 @@ export async function agentCommand(
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {
           config: cfg,
-          eligibility: { remote: getRemoteSkillEligibility() },
+          eligibility: { agentId: sessionAgentId, remote: getRemoteSkillEligibility() },
           snapshotVersion: skillsSnapshotVersion,
           skillFilter,
         })

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -3,6 +3,8 @@ export type SkillConfig = {
   apiKey?: string;
   env?: Record<string, string>;
   config?: Record<string, unknown>;
+  /** List of agent IDs that are allowed to use this skill. If undefined, all agents can use it. */
+  allowedAgents?: string[];
 };
 
 export type SkillsLoadConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -605,6 +605,7 @@ export const OpenClawSchema = z
                 apiKey: z.string().optional().register(sensitive),
                 env: z.record(z.string(), z.string()).optional(),
                 config: z.record(z.string(), z.unknown()).optional(),
+                allowedAgents: z.array(z.string()).optional(),
               })
               .strict(),
           )

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -637,6 +637,7 @@ export const OpenClawSchema = z
               .object({
                 enabled: z.boolean().optional(),
                 config: z.record(z.string(), z.unknown()).optional(),
+                allowedAgents: z.array(z.string()).optional(),
               })
               .strict(),
           )

--- a/src/cron/isolated-agent/skills-snapshot.ts
+++ b/src/cron/isolated-agent/skills-snapshot.ts
@@ -1,8 +1,8 @@
+import type { OpenClawConfig } from "../../config/config.js";
 import { resolveAgentSkillsFilter } from "../../agents/agent-scope.js";
 import { buildWorkspaceSkillSnapshot, type SkillSnapshot } from "../../agents/skills.js";
 import { matchesSkillFilter } from "../../agents/skills/filter.js";
 import { getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 
 export function resolveCronSkillsSnapshot(params: {
@@ -31,7 +31,7 @@ export function resolveCronSkillsSnapshot(params: {
   return buildWorkspaceSkillSnapshot(params.workspaceDir, {
     config: params.config,
     skillFilter,
-    eligibility: { remote: getRemoteSkillEligibility() },
+    eligibility: { agentId: params.agentId, remote: getRemoteSkillEligibility() },
     snapshotVersion,
   });
 }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,6 +1,6 @@
-import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { Command } from "commander";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthProfileCredential, OAuthCredential } from "../agents/auth-profiles/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
@@ -396,6 +396,13 @@ export type PluginHookAgentEndEvent = {
   success: boolean;
   error?: string;
   durationMs?: number;
+  tokenUsage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
 };
 
 // Compaction hooks


### PR DESCRIPTION
## Summary

Add `allowedAgents` configuration to control which Agents can access specific skills or plugins, and expose tokenUsage in agent_end hook.

## Changes

### Core Features
- Add `allowedAgents` field to `SkillConfig` and `PluginConfig` types
- Add `agentId` to `SkillEligibilityContext`
- Filter skills/plugins based on agent ID when `allowedAgents` is configured
- Expose `tokenUsage` in `agent_end` hook with optional fields

### Files Modified (11 files)
- src/agents/skills/config.ts
- src/agents/skills/types.ts
- src/agents/pi-embedded-runner/run/attempt.ts
- src/auto-reply/reply/commands-system-prompt.ts
- src/auto-reply/reply/session-updates.ts
- src/commands/agent.ts
- src/config/types.skills.ts
- src/config/zod-schema.ts
- src/cron/isolated-agent/skills-snapshot.ts
- src/plugins/loader.ts
- src/plugins/types.ts

## Usage

```json
{
  "skills": {
    "entries": {
      "some-skill": {
        "enabled": true,
        "allowedAgents": ["coder", "trade"]
      }
    }
  },
  "plugins": {
    "some-plugin": {
      "enabled": true,
      "allowedAgents": ["coder"]
    }
  }
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `allowedAgents` configuration to control agent-based access to skills and plugins, and exposed `tokenUsage` in the `agent_end` hook.

**Key Changes:**
- Added `allowedAgents` field to `SkillConfig` and plugin config schemas for agent-based filtering
- Added `agentId` to `SkillEligibilityContext` for skill filtering logic
- Exposed optional `tokenUsage` metrics in `agent_end` hook event

**Critical Bug Found:**
- The `allowedAgents` field for plugins won't work correctly because `normalizePluginEntries` in `src/plugins/config-state.ts` doesn't preserve the `allowedAgents` field during configuration normalization
- The `NormalizedPluginsConfig` type definition is also missing the `allowedAgents` field
- This means the agent filtering logic in `src/plugins/loader.ts:285-293` will never execute as intended

**Integration Gap:**
- The `agentId` parameter was added to `loadOpenClawPlugins` options, but no call sites were updated to pass the `agentId` value. This means plugins won't be filtered by agent in practice, even after fixing the normalization bug.

<h3>Confidence Score: 2/5</h3>

- This PR has a critical implementation bug that prevents the plugin agent filtering from working
- The plugin `allowedAgents` filtering won't work due to a bug in `normalizePluginEntries` that doesn't preserve the field. Additionally, no call sites pass `agentId` to `loadOpenClawPlugins`, so the feature is incomplete. Skills filtering appears properly implemented.
- Pay close attention to `src/plugins/config-state.ts` and all call sites of `loadOpenClawPlugins`

<sub>Last reviewed commit: 5f0904a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->