### PR TITLE
fix(memory/qmd): migrate orphaned unscoped collections on upgrade

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1411,6 +1411,110 @@ describe("QmdMemoryManager", () => {
       await manager.close();
     });
   });
+
+  it("removes orphaned unscoped collections left from before agent-scoped naming", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [],
+        },
+      },
+    } as OpenClawConfig;
+
+    // Simulate pre-migration state: qmd has unscoped collection names.
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            { name: "memory-root", path: workspaceDir, mask: "MEMORY.md" },
+            { name: "memory-alt", path: workspaceDir, mask: "memory.md" },
+            { name: "memory-dir", path: path.join(workspaceDir, "memory"), mask: "**/*.md" },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    expect(manager).toBeTruthy();
+    await manager.close();
+
+    const commands = spawnMock.mock.calls.map((call: unknown[]) => call[1] as string[]);
+
+    // Old unscoped collections should be removed.
+    const removeNames = commands
+      .filter((args: string[]) => args[0] === "collection" && args[1] === "remove")
+      .map((args: string[]) => args[2]);
+    expect(removeNames).toContain("memory-root");
+    expect(removeNames).toContain("memory-alt");
+    expect(removeNames).toContain("memory-dir");
+
+    // New scoped collections should be added.
+    const addNames = commands
+      .filter((args: string[]) => args[0] === "collection" && args[1] === "add")
+      .map((args: string[]) => args[args.indexOf("--name") + 1]);
+    expect(addNames).toContain("memory-root-main");
+    expect(addNames).toContain("memory-alt-main");
+    expect(addNames).toContain("memory-dir-main");
+  });
+
+  it("skips migration when collections are already scoped", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [],
+        },
+      },
+    } as OpenClawConfig;
+
+    // Simulate post-migration state: qmd already has scoped names.
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            { name: "memory-root-main", path: workspaceDir, mask: "MEMORY.md" },
+            { name: "memory-alt-main", path: workspaceDir, mask: "memory.md" },
+            { name: "memory-dir-main", path: path.join(workspaceDir, "memory"), mask: "**/*.md" },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    expect(manager).toBeTruthy();
+    await manager.close();
+
+    const commands = spawnMock.mock.calls.map((call: unknown[]) => call[1] as string[]);
+
+    // No removal should happen — collections are already scoped.
+    const removeNames = commands
+      .filter((args: string[]) => args[0] === "collection" && args[1] === "remove")
+      .map((args: string[]) => args[2]);
+    expect(removeNames).toHaveLength(0);
+
+    // No adds either — they already exist and paths match.
+    const addNames = commands
+      .filter((args: string[]) => args[0] === "collection" && args[1] === "add")
+      .map((args: string[]) => args[args.indexOf("--name") + 1]);
+    expect(addNames).toHaveLength(0);
+  });
 });
 
 function createDeferred<T>() {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -244,6 +244,29 @@ export class QmdMemoryManager implements MemorySearchManager {
       // ignore; older qmd versions might not support list --json.
     }
 
+    // Migration: remove orphaned unscoped collections left over from before
+    // agent-scoped naming was introduced (b32ae6fa0).  Old collections like
+    // "memory-root" block the creation of new scoped "memory-root-main" when
+    // both point to the same path.
+    const agentSuffix = `-${this.sanitizeCollectionNameSegment(this.agentId)}`;
+    for (const collection of this.qmd.collections) {
+      if (!collection.name.endsWith(agentSuffix)) {
+        continue;
+      }
+      const unscopedName = collection.name.slice(0, -agentSuffix.length);
+      if (unscopedName && existing.has(unscopedName) && !existing.has(collection.name)) {
+        try {
+          await this.removeCollection(unscopedName);
+          existing.delete(unscopedName);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (!this.isCollectionMissingError(message)) {
+            log.warn(`qmd legacy collection cleanup failed for ${unscopedName}: ${message}`);
+          }
+        }
+      }
+    }
+
     for (const collection of this.qmd.collections) {
       const listed = existing.get(collection.name);
       if (listed && !this.shouldRebindCollection(collection, listed)) {


### PR DESCRIPTION
## Summary

Fixes #20727 — `memory_search` returns empty results after upgrading because qmd collections created before per-agent scoping (b32ae6fa0) are never migrated.

### Root Cause

Commit b32ae6fa0 introduced agent-scoped collection names (`memory-root-main` instead of `memory-root`). On upgrade:

1. `ensureCollections()` lists existing qmd collections → finds `memory-root`, `memory-alt`, `memory-dir`
2. Looks for scoped names `memory-root-main` etc. → not found
3. Tries to add `memory-root-main` → qmd rejects it (same path already monitored by `memory-root`)
4. Search passes `-c memory-root-main` → collection not found → empty results

### Fix

Added a migration step in `ensureCollections()` that runs before the main collection setup loop:

- For each expected scoped collection name (e.g. `memory-root-main`), compute the old unscoped name (`memory-root`)
- If the unscoped name exists in qmd but the scoped name does not, remove the unscoped collection
- The subsequent `addCollection` call then succeeds with the new scoped name

The migration is idempotent — it only runs when orphaned unscoped collections are detected and skips entirely when collections are already scoped.

### Files Changed (2)

- `src/memory/qmd-manager.ts` — migration loop in `ensureCollections()` (+23 lines)
- `src/memory/qmd-manager.test.ts` — 2 new tests: orphaned collection migration + already-scoped skip (+104 lines)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where `memory_search` returns empty results after upgrading from pre-agent-scoped collection names. The migration adds a cleanup step in `ensureCollections()` that removes orphaned unscoped collections (e.g., `memory-root`) when the corresponding scoped collection (e.g., `memory-root-main`) is expected but doesn't exist yet. This allows qmd to accept the new scoped collection names without path conflicts.

Key changes:
- Migration loop in `ensureCollections()` removes orphaned unscoped collections before the main setup
- Migration is idempotent and only runs when unscoped collections exist without their scoped counterparts
- Two comprehensive tests cover both migration scenarios (orphaned collections + already-scoped)
- Error handling accounts for missing collections and logs warnings for other failures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The migration logic is sound, idempotent, and well-tested. It only removes collections when it's safe to do so (unscoped exists, scoped doesn't exist), includes proper error handling, and has comprehensive test coverage for both migration and no-op scenarios. The fix directly addresses the reported issue without introducing breaking changes.
- No files require special attention

<sub>Last reviewed commit: ecc78f1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Testing: fully tested (automated + manual verification)
I understand and can explain all changes in this PR.