### PR TITLE
fix(tests): resolve TypeScript type errors in CLI test files

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,10 @@ self-hosted-runner:
     # Blacksmith CI runners
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-4vcpu-windows-2025
+    - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-8vcpu-windows-2025
+    - blacksmith-16vcpu-ubuntu-2404
+    - blacksmith-16vcpu-windows-2025
 
 # Ignore patterns for known issues
 paths:

--- a/src/cli/browser-cli-inspect.test.ts
+++ b/src/cli/browser-cli-inspect.test.ts
@@ -94,7 +94,7 @@ describe("browser cli snapshot defaults", () => {
       browser: { snapshotDefaults: { mode: "efficient" } },
     });
 
-    if (args.includes("--format")) {
+    if ((args as string[]).includes("--format")) {
       gatewayMocks.callGatewayFromCli.mockResolvedValueOnce({
         ok: true,
         format: "aria",

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -37,6 +37,7 @@ const { registerCronCli } = await import("./cron-cli.js");
 
 type CronUpdatePatch = {
   patch?: {
+    schedule?: { kind?: string; expr?: string; tz?: string; staggerMs?: number };
     payload?: { message?: string; model?: string; thinking?: string };
     delivery?: { mode?: string; channel?: string; to?: string; bestEffort?: boolean };
   };


### PR DESCRIPTION
- browser-cli-inspect.test.ts: Cast args to string[] for includes() call to fix TS2345 error when TypeScript infers narrow tuple types
- cron-cli.test.ts: Add missing 'schedule' property to CronUpdatePatch type to fix TS2339 error when accessing patch.schedule in tests

Fixes CI failures in run #22188147945

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Resolves TypeScript type errors in two CLI test files:

- **`browser-cli-inspect.test.ts`**: Casts `args` to `string[]` to fix TS2345 error. TypeScript inferred `args` as a narrow tuple type from `it.each` test cases, which doesn't have the `includes()` method. The cast resolves this.

- **`cron-cli.test.ts`**: Adds missing `schedule` property to `CronUpdatePatch` type definition to fix TS2339 error. The property is accessed in tests at lines 485-486 and 494 but was missing from the type definition.

Both fixes are straightforward type corrections that align the type definitions with actual runtime usage in the tests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects simple, well-scoped TypeScript type fixes with no runtime behavior changes. Both changes address real type errors where the type definitions didn't match actual usage in tests.
- No files require special attention

<sub>Last reviewed commit: 694f1da</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->