### PR TITLE
fix(security): eliminate timing side-channel length leak in safeEqualSecret

### DIFF
--- a/src/security/secret-equal.ts
+++ b/src/security/secret-equal.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 export function safeEqualSecret(
   provided: string | undefined | null,
@@ -7,10 +7,6 @@ export function safeEqualSecret(
   if (typeof provided !== "string" || typeof expected !== "string") {
     return false;
   }
-  const providedBuffer = Buffer.from(provided);
-  const expectedBuffer = Buffer.from(expected);
-  if (providedBuffer.length !== expectedBuffer.length) {
-    return false;
-  }
-  return timingSafeEqual(providedBuffer, expectedBuffer);
+  const hash = (s: string) => createHash("sha256").update(s).digest();
+  return timingSafeEqual(hash(provided), hash(expected));
 }


### PR DESCRIPTION
## Summary
`safeEqualSecret` previously returned early when the two input buffers had different lengths, leaking the expected secret's length via a timing side-channel. This fix hashes both inputs with SHA-256 before calling `timingSafeEqual`, ensuring fixed-length (32-byte) buffers and constant-time comparison regardless of input lengths.

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm equal strings still return `true` and unequal strings return `false`
- [ ] Confirm different-length inputs no longer short-circuit (both paths take equal time)

---
_Re-opened from #18978 (auto-closed during fork maintenance)._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Eliminated timing side-channel vulnerability in `safeEqualSecret` by hashing both inputs with SHA-256 before comparison. Previously, the function returned early when input lengths differed, allowing attackers to probe secret lengths via timing attacks. Now both inputs are hashed to fixed 32-byte buffers before `timingSafeEqual`, ensuring constant-time comparison regardless of input length.

- Replaced direct buffer length comparison with SHA-256 hashing
- Maintains functional correctness (all existing tests pass)
- Used in authentication flows (`src/gateway/auth.ts`) and pairing token verification (`src/infra/pairing-token.ts`)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - eliminates a real security vulnerability with minimal code change
- The fix correctly addresses a timing side-channel vulnerability using industry-standard cryptographic practice (SHA-256 hashing before constant-time comparison). The change is minimal, well-tested, and maintains backward compatibility while closing a security gap in authentication flows.
- No files require special attention

<sub>Last reviewed commit: ab1451a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->