### PR TITLE
fix: resolve option collision between browser and cookies set commands

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -18,7 +18,7 @@ Related:
 
 ## Common flags
 
-- `--url <gatewayWsUrl>`: Gateway WebSocket URL (defaults to config).
+- `--gateway-url <gatewayWsUrl>`: Gateway WebSocket URL (defaults to config).
 - `--token <token>`: Gateway token (if required).
 - `--timeout <ms>`: request timeout (ms).
 - `--browser-profile <name>`: choose a browser profile (default from config).

--- a/src/cli/gateway-rpc.ts
+++ b/src/cli/gateway-rpc.ts
@@ -4,7 +4,7 @@ import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-cha
 import { withProgress } from "./progress.js";
 
 export type GatewayRpcOpts = {
-  url?: string;
+  gatewayUrl?: string;
   token?: string;
   timeout?: string;
   expectFinal?: boolean;
@@ -13,7 +13,10 @@ export type GatewayRpcOpts = {
 
 export function addGatewayClientOptions(cmd: Command) {
   return cmd
-    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option(
+      "--gateway-url <url>",
+      "Gateway WebSocket URL (defaults to gateway.remote.url when configured)",
+    )
     .option("--token <token>", "Gateway token (if required)")
     .option("--timeout <ms>", "Timeout in ms", "30000")
     .option("--expect-final", "Wait for final response (agent)", false);
@@ -34,7 +37,7 @@ export async function callGatewayFromCli(
     },
     async () =>
       await callGateway({
-        url: opts.url,
+        url: opts.gatewayUrl,
         token: opts.token,
         method,
         params,

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -28,7 +28,7 @@ type LogsCliOptions = {
   plain?: boolean;
   color?: boolean;
   localTime?: boolean;
-  url?: string;
+  gatewayUrl?: string;
   token?: string;
   timeout?: string;
   expectFinal?: boolean;
@@ -163,7 +163,7 @@ function emitGatewayError(
   emitJsonLine: (payload: Record<string, unknown>, toStdErr?: boolean) => boolean,
   errorLine: (text: string) => boolean,
 ) {
-  const details = buildGatewayConnectionDetails({ url: opts.url });
+  const details = buildGatewayConnectionDetails({ url: opts.gatewayUrl });
   const message = "Gateway not reachable. Is it running and accessible?";
   const hint = `Hint: run \`${formatCliCommand("openclaw doctor")}\`.`;
   const errorText = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Fixes #20976

## What changed
- Renamed the global/parent '--url' option to '--gateway-url' in the gateway client options to avoid collision with the '--url' required option in the 'browser cookies set' subcommand.
- Updated GatewayRpcOpts type to use 'gatewayUrl' instead of 'url'
- Updated all usages in callGatewayFromCli and logs-cli.ts

## AI-assisted contribution
- This fix was generated by an AI agent (OpenClaw cron: gh-issues-fix)
- Testing depth: validated with pnpm build && pnpm check && pnpm test
- The fix addresses the root cause described in the issue by renaming the parent command's --url option to avoid collision with the cookies set subcommand's required --url option

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renamed the global `--url` option to `--gateway-url` in gateway client options to prevent collision with the `--url` required option in the `browser cookies set` subcommand. Updated `GatewayRpcOpts` type and all usages in `callGatewayFromCli` and `logs-cli.ts`. The fix correctly resolves the option collision issue described in #20976.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and focused: renaming a single CLI option to avoid collision. All usages have been correctly updated in both type definitions and implementations. The fix directly addresses the reported issue and follows a clear renaming pattern. No logic changes, no security implications.
- No files require special attention

<sub>Last reviewed commit: 117ccfc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->