### PR TITLE
fix(security): use YAML core schema to prevent type coercion in frontmatter

### DIFF
--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -34,7 +34,7 @@ function coerceFrontmatterValue(value: unknown): string | undefined {
 
 function parseYamlFrontmatter(block: string): ParsedFrontmatter | null {
   try {
-    const parsed = YAML.parse(block) as unknown;
+    const parsed = YAML.parse(block, { schema: "core" }) as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return null;
     }


### PR DESCRIPTION
## Summary
The YAML frontmatter parser used the default YAML 1.1 schema, which silently coerces values like `on`/`off`/`yes`/`no` to booleans and certain numeric strings to octal/hex. This fix explicitly sets `schema: "core"` (YAML 1.2) so only `true`/`false`/`null` are recognized as special values, preventing unexpected type coercion in user-authored frontmatter.

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm frontmatter with `on`/`off` values are preserved as strings, not coerced to booleans

---
_Re-opened from #18979 (auto-closed during fork maintenance)._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes YAML frontmatter parser to prevent silent type coercion of values like `on`/`off`/`yes`/`no` by switching from YAML 1.1 default schema to YAML 1.2 core schema.

- Sets `schema: "core"` in `YAML.parse()` call to prevent automatic boolean coercion
- Only `true`/`false`/`null` will be recognized as special values; other keywords remain strings
- The existing `coerceFrontmatterValue` function already handles explicit type conversion to strings
- This is a one-line security fix with no breaking changes to the API

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line change that adds explicit schema configuration to prevent unwanted type coercion. The change aligns with the existing explicit type handling in `coerceFrontmatterValue` and prevents a common YAML parsing footgun. No breaking changes to the API surface.
- No files require special attention

<sub>Last reviewed commit: 29ccc3c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->