### PR TITLE
Security/Gateway: require explicit break-glass env for Control UI bypass flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Gateway: fail startup when `gateway.controlUi.allowInsecureAuth` or `gateway.controlUi.dangerouslyDisableDeviceAuth` is set unless `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1` is explicitly provided, and document the break-glass requirement in config help text.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -33,9 +33,9 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.controlUi.allowedOrigins":
     "Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com).",
   "gateway.controlUi.allowInsecureAuth":
-    "Allow Control UI auth over insecure HTTP (token-only; not recommended).",
+    "Allow Control UI auth over insecure HTTP (token-only; not recommended). Requires OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1 at startup.",
   "gateway.controlUi.dangerouslyDisableDeviceAuth":
-    "DANGEROUS. Disable Control UI device identity checks (token/password only).",
+    "DANGEROUS. Disable Control UI device identity checks (token/password only). Requires OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1 at startup.",
   "gateway.http.endpoints.chatCompletions.enabled":
     "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
   "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -78,6 +78,61 @@ describe("resolveGatewayRuntimeConfig", () => {
   });
 
   describe("token/password auth modes", () => {
+    it("should reject control UI bypass flags without explicit break-glass env", async () => {
+      const cfg = {
+        gateway: {
+          bind: "loopback" as const,
+          auth: {
+            mode: "token" as const,
+            token: "test-token-123",
+          },
+          controlUi: {
+            allowInsecureAuth: true,
+          },
+        },
+      };
+
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        }),
+      ).rejects.toThrow("refusing to start gateway with insecure Control UI bypass flags");
+    });
+
+    it("should allow control UI bypass flags with explicit break-glass env", async () => {
+      const previous = process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS;
+      process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS = "1";
+      try {
+        const cfg = {
+          gateway: {
+            bind: "loopback" as const,
+            auth: {
+              mode: "token" as const,
+              token: "test-token-123",
+            },
+            controlUi: {
+              dangerouslyDisableDeviceAuth: true,
+            },
+          },
+        };
+
+        const result = await resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        });
+
+        expect(result.authMode).toBe("token");
+        expect(result.bindHost).toBe("127.0.0.1");
+      } finally {
+        if (previous === undefined) {
+          delete process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS;
+        } else {
+          process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS = previous;
+        }
+      }
+    });
+
     it("should reject token mode without token configured", async () => {
       const cfg = {
         gateway: {

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -4,12 +4,12 @@ import type {
   GatewayTailscaleConfig,
   loadConfig,
 } from "../config/config.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import {
   assertGatewayAuthConfigured,
   type ResolvedGatewayAuth,
   resolveGatewayAuth,
 } from "./auth.js";
-import { isTruthyEnvValue } from "../infra/env.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import { resolveHooksConfig } from "./hooks.js";
 import { isLoopbackHost, isValidIPv4, resolveGatewayBindHost } from "./net.js";

--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -688,111 +688,117 @@ describe("gateway server auth/connect", () => {
   });
 
   test("allows control ui without device identity when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    const { server, ws, prevToken } = await startServerWithClient("secret", {
-      wsHeaders: { origin: "http://127.0.0.1" },
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      const { server, ws, prevToken } = await startServerWithClient("secret", {
+        wsHeaders: { origin: "http://127.0.0.1" },
+      });
+      const res = await connectReq(ws, {
+        token: "secret",
+        device: null,
+        client: {
+          id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+          version: "1.0.0",
+          platform: "web",
+          mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+        },
+      });
+      expect(res.ok).toBe(true);
+      ws.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
     });
-    const res = await connectReq(ws, {
-      token: "secret",
-      device: null,
-      client: {
-        id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-        version: "1.0.0",
-        platform: "web",
-        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-      },
-    });
-    expect(res.ok).toBe(true);
-    ws.close();
-    await server.close();
-    restoreGatewayToken(prevToken);
   });
 
   test("allows control ui with device identity when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    testState.gatewayAuth = { mode: "token", token: "secret" };
-    const { writeConfigFile } = await import("../config/config.js");
-    await writeConfigFile({
-      gateway: {
-        trustedProxies: ["127.0.0.1"],
-      },
-      // oxlint-disable-next-line typescript/no-explicit-any
-    } as any);
-    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
-    try {
-      await withGatewayServer(async ({ port }) => {
-        const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
-          headers: {
-            origin: "https://localhost",
-            "x-forwarded-for": "203.0.113.10",
-          },
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const { writeConfigFile } = await import("../config/config.js");
+      await writeConfigFile({
+        gateway: {
+          trustedProxies: ["127.0.0.1"],
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+      } as any);
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await withGatewayServer(async ({ port }) => {
+          const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+            headers: {
+              origin: "https://localhost",
+              "x-forwarded-for": "203.0.113.10",
+            },
+          });
+          const challengePromise = onceMessage<{
+            type?: string;
+            event?: string;
+            payload?: Record<string, unknown> | null;
+          }>(ws, (o) => o.type === "event" && o.event === "connect.challenge");
+          await new Promise<void>((resolve) => ws.once("open", resolve));
+          const challenge = await challengePromise;
+          const nonce = (challenge.payload as { nonce?: unknown } | undefined)?.nonce;
+          expect(typeof nonce).toBe("string");
+          const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+          const { device } = await createSignedDevice({
+            token: "secret",
+            scopes,
+            clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+            clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            nonce: String(nonce),
+          });
+          const res = await connectReq(ws, {
+            token: "secret",
+            scopes,
+            device,
+            client: {
+              ...CONTROL_UI_CLIENT,
+            },
+          });
+          expect(res.ok).toBe(true);
+          ws.close();
         });
-        const challengePromise = onceMessage<{
-          type?: string;
-          event?: string;
-          payload?: Record<string, unknown> | null;
-        }>(ws, (o) => o.type === "event" && o.event === "connect.challenge");
-        await new Promise<void>((resolve) => ws.once("open", resolve));
-        const challenge = await challengePromise;
-        const nonce = (challenge.payload as { nonce?: unknown } | undefined)?.nonce;
-        expect(typeof nonce).toBe("string");
-        const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
-        const { device } = await createSignedDevice({
-          token: "secret",
-          scopes,
-          clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          nonce: String(nonce),
-        });
-        const res = await connectReq(ws, {
-          token: "secret",
-          scopes,
-          device,
-          client: {
-            ...CONTROL_UI_CLIENT,
-          },
-        });
-        expect(res.ok).toBe(true);
-        ws.close();
-      });
-    } finally {
-      restoreGatewayToken(prevToken);
-    }
+      } finally {
+        restoreGatewayToken(prevToken);
+      }
+    });
   });
 
   test("allows control ui with stale device identity when device auth is disabled", async () => {
-    testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
-    testState.gatewayAuth = { mode: "token", token: "secret" };
-    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
-    try {
-      await withGatewayServer(async ({ port }) => {
-        const ws = await openWs(port, { origin: originForPort(port) });
-        const { device } = await createSignedDevice({
-          token: "secret",
-          scopes: [],
-          clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          signedAtMs: Date.now() - 60 * 60 * 1000,
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await withGatewayServer(async ({ port }) => {
+          const ws = await openWs(port, { origin: originForPort(port) });
+          const { device } = await createSignedDevice({
+            token: "secret",
+            scopes: [],
+            clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+            clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            signedAtMs: Date.now() - 60 * 60 * 1000,
+          });
+          const res = await connectReq(ws, {
+            token: "secret",
+            scopes: ["operator.read"],
+            device,
+            client: {
+              ...CONTROL_UI_CLIENT,
+            },
+          });
+          expect(res.ok).toBe(true);
+          expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+          const health = await rpcReq(ws, "health");
+          expect(health.ok).toBe(true);
+          ws.close();
         });
-        const res = await connectReq(ws, {
-          token: "secret",
-          scopes: ["operator.read"],
-          device,
-          client: {
-            ...CONTROL_UI_CLIENT,
-          },
-        });
-        expect(res.ok).toBe(true);
-        expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
-        const health = await rpcReq(ws, "health");
-        expect(health.ok).toBe(true);
-        ws.close();
-      });
-    } finally {
-      restoreGatewayToken(prevToken);
-    }
+      } finally {
+        restoreGatewayToken(prevToken);
+      }
+    });
   });
 
   test("accepts device token auth for paired device", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `gateway.controlUi.allowInsecureAuth` and `gateway.controlUi.dangerouslyDisableDeviceAuth` could be enabled without an explicit runtime break-glass acknowledgement.
- Why it matters: these flags intentionally weaken Control UI auth/device protections and should not be enabled silently in normal startup paths.
- What changed: gateway startup now fails closed when either bypass flag is set unless `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1` is present; tests and config help text were updated accordingly.
- What did NOT change (scope boundary): websocket handshake semantics and existing bypass behavior under explicit opt-in were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Gateway startup now rejects Control UI bypass flags unless `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1` is explicitly set.
- Config help text for `gateway.controlUi.allowInsecureAuth` and `gateway.controlUi.dangerouslyDisableDeviceAuth` now documents the break-glass env requirement.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: not executed locally in this shell (Node/pnpm unavailable)
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI
- Relevant config (redacted):

### Steps

1. Set `gateway.controlUi.allowInsecureAuth: true` (or `gateway.controlUi.dangerouslyDisableDeviceAuth: true`).
2. Start gateway without `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS`.
3. Observe startup failure.
4. Set `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1` and restart.
5. Observe startup succeeds.

### Expected

- Startup fails closed by default for bypass flags.
- Startup succeeds only with explicit break-glass env opt-in.

### Actual

- Matches expected by code path + unit/e2e test updates.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed runtime guard in `src/gateway/server-runtime-config.ts`; verified dedicated unit tests added in `src/gateway/server-runtime-config.test.ts`; verified existing bypass e2e tests now opt-in with env in `src/gateway/server.auth.e2e.test.ts`.
- Edge cases checked: both bypass flags; explicit env opt-in path; help text guidance update.
- What you did **not** verify: local test execution in this shell (Node/pnpm unavailable).

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes, with explicit env opt-in for unsafe modes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) Only for users intentionally running bypass flags
- If yes, exact upgrade steps:
  1. Keep bypass flags disabled (recommended), or
  2. Set `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1` only for short-lived break-glass sessions.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove bypass flags from config, or set the explicit break-glass env var for temporary operation.
