### PR TITLE
fix: Rename --url to --cookie-url in browser cookies set

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -424,7 +424,7 @@ Actions:
 State:
 
 - `openclaw browser cookies`
-- `openclaw browser cookies set session abc123 --url "https://example.com"`
+- `openclaw browser cookies set session abc123 --cookie-url "https://example.com"`
 - `openclaw browser cookies clear`
 - `openclaw browser storage local get`
 - `openclaw browser storage local set theme dark`

--- a/docs/zh-CN/tools/browser.md
+++ b/docs/zh-CN/tools/browser.md
@@ -399,7 +399,7 @@ docker compose run --rm openclaw-cli \
 状态：
 
 - `openclaw browser cookies`
-- `openclaw browser cookies set session abc123 --url "https://example.com"`
+- `openclaw browser cookies set session abc123 --cookie-url "https://example.com"`
 - `openclaw browser cookies clear`
 - `openclaw browser storage local get`
 - `openclaw browser storage local set theme dark`

--- a/src/cli/browser-cli-state.cookies-storage.ts
+++ b/src/cli/browser-cli-state.cookies-storage.ts
@@ -55,10 +55,10 @@ export function registerBrowserCookiesAndStorageCommands(
 
   cookies
     .command("set")
-    .description("Set a cookie (requires --url or domain+path)")
+    .description("Set a cookie (requires --cookie-url or domain+path)")
     .argument("<name>", "Cookie name")
     .argument("<value>", "Cookie value")
-    .requiredOption("--url <url>", "Cookie URL scope (recommended)")
+    .requiredOption("--cookie-url <url>", "Cookie URL scope (recommended)")
     .option("--target-id <id>", "CDP target id (or unique prefix)")
     .action(async (name: string, value: string, opts, cmd) => {
       const parent = parentOpts(cmd);
@@ -73,7 +73,7 @@ export function registerBrowserCookiesAndStorageCommands(
             query: profile ? { profile } : undefined,
             body: {
               targetId,
-              cookie: { name, value, url: opts.url },
+              cookie: { name, value, url: opts.cookieUrl },
             },
           },
           { timeoutMs: 20000 },

--- a/src/cli/browser-cli-state.option-collisions.test.ts
+++ b/src/cli/browser-cli-state.option-collisions.test.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserParentOpts } from "./browser-cli-shared.js";
 import { registerBrowserStateCommands } from "./browser-cli-state.js";
+import { addGatewayClientOptions } from "./gateway-rpc.js";
 
 const mocks = vi.hoisted(() => ({
   callBrowserRequest: vi.fn(async (..._args: unknown[]) => ({ ok: true })),
@@ -32,6 +33,7 @@ describe("browser state option collisions", () => {
       .command("browser")
       .option("--browser-profile <name>", "Browser profile")
       .option("--json", "Output JSON", false);
+    addGatewayClientOptions(browser); // Add --url option that causes collision
     const parentOpts = (cmd: Command) => cmd.parent?.opts?.() as BrowserParentOpts;
     registerBrowserStateCommands(browser, parentOpts);
     return program;
@@ -70,13 +72,35 @@ describe("browser state option collisions", () => {
       "set",
       "session",
       "abc",
-      "--url",
+      "--cookie-url",
       "https://example.com",
       "--target-id",
       "tab-1",
     ]);
 
     expect((request as { body?: { targetId?: string } }).body?.targetId).toBe("tab-1");
+  });
+
+  it("accepts --cookie-url without collision from parent --url", async () => {
+    const program = createBrowserProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "--url",
+        "ws://localhost:3030",
+        "cookies",
+        "set",
+        "test_cookie",
+        "test_value",
+        "--cookie-url",
+        "https://example.com",
+      ],
+      { from: "user" },
+    );
+
+    const request = getLastRequest() as { body?: { cookie?: { url?: string } } };
+    expect(request.body?.cookie?.url).toBe("https://example.com");
   });
 
   it("accepts legacy parent `--json` by parsing payload via positional headers fallback", async () => {


### PR DESCRIPTION
## Summary

Fixes #20976

The `browser` parent command has `--url` (Gateway WebSocket URL) via `addGatewayClientOptions`, which collides with `--url` needed by the `cookies set` subcommand (cookie domain URL).

Commander.js can't distinguish between parent and child options with the same name, causing:
```bash
$ openclaw browser cookies set name value --url "https://x.com"
error: required option '--url <url>' not specified
```

## Changes

- Renamed `--url` → `--cookie-url` in cookies set command
- Updated `opts.url` → `opts.cookieUrl` in cookie body
- Updated description to reference `--cookie-url`

## Testing

Updated test suite:
- Added `addGatewayClientOptions` to test to properly simulate the collision
- Updated existing test to use `--cookie-url`
- Added new test case verifying parent `--url` + child `--cookie-url` coexist

```bash
$ pnpm test src/cli/browser-cli-state.option-collisions.test.ts
Test Files  1 passed (1)
     Tests  3 passed (3) ✅
```

## Usage After Fix

```bash
$ openclaw browser cookies set session_id 12345 --cookie-url "https://x.com"
cookie set: session_id ✅
```

## Impact

**Low risk** - Changes only CLI flag name. The old `--url` flag was broken due to collision, so no existing working usage is affected.

Closes #20976

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renamed `--url` to `--cookie-url` in `browser cookies set` command to resolve Commander.js option collision with parent command's `--url` flag (Gateway WebSocket URL).

**Key changes:**
- Updated flag name from `--url` to `--cookie-url` in command definition
- Updated option access from `opts.url` to `opts.cookieUrl` in cookie body
- Added `addGatewayClientOptions` to test setup to properly simulate collision scenario
- Added test case verifying parent `--url` and child `--cookie-url` coexist correctly

**Issues found:**
- Documentation in `docs/tools/browser.md` and `docs/zh-CN/tools/browser.md` still references old `--url` flag and needs updating

<h3>Confidence Score: 4/5</h3>

- Safe to merge after updating documentation to reflect the new flag name
- The code change correctly resolves the Commander.js option collision and is well-tested. Test coverage includes verification that both parent and child options coexist properly. The only issue is outdated documentation that still references `--url` instead of `--cookie-url`, which prevents a score of 5.
- Documentation files `docs/tools/browser.md` and `docs/zh-CN/tools/browser.md` need updates to match the new flag name

<sub>Last reviewed commit: 09abbce</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->