### PR TITLE
fix: Handle single-element type arrays in tryFlattenLiteralAnyOf

### DIFF
--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import { cleanSchemaForGemini } from "./clean-for-gemini.js";
+
+describe("cleanSchemaForGemini", () => {
+  describe("tryFlattenLiteralAnyOf with single-element type arrays", () => {
+    test("flattens anyOf with type as string", () => {
+      const schema = {
+        anyOf: [
+          { type: "string", const: "foo" },
+          { type: "string", const: "bar" },
+        ],
+      };
+
+      const result = cleanSchemaForGemini(schema);
+
+      expect(result).toEqual({
+        type: "string",
+        enum: ["foo", "bar"],
+      });
+    });
+
+    test("flattens anyOf with type as single-element array", () => {
+      const schema = {
+        anyOf: [
+          { type: ["string"], const: "foo" },
+          { type: ["string"], const: "bar" },
+        ],
+      };
+
+      const result = cleanSchemaForGemini(schema);
+
+      expect(result).toEqual({
+        type: "string",
+        enum: ["foo", "bar"],
+      });
+    });
+
+    test("flattens mixed string and single-element array types", () => {
+      const schema = {
+        anyOf: [
+          { type: "string", const: "foo" },
+          { type: ["string"], const: "bar" },
+          { type: "string", const: "baz" },
+        ],
+      };
+
+      const result = cleanSchemaForGemini(schema);
+
+      expect(result).toEqual({
+        type: "string",
+        enum: ["foo", "bar", "baz"],
+      });
+    });
+
+    test("does not flatten when types differ", () => {
+      const schema = {
+        anyOf: [
+          { type: ["string"], const: "foo" },
+          { type: ["number"], const: 42 },
+        ],
+      };
+
+      const result = cleanSchemaForGemini(schema);
+
+      // Should not flatten mismatched types
+      expect(result).toHaveProperty("anyOf");
+      expect(result).not.toHaveProperty("enum");
+    });
+
+    test("handles multi-element type arrays with null stripping", () => {
+      const schema = {
+        anyOf: [
+          { type: ["string", "null"], const: "foo" },
+          { type: ["string", "null"], const: "bar" },
+        ],
+      };
+
+      const result = cleanSchemaForGemini(schema);
+
+      // cleanSchemaForGemini strips null variants and normalizes ["string", "null"] to "string"
+      // So this should successfully flatten
+      expect(result).toEqual({
+        type: "string",
+        enum: ["foo", "bar"],
+      });
+    });
+  });
+});

--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -52,7 +52,7 @@ describe("cleanSchemaForGemini", () => {
       });
     });
 
-    test("does not flatten when types differ", () => {
+    test("falls back to representative type when types differ", () => {
       const schema = {
         anyOf: [
           { type: ["string"], const: "foo" },
@@ -62,8 +62,9 @@ describe("cleanSchemaForGemini", () => {
 
       const result = cleanSchemaForGemini(schema);
 
-      // Should not flatten mismatched types
-      expect(result).toHaveProperty("anyOf");
+      // Mismatched union types fall back to a representative type
+      // in flattenUnionFallback, but should not become a literal enum union.
+      expect(result).toEqual({ type: "string" });
       expect(result).not.toHaveProperty("enum");
     });
 

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -39,6 +39,18 @@ function copySchemaMeta(from: Record<string, unknown>, to: Record<string, unknow
   }
 }
 
+// Resolve variant type from string or single-element array
+// Per JSON Schema spec, type: "string" and type: ["string"] are equivalent
+function resolveVariantType(type: unknown): string | null {
+  if (typeof type === "string") {
+    return type;
+  }
+  if (Array.isArray(type) && type.length === 1 && typeof type[0] === "string") {
+    return type[0];
+  }
+  return null;
+}
+
 // Check if an anyOf/oneOf array contains only literal values that can be flattened.
 // TypeBox Type.Literal generates { const: "value", type: "string" }.
 // Some schemas may use { enum: ["value"], type: "string" }.
@@ -66,7 +78,7 @@ function tryFlattenLiteralAnyOf(variants: unknown[]): { type: string; enum: unkn
       return null;
     }
 
-    const variantType = typeof v.type === "string" ? v.type : null;
+    const variantType = resolveVariantType(v.type);
     if (!variantType) {
       return null;
     }


### PR DESCRIPTION
## Summary

Fixes #20898

`tryFlattenLiteralAnyOf` was failing to flatten unions when schema variants used `type: ["string"]` instead of `type: "string"`, even though both are valid and semantically identical per JSON Schema spec.

## Changes

Added `resolveVariantType()` helper function that normalizes type representation:
- `type: "string"` → `"string"`
- `type: ["string"]` → `"string"` (single-element array)
- `type: ["string", "null"]` → `null` (multi-element, bail out)

## Testing

Added comprehensive test suite (`src/agents/schema/clean-for-gemini.test.ts`):
- ✅ Flattens anyOf with type as string
- ✅ Flattens anyOf with type as single-element array  
- ✅ Flattens mixed string and array types
- ✅ Does not flatten when types differ
- ✅ Handles multi-element type arrays with null stripping

```bash
pnpm test src/agents/schema/clean-for-gemini.test.ts
# Test Files  1 passed (1)
#      Tests  5 passed (5)
```

## Impact

**Low risk** - Only affects schema normalization for Gemini. Existing behavior preserved for all other cases.

Closes #20898

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `resolveVariantType()` helper to normalize type representation in `tryFlattenLiteralAnyOf`, fixing a bug where schemas with `type: ["string"]` (single-element array) were not being flattened even though they're semantically identical to `type: "string"` per JSON Schema spec.

- Handles string types, single-element type arrays, and correctly bails on multi-element arrays
- Comprehensive test coverage validates the fix for all edge cases
- Minimal change with clear focus on the reported issue

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- The change is minimal, well-tested, and narrowly scoped to fixing a specific schema normalization issue. The helper function correctly handles all edge cases, and comprehensive tests verify the behavior. No breaking changes or side effects.
- No files require special attention

<sub>Last reviewed commit: 3266004</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->