### PR TITLE
feat: per-agent model allowlist

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -89,6 +89,52 @@ Example allowlist config:
 }
 ```
 
+### Per-agent model allowlist
+
+Individual agents in `agents.list[]` can define their own `models` map. When
+present, it **replaces** the global `agents.defaults.models` for that agent (no
+merge). When absent, the agent uses the global allowlist as before.
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "models": {
+        "anthropic/claude-opus-4-6": { "alias": "Opus 4.6" },
+        "anthropic/claude-sonnet-4-6": { "alias": "Sonnet 4.6" },
+        "google/gemini-2.5-pro": { "alias": "Gemini Pro" },
+        "openai/gpt-4o": { "alias": "GPT-4o" }
+      }
+    },
+    "list": [
+      {
+        "id": "karl-jacob",
+        "model": { "primary": "anthropic/claude-opus-4-6" },
+        "models": {
+          "anthropic/claude-opus-4-6": { "alias": "Opus 4.6" },
+          "anthropic/claude-sonnet-4-6": { "alias": "Sonnet 4.6" }
+        }
+      }
+    ]
+  }
+}
+```
+
+In this example, `karl-jacob` can only use Opus 4.6 and Sonnet 4.6. All other
+agents without a per-agent `models` see the full global catalog (including
+Gemini Pro and GPT-4o).
+
+This affects:
+
+- `/model` switching (only allowlisted models are selectable)
+- `/models` listing (shows only the agent's allowlist)
+- Telegram model picker buttons (scoped to the agent's allowlist)
+- Session model override validation (resets disallowed overrides)
+
+The per-agent `models` map uses the same shape as the global
+`agents.defaults.models`: keys are `provider/model`, values have optional
+`alias`, `params`, and `streaming` fields.
+
 ## Switching models in chat (`/model`)
 
 You can switch models for the current session without restarting:

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -534,3 +534,31 @@ If you need per-agent boundaries, use `agents.list[].tools` to deny `exec`.
 For group targeting, use `agents.list[].groupChat.mentionPatterns` so @mentions map cleanly to the intended agent.
 
 See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for detailed examples.
+
+## Per-Agent Model Allowlist
+
+Each agent can restrict which models are available via `/model` and the Telegram
+model picker. Set `models` on the agent entry to override the global
+`agents.defaults.models` allowlist:
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "karl-jacob",
+        "model": { "primary": "anthropic/claude-opus-4-6" },
+        "models": {
+          "anthropic/claude-opus-4-6": { "alias": "Opus 4.6" },
+          "anthropic/claude-sonnet-4-6": { "alias": "Sonnet 4.6" }
+        }
+      }
+    ]
+  }
+}
+```
+
+When `models` is present, it **replaces** (not merges) the global allowlist for
+that agent. Agents without a `models` field continue to use the global catalog.
+
+See [Models CLI - Per-agent model allowlist](/concepts/models#per-agent-model-allowlist) for details.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -983,6 +983,11 @@ scripts/sandbox-browser-setup.sh   # optional browser image
         workspace: "~/.openclaw/workspace",
         agentDir: "~/.openclaw/agents/main/agent",
         model: "anthropic/claude-opus-4-6", // or { primary, fallbacks }
+        models: {
+          // optional; replaces agents.defaults.models for this agent
+          "anthropic/claude-opus-4-6": { alias: "Opus" },
+          "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+        },
         identity: {
           name: "Samantha",
           theme: "helpful sloth",
@@ -1007,6 +1012,7 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `id`: stable agent id (required).
 - `default`: when multiple are set, first wins (warning logged). If none set, first list entry is default.
 - `model`: string form overrides `primary` only; object form `{ primary, fallbacks }` overrides both (`[]` disables global fallbacks). Cron jobs that only override `primary` still inherit default fallbacks unless you set `fallbacks: []`.
+- `models`: per-agent model allowlist. Same shape as `agents.defaults.models`. When present, **replaces** (not merges) the global allowlist for this agent. Omit to use global. See [Models CLI](/concepts/models#per-agent-model-allowlist).
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).

--- a/skills/findmy/SKILL.md
+++ b/skills/findmy/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: findmy
+description: Locate Cole's Apple devices using Find My via pyicloud on the Mac Mini. Use when asked to find a device, check phone location/battery, or locate anything Apple.
+metadata: { "openclaw": { "emoji": "📍" } }
+---
+
+# Find My Devices
+
+## Overview
+
+Query Apple Find My device locations by SSHing into Cole's Mac Mini and running pyicloud. Returns device names, locations (lat/lon), and battery levels.
+
+## Requirements
+
+- SSH key access to `coletebou@100.120.154.29` (Mac Mini on Tailscale)
+- Key at `/root/.ssh/id_ed25519` — **unsandboxed agents only**
+- pyicloud installed on the Mac (`/Library/Developer/CommandLineTools/usr/bin/python3`)
+- Cached iCloud session for `coletebou@gmail.com` (already authenticated)
+
+## Usage
+
+```bash
+python3 /opt/openclaw/skills/findmy/scripts/find_my_devices.py
+```
+
+### Options
+
+- `--json` — Output raw JSON (for programmatic use)
+- No flags — Human-readable output with names, locations, battery
+
+### Example output
+
+```
+Future Fone (iPhone 15 Pro): 39.043, -77.112 | Battery: 62%
+Cole's Apple Watch (Apple Watch Ultra 2): 39.043, -77.112 | Battery: 87%
+Cole's Mac mini (Mac mini (2024)): 39.049, -77.107 | Battery: 0%
+```
+
+## Limitations
+
+- **Only Cole's own devices** — Find My Friends (other people's locations) is not available via the iCloud web API. Apple deprecated it.
+- **Unsandboxed agents only** — Requires SSH key at `/root/.ssh/id_ed25519`. Sandboxed agents in Docker cannot access this.
+- Some devices (old iPhones, iPods, iPads not in use) will show "No location".
+
+## Reverse Geocoding
+
+The script returns raw lat/lon. To make it human-readable, use a web search or geocoding service to convert coordinates to an address/neighborhood.

--- a/skills/findmy/scripts/find_my_devices.py
+++ b/skills/findmy/scripts/find_my_devices.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Query Find My device locations via pyicloud on Cole's Mac Mini."""
+import json
+import subprocess
+import sys
+import tempfile
+import os
+
+REMOTE_SCRIPT = r'''
+import json
+from pyicloud import PyiCloudService
+api = PyiCloudService('coletebou@gmail.com')
+devices = api.devices
+r = devices.response
+content = r.get('content', [])
+results = []
+for d in content:
+    loc = d.get('location')
+    results.append({
+        'name': d.get('name', 'Unknown'),
+        'model': d.get('deviceDisplayName', ''),
+        'class': d.get('deviceClass', ''),
+        'battery': d.get('batteryLevel', None),
+        'batteryStatus': d.get('batteryStatus', ''),
+        'latitude': loc.get('latitude') if loc else None,
+        'longitude': loc.get('longitude') if loc else None,
+        'locationTimestamp': loc.get('timeStamp') if loc else None,
+    })
+print(json.dumps(results, indent=2))
+'''
+
+SSH_OPTS = ['-o', 'ConnectTimeout=10', '-o', 'IdentitiesOnly=yes', '-i', '/root/.ssh/id_ed25519']
+SSH_HOST = 'coletebou@100.120.154.29'
+PYTHON = '/Library/Developer/CommandLineTools/usr/bin/python3'
+
+def get_devices():
+    # Write script to remote, then execute it
+    # Step 1: write script to temp file on Mac
+    result = subprocess.run(
+        ['ssh'] + SSH_OPTS + [SSH_HOST, f'cat > /tmp/_findmy.py << \'PYEOF\'\n{REMOTE_SCRIPT}\nPYEOF'],
+        capture_output=True, text=True, timeout=15
+    )
+    # Step 2: run it
+    result = subprocess.run(
+        ['ssh'] + SSH_OPTS + [SSH_HOST, f'{PYTHON} /tmp/_findmy.py'],
+        capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+if __name__ == '__main__':
+    devices = get_devices()
+    if '--json' in sys.argv:
+        print(json.dumps(devices, indent=2))
+    else:
+        for d in devices:
+            loc_str = f"{d['latitude']}, {d['longitude']}" if d['latitude'] else "No location"
+            battery = f" | Battery: {int(d['battery']*100)}%" if d['battery'] is not None else ""
+            print(f"  {d['name']} ({d['model']}): {loc_str}{battery}")

--- a/skills/group-manager/SKILL.md
+++ b/skills/group-manager/SKILL.md
@@ -1,0 +1,166 @@
+# Group Manager Skill
+
+Manage iMessage group chat bindings for multi-agent BlueBubbles deployments.
+
+## Overview
+
+When multiple agents share a single BlueBubbles/iCloud account (e.g., karl-brett, karl-kellen, karl-grant all on the `karl` account), group chats need explicit bindings to route to the correct agent. This skill handles:
+
+1. **Auto-binding** — Detect new groups, match members to existing customers, auto-bind unambiguous ones
+2. **Manual claim/unclaim** — Let agents claim or release groups
+3. **Group listing** — Show which groups are bound to which agents
+
+## How It Works
+
+- Each customer has a **DM peer binding** (e.g., +12035548311 → karl-brett)
+- When the iCloud account is added to a group, we check which customers are members
+- **Exactly 1 customer** → auto-bind to their agent
+- **Multiple customers** → conflict → stay silent until someone claims
+- **Zero customers** → ignore (no customer in this group)
+
+## Scripts
+
+All scripts are in `scripts/` relative to this skill directory. They output JSON.
+
+### scan-groups.sh
+
+Scans all BlueBubbles groups and analyzes binding status.
+
+```bash
+scripts/scan-groups.sh
+```
+
+Output: `{ summary: {...}, groups: [{guid, displayName, status, boundTo, matchingCustomers}] }`
+
+Status values:
+
+- `bound` — already has a binding
+- `auto-bindable` — exactly 1 customer member, safe to auto-bind
+- `conflict` — multiple customers, needs manual resolution
+- `unbound-no-customers` — no known customers in group
+
+### auto-bind.sh
+
+Detects auto-bindable groups and generates a config patch.
+
+```bash
+scripts/auto-bind.sh [--dry-run]
+```
+
+- `--dry-run` — show what would be bound without generating a live patch
+- Without `--dry-run` — generates a `patch` field ready for `gateway config.patch`
+
+Output includes `patch` field — apply it with the gateway tool:
+
+```
+gateway(action="config.patch", raw=<patch JSON>, note="Auto-bound N groups")
+```
+
+### claim-group.sh
+
+Claim or unclaim a specific group.
+
+```bash
+# Claim
+scripts/claim-group.sh --claim --agent-id karl-brett --group-identifier <id>
+
+# Unclaim
+scripts/claim-group.sh --unclaim --group-identifier <id>
+```
+
+The `--group-identifier` accepts:
+
+- Full GUID (e.g., `any;+;abc123...`)
+- Chat identifier (e.g., `abc123...` or `chat12345...`)
+- Display name (case-insensitive, must be unique match)
+
+Output includes `patch` field for `gateway config.patch`.
+
+### list-groups.sh
+
+List bound groups, optionally filtered by agent.
+
+```bash
+# All groups
+scripts/list-groups.sh
+
+# Groups for a specific agent
+scripts/list-groups.sh --agent-id karl-brett
+```
+
+## Environment
+
+Scripts use these defaults (override via args or env vars):
+
+| Variable      | Default                      | Description                           |
+| ------------- | ---------------------------- | ------------------------------------- |
+| `BB_URL`      | `http://100.120.154.29:1235` | BlueBubbles server URL (karl account) |
+| `BB_PASSWORD` | `$BLUEBUBBLES_KARL_PASSWORD` | BlueBubbles password                  |
+| `CONFIG_PATH` | `~/.openclaw/openclaw.json`  | OpenClaw config path                  |
+| `ACCOUNT_ID`  | `karl`                       | BlueBubbles account ID                |
+
+## Agent Integration
+
+### For karl-default (catch-all agent)
+
+karl-default receives messages from unbound groups. When it gets a group message, it should:
+
+1. Run `scan-groups.sh` to check if there are auto-bindable groups
+2. If auto-bindable groups exist, run `auto-bind.sh` (NOT --dry-run)
+3. Apply the patch via `gateway config.patch`
+4. Notify the customer via their DM that their group was activated
+5. Stay silent in the group (don't respond to the triggering message)
+
+For conflicts, notify all matching customers via DM about the conflict and ask them to `/claim` it.
+
+### For customer agents (karl-brett, karl-kellen, etc.)
+
+Handle these commands from their DM user:
+
+- **`/groups`** — Run `list-groups.sh --agent-id <self>` and show results
+- **`/claim <group>`** — Run `claim-group.sh --claim --agent-id <self> --group-identifier <group>`, apply the patch
+- **`/unclaim <group>`** — Run `claim-group.sh --unclaim --group-identifier <group>`, apply the patch
+
+### Applying Patches
+
+All scripts that modify config output a `patch` field. Apply it like this:
+
+```
+gateway(action="config.patch", raw=JSON.stringify(result.patch), note="<description>")
+```
+
+**Important:** After applying a patch, the gateway restarts. The group binding takes effect immediately on restart.
+
+## What Gets Modified
+
+When binding a group:
+
+1. **`bindings` array** — new entry routing the group to the customer's agent
+2. **`channels.bluebubbles.accounts.karl.groupAllowFrom`** — group members' phone numbers added so their messages pass the allowlist
+
+When unbinding:
+
+1. **`bindings` array** — entry removed (members stay in allowlist for simplicity)
+
+## Examples
+
+### Auto-bind flow (karl-default)
+
+```
+1. Message arrives in unbound group
+2. karl-default runs: exec("scripts/scan-groups.sh")
+3. Sees status: "auto-bindable", matchingCustomers: [{member: "+12035548311", agentId: "karl-brett"}]
+4. Runs: exec("scripts/auto-bind.sh")
+5. Applies patch via gateway config.patch
+6. Sends DM to Brett: "I've joined your group chat with +16468318810. I'm now active there!"
+7. Does NOT respond in the group to the triggering message
+```
+
+### Manual claim flow (karl-brett)
+
+```
+Brett DMs: /claim "Family Chat"
+karl-brett runs: exec("scripts/claim-group.sh --claim --agent-id karl-brett --group-identifier 'Family Chat'")
+Applies patch
+Confirms: "Done! I'm now active in Family Chat (3 members)."
+```

--- a/skills/group-manager/scripts/auto-bind.sh
+++ b/skills/group-manager/scripts/auto-bind.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# auto-bind.sh — Auto-bind unambiguous groups and output the config patch
+#
+# Usage: auto-bind.sh [--dry-run] [--bb-url URL] [--bb-password PASS] [--config PATH] [--account ACCOUNT_ID]
+#
+# Outputs a JSON config patch for gateway config.patch, or dry-run report.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DRY_RUN=false
+BB_URL="${BB_URL:-http://100.120.154.29:1235}"
+BB_PASSWORD="${BB_PASSWORD:-${BLUEBUBBLES_KARL_PASSWORD:-}}"
+CONFIG_PATH="${CONFIG_PATH:-$HOME/.openclaw/openclaw.json}"
+ACCOUNT_ID="${ACCOUNT_ID:-karl}"
+EXCLUDE_AGENTS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --bb-url) BB_URL="$2"; shift 2 ;;
+    --bb-password) BB_PASSWORD="$2"; shift 2 ;;
+    --config) CONFIG_PATH="$2"; shift 2 ;;
+    --account) ACCOUNT_ID="$2"; shift 2 ;;
+    --exclude-agent) EXCLUDE_AGENTS+=("$2"); shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Build jq exclude filter from EXCLUDE_AGENTS array
+EXCLUDE_JSON="[]"
+if [[ ${#EXCLUDE_AGENTS[@]} -gt 0 ]]; then
+  EXCLUDE_JSON=$(printf '%s\n' "${EXCLUDE_AGENTS[@]}" | jq -R . | jq -s .)
+fi
+
+# Run scan
+SCAN=$(BB_URL="$BB_URL" BB_PASSWORD="$BB_PASSWORD" CONFIG_PATH="$CONFIG_PATH" ACCOUNT_ID="$ACCOUNT_ID" \
+  "$SCRIPT_DIR/scan-groups.sh" 2>/dev/null)
+
+# Get auto-bindable groups, filtering out excluded agents
+AUTO_BINDABLE=$(echo "$SCAN" | jq --argjson exclude "$EXCLUDE_JSON" '[
+  .groups[] |
+  select(.status == "auto-bindable") |
+  select(.matchingCustomers[0].agentId as $aid | ($exclude | index($aid)) == null)
+]')
+# Conflicts also filtered — if all matching customers are excluded, demote to no-customers
+CONFLICTS=$(echo "$SCAN" | jq --argjson exclude "$EXCLUDE_JSON" '[
+  .groups[] |
+  select(.status == "conflict") |
+  .matchingCustomers = [.matchingCustomers[] | select((.agentId as $aid | ($exclude | index($aid)) == null))] |
+  select(.matchingCustomers | length > 1)
+]')
+
+COUNT=$(echo "$AUTO_BINDABLE" | jq 'length')
+CONFLICT_COUNT=$(echo "$CONFLICTS" | jq 'length')
+
+if [[ "$COUNT" -eq 0 && "$CONFLICT_COUNT" -eq 0 ]]; then
+  echo '{"action":"none","message":"No unbound groups need attention.","bindings_added":[],"conflicts":[]}'
+  exit 0
+fi
+
+# Build new bindings for auto-bindable groups
+NEW_BINDINGS=$(echo "$AUTO_BINDABLE" | jq --arg acct "$ACCOUNT_ID" '[
+  .[] |
+  {
+    agentId: .matchingCustomers[0].agentId,
+    match: {
+      channel: "bluebubbles",
+      accountId: $acct,
+      peer: {
+        kind: "group",
+        id: .guid
+      }
+    }
+  }
+]')
+
+# Build list of new group members to add to groupAllowFrom
+# For each auto-bindable group, collect all participant phone numbers
+NEW_ALLOW_ENTRIES=$(echo "$AUTO_BINDABLE" | jq '[
+  .[].participants[] |
+  select(startswith("+"))
+] | unique')
+
+# Get current bindings and groupAllowFrom
+CURRENT_BINDINGS=$(jq '.bindings // []' "$CONFIG_PATH")
+CURRENT_ALLOW=$(jq --arg acct "$ACCOUNT_ID" '
+  .channels.bluebubbles.accounts[$acct].groupAllowFrom // []
+' "$CONFIG_PATH")
+
+# Merge new bindings (insert before catch-alls so specific routes match first)
+MERGED_BINDINGS=$(jq -n \
+  --argjson current "$CURRENT_BINDINGS" \
+  --argjson new "$NEW_BINDINGS" \
+  '# Split current into specific (has .match.peer) and catch-all (no .match.peer)
+   [$current[] | select(.match.peer != null)] +
+   $new +
+   [$current[] | select(.match.peer == null)]')
+
+# Merge groupAllowFrom (union)
+MERGED_ALLOW=$(jq -n \
+  --argjson current "$CURRENT_ALLOW" \
+  --argjson new "$NEW_ALLOW_ENTRIES" \
+  '($current + $new) | unique | sort')
+
+# Build conflict notifications
+CONFLICT_REPORT=$(echo "$CONFLICTS" | jq '[
+  .[] | {
+    guid,
+    displayName,
+    chatIdentifier,
+    participants,
+    matchingCustomers
+  }
+]')
+
+# Build the config patch
+PATCH=$(jq -n \
+  --argjson bindings "$MERGED_BINDINGS" \
+  --argjson allow "$MERGED_ALLOW" \
+  --arg acct "$ACCOUNT_ID" \
+  '{
+    bindings: $bindings,
+    channels: {
+      bluebubbles: {
+        accounts: {
+          ($acct): {
+            groupAllowFrom: $allow
+          }
+        }
+      }
+    }
+  }')
+
+# Build summary of what was bound
+BOUND_SUMMARY=$(echo "$AUTO_BINDABLE" | jq '[
+  .[] | {
+    guid,
+    displayName: (if .displayName == "" then "(unnamed)" else .displayName end),
+    chatIdentifier,
+    boundTo: .matchingCustomers[0].agentId,
+    customer: .matchingCustomers[0].member,
+    memberCount: (.participants | length)
+  }
+]')
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  jq -n \
+    --argjson bound "$BOUND_SUMMARY" \
+    --argjson conflicts "$CONFLICT_REPORT" \
+    --argjson patch "$PATCH" \
+    '{
+      action: "dry-run",
+      message: "Would auto-bind \($bound | length) group(s). \($conflicts | length) conflict(s) detected.",
+      bindings_to_add: $bound,
+      conflicts: $conflicts,
+      patch_preview: $patch
+    }'
+else
+  jq -n \
+    --argjson bound "$BOUND_SUMMARY" \
+    --argjson conflicts "$CONFLICT_REPORT" \
+    --argjson patch "$PATCH" \
+    '{
+      action: "apply",
+      message: "Auto-bound \($bound | length) group(s). \($conflicts | length) conflict(s) need manual resolution.",
+      bindings_added: $bound,
+      conflicts: $conflicts,
+      patch: $patch
+    }'
+fi

--- a/skills/group-manager/scripts/claim-group.sh
+++ b/skills/group-manager/scripts/claim-group.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# claim-group.sh — Claim or unclaim a group for a specific agent
+#
+# Usage:
+#   claim-group.sh --claim --agent-id karl-brett --group-identifier <chatIdentifier|guid> [--config PATH] [--account ACCOUNT_ID]
+#   claim-group.sh --unclaim --group-identifier <chatIdentifier|guid> [--config PATH] [--account ACCOUNT_ID]
+#
+# Output: JSON with the patch to apply (or error).
+set -euo pipefail
+
+ACTION=""
+AGENT_ID=""
+GROUP_ID=""
+CONFIG_PATH="${CONFIG_PATH:-$HOME/.openclaw/openclaw.json}"
+ACCOUNT_ID="${ACCOUNT_ID:-karl}"
+BB_URL="${BB_URL:-http://100.120.154.29:1235}"
+BB_PASSWORD="${BB_PASSWORD:-${BLUEBUBBLES_KARL_PASSWORD:-}}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --claim) ACTION="claim"; shift ;;
+    --unclaim) ACTION="unclaim"; shift ;;
+    --agent-id) AGENT_ID="$2"; shift 2 ;;
+    --group-identifier) GROUP_ID="$2"; shift 2 ;;
+    --config) CONFIG_PATH="$2"; shift 2 ;;
+    --account) ACCOUNT_ID="$2"; shift 2 ;;
+    --bb-url) BB_URL="$2"; shift 2 ;;
+    --bb-password) BB_PASSWORD="$2"; shift 2 ;;
+    *) echo "{\"error\":\"Unknown arg: $1\"}" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ACTION" ]]; then
+  echo '{"error":"Must specify --claim or --unclaim"}' >&2
+  exit 1
+fi
+if [[ -z "$GROUP_ID" ]]; then
+  echo '{"error":"Must specify --group-identifier"}' >&2
+  exit 1
+fi
+if [[ "$ACTION" == "claim" && -z "$AGENT_ID" ]]; then
+  echo '{"error":"Must specify --agent-id for claim"}' >&2
+  exit 1
+fi
+
+# Resolve group GUID from identifier
+# The group-identifier could be a chatIdentifier, full guid, or partial match
+resolve_guid() {
+  local search="$1"
+
+  # If it already looks like a full guid (has semicolons), use it
+  if [[ "$search" == *";"* ]]; then
+    echo "$search"
+    return
+  fi
+
+  # Query BlueBubbles to find the group
+  local groups
+  groups=$(curl -s -m 30 -X POST "${BB_URL}/api/v1/chat/query?password=${BB_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d '{"limit":200,"offset":0,"with":["participants"],"sort":"lastmessage"}')
+
+  if [[ -z "$groups" ]] || ! echo "$groups" | jq -e '.data' >/dev/null 2>&1; then
+    echo ""
+    return
+  fi
+
+  # Search by chatIdentifier, displayName (case-insensitive), or partial guid match
+  local match
+  match=$(echo "$groups" | jq -r --arg search "$search" '
+    [.data[] | select(.style == 43)] |
+    (
+      # Exact chatIdentifier match
+      [.[] | select(.chatIdentifier == $search)] //
+      # Case-insensitive displayName match
+      [.[] | select(.displayName != "" and (.displayName | ascii_downcase) == ($search | ascii_downcase))] //
+      # Partial guid match
+      [.[] | select(.guid | contains($search))] //
+      []
+    ) |
+    if length == 1 then .[0].guid
+    elif length > 1 then "AMBIGUOUS:" + (length | tostring)
+    else ""
+    end
+  ')
+
+  echo "$match"
+}
+
+FULL_GUID=$(resolve_guid "$GROUP_ID")
+
+if [[ -z "$FULL_GUID" ]]; then
+  echo "{\"error\":\"Group not found: $GROUP_ID\"}" >&2
+  exit 1
+fi
+if [[ "$FULL_GUID" == AMBIGUOUS:* ]]; then
+  COUNT="${FULL_GUID#AMBIGUOUS:}"
+  echo "{\"error\":\"Ambiguous match: $COUNT groups match '$GROUP_ID'. Be more specific.\"}" >&2
+  exit 1
+fi
+
+CURRENT_BINDINGS=$(jq '.bindings // []' "$CONFIG_PATH")
+
+if [[ "$ACTION" == "claim" ]]; then
+  # Check if already bound
+  EXISTING=$(echo "$CURRENT_BINDINGS" | jq --arg guid "$FULL_GUID" --arg acct "$ACCOUNT_ID" '
+    [.[] | select(
+      .match.channel == "bluebubbles" and
+      .match.accountId == $acct and
+      .match.peer.kind == "group" and
+      .match.peer.id == $guid
+    )]
+  ')
+  if [[ $(echo "$EXISTING" | jq 'length') -gt 0 ]]; then
+    EXISTING_AGENT=$(echo "$EXISTING" | jq -r '.[0].agentId')
+    echo "{\"error\":\"Group already bound to $EXISTING_AGENT. Use --unclaim first.\"}" >&2
+    exit 1
+  fi
+
+  # Build new binding
+  NEW_BINDING=$(jq -n --arg agent "$AGENT_ID" --arg acct "$ACCOUNT_ID" --arg guid "$FULL_GUID" '{
+    agentId: $agent,
+    match: {
+      channel: "bluebubbles",
+      accountId: $acct,
+      peer: {
+        kind: "group",
+        id: $guid
+      }
+    }
+  }')
+
+  # Get group members to add to allowlist
+  GROUP_MEMBERS=$(curl -s -m 30 -X POST "${BB_URL}/api/v1/chat/query?password=${BB_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d '{"limit":200,"offset":0,"with":["participants"]}' | \
+    jq --arg guid "$FULL_GUID" '[.data[] | select(.guid == $guid) | .participants[].address] | unique')
+
+  CURRENT_ALLOW=$(jq --arg acct "$ACCOUNT_ID" '
+    .channels.bluebubbles.accounts[$acct].groupAllowFrom // []
+  ' "$CONFIG_PATH")
+
+  MERGED_ALLOW=$(jq -n --argjson current "$CURRENT_ALLOW" --argjson new "$GROUP_MEMBERS" \
+    '($current + $new) | unique | sort')
+
+  MERGED_BINDINGS=$(echo "$CURRENT_BINDINGS" | jq --argjson new "[$NEW_BINDING]" '. + $new')
+
+  PATCH=$(jq -n \
+    --argjson bindings "$MERGED_BINDINGS" \
+    --argjson allow "$MERGED_ALLOW" \
+    --arg acct "$ACCOUNT_ID" \
+    '{
+      bindings: $bindings,
+      channels: {
+        bluebubbles: {
+          accounts: {
+            ($acct): {
+              groupAllowFrom: $allow
+            }
+          }
+        }
+      }
+    }')
+
+  # Get group display name
+  GROUP_NAME=$(curl -s -m 30 -X POST "${BB_URL}/api/v1/chat/query?password=${BB_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d '{"limit":200,"offset":0}' | \
+    jq -r --arg guid "$FULL_GUID" '.data[] | select(.guid == $guid) | .displayName // "(unnamed)"')
+
+  jq -n \
+    --arg action "claimed" \
+    --arg agent "$AGENT_ID" \
+    --arg guid "$FULL_GUID" \
+    --arg name "$GROUP_NAME" \
+    --argjson members "$GROUP_MEMBERS" \
+    --argjson patch "$PATCH" \
+    '{
+      action: $action,
+      message: "Group \($name) claimed by \($agent).",
+      group: {guid: $guid, displayName: $name, members: $members},
+      patch: $patch
+    }'
+
+elif [[ "$ACTION" == "unclaim" ]]; then
+  # Remove binding for this group
+  REMOVED=$(echo "$CURRENT_BINDINGS" | jq --arg guid "$FULL_GUID" --arg acct "$ACCOUNT_ID" '
+    [.[] | select(
+      .match.channel == "bluebubbles" and
+      .match.accountId == $acct and
+      .match.peer.kind == "group" and
+      .match.peer.id == $guid
+    )]
+  ')
+  if [[ $(echo "$REMOVED" | jq 'length') -eq 0 ]]; then
+    echo "{\"error\":\"Group not currently bound: $FULL_GUID\"}" >&2
+    exit 1
+  fi
+
+  REMOVED_AGENT=$(echo "$REMOVED" | jq -r '.[0].agentId')
+  FILTERED_BINDINGS=$(echo "$CURRENT_BINDINGS" | jq --arg guid "$FULL_GUID" --arg acct "$ACCOUNT_ID" '
+    [.[] | select(
+      (.match.channel == "bluebubbles" and .match.accountId == $acct and .match.peer.kind == "group" and .match.peer.id == $guid) | not
+    )]
+  ')
+
+  PATCH=$(jq -n --argjson bindings "$FILTERED_BINDINGS" '{bindings: $bindings}')
+
+  jq -n \
+    --arg action "unclaimed" \
+    --arg agent "$REMOVED_AGENT" \
+    --arg guid "$FULL_GUID" \
+    --argjson patch "$PATCH" \
+    '{
+      action: $action,
+      message: "Group unbound from \($agent).",
+      group: {guid: $guid},
+      previousAgent: $agent,
+      patch: $patch
+    }'
+fi

--- a/skills/group-manager/scripts/list-groups.sh
+++ b/skills/group-manager/scripts/list-groups.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# list-groups.sh — List groups for a specific agent or all agents
+#
+# Usage:
+#   list-groups.sh [--agent-id karl-brett] [--config PATH] [--account ACCOUNT_ID] [--bb-url URL] [--bb-password PASS]
+#
+# If --agent-id is provided, shows only groups bound to that agent.
+# Otherwise shows all bound groups.
+set -euo pipefail
+
+AGENT_ID=""
+CONFIG_PATH="${CONFIG_PATH:-$HOME/.openclaw/openclaw.json}"
+ACCOUNT_ID="${ACCOUNT_ID:-karl}"
+BB_URL="${BB_URL:-http://100.120.154.29:1235}"
+BB_PASSWORD="${BB_PASSWORD:-${BLUEBUBBLES_KARL_PASSWORD:-}}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent-id) AGENT_ID="$2"; shift 2 ;;
+    --config) CONFIG_PATH="$2"; shift 2 ;;
+    --account) ACCOUNT_ID="$2"; shift 2 ;;
+    --bb-url) BB_URL="$2"; shift 2 ;;
+    --bb-password) BB_PASSWORD="$2"; shift 2 ;;
+    *) echo "{\"error\":\"Unknown arg: $1\"}" >&2; exit 1 ;;
+  esac
+done
+
+# Get bound groups from config
+if [[ -n "$AGENT_ID" ]]; then
+  BINDINGS=$(jq --arg acct "$ACCOUNT_ID" --arg agent "$AGENT_ID" '[
+    .bindings // [] | .[] |
+    select(.match.channel == "bluebubbles" and .match.accountId == $acct and .match.peer.kind == "group" and .agentId == $agent) |
+    {agentId, guid: .match.peer.id}
+  ]' "$CONFIG_PATH")
+else
+  BINDINGS=$(jq --arg acct "$ACCOUNT_ID" '[
+    .bindings // [] | .[] |
+    select(.match.channel == "bluebubbles" and .match.accountId == $acct and .match.peer.kind == "group") |
+    {agentId, guid: .match.peer.id}
+  ]' "$CONFIG_PATH")
+fi
+
+# Enrich with BlueBubbles data (display name, participants)
+BB_GROUPS=$(curl -s -m 30 -X POST "${BB_URL}/api/v1/chat/query?password=${BB_PASSWORD}" \
+  -H "Content-Type: application/json" \
+  -d '{"limit":200,"offset":0,"with":["participants"],"sort":"lastmessage"}' 2>/dev/null)
+
+if echo "$BB_GROUPS" | jq -e '.data' >/dev/null 2>&1; then
+  BB_DATA=$(echo "$BB_GROUPS" | jq '[.data[] | select(.style == 43) | {
+    guid,
+    displayName,
+    chatIdentifier,
+    participants: [.participants[].address],
+    memberCount: (.participants | length)
+  }]')
+else
+  BB_DATA="[]"
+fi
+
+jq -n \
+  --argjson bindings "$BINDINGS" \
+  --argjson bb "$BB_DATA" \
+  '
+  # Build lookup: guid -> bb info
+  ($bb | map({key: .guid, value: .}) | from_entries) as $bb_map |
+  {
+    groups: [
+      $bindings[] |
+      . as $binding |
+      ($bb_map[$binding.guid] // null) as $info |
+      {
+        agentId: $binding.agentId,
+        guid: $binding.guid,
+        displayName: ($info.displayName // "(unknown)"),
+        chatIdentifier: ($info.chatIdentifier // null),
+        participants: ($info.participants // []),
+        memberCount: ($info.memberCount // 0)
+      }
+    ],
+    count: ($bindings | length)
+  }
+  '

--- a/skills/group-manager/scripts/scan-groups.sh
+++ b/skills/group-manager/scripts/scan-groups.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# scan-groups.sh — Detect unbound BlueBubbles groups and recommend auto-bindings
+#
+# Usage: scan-groups.sh [--bb-url URL] [--bb-password PASS] [--config PATH] [--account ACCOUNT_ID]
+#
+# Output: JSON array of unbound groups with member analysis and recommendations.
+# Exit codes: 0 = success, 1 = error
+set -euo pipefail
+
+BB_URL="${BB_URL:-http://100.120.154.29:1235}"
+BB_PASSWORD="${BB_PASSWORD:-${BLUEBUBBLES_KARL_PASSWORD:-}}"
+CONFIG_PATH="${CONFIG_PATH:-$HOME/.openclaw/openclaw.json}"
+ACCOUNT_ID="${ACCOUNT_ID:-karl}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bb-url) BB_URL="$2"; shift 2 ;;
+    --bb-password) BB_PASSWORD="$2"; shift 2 ;;
+    --config) CONFIG_PATH="$2"; shift 2 ;;
+    --account) ACCOUNT_ID="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$BB_PASSWORD" ]]; then
+  echo '{"error":"BlueBubbles password not set. Set BB_PASSWORD or BLUEBUBBLES_KARL_PASSWORD."}' >&2
+  exit 1
+fi
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "{\"error\":\"Config file not found: $CONFIG_PATH\"}" >&2
+  exit 1
+fi
+
+# Step 1: Get all group chats with participants from BlueBubbles
+GROUPS_JSON=$(curl -s -m 30 -X POST "${BB_URL}/api/v1/chat/query?password=${BB_PASSWORD}" \
+  -H "Content-Type: application/json" \
+  -d '{"limit":200,"offset":0,"with":["participants"],"sort":"lastmessage"}')
+
+if [[ -z "$GROUPS_JSON" ]] || ! echo "$GROUPS_JSON" | jq -e '.data' >/dev/null 2>&1; then
+  echo '{"error":"Failed to query BlueBubbles groups API"}' >&2
+  exit 1
+fi
+
+# Extract only group chats (style 43 = group)
+BB_GROUPS=$(echo "$GROUPS_JSON" | jq '[.data[] | select(.style == 43) | {
+  guid,
+  displayName,
+  chatIdentifier,
+  participants: [.participants[].address]
+}]')
+
+# Step 2: Get current bindings from config
+# Peer group bindings for this account
+EXISTING_GROUP_BINDINGS=$(jq --arg acct "$ACCOUNT_ID" '[
+  .bindings // [] | .[] |
+  select(.match.channel == "bluebubbles" and .match.accountId == $acct and .match.peer.kind == "group") |
+  {agentId, groupId: .match.peer.id}
+]' "$CONFIG_PATH")
+
+# Peer DM bindings for this account (these are "customers")
+DM_BINDINGS=$(jq --arg acct "$ACCOUNT_ID" '[
+  .bindings // [] | .[] |
+  select(.match.channel == "bluebubbles" and .match.accountId == $acct and .match.peer.kind == "direct") |
+  {agentId, peerId: .match.peer.id}
+]' "$CONFIG_PATH")
+
+# Step 3: Build set of already-bound group GUIDs
+BOUND_GUIDS=$(echo "$EXISTING_GROUP_BINDINGS" | jq -r '.[].groupId')
+
+# Step 4: Analyze each group
+jq -n \
+  --argjson bb_groups "$BB_GROUPS" \
+  --argjson existing "$EXISTING_GROUP_BINDINGS" \
+  --argjson dm_bindings "$DM_BINDINGS" \
+  '
+  # Build lookup: peerId -> agentId
+  ($dm_bindings | map({key: .peerId, value: .agentId}) | from_entries) as $customer_map |
+  # Build set of bound group GUIDs
+  ($existing | map(.groupId) | sort | unique) as $bound_guids |
+  # Get all customer phone numbers/emails
+  ($dm_bindings | map(.peerId)) as $customer_ids |
+
+  [
+    $bb_groups[] |
+    . as $group |
+
+    # Check if this group is already bound
+    ($bound_guids | index($group.guid)) as $is_bound |
+    if $is_bound != null then
+      # Already bound — include in output with status
+      ($existing[] | select(.groupId == $group.guid)) as $binding |
+      {
+        guid: $group.guid,
+        displayName: $group.displayName,
+        chatIdentifier: $group.chatIdentifier,
+        participants: $group.participants,
+        status: "bound",
+        boundTo: $binding.agentId,
+        matchingCustomers: []
+      }
+    else
+      # Unbound — check for customer members
+      [
+        $group.participants[] |
+        . as $member |
+        $customer_map[$member] // null |
+        if . != null then
+          {member: $member, agentId: .}
+        else
+          empty
+        end
+      ] as $matches |
+
+      {
+        guid: $group.guid,
+        displayName: $group.displayName,
+        chatIdentifier: $group.chatIdentifier,
+        participants: $group.participants,
+        status: (
+          if ($matches | length) == 0 then "unbound-no-customers"
+          elif ($matches | length) == 1 then "auto-bindable"
+          else "conflict"
+          end
+        ),
+        boundTo: null,
+        matchingCustomers: $matches
+      }
+    end
+  ] |
+  {
+    summary: {
+      total: length,
+      bound: [.[] | select(.status == "bound")] | length,
+      autoBindable: [.[] | select(.status == "auto-bindable")] | length,
+      conflict: [.[] | select(.status == "conflict")] | length,
+      noCustomers: [.[] | select(.status == "unbound-no-customers")] | length
+    },
+    groups: .
+  }
+  '

