### PR TITLE
feat(memory): add durable memory_write + memory_upsert tools

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -369,6 +369,8 @@ Tools:
 
 - `memory_search` — returns snippets with file + line ranges.
 - `memory_get` — read memory file content by path.
+- `memory_write` — append a durable memory line to daily (`memory/YYYY-MM-DD.md`) or long-term (`MEMORY.md`) memory.
+- `memory_upsert` — keyed update/insert for durable memory entries to avoid duplicates.
 
 Local mode:
 
@@ -380,7 +382,9 @@ Local mode:
 
 - `memory_search` semantically searches Markdown chunks (~400 token target, 80-token overlap) from `MEMORY.md` + `memory/**/*.md`. It returns snippet text (capped ~700 chars), file path, line range, score, provider/model, and whether we fell back from local → remote embeddings. No full file payload is returned.
 - `memory_get` reads a specific memory Markdown file (workspace-relative), optionally from a starting line and for N lines. Paths outside `MEMORY.md` / `memory/` are rejected.
-- Both tools are enabled only when `memorySearch.enabled` resolves true for the agent.
+- `memory_write` appends one normalized Markdown bullet to daily or long-term memory files.
+- `memory_upsert` writes a keyed bullet (`[key:<id>]`) and updates existing entries that share the same key.
+- Search tools require `memorySearch.enabled`; write tools require memory plugin availability and a writable workspace.
 
 ### What gets indexed (and when)
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1419,7 +1419,7 @@ Defaults for Talk mode (macOS/iOS/Android).
 | `group:runtime`    | `exec`, `process` (`bash` is accepted as an alias for `exec`)                            |
 | `group:fs`         | `read`, `write`, `edit`, `apply_patch`                                                   |
 | `group:sessions`   | `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status` |
-| `group:memory`     | `memory_search`, `memory_get`                                                            |
+| `group:memory`     | `memory_search`, `memory_get`, `memory_write`, `memory_upsert`                           |
 | `group:web`        | `web_search`, `web_fetch`                                                                |
 | `group:ui`         | `browser`, `canvas`                                                                      |
 | `group:automation` | `cron`, `gateway`                                                                        |

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -88,7 +88,7 @@ Available groups:
 - `group:runtime`: `exec`, `bash`, `process`
 - `group:fs`: `read`, `write`, `edit`, `apply_patch`
 - `group:sessions`: `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status`
-- `group:memory`: `memory_search`, `memory_get`
+- `group:memory`: `memory_search`, `memory_get`, `memory_write`, `memory_upsert`
 - `group:ui`: `browser`, `canvas`
 - `group:automation`: `cron`, `gateway`
 - `group:messaging`: `message`

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -145,7 +145,7 @@ Available groups:
 - `group:runtime`: `exec`, `bash`, `process`
 - `group:fs`: `read`, `write`, `edit`, `apply_patch`
 - `group:sessions`: `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status`
-- `group:memory`: `memory_search`, `memory_get`
+- `group:memory`: `memory_search`, `memory_get`, `memory_write`, `memory_upsert`
 - `group:web`: `web_search`, `web_fetch`
 - `group:ui`: `browser`, `canvas`
 - `group:automation`: `cron`, `gateway`

--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -229,7 +229,7 @@ Tool policies (global, agent, sandbox) support `group:*` entries that expand to 
 - `group:runtime`: `exec`, `bash`, `process`
 - `group:fs`: `read`, `write`, `edit`, `apply_patch`
 - `group:sessions`: `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status`
-- `group:memory`: `memory_search`, `memory_get`
+- `group:memory`: `memory_search`, `memory_get`, `memory_write`, `memory_upsert`
 - `group:ui`: `browser`, `canvas`
 - `group:automation`: `cron`, `gateway`
 - `group:messaging`: `message`

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -124,6 +124,9 @@ function createMockRuntime(): PluginRuntime {
       createMemoryGetTool: vi.fn() as unknown as PluginRuntime["tools"]["createMemoryGetTool"],
       createMemorySearchTool:
         vi.fn() as unknown as PluginRuntime["tools"]["createMemorySearchTool"],
+      createMemoryWriteTool: vi.fn() as unknown as PluginRuntime["tools"]["createMemoryWriteTool"],
+      createMemoryUpsertTool:
+        vi.fn() as unknown as PluginRuntime["tools"]["createMemoryUpsertTool"],
       registerMemoryCli: vi.fn() as unknown as PluginRuntime["tools"]["registerMemoryCli"],
     },
     channel: {

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -18,12 +18,20 @@ const memoryCorePlugin = {
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
         });
