### PR TITLE
feat(browser): Add GPU configuration support for headless Chrome

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -297,7 +297,16 @@ export async function launchOpenClawChrome(
     if (resolved.headless) {
       // Best-effort; older Chromes may ignore.
       args.push("--headless=new");
-      args.push("--disable-gpu");
+      // GPU acceleration in headless mode (requires GPU devices available)
+      if (resolved.gpuEnabled) {
+        args.push("--enable-gpu");
+        args.push("--use-angle=vulkan");
+        args.push("--enable-features=Vulkan");
+      } else {
+        args.push("--disable-gpu");
+      }
+    } else if (resolved.gpuEnabled) {
+      log.warn("gpuEnabled is set but headless mode is disabled — GPU flags will not be applied");
     }
     if (resolved.noSandbox) {
       args.push("--no-sandbox");

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -37,6 +37,7 @@ export type ResolvedBrowserConfig = {
   profiles: Record<string, BrowserProfileConfig>;
   ssrfPolicy?: SsrFPolicy;
   extraArgs: string[];
+  gpuEnabled: boolean;
 };
 
 export type ResolvedBrowserProfile = {
@@ -248,6 +249,7 @@ export function resolveBrowserConfig(
   }
 
   const headless = cfg?.headless === true;
+  const gpuEnabled = cfg?.gpuEnabled === true;
   const noSandbox = cfg?.noSandbox === true;
   const attachOnly = cfg?.attachOnly === true;
   const executablePath = cfg?.executablePath?.trim() || undefined;
@@ -300,6 +302,7 @@ export function resolveBrowserConfig(
     profiles,
     ssrfPolicy,
     extraArgs,
+    gpuEnabled,
   };
 }
 

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -68,4 +68,6 @@ export type BrowserConfig = {
    * Example: ["--window-size=1920,1080", "--disable-infobars"]
    */
   extraArgs?: string[];
+  /** Enable GPU acceleration in headless mode. Requires GPU devices (/dev/dri/*). Default: false */
+  gpuEnabled?: boolean;
 };


### PR DESCRIPTION
## Summary

Adds `browser.gpuEnabled` configuration option to enable GPU hardware acceleration in headless Chrome for improved browser automation performance.

## Problem

OpenClaw currently hardcodes `--disable-gpu` when running Chrome in headless mode, forcing all rendering to CPU-only software mode. This prevents GPU acceleration even when GPU devices (`/dev/dri/*`) are available in the container.

**Impact:**
- Slower screenshot/page rendering (especially charts, SVG, Canvas)
- Higher CPU usage during browser automation
- Poor performance for WebGL/WebGPU content
- No hardware video decode

**Use cases blocked:**
- Autonomous testing of React/Vue components with complex rendering
- Screenshot-based UI validation workflows
- Browser automation of data visualization tools (charts, dashboards)
- Testing WebGL/Canvas-heavy applications

## Solution

Add a new config option `browser.gpuEnabled` (default: `false`) that when set to `true`:
- Prevents the `--disable-gpu` flag
- Adds `--enable-gpu`, `--use-angle=vulkan`, and `--enable-features=Vulkan` flags
- Enables hardware-accelerated rendering in headless mode

**Benefits:**
- **Faster rendering:** Hardware-accelerated canvas, compositing, and rasterization
- **Lower CPU usage:** Offload rendering work to GPU
- **Better compatibility:** WebGL/WebGPU content works properly
- **Autonomous testing:** Enable GPU-dependent UI tests in agent workflows
- **Screenshot quality:** Improved rendering of complex visualizations

## Use Case: Autonomous Testing

This feature is particularly valuable for agent-driven browser automation:

```json
{
  "browser": {
    "headless": true,
    "gpuEnabled": true
  }
}
```

**Example scenarios:**
- Agent takes screenshots of data visualizations and validates chart rendering
- Autonomous testing of React component libraries with complex animations
- Browser-based UI regression testing in CI/CD pipelines
- Testing WebGL-based data exploration tools

## Changes

- Added `gpuEnabled?: boolean` to `BrowserConfig` type
- Updated Zod schema to include the new field  
- Modified browser launch logic in `chrome.ts` to conditionally add GPU flags
- Updated `ResolvedBrowserConfig` type and resolution logic
- Fixed test mocks and sandbox config to include `gpuEnabled: false`

## Configuration Example

```json
{
  "browser": {
    "headless": true,
    "gpuEnabled": true
  }
}
```

**Requirements:**
- GPU devices must be available in the container (e.g., `/dev/dri/renderD128`)
- Mesa drivers or equivalent GPU drivers installed
- Not recommended for environments without GPU access (will fail or fall back)

## Testing

Verified on:
- **Platform:** Home Assistant OS (Debian container)
- **Hardware:** Intel NUC i7-1360P with Intel Iris Xe Graphics
- **GPU device:** `/dev/dri/renderD128` exposed to container
- **Result:** Hardware acceleration confirmed via `chrome://gpu`

**Before (gpuEnabled: false):**
- Canvas: Software only
- Compositing: Software only
- OpenGL: Disabled

**After (gpuEnabled: true):**
- Canvas: Hardware accelerated
- Compositing: Hardware accelerated
- OpenGL: Enabled
- Rasterization: Hardware accelerated on all pages
- WebGL: Hardware accelerated
- WebGPU: Hardware accelerated

## Backward Compatibility

Default is `false` to maintain existing behavior. No breaking changes.
