### PR TITLE
fix(memory): add gpu config option for local embeddings and surface indexer errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/Local: add `memorySearch.local.gpu` config option to control GPU compute backend for local embeddings (workaround for Metal GPU OOM on Apple Silicon) and surface indexer errors instead of silently swallowing them. (#20882) Thanks @irchelper.
+
 - Gateway/Subagents: guard gateway and subagent session-key/message trim paths against undefined inputs to prevent early `Cannot read properties of undefined (reading 'trim')` crashes during subagent spawn and wait flows.
 - Agents/Workspace: guard `resolveUserPath` against undefined/null input to prevent `Cannot read properties of undefined (reading 'trim')` crashes when workspace paths are missing in embedded runner flows.
 - Auth/Profiles: keep active `cooldownUntil`/`disabledUntil` windows immutable across retries so mid-window failures cannot extend recovery indefinitely; only recompute a backoff window after the previous deadline has expired. This resolves cron/inbound retry loops that could trap gateways until manual `usageStats` cleanup. (#23516, #23536) Thanks @arosstale.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -703,6 +703,7 @@ Notes:
 
 - Default local embedding model: `hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf` (~0.6 GB).
 - When `memorySearch.provider = "local"`, `node-llama-cpp` resolves `modelPath`; if the GGUF is missing it **auto-downloads** to the cache (or `local.modelCacheDir` if set), then loads it. Downloads resume on retry.
+- `local.gpu`: Controls the GPU compute backend for local embeddings. Options: `"auto"` (default, best available), `"metal"` (macOS only), `"cuda"` (NVIDIA), `"vulkan"` (cross-platform), or `false` (CPU only). **Note:** setting `gpu: false` or a platform-specific backend not available as a prebuilt binary will trigger an on-demand source compilation (~10–20 min).
 - Native build requirement: run `pnpm approve-builds`, pick `node-llama-cpp`, then `pnpm rebuild node-llama-cpp`.
 - Fallback: if local setup fails and `memorySearch.fallback = "openai"`, we automatically switch to remote embeddings (`openai/text-embedding-3-small` unless overridden) and record the reason.
 

--- a/docs/zh-CN/concepts/memory.md
+++ b/docs/zh-CN/concepts/memory.md
@@ -382,6 +382,7 @@ agents: {
 
 - 默认本地嵌入模型：`hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf`（约 0.6 GB）。
 - 当 `memorySearch.provider = "local"` 时，`node-llama-cpp` 解析 `modelPath`；如果 GGUF 缺失，它会**自动下载**到缓存（或 `local.modelCacheDir`，如果已设置），然后加载它。下载在重试时会续传。
+- `local.gpu`：控制本地 embedding 的 GPU 计算后端。可选值：`"auto"`（默认，自动选最佳）、`"metal"`（仅 macOS）、`"cuda"`（NVIDIA）、`"vulkan"`（跨平台）、`false`（纯 CPU）。**注意：** 设置 `gpu: false` 或当前平台不支持的后端时，若无预编译 binary，会触发从源码编译（约 10-20 分钟）。
 - 原生构建要求：运行 `pnpm approve-builds`，选择 `node-llama-cpp`，然后运行 `pnpm rebuild node-llama-cpp`。
 - 回退：如果本地设置失败且 `memorySearch.fallback = "openai"`，我们自动切换到远程嵌入（`openai/text-embedding-3-small`，除非被覆盖）并记录原因。
 

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -30,6 +30,7 @@ export type ResolvedMemorySearchConfig = {
   local: {
     modelPath?: string;
     modelCacheDir?: string;
+    gpu?: "auto" | "metal" | "cuda" | "vulkan" | false;
   };
   store: {
     driver: "sqlite";
@@ -187,6 +188,7 @@ function mergeConfig(
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,
     modelCacheDir: overrides?.local?.modelCacheDir ?? defaults?.local?.modelCacheDir,
+    gpu: overrides?.local?.gpu ?? defaults?.local?.gpu,
   };
   const sources = normalizeSources(overrides?.sources ?? defaults?.sources, sessionMemory);
   const rawPaths = [...(defaults?.extraPaths ?? []), ...(overrides?.extraPaths ?? [])]

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -91,4 +91,96 @@ describe("config schema regressions", () => {
       expect(res.issues[0]?.path).toBe("channels.imessage.attachmentRoots.0");
     }
   });
+
+  it("accepts memorySearch.local.gpu = false (CPU only)", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "local",
+            local: {
+              modelPath: "/path/to/model.gguf",
+              gpu: false,
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts memorySearch.local.gpu = "metal"', () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "local",
+            local: {
+              modelPath: "/path/to/model.gguf",
+              gpu: "metal",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects memorySearch.local.gpu with invalid value", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "local",
+            local: {
+              gpu: "opengl",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('accepts memorySearch.local.gpu = "auto"', () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "local",
+            local: { gpu: "auto" },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts memorySearch.local.gpu = "cuda"', () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "local",
+            local: { gpu: "cuda" },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts memorySearch.local.gpu = "vulkan"', () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "local",
+            local: { gpu: "vulkan" },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -149,6 +149,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.model": "Memory Search Model",
   "agents.defaults.memorySearch.fallback": "Memory Search Fallback",
   "agents.defaults.memorySearch.local.modelPath": "Local Embedding Model Path",
+  "agents.defaults.memorySearch.local.gpu": "Local Embedding GPU Mode",
   "agents.defaults.memorySearch.store.path": "Memory Search Index Path",
   "agents.defaults.memorySearch.store.vector.enabled": "Memory Search Vector Index",
   "agents.defaults.memorySearch.store.vector.extensionPath": "Memory Search Vector Extension Path",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -304,6 +304,8 @@ export type MemorySearchConfig = {
     modelPath?: string;
     /** Optional cache directory for local models. */
     modelCacheDir?: string;
+    /** GPU compute backend. false = CPU only, auto = best available (default). */
+    gpu?: "auto" | "metal" | "cuda" | "vulkan" | false;
   };
   /** Index storage configuration. */
   store?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -520,6 +520,18 @@ export const MemorySearchSchema = z
       .object({
         modelPath: z.string().optional(),
         modelCacheDir: z.string().optional(),
+        gpu: z
+          .union([
+            z.literal("auto"),
+            z.literal("metal"),
+            z.literal("cuda"),
+            z.literal("vulkan"),
+            z.literal(false),
+          ])
+          .optional()
+          .describe(
+            "GPU compute backend for local embeddings. false = CPU only, auto = best available (default).",
+          ),
       })
       .strict()
       .optional(),

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -60,6 +60,7 @@ export type EmbeddingProviderOptions = {
   local?: {
     modelPath?: string;
     modelCacheDir?: string;
+    gpu?: "auto" | "metal" | "cuda" | "vulkan" | false;
   };
 };
 
@@ -102,7 +103,14 @@ async function createLocalEmbeddingProvider(
 
   const ensureContext = async () => {
     if (!llama) {
-      llama = await getLlama({ logLevel: LlamaLogLevel.error });
+      const gpuOption = options.local?.gpu;
+      // Build options object; spread typed as `object` to satisfy tsgo's strict
+      // overload resolution on the lazy-loaded getLlama function.
+      const llamaArgs =
+        gpuOption !== undefined
+          ? { logLevel: LlamaLogLevel.error, gpu: gpuOption }
+          : { logLevel: LlamaLogLevel.error };
+      llama = await getLlama(llamaArgs);
     }
     if (!embeddingModel) {
       const resolved = await resolveModelFile(modelPath, modelCacheDir || undefined);

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -6,6 +6,7 @@ import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope
 import type { ResolvedMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   createEmbeddingProvider,
@@ -194,7 +195,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return;
     }
     void this.sync({ reason: "session-start" }).catch((err) => {
-      log.warn(`memory sync failed (session-start): ${String(err)}`);
+      log.error(`[memory/embed] memory sync failed (session-start): ${formatErrorMessage(err)}`);
     });
     if (key) {
       this.sessionWarm.add(key);
@@ -212,7 +213,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     void this.warmSession(opts?.sessionKey);
     if (this.settings.sync.onSearch && (this.dirty || this.sessionsDirty)) {
       void this.sync({ reason: "search" }).catch((err) => {
-        log.warn(`memory sync failed (search): ${String(err)}`);
+        log.error(`[memory/embed] memory sync failed (search): ${formatErrorMessage(err)}`);
       });
     }
     const cleaned = query.trim();


### PR DESCRIPTION
## Summary

Fixes two related issues with local embedding (node-llama-cpp):

1. **Add `memorySearch.local.gpu` config option** — lets users control the GPU compute backend to work around Metal GPU OOM errors on Apple Silicon
2. **Surface indexer errors** — local embedding failures were silently swallowed at `log.warn` level; now surfaced as `log.error` with full error context via `formatErrorMessage`

### Root cause

On Apple Silicon Macs with constrained GPU memory, the Metal backend crashes with `kIOGPUCommandBufferCallbackErrorOutOfMemory` during embedding inference. The error was caught and logged as a warning, leaving the index in a permanently `Dirty: yes` state with 0 chunks (reported in #16164).

Setting `gpu: false` forces CPU-only inference and avoids the OOM.

### Changes

- `src/config/zod-schema.agent-runtime.ts`: add `gpu` field to `memorySearch.local` schema
- `src/config/types.tools.ts`: add `gpu` to `MemorySearchConfig.local` TypeScript type
- `src/agents/memory-search.ts`: propagate `gpu` through `ResolvedMemorySearchConfig` and `mergeConfig`
- `src/memory/embeddings.ts`: pass `gpu` to `getLlama()` in `createLocalEmbeddingProvider`
- `src/memory/manager.ts`: upgrade sync failure logging from `log.warn` to `log.error` with `formatErrorMessage`
- `src/config/schema.labels.ts`: add UI label for new field
- `src/config/config.schema-regressions.test.ts`: 6 new schema regression tests (false/auto/metal/cuda/vulkan/invalid)
- `docs/concepts/memory.md` + `docs/zh-CN/concepts/memory.md`: document `local.gpu` option including the source-build warning

### Usage

```json5
{
  agents: {
    defaults: {
      memorySearch: {
        provider: "local",
        local: {
          modelPath: "/path/to/nomic-embed-text-v1.5.Q8_0.gguf",
          gpu: false  // force CPU-only to avoid Metal OOM
        }
      }
    }
  }
}
```

Valid values: `false` (CPU only), `"auto"` (default), `"metal"` (macOS), `"cuda"` (NVIDIA), `"vulkan"` (cross-platform)

> **Note:** `gpu: false` or an unsupported platform backend triggers on-demand source compilation (~10–20 min) if no matching prebuilt binary is available.

### Testing

```bash
pnpm build         # 0 TS errors
pnpm lint          # 0 warnings, 0 errors
npx vitest run src/config/config.schema-regressions  # 8 tests passed
npx vitest run src/memory/                            # all passing
```

Closes #16164

## AI-Assisted

Built with Claude Sonnet 4.6 (implementation) + Claude Opus 4.6 (review).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a GPU config option for local embeddings to avoid Metal OOM errors on Apple Silicon, plus error surfacing improvements. However, the PR contains significantly more than described:

**What's described in PR title/description:**
- Add `memorySearch.local.gpu` config option
- Surface indexer errors (upgrade `log.warn` to `log.error`)
- 6 new schema regression tests
- Documentation updates

**What's actually in the PR:**
- All of the above memory fixes ✓
- Complete routing system implementation (~1,500 lines): budget tracking, health monitoring, review gates, antiflap cooldown, model selection, safety gates
- Routing integration into agent execution pipeline
- Subagent announce improvements (display model in completion messages)
- Only 3 new schema tests (not 6 as claimed)
- No documentation updates included (claimed in description but missing from diff)

**Memory implementation review:**
- `gpu` config option correctly threaded through all layers (schema → types → memory-search → embeddings)
- Type union `"auto" | "metal" | "cuda" | "vulkan" | false` is correct
- Error logging upgrade from `warn` to `error` with `formatErrorMessage` is appropriate
- Schema validation tests cover the new field properly

**Concerns:**
- PR scope creep: 11 commits with multiple unrelated features bundled together
- Description inaccuracies: test count and missing docs
- Routing system code (~2,500 line delta) should likely be in separate PR(s) for easier review

<h3>Confidence Score: 3/5</h3>

- The memory GPU config changes are safe, but PR contains extensive unreviewed routing system code
- The core memory GPU feature is well-implemented with proper type safety and testing. However, the PR bundles ~2,500 lines of routing system code across 11 commits that are unrelated to the stated PR purpose. The routing code includes budget tracking, health monitoring, and model selection logic that deserves dedicated review. Additionally, the PR description contains inaccuracies (claims 6 tests but adds 3, claims docs updates but none present).
- All routing-related files (`src/gateway/routing/**`) need thorough review as they represent a complete feature implementation bundled into this PR

<sub>Last reviewed commit: 55bed3b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->