-        if (!memorySearchTool || !memoryGetTool) {
-          return null;
-        }
-        return [memorySearchTool, memoryGetTool];
+        const memoryWriteTool = api.runtime.tools.createMemoryWriteTool({
+          config: ctx.config,
+          agentSessionKey: ctx.sessionKey,
+        });
+        const memoryUpsertTool = api.runtime.tools.createMemoryUpsertTool({
+          config: ctx.config,
+          agentSessionKey: ctx.sessionKey,
+        });
+        const tools = [memorySearchTool, memoryGetTool, memoryWriteTool, memoryUpsertTool].filter(
+          (tool): tool is NonNullable<typeof tool> => Boolean(tool),
+        );
+        return tools.length > 0 ? tools : null;
       },
-      { names: ["memory_search", "memory_get"] },
+      { names: ["memory_search", "memory_get", "memory_write", "memory_upsert"] },
     );
 
     api.registerCli(

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -137,6 +137,8 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     expect(isToolAllowedByPolicyName("cron", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("memory_write", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("memory_upsert", policy)).toBe(false);
   });
 
   it("depth-2 leaf denies sessions_spawn", () => {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -54,6 +54,8 @@ const SUBAGENT_TOOL_DENY_ALWAYS = [
   // Memory - pass relevant info in spawn prompt instead
   "memory_search",
   "memory_get",
+  "memory_write",
+  "memory_upsert",
   // Direct session sends - subagents communicate through announce chain
   "sessions_send",
 ];

--- a/src/agents/sandbox-explain.test.ts
+++ b/src/agents/sandbox-explain.test.ts
@@ -57,6 +57,8 @@ describe("sandbox explain helpers", () => {
     expect(policy.allow).toEqual([
       "memory_search",
       "memory_get",
+      "memory_write",
+      "memory_upsert",
       "read",
       "write",
       "edit",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -55,6 +55,11 @@ function buildMemorySection(params: {
     "## Memory Recall",
     "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
   ];
+  if (params.availableTools.has("memory_write") || params.availableTools.has("memory_upsert")) {
+    lines.push(
+      "When the user explicitly asks to remember/update something, use memory_write (append) or memory_upsert (keyed update) so durable memory is saved to disk.",
+    );
+  }
   if (params.citationsMode === "off") {
     lines.push(
       "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -294,6 +294,16 @@
       "title": "Memory Get",
       "detailKeys": ["path", "from", "lines"]
     },
+    "memory_write": {
+      "emoji": "📝",
+      "title": "Memory Write",
+      "detailKeys": ["target", "date", "kind"]
+    },
+    "memory_upsert": {
+      "emoji": "🧷",
+      "title": "Memory Upsert",
+      "detailKeys": ["key", "target", "date", "kind"]
+    },
     "web_search": {
       "emoji": "🔎",
       "title": "Web Search",

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -12,7 +12,7 @@ const TOOL_NAME_ALIASES: Record<string, string> = {
 
 export const TOOL_GROUPS: Record<string, string[]> = {
   // NOTE: Keep canonical (lowercase) tool names here.
-  "group:memory": ["memory_search", "memory_get"],
+  "group:memory": ["memory_search", "memory_get", "memory_write", "memory_upsert"],
   "group:web": ["web_search", "web_fetch"],
   // Basic workspace/file tools
   "group:fs": ["read", "write", "edit", "apply_patch"],
@@ -52,6 +52,8 @@ export const TOOL_GROUPS: Record<string, string[]> = {
     "session_status",
     "memory_search",
     "memory_get",
+    "memory_write",
+    "memory_upsert",
     "web_search",
     "web_fetch",
     "image",

--- a/src/agents/tools/memory-tool.citations.test.ts
+++ b/src/agents/tools/memory-tool.citations.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   resetMemoryToolMockState,
@@ -7,10 +10,27 @@ import {
   type MemoryReadParams,
 } from "../../../test/helpers/memory-tool-manager-mock.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { createMemoryGetTool, createMemorySearchTool } from "./memory-tool.js";
+import {
+  createMemoryGetTool,
+  createMemorySearchTool,
+  createMemoryUpsertTool,
+  createMemoryWriteTool,
+} from "./memory-tool.js";
 
 function asOpenClawConfig(config: Partial<OpenClawConfig>): OpenClawConfig {
   return config as OpenClawConfig;
+}
+
+function configWithWorkspace(workspace: string): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        workspace,
+        memorySearch: { enabled: true },
+      },
+      list: [{ id: "main", default: true }],
+    },
+  } as unknown as OpenClawConfig;
 }
 
 beforeEach(() => {
@@ -177,5 +197,86 @@ describe("memory tools", () => {
       text: "",
       path: "memory/2026-02-19.md",
     });
+  });
+});
+
+describe("memory write tools", () => {
+  it("memory_write appends to daily memory file", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-write-"));
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryWriteTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    const result = await tool.execute("call_write", {
+      text: "remember this",
+      date: "2026-02-18",
+      kind: "preference",
+    });
+    const details = result.details as { path: string; target: string };
+    expect(details.path).toBe("memory/2026-02-18.md");
+    expect(details.target).toBe("daily");
+
+    const content = await fs.readFile(path.join(workspace, "memory", "2026-02-18.md"), "utf-8");
+    expect(content).toContain("remember this");
+    expect(content).toContain("kind:preference");
+  });
+
+  it("memory_upsert updates existing keyed entries", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-upsert-"));
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryUpsertTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await tool.execute("call_upsert_1", {
+      key: "favorite-food",
+      text: "pizza",
+      target: "longterm",
+    });
+    await tool.execute("call_upsert_2", {
+      key: "favorite-food",
+      text: "sushi",
+      target: "longterm",
+    });
+
+    const content = await fs.readFile(path.join(workspace, "MEMORY.md"), "utf-8");
+    expect(content).toContain("[key:favorite-food]");
+    expect(content).toContain("sushi");
+    expect(content).not.toContain("pizza");
+    expect(content.match(/\[key:favorite-food\]/g)?.length).toBe(1);
+  });
+
+  it("memory_upsert preserves all concurrent keyed writes to the same file", async () => {
+    const workspace = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-memory-upsert-concurrent-"),
+    );
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryUpsertTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    const count = 20;
+    await Promise.all(
+      Array.from({ length: count }, (_, index) =>
+        tool.execute(`call_upsert_concurrent_${index}`, {
+          key: `pref-${index}`,
+          text: `value-${index}`,
+          target: "longterm",
+        }),
+      ),
+    );
+
+    const content = await fs.readFile(path.join(workspace, "MEMORY.md"), "utf-8");
+    for (let index = 0; index < count; index += 1) {
+      expect(content).toContain(`[key:pref-${index}]`);
+      expect(content).toContain(`value-${index}`);
+    }
   });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,6 +1,11 @@
 import { createRequire } from "node:module";
 import { resolveEffectiveMessagesConfig, resolveHumanDelayConfig } from "../../agents/identity.js";
-import { createMemoryGetTool, createMemorySearchTool } from "../../agents/tools/memory-tool.js";
+import {
+  createMemoryGetTool,
+  createMemorySearchTool,
+  createMemoryUpsertTool,
+  createMemoryWriteTool,
+} from "../../agents/tools/memory-tool.js";
 import { handleSlackAction } from "../../agents/tools/slack-actions.js";
 import {
   chunkByNewline,
@@ -280,6 +285,8 @@ function createRuntimeTools(): PluginRuntime["tools"] {
   return {
     createMemoryGetTool,
     createMemorySearchTool,
+    createMemoryWriteTool,
+    createMemoryUpsertTool,
     registerMemoryCli,
   };
 }

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -84,6 +84,10 @@ type ResizeToJpeg = typeof import("../../media/image-ops.js").resizeToJpeg;
 type CreateMemoryGetTool = typeof import("../../agents/tools/memory-tool.js").createMemoryGetTool;
 type CreateMemorySearchTool =
   typeof import("../../agents/tools/memory-tool.js").createMemorySearchTool;
+type CreateMemoryWriteTool =
+  typeof import("../../agents/tools/memory-tool.js").createMemoryWriteTool;
+type CreateMemoryUpsertTool =
+  typeof import("../../agents/tools/memory-tool.js").createMemoryUpsertTool;
 type RegisterMemoryCli = typeof import("../../cli/memory-cli.js").registerMemoryCli;
 type DiscordMessageActions =
   typeof import("../../channels/plugins/actions/discord.js").discordMessageActions;
@@ -201,6 +205,8 @@ export type PluginRuntime = {
   tools: {
     createMemoryGetTool: CreateMemoryGetTool;
     createMemorySearchTool: CreateMemorySearchTool;
+    createMemoryWriteTool: CreateMemoryWriteTool;
+    createMemoryUpsertTool: CreateMemoryUpsertTool;
     registerMemoryCli: RegisterMemoryCli;
   };
   channel: {


### PR DESCRIPTION
## Summary
- add new durable memory tools: `memory_write` (append) and `memory_upsert` (keyed update/insert)
- wire new tools through runtime + memory-core extension + tool-policy groups
- update prompt/tool metadata and docs for new memory tool capabilities
- add/extend tests for memory tool behavior and policy handling
- serialize same-process concurrent writes with a per-file in-process mutex

## Why
This enables explicit, structured durable-memory writes when users ask the assistant to remember or update long-term context, while keeping tool-policy controls explicit.

## Validation
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/tools/memory-tool.e2e.test.ts src/agents/pi-tools.policy.e2e.test.ts`

## Follow-up split
Cross-process file-lock hardening was split into a stacked follow-up PR (per review request):
- https://github.com/SmithLabsLLC/openclaw/pull/1
