### PR TITLE
fix: resolve {model} responsePrefix vars in non-agent-turn paths

### DIFF
--- a/src/channels/reply-prefix.test.ts
+++ b/src/channels/reply-prefix.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { createReplyPrefixContext } from "./reply-prefix.js";
+
+describe("createReplyPrefixContext", () => {
+  it("seeds template context with the configured default model before model selection", () => {
+    const ctx = createReplyPrefixContext({
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "openai-codex/gpt-5.3-codex" },
+            thinkingDefault: "low",
+          },
+        },
+        messages: { responsePrefix: "[{model}]" },
+      } as OpenClawConfig,
+      agentId: "main",
+    });
+
+    expect(ctx.prefixContext.provider).toBe("openai-codex");
+    expect(ctx.prefixContext.model).toBe("gpt-5.3-codex");
+    expect(ctx.prefixContext.modelFull).toBe("openai-codex/gpt-5.3-codex");
+    expect(ctx.prefixContext.thinkingLevel).toBe("low");
+  });
+
+  it("still updates template context when a runtime model is selected", () => {
+    const ctx = createReplyPrefixContext({
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "openai-codex/gpt-5.3-codex" },
+          },
+        },
+        messages: { responsePrefix: "[{model}]" },
+      } as OpenClawConfig,
+      agentId: "main",
+    });
+
+    ctx.onModelSelected({
+      provider: "anthropic",
+      model: "claude-opus-4-6-20260205",
+      thinkLevel: "high",
+    });
+
+    expect(ctx.prefixContext.provider).toBe("anthropic");
+    expect(ctx.prefixContext.model).toBe("claude-opus-4-6");
+    expect(ctx.prefixContext.modelFull).toBe("anthropic/claude-opus-4-6-20260205");
+    expect(ctx.prefixContext.thinkingLevel).toBe("high");
+  });
+});

--- a/src/channels/reply-prefix.ts
+++ b/src/channels/reply-prefix.ts
@@ -1,4 +1,5 @@
 import { resolveEffectiveMessagesConfig, resolveIdentityName } from "../agents/identity.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import {
   extractShortModelName,
   type ResponsePrefixContext,
@@ -27,8 +28,13 @@ export function createReplyPrefixContext(params: {
   accountId?: string;
 }): ReplyPrefixContextBundle {
   const { cfg, agentId } = params;
+  const defaultModel = resolveDefaultModelForAgent({ cfg, agentId });
   const prefixContext: ResponsePrefixContext = {
     identityName: resolveIdentityName(cfg, agentId),
+    provider: defaultModel.provider,
+    model: extractShortModelName(defaultModel.model),
+    modelFull: `${defaultModel.provider}/${defaultModel.model}`,
+    thinkingLevel: cfg.agents?.defaults?.thinkingDefault ?? "off",
   };
 
   const onModelSelected = (ctx: ModelSelectionContext) => {


### PR DESCRIPTION
## Summary
- seed responsePrefix template context with the agent default model/provider at context creation time
- keep runtime onModelSelected override behavior unchanged for agent-turn paths
- add regression tests for both default seeding and runtime override updates

## Problem
messages.responsePrefix templates like [{model}] could remain unresolved in non-agent-turn reply paths that never invoke onModelSelected.

## Fix
Initialize prefixContext with resolveDefaultModelForAgent() so {model}, {provider}, and {modelFull} are available before runtime model selection callbacks fire.

## Validation
- npm test -- src/channels/reply-prefix.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes unresolved template variables in responsePrefix for non-agent-turn reply paths by seeding the prefix context with default model info at creation time. Also adds a `delayMs` option to `process send-keys` for paced PTY writes.

**Key changes:**
- `reply-prefix.ts`: Seeds `prefixContext` with default model/provider/thinkingLevel at initialization using `resolveDefaultModelForAgent()`
- `reply-prefix.test.ts`: Adds regression tests for both default seeding and runtime override behavior
- `bash-tools.process.ts`: Adds optional `delayMs` parameter to pace key token writes in PTY sessions (max 5000ms)
- `bash-tools.process.send-keys.e2e.test.ts`: Adds timing validation test for the paced write feature

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested bug fix with comprehensive regression tests
- The PR addresses a clear bug (unresolved template vars in non-agent-turn paths) with a clean solution that seeds default values at initialization. Both changes have good test coverage - regression tests validate the fix works, and E2E tests confirm the paced write feature. The implementation follows existing patterns and doesn't introduce breaking changes.
- No files require special attention

<sub>Last reviewed commit: 655a106</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->