### PR TITLE
fix(security): block prototype chain traversal in hook template resolution

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import type { HookMessageChannel } from "./hooks.js";
 import { CONFIG_PATH, type HookMappingConfig, type HooksConfig } from "../config/config.js";
+import type { HookMessageChannel } from "./hooks.js";
 
 export type HookMappingResolved = {
   id: string;

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { CONFIG_PATH, type HookMappingConfig, type HooksConfig } from "../config/config.js";
 import type { HookMessageChannel } from "./hooks.js";
+import { CONFIG_PATH, type HookMappingConfig, type HooksConfig } from "../config/config.js";
 
 export type HookMappingResolved = {
   id: string;
@@ -437,6 +437,8 @@ function resolveTemplateExpr(expr: string, ctx: HookMappingContext) {
   return getByPath(ctx.payload, expr);
 }
 
+const BLOCKED_TRAVERSE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 function getByPath(input: Record<string, unknown>, pathExpr: string): unknown {
   if (!pathExpr) {
     return undefined;
@@ -463,6 +465,9 @@ function getByPath(input: Record<string, unknown>, pathExpr: string): unknown {
       }
       current = current[part] as unknown;
       continue;
+    }
+    if (BLOCKED_TRAVERSE_KEYS.has(part)) {
+      return undefined;
     }
     if (typeof current !== "object") {
       return undefined;


### PR DESCRIPTION
## Summary
The `getByPath` function used for resolving template variables in webhook hook mappings did not guard against prototype-polluting path segments (`__proto__`, `prototype`, `constructor`). A crafted webhook payload could use these segments to traverse the prototype chain and access unintended properties. This fix adds a blocklist that returns `undefined` for those keys.

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm template expressions with `__proto__` or `constructor` path segments resolve to `undefined`
- [ ] Confirm legitimate nested payload access still works (e.g., `payload.data.name`)

---
_Re-opened from #18981 (auto-closed during fork maintenance)._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds prototype chain traversal protection to the `getByPath` function used for webhook template variable resolution. The fix blocks dangerous path segments (`__proto__`, `prototype`, `constructor`) that could allow crafted payloads to access unintended properties via prototype chain traversal.

The implementation:
- Adds a `BLOCKED_TRAVERSE_KEYS` Set containing the three dangerous keys
- Returns `undefined` when any path segment matches a blocked key
- Applies consistently to all template expression types (`payload`, `headers`, `query`)
- Follows the existing pattern used in `src/config/config-paths.ts` for similar protection

Test coverage includes:
- Direct access attempts (`{{__proto__}}`, `{{prototype}}`, `{{constructor}}`)
- Nested path traversal attempts (`{{payload.foo.__proto__.bar}}`)
- Verification that legitimate nested paths still work correctly

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The security fix is straightforward, well-tested, and follows existing patterns in the codebase. The implementation correctly blocks all three dangerous prototype chain keys at any depth in the path. Test coverage is comprehensive, covering both blocked and allowed cases. The fix is minimal and surgical, affecting only the vulnerable function without changing behavior for legitimate use cases.
- No files require special attention

<sub>Last reviewed commit: 01ae2f2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->