### PR TITLE
fix(security): Windows ACL audit false-positive with localized SYSTEM (ru-RU)

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -287,10 +287,27 @@ Successfully processed 1 files`;
   });
 
   describe("inspectWindowsAcl", () => {
+    // Helper: create a mock exec that routes by command name.
+    // whoami → rejected (not on Windows), powershell → rejected (SDDL unavailable),
+    // icacls → provided output. This ensures the icacls-only fallback path is tested.
+    function mockExecForIcacls(icaclsResult: { stdout: string; stderr: string }) {
+      return vi.fn().mockImplementation((cmd: string) => {
+        if (cmd === "whoami") {
+          return Promise.reject(new Error("not Windows"));
+        }
+        if (cmd === "powershell") {
+          return Promise.reject(new Error("not Windows"));
+        }
+        if (cmd === "icacls") {
+          return Promise.resolve(icaclsResult);
+        }
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
+    }
+
     it("returns parsed ACL entries on success", async () => {
-      const mockExec = vi.fn().mockResolvedValue({
-        stdout: `C:\\test\\file.txt BUILTIN\\Administrators:(F)
-                NT AUTHORITY\\SYSTEM:(F)`,
+      const mockExec = mockExecForIcacls({
+        stdout: `C:\\test\\file.txt BUILTIN\\Administrators:(F)\n                NT AUTHORITY\\SYSTEM:(F)`,
         stderr: "",
       });
 
@@ -310,7 +327,7 @@ Successfully processed 1 files`;
     });
 
     it("combines stdout and stderr for parsing", async () => {
-      const mockExec = vi.fn().mockResolvedValue({
+      const mockExec = mockExecForIcacls({
         stdout: "C:\\test\\file.txt BUILTIN\\Administrators:(F)",
         stderr: "C:\\test\\file.txt NT AUTHORITY\\SYSTEM:(F)",
       });
@@ -318,6 +335,60 @@ Successfully processed 1 files`;
       const result = await inspectWindowsAcl("C:\\test\\file.txt", { exec: mockExec });
       expect(result.ok).toBe(true);
       expect(result.entries).toHaveLength(2);
+    });
+
+    it("uses SDDL fast path with currentUserSid when PowerShell available", async () => {
+      const userSid = "S-1-5-21-123-456-789-1001";
+      const mockExec = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd === "whoami") {
+          return Promise.resolve({ stdout: `"DOMAIN\\User","${userSid}"`, stderr: "" });
+        }
+        if (cmd === "powershell") {
+          return Promise.resolve({
+            stdout: `O:SYG:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;${userSid})`,
+            stderr: "",
+          });
+        }
+        if (cmd === "icacls") {
+          return Promise.resolve({
+            stdout: `C:\\test\\file.txt NT AUTHORITY\\SYSTEM:(F)\n                BUILTIN\\Administrators:(F)\n                DOMAIN\\User:(F)`,
+            stderr: "",
+          });
+        }
+        return Promise.reject(new Error(`unexpected: ${cmd}`));
+      });
+
+      const result = await inspectWindowsAcl("C:\\test\\file.txt", { exec: mockExec });
+      expect(result.ok).toBe(true);
+      // All three ACEs should be trusted (SY + BA + current user SID)
+      expect(result.trusted).toHaveLength(3);
+      expect(result.untrustedGroup).toHaveLength(0);
+    });
+
+    it("escapes backticks in path for PowerShell", async () => {
+      const mockExec = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd === "whoami") {
+          return Promise.reject(new Error("skip"));
+        }
+        if (cmd === "powershell") {
+          return Promise.reject(new Error("skip"));
+        }
+        if (cmd === "icacls") {
+          return Promise.resolve({
+            stdout: "C:\\te`st\\file.txt BUILTIN\\Administrators:(F)",
+            stderr: "",
+          });
+        }
+        return Promise.reject(new Error(`unexpected: ${cmd}`));
+      });
+
+      await inspectWindowsAcl("C:\\te`st\\file.txt", { exec: mockExec });
+      // Verify the powershell call escaped backticks
+      const psCall = mockExec.mock.calls.find((c: unknown[]) => c[0] === "powershell");
+      if (psCall) {
+        const command = psCall[1][2] as string;
+        expect(command).toContain("``");
+      }
     });
   });
 
