### PR TITLE
Store config backups in their own directory

### DIFF
--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -1,26 +1,61 @@
+import path from "node:path";
+
 export const CONFIG_BACKUP_COUNT = 5;
+export const CONFIG_BACKUP_DIR_NAME = "config-backup";
+
+function formatBackupTimestamp(date: Date = new Date()): string {
+  return date.toISOString().replace(/:/g, "-");
+}
+
+export function resolveConfigBackupDir(configPath: string): string {
+  return path.join(path.dirname(configPath), CONFIG_BACKUP_DIR_NAME);
+}
+
+export function resolveConfigBackupPath(configPath: string, date?: Date): string {
+  const backupDir = resolveConfigBackupDir(configPath);
+  const baseName = path.basename(configPath);
+  return path.join(backupDir, `${baseName}.bak.${formatBackupTimestamp(date)}`);
+}
 
 export async function rotateConfigBackups(
   configPath: string,
   ioFs: {
+    mkdir?: (
+      path: string,
+      options: { recursive: boolean; mode?: number },
+    ) => Promise<string | undefined>;
+    readdir?: (path: string) => Promise<string[]>;
     unlink: (path: string) => Promise<void>;
     rename: (from: string, to: string) => Promise<void>;
   },
 ): Promise<void> {
-  if (CONFIG_BACKUP_COUNT <= 1) {
-    return;
-  }
-  const backupBase = `${configPath}.bak`;
-  const maxIndex = CONFIG_BACKUP_COUNT - 1;
-  await ioFs.unlink(`${backupBase}.${maxIndex}`).catch(() => {
-    // best-effort
-  });
-  for (let index = maxIndex - 1; index >= 1; index -= 1) {
-    await ioFs.rename(`${backupBase}.${index}`, `${backupBase}.${index + 1}`).catch(() => {
+  const backupDir = resolveConfigBackupDir(configPath);
+  const baseName = path.basename(configPath);
+  const prefix = `${baseName}.bak.`;
+
+  // Ensure backup directory exists
+  if (ioFs.mkdir) {
+    await ioFs.mkdir(backupDir, { recursive: true, mode: 0o700 }).catch(() => {
       // best-effort
     });
   }
-  await ioFs.rename(backupBase, `${backupBase}.1`).catch(() => {
-    // best-effort
-  });
+
+  // Prune old backups beyond CONFIG_BACKUP_COUNT - 1 (leaving room for the new one)
+  if (ioFs.readdir && CONFIG_BACKUP_COUNT > 1) {
+    try {
+      const entries = await ioFs.readdir(backupDir);
+      const backups = entries.filter((e) => e.startsWith(prefix)).sort();
+      const maxExisting = CONFIG_BACKUP_COUNT - 1; // leave room for the upcoming backup
+      if (backups.length >= maxExisting) {
+        const toRemove = backups.slice(0, backups.length - maxExisting + 1);
+        for (const entry of toRemove) {
+          await ioFs.unlink(path.join(backupDir, entry)).catch(() => {
+            // best-effort
+          });
+        }
+      }
+    } catch {
+      // best-effort — directory may not exist yet
+    }
+  }
 }

--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -44,7 +44,7 @@ export async function rotateConfigBackups(
   if (ioFs.readdir && CONFIG_BACKUP_COUNT > 1) {
     try {
       const entries = await ioFs.readdir(backupDir);
-      const backups = entries.filter((e) => e.startsWith(prefix)).sort();
+      const backups = entries.filter((e) => e.startsWith(prefix)).toSorted();
       const maxExisting = CONFIG_BACKUP_COUNT - 1; // leave room for the upcoming backup
       if (backups.length >= maxExisting) {
         const toRemove = backups.slice(0, backups.length - maxExisting + 1);

--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -47,7 +47,7 @@ export async function rotateConfigBackups(
       const backups = entries.filter((e) => e.startsWith(prefix)).toSorted();
       const maxExisting = CONFIG_BACKUP_COUNT - 1; // leave room for the upcoming backup
       if (backups.length >= maxExisting) {
-        const toRemove = backups.slice(0, backups.length - maxExisting + 1);
+        const toRemove = backups.slice(0, backups.length - maxExisting);
         for (const entry of toRemove) {
           await ioFs.unlink(path.join(backupDir, entry)).catch(() => {
             // best-effort

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -1,18 +1,23 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { rotateConfigBackups } from "./backup-rotation.js";
+import {
+  CONFIG_BACKUP_DIR_NAME,
+  resolveConfigBackupPath,
+  rotateConfigBackups,
+} from "./backup-rotation.js";
 import { withTempHome } from "./test-helpers.js";
 import type { OpenClawConfig } from "./types.js";
 
 describe("config backup rotation", () => {
-  it("keeps a 5-deep backup ring for config writes", async () => {
+  it("keeps backups in config-backup/ with datetime naming", async () => {
     await withTempHome(async () => {
       const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
       if (!stateDir) {
         throw new Error("Expected OPENCLAW_STATE_DIR to be set by withTempHome");
       }
       const configPath = path.join(stateDir, "openclaw.json");
+      const backupDir = path.join(stateDir, CONFIG_BACKUP_DIR_NAME);
       const buildConfig = (version: number): OpenClawConfig =>
         ({
           agents: { list: [{ id: `v${version}` }] },
@@ -26,27 +31,37 @@ describe("config backup rotation", () => {
       await writeVersion(0);
       for (let version = 1; version <= 6; version += 1) {
         await rotateConfigBackups(configPath, fs);
-        await fs.copyFile(configPath, `${configPath}.bak`).catch(() => {
+        const backupPath = resolveConfigBackupPath(configPath);
+        await fs.mkdir(path.dirname(backupPath), { recursive: true });
+        await fs.copyFile(configPath, backupPath).catch(() => {
           // best-effort
         });
         await writeVersion(version);
+        // Small delay to ensure unique timestamps
+        await new Promise((resolve) => setTimeout(resolve, 5));
       }
 
-      const readName = async (suffix = "") => {
-        const raw = await fs.readFile(`${configPath}${suffix}`, "utf-8");
-        return (
-          (JSON.parse(raw) as { agents?: { list?: Array<{ id?: string }> } }).agents?.list?.[0]
-            ?.id ?? null
-        );
-      };
+      // Current config should be latest
+      const currentRaw = await fs.readFile(configPath, "utf-8");
+      expect(
+        (JSON.parse(currentRaw) as { agents?: { list?: Array<{ id?: string }> } }).agents?.list?.[0]
+          ?.id,
+      ).toBe("v6");
 
-      await expect(readName()).resolves.toBe("v6");
-      await expect(readName(".bak")).resolves.toBe("v5");
-      await expect(readName(".bak.1")).resolves.toBe("v4");
-      await expect(readName(".bak.2")).resolves.toBe("v3");
-      await expect(readName(".bak.3")).resolves.toBe("v2");
-      await expect(readName(".bak.4")).resolves.toBe("v1");
-      await expect(fs.stat(`${configPath}.bak.5`)).rejects.toThrow();
+      // Backup directory should exist with datetime-named files
+      const entries = await fs.readdir(backupDir);
+      const backups = entries.filter((e) => e.startsWith("openclaw.json.bak.")).sort();
+
+      // Should have at most CONFIG_BACKUP_COUNT (5) backups
+      expect(backups.length).toBeLessThanOrEqual(5);
+      expect(backups.length).toBeGreaterThan(0);
+
+      // Each backup should match the datetime pattern
+      for (const backup of backups) {
+        expect(backup).toMatch(
+          /^openclaw\.json\.bak\.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z$/,
+        );
+      }
     });
   });
 });

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -50,7 +50,7 @@ describe("config backup rotation", () => {
 
       // Backup directory should exist with datetime-named files
       const entries = await fs.readdir(backupDir);
-      const backups = entries.filter((e) => e.startsWith("openclaw.json.bak.")).sort();
+      const backups = entries.filter((e) => e.startsWith("openclaw.json.bak.")).toSorted();
 
       // Should have at most CONFIG_BACKUP_COUNT (5) backups
       expect(backups.length).toBeLessThanOrEqual(5);

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -15,7 +15,11 @@ import {
 } from "../infra/shell-env.js";
 import { VERSION } from "../version.js";
 import { DuplicateAgentDirError, findDuplicateAgentDirs } from "./agent-dirs.js";
-import { rotateConfigBackups } from "./backup-rotation.js";
+import {
+  resolveConfigBackupDir,
+  resolveConfigBackupPath,
+  rotateConfigBackups,
+} from "./backup-rotation.js";
 import {
   applyCompactionDefaults,
   applyContextPruningDefaults,
@@ -1142,7 +1146,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const changeSummary =
         typeof changedPathCount === "number" ? `, changedPaths=${changedPathCount}` : "";
       deps.logger.warn(
-        `Config overwrite: ${configPath} (sha256 ${previousHash ?? "unknown"} -> ${nextHash}, backup=${configPath}.bak${changeSummary})`,
+        `Config overwrite: ${configPath} (sha256 ${previousHash ?? "unknown"} -> ${nextHash}, backup=${resolveConfigBackupDir(configPath)}/${changeSummary})`,
       );
     };
     const logConfigWriteAnomalies = () => {
@@ -1221,8 +1225,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       });
 
       if (deps.fs.existsSync(configPath)) {
+        const backupDir = resolveConfigBackupDir(configPath);
+        await deps.fs.promises.mkdir(backupDir, { recursive: true, mode: 0o700 }).catch(() => {
+          // best-effort
+        });
         await rotateConfigBackups(configPath, deps.fs.promises);
-        await deps.fs.promises.copyFile(configPath, `${configPath}.bak`).catch(() => {
+        const backupPath = resolveConfigBackupPath(configPath);
+        await deps.fs.promises.copyFile(configPath, backupPath).catch(() => {
           // best-effort
         });
       }

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -445,7 +445,7 @@ describe("config io write", () => {
         .find((entry) => typeof entry === "string" && entry.startsWith("Config overwrite:"));
       expect(typeof overwriteLog).toBe("string");
       expect(overwriteLog).toContain(configPath);
-      expect(overwriteLog).toContain(`${configPath}.bak`);
+      expect(overwriteLog).toContain("config-backup");
       expect(overwriteLog).toContain("sha256");
     });
   });


### PR DESCRIPTION
Config backup files were piling up directly in the .openclaw/ directory (openclaw.json.bak.1, .bak.2, etc). This moves them into a dedicated .openclaw/config-backup/ subdirectory and switches to datetime-based naming like openclaw.json.bak.2026-02-18T14-37-28.123Z.

Changes:
- backup-rotation.ts: new helpers to resolve backup dir/path, pruning now works with datetime-sorted files in the subdirectory
- io.ts: creates the config-backup/ dir and copies backups there instead of alongside the config
- Updated tests to match the new behavior

Keeps the same max backup count (5). Old numbered backups in .openclaw/ won't be cleaned up automatically but they can be deleted manually.

Fixes #20460

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves config backups from `.openclaw/` to `.openclaw/config-backup/` with datetime-based naming (`openclaw.json.bak.2026-02-18T14-37-28.123Z` instead of `.bak.1`, `.bak.2`, etc).

- New helper functions `resolveConfigBackupDir()` and `resolveConfigBackupPath()` encapsulate backup path logic
- Backup rotation now creates the subdirectory and prunes datetime-sorted files
- Tests updated to verify datetime naming and max backup count
- Log messages updated to reference the new backup directory

**Issue found**: The pruning logic has an off-by-one error on line 50 of `backup-rotation.ts`. The expression `backups.length - maxExisting + 1` removes one too many files, resulting in only 4 backups being kept instead of the intended 5 (`CONFIG_BACKUP_COUNT`).

<h3>Confidence Score: 2/5</h3>

- Has a logical error that prevents correct backup rotation behavior
- The off-by-one error in the pruning logic means the PR doesn't deliver on its promise to "keep the same max backup count (5)". While the test passes (it only checks `<= 5`), the actual behavior keeps only 4 backups. The rest of the refactoring (directory structure, datetime naming) is well-implemented, but this bug affects the core rotation logic.
- src/config/backup-rotation.ts line 50 requires correction to maintain 5 backups as intended

<sub>Last reviewed commit: cef6a59</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->