### PR TITLE
autofix: format 3 files (oxfmt)

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -7,8 +7,6 @@ import {
   DEFAULT_GROUP_HISTORY_LIMIT,
   type HistoryEntry,
 } from "openclaw/plugin-sdk";
-import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
-import type { DynamicAgentCreationConfig } from "./types.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { tryRecordMessage } from "./dedup.js";
@@ -25,6 +23,8 @@ import {
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, sendMessageFeishu } from "./send.js";
+import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
+import type { DynamicAgentCreationConfig } from "./types.js";
 
 // --- Permission error extraction ---
 // Extract permission grant URL from Feishu API error response.

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
-import { withTempDownloadPath, type ClawdbotConfig } from "openclaw/plugin-sdk";
 import path from "path";
 import { Readable } from "stream";
+import { withTempDownloadPath, type ClawdbotConfig } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";

--- a/src/media-understanding/attachments.ts
+++ b/src/media-understanding/attachments.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { MediaUnderstandingAttachmentsConfig } from "../config/types.tools.js";
-import type { MediaAttachment, MediaUnderstandingCapability } from "./types.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { isAbortError } from "../infra/unhandled-rejections.js";
 import { fetchRemoteMedia, MediaFetchError } from "../media/fetch.js";
@@ -11,6 +10,7 @@ import { detectMime, getFileExtension, isAudioFileName, kindFromMime } from "../
 import { buildRandomTempFilePath } from "../plugin-sdk/temp-path.js";
 import { MediaUnderstandingSkipError } from "./errors.js";
 import { fetchWithTimeout } from "./providers/shared.js";
+import type { MediaAttachment, MediaUnderstandingCapability } from "./types.js";
 
 type MediaBufferResult = {
   buffer: Buffer;


### PR DESCRIPTION
Auto-fix formatting issues detected in CI run #22183088474

Files formatted:
- extensions/feishu/src/bot.ts
- extensions/feishu/src/media.ts  
- src/media-understanding/attachments.ts

*Generated by tofu-autofix monitor*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Automated formatting fix that reorders import statements in 3 files according to `oxfmt` rules. All changes are purely stylistic - type-only imports are moved after regular imports, following TypeScript best practices. No functional changes to the code.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- All changes are formatting-only import reordering with no logic changes. Import order doesn't affect runtime behavior in JavaScript/TypeScript, and the formatting follows standard conventions (type imports after regular imports).
- No files require special attention

<sub>Last reviewed commit: 83d02ad</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->