### PR TITLE
docs: fix dead links to formal verification models repo

### DIFF
--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -42,7 +42,7 @@ Getting started:
 
 ```bash
 git clone https://github.com/vignesh07/clawdbot-formal-models
-cd openclaw-formal-models
+cd clawdbot-formal-models
 
 # Java 11+ required (TLC runs on the JVM).
 # The repo vendors a pinned `tla2tools.jar` (TLA+ tools) and provides `bin/tlc` + Make targets.

--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -23,7 +23,7 @@ misconfiguration safety), under explicit assumptions.
 
 ## Where the models live
 
-Models are maintained in a separate repo: [vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models).
+Models are maintained in a separate repo: [vignesh07/clawdbot-formal-models](https://github.com/vignesh07/clawdbot-formal-models).
 
 ## Important caveats
 
@@ -41,7 +41,7 @@ Today, results are reproduced by cloning the models repo locally and running TLC
 Getting started:
 
 ```bash
-git clone https://github.com/vignesh07/openclaw-formal-models
+git clone https://github.com/vignesh07/clawdbot-formal-models
 cd openclaw-formal-models
 
 # Java 11+ required (TLC runs on the JVM).


### PR DESCRIPTION
## Problem
The formal verification documentation references `vignesh07/openclaw-formal-models` which no longer exists.

Fixes #20871

## Fix
Updated links to point to the correct repository `vignesh07/clawdbot-formal-models`.

## AI Disclosure
This PR was AI-assisted using Twin (twin.so). Testing depth: lightly tested (link verified to exist).

## Checklist
- [x] No unrelated changes
- [x] AI-assisted disclosure included

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated documentation links from `vignesh07/openclaw-formal-models` to `vignesh07/clawdbot-formal-models` to fix dead links.

- Fixed GitHub repository links on lines 26 and 44
- **Issue found**: Line 45 still references the old directory name `openclaw-formal-models` which needs to be updated to `clawdbot-formal-models` to match the cloned repository name

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the directory name in the cd command
- The PR correctly updates the repository links, but misses updating the directory name in the cd command on line 45, which will cause the instructions to fail when users try to follow them
- docs/security/formal-verification.md needs the cd command fixed on line 45

<sub>Last reviewed commit: 5e015cf</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->