### PR TITLE
fix: intercept Discord embed images to enforce mediaMaxMb

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -29,6 +29,7 @@ import type { DiscordMessagePreflightContext } from "./message-handler.preflight
 import {
   buildDiscordMediaPayload,
   resolveDiscordMessageText,
+  resolveEmbedMediaList,
   resolveForwardedMediaList,
   resolveMediaList,
 } from "./message-utils.js";
@@ -318,6 +319,10 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   const mediaList = await resolveMediaList(message, mediaMaxBytes);
   const forwardedMediaList = await resolveForwardedMediaList(message, mediaMaxBytes);
   mediaList.push(...forwardedMediaList);
+  // Intercept images embedded in Discord embeds (inline pastes, link previews).
+  // Without this, large images bypass mediaMaxMb and can brick sessions (#20906).
+  const embedMediaList = await resolveEmbedMediaList(message, mediaMaxBytes);
+  mediaList.push(...embedMediaList);
   const text = messageText;
   if (!text) {
     logVerbose(`discord: drop message ${message.id} (empty content)`);

--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -21,6 +21,7 @@ const {
   resolveDiscordChannelInfo,
   resolveDiscordMessageChannelId,
   resolveDiscordMessageText,
+  resolveEmbedMediaList,
   resolveForwardedMediaList,
 } = await import("./message-utils.js");
 
@@ -194,5 +195,119 @@ describe("resolveDiscordChannelInfo", () => {
     expect(first).toBeNull();
     expect(second).toBeNull();
     expect(fetchChannel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveEmbedMediaList", () => {
+  const MAX_BYTES = 5 * 1024 * 1024;
+
+  beforeEach(() => {
+    fetchRemoteMedia.mockReset();
+    saveMediaBuffer.mockReset();
+  });
+
+  it("returns empty array when message has no embeds", async () => {
+    const result = await resolveEmbedMediaList(asMessage({ embeds: [] }), MAX_BYTES);
+    expect(result).toEqual([]);
+  });
+
+  it("downloads and saves embed image (Carbon string format)", async () => {
+    const buf = Buffer.from("fake-image");
+    fetchRemoteMedia.mockResolvedValue({ buffer: buf, contentType: "image/png" });
+    saveMediaBuffer.mockResolvedValue({
+      path: "/media/test.png",
+      contentType: "image/png",
+    });
+
+    const result = await resolveEmbedMediaList(
+      asMessage({
+        attachments: [],
+        embeds: [{ image: "https://cdn.discord.com/img.png" }],
+      }),
+      MAX_BYTES,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      path: "/media/test.png",
+      contentType: "image/png",
+      placeholder: "<media:image>",
+    });
+    expect(saveMediaBuffer).toHaveBeenCalledWith(buf, "image/png", "inbound", MAX_BYTES);
+  });
+
+  it("handles raw API embed object format with proxy_url", async () => {
+    const buf = Buffer.from("fake");
+    fetchRemoteMedia.mockResolvedValue({ buffer: buf, contentType: "image/jpeg" });
+    saveMediaBuffer.mockResolvedValue({ path: "/media/p.jpg", contentType: "image/jpeg" });
+
+    await resolveEmbedMediaList(
+      asMessage({
+        attachments: [],
+        embeds: [
+          {
+            image: {
+              url: "https://original.com/img.png",
+              proxy_url: "https://proxy.discord.com/img.png",
+            },
+          },
+        ],
+      }),
+      MAX_BYTES,
+    );
+
+    // proxy_url is pushed first, so it's fetched; original url is deduped or also fetched
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://proxy.discord.com/img.png" }),
+    );
+  });
+
+  it("skips embed images that duplicate attachment URLs", async () => {
+    const result = await resolveEmbedMediaList(
+      asMessage({
+        attachments: [{ url: "https://cdn.discord.com/dup.png" }],
+        embeds: [{ image: "https://cdn.discord.com/dup.png" }],
+      }),
+      MAX_BYTES,
+    );
+
+    expect(result).toEqual([]);
+    expect(fetchRemoteMedia).not.toHaveBeenCalled();
+  });
+
+  it("handles both image and thumbnail in same embed", async () => {
+    const buf = Buffer.from("img");
+    fetchRemoteMedia.mockResolvedValue({ buffer: buf, contentType: "image/png" });
+    saveMediaBuffer.mockResolvedValue({ path: "/media/x.png", contentType: "image/png" });
+
+    const result = await resolveEmbedMediaList(
+      asMessage({
+        attachments: [],
+        embeds: [
+          {
+            image: "https://a.com/img.png",
+            thumbnail: "https://b.com/thumb.png",
+          },
+        ],
+      }),
+      MAX_BYTES,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs and skips on download failure", async () => {
+    fetchRemoteMedia.mockRejectedValue(new Error("Media exceeds 5MB limit"));
+
+    const result = await resolveEmbedMediaList(
+      asMessage({
+        attachments: [],
+        embeds: [{ image: "https://big.com/huge.png" }],
+      }),
+      MAX_BYTES,
+    );
+
+    expect(result).toEqual([]);
   });
 });

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -140,6 +140,80 @@ export async function resolveMediaList(
   return out;
 }
 
+/**
+ * Extracts images from Discord embed objects (image/thumbnail fields).
+ *
+ * When a user pastes a screenshot directly into Discord, it may arrive as an
+ * embed with an `image` or `thumbnail` field rather than as a file attachment.
+ * Without this handler the image data bypasses `mediaMaxMb` and enters the LLM
+ * context unchecked, which can brick the session (see #20906).
+ */
+export async function resolveEmbedMediaList(
+  message: Message,
+  maxBytes: number,
+): Promise<DiscordMediaInfo[]> {
+  const embeds = message.embeds ?? [];
+  if (embeds.length === 0) {
+    return [];
+  }
+  const out: DiscordMediaInfo[] = [];
+  // Track URLs we already fetched via attachments to avoid duplicates.
+  // Discord sometimes duplicates attachment URLs in embed fields.
+  const seen = new Set<string>();
+  for (const attachment of message.attachments ?? []) {
+    if (attachment.url) {
+      seen.add(attachment.url);
+    }
+  }
+  for (const embed of embeds) {
+    // Carbon's Embed class flattens image/thumbnail to plain URL strings.
+    // The raw API type uses { url, proxy_url } objects. Handle both shapes.
+    const urls: string[] = [];
+    for (const field of ["image", "thumbnail"] as const) {
+      const value = embed[field];
+      if (!value) {
+        continue;
+      }
+      if (typeof value === "string") {
+        urls.push(value);
+      } else if (typeof value === "object" && "url" in value) {
+        const obj = value as { url?: string; proxy_url?: string };
+        if (obj.proxy_url) {
+          urls.push(obj.proxy_url);
+        } else if (obj.url) {
+          urls.push(obj.url);
+        }
+      }
+    }
+    for (const url of urls) {
+      if (seen.has(url)) {
+        continue;
+      }
+      seen.add(url);
+      try {
+        const fetched = await fetchRemoteMedia({
+          url,
+          filePathHint: url,
+        });
+        const saved = await saveMediaBuffer(
+          fetched.buffer,
+          fetched.contentType,
+          "inbound",
+          maxBytes,
+        );
+        out.push({
+          path: saved.path,
+          contentType: saved.contentType,
+          placeholder: "<media:image>",
+        });
+      } catch (err) {
+        logVerbose(`discord: failed to download embed image ${url}: ${String(err)}`);
+      }
+    }
+  }
+  return out;
+}
+
 export async function resolveForwardedMediaList(
   message: Message,
   maxBytes: number,


### PR DESCRIPTION
## Summary

Fixes #20906

- **Problem**: Discord inline/pasted screenshots arrive as embed `image`/`thumbnail` fields, not as file attachments. The `mediaMaxMb` check only gates file attachments via `resolveMediaList()`, so embed images bypass size limits entirely and enter the LLM context unchecked — bricking sessions permanently.
- **Why it matters**: A single large screenshot pasted into Discord can inject 5-10MB of data into context, causing permanent API failures with no user-visible error and no recovery path.
- **What changed**: Added `resolveEmbedMediaList()` to intercept images from Discord embed objects, routing them through the same `fetchRemoteMedia → saveMediaBuffer(maxBytes)` pipeline that file attachments use.
- **What did NOT change**: Attachment handling, forwarded message handling, outbound embed behavior, session history compaction.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

Fixes https://github.com/openclaw/openclaw/issues/20906
Related: #1210, #19622, #15638, #15045, #12838

## User-visible / Behavior Changes

- Discord embed images (inline pastes, link preview images) are now downloaded and size-checked against `mediaMaxMb` before entering context
- Oversized embed images are rejected with a log message instead of silently bricking the session
- No change for messages with only file attachments (existing path unchanged)

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — embed image URLs are now fetched via the existing `fetchRemoteMedia` pipeline (same SSRF protections apply)
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: Embed image downloads use the same `fetchRemoteMedia()` function as attachments, which already has SSRF guards (`resolvePinnedHostname`), redirect limits, and size caps.

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: N/A
- Model/provider: Anthropic (Claude)
- Integration/channel: Discord
- Relevant config: `channels.discord.mediaMaxMb: 2`

### Steps

1. Configure `channels.discord.mediaMaxMb: 2`
2. In Discord, paste a large screenshot (>5MB) directly into the message
3. **Before fix**: Image bypasses size check, enters context as base64, session bricks
4. **After fix**: Image is intercepted by `resolveEmbedMediaList`, `saveMediaBuffer` rejects it with "Media exceeds NMB limit", session continues normally

### Expected

- Oversized embed images are rejected; session remains functional

### Actual

- Oversized embed images are rejected; session remains functional

## Evidence

- [x] Unit tests for `resolveEmbedMediaList` covering: empty embeds, image download, proxy_url preference, attachment deduplication, image+thumbnail combo, download failure handling

## Verification (required)

- Verified scenarios: All 6 unit test cases pass
- Edge cases checked: Duplicate URL deduplication (attachment URL == embed URL), missing embeds, both image and thumbnail present, proxy_url preference
- What you did NOT verify: Live Discord integration test (requires Discord bot token + test server). I did not do the E2E test.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/discord/monitor/message-utils.ts`, `src/discord/monitor/message-handler.process.ts`
- Known bad symptoms: If embed image fetching fails silently, behavior degrades gracefully to pre-fix state (images just won't be processed)

## Risks and Mitigations

- Risk: Link preview embeds (YouTube, Twitter, etc.) may have thumbnails that get downloaded unnecessarily
  - Mitigation: These are small (typically <100KB) and go through the same maxBytes guard. The deduplication logic also prevents double-fetching when Discord includes the same URL in both attachments and embeds.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Intercepts Discord embed images (inline pastes, link previews) and routes them through the same `mediaMaxMb` validation pipeline as file attachments, preventing oversized images from bypassing limits and bricking sessions.

- Fixed critical bug where Discord embed images bypassed `mediaMaxMb` limits
- Added `resolveEmbedMediaList()` to download and validate embed images before they enter LLM context
- Implemented deduplication to avoid re-fetching URLs that are already in attachments
- Comprehensive test coverage with 6 test cases covering empty embeds, downloads, deduplication, and error handling
- Graceful error handling: failed downloads are logged and skipped rather than blocking the message

**Issue found:** The `proxy_url`/`url` handling will fetch both URLs when both are present, resulting in duplicate downloads of the same image.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the proxy_url/url duplicate fetch issue
- The PR addresses a critical bug and includes solid test coverage, but contains a logic error where both `proxy_url` and `url` are fetched when both exist, causing unnecessary duplicate downloads. This won't cause correctness issues but creates inefficiency. Once fixed, this is a well-structured addition.
- src/discord/monitor/message-utils.ts needs the proxy_url/url handling fixed (lines 181-186)

<sub>Last reviewed commit: 1fc95ad</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->