### PR TITLE
Security: disable plugin runtime command execution primitive

### DIFF
--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -1,9 +1,9 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { RuntimeEnv } from "openclaw/plugin-sdk";
-import { getMatrixRuntime } from "../runtime.js";
 
 const MATRIX_SDK_PACKAGE = "@vector-im/matrix-bot-sdk";
 
@@ -20,6 +20,85 @@ export function isMatrixSdkAvailable(): boolean {
 function resolvePluginRoot(): string {
   const currentDir = path.dirname(fileURLToPath(import.meta.url));
   return path.resolve(currentDir, "..", "..");
+}
+
+type CommandResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+async function runFixedCommandWithTimeout(params: {
+  argv: string[];
+  cwd: string;
+  timeoutMs: number;
+  env?: NodeJS.ProcessEnv;
+}): Promise<CommandResult> {
+  return await new Promise((resolve) => {
+    const [command, ...args] = params.argv;
+    if (!command) {
+      resolve({
+        code: 1,
+        stdout: "",
+        stderr: "command is required",
+      });
+      return;
+    }
+
+    const proc = spawn(command, args, {
+      cwd: params.cwd,
+      env: { ...process.env, ...params.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timer: NodeJS.Timeout | null = null;
+
+    const finalize = (result: CommandResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      resolve(result);
+    };
+
+    proc.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+
+    timer = setTimeout(() => {
+      proc.kill("SIGKILL");
+      finalize({
+        code: 124,
+        stdout,
+        stderr: stderr || `command timed out after ${params.timeoutMs}ms`,
+      });
+    }, params.timeoutMs);
+
+    proc.on("error", (err) => {
+      finalize({
+        code: 1,
+        stdout,
+        stderr: err.message,
+      });
+    });
+
+    proc.on("close", (code) => {
+      finalize({
+        code: code ?? 1,
+        stdout,
+        stderr,
+      });
+    });
+  });
 }
 
 export async function ensureMatrixSdkInstalled(params: {
@@ -42,7 +121,8 @@ export async function ensureMatrixSdkInstalled(params: {
     ? ["pnpm", "install"]
     : ["npm", "install", "--omit=dev", "--silent"];
   params.runtime.log?.(`matrix: installing dependencies via ${command[0]} (${root})…`);
-  const result = await getMatrixRuntime().system.runCommandWithTimeout(command, {
+  const result = await runFixedCommandWithTimeout({
+    argv: command,
     cwd: root,
     timeoutMs: 300_000,
     env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { createPluginRuntime } from "./index.js";
+
+describe("plugin runtime security hardening", () => {
+  it("blocks runtime.system.runCommandWithTimeout", async () => {
+    const runtime = createPluginRuntime();
+    await expect(
+      runtime.system.runCommandWithTimeout(["echo", "hello"], { timeoutMs: 1000 }),
+    ).rejects.toThrow(
+      "runtime.system.runCommandWithTimeout is disabled for security hardening. Use fixed-purpose runtime APIs instead.",
+    );
+  });
+});

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -105,7 +105,6 @@ import {
   readChannelAllowFromStore,
   upsertChannelPairingRequest,
 } from "../../pairing/pairing-store.js";
-import { runCommandWithTimeout } from "../../process/exec.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import { monitorSignalProvider } from "../../signal/index.js";
 import { probeSignal } from "../../signal/probe.js";
@@ -236,6 +235,13 @@ function loadWhatsAppActions() {
   return whatsappActionsPromise;
 }
 
+const runtimeCommandExecutionDisabled: PluginRuntime["system"]["runCommandWithTimeout"] =
+  async () => {
+    throw new Error(
+      "runtime.system.runCommandWithTimeout is disabled for security hardening. Use fixed-purpose runtime APIs instead.",
+    );
+  };
+
 export function createPluginRuntime(): PluginRuntime {
   return {
     version: resolveVersion(),
@@ -245,7 +251,7 @@ export function createPluginRuntime(): PluginRuntime {
     },
     system: {
       enqueueSystemEvent,
-      runCommandWithTimeout,
+      runCommandWithTimeout: runtimeCommandExecutionDisabled,
       formatNativeDependencyHint,
     },
     media: {

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -184,6 +184,7 @@ export type PluginRuntime = {
   };
   system: {
     enqueueSystemEvent: EnqueueSystemEvent;
+    /** @deprecated Runtime command execution is disabled at runtime for security hardening. */
     runCommandWithTimeout: RunCommandWithTimeout;
     formatNativeDependencyHint: FormatNativeDependencyHint;
   };


### PR DESCRIPTION
## Summary
- disable generic plugin runtime command execution by making `runtime.system.runCommandWithTimeout` fail closed
- preserve API compatibility shape while deprecating the runtime command path
- migrate built-in runtime users to fixed-purpose local command runners:
  - `extensions/matrix/src/matrix/deps.ts`
  - `extensions/device-pair/index.ts`
- add regression test to assert deprecated runtime command execution path throws

## Testing
- `pnpm -C /Users/mariano/Coding/openclaw-sec2 exec vitest run src/plugins/runtime/index.test.ts src/plugin-sdk/index.test.ts`
- `pnpm -C /Users/mariano/Coding/openclaw-sec2 exec tsx -e "import('./extensions/matrix/src/matrix/deps.ts').then(()=>console.log('matrix deps ok'))"`
- `pnpm -C /Users/mariano/Coding/openclaw-sec2 exec tsx -e "import('./extensions/device-pair/index.ts').then(()=>console.log('device-pair ok'))"`

## Security
- GHSA: `GHSA-ff98-w8hj-qrxf`
- Reporter attribution preserved in advisory text: `@markmusson`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Disables generic plugin runtime command execution (`runtime.system.runCommandWithTimeout`) to close a command injection vulnerability (GHSA-ff98-w8hj-qrxf). The API shape is preserved for backwards compatibility with a `@deprecated` JSDoc annotation, but the runtime implementation now throws an error. The two built-in usages (matrix dependency installation and device-pair Tailscale resolution) were successfully migrated to local `runFixedCommandWithTimeout` implementations using Node's `child_process.spawn` directly. A regression test validates that the deprecated path throws.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security hardening is implemented correctly with fail-closed behavior, all built-in runtime users have been migrated to fixed-purpose implementations, regression tests validate the block, and API compatibility is maintained through deprecation
- No files require special attention

<sub>Last reviewed commit: 7e689aa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->