### PR TITLE
ci(lobster): fix flakey test windows cmd shim script resolution

### DIFF
--- a/extensions/lobster/src/windows-spawn.ts
+++ b/extensions/lobster/src/windows-spawn.ts
@@ -121,13 +121,30 @@ function resolveLobsterScriptFromCmdShim(wrapperPath: string): string | null {
   try {
     const content = fs.readFileSync(wrapperPath, "utf8");
     const candidates: string[] = [];
-    const matches = content.matchAll(/"%~?dp0%\\([^"\r\n]+)"/gi);
-    for (const match of matches) {
+    const extractRelativeFromToken = (token: string): string | null => {
+      const match = token.match(/%~?dp0%\s*[\\/]*(.*)$/i);
+      if (!match) {
+        return null;
+      }
       const relative = match[1];
+      if (!relative) {
+        return null;
+      }
+      return relative;
+    };
+
+    const matches = content.matchAll(/"([^"\r\n]*)"/g);
+    for (const match of matches) {
+      const token = match[1] ?? "";
+      const relative = extractRelativeFromToken(token);
       if (!relative) {
         continue;
       }
-      const normalizedRelative = relative.replace(/[\\/]+/g, path.sep);
+
+      const normalizedRelative = relative
+        .trim()
+        .replace(/[\\/]+/g, path.sep)
+        .replace(/^[\\/]+/, "");
       const candidate = path.resolve(path.dirname(wrapperPath), normalizedRelative);
       if (isFilePath(candidate)) {
         candidates.push(candidate);


### PR DESCRIPTION
## Summary
- Fix Windows `.cmd`/`.bat` shim resolution in Lobster plugin when launching through `resolveWindowsLobsterSpawn`.
- Make cmd-wrapper parsing robust for rooted `%dp0%` / `%~dp0%` token variants so valid wrappers resolve to Node entrypoints without shell execution.
- Preserve existing security posture by continuing to reject wrappers that cannot be resolved without shell.

## Changes
- `extensions/lobster/src/windows-spawn.ts`
  - Harden `resolveLobsterScriptFromCmdShim` to parse `%dp0%`-style arguments more flexibly and normalize candidate paths reliably.
- `extensions/lobster/src/lobster-tool.test.ts`
  - Add regression test for rooted `%dp0%` shim format in Windows path handling.

## Validation
- Unit tests updated/covered in `extensions/lobster/src/lobster-tool.test.ts`.
- This PR is focused and does not include a full suite run.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Windows cmd shim resolution to handle rooted `%dp0%` token variants. The updated parser now extracts all quoted strings first, then checks for `%dp0%`/`%~dp0%` tokens within them, making it robust to different formatting styles. Includes regression test for rooted token format (`"%dp0%\\..\\path"`). Security posture preserved - continues to reject wrappers that require shell execution.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused fix for Windows cmd shim parsing with test coverage
- The changes are well-scoped, add robustness to path parsing without changing security model, include regression test coverage, and follow existing code patterns
- No files require special attention

<sub>Last reviewed commit: a829c4f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->