### PR TITLE
feat(runtime): enable loop detection by default + support timeout=0

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -138,7 +138,7 @@ See [Plugins](/tools/plugin#plugin-hooks) for the hook API and registration deta
 ## Timeouts
 
 - `agent.wait` default: 30s (just the wait). `timeoutMs` param overrides.
-- Agent runtime: `agents.defaults.timeoutSeconds` default 600s; enforced in `runEmbeddedPiAgent` abort timer.
+- Agent runtime: `agents.defaults.timeoutSeconds` defaults to `0` (no timeout, represented internally as a timer-safe max delay); enforced in `runEmbeddedPiAgent` abort timer.
 
 ## Where things can end early
 

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -262,7 +262,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
       humanDelay: {
         mode: "natural",
       },
-      timeoutSeconds: 600,
+      timeoutSeconds: 0,
       mediaMaxMb: 5,
       typingIntervalSeconds: 5,
       maxConcurrent: 3,

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -702,7 +702,7 @@ Time format in system prompt. Default: `auto` (OS preference).
       thinkingDefault: "low",
       verboseDefault: "off",
       elevatedDefault: "on",
-      timeoutSeconds: 600,
+      timeoutSeconds: 0,
       mediaMaxMb: 5,
       contextTokens: 200000,
       maxConcurrent: 3,
@@ -714,6 +714,7 @@ Time format in system prompt. Default: `auto` (OS preference).
 - `model.primary`: format `provider/model` (e.g. `anthropic/claude-opus-4-6`). If you omit the provider, OpenClaw assumes `anthropic` (deprecated).
 - `models`: the configured model catalog and allowlist for `/model`. Each entry can include `alias` (shortcut) and `params` (provider-specific: `temperature`, `maxTokens`).
 - `imageModel`: only used if the primary model lacks image input.
+- `timeoutSeconds`: default agent timeout (seconds). `0` means no timeout.
 - `maxConcurrent`: max parallel agent runs across sessions (each session still serialized). Default: 1.
 
 **Built-in alias shorthands** (only apply when the model is in `agents.defaults.models`):
@@ -1497,7 +1498,7 @@ Controls elevated (host) exec access:
 
 ### `tools.loopDetection`
 
-Tool-loop safety checks are **disabled by default**. Set `enabled: true` to activate detection.
+Tool-loop safety checks are **enabled by default**. Set `enabled: false` only if you explicitly want to disable detection.
 Settings can be defined globally in `tools.loopDetection` and overridden per-agent at `agents.list[].tools.loopDetection`.
 
 ```json5

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -227,7 +227,7 @@ Notes:
 ### `loop-detection` (tool-call loop guardrails)
 
 OpenClaw tracks recent tool-call history and blocks or warns when it detects repetitive no-progress loops.
-Enable with `tools.loopDetection.enabled: true` (default is `false`).
+Loop detection is enabled by default (`tools.loopDetection.enabled: true`).
 
 ```json5
 {

--- a/docs/zh-CN/concepts/agent-loop.md
+++ b/docs/zh-CN/concepts/agent-loop.md
@@ -136,7 +136,7 @@ OpenClaw 有两个钩子系统：
 ## 超时
 
 - `agent.wait` 默认：30 秒（仅等待）。`timeoutMs` 参数可覆盖。
-- 智能体运行时：`agents.defaults.timeoutSeconds` 默认 600 秒；在 `runEmbeddedPiAgent` 中止计时器中强制执行。
+- 智能体运行时：`agents.defaults.timeoutSeconds` 默认 `0`（无超时，内部以计时器安全最大延迟表示）；在 `runEmbeddedPiAgent` 中止计时器中强制执行。
 
 ## 可能提前结束的情况
 

--- a/docs/zh-CN/gateway/configuration-examples.md
+++ b/docs/zh-CN/gateway/configuration-examples.md
@@ -259,7 +259,7 @@ x-i18n:
       humanDelay: {
         mode: "natural",
       },
-      timeoutSeconds: 600,
+      timeoutSeconds: 0,
       mediaMaxMb: 5,
       typingIntervalSeconds: 5,
       maxConcurrent: 3,

--- a/docs/zh-CN/gateway/configuration.md
+++ b/docs/zh-CN/gateway/configuration.md
@@ -1769,7 +1769,7 @@ MiniMax 认证：设置 `MINIMAX_API_KEY`（环境变量）或配置 `models.pro
       thinkingDefault: "low",
       verboseDefault: "off",
       elevatedDefault: "on",
-      timeoutSeconds: 600,
+      timeoutSeconds: 0,
       mediaMaxMb: 5,
       heartbeat: {
         every: "30m",

--- a/src/agents/subagent-depth.test.ts
+++ b/src/agents/subagent-depth.test.ts
@@ -88,13 +88,17 @@ describe("getSubagentDepthFromSessionStore", () => {
 });
 
 describe("resolveAgentTimeoutMs", () => {
+  it("uses no-timeout by default", () => {
+    expect(resolveAgentTimeoutMs({})).toBe(2_147_483_647);
+  });
+
   it("uses a timer-safe sentinel for no-timeout overrides", () => {
-    expect(resolveAgentTimeoutMs({ overrideSeconds: 0 })).toBe(2_147_000_000);
-    expect(resolveAgentTimeoutMs({ overrideMs: 0 })).toBe(2_147_000_000);
+    expect(resolveAgentTimeoutMs({ overrideSeconds: 0 })).toBe(2_147_483_647);
+    expect(resolveAgentTimeoutMs({ overrideMs: 0 })).toBe(2_147_483_647);
   });
 
   it("clamps very large timeout overrides to timer-safe values", () => {
-    expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(2_147_000_000);
-    expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(2_147_000_000);
+    expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(2_147_483_647);
+    expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(2_147_483_647);
   });
 });

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 
-const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
-const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
+const DEFAULT_AGENT_TIMEOUT_SECONDS = 0;
+const MAX_SAFE_TIMEOUT_MS = 2_147_483_647;
 
 const normalizeNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;
@@ -9,7 +9,7 @@ const normalizeNumber = (value: unknown): number | undefined =>
 export function resolveAgentTimeoutSeconds(cfg?: OpenClawConfig): number {
   const raw = normalizeNumber(cfg?.agents?.defaults?.timeoutSeconds);
   const seconds = raw ?? DEFAULT_AGENT_TIMEOUT_SECONDS;
-  return Math.max(seconds, 1);
+  return Math.max(seconds, 0);
 }
 
 export function resolveAgentTimeoutMs(opts: {
@@ -21,9 +21,10 @@ export function resolveAgentTimeoutMs(opts: {
   const minMs = Math.max(normalizeNumber(opts.minMs) ?? 1, 1);
   const clampTimeoutMs = (valueMs: number) =>
     Math.min(Math.max(valueMs, minMs), MAX_SAFE_TIMEOUT_MS);
-  const defaultMs = clampTimeoutMs(resolveAgentTimeoutSeconds(opts.cfg) * 1000);
-  // Use the maximum timer-safe timeout to represent "no timeout" when explicitly set to 0.
+  // Use the maximum timer-safe timeout to represent "no timeout".
   const NO_TIMEOUT_MS = MAX_SAFE_TIMEOUT_MS;
+  const defaultSeconds = resolveAgentTimeoutSeconds(opts.cfg);
+  const defaultMs = defaultSeconds === 0 ? NO_TIMEOUT_MS : clampTimeoutMs(defaultSeconds * 1000);
   const overrideMs = normalizeNumber(opts.overrideMs);
   if (overrideMs !== undefined) {
     if (overrideMs === 0) {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -45,50 +45,6 @@ function recordSuccessfulCall(
   });
 }
 
-function recordSuccessfulPingPongCalls(params: {
-  state: SessionState;
-  readParams: { path: string };
-  listParams: { dir: string };
-  count: number;
-  textAtIndex: (toolName: "read" | "list", index: number) => string;
-}) {
-  for (let i = 0; i < params.count; i += 1) {
-    if (i % 2 === 0) {
-      recordSuccessfulCall(
-        params.state,
-        "read",
-        params.readParams,
-        { content: [{ type: "text", text: params.textAtIndex("read", i) }], details: { ok: true } },
-        i,
-      );
-    } else {
-      recordSuccessfulCall(
-        params.state,
-        "list",
-        params.listParams,
-        { content: [{ type: "text", text: params.textAtIndex("list", i) }], details: { ok: true } },
-        i,
-      );
-    }
-  }
-}
-
-function expectPingPongLoop(
-  loopResult: ReturnType<typeof detectToolCallLoop>,
-  expected: { level: "warning" | "critical"; count: number; expectCriticalText?: boolean },
-) {
-  expect(loopResult.stuck).toBe(true);
-  if (!loopResult.stuck) {
-    return;
-  }
-  expect(loopResult.level).toBe(expected.level);
-  expect(loopResult.detector).toBe("ping_pong");
-  expect(loopResult.count).toBe(expected.count);
-  if (expected.expectCriticalText) {
-    expect(loopResult.message).toContain("CRITICAL");
-  }
-}
-
 describe("tool-loop-detection", () => {
   describe("hashToolCall", () => {
     it("creates consistent hash for same tool and params", () => {
@@ -177,14 +133,23 @@ describe("tool-loop-detection", () => {
   });
 
   describe("detectToolCallLoop", () => {
-    it("is disabled by default", () => {
+    it("can be explicitly disabled", () => {
       const state = createState();
 
       for (let i = 0; i < 20; i += 1) {
-        recordToolCall(state, "read", { path: "/same.txt" }, `default-${i}`);
+        recordToolCall(state, "read", { path: "/same.txt" }, `default-${i}`, {
+          enabled: false,
+        });
       }
 
-      const loopResult = detectToolCallLoop(state, "read", { path: "/same.txt" });
+      const loopResult = detectToolCallLoop(
+        state,
+        "read",
+        { path: "/same.txt" },
+        {
+          enabled: false,
+        },
+      );
       expect(loopResult.stuck).toBe(false);
     });
 
@@ -400,8 +365,11 @@ describe("tool-loop-detection", () => {
       }
 
       const loopResult = detectToolCallLoop(state, "list", listParams, enabledLoopDetectionConfig);
-      expectPingPongLoop(loopResult, { level: "warning", count: WARNING_THRESHOLD });
+      expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("ping_pong");
+        expect(loopResult.count).toBe(WARNING_THRESHOLD);
         expect(loopResult.message).toContain("ping-pong loop");
       }
     });
@@ -411,21 +379,33 @@ describe("tool-loop-detection", () => {
       const readParams = { path: "/a.txt" };
       const listParams = { dir: "/workspace" };
 
-      recordSuccessfulPingPongCalls({
-        state,
-        readParams,
-        listParams,
-        count: CRITICAL_THRESHOLD - 1,
-        textAtIndex: (toolName) => (toolName === "read" ? "read stable" : "list stable"),
-      });
+      for (let i = 0; i < CRITICAL_THRESHOLD - 1; i += 1) {
+        if (i % 2 === 0) {
+          recordSuccessfulCall(
+            state,
+            "read",
+            readParams,
+            { content: [{ type: "text", text: "read stable" }], details: { ok: true } },
+            i,
+          );
+        } else {
+          recordSuccessfulCall(
+            state,
+            "list",
+            listParams,
+            { content: [{ type: "text", text: "list stable" }], details: { ok: true } },
+            i,
+          );
+        }
+      }
 
       const loopResult = detectToolCallLoop(state, "list", listParams, enabledLoopDetectionConfig);
-      expectPingPongLoop(loopResult, {
-        level: "critical",
-        count: CRITICAL_THRESHOLD,
-        expectCriticalText: true,
-      });
+      expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("ping_pong");
+        expect(loopResult.count).toBe(CRITICAL_THRESHOLD);
+        expect(loopResult.message).toContain("CRITICAL");
         expect(loopResult.message).toContain("ping-pong loop");
       }
     });
@@ -435,16 +415,33 @@ describe("tool-loop-detection", () => {
       const readParams = { path: "/a.txt" };
       const listParams = { dir: "/workspace" };
 
-      recordSuccessfulPingPongCalls({
-        state,
-        readParams,
-        listParams,
-        count: CRITICAL_THRESHOLD - 1,
-        textAtIndex: (toolName, index) => `${toolName} ${index}`,
-      });
+      for (let i = 0; i < CRITICAL_THRESHOLD - 1; i += 1) {
+        if (i % 2 === 0) {
+          recordSuccessfulCall(
+            state,
+            "read",
+            readParams,
+            { content: [{ type: "text", text: `read ${i}` }], details: { ok: true } },
+            i,
+          );
+        } else {
+          recordSuccessfulCall(
+            state,
+            "list",
+            listParams,
+            { content: [{ type: "text", text: `list ${i}` }], details: { ok: true } },
+            i,
+          );
+        }
+      }
 
       const loopResult = detectToolCallLoop(state, "list", listParams, enabledLoopDetectionConfig);
-      expectPingPongLoop(loopResult, { level: "warning", count: CRITICAL_THRESHOLD });
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("ping_pong");
+        expect(loopResult.count).toBe(CRITICAL_THRESHOLD);
+      }
     });
 
     it("does not flag ping-pong when alternation is broken", () => {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -29,7 +29,7 @@ export const WARNING_THRESHOLD = 10;
 export const CRITICAL_THRESHOLD = 20;
 export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
 const DEFAULT_LOOP_DETECTION_CONFIG = {
-  enabled: false,
+  enabled: true,
   historySize: TOOL_CALL_HISTORY_SIZE,
   warningThreshold: WARNING_THRESHOLD,
   criticalThreshold: CRITICAL_THRESHOLD,

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -91,7 +91,7 @@ describe("agentCliCommand", () => {
 
       expect(callGateway).toHaveBeenCalledTimes(1);
       const request = vi.mocked(callGateway).mock.calls[0]?.[0] as { timeoutMs?: number };
-      expect(request.timeoutMs).toBe(2_147_000_000);
+      expect(request.timeoutMs).toBe(2_147_483_647);
     });
   });
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1,4 +1,5 @@
 import { listAgentIds } from "../agents/agent-scope.js";
+import { resolveAgentTimeoutSeconds } from "../agents/timeout.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.js";
 import { withProgress } from "../cli/progress.js";
@@ -30,7 +31,7 @@ type GatewayAgentResponse = {
   result?: AgentGatewayResult;
 };
 
-const NO_GATEWAY_TIMEOUT_MS = 2_147_000_000;
+const NO_GATEWAY_TIMEOUT_MS = 2_147_483_647;
 
 export type AgentCliOpts = {
   message: string;
@@ -57,7 +58,7 @@ function parseTimeoutSeconds(opts: { cfg: ReturnType<typeof loadConfig>; timeout
   const raw =
     opts.timeout !== undefined
       ? Number.parseInt(String(opts.timeout), 10)
-      : (opts.cfg.agents?.defaults?.timeoutSeconds ?? 600);
+      : resolveAgentTimeoutSeconds(opts.cfg);
   if (Number.isNaN(raw) || raw < 0) {
     throw new Error("--timeout must be a non-negative integer (seconds; 0 means no timeout)");
   }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -80,7 +80,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.exec.applyPatch.allowModels":
     'Optional allowlist of model ids (e.g. "gpt-5.2" or "openai/gpt-5.2").',
   "tools.loopDetection.enabled":
-    "Enable repetitive tool-call loop detection and backoff safety checks (default: false).",
+    "Enable repetitive tool-call loop detection and backoff safety checks (default: true).",
   "tools.loopDetection.historySize": "Tool history window size for loop detection (default: 30).",
   "tools.loopDetection.warningThreshold":
     "Warning threshold for repetitive patterns when detector is enabled (default: 10).",
@@ -311,17 +311,6 @@ export const FIELD_HELP: Record<string, string> = {
   "plugins.installs.*.installPath":
     "Resolved install directory (usually ~/.openclaw/extensions/<id>).",
   "plugins.installs.*.version": "Version recorded at install time (if available).",
-  "plugins.installs.*.resolvedName": "Resolved npm package name from the fetched artifact.",
-  "plugins.installs.*.resolvedVersion":
-    "Resolved npm package version from the fetched artifact (useful for non-pinned specs).",
-  "plugins.installs.*.resolvedSpec":
-    "Resolved exact npm spec (<name>@<version>) from the fetched artifact.",
-  "plugins.installs.*.integrity":
-    "Resolved npm dist integrity hash for the fetched artifact (if reported by npm).",
-  "plugins.installs.*.shasum":
-    "Resolved npm dist shasum for the fetched artifact (if reported by npm).",
-  "plugins.installs.*.resolvedAt":
-    "ISO timestamp when npm package metadata was last resolved for this install record.",
   "plugins.installs.*.installedAt": "ISO timestamp of last install/update.",
   "agents.list.*.identity.avatar":
     "Agent avatar (workspace-relative path, http(s) URL, or data URI).",
@@ -348,7 +337,7 @@ export const FIELD_HELP: Record<string, string> = {
     "How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately).",
   "commands.config": "Allow /config chat command to read/write config on disk (default: false).",
   "commands.debug": "Allow /debug chat command for runtime-only overrides (default: false).",
-  "commands.restart": "Allow /restart and gateway restart tool actions (default: true).",
+  "commands.restart": "Allow /restart and gateway restart tool actions (default: false).",
   "commands.useAccessGroups": "Enforce access-group allowlists/policies for commands.",
   "commands.ownerAllowFrom":
     "Explicit owner allowlist for owner-only tools/commands. Use channel-native IDs (optionally prefixed like \"whatsapp:+15551234567\"). '*' is ignored.",

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -126,7 +126,7 @@ export const AgentDefaultsSchema = z
     blockStreamingChunk: BlockStreamingChunkSchema.optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     humanDelay: HumanDelaySchema.optional(),
-    timeoutSeconds: z.number().int().positive().optional(),
+    timeoutSeconds: z.number().int().nonnegative().optional(),
     mediaMaxMb: z.number().positive().optional(),
     imageMaxDimensionPx: z.number().int().positive().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary
- enable tool-loop detection by default
- allow `agents.defaults.timeoutSeconds = 0` to represent no-timeout (timer-safe max delay internally)
- align gateway timeout parsing and tests with new timeout semantics
- update config schema/help/docs (including zh-CN docs) for new defaults

## Why
This reduces runaway tool-loop incidents out of the box and makes timeout behavior explicit and consistent across runtime + gateway paths.

## Validation
- `pnpm vitest run --config vitest.unit.config.ts src/agents/tool-loop-detection.test.ts src/agents/subagent-depth.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/commands/agent-via-gateway.e2e.test.ts`