@@ -383,14 +454,34 @@ Successfully processed 1 files`;
   });
 
   describe("classifyFromSddl", () => {
-    it("classifies SDDL with trusted-only ACEs (SY + BA + user SID)", () => {
-      // Typical SDDL for a file restricted to SYSTEM + Administrators + current user
-      const sddl = "O:SYG:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;S-1-5-21-123-456-789-1001)";
+    it("classifies SDDL with trusted-only ACEs (SY + BA)", () => {
+      const sddl = "O:SYG:SYD:(A;;FA;;;SY)(A;;FA;;;BA)";
       const result = classifyFromSddl(sddl);
       expect(result).not.toBeNull();
       expect(result!.untrustedWorld).toHaveLength(0);
       expect(result!.untrustedGroup).toHaveLength(0);
-      expect(result!.trusted.length).toBeGreaterThanOrEqual(2);
+      expect(result!.trusted).toHaveLength(2);
+    });
+
+    it("trusts user SID only when it matches currentUserSid", () => {
+      const sddl = "O:SYG:SYD:(A;;FA;;;SY)(A;;FA;;;S-1-5-21-123-456-789-1001)";
+      // With matching currentUserSid → trusted
+      const withMatch = classifyFromSddl(sddl, undefined, "S-1-5-21-123-456-789-1001");
+      expect(withMatch).not.toBeNull();
+      expect(withMatch!.trusted).toHaveLength(2);
+      expect(withMatch!.untrustedGroup).toHaveLength(0);
+
+      // Without currentUserSid → untrustedGroup
+      const without = classifyFromSddl(sddl);
+      expect(without).not.toBeNull();
+      expect(without!.trusted).toHaveLength(1); // only SY
+      expect(without!.untrustedGroup).toHaveLength(1); // unknown user SID
+
+      // With non-matching currentUserSid → untrustedGroup
+      const noMatch = classifyFromSddl(sddl, undefined, "S-1-5-21-999-999-999-9999");
+      expect(noMatch).not.toBeNull();
+      expect(noMatch!.trusted).toHaveLength(1);
+      expect(noMatch!.untrustedGroup).toHaveLength(1);
     });
 
     it("detects world-readable ACEs (WD = Everyone)", () => {
@@ -463,11 +554,19 @@ Successfully processed 1 files`;
   describe("localized principal names (ru-RU regression)", () => {
     it("SDDL fast path correctly identifies localized SYSTEM as trusted", async () => {
       // Simulate ru-RU Windows: icacls shows "NT AUTHORITY\\СИСТЕМА" (Cyrillic)
-      // but SDDL always shows "SY" regardless of locale
+      // but SDDL always shows "SY" regardless of locale.
+      // whoami resolves the current user's SID for precise matching.
+      const userSid = "S-1-5-21-123-456-789-1001";
       const mockExec = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd === "whoami") {
+          return Promise.resolve({
+            stdout: `"BARSY\\karte","${userSid}"`,
+            stderr: "",
+          });
+        }
         if (cmd === "powershell") {
           return Promise.resolve({
-            stdout: "O:SYG:SYD:(A;;FA;;;SY)(A;;FA;;;S-1-5-21-123-456-789-1001)",
+            stdout: `O:SYG:SYD:(A;;FA;;;SY)(A;;FA;;;${userSid})`,
             stderr: "",
           });
         }
@@ -482,13 +581,16 @@ Successfully processed 1 files`;
       const result = await inspectWindowsAcl("C:\\test\\file.txt", { exec: mockExec, env });
 
       expect(result.ok).toBe(true);
-      // SDDL-based classification should mark everything as trusted
+      // SDDL-based classification: SY=trusted, user SID matched via whoami=trusted
       expect(result.untrustedWorld).toHaveLength(0);
       expect(result.untrustedGroup).toHaveLength(0);
     });
 
     it("falls back to icacls when PowerShell unavailable", async () => {
       const mockExec = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd === "whoami") {
+          return Promise.reject(new Error("not Windows"));
+        }
         if (cmd === "powershell") {
           return Promise.reject(new Error("powershell not found"));
         }

--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -9,6 +9,7 @@ vi.mock("node:os", () => ({
 }));
 
 const {
+  classifyFromSddl,
   createIcaclsResetCommand,
   formatIcaclsResetCommand,
   formatWindowsAclSummary,
@@ -378,6 +379,128 @@ Successfully processed 1 files`;
       };
       const result = formatWindowsAclSummary(summary);
       expect(result).toBe("Everyone:(R), DOMAIN\\OtherUser:(M)");
+    });
+  });
+
+  describe("classifyFromSddl", () => {
+    it("classifies SDDL with trusted-only ACEs (SY + BA + user SID)", () => {
+      // Typical SDDL for a file restricted to SYSTEM + Administrators + current user
+      const sddl = "O:SYG:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;S-1-5-21-123-456-789-1001)";
+      const result = classifyFromSddl(sddl);
+      expect(result).not.toBeNull();
+      expect(result!.untrustedWorld).toHaveLength(0);
+      expect(result!.untrustedGroup).toHaveLength(0);
+      expect(result!.trusted.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("detects world-readable ACEs (WD = Everyone)", () => {
+      const sddl = "O:SYG:SYD:(A;;FA;;;SY)(A;;FR;;;WD)";
+      const result = classifyFromSddl(sddl);
+      expect(result).not.toBeNull();
+      expect(result!.untrustedWorld).toHaveLength(1);
+      expect(result!.untrustedWorld[0].principal).toBe("WD");
+    });
+
+    it("detects BUILTIN\\Users via SDDL abbreviation BU", () => {
+      const sddl = "O:SYG:SYD:(A;;FA;;;SY)(A;;FR;;;BU)";
+      const result = classifyFromSddl(sddl);
+      expect(result).not.toBeNull();
+      expect(result!.untrustedWorld).toHaveLength(1);
+    });
+
+    it("skips deny ACEs", () => {
+      const sddl = "O:SYG:SYD:(D;;FA;;;WD)(A;;FA;;;SY)";
+      const result = classifyFromSddl(sddl);
+      expect(result).not.toBeNull();
+      // Deny WD should be skipped, only SY remain
+      expect(result!.untrustedWorld).toHaveLength(0);
+      expect(result!.trusted).toHaveLength(1);
+    });
+
+    it("returns null for malformed SDDL without DACL", () => {
+      const result = classifyFromSddl("O:SYG:SY");
+      expect(result).toBeNull();
+    });
+
+    it("handles Creator Owner (CO) as trusted", () => {
+      const sddl = "O:SYG:SYD:(A;;FA;;;CO)";
+      const result = classifyFromSddl(sddl);
+      expect(result).not.toBeNull();
+      expect(result!.trusted).toHaveLength(1);
+    });
+  });
+
+  describe("SID-based principal classification", () => {
+    it("classifies raw SID S-1-5-18 (SYSTEM) as trusted", () => {
+      const entries: WindowsAclEntry[] = [
+        {
+          principal: "*S-1-5-18",
+          rights: ["F"],
+          rawRights: "(F)",
+          canRead: true,
+          canWrite: true,
+        },
+      ];
+      const summary = summarizeWindowsAcl(entries);
+      expect(summary.trusted).toHaveLength(1);
+    });
+
+    it("classifies raw SID S-1-5-32-544 (Administrators) as trusted", () => {
+      const entries: WindowsAclEntry[] = [
+        {
+          principal: "S-1-5-32-544",
+          rights: ["F"],
+          rawRights: "(F)",
+          canRead: true,
+          canWrite: true,
+        },
+      ];
+      const summary = summarizeWindowsAcl(entries);
+      expect(summary.trusted).toHaveLength(1);
+    });
+  });
+
+  describe("localized principal names (ru-RU regression)", () => {
+    it("SDDL fast path correctly identifies localized SYSTEM as trusted", async () => {
+      // Simulate ru-RU Windows: icacls shows "NT AUTHORITY\\СИСТЕМА" (Cyrillic)
+      // but SDDL always shows "SY" regardless of locale
+      const mockExec = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd === "powershell") {
+          return Promise.resolve({
+            stdout: "O:SYG:SYD:(A;;FA;;;SY)(A;;FA;;;S-1-5-21-123-456-789-1001)",
+            stderr: "",
+          });
+        }
+        // icacls returns localized names
+        return Promise.resolve({
+          stdout: `C:\\test\\file.txt NT AUTHORITY\\СИСТЕМА:(F)\n                     BARSY\\karte:(F)`,
+          stderr: "",
+        });
+      });
+
+      const env = { USERNAME: "karte", USERDOMAIN: "BARSY" };
+      const result = await inspectWindowsAcl("C:\\test\\file.txt", { exec: mockExec, env });
+
+      expect(result.ok).toBe(true);
+      // SDDL-based classification should mark everything as trusted
+      expect(result.untrustedWorld).toHaveLength(0);
+      expect(result.untrustedGroup).toHaveLength(0);
+    });
+
+    it("falls back to icacls when PowerShell unavailable", async () => {
+      const mockExec = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd === "powershell") {
+          return Promise.reject(new Error("powershell not found"));
+        }
+        return Promise.resolve({
+          stdout: `C:\\test\\file.txt BUILTIN\\Administrators:(F)`,
+          stderr: "",
+        });
+      });
+
+      const result = await inspectWindowsAcl("C:\\test\\file.txt", { exec: mockExec });
+      expect(result.ok).toBe(true);
+      expect(result.entries).toHaveLength(1);
     });
   });
 

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -248,9 +248,10 @@ export function parseIcaclsOutput(output: string, targetPath: string): WindowsAc
 export function classifyFromSddl(
   sddl: string,
   _env?: NodeJS.ProcessEnv,
+  currentUserSid?: string,
 ): Pick<WindowsAclSummary, "trusted" | "untrustedWorld" | "untrustedGroup"> | null {
   // Extract DACL section: D:...
-  const daclMatch = sddl.match(/D:[A-Z]*(\(.*\))/);
+  const daclMatch = sddl.match(/D:[A-Z]*(\([^)]*\)(?:\([^)]*\))*)/);
   if (!daclMatch) {
     return null;
   }
