### PR TITLE
fix(tui): surface plugin commands in autocomplete via hello-ok snapshot

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -297,6 +297,7 @@ public struct Snapshot: Codable, Sendable {
     public let sessiondefaults: [String: AnyCodable]?
     public let authmode: AnyCodable?
     public let updateavailable: [String: AnyCodable]?
+    public let plugincommands: [[String: AnyCodable]]?
 
     public init(
         presence: [PresenceEntry],
@@ -307,7 +308,8 @@ public struct Snapshot: Codable, Sendable {
         statedir: String?,
         sessiondefaults: [String: AnyCodable]?,
         authmode: AnyCodable?,
-        updateavailable: [String: AnyCodable]?
+        updateavailable: [String: AnyCodable]?,
+        plugincommands: [[String: AnyCodable]]?
     ) {
         self.presence = presence
         self.health = health
@@ -318,6 +320,7 @@ public struct Snapshot: Codable, Sendable {
         self.sessiondefaults = sessiondefaults
         self.authmode = authmode
         self.updateavailable = updateavailable
+        self.plugincommands = plugincommands
     }
     private enum CodingKeys: String, CodingKey {
         case presence
@@ -329,6 +332,7 @@ public struct Snapshot: Codable, Sendable {
         case sessiondefaults = "sessionDefaults"
         case authmode = "authMode"
         case updateavailable = "updateAvailable"
+        case plugincommands = "pluginCommands"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -297,6 +297,7 @@ public struct Snapshot: Codable, Sendable {
     public let sessiondefaults: [String: AnyCodable]?
     public let authmode: AnyCodable?
     public let updateavailable: [String: AnyCodable]?
+    public let plugincommands: [[String: AnyCodable]]?
 
     public init(
         presence: [PresenceEntry],
@@ -307,7 +308,8 @@ public struct Snapshot: Codable, Sendable {
         statedir: String?,
         sessiondefaults: [String: AnyCodable]?,
         authmode: AnyCodable?,
-        updateavailable: [String: AnyCodable]?
+        updateavailable: [String: AnyCodable]?,
+        plugincommands: [[String: AnyCodable]]?
     ) {
         self.presence = presence
         self.health = health
@@ -318,6 +320,7 @@ public struct Snapshot: Codable, Sendable {
         self.sessiondefaults = sessiondefaults
         self.authmode = authmode
         self.updateavailable = updateavailable
+        self.plugincommands = plugincommands
     }
     private enum CodingKeys: String, CodingKey {
         case presence
@@ -329,6 +332,7 @@ public struct Snapshot: Codable, Sendable {
         case sessiondefaults = "sessionDefaults"
         case authmode = "authMode"
         case updateavailable = "updateAvailable"
+        case plugincommands = "pluginCommands"
     }
 }
 

--- a/src/gateway/protocol/schema/snapshot.ts
+++ b/src/gateway/protocol/schema/snapshot.ts
@@ -67,6 +67,14 @@ export const SnapshotSchema = Type.Object(
         channel: NonEmptyString,
       }),
     ),
+    pluginCommands: Type.Optional(
+      Type.Array(
+        Type.Object({
+          name: Type.String(),
+          description: Type.String(),
+        }),
+      ),
+    ),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -4,6 +4,7 @@ import { CONFIG_PATH, STATE_DIR, loadConfig } from "../../config/config.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
 import { listSystemPresence } from "../../infra/system-presence.js";
 import { getUpdateAvailable } from "../../infra/update-startup.js";
+import { listPluginCommands } from "../../plugins/commands.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolveGatewayAuth } from "../auth.js";
 import type { Snapshot } from "../protocol/index.js";
@@ -42,6 +43,7 @@ export function buildGatewaySnapshot(): Snapshot {
     },
     authMode: auth.mode,
     updateAvailable,
+    pluginCommands: listPluginCommands().map((c) => ({ name: c.name, description: c.description })),
   };
 }
 

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -18,6 +18,7 @@ export type SlashCommandOptions = {
   cfg?: OpenClawConfig;
   provider?: string;
   model?: string;
+  pluginCommands?: Array<{ name: string; description: string }>;
 };
 
 const COMMAND_ALIASES: Record<string, string> = {
@@ -132,6 +133,13 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
       }
       seen.add(name);
       commands.push({ name, description: command.description });
+    }
+  }
+
+  for (const cmd of options.pluginCommands ?? []) {
+    if (!seen.has(cmd.name)) {
+      seen.add(cmd.name);
+      commands.push({ name: cmd.name, description: cmd.description });
     }
   }
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -393,6 +393,7 @@ export async function runTui(opts: TuiOptions) {
           cfg: config,
           provider: sessionInfo.modelProvider,
           model: sessionInfo.model,
+          pluginCommands: client.hello?.snapshot?.pluginCommands,
         }),
         process.cwd(),
       ),
