### PR TITLE
fix(security): block prototype-polluting keys in deepMerge

### DIFF
--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -54,6 +54,8 @@ export class CircularIncludeError extends ConfigIncludeError {
 // Utilities
 // ============================================================================
 
+const BLOCKED_MERGE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 /** Deep merge: arrays concatenate, objects merge recursively, primitives: source wins */
 export function deepMerge(target: unknown, source: unknown): unknown {
   if (Array.isArray(target) && Array.isArray(source)) {
@@ -62,6 +64,9 @@ export function deepMerge(target: unknown, source: unknown): unknown {
   if (isPlainObject(target) && isPlainObject(source)) {
     const result: Record<string, unknown> = { ...target };
     for (const key of Object.keys(source)) {
+      if (BLOCKED_MERGE_KEYS.has(key)) {
+        continue;
+      }
       result[key] = key in result ? deepMerge(result[key], source[key]) : source[key];
     }
     return result;


### PR DESCRIPTION
## Summary
The `deepMerge` utility in `src/config/includes.ts` did not guard against prototype-polluting keys (`__proto__`, `prototype`, `constructor`). An attacker who controls a merged config object could inject properties onto `Object.prototype`, affecting all downstream code. This fix adds a blocklist that silently skips those keys during merge.

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm `deepMerge({}, JSON.parse('{"__proto__":{"polluted":true}}'))` does not pollute `Object.prototype`

---
_Re-opened from #18977 (auto-closed during fork maintenance)._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds prototype pollution protection to the `deepMerge` utility by blocking `__proto__`, `prototype`, and `constructor` keys during merge operations. The fix aligns with existing security patterns in the codebase (e.g., `src/config/config-paths.ts:5`). However, no tests were added to verify the protection works as documented in the test plan.

<h3>Confidence Score: 4/5</h3>

- Safe to merge - the fix correctly implements prototype pollution protection using an established pattern from the codebase
- The implementation is correct and follows existing security patterns in `config-paths.ts`. Import ordering is a trivial formatting issue. The missing test is a gap but the logic is sound and the security fix is critical enough to not block on test coverage
- No files require special attention - the implementation is straightforward and correct

<sub>Last reviewed commit: 4c7622f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->