### PR TITLE
fix: treat HTTP 503 as failover-eligible for LLM provider errors

### DIFF
--- a/src/agents/failover-error.e2e.test.ts
+++ b/src/agents/failover-error.e2e.test.ts
@@ -13,7 +13,7 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
-    expect(resolveFailoverReasonFromError({ status: 503 })).toBe("rate_limit");
+    expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.e2e.test.ts
+++ b/src/agents/failover-error.e2e.test.ts
@@ -13,6 +13,7 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
+    expect(resolveFailoverReasonFromError({ status: 503 })).toBe("rate_limit");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -162,7 +162,7 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
     return "timeout";
   }
   if (status === 503) {
-    return "rate_limit";
+    return "timeout";
   }
   if (status === 400) {
     return "format";

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -161,6 +161,9 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
+  if (status === 503) {
+    return "rate_limit";
+  }
   if (status === 400) {
     return "format";
   }

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -355,5 +355,10 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("rate_limit");
     expect(classifyFailoverReason("LLM error: service unavailable")).toBe("rate_limit");
+    expect(
+      classifyFailoverReason(
+        '{"error":{"code":503,"message":"The model is overloaded. Please try later","status":"UNAVAILABLE"}}',
+      ),
+    ).toBe("rate_limit");
   });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -348,4 +348,12 @@ describe("classifyFailoverReason", () => {
       "rate_limit",
     );
   });
+  it("classifies provider high-demand / service-unavailable messages as rate_limit", () => {
+    expect(
+      classifyFailoverReason(
+        "This model is currently experiencing high demand. Please try again later.",
+      ),
+    ).toBe("rate_limit");
+    expect(classifyFailoverReason("LLM error: service unavailable")).toBe("rate_limit");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -586,7 +586,6 @@ const ERROR_PATTERNS = {
   overloaded: [
     /overloaded_error|"type"\s*:\s*"overloaded_error"/i,
     "overloaded",
-    /\b503\b/,
     "service unavailable",
     "high demand",
   ],

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -583,7 +583,13 @@ const ERROR_PATTERNS = {
     "resource_exhausted",
     "usage limit",
   ],
-  overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
+  overloaded: [
+    /overloaded_error|"type"\s*:\s*"overloaded_error"/i,
+    "overloaded",
+    /\b503\b/,
+    "service unavailable",
+    "high demand",
+  ],
   timeout: [
     "timeout",
     "timed out",


### PR DESCRIPTION
## Summary

When LLM providers (e.g. Google Gemini) return HTTP 503 "Service Unavailable" errors, their SDKs sometimes strip the leading status code from the error message — producing messages like `"This model is currently experiencing high demand"` or `"UNAVAILABLE"` instead of `"503 ..."`.

The existing `isTransientHttpError` in `errors.ts` only matches messages **starting with** `"503"`, so these wrapped/rewritten error messages silently fall through without triggering failover (no profile rotation, no model fallback).

This patch closes that gap with two complementary changes:

- **`failover-error.ts`**: Map HTTP status code `503` → `rate_limit` in `resolveFailoverReasonFromError`, covering structured error objects that carry a numeric `.status` field.
- **`errors.ts`**: Add three patterns to `ERROR_PATTERNS.overloaded` — `/\b503\b/`, `"service unavailable"`, `"high demand"` — covering message-only classification when the leading status prefix is absent.

Existing `isTransientHttpError` behavior is **unchanged**; these additions are strictly complementary and only fire for errors that previously fell through unclassified.

## Test plan

- [x] Added e2e test: `resolveFailoverReasonFromError({ status: 503 })` returns `"rate_limit"`
- [x] Added e2e test: `classifyFailoverReason` correctly classifies Google "high demand" and generic "service unavailable" messages as `"rate_limit"`
- [x] Verified existing tests still pass

## Motivation

Observed frequent 503 errors from Google Gemini API (`"This model is currently experiencing high demand"`) that were **not** triggering openclaw's failover mechanism, causing tasks to fail instead of rotating to the next auth profile or falling back to an alternative model.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Maps HTTP 503 errors to failover-eligible classifications, closing a gap where SDK-rewritten error messages were silently failing without triggering profile rotation or model fallback.

- **Structured errors** (`status: 503`): now map to `"timeout"` via `resolveFailoverReasonFromError` 
- **SDK-rewritten messages** (lacking numeric prefix): "service unavailable" and "high demand" patterns map to `"rate_limit"` via `ERROR_PATTERNS.overloaded`
- Both classifications trigger failover; the distinction reflects error semantics (transient HTTP vs. overload)
- Comprehensive test coverage added for both code paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-tested, and address a real production issue (Google Gemini 503 errors not triggering failover). The implementation correctly handles both structured error objects and SDK-rewritten string messages. Previous semantic inconsistency concern was addressed by excluding the `/\b503\b/` pattern. Both new classifications (`"timeout"` and `"rate_limit"`) are failover-eligible, ensuring the core fix works as intended. Test coverage is comprehensive.
- No files require special attention

<sub>Last reviewed commit: 232d622</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->