### PR TITLE
Fix: Feishu duplicate plugin ID, Docker pairing docs, broken formal models link

### DIFF
--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -23,7 +23,10 @@ misconfiguration safety), under explicit assumptions.
 
 ## Where the models live
 
-Models are maintained in a separate repo: [vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models).
+> Note: The formal models repository is currently unavailable. If you have questions about
+> the formal verification work or need access to the models, please open an issue on GitHub.
+
+Models were previously maintained in a separate repo (github.com/vignesh07/openclaw-formal-models).
 
 ## Important caveats
 
@@ -33,22 +36,7 @@ Models are maintained in a separate repo: [vignesh07/openclaw-formal-models](htt
 
 ## Reproducing results
 
-Today, results are reproduced by cloning the models repo locally and running TLC (see below). A future iteration could offer:
-
-- CI-run models with public artifacts (counterexample traces, run logs)
-- a hosted “run this model” workflow for small, bounded checks
-
-Getting started:
-
-```bash
-git clone https://github.com/vignesh07/openclaw-formal-models
-cd openclaw-formal-models
-
-# Java 11+ required (TLC runs on the JVM).
-# The repo vendors a pinned `tla2tools.jar` (TLA+ tools) and provides `bin/tlc` + Make targets.
-
-make <target>
-```
+> Note: The formal models repository is currently unavailable.
 
 ### Gateway exposure and open gateway misconfiguration
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -37,7 +37,7 @@ const meta: ChannelMeta = {
 };
 
 export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
-  id: "feishu",
+  id: "feishu-channel",
   meta: {
     ...meta,
   },


### PR DESCRIPTION
## Summary

This PR addresses several issues:

### Fixed Issues

1. **#20932 - Feishu duplicate plugin ID warning**: Changed `feishuPlugin` id from "feishu" to "feishu-channel" to avoid conflict with the plugin id in index.ts

2. **#20871 - Repo where Models live (Link not exist)**: Updated documentation to note that the formal models repository is no longer available

3. **#20707 - Docker pairing documentation**: Added documentation about the internal gateway-client pairing issue in Docker and recommended solutions:
   - Use `trustedProxies` config for Docker bridge IP
   - Manual CLI approve workaround

### Not Addressed (Requires More Investigation)

- **#20787 - Feishu multi-session image target**: The issue description is vague and the code appears to correctly pass the `to` parameter
- **#20781 - Feishu ackReactionScope**: Complex change requiring significant modifications to Feishu bot.ts
- **#20903/#20807 - Control UI metadata leak**: UI-related issue requiring investigation of the control UI codebase
- **#20870 - Telegram media proxy**: Code appears to correctly use proxy, may be user configuration issue
- **#20924 - Save button disabled**: UI-related issue requiring investigation of the control UI codebase
- **#20918 - Critical system file validation**: Requires understanding of the tools that need validation

---

by MiniMax-M2.5 over opencode

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three documentation and configuration issues:

1. **Feishu duplicate plugin ID**: Changed the `feishuPlugin` channel plugin ID from `"feishu"` to `"feishu-channel"` in `extensions/feishu/src/channel.ts:40` to resolve a conflict with the top-level plugin ID defined in `extensions/feishu/index.ts:48`. This prevents duplicate plugin ID warnings in the system.

2. **Docker internal pairing documentation**: Added comprehensive troubleshooting section for Docker gateway-client pairing issues. The new documentation explains why Docker bridge IPs fail automatic pairing approval and provides two solutions: using `trustedProxies` config (recommended) or manual CLI approval workflow.

3. **Formal models repository link**: Updated documentation to reflect that the formal models repository is no longer available, replacing the broken GitHub link with a note directing users to open issues if they need access to the models.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- All changes are low-risk: a single-line configuration fix for a duplicate ID warning, documentation improvements for Docker troubleshooting, and updated documentation for an unavailable repository. No logic changes, no breaking changes, and the Feishu ID change only affects internal plugin registration without impacting existing functionality.
- No files require special attention

<sub>Last reviewed commit: 807e479</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->