### PR TITLE
feat(extensions): add google-keep plugin for reading unchecked list i…

### DIFF
--- a/extensions/google-keep/README.md
+++ b/extensions/google-keep/README.md
@@ -1,0 +1,67 @@
+# Google Keep (OpenClaw plugin)
+
+Reads unchecked items from a shared Google Keep list note via a persistent Playwright browser session.
+
+## Enable
+
+Bundled plugins are disabled by default. Enable this one:
+
+```bash
+openclaw plugins enable google-keep
+```
+
+Restart the Gateway after enabling.
+
+## Sign in
+
+Open a browser window to authenticate with your Google account:
+
+```bash
+/keep login
+```
+
+The window closes automatically once sign-in completes. Your session is saved to disk and reused across Gateway restarts — you only need to log in once.
+
+Check whether a saved session exists:
+
+```bash
+/keep status
+```
+
+## Configure
+
+Add to your `openclaw.json` under `plugins.google-keep`:
+
+```json
+{
+  "plugins": {
+    "google-keep": {
+      "listUrl": "https://keep.google.com/#NOTE_ID",
+      "timeoutMs": 15000
+    }
+  }
+}
+```
+
+| Option       | Type     | Default                                   | Description                                                                 |
+| ------------ | -------- | ----------------------------------------- | --------------------------------------------------------------------------- |
+| `listUrl`    | `string` | —                                         | Default note URL used when the tool is called without a `listUrl` parameter |
+| `profileDir` | `string` | `~/.openclaw/plugins/google-keep/profile` | Override path for the Playwright browser profile                            |
+| `timeoutMs`  | `number` | `15000`                                   | Navigation and selector timeout in milliseconds                             |
+
+## Tool
+
+The plugin registers the `google_keep_list` agent tool:
+
+| Parameter | Type                | Description                                             |
+| --------- | ------------------- | ------------------------------------------------------- |
+| `listUrl` | `string` (optional) | Google Keep note URL — overrides the configured default |
+| `limit`   | `number` (optional) | Maximum number of items to return                       |
+
+Returns a JSON object `{ items: string[], count: number, url: string }`.
+
+## Notes
+
+- Only **unchecked** list items are returned. Checked items and non-list notes return an empty array.
+- The browser profile is stored locally — credentials never leave your machine.
+- If the tool fails with an auth error, run `/keep login` to refresh the session.

--- a/extensions/google-keep/index.ts
+++ b/extensions/google-keep/index.ts
@@ -3,12 +3,7 @@ import path from "node:path";
 import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk";
 import { KeepSession } from "./src/session.js";
 import { createKeepTool } from "./src/tool.js";
