### PR TITLE
feat(hooks): add skipAuth option for webhook mappings

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -22,6 +22,8 @@ export type HookMappingConfig = {
   deliver?: boolean;
   /** DANGEROUS: Disable external content safety wrapping for this hook. */
   allowUnsafeExternalContent?: boolean;
+  /** Skip token authentication for this mapping (for external webhooks like GitHub). */
+  skipAuth?: boolean;
   channel?:
     | "last"
     | "whatsapp"

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -16,6 +16,7 @@ export type HookMappingResolved = {
   textTemplate?: string;
   deliver?: boolean;
   allowUnsafeExternalContent?: boolean;
+  skipAuth?: boolean;
   channel?: HookMessageChannel;
   to?: string;
   model?: string;
@@ -211,6 +212,7 @@ function normalizeHookMapping(
     textTemplate: mapping.textTemplate,
     deliver: mapping.deliver,
     allowUnsafeExternalContent: mapping.allowUnsafeExternalContent,
+    skipAuth: mapping.skipAuth,
     channel: mapping.channel,
     to: mapping.to,
     model: mapping.model,
@@ -233,6 +235,28 @@ function mappingMatches(mapping: HookMappingResolved, ctx: HookMappingContext) {
     }
   }
   return true;
+}
+
+/**
+ * Check if a path matches any mapping with skipAuth enabled.
+ * This is used before reading the body to determine if auth should be skipped.
+ * Only checks path matching (not source matching which requires body).
+ */
+export function hasSkipAuthMapping(mappings: HookMappingResolved[], path: string): boolean {
+  const normalizedPath = normalizeMatchPath(path);
+  for (const mapping of mappings) {
+    if (!mapping.skipAuth) {
+      continue;
+    }
+    // If no matchPath specified, it matches all paths
+    if (!mapping.matchPath) {
+      return true;
+    }
+    if (mapping.matchPath === normalizedPath) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function buildActionFromMapping(


### PR DESCRIPTION
## Summary
Add `skipAuth` option to hook mappings that allows receiving webhooks without token authentication. This is useful for external webhook providers like GitHub that cannot send authentication headers.

## Problem
GitHub webhooks POST directly to your endpoint with only `X-Hub-Signature-256` for verification. OpenClaw's current hooks require token auth via headers (`X-OpenClaw-Token` or `Authorization: Bearer`), causing all GitHub webhooks to receive 401 Unauthorized.

## Solution
Add a simple `skipAuth: true` option that bypasses token authentication for specific hook mappings.

## Config Example
```json
{
  "hooks": {
    "mappings": [{
      "match": { "path": "github" },
      "skipAuth": true,
      "transform": { "module": "github-transform.mjs" }
    }]
  }
}
```

## Changes
- Add `skipAuth` property to `HookMappingConfig` and `HookMappingResolved` types
- Add `hasSkipAuthMapping()` helper function to check if a path matches a skipAuth mapping
- Update `server-http.ts` to check for skipAuth before token validation
- Add comprehensive unit tests for the new functionality

## Testing
- Unit tests for `hasSkipAuthMapping()` function
- E2E test for skipAuth webhook behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `skipAuth` option to webhook mappings, allowing external webhook providers like GitHub to POST without OpenClaw token authentication. Implementation is clean and well-tested.

**Key Changes:**
- Added `skipAuth?: boolean` to `HookMappingConfig` and `HookMappingResolved` types
- Implemented `hasSkipAuthMapping()` helper that checks path-based matches before authentication
- Modified auth flow in `server-http.ts` to check for `skipAuth` mappings and bypass token validation
- Added comprehensive unit and E2E tests covering various scenarios

**Architecture:**
The feature checks for `skipAuth` mappings early (before reading request body) by matching against the path. If found, the entire token authentication block is skipped. This allows external webhooks to authenticate via their own mechanisms (e.g., GitHub's `X-Hub-Signature-256`).

**Test Coverage:**
- Unit tests verify `hasSkipAuthMapping()` logic with various path formats
- E2E test confirms `skipAuth` paths accept requests without tokens while protected paths still require auth
- Built-in endpoints like `/hooks/wake` remain protected

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor consideration for auth throttling edge case
- Implementation is clean, well-tested, and solves a legitimate use case. Only concern is potential interaction between auth failure throttling and skipAuth paths (see comment). The feature is opt-in via config, reducing unintended exposure risk.
- Pay attention to src/gateway/server-http.ts for the auth throttling interaction with skipAuth paths

<sub>Last reviewed commit: ad82ff5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->