- Files/config to restore: gateway control UI settings in `openclaw.json`.
- Known bad symptoms reviewers should watch for: gateway startup error mentioning insecure Control UI bypass flags.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: operators with intentionally insecure bypass configs may see startup failure after upgrade.
  - Mitigation: explicit runtime error with required env var and config-help docs updated.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents accidental enablement of insecure Control UI bypass flags by requiring an explicit break-glass environment variable (`OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1`) when `gateway.controlUi.allowInsecureAuth` or `gateway.controlUi.dangerouslyDisableDeviceAuth` is enabled.

- Added runtime validation in `server-runtime-config.ts:109-119` that fails gateway startup unless the explicit env var is present
- Updated config help text to document the break-glass requirement for both bypass flags
- Added comprehensive unit tests covering both rejection and acceptance paths
- Wrapped existing e2e tests with `withEnvAsync` to maintain test functionality with the new guard
- CHANGELOG entry added under Fixes section

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes implement a straightforward fail-safe security guard with proper test coverage. The implementation correctly checks both bypass flags when Control UI is enabled, uses existing `isTruthyEnvValue` helper for env parsing, provides clear error messages, and maintains backward compatibility through explicit opt-in. All existing tests were updated to use the break-glass env var, and new dedicated unit tests cover both the rejection and acceptance paths.
- No files require special attention

<sub>Last reviewed commit: 1d55e39</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->