### PR TITLE
feat(trading): add /buy and /sell order commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,3 +236,58 @@
   - `node --import tsx scripts/release-check.ts`
   - `pnpm release:check`
   - `pnpm test:install:smoke` or `OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke` for non-root smoke path.
+
+## Trading Plugin (`extensions/trading/`)
+
+Channel-agnostic plugin for portfolio tracking and price quotes via Alpaca Markets API (or mock provider for development).
+
+### Structure
+
+```
+extensions/trading/
+├── openclaw.plugin.json          # Plugin manifest + JSON Schema config
+├── package.json                  # @openclaw/trading (deps: @sinclair/typebox, zod)
+├── index.ts                      # Entry point — registers tools, commands, CLI, service
+└── src/
+    ├── config.ts                 # Zod schema, env resolution (ALPACA_API_KEY/SECRET), validation
+    ├── types.ts                  # Position, AccountInfo, Quote, BrokerProvider interface
+    ├── commands.ts               # /portfolio and /price auto-reply handlers (bypass LLM)
+    ├── cli.ts                    # CLI: openclaw trading status|portfolio|price <symbol>
+    └── providers/
+        ├── alpaca.ts             # Alpaca Markets REST API (paper + live)
+        └── mock.ts               # Mock provider with fictional AAPL/MSFT/BTC data
+```
+
+### Configuration
+
+```json
+{
+  "trading": {
+    "enabled": true,
+    "provider": "mock",
+    "paperTrading": true
+  }
+}
+```
+
+For Alpaca: set `provider: "alpaca"` and provide credentials via config (`apiKey`/`apiSecret`) or env vars (`ALPACA_API_KEY`/`ALPACA_API_SECRET`). Paper trading uses `paper-api.alpaca.markets`; live uses `api.alpaca.markets`.
+
+### Registered Components
+
+| Type    | Name                              | Description                              |
+| ------- | --------------------------------- | ---------------------------------------- |
+| Tool    | `trading_portfolio`               | Account + positions + P&L (for AI agent) |
+| Tool    | `trading_price`                   | Quote for a symbol (for AI agent)        |
+| Command | `/portfolio`                      | Portfolio summary bypassing LLM          |
+| Command | `/price <SYM>`                    | Price check bypassing LLM                |
+| CLI     | `openclaw trading status`         | Account info (JSON)                      |
+| CLI     | `openclaw trading portfolio`      | Account + positions (JSON)               |
+| CLI     | `openclaw trading price <symbol>` | Quote (JSON)                             |
+| Service | `trading`                         | Lazy provider initialization             |
+
+### Patterns Used
+
+- **Provider pattern**: `BrokerProvider` interface → `AlpacaProvider` + `MockProvider`
+- **Lazy init**: `ensureProvider()` creates provider on first use only
+- **Env fallback**: config values fall back to `ALPACA_API_KEY`/`ALPACA_API_SECRET`
+- **Object-form plugin**: `{ id, name, configSchema, register(api) }` default export

