### PR TITLE
fix(agents): replace AgentTool<any> with Record<string, unknown> generics

### DIFF
--- a/src/agents/bash-tools.exec.background-abort.e2e.test.ts
+++ b/src/agents/bash-tools.exec.background-abort.e2e.test.ts
@@ -39,7 +39,7 @@ function cleanupRunningSession(sessionId: string) {
 
 async function expectBackgroundSessionSurvivesAbort(params: {
   tool: ReturnType<typeof createExecTool>;
-  executeParams: Record<string, unknown>;
+  executeParams: Parameters<ReturnType<typeof createExecTool>["execute"]>[1];
 }) {
   const abortController = new AbortController();
   const result = await params.tool.execute(
@@ -75,7 +75,7 @@ async function expectBackgroundSessionSurvivesAbort(params: {
 
 async function expectBackgroundSessionTimesOut(params: {
   tool: ReturnType<typeof createExecTool>;
-  executeParams: Record<string, unknown>;
+  executeParams: Parameters<ReturnType<typeof createExecTool>["execute"]>[1];
   signal?: AbortSignal;
   abortAfterStart?: boolean;
 }) {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -213,8 +213,7 @@ async function validateScriptFileForShellBleed(params: {
 
 export function createExecTool(
   defaults?: ExecToolDefaults,
-  // oxlint-disable-next-line typescript/no-explicit-any
-): AgentTool<any, ExecToolDetails> {
+): AgentTool<typeof execSchema, ExecToolDetails> {
   const defaultBackgroundMs = clampWithDefault(
     defaults?.backgroundMs ?? readEnvInt("PI_BASH_YIELD_MS"),
     10_000,

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -34,7 +34,7 @@ async function pollSession(
   return processTool.execute(callId, {
     action: "poll",
     sessionId,
-    ...(timeout === undefined ? {} : { timeout }),
+    ...(timeout === undefined ? {} : { timeout: Number(timeout) }),
   });
 }
 

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -118,8 +118,7 @@ function resetPollRetrySuggestion(sessionId: string): void {
 
 export function createProcessTool(
   defaults?: ProcessToolDefaults,
-  // oxlint-disable-next-line typescript/no-explicit-any
-): AgentTool<any, unknown> {
+): AgentTool<typeof processSchema, unknown> {
   if (defaults?.cleanupMs !== undefined) {
     setJobTtlMs(defaults.cleanupMs);
   }


### PR DESCRIPTION
## Summary

Replace `any` generic parameter in `createProcessTool` and `createExecTool` return types with `Record<string, unknown>`.

## Changes

- `bash-tools.process.ts`: `AgentTool<any, unknown>` → `AgentTool<Record<string, unknown>, unknown>`
- `bash-tools.exec.ts`: `AgentTool<any, ExecToolDetails>` → `AgentTool<Record<string, unknown>, ExecToolDetails>`
- Remove both `oxlint-disable-next-line` comments

## Motivation

Both functions immediately cast `args` inside `execute()`. TypeBox validates runtime values, so `Record<string, unknown>` accurately describes the schema argument type without `any`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `any` generic parameter with `Record<string, unknown>` in `createProcessTool` and `createExecTool` return type signatures, and removed corresponding `oxlint-disable-next-line` comments.

**Changes:**
- `bash-tools.process.ts:121`: `AgentTool<any, unknown>` → `AgentTool<Record<string, unknown>, unknown>`
- `bash-tools.exec.ts:216`: `AgentTool<any, ExecToolDetails>` → `AgentTool<Record<string, unknown>, ExecToolDetails>`
- Removed both lint-disable comments

**Rationale:**
Both functions immediately cast `args` to specific types inside their `execute()` implementations (line 247 in exec.ts, line 155 in process.ts). TypeBox validates runtime values at the schema boundary, so `Record<string, unknown>` accurately represents the untyped schema arguments without using `any`.

This improves type safety by avoiding `any` while maintaining existing runtime behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward type improvement that replaces `any` with `Record<string, unknown>` in generic type parameters. Both functions already cast args immediately inside execute(), and TypeBox handles runtime validation. The change improves type safety without altering runtime behavior, and removes technical debt by eliminating lint-disable comments.
- No files require special attention

<sub>Last reviewed commit: 98e7f64</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->