### PR TITLE
fix: harden resolveUserPath and compact against undefined workspaceDir

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -21,7 +21,6 @@ import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
-import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
@@ -59,6 +58,7 @@ import {
   type SkillSnapshot,
 } from "../skills.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
+import { resolveRunWorkspaceDir } from "../workspace-run.js";
 import {
   compactWithSafetyTimeout,
   EMBEDDED_COMPACTION_TIMEOUT_MS,
@@ -254,7 +254,12 @@ export async function compactEmbeddedPiSessionDirect(
   const attempt = params.attempt ?? 1;
   const maxAttempts = params.maxAttempts ?? 1;
   const runId = params.runId ?? params.sessionId;
-  const resolvedWorkspace = resolveUserPath(params.workspaceDir);
+  const workspaceResolution = resolveRunWorkspaceDir({
+    workspaceDir: params.workspaceDir,
+    sessionKey: params.sessionKey,
+    config: params.config,
+  });
+  const resolvedWorkspace = workspaceResolution.workspaceDir;
   const prevCwd = process.cwd();
 
   const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
@@ -570,7 +575,7 @@ export async function compactEmbeddedPiSessionDirect(
       });
 
       const { session } = await createAgentSession({
-        cwd: resolvedWorkspace,
+        cwd: effectiveWorkspace,
         agentDir,
         authStorage,
         modelRegistry,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -664,7 +664,7 @@ export async function runEmbeddedAttempt(
       const allCustomTools = [...customTools, ...clientToolDefs];
 
       ({ session } = await createAgentSession({
-        cwd: resolvedWorkspace,
+        cwd: effectiveWorkspace,
         agentDir,
         authStorage: params.authStorage,
         modelRegistry: params.modelRegistry,


### PR DESCRIPTION
## Summary

Fix workspace directory resolution in compaction and session creation to use the correct workspace-aware utilities instead of the raw `resolveUserPath` helper.

Note: the separate `resolveUserPath` null-guard fix in `utils.ts` was merged independently in eec3182cb. This PR addresses the remaining call sites that need the higher-level `resolveRunWorkspaceDir` and `effectiveWorkspace` patterns.

## Changes

### `src/agents/pi-embedded-runner/compact.ts`
- Replace `resolveUserPath` with `resolveRunWorkspaceDir` for session-aware workspace resolution
- Uses `workspaceDir`, `sessionKey`, and `config` for proper resolution

### `src/agents/pi-embedded-runner/run/attempt.ts`
- Fix `createAgentSession` to use `effectiveWorkspace` (which accounts for sandbox overrides) instead of `resolvedWorkspace`

## Test plan

- [x] Compaction resolves workspace correctly via `resolveRunWorkspaceDir`
- [x] Agent session creation uses sandbox-aware workspace path
- [x] No regression on existing workspace resolution behavior