### PR TITLE
changelog: add unreleased fixes from recent PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/WebChat: block `sessions.patch` and `sessions.delete` for WebChat clients so session-store mutations stay restricted to non-WebChat operator flows. Thanks @allsmog for reporting.
 - Security/Skills: for the next npm release, reject symlinks during skill packaging to prevent external file inclusion in distributed `.skill` archives. Thanks @aether-ai-agent for reporting.
+- Security/Gateway: fail startup when `hooks.token` matches `gateway.auth.token` so hooks and gateway token reuse is rejected at boot. (#20813) Thanks @coygeek.
+- Security/Network: block plaintext `ws://` connections to non-loopback hosts and require secure websocket transport elsewhere. (#20803) Thanks @jscaldwell55.
+- Security/Config: parse frontmatter YAML using the YAML 1.2 core schema to avoid implicit coercion of `on`/`off`-style values. (#20857) Thanks @davidrudduck.
+- Security/Discord: escape backticks in exec-approval embed content to prevent markdown formatting injection via command text. (#20854) Thanks @davidrudduck.
+- Security/Agents: replace shell-based `execSync` usage with `execFileSync` in command lookup helpers to eliminate shell argument interpolation risk. (#20655) Thanks @mahanandhi.
+- Security/Media: use `crypto.randomBytes()` for temp file names and set owner-only permissions for TTS temp files. (#20654) Thanks @mahanandhi.
+- Security/Gateway: set baseline security headers (`X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`) on gateway HTTP responses. (#10526) Thanks @abdelsfane.
+- Tests/Security: refactor `src/security/audit.test.ts` by extracting shared helpers to reduce duplication in security audit test coverage. (#20087) Thanks @habakan.
+- Channels/Matrix: fix mention detection for `formatted_body` Matrix-to links by handling matrix.to mention formats consistently. (#16941) Thanks @zerone0x.
+- Scripts: update clawdock helper command support to include `docker-compose.extra.yml` where available. (#17094) Thanks @zerone0x.
 - Security/iMessage: harden remote attachment SSH/SCP handling by requiring strict host-key verification, validating `channels.imessage.remoteHost` as `host`/`user@host`, and rejecting unsafe host tokens from config or auto-detection. Thanks @allsmog for reporting.
 - Security/Feishu: prevent path traversal in Feishu inbound media temp-file writes by replacing key-derived temp filenames with UUID-based names. Thanks @allsmog for reporting.
 - LINE/Security: harden inbound media temp-file naming by using UUID-based temp paths for downloaded media instead of external message IDs. (#20792) Thanks @mbelinky.


### PR DESCRIPTION
## Summary

This PR updates `CHANGELOG.md` (`2026.2.18 - Unreleased`) with changelog entries for recently merged fixes:

- #20813
- #20803
- #20857
- #20854
- #20655
- #20654
- #10526
- #20087
- #16941
- #17094

No functional code changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added 10 changelog entries to the unreleased `2026.2.18` section documenting recently merged fixes from PRs #20813, #20803, #20857, #20854, #20655, #20654, #10526, #20087, #16941, and #17094.

- All entries follow the repository's changelog format conventions
- Entries are properly categorized (Security/, Tests/, Channels/, Scripts/)
- All referenced PRs exist in the git history and match the described changes
- New entries are appropriately placed in the Fixes section with security-related fixes grouped together
- No functional code changes, documentation-only update

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only change updating CHANGELOG.md with historical entries for recently merged PRs. All referenced PRs exist in git history, formatting is consistent with existing conventions, and there are no code changes that could introduce functional issues or regressions.
- No files require special attention

<sub>Last reviewed commit: 0259bcc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->