### PR TITLE
feat(telegram): add draftMinInitialChars and initialDraftText config options

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -101,6 +101,10 @@ export type TelegramAccountConfig = {
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
   /** Telegram stream preview mode (off|partial|block). Default: partial. */
   streamMode?: "off" | "partial" | "block";
+  /** Minimum chars before sending initial draft message. Set to 0 to send immediately on message receipt. Default: 30. */
+  draftMinInitialChars?: number;
+  /** Initial draft text to show immediately when processing starts. Use to acknowledge message receipt. */
+  initialDraftText?: string;
   mediaMaxMb?: number;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -122,6 +122,8 @@ export const TelegramAccountSchemaBase = z
     draftChunk: BlockStreamingChunkSchema.optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     streamMode: z.enum(["off", "partial", "block"]).optional().default("partial"),
+    draftMinInitialChars: z.number().int().min(0).optional(),
+    initialDraftText: z.string().optional(),
     mediaMaxMb: z.number().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -47,9 +47,12 @@ export function createTelegramDraftStream(params: {
   let stopped = false;
   let isFinal = false;
 
-  // Immediately send initial text if provided (e.g., "收到，正在思考...")
+  // Immediately send initial text if provided (e.g., "received, thinking...")
   const initialText = params.initialText?.trim();
+  let initialTextSent = false;
   if (initialText) {
+    // Mark as sent immediately to skip debounce for subsequent streaming updates
+    initialTextSent = true;
     void (async () => {
       try {
         const sent = await params.api.sendMessage(chatId, initialText, replyParams);
@@ -87,7 +90,13 @@ export function createTelegramDraftStream(params: {
     }
 
     // Debounce first preview send for better push notification quality.
-    if (typeof streamMessageId !== "number" && minInitialChars != null && !isFinal) {
+    // Skip debounce if initial text was already sent.
+    if (
+      !initialTextSent &&
+      typeof streamMessageId !== "number" &&
+      minInitialChars != null &&
+      !isFinal
+    ) {
       if (trimmed.length < minInitialChars) {
         return false;
       }

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -24,6 +24,8 @@ export function createTelegramDraftStream(params: {
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
+  /** Initial text to send immediately when stream starts (e.g., "收到，正在思考...") */
+  initialText?: string;
   log?: (message: string) => void;
   warn?: (message: string) => void;
 }): TelegramDraftStream {
@@ -44,6 +46,23 @@ export function createTelegramDraftStream(params: {
   let lastSentText = "";
   let stopped = false;
   let isFinal = false;
+
+  // Immediately send initial text if provided (e.g., "收到，正在思考...")
+  const initialText = params.initialText?.trim();
+  if (initialText) {
+    void (async () => {
+      try {
+        const sent = await params.api.sendMessage(chatId, initialText, replyParams);
+        const sentMessageId = sent?.message_id;
+        if (typeof sentMessageId === "number" && Number.isFinite(sentMessageId)) {
+          streamMessageId = Math.trunc(sentMessageId);
+          lastSentText = initialText;
+        }
+      } catch (err) {
+        params.warn?.(`telegram stream initial text send failed: ${String(err)}`);
+      }
+    })();
+  }
 
   const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
     // Allow final flush even if stopped (e.g., after clear()).


### PR DESCRIPTION
## Summary

Add two new Telegram channel configuration options to improve user experience by showing immediate feedback when a message is being processed:

- `draftMinInitialChars`: Minimum chars before sending initial draft message (default: 30). Set to 0 to send immediately on message receipt.
- `initialDraftText`: Initial draft text to show immediately when processing starts (e.g., "收到了 我想一想🤔……")

This allows bots to acknowledge message receipt before the AI starts generating a response, improving perceived responsiveness.

## Changes

- `src/config/types.telegram.ts`: Add type definitions
- `src/config/zod-schema.providers-core.ts`: Add Zod validation schema
- `src/telegram/bot-message-dispatch.ts`: Read config and pass to draft stream
- `src/telegram/draft-stream.ts`: Support immediate initial text send

## Usage

```json
{
  "channels": {
    "telegram": {
      "draftMinInitialChars": 0,
      "initialDraftText": "收到了 我想一想🤔……"
    }
  }
}
``"

## Testing

- [x] Verified config validation works
- [x] Verified hot reload applies config changes
- [x] Tested in group chat - initial text appears immediately before AI response

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new Telegram configuration options (`draftMinInitialChars` and `initialDraftText`) to allow immediate acknowledgment when messages are received, improving perceived bot responsiveness. 

- Type definitions and Zod schemas correctly added with appropriate validation (`.int().min(0)` for the numeric field)
- Configuration is properly threaded through `bot-message-dispatch.ts` to `draft-stream.ts`
- Default value of 30 chars maintained for backward compatibility

**Issue found:**
- Race condition in `draft-stream.ts` where the initial text send is fire-and-forget, potentially causing the first streaming update to be dropped if it arrives before the initial send completes

<h3>Confidence Score: 3/5</h3>

- Safe to merge with caution - race condition could cause intermittent initial message drops
- Configuration schema and type definitions are solid, and the feature implementation is straightforward. However, the fire-and-forget async pattern for sending initial text creates a timing issue that could cause the first streaming update to be incorrectly debounced. This is a functional bug but not critical - worst case is the initial acknowledgment message gets replaced by the first stream update instead of being edited.
- Pay close attention to `src/telegram/draft-stream.ts` - the race condition in initial text sending needs to be addressed

<sub>Last reviewed commit: f1ab431</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->