### PR TITLE
fix(message-tool): include other configured channels in tool description

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -200,6 +200,10 @@ describe("message tool schema scoping", () => {
 });
 
 describe("message tool description", () => {
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
   const bluebubblesPlugin: ChannelPlugin = {
     id: "bluebubbles",
     meta: {
@@ -250,8 +254,6 @@ describe("message tool description", () => {
     expect(tool.description).not.toContain("addParticipant");
     expect(tool.description).not.toContain("removeParticipant");
     expect(tool.description).not.toContain("leaveGroup");
-
-    setActivePluginRegistry(createTestRegistry([]));
   });
 
   it("includes other configured channels when currentChannel is set", () => {
@@ -310,6 +312,20 @@ describe("message tool description", () => {
     // Other configured channels are also listed
     expect(tool.description).toContain("Other configured channels:");
     expect(tool.description).toContain("telegram (delete, edit, react, send, topic-create)");
+  });
+
+  it("does not include 'Other configured channels' when only one channel is configured", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "bluebubbles", source: "test", plugin: bluebubblesPlugin }]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "bluebubbles",
+    });
+
+    expect(tool.description).toContain("Current channel (bluebubbles) supports:");
+    expect(tool.description).not.toContain("Other configured channels");
   });
 });
 

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -171,7 +171,8 @@ describe("message tool schema scoping", () => {
     expect(buttonItemProps.style).toBeDefined();
     expect(actionEnum).toContain("send");
     expect(actionEnum).toContain("react");
-    expect(actionEnum).not.toContain("poll");
+    // Other channels' actions are included so isolated/cron agents can use them
+    expect(actionEnum).toContain("poll");
   });
 
   it("shows discord components when scoped to discord", () => {
@@ -193,7 +194,8 @@ describe("message tool schema scoping", () => {
     expect(properties.buttons).toBeUndefined();
     expect(actionEnum).toContain("send");
     expect(actionEnum).toContain("poll");
-    expect(actionEnum).not.toContain("react");
+    // Other channels' actions are included so isolated/cron agents can use them
+    expect(actionEnum).toContain("react");
   });
 });
 
