### PR TITLE
fix(discord): prevent component handler cache collision for select menus

### DIFF
--- a/src/discord/monitor/agent-components.registration.test.ts
+++ b/src/discord/monitor/agent-components.registration.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseDiscordComponentCustomIdForCarbon } from "../components.js";
+import {
+  createDiscordComponentButton,
+  createDiscordComponentChannelSelect,
+  createDiscordComponentMentionableSelect,
+  createDiscordComponentRoleSelect,
+  createDiscordComponentStringSelect,
+  createDiscordComponentUserSelect,
+} from "./agent-components.js";
+
+const ctx = {
+  cfg: {},
+  discordConfig: {},
+  accountId: "default",
+  guildEntries: new Map(),
+  runtime: {},
+  token: "test",
+} as any;
+
+describe("discord component registration", () => {
+  it("uses unique wildcard customIds so Carbon registers all component types", () => {
+    const components = [
+      createDiscordComponentButton(ctx),
+      createDiscordComponentStringSelect(ctx),
+      createDiscordComponentUserSelect(ctx),
+      createDiscordComponentRoleSelect(ctx),
+      createDiscordComponentMentionableSelect(ctx),
+      createDiscordComponentChannelSelect(ctx),
+    ];
+
+    const ids = components.map((component) => component.customId);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    for (const component of components) {
+      expect(parseDiscordComponentCustomIdForCarbon(component.customId).key).toBe("*");
+    }
+  });
+});

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -1361,7 +1361,8 @@ export class AgentSelectMenu extends StringSelectMenu {
 
 class DiscordComponentButton extends Button {
   label = "component";
-  customId = "*";
+  // Carbon caches components by customId. Keep wildcard key (`*`) but make ids unique per type.
+  customId = "*:button";
   style = ButtonStyle.Primary;
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
@@ -1393,7 +1394,7 @@ class DiscordComponentButton extends Button {
 }
 
 class DiscordComponentStringSelect extends StringSelectMenu {
-  customId = "*";
+  customId = "*:string-select";
   options: APIStringSelectComponent["options"] = [];
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
@@ -1416,7 +1417,7 @@ class DiscordComponentStringSelect extends StringSelectMenu {
 }
 
 class DiscordComponentUserSelect extends UserSelectMenu {
-  customId = "*";
+  customId = "*:user-select";
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1438,7 +1439,7 @@ class DiscordComponentUserSelect extends UserSelectMenu {
 }
 
 class DiscordComponentRoleSelect extends RoleSelectMenu {
-  customId = "*";
+  customId = "*:role-select";
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1460,7 +1461,7 @@ class DiscordComponentRoleSelect extends RoleSelectMenu {
 }
 
 class DiscordComponentMentionableSelect extends MentionableSelectMenu {
-  customId = "*";
+  customId = "*:mentionable-select";
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1482,7 +1483,7 @@ class DiscordComponentMentionableSelect extends MentionableSelectMenu {
 }
 
 class DiscordComponentChannelSelect extends ChannelSelectMenu {
-  customId = "*";
+  customId = "*:channel-select";
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 


### PR DESCRIPTION
## Problem

Discord string select interactions (component type 3) always failed with "This interaction failed" in Discord.

**Root cause:** `@buape/carbon`'s `ComponentHandler` caches registered components by `customId`. OpenClaw registered 6 Discord component handlers all with the same `customId = "*"`:

- `DiscordComponentButton`
- `DiscordComponentStringSelect`
- `DiscordComponentUserSelect`
- `DiscordComponentRoleSelect`
- `DiscordComponentMentionableSelect`
- `DiscordComponentChannelSelect`

Since `registerComponent` skips duplicates (`if (!this.componentCache.has(component.customId))`), only the first handler (Button) survived in the cache. All select menu interactions (`component_type: 3`) hit a missing handler and threw:

> `Unknown component with type 3 and custom ID occomp:cid=... was received, did you forget to register the component?`

## Fix

Give each handler a **unique `customId`** while preserving wildcard matching behavior. The existing `parseDiscordComponentCustomIdForCarbon` parser already returns `key: "*"` for any `"*:..."` prefixed ID, so Carbon's fallback lookup loop still correctly finds the right handler by matching `component.type`:

```ts
// Before — all collide on same cache key, only Button survives:
class DiscordComponentButton       { customId = "*" }
class DiscordComponentStringSelect { customId = "*" }
class DiscordComponentUserSelect   { customId = "*" }
// ...

// After — unique cache keys, same wildcard matching behavior:
class DiscordComponentButton            { customId = "*:button" }
class DiscordComponentStringSelect      { customId = "*:string-select" }
class DiscordComponentUserSelect        { customId = "*:user-select" }
class DiscordComponentRoleSelect        { customId = "*:role-select" }
class DiscordComponentMentionableSelect { customId = "*:mentionable-select" }
class DiscordComponentChannelSelect     { customId = "*:channel-select" }
```

## Testing

Added regression test: `src/discord/monitor/agent-components.registration.test.ts`
- Verifies all 6 handlers have unique `customId` values
- Verifies `parseDiscordComponentCustomIdForCarbon` returns `key: "*"` for all of them (wildcard matching preserved)
- Confirmed fix on live Discord server: string select menus ACK cleanly, no interaction failures

## Affected file
`src/discord/monitor/agent-components.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Discord select menu interaction failures by giving each component handler a unique `customId` to prevent Carbon's component cache collision. Previously all 6 handlers (button + 5 select types) used `customId = "*"`, causing only the first registered handler to survive in the cache. The fix preserves wildcard matching behavior while ensuring all handlers register successfully.

- Changed 6 component handler `customId` values from `"*"` to unique patterns like `"*:button"`, `"*:string-select"`, etc.
- Added regression test verifying all handlers have unique IDs and maintain wildcard parsing behavior
- Confirmed fix resolves "Unknown component with type 3" errors on live Discord server

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix directly addresses a clear bug with a straightforward solution. The change is minimal (6 string updates), the root cause analysis is thorough and correct, test coverage was added to prevent regression, and the implementation correctly preserves existing wildcard matching behavior through the `parseDiscordComponentCustomIdForCarbon` parser.
- No files require special attention

<sub>Last reviewed commit: ac7684c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->