### PR TITLE
fix(feishu): escape regex metacharacters in stripBotMention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Docs: https://docs.openclaw.ai
 - Scripts: update clawdock helper command support to include `docker-compose.extra.yml` where available. (#17094) Thanks @zerone0x.
 - Security/iMessage: harden remote attachment SSH/SCP handling by requiring strict host-key verification, validating `channels.imessage.remoteHost` as `host`/`user@host`, and rejecting unsafe host tokens from config or auto-detection. Thanks @allsmog for reporting.
 - Security/Feishu: prevent path traversal in Feishu inbound media temp-file writes by replacing key-derived temp filenames with UUID-based names. Thanks @allsmog for reporting.
-- Security/Feishu: escape mention regex metacharacters in `stripBotMention` so crafted mention metadata cannot trigger regex injection or ReDoS during inbound message parsing. (#20916) Thanks @allsmog for reporting.
+- Security/Feishu: escape mention regex metacharacters in `stripBotMention` so crafted mention metadata cannot trigger regex injection or ReDoS during inbound message parsing. (#20916) Thanks @orlyjamie for the fix and @allsmog for reporting.
 - LINE/Security: harden inbound media temp-file naming by using UUID-based temp paths for downloaded media instead of external message IDs. (#20792) Thanks @mbelinky.
 - Security/Refactor: centralize hardened temp-file path generation for Feishu and LINE media downloads via shared `buildRandomTempFilePath` helper to reduce drift risk. (#20810) Thanks @mbelinky.
 - Security/Media: harden local media ingestion against TOCTOU/symlink swap attacks by pinning reads to a single file descriptor with symlink rejection and inode/device verification in `saveMediaSource`. Thanks @dorjoos for reporting.


### PR DESCRIPTION
## Summary

`stripBotMention()` in `extensions/feishu/src/bot.ts` passes `mention.name` and `mention.key` directly into `new RegExp()` without escaping regex metacharacters. This allows ReDoS via crafted nested quantifiers in Feishu mention metadata, and regex injection where metacharacters like `.*` in display names cause unintended content stripping before messages reach the LLM.

`extractMessageBody()` in `mention.ts` within the same extension already escapes correctly — this applies the same pattern consistently.

## Fix

Adds `escapeRegExp()` helper (identical pattern to `mention.ts:70`) and wraps both `mention.name` and `mention.key` before regex construction.

## Test plan

- [ ] Existing Feishu extension tests pass
- [ ] Mention stripping still works for normal display names
- [ ] Names containing `.`, `*`, `(`, `)` are treated as literals

Ref: GHSA-c6hr-w26q-c636

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a ReDoS and regex injection vulnerability in `stripBotMention()` by escaping regex metacharacters before constructing RegExp patterns from user-controlled input (`mention.name` and `mention.key`).

- Adds `escapeRegExp()` helper that escapes all regex metacharacters: `[.*+?^${}()|[\]\\]`
- Wraps both `mention.name` and `mention.key` before passing to RegExp constructor
- Uses identical escape pattern to existing code in `mention.ts:70` (`extractMessageBody`)
- Prevents crafted Feishu mention metadata with nested quantifiers from causing ReDoS
- Prevents display names containing metacharacters like `.*` from unintentionally stripping content

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward security patch that uses an identical escape pattern already proven in the same codebase (mention.ts:70). The change is minimal, focused, and addresses a documented security vulnerability (GHSA-c6hr-w26q-c636). The escapeRegExp implementation correctly escapes all 12 regex metacharacters and matches the standard pattern used across the JavaScript ecosystem.
- No files require special attention

<sub>Last reviewed commit: 89d2a0f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->