@@ -250,6 +252,64 @@ describe("message tool description", () => {
     expect(tool.description).not.toContain("leaveGroup");
 
     setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("includes other configured channels when currentChannel is set", () => {
+    const signalPlugin: ChannelPlugin = {
+      id: "signal",
+      meta: {
+        id: "signal",
+        label: "Signal",
+        selectionLabel: "Signal",
+        docsPath: "/channels/signal",
+        blurb: "Signal test plugin.",
+      },
+      capabilities: { chatTypes: ["direct", "group"], media: true },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({}),
+      },
+      actions: {
+        listActions: () => ["send", "react"] as const,
+      },
+    };
+
+    const telegramPluginFull: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram test plugin.",
+      },
+      capabilities: { chatTypes: ["direct", "group"], media: true },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({}),
+      },
+      actions: {
+        listActions: () => ["send", "react", "delete", "edit", "topic-create"] as const,
+      },
+    };
+
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "signal", source: "test", plugin: signalPlugin },
+        { pluginId: "telegram", source: "test", plugin: telegramPluginFull },
+      ]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "signal",
+    });
+
+    // Current channel actions are listed
+    expect(tool.description).toContain("Current channel (signal) supports: react, send.");
+    // Other configured channels are also listed
+    expect(tool.description).toContain("Other configured channels:");
+    expect(tool.description).toContain("telegram (delete, edit, react, send, topic-create)");
   });
 });
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -553,7 +553,7 @@ function buildMessageToolDescription(options?: {
 }): string {
   const baseDescription = "Send, delete, and manage messages via channel plugins.";
 
-  // If we have a current channel, show only its supported actions
+  // If we have a current channel, show its actions and list other configured channels
   if (options?.currentChannel) {
     const channelActions = filterActionsForContext({
       actions: listChannelSupportedActions({

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1,5 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import { BLUEBUBBLES_GROUP_ACTIONS } from "../../channels/plugins/bluebubbles-actions.js";
+import { listChannelPlugins } from "../../channels/plugins/index.js";
 import {
   listChannelMessageActions,
   supportsChannelMessageButtons,
@@ -460,8 +461,18 @@ function resolveMessageToolSchemaActions(params: {
       channel: currentChannel,
       currentChannelId: params.currentChannelId,
     });
-    const withSend = new Set<string>(["send", ...scopedActions]);
-    return Array.from(withSend);
+    const allActions = new Set<string>(["send", ...scopedActions]);
+    // Include actions from other configured channels so isolated/cron agents
+    // can invoke cross-channel actions without validation errors.
+    for (const plugin of listChannelPlugins()) {
+      if (plugin.id === currentChannel) {
+        continue;
+      }
+      for (const action of listChannelSupportedActions({ cfg: params.cfg, channel: plugin.id })) {
+        allActions.add(action);
+      }
+    }
+    return Array.from(allActions);
   }
   const actions = listChannelMessageActions(params.cfg);
   return actions.length > 0 ? actions : ["send"];
@@ -556,7 +567,25 @@ function buildMessageToolDescription(options?: {
       // Always include "send" as a base action
       const allActions = new Set(["send", ...channelActions]);
       const actionList = Array.from(allActions).toSorted().join(", ");
-      return `${baseDescription} Current channel (${options.currentChannel}) supports: ${actionList}.`;
+      let desc = `${baseDescription} Current channel (${options.currentChannel}) supports: ${actionList}.`;
+
+      // Include other configured channels so cron/isolated agents can discover them
+      const otherChannels: string[] = [];
+      for (const plugin of listChannelPlugins()) {
+        if (plugin.id === options.currentChannel) {
+          continue;
+        }
+        const actions = listChannelSupportedActions({ cfg: options.config, channel: plugin.id });
+        if (actions.length > 0) {
+          const all = new Set(["send", ...actions]);
+          otherChannels.push(`${plugin.id} (${Array.from(all).toSorted().join(", ")})`);
+        }
+      }
+      if (otherChannels.length > 0) {
+        desc += ` Other configured channels: ${otherChannels.join(", ")}.`;
+      }
+
+      return desc;
     }
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** `buildMessageToolDescription()` and `resolveMessageToolSchemaActions()` both return early when `currentChannel` is set, only listing that channel's actions. Cron and isolated agents inherit a default channel (e.g. Signal), so they can neither discover nor invoke actions from other configured channels.
- **Why it matters:** The description hides other channels from the LLM, and the schema enum rejects cross-channel actions at validation time. Agents that need to send messages cross-channel require hardcoded workarounds in every prompt.
- **What changed:** Both functions now include actions from all configured channel plugins when `currentChannel` is set. Updated existing schema scoping tests and added new description tests covering multi-channel and single-channel output.
- **What did NOT change (scope boundary):** No changes to tool execution, routing, permissions, or sandbox logic. `runMessageAction()` is untouched — it already routes to the correct channel at runtime via the `to`/`target` parameter.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20754 
- Closes #20995 

## User-visible / Behavior Changes

Tool description seen by the LLM changes from:
```
Send, delete, and manage messages via channel plugins. Current channel (signal) supports: react, send.
```
To:
```
Send, delete, and manage messages via channel plugins. Current channel (signal) supports: react, send. Other configured channels: telegram (delete, edit, react, send, topic-create), whatsapp (react, send).
```

Tool schema `action` enum now includes the union of all configured channels' actions instead of only the current channel's. This means cross-channel actions (e.g. `poll` from Discord when scoped to Telegram) pass validation and are routed correctly.

No changes to config, defaults, or CLI behavior.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — the schema and description now accurately reflect channels the agent could already reach via `runMessageAction()`. No new access is granted; `currentChannel` was never a security boundary (the message tool is either fully enabled or disabled via `disableMessageTool`).

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0)
- Runtime/container: Node 22.16.0, pnpm 10.23.0
- Model/provider: N/A (description/schema change)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Register two channel plugins (e.g. signal + telegram)
2. Create message tool with `currentChannelProvider: "signal"`
3. Inspect `tool.description` and `tool.parameters` action enum

### Expected

- Description includes both signal actions AND other configured channel actions.
- Schema action enum includes the union of all channels' actions.

### Actual

- Description only includes signal actions; other channels are invisible to the agent.
- Schema action enum only includes signal actions; cross-channel actions are rejected at validation.

## Evidence

- [x] Failing test/log before + passing after

New tests in `message-tool.e2e.test.ts`:
- `"includes other configured channels when currentChannel is set"` — verifies multi-channel description and schema
- `"does not include 'Other configured channels' when only one channel is configured"` — verifies single-channel deployments produce clean descriptions

Updated existing schema scoping tests to assert cross-channel actions are included. Full e2e suite: 13/13 passed. Unit suite: 748/748 passed, 6177/6177 tests.

## Human Verification (required)

- Verified scenarios: Built from source, ran `pnpm build && pnpm check && pnpm test:fast`, ran e2e tests for message-tool specifically.
- Edge cases checked: Single channel (no "Other configured channels" suffix), channels with no actions (skipped), `filterActionsForContext` still applies to current channel, execution routing via `runMessageAction()` unchanged.
- What I did **not** verify: Live gateway with real channel connections (no API keys configured).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; both early returns are restored.
- Files/config to restore: `src/agents/tools/message-tool.ts`
- Known bad symptoms reviewers should watch for: Tool description becoming excessively long if many channels are configured (unlikely in single-user setups), or unexpected action validation passes (mitigated: `runMessageAction` still validates at execution time).

## Risks and Mitigations

- Risk: Description string grows longer with many configured channels, consuming more prompt tokens.
  - Mitigation: OpenClaw is a single-user assistant — typical setups have 2–4 channels. The added text is minimal (one line per channel).
- Risk: Wider action enum could let the LLM attempt an action unsupported by a specific channel.
  - Mitigation: `runMessageAction()` validates at execution time and returns clear errors. This matches the existing fallback behavior (no `currentChannel` path) which already exposes all actions.

## AI-Assisted Disclosure

This PR was reviewed and improved with assistance from Claude Code (Claude Opus 4.6). Specifically:
- **Code review**: Identified a stale comment on `message-tool.ts:542` that contradicted the new behavior, missing test cleanup (`afterEach`), and a gap in single-channel test coverage.
- **Fixes applied**: Updated the misleading comment, added `afterEach` registry cleanup to the description test block, and added a new test for single-channel deployments.
- **Manual verification**: Generated a throwaway script to verify multi-channel and single-channel tool description/schema output without requiring real channel connections.

All changes were human-reviewed before committing.
