### PR TITLE
fix: disable prompt caching for non-Anthropic Bedrock models

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -231,6 +231,28 @@ function createAnthropicBetaHeadersWrapper(
 }
 
 /**
+ * Check if a Bedrock model ID belongs to Anthropic (Claude).
+ */
+function isAnthropicBedrockModel(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  return id.includes("anthropic.claude") || id.includes("anthropic/claude");
+}
+
+/**
+ * Create a streamFn wrapper that disables prompt caching for non-Anthropic Bedrock models.
+ * The upstream pi-ai bedrock provider injects cachePoint blocks by default, but
+ * non-Anthropic models (Nova, Mistral, etc.) reject them as extraneous keys.
+ */
+function createBedrockNoCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) =>
+    underlying(model, context, {
+      ...options,
+      cacheRetention: "none",
+    });
+}
+
+/**
  * Create a streamFn wrapper that adds OpenRouter app attribution headers.
  * These headers allow OpenClaw to appear on OpenRouter's leaderboard.
  */
@@ -332,6 +354,14 @@ export function applyExtraParamsToAgent(
       log.debug(`enabling Z.AI tool_stream for ${provider}/${modelId}`);
       agent.streamFn = createZaiToolStreamWrapper(agent.streamFn, true);
     }
+  }
+
+  // Disable prompt caching for non-Anthropic Bedrock models.
+  // The upstream pi-ai bedrock provider injects cachePoint blocks by default, but
+  // non-Anthropic models (Nova, Mistral, etc.) reject them as extraneous keys.
+  if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {
+    log.debug(`disabling prompt caching for non-Anthropic Bedrock model ${provider}/${modelId}`);
+    agent.streamFn = createBedrockNoCacheWrapper(agent.streamFn);
   }
 
   // Work around upstream pi-ai hardcoding `store: false` for Responses API.


### PR DESCRIPTION
When using non-Anthropic models on Bedrock (like Amazon Nova or Mistral), the upstream pi-ai provider injects `cachePoint` blocks into message content by default. These models don't support the Anthropic-specific cache point extension and reject requests with 'extraneous key [cachePoint] is not permitted'.

This passes `cacheRetention: "none"` to the pi-ai stream options for non-Anthropic Bedrock models, which prevents cachePoint blocks from being added in the first place. Anthropic models on Bedrock are unaffected and keep their existing caching behavior.

Fixes #20815

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Bedrock API errors when using non-Anthropic models (Amazon Nova, Mistral) by disabling prompt caching for them. The pi-ai Bedrock provider injects `cachePoint` blocks by default, but only Claude models support this Anthropic-specific extension.

The fix adds a detection function to identify Claude model IDs (matching `anthropic.claude` or `anthropic/claude`) and wraps the stream function to pass `cacheRetention: "none"` for all other Bedrock models. This prevents the upstream provider from injecting unsupported cache control metadata that would cause API rejection errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is narrowly scoped, well-documented, and follows existing patterns in the codebase. The detection logic correctly identifies Anthropic models using case-insensitive string matching, and the wrapper correctly chains with existing streamFn wrappers. No tests need updating since this is defensive behavior that prevents errors rather than changing existing functionality.
- No files require special attention

<sub>Last reviewed commit: 2302126</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->