### PR TITLE
Improve 429 messaging for Retry-After parse failures and failover

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
@@ -95,7 +95,14 @@ describe("formatAssistantErrorText", () => {
   });
   it("returns a friendly message for rate limit errors", () => {
     const msg = makeAssistantError("429 rate limit reached");
-    expect(formatAssistantErrorText(msg)).toContain("rate limit reached");
+    expect(formatAssistantErrorText(msg)).toContain("Failed to parse Retry-After");
+    expect(formatAssistantErrorText(msg)).toContain("failover is engaged");
+  });
+
+  it("shows retry-after when available for rate limit errors", () => {
+    const msg = makeAssistantError('429 {"error":{"message":"rate limited"},"retry_after":12}');
+    expect(formatAssistantErrorText(msg)).toContain("Retry after about 12s");
+    expect(formatAssistantErrorText(msg)).toContain("failover is engaged");
   });
 
   it("returns a friendly message for empty stream chunk errors", () => {

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -13,6 +13,10 @@ export type AgentStreamParams = {
   /** Provider stream params override (best-effort). */
   temperature?: number;
   maxTokens?: number;
+  /** Internal retry hint: disable Anthropic context-1m beta on subsequent attempts. */
+  disableAnthropicContext1mBeta?: boolean;
+  /** Internal retry hint for Anthropic extra params override. */
+  context1m?: boolean;
 };
 
 export type AgentRunContext = {


### PR DESCRIPTION
## Summary
- update rate-limit user-facing copy to explicitly mention failover behavior
- parse Retry-After hints from provider error payloads/messages when present
- report an explicit parse-failure message when Retry-After cannot be extracted
- add tests for both parse-success and parse-failure 429 paths

## Why
When Anthropic/OpenClaw hits a 429, operators need clear messaging about:
- how long to wait (when available)
- whether failover is happening
- when Retry-After parsing failed

## Validation
- ran: 
 RUN  v4.0.18 /Users/tsopic/openclaw

 ✓ src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts (20 tests) 5ms

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  16:24:13
   Duration  1.29s (transform 650ms, setup 83ms, import 1.12s, tests 5ms, environment 9ms)
- result: 20 passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enhances 429 rate-limit error messaging by parsing `Retry-After` hints from provider error payloads and providing explicit feedback about failover behavior. The implementation adds a new `extractRetryAfterLabel` function that parses retry hints from JSON fields (`retry_after`, `retry_after_ms`) and natural language patterns in error messages. When a retry hint is successfully parsed, users see "Retry after about Xs" messaging; when parsing fails, they get an explicit "Failed to parse Retry-After" message. Both cases mention failover engagement.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The changes improve user-facing error messaging without affecting core logic. The new `extractRetryAfterLabel` function uses defensive parsing with proper null checks and finite number validation. Test coverage includes both success and failure paths for the new parsing logic. The implementation follows the repository's coding style and has thorough error handling.
- No files require special attention

<sub>Last reviewed commit: 77b2758</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->