@@ -283,13 +284,12 @@ export function classifyFromSddl(
 
     // Determine trust level from SDDL abbreviation or raw SID
     const upperSid = accountSid.toUpperCase();
+    // Tokenize SDDL rights into 2-character codes to avoid substring false positives
+    const rightsTokens = rightsStr.match(/.{1,2}/g) ?? [];
+    const rightsSet = new Set(rightsTokens);
     const canWrite =
-      rightsStr.includes("FA") ||
-      rightsStr.includes("GA") ||
-      rightsStr.includes("WD") ||
-      rightsStr.includes("WO");
-    const canRead =
-      rightsStr.includes("FA") || rightsStr.includes("GA") || rightsStr.includes("FR");
+      rightsSet.has("FA") || rightsSet.has("GA") || rightsSet.has("WD") || rightsSet.has("WO");
+    const canRead = rightsSet.has("FA") || rightsSet.has("GA") || rightsSet.has("FR");
 
     const entry: WindowsAclEntry = {
       principal: accountSid,
@@ -305,11 +305,8 @@ export function classifyFromSddl(
       untrustedWorld.push(entry);
     } else if (TRUSTED_SIDS.has(accountSid.toLowerCase())) {
       trusted.push(entry);
-    } else if (accountSid.startsWith("S-1-5-21-")) {
-      // Domain/local user SID — check if it matches the current user
-      // We can't resolve SID→name without Win32 API, so we treat
-      // single-user SIDs as trusted (the audit already verified the
-      // icacls output for the user's own account)
+    } else if (currentUserSid && accountSid.toLowerCase() === currentUserSid.toLowerCase()) {
+      // Current user's SID — trusted
       trusted.push(entry);
     } else {
       untrustedGroup.push(entry);
@@ -346,18 +343,31 @@ export async function inspectWindowsAcl(
 ): Promise<WindowsAclSummary> {
   const exec = opts?.exec ?? runExec;
 
+  // Resolve current user's SID for precise trust classification.
+  let currentUserSid: string | undefined;
+  try {
+    const { stdout: whoamiOut } = await exec("whoami", ["/user", "/fo", "csv", "/nh"]);
+    const sidMatch = whoamiOut.match(/"(S-1-[\d-]+)"/);
+    if (sidMatch) {
+      currentUserSid = sidMatch[1];
+    }
+  } catch {
+    // whoami failed — proceed without current user SID
+  }
+
   // Fast path: try SDDL-based classification first.
   // SDDL uses locale-independent SID abbreviations (SY, BA, etc.), avoiding
   // false positives from localized account names (e.g. ru-RU "СИСТЕМА").
   try {
+    const escapedPath = targetPath.replace(/'/g, "''").replace(/`/g, "``");
     const { stdout: sddlOut } = await exec("powershell", [
       "-NoProfile",
       "-Command",
-      `(Get-Acl '${targetPath.replace(/'/g, "''")}').Sddl`,
+      `(Get-Acl '${escapedPath}').Sddl`,
     ]);
     const sddl = sddlOut.trim();
     if (sddl && sddl.startsWith("O:")) {
-      const sddlResult = classifyFromSddl(sddl, opts?.env);
+      const sddlResult = classifyFromSddl(sddl, opts?.env, currentUserSid);
       if (sddlResult) {
         // Also get icacls entries for display purposes (human-readable names)
         try {

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -38,11 +38,35 @@ const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
 const TRUSTED_SUFFIXES = ["\\administrators", "\\system"];
 
 const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
+
+/**
+ * Well-known Windows SIDs that are always trusted, regardless of locale.
+ */
 const TRUSTED_SIDS = new Set([
-  "s-1-5-18",
-  "s-1-5-32-544",
-  "s-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464",
+  "s-1-5-18", // Local System (NT AUTHORITY\\SYSTEM)
+  "s-1-5-32-544", // BUILTIN\\Administrators
+  "s-1-3-0", // Creator Owner
+  "s-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464", // OpenClaw service SID
 ]);
+
+/**
+ * Well-known SDDL two-letter abbreviations for trusted principals.
+ */
+const TRUSTED_SDDL_ABBREVS = new Set([
+  "SY", // Local System
+  "BA", // BUILTIN\Administrators
+  "CO", // Creator Owner
+]);
+
+/**
+ * Well-known SDDL abbreviations for world/everyone principals.
+ */
+const WORLD_SDDL_ABBREVS = new Set([
+  "WD", // Everyone
+  "BU", // BUILTIN\Users
+  "AU", // Authenticated Users
+]);
+
 const STATUS_PREFIXES = [
   "successfully processed",
   "processed",
@@ -101,6 +125,18 @@ function classifyPrincipal(
   ) {
     return "world";
   }
+
+  // SID-based fallback: icacls may output raw SIDs (e.g. "*S-1-5-18") when the
+  // display name cannot be resolved, or when the locale uses non-ASCII names
+  // that get mangled. Check against well-known trusted/world SIDs.
+  const sidMatch = normalized.match(/^(?:\*?)(s-1-[\d-]+)$/);
+  if (sidMatch) {
+    const sid = sidMatch[1];
+    if (TRUSTED_SIDS.has(sid)) {
+      return "trusted";
+    }
+  }
+
   return "group";
 }
 
@@ -200,6 +236,89 @@ export function parseIcaclsOutput(output: string, targetPath: string): WindowsAc
   return entries;
 }
 
+/**
+ * Parses a Windows SDDL string to extract ACE (Access Control Entry) principals.
+ *
+ * SDDL principals are locale-independent: "SY" is always SYSTEM regardless of
+ * the OS display language. This makes SDDL parsing immune to the localization
+ * false-positive that affects icacls text output (e.g. "СИСТЕМА" in ru-RU).
+ *
+ * @returns classification summary, or null if the SDDL cannot be parsed
+ */
+export function classifyFromSddl(
+  sddl: string,
+  _env?: NodeJS.ProcessEnv,
+): Pick<WindowsAclSummary, "trusted" | "untrustedWorld" | "untrustedGroup"> | null {
+  // Extract DACL section: D:...
+  const daclMatch = sddl.match(/D:[A-Z]*(\(.*\))/);
+  if (!daclMatch) {
+    return null;
+  }
+
+  // Parse individual ACEs: (ace_type;ace_flags;rights;object_guid;inherit_object_guid;account_sid)
+  const acePattern = /\(([^)]+)\)/g;
+  const trusted: WindowsAclEntry[] = [];
+  const untrustedWorld: WindowsAclEntry[] = [];
+  const untrustedGroup: WindowsAclEntry[] = [];
+
+  let match: RegExpExecArray | null;
+  while ((match = acePattern.exec(daclMatch[1])) !== null) {
+    const parts = match[1].split(";");
+    if (parts.length < 6) {
+      continue;
+    }
+
+    const aceType = parts[0];
+    // Skip deny ACEs
+    if (aceType === "D") {
+      continue;
+    }
+    // Only process allow ACEs
+    if (aceType !== "A") {
+      continue;
+    }
+
+    const rightsStr = parts[2];
+    const accountSid = parts[5];
+
+    // Determine trust level from SDDL abbreviation or raw SID
+    const upperSid = accountSid.toUpperCase();
+    const canWrite =
+      rightsStr.includes("FA") ||
+      rightsStr.includes("GA") ||
+      rightsStr.includes("WD") ||
+      rightsStr.includes("WO");
+    const canRead =
+      rightsStr.includes("FA") || rightsStr.includes("GA") || rightsStr.includes("FR");
+
+    const entry: WindowsAclEntry = {
+      principal: accountSid,
+      rights: [rightsStr],
+      rawRights: rightsStr,
+      canRead,
+      canWrite,
+    };
+
+    if (TRUSTED_SDDL_ABBREVS.has(upperSid)) {
+      trusted.push(entry);
+    } else if (WORLD_SDDL_ABBREVS.has(upperSid)) {
+      untrustedWorld.push(entry);
+    } else if (TRUSTED_SIDS.has(accountSid.toLowerCase())) {
+      trusted.push(entry);
+    } else if (accountSid.startsWith("S-1-5-21-")) {
+      // Domain/local user SID — check if it matches the current user
+      // We can't resolve SID→name without Win32 API, so we treat
+      // single-user SIDs as trusted (the audit already verified the
+      // icacls output for the user's own account)
+      trusted.push(entry);
+    } else {
+      untrustedGroup.push(entry);
+    }
+  }
+
+  return { trusted, untrustedWorld, untrustedGroup };
+}
+
 export function summarizeWindowsAcl(
   entries: WindowsAclEntry[],
   env?: NodeJS.ProcessEnv,
@@ -226,6 +345,49 @@ export async function inspectWindowsAcl(
   opts?: { env?: NodeJS.ProcessEnv; exec?: ExecFn },
 ): Promise<WindowsAclSummary> {
   const exec = opts?.exec ?? runExec;
+
+  // Fast path: try SDDL-based classification first.
+  // SDDL uses locale-independent SID abbreviations (SY, BA, etc.), avoiding
+  // false positives from localized account names (e.g. ru-RU "СИСТЕМА").
+  try {
+    const { stdout: sddlOut } = await exec("powershell", [
+      "-NoProfile",
+      "-Command",
+      `(Get-Acl '${targetPath.replace(/'/g, "''")}').Sddl`,
+    ]);
+    const sddl = sddlOut.trim();
+    if (sddl && sddl.startsWith("O:")) {
+      const sddlResult = classifyFromSddl(sddl, opts?.env);
+      if (sddlResult) {
+        // Also get icacls entries for display purposes (human-readable names)
+        try {
+          const { stdout, stderr } = await exec("icacls", [targetPath]);
+          const output = `${stdout}\n${stderr}`.trim();
+          const entries = parseIcaclsOutput(output, targetPath);
+          return {
+            ok: true,
+            entries,
+            ...sddlResult,
+          };
+        } catch {
+          // icacls failed but SDDL succeeded — use SDDL entries as display
+          return {
+            ok: true,
+            entries: [
+              ...sddlResult.trusted,
+              ...sddlResult.untrustedWorld,
+              ...sddlResult.untrustedGroup,
+            ],
+            ...sddlResult,
+          };
+        }
+      }
+    }
+  } catch {
+    // PowerShell not available or failed — fall through to icacls-only path
+  }
+
+  // Fallback: icacls-only path (original behavior)
   try {
     const { stdout, stderr } = await exec("icacls", [targetPath]);
     const output = `${stdout}\n${stderr}`.trim();


### PR DESCRIPTION
## Problem

On non-English Windows (e.g. ru-RU), `openclaw security audit` reports false-positive CRITICAL findings for files that are correctly restricted to SYSTEM + current user only.

The root cause: `icacls` outputs localized account names (`NT AUTHORITY\СИСТЕМА` in Russian) but the ACL classifier only matches English names (`NT AUTHORITY\SYSTEM`). The localized name fails string comparison and gets classified as untrusted.

Fixes #20808

## Solution

Add a **SDDL fast path** in `inspectWindowsAcl()`:

1. Before parsing `icacls` text output, try `powershell -NoProfile -Command "(Get-Acl 'path').Sddl"`
2. SDDL uses **locale-independent abbreviations** (`SY`=SYSTEM, `BA`=Administrators, `CO`=Creator Owner) that are consistent across all Windows languages
3. Classify principals from SDDL abbreviations — immune to localization issues
4. If PowerShell is unavailable, fall back to the existing `icacls` text parsing

Also adds **SID-based fallback** in `classifyPrincipal()` for cases where `icacls` outputs raw SIDs (e.g. `*S-1-5-18`) instead of display names.

## Changes

- `src/security/windows-acl.ts`: Add `classifyFromSddl()`, well-known SID/SDDL constants, SID regex fallback in `classifyPrincipal()`, SDDL fast path in `inspectWindowsAcl()`
- `src/security/windows-acl.test.ts`: 10 new tests (SDDL parsing, SID classification, ru-RU simulation, PowerShell fallback)

## Testing

All 36 tests pass (26 existing + 10 new):
```
✓ src/security/windows-acl.test.ts (36 tests) 7ms
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security audit false-positive on non-English Windows systems by implementing SDDL-based ACL classification. The implementation adds a PowerShell fast path that uses locale-independent SID abbreviations (`SY`, `BA`, etc.) instead of relying on localized display names from `icacls` output.

Key improvements:
- Resolves current user SID via `whoami /user` for precise trust classification
- Falls back to `icacls` parsing when PowerShell unavailable
- Properly escapes PowerShell path parameters (single quotes and backticks)
- Tokenizes SDDL rights codes to avoid substring matching false positives

Previous security concerns have been addressed:
- User SIDs are only trusted when they match the current user's SID (obtained via `whoami`)
- PowerShell command includes backtick escaping alongside single-quote escaping
- SDDL rights parsing now tokenizes into 2-character codes

Test coverage is comprehensive with 10 new tests covering SDDL parsing, SID classification, localization scenarios, and fallback paths.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it addresses a legitimate security audit bug with comprehensive testing
- The code properly addresses previous security review comments (SID matching, PowerShell escaping, rights parsing). Test coverage is comprehensive with 10 new tests. One minor concern exists with the DACL regex pattern being slightly complex, but it appears to work correctly for the SDDL format. The changes are well-isolated to Windows ACL security auditing and include proper fallback mechanisms.
- No files require special attention

<sub>Last reviewed commit: 810583f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->