### PR TITLE
fix(auto-reply): replace any with unknown in extractTextFromToolResult

### DIFF
--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -53,8 +53,7 @@ export type InlineActionResult =
       abortedLastRun: boolean;
     };
 
-// oxlint-disable-next-line typescript/no-explicit-any
-function extractTextFromToolResult(result: any): string | null {
+function extractTextFromToolResult(result: unknown): string | null {
   if (!result || typeof result !== "object") {
     return null;
   }


### PR DESCRIPTION
## Summary

Replace `any` parameter type with `unknown` in the private `extractTextFromToolResult` function.

## Changes

- Remove `// oxlint-disable-next-line typescript/no-explicit-any` comment
- Change `result: any` to `result: unknown`

## Motivation

The function body already performs proper type narrowing via `typeof` checks and explicit casts, making the `any` annotation unnecessary.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `any` with `unknown` in the `extractTextFromToolResult` function parameter type, removing the associated oxlint disable comment. The function already performs proper type narrowing via `typeof` checks (line 57, 61) and explicit casts (line 60), making this change safe. The downstream `collectTextContentBlocks` function already accepts `unknown`, ensuring type compatibility. This aligns with the repository's coding style guideline to prefer strict typing and avoid `any`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change improves type safety by replacing `any` with `unknown` in a single function parameter. The function implementation already contains proper type guards and narrowing, and all downstream dependencies accept `unknown`. This is a straightforward refactoring with no behavioral changes.
- No files require special attention

<sub>Last reviewed commit: 5d0e1f7</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->