### PR TITLE
fix(export-session): prevent Prettier from corrupting template placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -901,6 +901,7 @@ Docs: https://docs.openclaw.ai
 - Security/Media: use `crypto.randomBytes()` for temp file names and set owner-only permissions for TTS temp files. (#20654) Thanks @mahanandhi.
 - Security/Gateway: set baseline security headers (`X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`) on gateway HTTP responses. (#10526) Thanks @abdelsfane.
 - Security/iMessage: harden remote attachment SSH/SCP handling by requiring strict host-key verification, validating `channels.imessage.remoteHost` as `host`/`user@host`, and rejecting unsafe host tokens from config or auto-detection. Thanks @allsmog for reporting.
+- Commands/Export: fix `/export-session` generating broken HTML by preventing Prettier from reformatting `{{PLACEHOLDER}}` template syntax inside script tags as JavaScript object literals. (#20816) Thanks @boris721.
 - Security/Feishu: prevent path traversal in Feishu inbound media temp-file writes by replacing key-derived temp filenames with UUID-based names. Thanks @allsmog for reporting.
 - Security/Feishu: escape mention regex metacharacters in `stripBotMention` so crafted mention metadata cannot trigger regex injection or ReDoS during inbound message parsing. (#20916) Thanks @orlyjamie for the fix and @allsmog for reporting.
 - LINE/Security: harden inbound media temp-file naming by using UUID-based temp paths for downloaded media instead of external message IDs. (#20792) Thanks @mbelinky.

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -59,30 +59,15 @@
     </script>
 
     <!-- Vendored libraries -->
-    <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{MARKED_JS}}</script>
 
     <!-- highlight.js -->
-    <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{HIGHLIGHT_JS}}</script>
 
     <!-- Main application code -->
-    <script>
-      {
-        {
-          JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{JS}}</script>
   </body>
 </html>


### PR DESCRIPTION
## Problem

The `/export-session` command generates HTML files with broken `<script>` tags. Instead of containing the actual JavaScript libraries (marked.js, highlight.js), the exported files contain literal placeholder text:

```html
<script>
  {
    {
      MARKED_JS;
    }
  }
</script>
```

## Root Cause

Prettier reformatted the template placeholders `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` inside `<script>` tags, interpreting them as JavaScript object literals. It added whitespace and semicolons, breaking the string replacement in `generateHtml()`:

```typescript
.replace("{{MARKED_JS}}", markedJs)  // Looking for '{{MARKED_JS}}'
                                      // But template contains '{ { MARKED_JS; } }'
```

## Fix

Add `<!-- prettier-ignore -->` comments before each script tag to preserve the exact placeholder syntax:

```html
<!-- prettier-ignore -->
<script>{{MARKED_JS}}</script>
```

## Testing

Tested locally - exported HTML now contains the actual library code and renders correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `/export-session` command generating broken HTML files by adding `<!-- prettier-ignore -->` comments before script tags containing template placeholders (`{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, `{{JS}}`).

- Prettier was reformatting these placeholders as JavaScript object literals, adding whitespace and semicolons
- This broke the string replacement in `generateHtml()` at `src/auto-reply/reply/commands-export-session.ts:96-97`
- The fix preserves exact placeholder syntax so template replacement works correctly
- CHANGELOG entry properly documents the fix

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is focused, well-tested, and addresses a clear formatting bug with a standard Prettier directive. The changes are minimal (adding three `<!-- prettier-ignore -->` comments), the root cause is well-documented, and the solution is the idiomatic approach for preventing Prettier from reformatting specific code blocks
- No files require special attention

<sub>Last reviewed commit: a20271c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->