--- a/skills/sonos-cloud/SKILL.md
+++ b/skills/sonos-cloud/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: sonos-cloud
+description: Control Sonos speakers remotely via the Sonos Cloud API (no local network needed). Play, pause, volume, favorites, grouping — works from any agent, anywhere.
+metadata: { "openclaw": { "emoji": "🔊" } }
+---
+
+# Sonos Cloud Control
+
+Control Sonos speakers through the Sonos Cloud API. No local network access required — works from any agent, sandboxed or not.
+
+## Setup (one-time)
+
+### 1. Store credentials
+
+```bash
+python3 /opt/openclaw/skills/sonos-cloud/scripts/token_manager.py setup <client_id> <client_secret> <redirect_uri>
+```
+
+### 2. Authorize a household
+
+Start the OAuth callback server:
+
+```bash
+python3 /opt/openclaw/skills/sonos-cloud/scripts/oauth_callback.py --household <name>
+```
+
+Send the user the auth URL (printed by the server). They log into Sonos, authorize, and tokens are saved automatically.
+
+Or manually:
+
+```bash
+# Get the auth URL
+python3 /opt/openclaw/skills/sonos-cloud/scripts/token_manager.py auth-url
+
+# After user authorizes, exchange the code
+python3 /opt/openclaw/skills/sonos-cloud/scripts/token_manager.py exchange <code> <household_name>
+```
+
+### 3. Set up token refresh cron
+
+Tokens expire every 24h. Set up a cron job to refresh them:
+
+```
+python3 /opt/openclaw/skills/sonos-cloud/scripts/token_manager.py refresh-all
+```
+
+## Usage
+
+### Discovery & Status
+
+```bash
+# Full discovery (households, groups, players, favorites)
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py discover [household]
+
+# Current status (what's playing, volume)
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py status [household]
+
+# List households
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py households [household]
+```
+
+### Playback
+
+```bash
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py play <group_id> [household]
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py pause <group_id> [household]
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py toggle <group_id> [household]
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py next <group_id> [household]
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py prev <group_id> [household]
+```
+
+### Volume
+
+```bash
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py volume <group_id> [household]
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py set-volume <group_id> <0-100> [household]
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py mute <group_id> [household]
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py unmute <group_id> [household]
+```
+
+### Favorites
+
+```bash
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py favorites <household_id> [household]
+python3 /opt/openclaw/skills/sonos-cloud/scripts/sonos_api.py play-favorite <group_id> <fav_id> [household]
+```
+
+### Token Management
+
+```bash
+python3 /opt/openclaw/skills/sonos-cloud/scripts/token_manager.py list          # Show all households
+python3 /opt/openclaw/skills/sonos-cloud/scripts/token_manager.py refresh-all   # Refresh expiring tokens
+python3 /opt/openclaw/skills/sonos-cloud/scripts/token_manager.py get-token [household]  # Get valid token
+```
+
+## Multi-Household Support
+
+Each authorized user gets a household name (e.g., "cole", "kellen"). Pass the household name as the last argument to any command:
+
+```bash
+python3 sonos_api.py status kellen
+python3 sonos_api.py play <group_id> kellen
+```
+
+## Architecture
+
+- **Credentials**: `/opt/openclaw/skills/sonos-cloud/config/credentials.json` — client_id, secret, redirect_uri
+- **Tokens**: `/opt/openclaw/skills/sonos-cloud/config/tokens.json` — per-household access + refresh tokens
+- **API base**: `api.ws.sonos.com/control/api/v1`
+- **Auth**: OAuth 2.0 with 24h access tokens + long-lived refresh tokens
+
+## Files
+
+- `scripts/token_manager.py` — Token storage, refresh, OAuth URL generation
+- `scripts/sonos_api.py` — Full Sonos Control API wrapper + CLI
+- `scripts/oauth_callback.py` — Temporary OAuth callback web server
+- `config/credentials.json` — Client credentials (created during setup)
+- `config/tokens.json` — Per-household OAuth tokens (created during authorization)

