### PR TITLE
docs: add troubleshooting for A2UI bundling and missing node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,39 @@ Browser control (optional):
 }
 ```
 
+## Troubleshooting
+
+### A2UI bundling fails with "node_modules missing" or exit code 254
+
+If you see errors like:
+
+- `Local package.json exists, but node_modules missing, did you mean to install?`
+- `A2UI bundling failed. Re-run with: pnpm canvas:a2ui:bundle`
+- `ELIFECYCLE Command failed with exit code 254`
+
+It usually means dependencies were not installed from the workspace root.
+
+Fix:
+
+```bash
+# from the repository root (where pnpm-workspace.yaml is)
+corepack enable
+corepack prepare pnpm@latest --activate
+pnpm install
+pnpm canvas:a2ui:bundle
+```
+
+If it still fails, try a clean install:
+
+```bash
+rm -rf node_modules **/node_modules
+pnpm store prune
+pnpm install
+pnpm canvas:a2ui:bundle
+```
+
+Also make sure you are running the commands from the workspace root (the folder that contains pnpm-workspace.yaml).
+
 ## Docs
 
 Use these when you’re past the onboarding flow and want the deeper reference.


### PR DESCRIPTION
Summary
	•	Problem: A2UI bundling can fail with node_modules missing / exit code 254 when dependencies aren’t installed from the workspace root.
	•	Why it matters: New contributors hit a hard stop during setup; the error looks like a build problem but is actually a missing install step / wrong working directory.
	•	What changed: Added a Troubleshooting section documenting the error signatures and the exact fix steps (pnpm install from workspace root + clean reinstall fallback).
	•	What did NOT change (scope boundary): No runtime behavior, code, build output, or dependencies changed—documentation only.

Change Type (select all)
	•	Docs

Scope (select all touched areas)
	•	UI / DX

Linked Issue/PR
	•	Related # (optional) N/A

User-visible / Behavior Changes

Documentation only: added troubleshooting instructions for A2UI bundling/setup. No behavior changes.

Security Impact (required)
	•	New permissions/capabilities? No
	•	Secrets/tokens handling changed? No
	•	New/changed network calls? No
	•	Command/tool execution surface changed? No
	•	Data access scope changed? No
	•	If any Yes, explain risk + mitigation: N/A

Repro + Verification

Environment
	•	OS: macOS
	•	Runtime/container: Node.js + pnpm workspace
	•	Model/provider: N/A
	•	Integration/channel (if any): N/A
	•	Relevant config (redacted): N/A

Steps
	1.	Fresh clone the repo.
	2.	Run pnpm canvas:a2ui:bundle without installing dependencies from the workspace root.
	3.	Observe error: node_modules missing / bundling failure (exit code 254).
	4.	Run the documented fix:
	•	corepack enable
	•	corepack prepare pnpm@latest --activate
	•	pnpm install (from workspace root)
	•	pnpm canvas:a2ui:bundle

Expected
	•	Bundling succeeds after installing deps from workspace root; clean install fallback works if needed.

Actual
	•	Bundling failed before; succeeded after following the documented steps.

Evidence
	•	Trace/log snippets

Human Verification (required)
	•	Verified scenarios: Reproduced the failure on a fresh clone and confirmed the documented steps resolve it.
	•	Edge cases checked: Clean reinstall path (rm -rf node_modules **/node_modules + pnpm store prune) resolves persistent failures.
	•	What you did not verify: No code-path/runtime verification (docs-only change).

Compatibility / Migration
	•	Backward compatible? Yes
	•	Config/env changes? No
	•	Migration needed? No
	•	If yes, exact upgrade steps: N/A

Failure Recovery (if this breaks)
	•	How to disable/revert this change quickly: Revert the documentation commit.
	•	Files/config to restore: N/A
	•	Known bad symptoms reviewers should watch for: N/A

Risks and Mitigations

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added troubleshooting documentation for A2UI bundling failures. The new section documents three common error signatures (`node_modules missing`, bundling failure message, and exit code 254) and provides step-by-step fixes including corepack setup, dependency installation from workspace root, and a clean install fallback. The troubleshooting section is appropriately placed after the channel configuration sections and before the main docs links section.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change that adds helpful troubleshooting guidance. The documented commands are accurate (verified `pnpm canvas:a2ui:bundle` exists in package.json and `pnpm-workspace.yaml` exists at repo root). The error messages and fixes align with common pnpm workspace setup issues. No code, dependencies, or runtime behavior changed.
- No files require special attention

<sub>Last reviewed commit: 33bb47d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->