### PR TITLE
fix(daemon): use execFileSync instead of execSync to prevent shell injection

### DIFF
--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -148,10 +148,10 @@ async function resolveNodePath(): Promise<string> {
 }
 
 async function resolveBinaryPath(binary: string): Promise<string> {
-  const { execSync } = await import("node:child_process");
+  const { execFileSync } = await import("node:child_process");
   const cmd = process.platform === "win32" ? "where" : "which";
   try {
-    const output = execSync(`${cmd} ${binary}`, { encoding: "utf8" }).trim();
+    const output = execFileSync(cmd, [binary], { encoding: "utf8" }).trim();
     const resolved = output.split(/\r?\n/)[0]?.trim();
     if (!resolved) {
       throw new Error("empty");


### PR DESCRIPTION
## Summary

- Replace `execSync` with `execFileSync` in `src/daemon/program-args.ts` to prevent shell injection when resolving binary paths.
- `execSync` passes the command through a shell, which could allow injection if the binary name were attacker-controlled. `execFileSync` invokes the target directly without a shell intermediary.

Supersedes #12253 (accidentally closed during fork maintenance).

## Test plan
- [ ] Verify `openclaw gateway start` still resolves binary paths correctly
- [ ] Verify `which`/`where` lookups work on Linux/macOS/Windows

---
_Re-opened from #13183 (auto-closed during fork maintenance)._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `execSync` with `execFileSync` in `resolveBinaryPath` function to eliminate shell injection risk when resolving binary paths.

**Key changes:**
- Changed from `execSync(\`${cmd} ${binary}\`)` to `execFileSync(cmd, [binary])`
- Binary name now passed as an array argument instead of string interpolation
- Prevents shell interpretation of the command string

**Impact:**
While the `binary` parameter is currently only called with hardcoded values `"node"` and `"bun"` (lines 141, 146), this change follows defense-in-depth principles and aligns with other recent security hardening in the codebase (similar fix in `cli-credentials.ts` for keychain operations). The change is correct, maintains existing functionality, and eliminates potential future risk if `resolveBinaryPath` is ever exposed to user input.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward security improvement with no functional impact. The migration from `execSync` to `execFileSync` is semantically equivalent for the current use case (calling `which`/`where` with a binary name), but eliminates shell interpretation. The implementation is correct, follows Node.js best practices, and aligns with similar security fixes in the codebase (commit 9dce3d8b). Current callers only pass hardcoded string literals `"node"` and `"bun"`, so there's no existing vulnerability, but this proactive hardening prevents future issues.
- No files require special attention

<sub>Last reviewed commit: 921075a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->