### PR TITLE
fix: allow 'video' and 'audio' in models.input config

### DIFF
--- a/src/agents/bedrock-discovery.ts
+++ b/src/agents/bedrock-discovery.ts
@@ -55,9 +55,11 @@ function isActive(summary: BedrockModelSummary): boolean {
   return typeof status === "string" ? status.toUpperCase() === "ACTIVE" : false;
 }
 
-function mapInputModalities(summary: BedrockModelSummary): Array<"text" | "image"> {
+function mapInputModalities(
+  summary: BedrockModelSummary,
+): Array<"text" | "image" | "video" | "audio"> {
   const inputs = summary.inputModalities ?? [];
-  const mapped = new Set<"text" | "image">();
+  const mapped = new Set<"text" | "image" | "video" | "audio">();
   for (const modality of inputs) {
     const lower = modality.toLowerCase();
     if (lower === "text") {
@@ -65,6 +67,12 @@ function mapInputModalities(summary: BedrockModelSummary): Array<"text" | "image
     }
     if (lower === "image") {
       mapped.add("image");
+    }
+    if (lower === "video") {
+      mapped.add("video");
+    }
+    if (lower === "audio") {
+      mapped.add("audio");
     }
   }
   if (mapped.size === 0) {

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -28,7 +28,7 @@ export type ModelDefinitionConfig = {
   name: string;
   api?: ModelApi;
   reasoning: boolean;
-  input: Array<"text" | "image">;
+  input: Array<"text" | "image" | "video" | "audio">;
   cost: {
     input: number;
     output: number;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -38,7 +38,11 @@ export const ModelDefinitionSchema = z
     name: z.string().min(1),
     api: ModelApiSchema.optional(),
     reasoning: z.boolean().optional(),
-    input: z.array(z.union([z.literal("text"), z.literal("image")])).optional(),
+    input: z
+      .array(
+        z.union([z.literal("text"), z.literal("image"), z.literal("video"), z.literal("audio")]),
+      )
+      .optional(),
     cost: z
       .object({
         input: z.number().optional(),


### PR DESCRIPTION
The zod schema for model input modalities only accepted 'text' and 'image', but the codebase already supports video and audio through MediaUnderstandingCapabilitiesSchema and related constants. Trying to configure a model with video or audio input would fail validation.

This adds 'video' and 'audio' as valid values in both the zod schema and the TypeScript type. Also updates the Bedrock discovery module to pass through video/audio modalities from the AWS API instead of dropping them.

Fixes #20721

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended model input modalities to support `video` and `audio` in addition to `text` and `image`. The codebase already supported these modalities through `MediaUnderstandingCapabilitiesSchema` (src/config/zod-schema.core.ts:408-410), but the `ModelDefinitionSchema.input` field was limited to `text` and `image`, causing validation failures when configuring models with video or audio capabilities. This change aligns the model configuration schema with existing media understanding capabilities throughout the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward type additions that align the model input schema with existing media capabilities. The modifications are consistent across all three affected files (TypeScript type, Zod schema, and Bedrock discovery), with no breaking changes to existing functionality. The code already handles video and audio throughout the media understanding system.
- No files require special attention

<sub>Last reviewed commit: 4906ac0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->