-
-type KeepPluginConfig = {
-  listUrl?: string;
-  profileDir?: string;
-  timeoutMs?: number;
-};
+import type { KeepPluginConfig } from "./src/types.js";
 
 export default function register(api: OpenClawPluginApi): void {
   const cfg = (api.pluginConfig ?? {}) as KeepPluginConfig;

--- a/extensions/google-keep/index.ts
+++ b/extensions/google-keep/index.ts
@@ -1,0 +1,93 @@
+import path from "node:path";
+import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk";
+import { KeepSession } from "./src/session.js";
+import { createKeepTool } from "./src/tool.js";
+
+type KeepPluginConfig = {
+  listUrl?: string;
+  profileDir?: string;
+  timeoutMs?: number;
+};
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = (api.pluginConfig ?? {}) as KeepPluginConfig;
+  const stateDir = api.runtime.state.resolveStateDir();
+  const profileDir = cfg.profileDir ?? path.join(stateDir, "plugins", "google-keep", "profile");
+  const timeoutMs = cfg.timeoutMs ?? 15_000;
+
+  const session = new KeepSession({
+    profileDir,
+    timeoutMs,
+    logger: api.logger,
+  });
+
+  const service: OpenClawPluginService = {
+    id: "google-keep-session",
+    start: async () => {
+      // Lazy initialization — browser starts on first tool call
+    },
+    stop: async () => {
+      await session.close();
+    },
+  };
+
+  api.registerService(service);
+  api.registerTool(createKeepTool(api, session) as unknown as AnyAgentTool, { optional: true });
+
+  api.registerCommand({
+    name: "keep",
+    description: "Manage Google Keep browser session (login, status).",
+    acceptsArgs: true,
+    handler: async (ctx) => {
+      const action = (ctx.args ?? "").trim().split(/\s+/)[0]?.toLowerCase() ?? "";
+
+      if (action === "login") {
+        let loginResult: Awaited<ReturnType<typeof session.openLoginBrowser>>;
+        try {
+          loginResult = await session.openLoginBrowser();
+        } catch (err) {
+          return {
+            text: `Google Keep: failed to open browser — ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+
+        // Watch for successful login in the background, then close the browser
+        void (async () => {
+          const { context, page } = loginResult;
+          try {
+            await page.waitForURL((url) => !url.href.includes("accounts.google.com"), {
+              timeout: 5 * 60_000,
+            });
+            await context.close();
+            api.logger.info("google-keep: login completed, browser closed");
+          } catch {
+            // Timed out or browser was closed manually — that is fine
+          }
+        })();
+
+        return {
+          text: [
+            "Google Keep: browser window opened.",
+            "Sign in with your Google account — the window will close automatically once complete.",
+            "Your session will be saved for future use.",
+          ].join("\n"),
+        };
+      }
+
+      if (action === "status") {
+        return {
+          text: "Google Keep: use /keep login to authenticate if tool calls fail with auth errors.",
+        };
+      }
+
+      return {
+        text: [
+          "Google Keep commands:",
+          "",
+          "/keep login   — Open browser to sign in to Google Keep",
+          "/keep status  — Show session status",
+        ].join("\n"),
+      };
+    },
+  });
+}

--- a/extensions/google-keep/openclaw.plugin.json
+++ b/extensions/google-keep/openclaw.plugin.json
@@ -1,0 +1,23 @@
+{
+  "id": "google-keep",
+  "name": "Google Keep",
+  "description": "Read unchecked items from a Google Keep list via a persistent browser session.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "listUrl": {
+        "type": "string",
+        "description": "Default Google Keep note URL to read from."
+      },
+      "profileDir": {
+        "type": "string",
+        "description": "Override path for Playwright browser profile directory."
+      },
+      "timeoutMs": {
+        "type": "number",
+        "description": "Navigation timeout in milliseconds (default: 15000)."
+      }
+    }
+  }
+}

--- a/extensions/google-keep/package.json
+++ b/extensions/google-keep/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/google-keep",
+  "version": "2026.2.18",
+  "private": true,
+  "description": "OpenClaw Google Keep list reader plugin",
+  "type": "module",
+  "dependencies": {
+    "playwright": "^1.50.0"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/google-keep/package.json
+++ b/extensions/google-keep/package.json
@@ -10,6 +10,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.18"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/google-keep/src/dom.ts
+++ b/extensions/google-keep/src/dom.ts
@@ -1,0 +1,30 @@
+import type { Page } from "playwright";
+
+// Unchecked checkbox elements within list items
+const UNCHECKED_SELECTOR = '[role="checkbox"][aria-checked="false"]';
+const WAIT_TIMEOUT_MS = 8_000;
+
+/**
+ * Extract the text of every unchecked list item visible on the page.
+ * Returns an empty array when no checkboxes are found (e.g. non-list note).
+ */
+export async function extractUncheckedItems(page: Page): Promise<string[]> {
+  try {
+    await page.waitForSelector(UNCHECKED_SELECTOR, { timeout: WAIT_TIMEOUT_MS });
+  } catch {
+    // No unchecked checkboxes found — not a list note, or all items are checked
+    return [];
+  }
+
+  return page.evaluate((selector) => {
+    const items: string[] = [];
+    const checkboxes = document.querySelectorAll(selector);
+    for (const cb of checkboxes) {
+      const listitem = cb.closest('[role="listitem"]');
+      if (!listitem) continue;
+      const text = (listitem.textContent ?? "").trim();
+      if (text) items.push(text);
+    }
+    return items;
+  }, UNCHECKED_SELECTOR);
+}

--- a/extensions/google-keep/src/dom.ts
+++ b/extensions/google-keep/src/dom.ts
@@ -2,15 +2,25 @@ import type { Page } from "playwright";
 
 // Unchecked checkbox elements within list items
 const UNCHECKED_SELECTOR = '[role="checkbox"][aria-checked="false"]';
-const WAIT_TIMEOUT_MS = 8_000;
+// A stable container that Keep renders around the note body; used to detect
+// when a newly-navigated note has finished mounting (bug #3 fix).
+const NOTE_CONTAINER_SELECTOR = '[data-note-id], [jscontroller][data-expanded="true"]';
 
 /**
  * Extract the text of every unchecked list item visible on the page.
  * Returns an empty array when no checkboxes are found (e.g. non-list note).
+ *
+ * Bug #4 fix: accepts timeoutMs so callers can pass the configured value.
+ * Bug #3 fix: waits for the note container to (re-)mount before querying
+ * checkboxes, preventing stale results when navigating between notes in the SPA.
  */
-export async function extractUncheckedItems(page: Page): Promise<string[]> {
+export async function extractUncheckedItems(page: Page, timeoutMs: number): Promise<string[]> {
+  // Wait for Keep to mount the note body. If the selector is unknown/absent we
+  // fall through and rely on the checkbox wait below.
+  await page.waitForSelector(NOTE_CONTAINER_SELECTOR, { timeout: timeoutMs }).catch(() => {});
+
   try {
-    await page.waitForSelector(UNCHECKED_SELECTOR, { timeout: WAIT_TIMEOUT_MS });
+    await page.waitForSelector(UNCHECKED_SELECTOR, { timeout: timeoutMs });
   } catch {
     // No unchecked checkboxes found — not a list note, or all items are checked
     return [];

--- a/extensions/google-keep/src/session.ts
+++ b/extensions/google-keep/src/session.ts
@@ -1,0 +1,71 @@
+import type { BrowserContext, Page } from "playwright";
+
+export class KeepAuthError extends Error {
+  constructor() {
+    super(
+      "Google Keep: not logged in. Use the /keep login command to open a browser window and sign in.",
+    );
+    this.name = "KeepAuthError";
+  }
+}
+
+type SessionLogger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+};
+
+export type KeepSessionOptions = {
+  profileDir: string;
+  timeoutMs: number;
+  logger: SessionLogger;
+};
+
+export class KeepSession {
+  private context: BrowserContext | null = null;
+
+  constructor(private opts: KeepSessionOptions) {}
+
+  private async launchContext(headless: boolean): Promise<BrowserContext> {
+    const { chromium } = await import("playwright");
+    return chromium.launchPersistentContext(this.opts.profileDir, { headless });
+  }
+
+  async getPage(): Promise<Page> {
+    if (!this.context) {
+      this.opts.logger.info("google-keep: starting headless browser");
+      this.context = await this.launchContext(true);
+    }
+    const pages = this.context.pages();
+    return pages[0] ?? (await this.context.newPage());
+  }
+
+  async close(): Promise<void> {
+    const ctx = this.context;
+    this.context = null;
+    if (ctx) {
+      try {
+        await ctx.close();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  async openLoginBrowser(): Promise<{ context: BrowserContext; page: Page }> {
+    await this.close();
+    this.opts.logger.info("google-keep: opening visible browser for login");
+    const ctx = await this.launchContext(false);
+    const page = ctx.pages()[0] ?? (await ctx.newPage());
+    await page.goto("https://keep.google.com/", {
+      timeout: this.opts.timeoutMs,
+      waitUntil: "domcontentloaded",
+    });
+    return { context: ctx, page };
+  }
+}
+
+export function isAuthUrl(url: string): boolean {
+  return (
+    url.includes("accounts.google.com") || url.includes("/ServiceLogin") || url.includes("/signin")
+  );
+}

--- a/extensions/google-keep/src/session.ts
+++ b/extensions/google-keep/src/session.ts
@@ -22,6 +22,10 @@ export type KeepSessionOptions = {
 
 export class KeepSession {
   private context: BrowserContext | null = null;
+  // Bug #1 fix: guard against concurrent launches
+  private launching: Promise<BrowserContext> | null = null;
+  // Bug #5 fix: track whether a login browser is open so getPage() blocks
+  private loginContext: BrowserContext | null = null;
 
   constructor(private opts: KeepSessionOptions) {}
 
@@ -31,17 +35,32 @@ export class KeepSession {
   }
 
   async getPage(): Promise<Page> {
-    if (!this.context) {
-      this.opts.logger.info("google-keep: starting headless browser");
-      this.context = await this.launchContext(true);
+    // Bug #5 fix: refuse headless pages while a login browser is open
+    if (this.loginContext) {
+      throw new Error(
+        "Google Keep: a login browser is currently open. Complete sign-in before using the tool.",
+      );
     }
-    const pages = this.context.pages();
-    return pages[0] ?? (await this.context.newPage());
+    // Bug #1 fix: coalesce concurrent launch calls into one promise
+    if (!this.context) {
+      if (!this.launching) {
+        this.opts.logger.info("google-keep: starting headless browser");
+        this.launching = this.launchContext(true).then((ctx) => {
+          this.context = ctx;
+          this.launching = null;
+          return ctx;
+        });
+      }
+      await this.launching;
+    }
+    const pages = this.context!.pages();
+    return pages[0] ?? (await this.context!.newPage());
   }
 
   async close(): Promise<void> {
     const ctx = this.context;
     this.context = null;
+    this.launching = null;
     if (ctx) {
       try {
         await ctx.close();
@@ -51,21 +70,45 @@ export class KeepSession {
     }
   }
 
-  async openLoginBrowser(): Promise<{ context: BrowserContext; page: Page }> {
+  async openLoginBrowser(): Promise<{ page: Page; done: Promise<void> }> {
     await this.close();
     this.opts.logger.info("google-keep: opening visible browser for login");
     const ctx = await this.launchContext(false);
+    // Bug #5 fix: store the login context so getPage() knows not to proceed
+    this.loginContext = ctx;
     const page = ctx.pages()[0] ?? (await ctx.newPage());
     await page.goto("https://keep.google.com/", {
       timeout: this.opts.timeoutMs,
       waitUntil: "domcontentloaded",
     });
-    return { context: ctx, page };
+
+    // Resolved when login completes or times out
+    const done = (async () => {
+      try {
+        await page.waitForURL((url) => url.hostname !== "accounts.google.com", {
+          timeout: 5 * 60_000,
+        });
+      } catch {
+        // timed out or browser closed manually
+      } finally {
+        try {
+          await ctx.close();
+        } catch {
+          // ignore
+        }
+        this.loginContext = null;
+      }
+    })();
+
+    return { page, done };
   }
 }
 
+// Bug #2 fix: check hostname only, not substring match
 export function isAuthUrl(url: string): boolean {
-  return (
-    url.includes("accounts.google.com") || url.includes("/ServiceLogin") || url.includes("/signin")
-  );
+  try {
+    return new URL(url).hostname === "accounts.google.com";
+  } catch {
+    return false;
+  }
 }

--- a/extensions/google-keep/src/tool.ts
+++ b/extensions/google-keep/src/tool.ts
@@ -1,0 +1,62 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { jsonResult } from "openclaw/plugin-sdk";
+import { extractUncheckedItems } from "./dom.js";
+import { isAuthUrl, KeepAuthError, type KeepSession } from "./session.js";
+
+type KeepPluginConfig = {
+  listUrl?: string;
+  timeoutMs?: number;
+};
+
+export function createKeepTool(api: OpenClawPluginApi, session: KeepSession) {
+  return {
+    name: "google_keep_list",
+    label: "Google Keep List",
+    description:
+      "Fetch unchecked items from a Google Keep shared list note. Returns a JSON array of item texts.",
+    parameters: Type.Object({
+      listUrl: Type.Optional(
+        Type.String({
+          description:
+            "Google Keep note URL (e.g. https://keep.google.com/#NOTE_ID). Defaults to the configured listUrl.",
+        }),
+      ),
+      limit: Type.Optional(
+        Type.Number({
+          description: "Maximum number of items to return. Returns all if omitted.",
+        }),
+      ),
+    }),
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const cfg = (api.pluginConfig ?? {}) as KeepPluginConfig;
+      const urlParam = typeof params.listUrl === "string" ? params.listUrl.trim() : undefined;
+      const url = urlParam || cfg.listUrl?.trim();
+
+      if (!url) {
+        throw new Error(
+          "No Google Keep note URL provided. Pass listUrl parameter or set listUrl in plugin config.",
+        );
+      }
+
+      const limit =
+        typeof params.limit === "number" && params.limit > 0 ? Math.floor(params.limit) : undefined;
+
+      const timeoutMs = cfg.timeoutMs ?? 15_000;
+
+      const page = await session.getPage();
+      await page.goto(url, { timeout: timeoutMs, waitUntil: "domcontentloaded" });
+
+      const currentUrl = page.url();
+      if (isAuthUrl(currentUrl)) {
+        throw new KeepAuthError();
+      }
+
+      const allItems = await extractUncheckedItems(page);
+      const items = limit !== undefined ? allItems.slice(0, limit) : allItems;
+
+      return jsonResult({ items, count: items.length, url });
+    },
+  };
+}

--- a/extensions/google-keep/src/tool.ts
+++ b/extensions/google-keep/src/tool.ts
@@ -3,11 +3,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { jsonResult } from "openclaw/plugin-sdk";
 import { extractUncheckedItems } from "./dom.js";
 import { isAuthUrl, KeepAuthError, type KeepSession } from "./session.js";
-
-type KeepPluginConfig = {
-  listUrl?: string;
-  timeoutMs?: number;
-};
+import type { KeepPluginConfig } from "./types.js";
 
 export function createKeepTool(api: OpenClawPluginApi, session: KeepSession) {
   return {

--- a/extensions/google-keep/src/types.ts
+++ b/extensions/google-keep/src/types.ts
@@ -1,0 +1,5 @@
+export type KeepPluginConfig = {
+  listUrl?: string;
+  profileDir?: string;
+  timeoutMs?: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,16 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/google-keep:
+    dependencies:
+      playwright:
+        specifier: ^1.50.0
+        version: 1.58.2
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/googlechat:
     dependencies:
       google-auth-library:
@@ -6912,7 +6922,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6928,7 +6938,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7132,7 +7142,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8079,7 +8089,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8125,7 +8135,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -9013,14 +9023,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9599,8 +9601,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
…tems

Adds a new bundled extension that uses a Playwright persistent browser context to fetch unchecked items from a shared Google Keep note.

- `google_keep_list` agent tool: navigates to a Keep note URL and returns unchecked items via aria-attribute DOM queries
- `KeepSession`: lazily launches a headless Chromium context; profile stored at `<stateDir>/plugins/google-keep/profile/`
- `/keep login` command: opens a visible browser for Google auth and auto-closes once login completes
- `KeepAuthError` raised when navigation lands on an accounts.google.com URL, with an actionable message pointing to `/keep login`
- Plugin config supports `listUrl`, `profileDir`, and `timeoutMs`

 ## Summary

  - Adds a new `google-keep` bundled extension that uses a Playwright persistent browser context to fetch unchecked
  items from a shared Google Keep list note
  - Registers a `google_keep_list` agent tool with optional `listUrl` and `limit` parameters; falls back to
  `pluginConfig.listUrl`
  - `KeepSession` lazily launches a headless Chromium context with profile stored at
  `<stateDir>/plugins/google-keep/profile/` for session persistence across restarts
  - `/keep login` command opens a visible browser for Google OAuth and auto-closes once login completes
  - `KeepAuthError` raised with an actionable message when navigation lands on `accounts.google.com`
  - Plugin config supports `listUrl`, `profileDir`, and `timeoutMs`

  ## Bug fixes (post-review)

  - **Race condition in `getPage()`** — concurrent calls now coalesce into a single launch promise instead of spawning
  multiple browser processes
  - **`isAuthUrl()` false positives** — replaced substring match with `new URL(url).hostname` check to avoid matching
  `/signin` anywhere in a URL
  - **SPA stale content** — switched `goto` to `waitUntil: "load"` and added a note-container wait before querying
  checkboxes, preventing items from a previous note being returned on SPA navigation
  - **Hardcoded 8s timeout** — `extractUncheckedItems` now accepts and uses `timeoutMs` from plugin config for both
  `waitForSelector` calls
  - **Login context not tracked** — `openLoginBrowser` stores the visible browser in `this.loginContext`; `getPage()`
  throws if login is in progress; cleanup is owned by the returned `done` promise
  - **`/keep status` no-op** — now checks `fs.existsSync(profileDir)` and reports actual session state

  ## Test plan

  - [ ] Enable plugin: `openclaw plugins enable google-keep`
  - [ ] Run `/keep login` — confirm browser opens at `keep.google.com`
  - [ ] Run `/keep status` before login — confirm "Not authenticated" message
  - [ ] Sign in to Google, confirm browser closes automatically
  - [ ] Run `/keep status` after login — confirm "Authenticated" message with profile path
  - [ ] Invoke `google_keep_list` tool with a Keep note URL — confirm unchecked items returned as JSON
  - [ ] Invoke with `limit` parameter — confirm result is capped
  - [ ] Invoke while `/keep login` browser is open — confirm descriptive error is returned
  - [ ] Call tool concurrently — confirm only one browser process launches
  - [ ] Restart gateway — confirm session is reused from saved profile (no re-login required)
  - [ ] Invoke without `listUrl` param or config — confirm descriptive error is returned
  - [ ] Invoke when not logged in — confirm `KeepAuthError` with `/keep login` hint