### PR TITLE
chore(ci): fix import-order drift in formatter check

### DIFF
--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -2,14 +2,14 @@ import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { OpenClawConfig } from "../../config/config.js";
-import type { MsgContext, TemplateContext } from "../templating.js";
 import { assertSandboxPath } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { normalizeScpRemoteHost } from "../../infra/scp-host.js";
 import { getMediaDir } from "../../media/store.js";
 import { CONFIG_DIR } from "../../utils.js";
+import type { MsgContext, TemplateContext } from "../templating.js";
 
 export async function stageSandboxMedia(params: {
   ctx: MsgContext;

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import type { IMessagePayload, MonitorIMessageOpts } from "./types.js";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
@@ -41,6 +40,7 @@ import {
 } from "./inbound-processing.js";
 import { parseIMessageNotification } from "./parse-notification.js";
 import { normalizeAllowList, resolveRuntime } from "./runtime.js";
+import type { IMessagePayload, MonitorIMessageOpts } from "./types.js";
 
 /**
  * Try to detect remote host from an SSH wrapper script like:


### PR DESCRIPTION
## Summary

- Problem: `pnpm format:check` on `main` reported formatting drift in two files.
- Why it matters: CI formatting gate fails until files are normalized.
- What changed: Ran full formatter pass and committed only the resulting import-order formatting updates in the two flagged files.
- What did NOT change (scope boundary): No logic/behavioral changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev shell
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `git checkout main && git pull --rebase upstream main`
2. `pnpm install`
3. `pnpm format:fix`
4. `pnpm format:check`

### Expected

- Formatter check passes.

### Actual

- Formatter check passes after formatting.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm format:check` now passes; only two files changed.
- Edge cases checked: N/A (format-only).
- What you did **not** verify: `pnpm tsgo` and `pnpm lint` currently fail on unrelated baseline errors in `extensions/diagnostics-otel/src/service.test.ts` and `src/daemon/launchd.test.ts` on latest `main`.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: `src/auto-reply/reply/stage-sandbox-media.ts`, `src/imessage/monitor/monitor-provider.ts`
- Known bad symptoms reviewers should watch for: None expected.

## Risks and Mitigations

- Risk: None (format-only import ordering).
  - Mitigation: Scoped diff to formatter output only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes import-order formatting drift in two files to pass `pnpm format:check`.

**Changes:**
- `src/auto-reply/reply/stage-sandbox-media.ts`: Reordered type imports to follow project style (moved type imports after regular imports)
- `src/imessage/monitor/monitor-provider.ts`: Moved type import to end of import block

All changes are formatting-only with no logic modifications.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- Score reflects that changes are purely cosmetic import reordering with no functional changes - only 6 lines touched across 2 files to fix formatter compliance
- No files require special attention

<sub>Last reviewed commit: 2065fad</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->