### PR TITLE
Fix: Discord link consistency and improve TypeScript type safety

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Welcome to the lobster tank! 🦞
 
 - **GitHub:** https://github.com/openclaw/openclaw
 - **Vision:** [`VISION.md`](VISION.md)
-- **Discord:** https://discord.gg/qkhbAGHRBT
+- **Discord:** https://discord.gg/clawd
 - **X/Twitter:** [@steipete](https://x.com/steipete) / [@openclaw](https://x.com/openclaw)
 
 ## Maintainers

--- a/src/discord/monitor/sender-identity.ts
+++ b/src/discord/monitor/sender-identity.ts
@@ -21,6 +21,11 @@ type DiscordWebhookMessageLike = {
   webhook_id?: string | null;
 };
 
+export type DiscordMember = {
+  nickname?: string | null;
+  nick?: string | null;
+};
+
 export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): string | null {
   const candidate = message.webhookId ?? message.webhook_id;
   return typeof candidate === "string" && candidate.trim() ? candidate.trim() : null;
@@ -28,8 +33,7 @@ export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): str
 
 export function resolveDiscordSenderIdentity(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMember;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): DiscordSenderIdentity {
   const pkInfo = params.pluralkitInfo ?? null;
@@ -74,8 +78,7 @@ export function resolveDiscordSenderIdentity(params: {
 
 export function resolveDiscordSenderLabel(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMember;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): string {
   return resolveDiscordSenderIdentity(params).label;


### PR DESCRIPTION
## Summary

This PR addresses two issues to improve code consistency and type safety:

- **Discord Link Inconsistency**: Updated the Discord invite link in CONTRIBUTING.md from `https://discord.gg/qkhbAGHRBT` to `https://discord.gg/clawd` to maintain consistency across the project documentation
- **TypeScript Type Safety Improvement**: Replaced `any` types with proper `DiscordMember` interface in `src/discord/monitor/sender-identity.ts`

## Changes

### CONTRIBUTING.md
- Standardized Discord URL to `https://discord.gg/clawd` (matches README.md and other project files)

### src/discord/monitor/sender-identity.ts
- Added `DiscordMember` type interface with `nickname` and `nick` properties
- Replaced `any` types in `resolveDiscordSenderIdentity()` and `resolveDiscordSenderLabel()` functions
- Removed unnecessary `oxlint-disable-next-line typescript/no-explicit-any` comments

## Test plan

- [x] Code follows existing type patterns used in other Discord-related files
- [x] Changes are minimal and focused on consistency/type safety
- [x] No behavioral changes - only type improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated Discord invite link in `CONTRIBUTING.md` to match the consistent URL used across the project (`discord.gg/clawd`), and improved type safety in `src/discord/monitor/sender-identity.ts` by replacing `any` types with a new `DiscordMember` interface.

**Key changes:**
- Standardized Discord URL for consistency
- Removed `typescript/no-explicit-any` lint disable comments
- Added typed `DiscordMember` interface

**Potential issue:**
- The `DiscordMember` type defines both `nickname` and `nick` properties, but the actual Discord API uses `nick`. The code on line 65 accesses `nickname`, while other files in the codebase (`resolve-users.ts`, `directory-live.ts`, `threading.ts`) consistently use `nick`. This inconsistency may cause the nickname to not be resolved correctly at runtime.

<h3>Confidence Score: 3/5</h3>

- This PR has minimal changes and improves type safety, but contains a potential runtime bug with property access
- The Discord link update is safe and correct. The type safety improvement is good in principle, but there's a concerning inconsistency: the `DiscordMember` type allows both `nickname` and `nick`, yet the code accesses `nickname` while the actual Discord API and other parts of the codebase use `nick`. This could result in nicknames not being displayed correctly at runtime, though it won't cause crashes.
- Pay close attention to `src/discord/monitor/sender-identity.ts` - verify that the property access on line 65 matches the actual Discord API structure

<sub>Last reviewed commit: dcdfff0</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->