### PR TITLE
feat(tts): add path delivery mode to prevent duplicate sends

### DIFF
--- a/src/agents/tools/tts-tool.test.ts
+++ b/src/agents/tools/tts-tool.test.ts
@@ -4,13 +4,52 @@ vi.mock("../../auto-reply/tokens.js", () => ({
   SILENT_REPLY_TOKEN: "QUIET_TOKEN",
 }));
 
+vi.mock("../../tts/tts.js", () => ({
+  textToSpeech: vi.fn(),
+}));
+
 const { createTtsTool } = await import("./tts-tool.js");
+const { textToSpeech } = await import("../../tts/tts.js");
 
 describe("createTtsTool", () => {
   it("uses SILENT_REPLY_TOKEN in guidance text", () => {
     const tool = createTtsTool();
 
     expect(tool.description).toContain("QUIET_TOKEN");
+    expect(tool.description).toContain('delivery="path"');
     expect(tool.description).not.toContain("NO_REPLY");
+  });
+
+  it("emits MEDIA output by default", async () => {
+    vi.mocked(textToSpeech).mockResolvedValueOnce({
+      success: true,
+      audioPath: "/tmp/voice.ogg",
+      provider: "edge",
+      voiceCompatible: true,
+    });
+
+    const tool = createTtsTool({ config: {} as never });
+    const result = await tool.execute("tool-1", { text: "hello" });
+    const text = result.content?.[0]?.type === "text" ? result.content[0].text : "";
+
+    expect(text).toContain("[[audio_as_voice]]");
+    expect(text).toContain("MEDIA:/tmp/voice.ogg");
+  });
+
+  it("returns AUDIO_PATH in delivery=path mode to avoid duplicate auto-sends", async () => {
+    vi.mocked(textToSpeech).mockResolvedValueOnce({
+      success: true,
+      audioPath: "/tmp/voice.ogg",
+      provider: "edge",
+      voiceCompatible: true,
+    });
+
+    const tool = createTtsTool({ config: {} as never });
+    const result = await tool.execute("tool-2", { text: "hello", delivery: "path" });
+    const text = result.content?.[0]?.type === "text" ? result.content[0].text : "";
+
+    expect(text).toBe("AUDIO_PATH:/tmp/voice.ogg");
+    expect(text).not.toContain("MEDIA:");
+    expect(text).not.toContain("[[audio_as_voice]]");
   });
 });

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { textToSpeech } from "../../tts/tts.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import { optionalStringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
 import { readStringParam } from "./common.js";
 
@@ -12,6 +13,10 @@ const TtsToolSchema = Type.Object({
   channel: Type.Optional(
     Type.String({ description: "Optional channel id to pick output format (e.g. telegram)." }),
   ),
+  delivery: optionalStringEnum(["auto", "path"], {
+    description:
+      'Delivery mode. "auto" (default) emits MEDIA for automatic send; "path" returns an AUDIO_PATH for manual message.send flows.',
+  }),
 });
 
 export function createTtsTool(opts?: {
@@ -21,12 +26,14 @@ export function createTtsTool(opts?: {
   return {
     label: "TTS",
     name: "tts",
-    description: `Convert text to speech. Audio is delivered automatically from the tool result — reply with ${SILENT_REPLY_TOKEN} after a successful call to avoid duplicate messages.`,
+    description: `Convert text to speech. Default delivery is automatic from the tool result. Use delivery="path" when you will send audio manually via message.send to avoid duplicate sends. Reply with ${SILENT_REPLY_TOKEN} after successful auto delivery.`,
     parameters: TtsToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const text = readStringParam(params, "text", { required: true });
       const channel = readStringParam(params, "channel");
+      const deliveryRaw = readStringParam(params, "delivery")?.trim().toLowerCase();
+      const delivery = deliveryRaw === "path" ? "path" : "auto";
       const cfg = opts?.config ?? loadConfig();
       const result = await textToSpeech({
         text,
@@ -35,15 +42,31 @@ export function createTtsTool(opts?: {
       });
 
       if (result.success && result.audioPath) {
+        if (delivery === "path") {
+          return {
+            content: [{ type: "text", text: `AUDIO_PATH:${result.audioPath}` }],
+            details: {
+              audioPath: result.audioPath,
+              provider: result.provider,
+              delivery,
+              voiceCompatible: result.voiceCompatible,
+            },
+          };
+        }
         const lines: string[] = [];
-        // Tag Telegram Opus output as a voice bubble instead of a file attachment.
+        // Tag Telegram-compatible output as a voice bubble instead of a file attachment.
         if (result.voiceCompatible) {
           lines.push("[[audio_as_voice]]");
         }
         lines.push(`MEDIA:${result.audioPath}`);
         return {
           content: [{ type: "text", text: lines.join("\n") }],
-          details: { audioPath: result.audioPath, provider: result.provider },
+          details: {
+            audioPath: result.audioPath,
+            provider: result.provider,
+            delivery,
+            voiceCompatible: result.voiceCompatible,
+          },
         };
       }
 


### PR DESCRIPTION
## Summary
- add optional `delivery` parameter to the `tts` tool:
  - `auto` (default): existing behavior, emits `MEDIA:` for automatic delivery
  - `path`: returns `AUDIO_PATH:` for manual `message.send` workflows
- update tool guidance text to make duplicate-send avoidance explicit
- add unit tests for default auto mode and new path mode

## Why
When callers need manual control (for example, custom Telegram voice-note pipelines), returning a plain path avoids accidental duplicate audio sends while preserving backward compatibility.

## Validation
- `pnpm vitest run --config vitest.unit.config.ts src/agents/tools/tts-tool.test.ts`