@@ -778,6 +779,7 @@ export async function runTui(opts: TuiOptions) {
     void (async () => {
       await refreshAgents();
       updateHeader();
+      updateAutocompleteProvider();
       await loadHistory();
       setConnectionStatus(reconnected ? "gateway reconnected" : "gateway connected", 4000);
       tui.requestRender();


### PR DESCRIPTION
## Summary

- Plugin commands registered via `api.registerCommand()` never appear in TUI autocomplete because plugins load in the gateway process, not the TUI process — `listPluginCommands()` always returns empty in the TUI
- Adds `pluginCommands` (optional `{name, description}[]`) to the `SnapshotSchema` sent in the hello-ok handshake
- Gateway populates the field from `listPluginCommands()` when building the snapshot
- TUI reads `client.hello.snapshot.pluginCommands` and refreshes autocomplete on connect

## Files changed

| File | Change |
|------|--------|
| `src/gateway/protocol/schema/snapshot.ts` | Add `pluginCommands` optional array to `SnapshotSchema` |
| `src/gateway/server/health-state.ts` | Populate `pluginCommands` in `buildGatewaySnapshot()` |
| `src/tui/commands.ts` | Accept `pluginCommands` in `SlashCommandOptions`, append to command list |
| `src/tui/tui.ts` | Pass snapshot plugin commands to autocomplete, refresh on connect |

## Test plan

- [x] `pnpm vitest run src/tui/` — 14 files, 101 tests pass
- [x] `pnpm vitest run src/gateway/` — 45 files, 440 tests pass (6 pre-existing failures from missing `https-proxy-agent`)
- [x] Deployed to production gateway with a custom plugin (`/reflexes`), confirmed autocomplete works in TUI after connect

## AI disclosure

This PR was AI-assisted (Claude). The code has been tested locally and deployed to a production instance. I understand what the code does and have verified the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Plugin commands registered via `api.registerCommand()` in plugins now correctly appear in TUI autocomplete. The fix addresses the issue where plugins load in the gateway process but the TUI runs in a separate process, so `listPluginCommands()` always returned empty in the TUI.

The implementation adds an optional `pluginCommands` field to the `SnapshotSchema` (sent in the hello-ok handshake), populates it from `listPluginCommands()` in the gateway's `buildGatewaySnapshot()`, and reads it in the TUI to refresh autocomplete on connect.

- `src/gateway/protocol/schema/snapshot.ts:70-77` - adds optional `pluginCommands` array with `name` and `description` fields to the snapshot schema
- `src/gateway/server/health-state.ts:7,46` - imports and calls `listPluginCommands()` to populate snapshot field
- `src/tui/commands.ts:21,139-144` - accepts `pluginCommands` in options, appends to command list with deduplication
- `src/tui/tui.ts:396,782` - passes snapshot plugin commands to autocomplete and refreshes on connect

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-structured, and follows TypeScript best practices. The changes are minimal and scoped to the specific issue. The optional field addition to the schema maintains backward compatibility. The code properly handles null/undefined cases with optional chaining and nullish coalescing. All tests pass (101 TUI tests, 440 gateway tests), and the author verified the fix end-to-end in production with a custom plugin.
- No files require special attention

<sub>Last reviewed commit: ef65166</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->