### PR TITLE
fix(docs): remove dead link to non-existent formal-models repo

### DIFF
--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -23,7 +23,7 @@ misconfiguration safety), under explicit assumptions.
 
 ## Where the models live
 
-Models are maintained in a separate repo: [vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models).
+Models are maintained in a separate repo (not yet publicly available — see [#20871](https://github.com/openclaw/openclaw/issues/20871)).
 
 ## Important caveats
 
@@ -41,7 +41,8 @@ Today, results are reproduced by cloning the models repo locally and running TLC
 Getting started:
 
 ```bash
-git clone https://github.com/vignesh07/openclaw-formal-models
+# Once the models repo is publicly available:
+# git clone https://github.com/openclaw/openclaw-formal-models
 cd openclaw-formal-models
 
 # Java 11+ required (TLC runs on the JVM).

--- a/docs/zh-CN/security/formal-verification.md
+++ b/docs/zh-CN/security/formal-verification.md
@@ -30,7 +30,7 @@ x-i18n:
 
 ## 模型存放位置
 
-模型维护在一个单独的仓库中：[vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models)。
+模型维护在一个单独的仓库中（尚未公开 — 参见 [#20871](https://github.com/openclaw/openclaw/issues/20871)）。
 
 ## 重要注意事项
 
@@ -48,7 +48,8 @@ x-i18n:
 开始使用：
 
 ```bash
-git clone https://github.com/vignesh07/openclaw-formal-models
+# 模型仓库公开后：
+# git clone https://github.com/openclaw/openclaw-formal-models
 cd openclaw-formal-models
 
 # 需要 Java 11+（TLC 在 JVM 上运行）。


### PR DESCRIPTION
## Summary

Removes dead links to `vignesh07/openclaw-formal-models` (returns 404) in the formal verification docs. Replaces with a note that the repo is not yet publicly available.

## Problem

The formal verification docs reference a GitHub repo that does not exist:
- `https://github.com/vignesh07/openclaw-formal-models` → **404**

This affects both the English and Chinese documentation pages.

## Fix

- Replaced the dead link text with a note + reference to this issue
- Updated the `git clone` command in the code block to a commented placeholder
- Fixed in both `docs/security/formal-verification.md` and `docs/zh-CN/security/formal-verification.md`

**2 files changed**

Fixes #20871

## Local Validation

- Verified both files render correctly
- Confirmed no other references to the dead URL exist in the codebase

## Scope

Docs-only change. Zero code impact.

## Author

**Miloud Belarebia** — [@miloudbelarebia](https://github.com/miloudbelarebia)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes dead link to non-existent `vignesh07/openclaw-formal-models` repository (404) from formal verification docs. Replaces with note that repo is not yet publicly available, referencing issue [#20871](https://github.com/openclaw/openclaw/issues/20871).

- Updated both English (`docs/security/formal-verification.md`) and Chinese (`docs/zh-CN/security/formal-verification.md`) documentation
- Converted `git clone` command to commented placeholder with updated organization path (`openclaw/openclaw-formal-models`)
- Verified no other references to the dead URL exist in codebase

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- Documentation-only change that fixes a broken link with no code impact. Changes are straightforward, properly localized, and verified to be complete across the codebase.
- No files require special attention

<sub>Last reviewed commit: 668ceca</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->