--- a/skills/sonos-cloud/scripts/oauth_callback.py
+++ b/skills/sonos-cloud/scripts/oauth_callback.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Lightweight OAuth callback server for Sonos authorization.
+Runs temporarily to catch the OAuth redirect, then shuts down.
+
+Usage:
+  python3 oauth_callback.py [--port 8732] [--household kellen]
+
+The redirect_uri in your Sonos integration should point to:
+  https://your-domain.com/callback  (proxied to this server)
+  or for local testing: http://localhost:8732/callback
+"""
+
+import json
+import os
+import sys
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse, parse_qs
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from token_manager import exchange_code, get_auth_url
+
+HOUSEHOLD_NAME = "default"
+
+
+class OAuthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+
+        if parsed.path == "/":
+            # Show the auth link
+            auth_url = get_auth_url()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            html = f"""<!DOCTYPE html>
+<html>
+<head><title>Sonos Authorization — OpenClaw</title>
+<style>
+  body {{ font-family: -apple-system, sans-serif; max-width: 600px; margin: 80px auto; padding: 20px; background: #0a0a0a; color: #e0e0e0; }}
+  a {{ color: #4fc3f7; text-decoration: none; font-size: 1.2em; }}
+  a:hover {{ text-decoration: underline; }}
+  .logo {{ font-size: 2em; margin-bottom: 20px; }}
+  .card {{ background: #1a1a1a; border-radius: 12px; padding: 30px; border: 1px solid #333; }}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="logo">🔊 🦞</div>
+  <h2>Sonos × OpenClaw</h2>
+  <p>Click below to authorize OpenClaw to control your Sonos speakers:</p>
+  <p><a href="{auth_url}">→ Sign in with Sonos</a></p>
+  <p style="color:#888; font-size:0.9em; margin-top:20px;">
+    This will connect your Sonos household as: <strong>{HOUSEHOLD_NAME}</strong>
+  </p>
+</div>
+</body>
+</html>"""
+            self.wfile.write(html.encode())
+
+        elif parsed.path == "/callback":
+            params = parse_qs(parsed.query)
+            code = params.get("code", [None])[0]
+            state = params.get("state", [None])[0]
+            error = params.get("error", [None])[0]
+
+            if error:
+                self.send_response(400)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(f"<h2>Authorization failed: {error}</h2>".encode())
+                return
+
+            if not code:
+                self.send_response(400)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(b"<h2>No authorization code received</h2>")
+                return
+
+            # Exchange the code for tokens
+            try:
+                exchange_code(code, HOUSEHOLD_NAME)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                html = f"""<!DOCTYPE html>
+<html>
+<head><title>Success — Sonos × OpenClaw</title>
+<style>
+  body {{ font-family: -apple-system, sans-serif; max-width: 600px; margin: 80px auto; padding: 20px; background: #0a0a0a; color: #e0e0e0; }}
+  .card {{ background: #1a1a1a; border-radius: 12px; padding: 30px; border: 1px solid #2e7d32; }}
+  .check {{ font-size: 3em; }}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="check">✅</div>
+  <h2>Sonos Connected!</h2>
+  <p>Household <strong>'{HOUSEHOLD_NAME}'</strong> is now authorized.</p>
+  <p>OpenClaw agents can now control your Sonos speakers.</p>
+  <p style="color:#888; font-size:0.9em;">You can close this window.</p>
+</div>
+</body>
+</html>"""
+                self.wfile.write(html.encode())
+                print(f"\n✅ Authorization complete for '{HOUSEHOLD_NAME}'! Shutting down server...")
+                # Schedule shutdown
+                import threading
+                threading.Timer(1.0, lambda: os._exit(0)).start()
+
+            except Exception as e:
+                self.send_response(500)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(f"<h2>Token exchange failed: {e}</h2>".encode())
+
+        else:
+            self.send_response(404)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"Not found")
+
+    def log_message(self, format, *args):
+        print(f"[OAuth] {args[0]}")
+
+
+def main():
+    port = 8732
+    global HOUSEHOLD_NAME
+
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--port" and i + 1 < len(args):
+            port = int(args[i + 1])
+            i += 2
+        elif args[i] == "--household" and i + 1 < len(args):
+            HOUSEHOLD_NAME = args[i + 1]
+            i += 2
+        else:
+            i += 1
+
+    auth_url = get_auth_url()
+    print(f"🔊 Sonos OAuth Callback Server")
+    print(f"   Household: {HOUSEHOLD_NAME}")
+    print(f"   Listening: http://0.0.0.0:{port}")
+    print(f"   Landing:   http://localhost:{port}/")
+    print(f"   Callback:  http://localhost:{port}/callback")
+    print(f"\n   Auth URL:  {auth_url}")
+    print(f"\nWaiting for authorization...")
+
+    server = HTTPServer(("0.0.0.0", port), OAuthHandler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/sonos-cloud/scripts/sonos_api.py
+++ b/skills/sonos-cloud/scripts/sonos_api.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Sonos Cloud Control API wrapper."""
+
+import json
+import sys
+import urllib.request
+import urllib.error
+import os
+
+# Add parent scripts dir to path for token_manager import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from token_manager import get_access_token
+
+BASE_URL = "https://api.ws.sonos.com/control/api/v1"
+
+
+def api_request(method, path, household_name="default", body=None):
+    """Make an authenticated request to the Sonos Control API."""
+    token = get_access_token(household_name)
+    url = f"{BASE_URL}{path}"
+
+    data = json.dumps(body).encode() if body else None
+    if method == "GET":
+        data = None
+
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    if method in ("POST", "PUT") and data is None:
+        req.add_header("Content-Length", "0")
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode()
+        print(f"API Error {e.code}: {body_text}", file=sys.stderr)
+        raise
+
+
+# ─── Discovery ─────────────────────────────────────────────
+
+def get_households(household_name="default"):
+    """Get all households for the authorized user."""
+    return api_request("GET", "/households", household_name)
+
+
+def get_groups(household_id, household_name="default"):
+    """Get all groups and players in a household."""
+    return api_request("GET", f"/households/{household_id}/groups", household_name)
+
+
+def get_favorites(household_id, household_name="default"):
+    """Get favorites for a household."""
+    return api_request("GET", f"/households/{household_id}/favorites", household_name)
+
+
+def get_playlists(household_id, household_name="default"):
+    """Get playlists for a household."""
+    return api_request("GET", f"/households/{household_id}/playlists", household_name)
+
+
+# ─── Playback Control ──────────────────────────────────────
+
+def play(group_id, household_name="default"):
+    """Start playback."""
+    return api_request("POST", f"/groups/{group_id}/playback/play", household_name)
+
+
+def pause(group_id, household_name="default"):
+    """Pause playback."""
+    return api_request("POST", f"/groups/{group_id}/playback/pause", household_name)
+
+
+def toggle_play_pause(group_id, household_name="default"):
+    """Toggle play/pause."""
+    return api_request("POST", f"/groups/{group_id}/playback/togglePlayPause", household_name)
+
+
+def skip_to_next(group_id, household_name="default"):
+    """Skip to next track."""
+    return api_request("POST", f"/groups/{group_id}/playback/skipToNextTrack", household_name)
+
+
+def skip_to_previous(group_id, household_name="default"):
+    """Skip to previous track."""
+    return api_request("POST", f"/groups/{group_id}/playback/skipToPreviousTrack", household_name)
+
+
+def get_playback(group_id, household_name="default"):
+    """Get current playback state."""
+    return api_request("GET", f"/groups/{group_id}/playback", household_name)
+
+
+def get_metadata(group_id, household_name="default"):
+    """Get current track metadata."""
+    return api_request("GET", f"/groups/{group_id}/playbackMetadata", household_name)
+
+
+# ─── Volume ─────────────────────────────────────────────────
+
+def get_volume(group_id, household_name="default"):
+    """Get group volume."""
+    return api_request("GET", f"/groups/{group_id}/groupVolume", household_name)
+
+
+def set_volume(group_id, volume, household_name="default"):
+    """Set group volume (0-100)."""
+    return api_request("POST", f"/groups/{group_id}/groupVolume",
+                       household_name, {"volume": int(volume)})
+
+
+def set_mute(group_id, muted, household_name="default"):
+    """Mute or unmute group."""
+    return api_request("POST", f"/groups/{group_id}/groupVolume/mute",
+                       household_name, {"muted": bool(muted)})
+
+
+def set_relative_volume(group_id, delta, household_name="default"):
+    """Adjust volume by delta (-100 to 100)."""
+    return api_request("POST", f"/groups/{group_id}/groupVolume/relative",
+                       household_name, {"volumeDelta": int(delta)})
+
+
+# ─── Player Volume ──────────────────────────────────────────
+
+def get_player_volume(player_id, household_name="default"):
+    """Get individual player volume."""
+    return api_request("GET", f"/players/{player_id}/playerVolume", household_name)
+
+
+def set_player_volume(player_id, volume, household_name="default"):
+    """Set individual player volume (0-100)."""
+    return api_request("POST", f"/players/{player_id}/playerVolume",
+                       household_name, {"volume": int(volume)})
+
+
+# ─── Favorites ──────────────────────────────────────────────
+
+def load_favorite(group_id, favorite_id, household_name="default",
+                  play_on_completion=True, play_modes=None):
+    """Load a favorite into a group."""
+    body = {
+        "favoriteId": favorite_id,
+        "playOnCompletion": play_on_completion,
+    }
+    if play_modes:
+        body["playModes"] = play_modes
+    return api_request("POST", f"/groups/{group_id}/favorites",
+                       household_name, body)
+
+
+# ─── Groups ─────────────────────────────────────────────────
+
+def create_group(household_id, player_ids, household_name="default"):
+    """Create a new group with the given players."""
+    return api_request("POST", f"/households/{household_id}/groups/createGroup",
+                       household_name, {"playerIds": player_ids})
+
+
+def modify_group(group_id, player_ids_to_add=None, player_ids_to_remove=None,
+                 household_name="default"):
+    """Add or remove players from a group."""
+    body = {}
+    if player_ids_to_add:
+        body["playerIdsToAdd"] = player_ids_to_add
+    if player_ids_to_remove:
+        body["playerIdsToRemove"] = player_ids_to_remove
+    return api_request("POST", f"/groups/{group_id}/groups/modifyGroupMembers",
+                       household_name, body)
+
+
+# ─── Audio Clip ─────────────────────────────────────────────
+
+def play_audio_clip(player_id, app_id, name, clip_uri=None, volume=None,
+                    household_name="default"):
+    """Play an audio clip on a player (overlays on current playback)."""
+    body = {"appId": app_id, "name": name}
+    if clip_uri:
+        body["streamUrl"] = clip_uri
+    if volume is not None:
+        body["volume"] = int(volume)
+    return api_request("POST", f"/players/{player_id}/audioClip",
+                       household_name, body)
+
+
+# ─── Convenience ────────────────────────────────────────────
+
+def discover(household_name="default"):
+    """Full discovery: households, groups, players, favorites."""
+    result = {}
+
+    households = get_households(household_name)
+    result["households"] = households.get("households", [])
+
+    for hh in result["households"]:
+        hh_id = hh["id"]
+        groups_data = get_groups(hh_id, household_name)
+        hh["groups"] = groups_data.get("groups", [])
+        hh["players"] = groups_data.get("players", [])
+
+        try:
+            favs = get_favorites(hh_id, household_name)
+            hh["favorites"] = favs.get("items", [])
+        except Exception:
+            hh["favorites"] = []
+
+    return result
+
+
+def status(household_name="default"):
+    """Get current status of all groups: what's playing, volume, etc."""
+    data = discover(household_name)
+    result = []
+
+    for hh in data["households"]:
+        for group in hh.get("groups", []):
+            group_id = group["id"]
+            group_info = {
+                "name": group.get("name", "Unknown"),
+                "id": group_id,
+                "playerIds": group.get("playerIds", []),
+            }
+
+            try:
+                pb = get_playback(group_id, household_name)
+                group_info["playbackState"] = pb.get("playbackState", "unknown")
+            except Exception:
+                group_info["playbackState"] = "error"
+
+            try:
+                meta = get_metadata(group_id, household_name)
+                container = meta.get("container", {})
+                current = meta.get("currentItem", {})
+                track = current.get("track", {})
+                group_info["nowPlaying"] = {
+                    "track": track.get("name"),
+                    "artist": track.get("artist", {}).get("name"),
+                    "album": track.get("album", {}).get("name"),
+                    "service": container.get("service", {}).get("name"),
+                }
+            except Exception:
+                group_info["nowPlaying"] = None
+
+            try:
+                vol = get_volume(group_id, household_name)
+                group_info["volume"] = vol.get("volume")
+                group_info["muted"] = vol.get("muted")
+            except Exception:
+                pass
+
+            result.append(group_info)
+
+    return {"groups": result, "players": data["households"][0].get("players", []) if data["households"] else []}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: sonos_api.py <command> [args...]")
+        print()
+        print("Discovery:")
+        print("  discover [household]     — Full discovery (households, groups, players, favorites)")
+        print("  status [household]       — Current status of all groups")
+        print("  households [household]   — List households")
+        print("  groups <hh_id> [household]")
+        print("  favorites <hh_id> [household]")
+        print()
+        print("Playback:")
+        print("  play <group_id> [household]")
+        print("  pause <group_id> [household]")
+        print("  toggle <group_id> [household]")
+        print("  next <group_id> [household]")
+        print("  prev <group_id> [household]")
+        print("  now-playing <group_id> [household]")
+        print()
+        print("Volume:")
+        print("  volume <group_id> [household]")
+        print("  set-volume <group_id> <0-100> [household]")
+        print("  mute <group_id> [household]")
+        print("  unmute <group_id> [household]")
+        print()
+        print("Favorites:")
+        print("  play-favorite <group_id> <fav_id> [household]")
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    hh_name = "default"
+
+    try:
+        if cmd == "discover":
+            hh_name = sys.argv[2] if len(sys.argv) > 2 else "default"
+            print(json.dumps(discover(hh_name), indent=2))
+
+        elif cmd == "status":
+            hh_name = sys.argv[2] if len(sys.argv) > 2 else "default"
+            s = status(hh_name)
+            for g in s["groups"]:
+                state = g["playbackState"]
+                vol = g.get("volume", "?")
+                muted = " [MUTED]" if g.get("muted") else ""
+                print(f"\n🔊 {g['name']} — {state} | Volume: {vol}{muted}")
+                if g.get("nowPlaying") and g["nowPlaying"].get("track"):
+                    np = g["nowPlaying"]
+                    print(f"   🎵 {np['track']} — {np.get('artist', '?')}")
+                    if np.get("album"):
+                        print(f"   💿 {np['album']}")
+                    if np.get("service"):
+                        print(f"   📡 {np['service']}")
+
+            if s.get("players"):
+                print(f"\n📍 Players:")
+                for p in s["players"]:
+                    print(f"   {p.get('name', '?')} ({p.get('id', '?')[:20]}...)")
+
+        elif cmd == "households":
+            hh_name = sys.argv[2] if len(sys.argv) > 2 else "default"
+            print(json.dumps(get_households(hh_name), indent=2))
+
+        elif cmd == "groups":
+            print(json.dumps(get_groups(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "default"), indent=2))
+
+        elif cmd == "favorites":
+            print(json.dumps(get_favorites(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "default"), indent=2))
+
+        elif cmd == "play":
+            play(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "default")
+            print("▶️  Playing")
+
+        elif cmd == "pause":
+            pause(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "default")
+            print("⏸  Paused")
+
+        elif cmd == "toggle":
+            toggle_play_pause(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "default")
+            print("⏯  Toggled")
+
+        elif cmd == "next":
+            skip_to_next(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "default")
+            print("⏭  Next track")
+
+        elif cmd == "prev":
+            skip_to_previous(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "default")
+            print("⏮  Previous track")
+
+        elif cmd == "now-playing":
+            meta = get_metadata(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "default")
+            print(json.dumps(meta, indent=2))
+
+        elif cmd == "volume":
+            vol = get_volume(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "default")
+            print(f"Volume: {vol.get('volume')} | Muted: {vol.get('muted')}")
+
+        elif cmd == "set-volume":
+            set_volume(sys.argv[2], sys.argv[3], sys.argv[4] if len(sys.argv) > 4 else "default")
+            print(f"🔊 Volume set to {sys.argv[3]}")
+
+        elif cmd == "mute":
+            set_mute(sys.argv[2], True, sys.argv[3] if len(sys.argv) > 3 else "default")
+            print("🔇 Muted")
+
+        elif cmd == "unmute":
+            set_mute(sys.argv[2], False, sys.argv[3] if len(sys.argv) > 3 else "default")
+            print("🔊 Unmuted")
+
+        elif cmd == "play-favorite":
+            load_favorite(sys.argv[2], sys.argv[3], sys.argv[4] if len(sys.argv) > 4 else "default")
+            print(f"▶️  Playing favorite {sys.argv[3]}")
+
+        else:
+            print(f"Unknown command: {cmd}")
+            sys.exit(1)
+
+    except IndexError:
+        print(f"Missing arguments for '{cmd}'. Run without args for usage.", file=sys.stderr)
+        sys.exit(1)

--- a/skills/sonos-cloud/scripts/token_manager.py
+++ b/skills/sonos-cloud/scripts/token_manager.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Sonos Cloud API token manager — stores, refreshes, and retrieves OAuth tokens."""
+
+import json
+import os
+import sys
+import time
+import base64
+import urllib.request
+import urllib.parse
+import urllib.error
+
+CONFIG_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "config")
+CREDENTIALS_FILE = os.path.join(CONFIG_DIR, "credentials.json")
+TOKENS_FILE = os.path.join(CONFIG_DIR, "tokens.json")
+
+SONOS_TOKEN_URL = "https://api.sonos.com/login/v3/oauth/access"
+
+
+def load_credentials():
+    """Load client_id and client_secret from credentials file."""
+    if not os.path.exists(CREDENTIALS_FILE):
+        print(f"Error: No credentials file at {CREDENTIALS_FILE}", file=sys.stderr)
+        print("Create it with: python3 token_manager.py setup <client_id> <client_secret> <redirect_uri>", file=sys.stderr)
+        sys.exit(1)
+    with open(CREDENTIALS_FILE) as f:
+        return json.load(f)
+
+
+def load_tokens():
+    """Load all household tokens. Returns dict of {household_name: token_data}."""
+    if not os.path.exists(TOKENS_FILE):
+        return {}
+    with open(TOKENS_FILE) as f:
+        return json.load(f)
+
+
+def save_tokens(tokens):
+    """Save tokens to disk."""
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    with open(TOKENS_FILE, "w") as f:
+        json.dump(tokens, f, indent=2)
+
+
+def get_auth_header(creds):
+    """Build Basic auth header from client credentials."""
+    pair = f"{creds['client_id']}:{creds['client_secret']}"
+    encoded = base64.b64encode(pair.encode()).decode()
+    return f"Basic {encoded}"
+
+
+def exchange_code(auth_code, household_name="default"):
+    """Exchange authorization code for access + refresh tokens."""
+    creds = load_credentials()
+    data = urllib.parse.urlencode({
+        "grant_type": "authorization_code",
+        "code": auth_code,
+        "redirect_uri": creds["redirect_uri"],
+    }).encode()
+
+    req = urllib.request.Request(SONOS_TOKEN_URL, data=data, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+    req.add_header("Authorization", get_auth_header(creds))
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            token_data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"Error exchanging code: {e.code} — {body}", file=sys.stderr)
+        sys.exit(1)
+
+    tokens = load_tokens()
+    tokens[household_name] = {
+        "access_token": token_data["access_token"],
+        "refresh_token": token_data["refresh_token"],
+        "expires_at": time.time() + token_data.get("expires_in", 86400),
+        "scope": token_data.get("scope", "playback-control-all"),
+        "updated_at": time.time(),
+    }
+    save_tokens(tokens)
+    print(f"✅ Tokens saved for household '{household_name}'")
+    return tokens[household_name]
+
+
+def refresh_token(household_name="default"):
+    """Refresh an expired access token."""
+    creds = load_credentials()
+    tokens = load_tokens()
+
+    if household_name not in tokens:
+        print(f"Error: No tokens for household '{household_name}'", file=sys.stderr)
+        sys.exit(1)
+
+    data = urllib.parse.urlencode({
+        "grant_type": "refresh_token",
+        "refresh_token": tokens[household_name]["refresh_token"],
+    }).encode()
+
+    req = urllib.request.Request(SONOS_TOKEN_URL, data=data, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+    req.add_header("Authorization", get_auth_header(creds))
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            token_data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"Error refreshing token for '{household_name}': {e.code} — {body}", file=sys.stderr)
+        return False
+
+    tokens[household_name] = {
+        "access_token": token_data["access_token"],
+        "refresh_token": token_data["refresh_token"],
+        "expires_at": time.time() + token_data.get("expires_in", 86400),
+        "scope": token_data.get("scope", "playback-control-all"),
+        "updated_at": time.time(),
+    }
+    save_tokens(tokens)
+    print(f"✅ Token refreshed for household '{household_name}'")
+    return True
+
+
+def refresh_all():
+    """Refresh all stored tokens that are expiring within 2 hours."""
+    tokens = load_tokens()
+    threshold = time.time() + 7200  # 2 hours from now
+    refreshed = 0
+    failed = 0
+
+    for name, data in tokens.items():
+        if data.get("expires_at", 0) < threshold:
+            print(f"Refreshing token for '{name}'...")
+            if refresh_token(name):
+                refreshed += 1
+            else:
+                failed += 1
+        else:
+            remaining = (data["expires_at"] - time.time()) / 3600
+            print(f"'{name}' still valid ({remaining:.1f}h remaining)")
+
+    print(f"\nDone: {refreshed} refreshed, {failed} failed, {len(tokens) - refreshed - failed} still valid")
+    return failed == 0
+
+
+def get_access_token(household_name="default"):
+    """Get a valid access token, refreshing if needed."""
+    tokens = load_tokens()
+    if household_name not in tokens:
+        print(f"Error: No tokens for '{household_name}'. Run authorization first.", file=sys.stderr)
+        sys.exit(1)
+
+    token_data = tokens[household_name]
+
+    # Refresh if expiring within 5 minutes
+    if token_data.get("expires_at", 0) < time.time() + 300:
+        print(f"Token expiring soon, refreshing...", file=sys.stderr)
+        refresh_token(household_name)
+        tokens = load_tokens()
+        token_data = tokens[household_name]
+
+    return token_data["access_token"]
+
+
+def get_auth_url():
+    """Generate the OAuth authorization URL for a user to click."""
+    creds = load_credentials()
+    params = urllib.parse.urlencode({
+        "client_id": creds["client_id"],
+        "response_type": "code",
+        "state": f"openclaw_{int(time.time())}",
+        "scope": "playback-control-all",
+        "redirect_uri": creds["redirect_uri"],
+    })
+    return f"https://api.sonos.com/login/v3/oauth?{params}"
+
+
+def setup(client_id, client_secret, redirect_uri):
+    """Save client credentials."""
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    creds = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+    }
+    with open(CREDENTIALS_FILE, "w") as f:
+        json.dump(creds, f, indent=2)
+    print(f"✅ Credentials saved to {CREDENTIALS_FILE}")
+
+
+def list_households():
+    """List all authorized households."""
+    tokens = load_tokens()
+    if not tokens:
+        print("No households authorized yet.")
+        return
+    for name, data in tokens.items():
+        expires = data.get("expires_at", 0)
+        remaining = (expires - time.time()) / 3600
+        status = f"{remaining:.1f}h remaining" if remaining > 0 else "EXPIRED"
+        updated = time.strftime("%Y-%m-%d %H:%M", time.localtime(data.get("updated_at", 0)))
+        print(f"  {name}: {status} (last refreshed: {updated})")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage:")
+        print("  token_manager.py setup <client_id> <client_secret> <redirect_uri>")
+        print("  token_manager.py auth-url              — Generate OAuth URL")
+        print("  token_manager.py exchange <code> [name] — Exchange auth code for tokens")
+        print("  token_manager.py refresh [name]         — Refresh a specific token")
+        print("  token_manager.py refresh-all            — Refresh all expiring tokens")
+        print("  token_manager.py get-token [name]       — Get valid access token")
+        print("  token_manager.py list                   — List households")
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+
+    if cmd == "setup":
+        if len(sys.argv) != 5:
+            print("Usage: token_manager.py setup <client_id> <client_secret> <redirect_uri>")
+            sys.exit(1)
+        setup(sys.argv[2], sys.argv[3], sys.argv[4])
+
+    elif cmd == "auth-url":
+        print(get_auth_url())
+
+    elif cmd == "exchange":
+        code = sys.argv[2] if len(sys.argv) > 2 else input("Authorization code: ").strip()
+        name = sys.argv[3] if len(sys.argv) > 3 else "default"
+        exchange_code(code, name)
+
+    elif cmd == "refresh":
+        name = sys.argv[2] if len(sys.argv) > 2 else "default"
+        refresh_token(name)
+
+    elif cmd == "refresh-all":
+        success = refresh_all()
+        sys.exit(0 if success else 1)
+
+    elif cmd == "get-token":
+        name = sys.argv[2] if len(sys.argv) > 2 else "default"
+        print(get_access_token(name))
+
+    elif cmd == "list":
+        list_households()
+
+    else:
+        print(f"Unknown command: {cmd}")
+        sys.exit(1)

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -19,6 +19,7 @@ type ResolvedAgentConfig = {
   workspace?: string;
   agentDir?: string;
   model?: AgentEntry["model"];
+  models?: AgentEntry["models"];
   skills?: AgentEntry["skills"];
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
@@ -112,6 +113,10 @@ export function resolveAgentConfig(
     model:
       typeof entry.model === "string" || (entry.model && typeof entry.model === "object")
         ? entry.model
+        : undefined,
+    models:
+      entry.models && typeof entry.models === "object" && Object.keys(entry.models).length > 0
+        ? entry.models
         : undefined,
     skills: Array.isArray(entry.skills) ? entry.skills : undefined,
     memorySearch: entry.memorySearch,

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -93,6 +93,7 @@ export async function handleDirectiveOnly(
   }).sandboxed;
   const shouldHintDirectRuntime = directives.hasElevatedDirective && !runtimeIsSandboxed;
 
+  const agentModels = resolveAgentConfig(params.cfg, activeAgentId)?.models;
   const modelInfo = await maybeHandleModelDirectiveInfo({
     directives,
     cfg: params.cfg,
@@ -106,6 +107,7 @@ export async function handleDirectiveOnly(
     allowedModelCatalog,
     resetModelOverride,
     surface: params.surface,
+    agentModels,
   });
   if (modelInfo) {
     return modelInfo;

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -198,6 +198,10 @@ export async function maybeHandleModelDirectiveInfo(params: {
   allowedModelCatalog: Array<{ provider: string; id?: string; name?: string }>;
   resetModelOverride: boolean;
   surface?: string;
+  agentModels?: Record<
+    string,
+    import("../../config/types.agent-defaults.js").AgentModelEntryConfig
+  >;
 }): Promise<ReplyPayload | undefined> {
   if (!params.directives.hasModelDirective) {
     return undefined;
@@ -228,6 +232,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
     const reply = await resolveModelsCommandReply({
       cfg: params.cfg,
       commandBodyNormalized: "/models",
+      agentModels: params.agentModels,
     });
     return reply ?? { text: "No models available." };
   }

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -14,6 +14,7 @@ import {
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
+import type { AgentModelEntryConfig } from "../../config/types.agent-defaults.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
@@ -216,7 +217,11 @@ export async function persistInlineDirectives(params: {
   };
 }
 
-export function resolveDefaultModel(params: { cfg: OpenClawConfig; agentId?: string }): {
+export function resolveDefaultModel(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  agentModels?: Record<string, AgentModelEntryConfig>;
+}): {
   defaultProvider: string;
   defaultModel: string;
   aliasIndex: ModelAliasIndex;
@@ -230,6 +235,7 @@ export function resolveDefaultModel(params: { cfg: OpenClawConfig; agentId?: str
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
     defaultProvider,
+    agentModels: params.agentModels,
   });
   return { defaultProvider, defaultModel, aliasIndex };
 }

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -4,6 +4,7 @@ import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { AgentModelEntryConfig } from "../../config/types.agent-defaults.js";
 import { listChatCommands, shouldHandleTextCommands } from "../commands-registry.js";
 import { listSkillCommandsForWorkspace } from "../skill-commands.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
@@ -110,6 +111,7 @@ export async function resolveReplyDirectives(params: {
   typing: TypingController;
   opts?: GetReplyOptions;
   skillFilter?: string[];
+  agentModels?: Record<string, AgentModelEntryConfig>;
 }): Promise<ReplyDirectiveResult> {
   const {
     ctx,
@@ -175,7 +177,11 @@ export async function resolveReplyDirectives(params: {
     ),
   );
 
-  const rawAliases = Object.values(cfg.agents?.defaults?.models ?? {})
+  const modelsSource =
+    params.agentModels && Object.keys(params.agentModels).length > 0
+      ? params.agentModels
+      : (cfg.agents?.defaults?.models ?? {});
+  const rawAliases = Object.values(modelsSource)
     .map((entry) => entry.alias?.trim())
     .filter((alias): alias is string => Boolean(alias))
     .filter((alias) => !reservedCommands.has(alias.toLowerCase()));
@@ -385,6 +391,7 @@ export async function resolveReplyDirectives(params: {
     model,
     hasModelDirective: directives.hasModelDirective,
     hasResolvedHeartbeatModelOverride,
+    agentModels: params.agentModels,
   });
   provider = modelState.provider;
   model = modelState.model;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,4 +1,5 @@
 import {
+  resolveAgentConfig,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
@@ -72,9 +73,11 @@ export async function getReplyFromConfig(
     mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
   const agentCfg = cfg.agents?.defaults;
   const sessionCfg = cfg.session;
+  const agentModels = resolveAgentConfig(cfg, agentId)?.models;
   const { defaultProvider, defaultModel, aliasIndex } = resolveDefaultModel({
     cfg,
     agentId,
+    agentModels,
   });
   let provider = defaultProvider;
   let model = defaultModel;
@@ -177,6 +180,7 @@ export async function getReplyFromConfig(
     defaultProvider,
     defaultModel,
     aliasIndex,
+    agentModels,
   });
 
   const directiveResult = await resolveReplyDirectives({
@@ -205,6 +209,7 @@ export async function getReplyFromConfig(
     typing,
     opts: resolvedOpts,
     skillFilter: mergedSkillFilter,
+    agentModels,
   });
   if (directiveResult.kind === "reply") {
     return directiveResult.reply;

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -9,6 +9,7 @@ import {
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { updateSessionStore } from "../../config/sessions.js";
+import type { AgentModelEntryConfig } from "../../config/types.agent-defaults.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { resolveModelDirectiveSelection, type ModelDirectiveSelection } from "./model-selection.js";
@@ -98,6 +99,7 @@ export async function applyResetModelOverride(params: {
   defaultProvider: string;
   defaultModel: string;
   aliasIndex: ModelAliasIndex;
+  agentModels?: Record<string, AgentModelEntryConfig>;
 }): Promise<ResetModelResult> {
   if (!params.resetTriggered) {
     return {};
@@ -118,6 +120,7 @@ export async function applyResetModelOverride(params: {
     catalog,
     defaultProvider: params.defaultProvider,
     defaultModel: params.defaultModel,
+    agentModels: params.agentModels,
   });
   const allowedModelKeys = allowed.allowedKeys;
   if (allowedModelKeys.size === 0) {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,5 +1,5 @@
 import type { ChatType } from "../channels/chat-type.js";
-import type { AgentDefaultsConfig } from "./types.agent-defaults.js";
+import type { AgentDefaultsConfig, AgentModelEntryConfig } from "./types.agent-defaults.js";
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type {
@@ -25,6 +25,8 @@ export type AgentConfig = {
   workspace?: string;
   agentDir?: string;
   model?: AgentModelConfig;
+  /** Per-agent model allowlist (replaces global `agents.defaults.models` when present). */
+  models?: Record<string, AgentModelEntryConfig>;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];
   memorySearch?: MemorySearchConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -588,6 +588,18 @@ export const AgentEntrySchema = z
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
+    models: z
+      .record(
+        z.string(),
+        z
+          .object({
+            alias: z.string().optional(),
+            params: z.record(z.string(), z.unknown()).optional(),
+            streaming: z.boolean().optional(),
+          })
+          .strict(),
+      )
+      .optional(),
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),


### PR DESCRIPTION
## Summary

- Adds `models` field to `agents.list[]` entries that, when present, **replaces** the global `agents.defaults.models` allowlist for that agent
- Agents without per-agent `models` continue using the global catalog (no breaking change)
- Scopes `/model` switching, `/models` listing, Telegram model picker buttons, and session override validation to the agent's allowlist
- Fixes global defaults/fallbacks leaking into agent-scoped model lists

## Changes

**Type + schema:**
- `AgentConfig.models` type in `types.agents.ts`
- Zod validation in `zod-schema.agent-runtime.ts`

**Core threading:**
- `agentModels` param added to `buildAllowedModelSet()`, `buildModelAliasIndex()`, `buildConfiguredAllowlistKeys()`, `getModelRefStatus()`, `resolveAllowedModelRef()`
- `resolveAgentConfig()` passes through `entry.models`
- `createModelSelectionState()` considers agent-level models for allowlist detection

**Call sites:**
- `getReplyFromConfig()` resolves agent models and passes through the full reply pipeline
- `resolveReplyDirectives()` uses agent models for alias resolution
- `buildModelsProviderData()` skips global default/fallback injection when agent allowlist is active
- Telegram callback handler resolves agent route before building model picker data

**Docs:**
- `models.md`: new "Per-agent model allowlist" subsection
- `multi-agent.md`: new section with config example
- `configuration-reference.md`: `models` field reference

## Config example

```json
{
  "id": "karl-brett",
  "model": { "primary": "openrouter/minimax/minimax-m2.5" },
  "models": {
    "openrouter/minimax/minimax-m2.5": { "alias": "MiniMax M2.5" },
    "openrouter/moonshotai/kimi-k2.5": { "alias": "Kimi K2.5" },
    "openrouter/z-ai/glm-5": { "alias": "GLM 5" }
  }
}
```

## Test plan

- [ ] `npx tsc --noEmit` passes (only pre-existing test file errors)
- [ ] Agent with per-agent `models` only sees those models in `/models` and Telegram picker
- [ ] Agent without per-agent `models` sees full global catalog
- [ ] Global defaults/fallbacks do not leak into agent-scoped model lists
- [ ] `/model <ref>` rejects models not in the agent's allowlist
- [ ] Session model override resets correctly when model is not in agent allowlist

✨ Per aspera ad astra — Nebulatio

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds per-agent model allowlists via `agents.list[].models`, scoping `/model`, `/models`, and Telegram pickers to each agent's catalog.

**Key changes:**
- New `models` field in `AgentConfig` type and Zod schema
- Core model selection functions updated to accept optional `agentModels` parameter
- Agent-scoped allowlists replace global defaults (no merge)
- Model validation, alias resolution, and command handlers thread `agentModels` through the reply pipeline
- Telegram callback handler resolves agent route before building picker data
- Global defaults/fallbacks correctly excluded when agent allowlist is active

**Issues found:**
- `openclaw agent` CLI command (line 394 in `src/commands/agent.ts`) checks global `agentCfg?.models` instead of resolving per-agent models for `sessionAgentId`, causing agent allowlists to be ignored
- `sessions_model` tool (`src/agents/tools/session-status-tool.ts:141-151`) doesn't pass agent models to validation, allowing agents to bypass their allowlists via tool calls

**Unrelated changes bundled in this PR:**
- BlueBubbles extension: surfaces inbound message IDs via system events
- Three new skills added: findmy, group-manager, sonos-cloud

<h3>Confidence Score: 3/5</h3>

- This PR has critical logic gaps that allow per-agent model allowlists to be bypassed
- The core implementation is solid: types, schema validation, reply pipeline threading, and Telegram integration all correctly handle per-agent models. However, two critical code paths bypass the feature: the `openclaw agent` CLI command and the `sessions_model` tool both fail to resolve and pass agent models, allowing users to select disallowed models. These gaps undermine the security/policy enforcement aspect of per-agent allowlists. The PR also bundles unrelated changes (BlueBubbles, skills) which should be separate commits.
- Pay close attention to `src/commands/agent.ts` and `src/agents/tools/session-status-tool.ts` - both have logic bugs that bypass per-agent model allowlists

<sub>Last reviewed commit: 8c9c9b3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->