### PR TITLE
fix(security): escape backticks in exec-approval Discord embeds

### DIFF
--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -230,8 +230,8 @@ function createExecApprovalRequestContainer(params: {
   actionRow?: Row<Button>;
 }): ExecApprovalContainer {
   const commandText = params.request.request.command;
-  const commandPreview =
-    commandText.length > 1000 ? `${commandText.slice(0, 1000)}...` : commandText;
+  const commandRaw = commandText.length > 1000 ? `${commandText.slice(0, 1000)}...` : commandText;
+  const commandPreview = commandRaw.replace(/`/g, "\u200b`");
   const expiresAtSeconds = Math.max(0, Math.floor(params.request.expiresAtMs / 1000));
 
   return new ExecApprovalContainer({
@@ -255,7 +255,8 @@ function createResolvedContainer(params: {
   accountId: string;
 }): ExecApprovalContainer {
   const commandText = params.request.request.command;
-  const commandPreview = commandText.length > 500 ? `${commandText.slice(0, 500)}...` : commandText;
+  const commandRaw = commandText.length > 500 ? `${commandText.slice(0, 500)}...` : commandText;
+  const commandPreview = commandRaw.replace(/`/g, "\u200b`");
 
   const decisionLabel =
     params.decision === "allow-once"
@@ -288,7 +289,8 @@ function createExpiredContainer(params: {
   accountId: string;
 }): ExecApprovalContainer {
   const commandText = params.request.request.command;
-  const commandPreview = commandText.length > 500 ? `${commandText.slice(0, 500)}...` : commandText;
+  const commandRaw = commandText.length > 500 ? `${commandText.slice(0, 500)}...` : commandText;
+  const commandPreview = commandRaw.replace(/`/g, "\u200b`");
 
   return new ExecApprovalContainer({
     cfg: params.cfg,


### PR DESCRIPTION
## Summary
Command text displayed in Discord exec-approval embeds was not sanitized, allowing crafted commands containing backticks to break out of the markdown code block and inject arbitrary Discord formatting. This fix inserts a zero-width space (`\u200b`) before each backtick to neutralize the markdown injection vector. Applied to all three embed constructors (request, resolved, expired).

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm commands containing backticks render safely inside the code block in Discord
- [ ] Confirm normal commands without backticks are unaffected

---
_Re-opened from #18983 (auto-closed during fork maintenance)._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a markdown injection vulnerability in Discord exec-approval embeds by escaping backticks with zero-width spaces (`\u200b`). Applied consistently across all three embed constructors (`createExecApprovalRequestContainer`, `createResolvedContainer`, `createExpiredContainer`). The fix also includes import statement reordering to match repository formatting standards.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix properly addresses a markdown injection vulnerability using a well-established technique (zero-width space before backticks). The change is minimal, focused, and applied consistently to all three affected functions. No logic bugs, syntax errors, or edge cases identified. Import reordering follows project standards.
- No files require special attention

<sub>Last reviewed commit: effc02f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->