### PR TITLE
fix(hooks): wire message_sent hook into reply dispatcher for all channels

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -623,7 +623,7 @@ export function buildAgentSystemPrompt(params: {
     }
     lines.push("");
     for (const file of validContextFiles) {
-      lines.push(`## ${file.path}`, "", file.content, "");
+      lines.push(`## ${file.path ?? "(unnamed)"}`, "", file.content, "");
     }
   }
 

--- a/src/auto-reply/reply/reply-dispatcher.test.ts
+++ b/src/auto-reply/reply/reply-dispatcher.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getGlobalHookRunner: vi.fn(),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: mocks.getGlobalHookRunner,
+}));
+
+const { createReplyDispatcher } = await import("./reply-dispatcher.js");
+
+describe("createReplyDispatcher – message_sent hook", () => {
+  let mockRunMessageSent: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockRunMessageSent = vi.fn().mockResolvedValue(undefined);
+    mocks.getGlobalHookRunner.mockReturnValue({
+      runMessageSent: mockRunMessageSent,
+      hasHooks: vi.fn().mockReturnValue(true),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls runMessageSent after successful delivery", async () => {
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      hookContext: {
+        channelId: "telegram",
+        accountId: "acct-1",
+        conversationId: "conv-1",
+      },
+    });
+
+    dispatcher.sendFinalReply({ text: "Hello world" });
+    await dispatcher.waitForIdle();
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(mockRunMessageSent).toHaveBeenCalledTimes(1);
+    expect(mockRunMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "conv-1",
+        content: "Hello world",
+        success: true,
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+        accountId: "acct-1",
+        conversationId: "conv-1",
+      }),
+    );
+  });
+
+  it("passes hookContext through to the hook context", async () => {
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      hookContext: {
+        channelId: "discord",
+        accountId: "bot-7",
+        conversationId: "ch-42",
+      },
+    });
+
+    dispatcher.sendBlockReply({ text: "hi" });
+    await dispatcher.waitForIdle();
+
+    expect(mockRunMessageSent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channelId: "discord",
+        accountId: "bot-7",
+        conversationId: "ch-42",
+      }),
+    );
+  });
+
+  it("does NOT call runMessageSent when delivery fails", async () => {
+    const deliver = vi.fn().mockRejectedValue(new Error("network down"));
+    const onError = vi.fn();
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      onError,
+      hookContext: {
+        channelId: "telegram",
+        conversationId: "conv-1",
+      },
+    });
+
+    dispatcher.sendFinalReply({ text: "fail" });
+    await dispatcher.waitForIdle();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(mockRunMessageSent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call runMessageSent when normalized text is empty", async () => {
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    // Empty text payload is dropped by normalizeReplyPayload, so deliver is never called
+    const enqueued = dispatcher.sendFinalReply({ text: "" });
+    await dispatcher.waitForIdle();
+
+    expect(enqueued).toBe(false);
+    expect(deliver).not.toHaveBeenCalled();
+    expect(mockRunMessageSent).not.toHaveBeenCalled();
+  });
+
+  it("runMessageSent errors don't break delivery (fire-and-forget)", async () => {
+    mockRunMessageSent.mockRejectedValue(new Error("hook exploded"));
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const onError = vi.fn();
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      onError,
+      hookContext: {
+        channelId: "telegram",
+        conversationId: "conv-1",
+      },
+    });
+
+    dispatcher.sendFinalReply({ text: "safe" });
+    await dispatcher.waitForIdle();
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    // onError should NOT have been called — the hook error is swallowed
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -14,7 +14,9 @@ import { createInternalHookEventPayload } from "../../test-utils/internal-hook-e
 
 const mocks = vi.hoisted(() => ({
   appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
+  getGlobalHookRunner: vi.fn(),
 }));
+
 const hookMocks = vi.hoisted(() => ({
   runner: {
     hasHooks: vi.fn(() => false),
@@ -120,6 +122,7 @@ describe("deliverOutboundPayloads", () => {
 
   afterEach(() => {
     setActivePluginRegistry(emptyRegistry);
+    mocks.getGlobalHookRunner.mockReturnValue(undefined);
   });
   it("chunks telegram markdown and passes through accountId", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
@@ -564,6 +567,69 @@ describe("deliverOutboundPayloads", () => {
       expect.any(Error),
       expect.objectContaining({ text: "hi", mediaUrls: ["https://x.test/a.jpg"] }),
     );
+  });
+
+  it("calls runMessageSent per payload after successful delivery", async () => {
+    const mockRunMessageSent = vi.fn().mockResolvedValue(undefined);
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    hookMocks.runner.runMessageSent = mockRunMessageSent;
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const cfg: OpenClawConfig = {};
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "whatsapp",
+      to: "+1555",
+      accountId: "acct-1",
+      payloads: [{ text: "Hello" }, { text: "World" }],
+      deps: { sendWhatsApp },
+    });
+
+    expect(mockRunMessageSent).toHaveBeenCalledTimes(2);
+    expect(mockRunMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "+1555",
+        content: "Hello",
+        success: true,
+      }),
+      expect.objectContaining({
+        channelId: "whatsapp",
+        accountId: "acct-1",
+        conversationId: "+1555",
+      }),
+    );
+    expect(mockRunMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "+1555",
+        content: "World",
+        success: true,
+      }),
+      expect.objectContaining({
+        channelId: "whatsapp",
+        accountId: "acct-1",
+        conversationId: "+1555",
+      }),
+    );
+  });
+
+  it("runMessageSent errors don't propagate to caller", async () => {
+    const mockRunMessageSent = vi.fn().mockRejectedValue(new Error("hook boom"));
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    hookMocks.runner.runMessageSent = mockRunMessageSent;
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const cfg: OpenClawConfig = {};
+
+    // Should not throw despite the hook rejection
+    const results = await deliverOutboundPayloads({
+      cfg,
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "safe" }],
+      deps: { sendWhatsApp },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(mockRunMessageSent).toHaveBeenCalledTimes(1);
   });
 
   it("mirrors delivered output when mirror options are provided", async () => {


### PR DESCRIPTION
## Summary

Wire the `message_sent` plugin hook into the reply dispatcher path, complementing the existing hook in `deliver.ts` (merged in #15104). This ensures plugins receive `message_sent` events regardless of which code path delivers the message.

Also adds a null guard for `file.path` in system prompt context file rendering.

## Changes

### `src/auto-reply/reply/reply-dispatcher.ts`
- Add `hookContext` option to `createReplyDispatcher` for channel/routing context
- Fire `runMessageSent` after successful delivery (fire-and-forget, errors swallowed)
- Only fires when `hookContext` is provided and text is non-empty

### `src/auto-reply/reply/reply-dispatcher.test.ts` (new)
- Tests for hook invocation after successful delivery
- Tests for hookContext passthrough
- Tests that hook is NOT called on delivery failure or empty text
- Tests that hook errors don't break delivery

### `src/agents/system-prompt.ts`
- Guard `file.path` with `?? "(unnamed)"` fallback in context file rendering

## Test plan

- [x] `message_sent` fires after successful reply-dispatcher delivery
- [x] Hook context (channelId, accountId, conversationId) passed correctly
- [x] Hook errors are swallowed (fire-and-forget)
- [x] Hook not called on delivery failure or empty text
- [x] No regression on existing deliver.ts hook path