--- a/extensions/trading/index.ts
+++ b/extensions/trading/index.ts
@@ -1,0 +1,242 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { registerTradingCli } from "./src/cli.js";
+import { handlePortfolioCommand, handlePriceCommand } from "./src/commands.js";
+import {
+  TradingConfigSchema,
+  resolveTradingConfig,
+  validateProviderConfig,
+  type TradingConfig,
+} from "./src/config.js";
+import { AlpacaProvider } from "./src/providers/alpaca.js";
+import { MockProvider } from "./src/providers/mock.js";
+import type { BrokerProvider } from "./src/types.js";
+
+// =============================================================================
+// Config Schema (parse + uiHints)
+// =============================================================================
+
+const tradingConfigSchema = {
+  parse(value: unknown): TradingConfig {
+    const raw =
+      value && typeof value === "object" && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+
+    const enabled = typeof raw.enabled === "boolean" ? raw.enabled : false;
+    const provider = raw.provider ?? (enabled ? "mock" : "mock");
+
+    return TradingConfigSchema.parse({
+      ...raw,
+      enabled,
+      provider,
+    });
+  },
+  uiHints: {
+    provider: {
+      label: "Broker Provider",
+      help: "Use alpaca for live/paper trading, or mock for dev/no-network.",
+    },
+    apiKey: { label: "API Key", sensitive: true },
+    apiSecret: { label: "API Secret", sensitive: true },
+    paperTrading: { label: "Paper Trading" },
+    baseUrl: { label: "Base URL Override", advanced: true },
+  },
+};
+
+// =============================================================================
+// Tool Schemas (TypeBox)
+// =============================================================================
+
+const PortfolioToolSchema = Type.Object({});
+
+const PriceToolSchema = Type.Object({
+  symbol: Type.String({ description: "Ticker symbol (e.g. AAPL, MSFT, BTC/USD)" }),
+});
+
+// =============================================================================
+// Provider Factory
+// =============================================================================
+
+function createProvider(config: TradingConfig): BrokerProvider {
+  switch (config.provider) {
+    case "alpaca":
+      return new AlpacaProvider(config);
+    case "mock":
+      return new MockProvider();
+    default:
+      throw new Error(`Unknown trading provider: ${config.provider}`);
+  }
+}
+
+// =============================================================================
+// Plugin Definition
+// =============================================================================
+
+const tradingPlugin = {
+  id: "trading",
+  name: "Trading",
+  description: "Portfolio tracking and price quotes via Alpaca Markets (or mock provider).",
+  configSchema: tradingConfigSchema,
+  register(api: OpenClawPluginApi) {
+    const config = resolveTradingConfig(tradingConfigSchema.parse(api.pluginConfig));
+    const validation = validateProviderConfig(config);
+
+    // Lazy provider initialization
+    let provider: BrokerProvider | null = null;
+
+    const ensureProvider = async (): Promise<BrokerProvider> => {
+      if (!config.enabled) {
+        throw new Error("Trading plugin is disabled in config");
+      }
+      if (!validation.valid) {
+        throw new Error(validation.errors.join("; "));
+      }
+      if (!provider) {
+        provider = createProvider(config);
+      }
+      return provider;
+    };
+
+    // -------------------------------------------------------------------------
+    // Agent Tools
+    // -------------------------------------------------------------------------
+
+    api.registerTool({
+      name: "trading_portfolio",
+      label: "Trading Portfolio",
+      description:
+        "Get the current trading account status, all open positions, and P&L summary. " +
+        "Use this when the user asks about their portfolio, positions, account balance, or P&L.",
+      parameters: PortfolioToolSchema,
+      async execute() {
+        try {
+          const p = await ensureProvider();
+          const [account, positions] = await Promise.all([p.getAccount(), p.getPositions()]);
+          const totalUnrealizedPL = positions.reduce((sum, pos) => sum + pos.unrealizedPL, 0);
+          const payload = { account, positions, totalUnrealizedPL };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+            details: payload,
+          };
+        } catch (err) {
+          const payload = { error: err instanceof Error ? err.message : String(err) };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+            details: payload,
+          };
+        }
+      },
+    });
+
+    api.registerTool({
+      name: "trading_price",
+      label: "Trading Price",
+      description:
+        "Get the current price and change for a stock or crypto symbol. " +
+        "Use this when the user asks about the price of a specific ticker.",
+      parameters: PriceToolSchema,
+      async execute(_toolCallId, params) {
+        try {
+          const symbol = typeof params?.symbol === "string" ? params.symbol.trim() : "";
+          if (!symbol) {
+            throw new Error("symbol is required");
+          }
+          const p = await ensureProvider();
+          const quote = await p.getQuote(symbol);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(quote, null, 2) }],
+            details: quote,
+          };
+        } catch (err) {
+          const payload = { error: err instanceof Error ? err.message : String(err) };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+            details: payload,
+          };
+        }
+      },
+    });
+
+    // -------------------------------------------------------------------------
+    // Auto-reply Commands (bypass LLM)
+    // -------------------------------------------------------------------------
+
+    api.registerCommand({
+      name: "portfolio",
+      description: "Show portfolio summary with positions and P&L.",
+      handler: async () => {
+        try {
+          const p = await ensureProvider();
+          const text = await handlePortfolioCommand(p);
+          return { text };
+        } catch (err) {
+          return {
+            text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+            isError: true,
+          };
+        }
+      },
+    });
+
+    api.registerCommand({
+      name: "price",
+      description: "Get the current price of a symbol. Usage: /price <SYMBOL>",
+      acceptsArgs: true,
+      handler: async (ctx) => {
+        try {
+          const symbol = ctx.args?.trim() ?? "";
+          const p = await ensureProvider();
+          const text = await handlePriceCommand(p, symbol);
+          return { text };
+        } catch (err) {
+          return {
+            text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+            isError: true,
+          };
+        }
+      },
+    });
+
+    // -------------------------------------------------------------------------
+    // CLI Commands
+    // -------------------------------------------------------------------------
+
+    api.registerCli(
+      ({ program }) =>
+        registerTradingCli({
+          program,
+          ensureProvider,
+          logger: api.logger,
+        }),
+      { commands: ["trading"] },
+    );
+
+    // -------------------------------------------------------------------------
+    // Background Service (lazy init)
+    // -------------------------------------------------------------------------
+
+    api.registerService({
+      id: "trading",
+      start: async () => {
+        if (!config.enabled) {
+          return;
+        }
+        try {
+          await ensureProvider();
+        } catch (err) {
+          api.logger.error(
+            `[trading] Failed to initialize provider: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      },
+      stop: async () => {
+        provider = null;
+      },
+    });
+  },
+};
+
+export default tradingPlugin;

--- a/extensions/trading/openclaw.plugin.json
+++ b/extensions/trading/openclaw.plugin.json
@@ -1,0 +1,59 @@
+{
+  "id": "trading",
+  "uiHints": {
+    "provider": {
+      "label": "Broker Provider",
+      "help": "Use alpaca for live/paper trading, or mock for dev/no-network."
+    },
+    "apiKey": {
+      "label": "API Key",
+      "sensitive": true
+    },
+    "apiSecret": {
+      "label": "API Secret",
+      "sensitive": true
+    },
+    "paperTrading": {
+      "label": "Paper Trading",
+      "help": "Use Alpaca paper trading endpoint (recommended for testing)."
+    },
+    "baseUrl": {
+      "label": "Base URL Override",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable or disable the trading plugin."
+      },
+      "provider": {
+        "type": "string",
+        "enum": ["alpaca", "mock"],
+        "default": "mock",
+        "description": "Broker provider to use."
+      },
+      "apiKey": {
+        "type": "string",
+        "description": "Broker API key."
+      },
+      "apiSecret": {
+        "type": "string",
+        "description": "Broker API secret."
+      },
+      "paperTrading": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use paper trading endpoints."
+      },
+      "baseUrl": {
+        "type": "string",
+        "description": "Override the broker API base URL."
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/extensions/trading/package.json
+++ b/extensions/trading/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/trading",
+  "version": "0.1.0",
+  "description": "OpenClaw trading plugin — portfolio tracking and price quotes via Alpaca Markets",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/trading/src/cli.ts
+++ b/extensions/trading/src/cli.ts
@@ -1,0 +1,56 @@
+import type { Command } from "commander";
+import type { BrokerProvider } from "./types.js";
+
+// =============================================================================
+// CLI Registration: openclaw trading <subcommand>
+// =============================================================================
+
+type Logger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+};
+
+export function registerTradingCli(params: {
+  program: Command;
+  ensureProvider: () => Promise<BrokerProvider>;
+  logger: Logger;
+}) {
+  const { program, ensureProvider } = params;
+
+  const root = program.command("trading").description("Trading portfolio & price utilities");
+
+  root
+    .command("status")
+    .description("Show account status")
+    .action(async () => {
+      const provider = await ensureProvider();
+      const account = await provider.getAccount();
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(account, null, 2));
+    });
+
+  root
+    .command("portfolio")
+    .description("Show all open positions")
+    .action(async () => {
+      const provider = await ensureProvider();
+      const [account, positions] = await Promise.all([
+        provider.getAccount(),
+        provider.getPositions(),
+      ]);
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify({ account, positions }, null, 2));
+    });
+
+  root
+    .command("price")
+    .description("Get the latest price for a symbol")
+    .argument("<symbol>", "Ticker symbol (e.g., AAPL, BTC/USD)")
+    .action(async (symbol: string) => {
+      const provider = await ensureProvider();
+      const quote = await provider.getQuote(symbol);
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(quote, null, 2));
+    });
+}

--- a/extensions/trading/src/cli.ts
+++ b/extensions/trading/src/cli.ts
@@ -53,4 +53,46 @@ export function registerTradingCli(params: {
       // eslint-disable-next-line no-console
       console.log(JSON.stringify(quote, null, 2));
     });
+
+  root
+    .command("buy")
+    .description("Place a market or limit buy order")
+    .argument("<symbol>", "Ticker symbol (e.g., AAPL)")
+    .argument("<qty>", "Number of shares to buy")
+    .option("--limit <price>", "Place a limit order at this price")
+    .action(async (symbol: string, qtyStr: string, options: { limit?: string }) => {
+      const provider = await ensureProvider();
+      const qty = Number(qtyStr);
+      const limitPrice = options.limit !== undefined ? Number(options.limit) : undefined;
+      const result = await provider.placeOrder({
+        symbol,
+        qty,
+        side: "buy",
+        type: options.limit !== undefined ? "limit" : "market",
+        limitPrice,
+      });
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(result, null, 2));
+    });
+
+  root
+    .command("sell")
+    .description("Place a market or limit sell order")
+    .argument("<symbol>", "Ticker symbol (e.g., AAPL)")
+    .argument("<qty>", "Number of shares to sell")
+    .option("--limit <price>", "Place a limit order at this price")
+    .action(async (symbol: string, qtyStr: string, options: { limit?: string }) => {
+      const provider = await ensureProvider();
+      const qty = Number(qtyStr);
+      const limitPrice = options.limit !== undefined ? Number(options.limit) : undefined;
+      const result = await provider.placeOrder({
+        symbol,
+        qty,
+        side: "sell",
+        type: options.limit !== undefined ? "limit" : "market",
+        limitPrice,
+      });
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(result, null, 2));
+    });
 }

--- a/extensions/trading/src/commands.ts
+++ b/extensions/trading/src/commands.ts
@@ -1,0 +1,63 @@
+import type { BrokerProvider, Position } from "./types.js";
+
+// =============================================================================
+// Auto-reply command handlers (bypass LLM)
+// =============================================================================
+
+function formatMoney(n: number): string {
+  return n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+}
+
+function formatPercent(n: number): string {
+  const sign = n >= 0 ? "+" : "";
+  return `${sign}${n.toFixed(2)}%`;
+}
+
+function formatPosition(p: Position): string {
+  const pl = `${formatMoney(p.unrealizedPL)} (${formatPercent(p.unrealizedPLPercent)})`;
+  return `${p.symbol}: ${p.qty} shares @ ${formatMoney(p.avgEntryPrice)} → ${formatMoney(p.currentPrice)} | P&L: ${pl}`;
+}
+
+export async function handlePortfolioCommand(provider: BrokerProvider): Promise<string> {
+  const [account, positions] = await Promise.all([provider.getAccount(), provider.getPositions()]);
+
+  const lines: string[] = [
+    "📊 Portfolio Summary",
+    `Equity: ${formatMoney(account.equity)}`,
+    `Cash: ${formatMoney(account.cash)}`,
+    `Buying Power: ${formatMoney(account.buyingPower)}`,
+    `Day P&L: ${formatMoney(account.dayPL)} (${formatPercent(account.dayPLPercent)})`,
+    "",
+  ];
+
+  if (positions.length === 0) {
+    lines.push("No open positions.");
+  } else {
+    lines.push(`Positions (${positions.length}):`);
+    for (const p of positions) {
+      lines.push(`  ${formatPosition(p)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export async function handlePriceCommand(
+  provider: BrokerProvider,
+  symbol: string,
+): Promise<string> {
+  if (!symbol) {
+    return "Usage: /price <SYMBOL>  (e.g., /price AAPL)";
+  }
+
+  const quote = await provider.getQuote(symbol);
+  const sign = quote.change >= 0 ? "+" : "";
+  return [
+    `💰 ${quote.symbol}`,
+    `Price: ${formatMoney(quote.lastPrice)}`,
+    `Change: ${sign}${formatMoney(quote.change)} (${formatPercent(quote.changePercent)})`,
+    quote.volume > 0 ? `Volume: ${quote.volume.toLocaleString("en-US")}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/extensions/trading/src/commands.ts
+++ b/extensions/trading/src/commands.ts
@@ -1,4 +1,4 @@
-import type { BrokerProvider, Position } from "./types.js";
+import type { BrokerProvider, OrderSide, OrderType, Position } from "./types.js";
 
 // =============================================================================
 // Auto-reply command handlers (bypass LLM)
@@ -40,6 +40,72 @@ export async function handlePortfolioCommand(provider: BrokerProvider): Promise<
   }
 
   return lines.join("\n");
+}
+
+export async function handleBuyCommand(provider: BrokerProvider, args: string): Promise<string> {
+  return handleOrderCommand(provider, "buy", args);
+}
+
+export async function handleSellCommand(provider: BrokerProvider, args: string): Promise<string> {
+  return handleOrderCommand(provider, "sell", args);
+}
+
+async function handleOrderCommand(
+  provider: BrokerProvider,
+  side: OrderSide,
+  args: string,
+): Promise<string> {
+  const parts = args.trim().split(/\s+/).filter(Boolean);
+  const symbol = parts[0];
+  const qty = Number(parts[1]);
+
+  if (!symbol || !parts[1]) {
+    return (
+      `Usage: /${side} <SYMBOL> <QTY> [limit <PRICE>]\n` +
+      `  /${side} AAPL 10            — market ${side}\n` +
+      `  /${side} AAPL 10 limit 150  — limit ${side} @ $150`
+    );
+  }
+
+  if (isNaN(qty) || qty <= 0) {
+    return `Error: qty must be a positive number (got "${parts[1]}")`;
+  }
+
+  let orderType: OrderType = "market";
+  let limitPrice: number | undefined;
+
+  if (parts[2]?.toLowerCase() === "limit") {
+    if (!parts[3]) {
+      return `Error: limit order requires a price — e.g. /${side} ${symbol} ${qty} limit 150`;
+    }
+    limitPrice = Number(parts[3]);
+    if (isNaN(limitPrice) || limitPrice <= 0) {
+      return `Error: limit price must be a positive number (got "${parts[3]}")`;
+    }
+    orderType = "limit";
+  }
+
+  const result = await provider.placeOrder({ symbol, qty, side, type: orderType, limitPrice });
+
+  const sideLabel = side === "buy" ? "Buy" : "Sell";
+  const orderDesc =
+    orderType === "limit" && result.limitPrice !== undefined
+      ? `${result.qty} shares (limit @ ${formatMoney(result.limitPrice)})`
+      : `${result.qty} shares (market)`;
+
+  const warning =
+    side === "sell" && provider.name !== "mock"
+      ? "\n⚠️  Warning: sell orders in live mode are irreversible."
+      : "";
+
+  return [
+    `✅ ${sideLabel} Order Submitted`,
+    `${result.symbol}: ${orderDesc}`,
+    `Status: ${result.status} | ID: ${result.id}`,
+    warning,
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 export async function handlePriceCommand(

--- a/extensions/trading/src/config.ts
+++ b/extensions/trading/src/config.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+// =============================================================================
+// Trading Configuration Schema
+// =============================================================================
+
+export const TradingConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    provider: z.enum(["alpaca", "mock"]).default("mock"),
+    apiKey: z.string().min(1).optional(),
+    apiSecret: z.string().min(1).optional(),
+    paperTrading: z.boolean().default(true),
+    baseUrl: z.string().url().optional(),
+  })
+  .strict();
+
+export type TradingConfig = z.infer<typeof TradingConfigSchema>;
+
+// =============================================================================
+// Config Resolution (env fallback)
+// =============================================================================
+
+export function resolveTradingConfig(config: TradingConfig): TradingConfig {
+  return {
+    ...config,
+    apiKey: config.apiKey || process.env.ALPACA_API_KEY || undefined,
+    apiSecret: config.apiSecret || process.env.ALPACA_API_SECRET || undefined,
+  };
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+export function validateProviderConfig(config: TradingConfig): {
+  valid: boolean;
+  errors: string[];
+} {
+  const errors: string[] = [];
+
+  if (!config.enabled) {
+    return { valid: false, errors: ["Trading plugin is disabled"] };
+  }
+
+  if (config.provider === "alpaca") {
+    if (!config.apiKey) {
+      errors.push("Alpaca API key is required. Set apiKey in config or ALPACA_API_KEY env var.");
+    }
+    if (!config.apiSecret) {
+      errors.push(
+        "Alpaca API secret is required. Set apiSecret in config or ALPACA_API_SECRET env var.",
+      );
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/extensions/trading/src/providers/alpaca.ts
+++ b/extensions/trading/src/providers/alpaca.ts
@@ -1,0 +1,166 @@
+import type { TradingConfig } from "../config.js";
+import type { AccountInfo, BrokerProvider, Position, Quote } from "../types.js";
+
+// =============================================================================
+// Alpaca Markets REST API Provider
+// =============================================================================
+
+export class AlpacaProvider implements BrokerProvider {
+  readonly name = "alpaca";
+  private readonly baseUrl: string;
+  private readonly dataUrl = "https://data.alpaca.markets";
+  private readonly headers: Record<string, string>;
+
+  constructor(config: TradingConfig) {
+    if (!config.apiKey || !config.apiSecret) {
+      throw new Error("Alpaca provider requires apiKey and apiSecret");
+    }
+
+    this.baseUrl =
+      config.baseUrl ??
+      (config.paperTrading ? "https://paper-api.alpaca.markets" : "https://api.alpaca.markets");
+
+    this.headers = {
+      "APCA-API-KEY-ID": config.apiKey,
+      "APCA-API-SECRET-KEY": config.apiSecret,
+      Accept: "application/json",
+    };
+  }
+
+  private async request<T>(url: string, headers?: Record<string, string>): Promise<T> {
+    const res = await fetch(url, {
+      headers: headers ?? this.headers,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`Alpaca API error ${res.status}: ${body}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  async getAccount(): Promise<AccountInfo> {
+    const acc = await this.request<AlpacaAccount>(`${this.baseUrl}/v2/account`);
+    const equity = Number(acc.equity);
+    const lastEquity = Number(acc.last_equity);
+    const dayPL = equity - lastEquity;
+    return {
+      equity,
+      cash: Number(acc.cash),
+      buyingPower: Number(acc.buying_power),
+      portfolioValue: equity,
+      dayPL,
+      dayPLPercent: lastEquity !== 0 ? (dayPL / lastEquity) * 100 : 0,
+    };
+  }
+
+  async getPositions(): Promise<Position[]> {
+    const positions = await this.request<AlpacaPosition[]>(`${this.baseUrl}/v2/positions`);
+    return positions.map((p) => ({
+      symbol: p.symbol,
+      qty: Number(p.qty),
+      marketValue: Number(p.market_value),
+      avgEntryPrice: Number(p.avg_entry_price),
+      currentPrice: Number(p.current_price),
+      unrealizedPL: Number(p.unrealized_pl),
+      unrealizedPLPercent: Number(p.unrealized_plpc) * 100,
+    }));
+  }
+
+  async getQuote(symbol: string): Promise<Quote> {
+    const upper = symbol.toUpperCase();
+    const isCrypto = upper.includes("/");
+
+    let lastPrice: number;
+    let volume: number;
+
+    if (isCrypto) {
+      const encoded = encodeURIComponent(upper);
+      const data = await this.request<AlpacaCryptoQuote>(
+        `${this.dataUrl}/v1beta3/crypto/us/latest/quotes?symbols=${encoded}`,
+      );
+      const quote = data.quotes?.[upper];
+      if (!quote) {
+        throw new Error(`No crypto quote found for ${upper}`);
+      }
+      lastPrice = (Number(quote.ap) + Number(quote.bp)) / 2;
+      volume = 0; // Crypto quotes don't include volume in quote endpoint
+    } else {
+      const data = await this.request<AlpacaStockQuote>(
+        `${this.dataUrl}/v2/stocks/${encodeURIComponent(upper)}/quotes/latest`,
+      );
+      lastPrice = (Number(data.quote.ap) + Number(data.quote.bp)) / 2;
+      volume = 0; // Latest quote doesn't include volume; would need snapshot
+    }
+
+    // Try to get previous close for change calculation via snapshot
+    let change = 0;
+    let changePercent = 0;
+    try {
+      if (!isCrypto) {
+        const snap = await this.request<AlpacaStockSnapshot>(
+          `${this.dataUrl}/v2/stocks/${encodeURIComponent(upper)}/snapshot`,
+        );
+        const prevClose = Number(snap.prevDailyBar?.c ?? 0);
+        if (prevClose > 0) {
+          change = lastPrice - prevClose;
+          changePercent = (change / prevClose) * 100;
+        }
+        volume = Number(snap.dailyBar?.v ?? 0);
+      }
+    } catch {
+      // Snapshot may not be available for all symbols
+    }
+
+    return {
+      symbol: upper,
+      lastPrice: Math.round(lastPrice * 100) / 100,
+      change: Math.round(change * 100) / 100,
+      changePercent: Math.round(changePercent * 100) / 100,
+      volume,
+    };
+  }
+}
+
+// =============================================================================
+// Alpaca API Response Types
+// =============================================================================
+
+type AlpacaAccount = {
+  equity: string;
+  cash: string;
+  buying_power: string;
+  last_equity: string;
+  portfolio_value: string;
+};
+
+type AlpacaPosition = {
+  symbol: string;
+  qty: string;
+  market_value: string;
+  avg_entry_price: string;
+  current_price: string;
+  unrealized_pl: string;
+  unrealized_plpc: string;
+};
+
+type AlpacaStockQuote = {
+  quote: {
+    ap: number; // ask price
+    bp: number; // bid price
+  };
+};
+
+type AlpacaCryptoQuote = {
+  quotes?: Record<
+    string,
+    {
+      ap: number;
+      bp: number;
+    }
+  >;
+};
+
+type AlpacaStockSnapshot = {
+  prevDailyBar?: { c: number };
+  dailyBar?: { v: number };
+};

--- a/extensions/trading/src/providers/mock.ts
+++ b/extensions/trading/src/providers/mock.ts
@@ -1,0 +1,98 @@
+import type { AccountInfo, BrokerProvider, Position, Quote } from "../types.js";
+
+// =============================================================================
+// Mock Broker Provider — returns fictional data for development/testing
+// =============================================================================
+
+const MOCK_POSITIONS: Position[] = [
+  {
+    symbol: "AAPL",
+    qty: 10,
+    marketValue: 1_890.0,
+    avgEntryPrice: 175.0,
+    currentPrice: 189.0,
+    unrealizedPL: 140.0,
+    unrealizedPLPercent: 8.0,
+  },
+  {
+    symbol: "MSFT",
+    qty: 5,
+    marketValue: 2_100.0,
+    avgEntryPrice: 390.0,
+    currentPrice: 420.0,
+    unrealizedPL: 150.0,
+    unrealizedPLPercent: 7.69,
+  },
+  {
+    symbol: "BTC/USD",
+    qty: 0.5,
+    marketValue: 25_000.0,
+    avgEntryPrice: 45_000.0,
+    currentPrice: 50_000.0,
+    unrealizedPL: 2_500.0,
+    unrealizedPLPercent: 11.11,
+  },
+];
+
+const MOCK_QUOTES: Record<string, Quote> = {
+  AAPL: { symbol: "AAPL", lastPrice: 189.0, change: 2.5, changePercent: 1.34, volume: 52_431_000 },
+  MSFT: {
+    symbol: "MSFT",
+    lastPrice: 420.0,
+    change: -1.2,
+    changePercent: -0.28,
+    volume: 21_890_000,
+  },
+  "BTC/USD": {
+    symbol: "BTC/USD",
+    lastPrice: 50_000.0,
+    change: 1_200.0,
+    changePercent: 2.46,
+    volume: 18_200,
+  },
+  TSLA: { symbol: "TSLA", lastPrice: 245.0, change: 5.3, changePercent: 2.21, volume: 98_200_000 },
+  GOOGL: {
+    symbol: "GOOGL",
+    lastPrice: 155.0,
+    change: -0.8,
+    changePercent: -0.51,
+    volume: 28_100_000,
+  },
+};
+
+export class MockProvider implements BrokerProvider {
+  readonly name = "mock";
+
+  async getAccount(): Promise<AccountInfo> {
+    return {
+      equity: 28_990.0,
+      cash: 5_000.0,
+      buyingPower: 10_000.0,
+      portfolioValue: 28_990.0,
+      dayPL: 320.5,
+      dayPLPercent: 1.12,
+    };
+  }
+
+  async getPositions(): Promise<Position[]> {
+    return MOCK_POSITIONS;
+  }
+
+  async getQuote(symbol: string): Promise<Quote> {
+    const upper = symbol.toUpperCase();
+    const quote = MOCK_QUOTES[upper];
+    if (quote) {
+      return quote;
+    }
+    // Generate a random-ish quote for unknown symbols
+    const price = 100 + Math.random() * 200;
+    const change = (Math.random() - 0.5) * 10;
+    return {
+      symbol: upper,
+      lastPrice: Math.round(price * 100) / 100,
+      change: Math.round(change * 100) / 100,
+      changePercent: Math.round((change / price) * 10000) / 100,
+      volume: Math.floor(Math.random() * 50_000_000),
+    };
+  }
+}

--- a/extensions/trading/src/providers/mock.ts
+++ b/extensions/trading/src/providers/mock.ts
@@ -1,4 +1,11 @@
-import type { AccountInfo, BrokerProvider, Position, Quote } from "../types.js";
+import type {
+  AccountInfo,
+  BrokerProvider,
+  OrderRequest,
+  OrderResult,
+  Position,
+  Quote,
+} from "../types.js";
 
 // =============================================================================
 // Mock Broker Provider — returns fictional data for development/testing
@@ -76,6 +83,20 @@ export class MockProvider implements BrokerProvider {
 
   async getPositions(): Promise<Position[]> {
     return MOCK_POSITIONS;
+  }
+
+  async placeOrder(req: OrderRequest): Promise<OrderResult> {
+    const id = `mock-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+    return {
+      id,
+      symbol: req.symbol.toUpperCase(),
+      qty: req.qty,
+      side: req.side,
+      type: req.type,
+      status: "accepted",
+      submittedAt: new Date().toISOString(),
+      limitPrice: req.limitPrice,
+    };
   }
 
   async getQuote(symbol: string): Promise<Quote> {

--- a/extensions/trading/src/types.ts
+++ b/extensions/trading/src/types.ts
@@ -1,0 +1,41 @@
+// =============================================================================
+// Trading Data Types
+// =============================================================================
+
+export type Position = {
+  symbol: string;
+  qty: number;
+  marketValue: number;
+  avgEntryPrice: number;
+  currentPrice: number;
+  unrealizedPL: number;
+  unrealizedPLPercent: number;
+};
+
+export type AccountInfo = {
+  equity: number;
+  cash: number;
+  buyingPower: number;
+  portfolioValue: number;
+  dayPL: number;
+  dayPLPercent: number;
+};
+
+export type Quote = {
+  symbol: string;
+  lastPrice: number;
+  change: number;
+  changePercent: number;
+  volume: number;
+};
+
+// =============================================================================
+// Broker Provider Interface
+// =============================================================================
+
+export interface BrokerProvider {
+  readonly name: string;
+  getAccount(): Promise<AccountInfo>;
+  getPositions(): Promise<Position[]>;
+  getQuote(symbol: string): Promise<Quote>;
+}

--- a/extensions/trading/src/types.ts
+++ b/extensions/trading/src/types.ts
@@ -30,6 +30,32 @@ export type Quote = {
 };
 
 // =============================================================================
+// Order Types
+// =============================================================================
+
+export type OrderSide = "buy" | "sell";
+export type OrderType = "market" | "limit";
+
+export type OrderRequest = {
+  symbol: string;
+  qty: number;
+  side: OrderSide;
+  type: OrderType;
+  limitPrice?: number;
+};
+
+export type OrderResult = {
+  id: string;
+  symbol: string;
+  qty: number;
+  side: OrderSide;
+  type: OrderType;
+  status: string;
+  submittedAt: string;
+  limitPrice?: number;
+};
+
+// =============================================================================
 // Broker Provider Interface
 // =============================================================================
 
@@ -38,4 +64,5 @@ export interface BrokerProvider {
   getAccount(): Promise<AccountInfo>;
   getPositions(): Promise<Position[]>;
   getQuote(symbol: string): Promise<Quote>;
+  placeOrder(req: OrderRequest): Promise<OrderResult>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,19 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/trading:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/twitch:
     dependencies:
       '@twurple/api':
@@ -6912,7 +6925,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6928,7 +6941,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7132,7 +7145,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8079,7 +8092,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8125,7 +8138,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -9013,14 +9026,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9599,8 +9604,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Add `OrderSide`, `OrderType`, `OrderRequest`, `OrderResult` types and extend `BrokerProvider` with `placeOrder()`
- Implement `placeOrder` in `AlpacaProvider` via `POST /v2/orders` (paper trading by default)
- Implement mock `placeOrder` returning `status: "accepted"` with a fake ID
- Add `/buy` and `/sell` auto-reply commands with market and limit order support
- Add `trading_order` agent tool (TypeBox schema) for LLM-driven order placement
- Add `trading buy` / `trading sell` CLI subcommands with `--limit` flag

## Usage

```
/buy AAPL 10            → market buy 10 shares
/buy AAPL 10 limit 150  → limit buy @ $150
/sell AAPL 5            → market sell 5 shares
/sell AAPL 5 limit 180  → limit sell @ $180

openclaw trading buy AAPL 10
openclaw trading sell AAPL 5 --limit 180
```

## Test plan

- [ ] Mock provider: `/buy AAPL 10` → confirmation with fake ID
- [ ] Mock provider: `/sell AAPL 5 limit 180` → limit order confirmation
- [ ] Mock provider: `/buy` (no args) → usage hint
- [ ] CLI: `openclaw trading buy AAPL 10` → JSON output
- [ ] TypeScript: `pnpm tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added trading plugin with `/buy` and `/sell` order commands via Alpaca Markets API. Implemented order placement with market and limit order types, plus portfolio tracking and price quotes. Added CLI subcommands (`openclaw trading buy/sell`) and agent tools (`trading_order`, `trading_portfolio`, `trading_price`).

- Uses `Type.Union` in tool schemas which violates AGENTS.md:184 guardrails (produces `anyOf` that some providers reject) — must use `stringEnum` helper instead
- AGENTS.md documentation incomplete — missing `/buy`, `/sell` commands and `trading_order` tool in Registered Components table
- Clean provider pattern with mock and Alpaca implementations
- Proper lazy initialization and error handling throughout
- Warning messages for irreversible sell orders in live mode

<h3>Confidence Score: 3/5</h3>

- Safe to merge with fixes — schema issue will cause tool failures on some LLM providers
- Score reflects one critical syntax issue (`Type.Union` in tool schemas violates established guardrails and will break on providers like Vertex AI) and incomplete documentation. The implementation is otherwise solid with proper validation, error handling, and safety warnings for live trading. The schema fix is straightforward (swap `Type.Union` for `stringEnum`), and docs need updating to match implemented features.
- extensions/trading/index.ts requires schema fix, AGENTS.md needs complete feature documentation

<sub>Last reviewed commit: 04de311</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->