### PR TITLE
fix(cron): suppress main-session summary for HEARTBEAT_OK responses

### DIFF
--- a/src/cron/isolated-agent.heartbeat-ok-skips-main-session-summary.test.ts
+++ b/src/cron/isolated-agent.heartbeat-ok-skips-main-session-summary.test.ts
@@ -1,0 +1,117 @@
+import "./isolated-agent.mocks.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
+import type { CliDeps } from "../cli/deps.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+import {
+  makeCfg,
+  makeJob,
+  withTempCronHome,
+  writeSessionStore,
+} from "./isolated-agent.test-harness.js";
+import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
+
+describe("runCronIsolatedAgentTurn – HEARTBEAT_OK summary suppression (#20941)", () => {
+  beforeEach(() => {
+    setupIsolatedAgentTurnMocks({ fast: true });
+  });
+
+  it("sets delivered=true when response is HEARTBEAT_OK so caller skips main-session summary", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "telegram",
+        lastChannel: "telegram",
+        lastTo: "123",
+      });
+      const deps: CliDeps = {
+        sendMessageSlack: vi.fn(),
+        sendMessageWhatsApp: vi.fn(),
+        sendMessageTelegram: vi.fn(),
+        sendMessageDiscord: vi.fn(),
+        sendMessageSignal: vi.fn(),
+        sendMessageIMessage: vi.fn(),
+      };
+
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "HEARTBEAT_OK" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps,
+        job: {
+          ...makeJob({
+            kind: "agentTurn",
+            message: "check things",
+          }),
+          delivery: { mode: "announce", channel: "telegram", to: "123" },
+        },
+        message: "check things",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      // The key assertion: delivered must be true so the caller does NOT
+      // inject "Cron: HEARTBEAT_OK" into the main session.
+      expect(res.delivered).toBe(true);
+      // Neither outbound delivery nor announce flow should have fired.
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    });
+  });
+
+  it("still delivers when HEARTBEAT_OK includes media (structured content)", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "telegram",
+        lastChannel: "telegram",
+        lastTo: "123",
+      });
+      const deps: CliDeps = {
+        sendMessageSlack: vi.fn(),
+        sendMessageWhatsApp: vi.fn(),
+        sendMessageTelegram: vi.fn().mockResolvedValue({
+          messageId: "t1",
+          chatId: "123",
+        }),
+        sendMessageDiscord: vi.fn(),
+        sendMessageSignal: vi.fn(),
+        sendMessageIMessage: vi.fn(),
+      };
+
+      // Media payload should bypass heartbeat suppression
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "HEARTBEAT_OK", mediaUrl: "https://example.com/img.png" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps,
+        job: {
+          ...makeJob({
+            kind: "agentTurn",
+            message: "check things",
+          }),
+          delivery: { mode: "announce", channel: "telegram", to: "123" },
+        },
+        message: "check things",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      // Media should still be delivered even when text is HEARTBEAT_OK
+      expect(deps.sendMessageTelegram).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -589,7 +589,9 @@ export async function runCronIsolatedAgentTurn(params: {
 
   // `true` means we confirmed at least one outbound send reached the target.
   // Keep this strict so timer fallback can safely decide whether to wake main.
-  let delivered = skipMessagingToolDelivery;
+  // Treat heartbeat-only suppression as "delivered" so the caller does not
+  // inject a spurious "Cron: HEARTBEAT_OK" summary into the main session.
+  let delivered = skipMessagingToolDelivery || skipHeartbeatDelivery;
   if (deliveryRequested && !skipHeartbeatDelivery && !skipMessagingToolDelivery) {
     if (resolvedDelivery.error) {
       if (!deliveryBestEffort) {


### PR DESCRIPTION
## Summary

Fixes #20941.

When an isolated cron job with `delivery.mode = "announce"` returns `HEARTBEAT_OK`, the announce delivery correctly suppresses the external message — but the gateway still injects a `Cron: HEARTBEAT_OK` summary into the main session. This triggers the heartbeat system to relay it as a spurious reminder to the user.

## Root Cause

In `src/cron/isolated-agent/run.ts`, `skipHeartbeatDelivery` gates the delivery block (preventing outbound sends and announce flow), but does **not** set `delivered = true`. The caller in `timer.ts` checks `!res.delivered` before injecting the summary into the main session — so the summary leaks through.

## Fix

One-line change: treat heartbeat-only suppression as "delivered" so the caller skips main-session summary injection:

```typescript
let delivered = skipMessagingToolDelivery || skipHeartbeatDelivery;
```

## Tests

Two new tests (175 total cron tests passing):

1. **HEARTBEAT_OK sets `delivered=true`** — verifies no announce flow fires and no outbound send occurs
2. **HEARTBEAT_OK with media still delivers** — verifies structured content (media URLs) bypasses heartbeat suppression as intended

## Checklist

- [x] One-line fix in `run.ts`
- [x] 2 new tests, 175 total cron tests passing
- [x] No breaking changes — only affects the `delivered` flag when heartbeat suppression is active

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `HEARTBEAT_OK` responses from isolated cron jobs were leaking into the main session as spurious summaries. The fix correctly treats heartbeat suppression as "delivered" so the caller in `timer.ts` skips injecting `Cron: HEARTBEAT_OK` messages that would trigger unnecessary user notifications.

The one-line change in `src/cron/isolated-agent/run.ts:594` is surgical and correct:
- Previously: `let delivered = skipMessagingToolDelivery;`
- Now: `let delivered = skipMessagingToolDelivery || skipHeartbeatDelivery;`

This ensures that when `skipHeartbeatDelivery` is true (heartbeat-only response with no real content), the `delivered` flag is set, preventing the main session summary injection in `timer.ts:541`.

Two comprehensive tests validate the behavior:
- Test 1 verifies `HEARTBEAT_OK` sets `delivered=true` and suppresses both announce flow and outbound delivery
- Test 2 verifies `HEARTBEAT_OK` with media still delivers (media bypasses heartbeat suppression via `isHeartbeatOnlyResponse`)

The fix aligns with the existing heartbeat suppression logic where `isHeartbeatOnlyResponse` already checks for media/structured content and returns false when present, ensuring those payloads still get delivered.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal one-line change that correctly addresses the root cause. The logic is sound: treating heartbeat suppression as "delivered" prevents spurious main-session summaries while preserving all existing delivery behavior for real content. Two comprehensive tests validate both the fix (HEARTBEAT_OK suppression) and the edge case (media still delivers). The change is well-contained with no breaking changes or unexpected side effects.
- No files require special attention

<sub>Last reviewed commit: 8dc7837</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->