### PR TITLE
fix(ui): render images in tool result content blocks [AI-assisted]

### DIFF
--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -55,6 +55,10 @@ function extractToolOutputText(value: unknown): string | null {
       if (entry.type === "text" && typeof entry.text === "string") {
         return entry.text;
       }
+      if (entry.type === "image") {
+        const mimeType = typeof entry.mimeType === "string" ? entry.mimeType : "image/png";
+        return `[image: ${mimeType}]`;
+      }
       return null;
     })
     .filter((part): part is string => Boolean(part));

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -285,10 +285,13 @@ function renderGroupedMessage(
             : nothing
         }
       ${markdown
-            ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
+            ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(
+                toSanitizedMarkdownHtml(markdown),
+            )}</div>`
             : nothing
         }
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}
     </div>
   `;
 }
+

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -6,71 +6,71 @@ import { detectTextDirection } from "../text-direction.ts";
 import type { MessageGroup } from "../types/chat-types.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
 import {
-  extractTextCached,
-  extractThinkingCached,
-  formatReasoningMarkdown,
+    extractTextCached,
+    extractThinkingCached,
+    formatReasoningMarkdown,
 } from "./message-extract.ts";
 import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer.ts";
 import { extractToolCards, renderToolCardSidebar } from "./tool-cards.ts";
 
 type ImageBlock = {
-  url: string;
-  alt?: string;
+    url: string;
+    alt?: string;
 };
 
 function extractImages(message: unknown): ImageBlock[] {
-  const m = message as Record<string, unknown>;
-  const content = m.content;
-  const images: ImageBlock[] = [];
+    const m = message as Record<string, unknown>;
+    const content = m.content;
+    const images: ImageBlock[] = [];
 
-  if (!Array.isArray(content)) {
+    if (!Array.isArray(content)) {
+        return images;
+    }
+
+    for (const block of content) {
+        if (typeof block !== "object" || block === null) {
+            continue;
+        }
+        const b = block as Record<string, unknown>;
+
+        if (b.type === "image") {
+            // Tool result images: { type: "image", data: string, mimeType: string }
+            if (typeof b.data === "string" && b.data) {
+                const data = b.data;
+                const mimeType = (b.mimeType as string) || "image/png";
+                const url = data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`;
+                images.push({ url });
+                continue;
+            }
+
+            // sendChatMessage images: { source: { type: "base64", data, media_type } } or { url }
+            const source = b.source as Record<string, unknown> | undefined;
+            if (source?.type === "base64" && typeof source.data === "string") {
+                const data = source.data;
+                const mediaType = (source.media_type as string) || "image/png";
+                const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
+                images.push({ url });
+            } else if (typeof b.url === "string") {
+                images.push({ url: b.url });
+            }
+
+            continue;
+        }
+
+        if (b.type === "image_url") {
+            // OpenAI format: { type: "image_url", image_url: { url: string } }
+            const imageUrl = b.image_url as Record<string, unknown> | undefined;
+            if (typeof imageUrl?.url === "string") {
+                images.push({ url: imageUrl.url });
+            }
+        }
+    }
+
     return images;
-  }
-
-  for (const block of content) {
-    if (typeof block !== "object" || block === null) {
-  continue;
-}
-    const b = block as Record<string, unknown>;
-
-    if (b.type === "image") {
-      // Tool result images: { type: "image", data: string, mimeType: string }
-      if (typeof b.data === "string" && b.data) {
-        const data = b.data;
-        const mimeType = (b.mimeType as string) || "image/png";
-        const url = data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`;
-        images.push({ url });
-        continue;
-      }
-
-      // sendChatMessage images: { source: { type: "base64", data, media_type } } or { url }
-      const source = b.source as Record<string, unknown> | undefined;
-      if (source?.type === "base64" && typeof source.data === "string") {
-        const data = source.data;
-        const mediaType = (source.media_type as string) || "image/png";
-        const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
-        images.push({ url });
-      } else if (typeof b.url === "string") {
-        images.push({ url: b.url });
-      }
-
-      continue;
-    }
-
-    if (b.type === "image_url") {
-      // OpenAI format: { type: "image_url", image_url: { url: string } }
-      const imageUrl = b.image_url as Record<string, unknown> | undefined;
-      if (typeof imageUrl?.url === "string") {
-        images.push({ url: imageUrl.url });
-      }
-    }
-  }
-
-  return images;
 }
 
 export function renderReadingIndicatorGroup(assistant?: AssistantIdentity) {
-  return html`
+    return html`
     <div class="chat-group assistant">
       ${renderAvatar("assistant", assistant)}
       <div class="chat-group-messages">
@@ -85,30 +85,30 @@ export function renderReadingIndicatorGroup(assistant?: AssistantIdentity) {
 }
 
 export function renderStreamingGroup(
-  text: string,
-  startedAt: number,
-  onOpenSidebar?: (content: string) => void,
-  assistant?: AssistantIdentity,
+    text: string,
+    startedAt: number,
+    onOpenSidebar?: (content: string) => void,
+    assistant?: AssistantIdentity,
 ) {
-  const timestamp = new Date(startedAt).toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-  const name = assistant?.name ?? "Assistant";
+    const timestamp = new Date(startedAt).toLocaleTimeString([], {
+        hour: "numeric",
+        minute: "2-digit",
+    });
+    const name = assistant?.name ?? "Assistant";
 
-  return html`
+    return html`
     <div class="chat-group assistant">
       ${renderAvatar("assistant", assistant)}
       <div class="chat-group-messages">
         ${renderGroupedMessage(
-          {
+        {
             role: "assistant",
             content: [{ type: "text", text }],
             timestamp: startedAt,
-          },
-          { isStreaming: true, showReasoning: false },
-          onOpenSidebar,
-        )}
+        },
+        { isStreaming: true, showReasoning: false },
+        onOpenSidebar,
+    )}
         <div class="chat-group-footer">
           <span class="chat-sender-name">${name}</span>
           <span class="chat-group-timestamp">${timestamp}</span>
@@ -119,46 +119,46 @@ export function renderStreamingGroup(
 }
 
 export function renderMessageGroup(
-  group: MessageGroup,
-  opts: {
-    onOpenSidebar?: (content: string) => void;
-    showReasoning: boolean;
-    assistantName?: string;
-    assistantAvatar?: string | null;
-  },
+    group: MessageGroup,
+    opts: {
+        onOpenSidebar?: (content: string) => void;
+        showReasoning: boolean;
+        assistantName?: string;
+        assistantAvatar?: string | null;
+    },
 ) {
-  const normalizedRole = normalizeRoleForGrouping(group.role);
-  const assistantName = opts.assistantName ?? "Assistant";
-  const who =
-    normalizedRole === "user"
-      ? "You"
-      : normalizedRole === "assistant"
-        ? assistantName
-        : normalizedRole;
-  const roleClass =
-    normalizedRole === "user" ? "user" : normalizedRole === "assistant" ? "assistant" : "other";
-  const timestamp = new Date(group.timestamp).toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-  });
+    const normalizedRole = normalizeRoleForGrouping(group.role);
+    const assistantName = opts.assistantName ?? "Assistant";
+    const who =
+        normalizedRole === "user"
+            ? "You"
+            : normalizedRole === "assistant"
+                ? assistantName
+                : normalizedRole;
+    const roleClass =
+        normalizedRole === "user" ? "user" : normalizedRole === "assistant" ? "assistant" : "other";
+    const timestamp = new Date(group.timestamp).toLocaleTimeString([], {
+        hour: "numeric",
+        minute: "2-digit",
+    });
 
-  return html`
+    return html`
     <div class="chat-group ${roleClass}">
       ${renderAvatar(group.role, {
         name: assistantName,
         avatar: opts.assistantAvatar ?? null,
-      })}
+    })}
       <div class="chat-group-messages">
         ${group.messages.map((item, index) =>
-          renderGroupedMessage(
+        renderGroupedMessage(
             item.message,
             {
-              isStreaming: group.isStreaming && index === group.messages.length - 1,
-              showReasoning: opts.showReasoning,
+                isStreaming: group.isStreaming && index === group.messages.length - 1,
+                showReasoning: opts.showReasoning,
             },
             opts.onOpenSidebar,
-          ),
-        )}
+        ),
+    )}
         <div class="chat-group-footer">
           <span class="chat-sender-name">${who}</span>
           <span class="chat-group-timestamp">${timestamp}</span>
@@ -169,52 +169,52 @@ export function renderMessageGroup(
 }
 
 function renderAvatar(role: string, assistant?: Pick<AssistantIdentity, "name" | "avatar">) {
-  const normalized = normalizeRoleForGrouping(role);
-  const assistantName = assistant?.name?.trim() || "Assistant";
-  const assistantAvatar = assistant?.avatar?.trim() || "";
-  const initial =
-    normalized === "user"
-      ? "U"
-      : normalized === "assistant"
-        ? assistantName.charAt(0).toUpperCase() || "A"
-        : normalized === "tool"
-          ? "⚙"
-          : "?";
-  const className =
-    normalized === "user"
-      ? "user"
-      : normalized === "assistant"
-        ? "assistant"
-        : normalized === "tool"
-          ? "tool"
-          : "other";
+    const normalized = normalizeRoleForGrouping(role);
+    const assistantName = assistant?.name?.trim() || "Assistant";
+    const assistantAvatar = assistant?.avatar?.trim() || "";
+    const initial =
+        normalized === "user"
+            ? "U"
+            : normalized === "assistant"
+                ? assistantName.charAt(0).toUpperCase() || "A"
+                : normalized === "tool"
+                    ? "⚙"
+                    : "?";
+    const className =
+        normalized === "user"
+            ? "user"
+            : normalized === "assistant"
+                ? "assistant"
+                : normalized === "tool"
+                    ? "tool"
+                    : "other";
 
-  if (assistantAvatar && normalized === "assistant") {
-    if (isAvatarUrl(assistantAvatar)) {
-      return html`<img
+    if (assistantAvatar && normalized === "assistant") {
+        if (isAvatarUrl(assistantAvatar)) {
+            return html`<img
         class="chat-avatar ${className}"
         src="${assistantAvatar}"
         alt="${assistantName}"
       />`;
+        }
+        return html`<div class="chat-avatar ${className}">${assistantAvatar}</div>`;
     }
-    return html`<div class="chat-avatar ${className}">${assistantAvatar}</div>`;
-  }
 
-  return html`<div class="chat-avatar ${className}">${initial}</div>`;
+    return html`<div class="chat-avatar ${className}">${initial}</div>`;
 }
 
 function isAvatarUrl(value: string): boolean {
-  return (
-    /^https?:\/\//i.test(value) || /^data:image\//i.test(value) || value.startsWith("/") // Relative paths from avatar endpoint
-  );
+    return (
+        /^https?:\/\//i.test(value) || /^data:image\//i.test(value) || value.startsWith("/") // Relative paths from avatar endpoint
+    );
 }
 
 function renderMessageImages(images: ImageBlock[]) {
-  if (images.length === 0) {
-    return nothing;
-  }
+    if (images.length === 0) {
+        return nothing;
+    }
 
-  return html`
+    return html`
     <div class="chat-message-images">
       ${images.map(
         (img) => html`
@@ -225,71 +225,69 @@ function renderMessageImages(images: ImageBlock[]) {
             @click=${() => window.open(img.url, "_blank")}
           />
         `,
-      )}
+    )}
     </div>
   `;
 }
 
 function renderGroupedMessage(
-  message: unknown,
-  opts: { isStreaming: boolean; showReasoning: boolean },
-  onOpenSidebar?: (content: string) => void,
+    message: unknown,
+    opts: { isStreaming: boolean; showReasoning: boolean },
+    onOpenSidebar?: (content: string) => void,
 ) {
-  const m = message as Record<string, unknown>;
-  const role = typeof m.role === "string" ? m.role : "unknown";
-  const isToolResult =
-    isToolResultMessage(message) ||
-    role.toLowerCase() === "toolresult" ||
-    role.toLowerCase() === "tool_result" ||
-    typeof m.toolCallId === "string" ||
-    typeof m.tool_call_id === "string";
+    const m = message as Record<string, unknown>;
+    const role = typeof m.role === "string" ? m.role : "unknown";
+    const isToolResult =
+        isToolResultMessage(message) ||
+        role.toLowerCase() === "toolresult" ||
+        role.toLowerCase() === "tool_result" ||
+        typeof m.toolCallId === "string" ||
+        typeof m.tool_call_id === "string";
 
-  const toolCards = extractToolCards(message);
-  const hasToolCards = toolCards.length > 0;
-  const images = extractImages(message);
-  const hasImages = images.length > 0;
+    const toolCards = extractToolCards(message);
+    const hasToolCards = toolCards.length > 0;
+    const images = extractImages(message);
+    const hasImages = images.length > 0;
 
-  const extractedText = extractTextCached(message);
-  const extractedThinking =
-    opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
-  const markdownBase = extractedText?.trim() ? extractedText : null;
-  const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
-  const markdown = markdownBase;
-  const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
+    const extractedText = extractTextCached(message);
+    const extractedThinking =
+        opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
+    const markdownBase = extractedText?.trim() ? extractedText : null;
+    const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
+    const markdown = markdownBase;
+    const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
 
-  const bubbleClasses = [
-    "chat-bubble",
-    canCopyMarkdown ? "has-copy" : "",
-    opts.isStreaming ? "streaming" : "",
-    "fade-in",
-  ]
-    .filter(Boolean)
-    .join(" ");
+    const bubbleClasses = [
+        "chat-bubble",
+        canCopyMarkdown ? "has-copy" : "",
+        opts.isStreaming ? "streaming" : "",
+        "fade-in",
+    ]
+        .filter(Boolean)
+        .join(" ");
 
-  if (!markdown && hasToolCards && isToolResult) {
-    return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
-  }
+    if (!markdown && hasToolCards && isToolResult) {
+        return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
+    }
 
-  if (!markdown && !hasToolCards && !hasImages) {
-    return nothing;
-  }
+    if (!markdown && !hasToolCards && !hasImages) {
+        return nothing;
+    }
 
-  return html`
+    return html`
     <div class="${bubbleClasses}">
       ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
       ${renderMessageImages(images)}
-      ${
-        reasoningMarkdown
-          ? html`<div class="chat-thinking">${unsafeHTML(
-              toSanitizedMarkdownHtml(reasoningMarkdown),
+      ${reasoningMarkdown
+            ? html`<div class="chat-thinking">${unsafeHTML(
+                toSanitizedMarkdownHtml(reasoningMarkdown),
             )}</div>`
-          : nothing
-      }
-      ${
-        markdown
-          ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
-          : nothing
-      }
+            : nothing
+        }
+      ${markdown
+            ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
+            : nothing
+        }
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}
     </div>
   `;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -28,7 +28,9 @@ function extractImages(message: unknown): ImageBlock[] {
   }
 
   for (const block of content) {
-    if (typeof block !== "object" || block === null) continue;
+    if (typeof block !== "object" || block === null) {
+  continue;
+}
     const b = block as Record<string, unknown>;
 
     if (b.type === "image") {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -41,6 +41,25 @@ function extractImages(message: unknown): ImageBlock[] {
           images.push({ url });
         } else if (typeof b.url === "string") {
           images.push({ url: b.url });
+      if (b.type === "image") {
+        // Handle direct data/mimeType format (from tool results)
+        if (typeof b.data === "string" && b.data) {
+          const mimeType = (b.mimeType as string) || "image/png";
+          const url = b.data.startsWith("data:") ? b.data : `data:${mimeType};base64,${b.data}`;
+          images.push({ url });
+        }
+        // Handle source object format (from sendChatMessage)
+        else {
+          const source = b.source as Record<string, unknown> | undefined;
+          if (source?.type === "base64" && typeof source.data === "string") {
+            const data = source.data;
+            const mediaType = (source.media_type as string) || "image/png";
+            // If data is already a data URL, use it directly
+            const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
+            images.push({ url });
+          } else if (typeof b.url === "string") {
+            images.push({ url: b.url });
+          }
         }
       } else if (b.type === "image_url") {
         // OpenAI format

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -10,10 +10,7 @@ import {
   extractThinkingCached,
   formatReasoningMarkdown,
 } from "./message-extract.ts";
-import {
-  isToolResultMessage,
-  normalizeRoleForGrouping,
-} from "./message-normalizer.ts";
+import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer.ts";
 import { extractToolCards, renderToolCardSidebar } from "./tool-cards.ts";
 
 type ImageBlock = {
@@ -41,9 +38,7 @@ function extractImages(message: unknown): ImageBlock[] {
       if (typeof b.data === "string" && b.data) {
         const data = b.data;
         const mimeType = (b.mimeType as string) || "image/png";
-        const url = data.startsWith("data:")
-          ? data
-          : `data:${mimeType};base64,${data}`;
+        const url = data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`;
         images.push({ url });
         continue;
       }
@@ -53,9 +48,7 @@ function extractImages(message: unknown): ImageBlock[] {
       if (source?.type === "base64" && typeof source.data === "string") {
         const data = source.data;
         const mediaType = (source.media_type as string) || "image/png";
-        const url = data.startsWith("data:")
-          ? data
-          : `data:${mediaType};base64,${data}`;
+        const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
         images.push({ url });
       } else if (typeof b.url === "string") {
         images.push({ url: b.url });
@@ -143,11 +136,7 @@ export function renderMessageGroup(
         ? assistantName
         : normalizedRole;
   const roleClass =
-    normalizedRole === "user"
-      ? "user"
-      : normalizedRole === "assistant"
-        ? "assistant"
-        : "other";
+    normalizedRole === "user" ? "user" : normalizedRole === "assistant" ? "assistant" : "other";
   const timestamp = new Date(group.timestamp).toLocaleTimeString([], {
     hour: "numeric",
     minute: "2-digit",
@@ -164,8 +153,7 @@ export function renderMessageGroup(
           renderGroupedMessage(
             item.message,
             {
-              isStreaming:
-                group.isStreaming && index === group.messages.length - 1,
+              isStreaming: group.isStreaming && index === group.messages.length - 1,
               showReasoning: opts.showReasoning,
             },
             opts.onOpenSidebar,
@@ -180,10 +168,7 @@ export function renderMessageGroup(
   `;
 }
 
-function renderAvatar(
-  role: string,
-  assistant?: Pick<AssistantIdentity, "name" | "avatar">,
-) {
+function renderAvatar(role: string, assistant?: Pick<AssistantIdentity, "name" | "avatar">) {
   const normalized = normalizeRoleForGrouping(role);
   const assistantName = assistant?.name?.trim() || "Assistant";
   const assistantAvatar = assistant?.avatar?.trim() || "";
@@ -220,9 +205,7 @@ function renderAvatar(
 
 function isAvatarUrl(value: string): boolean {
   return (
-    /^https?:\/\//i.test(value) ||
-    /^data:image\//i.test(value) ||
-    value.startsWith("/") // Relative paths from avatar endpoint
+    /^https?:\/\//i.test(value) || /^data:image\//i.test(value) || value.startsWith("/") // Relative paths from avatar endpoint
   );
 }
 
@@ -268,13 +251,9 @@ function renderGroupedMessage(
 
   const extractedText = extractTextCached(message);
   const extractedThinking =
-    opts.showReasoning && role === "assistant"
-      ? extractThinkingCached(message)
-      : null;
+    opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
   const markdownBase = extractedText?.trim() ? extractedText : null;
-  const reasoningMarkdown = extractedThinking
-    ? formatReasoningMarkdown(extractedThinking)
-    : null;
+  const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
 
@@ -288,9 +267,7 @@ function renderGroupedMessage(
     .join(" ");
 
   if (!markdown && hasToolCards && isToolResult) {
-    return html`${toolCards.map((card) =>
-      renderToolCardSidebar(card, onOpenSidebar),
-    )}`;
+    return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
   }
 
   if (!markdown && !hasToolCards && !hasImages) {
@@ -301,16 +278,20 @@ function renderGroupedMessage(
     <div class="${bubbleClasses}">
       ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
       ${renderMessageImages(images)}
-      ${reasoningMarkdown
-        ? html`<div class="chat-thinking">
+      ${
+        reasoningMarkdown
+          ? html`<div class="chat-thinking">
             ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
           </div>`
-        : nothing}
-      ${markdown
-        ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+          : nothing
+      }
+      ${
+        markdown
+          ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
             ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
           </div>`
-        : nothing}
+          : nothing
+      }
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}
     </div>
   `;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -42,19 +42,19 @@ function extractImages(message: unknown): ImageBlock[] {
         } else if (typeof b.url === "string") {
           images.push({ url: b.url });
       if (b.type === "image") {
-        // Handle direct data/mimeType format (from tool results)
+        // Tool result images: { type: "image", data: string, mimeType: string }
         if (typeof b.data === "string" && b.data) {
           const mimeType = (b.mimeType as string) || "image/png";
-          const url = b.data.startsWith("data:") ? b.data : `data:${mimeType};base64,${b.data}`;
+          const data = b.data;
+          const url = data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`;
           images.push({ url });
-        }
-        // Handle source object format (from sendChatMessage)
-        else {
+        } else {
+          // sendChatMessage images: { source: { type: "base64", data, media_type } } or { url }
           const source = b.source as Record<string, unknown> | undefined;
+
           if (source?.type === "base64" && typeof source.data === "string") {
             const data = source.data;
             const mediaType = (source.media_type as string) || "image/png";
-            // If data is already a data URL, use it directly
             const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
             images.push({ url });
           } else if (typeof b.url === "string") {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -6,71 +6,78 @@ import { detectTextDirection } from "../text-direction.ts";
 import type { MessageGroup } from "../types/chat-types.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
 import {
-    extractTextCached,
-    extractThinkingCached,
-    formatReasoningMarkdown,
+  extractTextCached,
+  extractThinkingCached,
+  formatReasoningMarkdown,
 } from "./message-extract.ts";
-import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer.ts";
+import {
+  isToolResultMessage,
+  normalizeRoleForGrouping,
+} from "./message-normalizer.ts";
 import { extractToolCards, renderToolCardSidebar } from "./tool-cards.ts";
 
 type ImageBlock = {
-    url: string;
-    alt?: string;
+  url: string;
+  alt?: string;
 };
 
 function extractImages(message: unknown): ImageBlock[] {
-    const m = message as Record<string, unknown>;
-    const content = m.content;
-    const images: ImageBlock[] = [];
+  const m = message as Record<string, unknown>;
+  const content = m.content;
+  const images: ImageBlock[] = [];
 
-    if (!Array.isArray(content)) {
-        return images;
-    }
-
-    for (const block of content) {
-        if (typeof block !== "object" || block === null) {
-            continue;
-        }
-        const b = block as Record<string, unknown>;
-
-        if (b.type === "image") {
-            // Tool result images: { type: "image", data: string, mimeType: string }
-            if (typeof b.data === "string" && b.data) {
-                const data = b.data;
-                const mimeType = (b.mimeType as string) || "image/png";
-                const url = data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`;
-                images.push({ url });
-                continue;
-            }
-
-            // sendChatMessage images: { source: { type: "base64", data, media_type } } or { url }
-            const source = b.source as Record<string, unknown> | undefined;
-            if (source?.type === "base64" && typeof source.data === "string") {
-                const data = source.data;
-                const mediaType = (source.media_type as string) || "image/png";
-                const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
-                images.push({ url });
-            } else if (typeof b.url === "string") {
-                images.push({ url: b.url });
-            }
-
-            continue;
-        }
-
-        if (b.type === "image_url") {
-            // OpenAI format: { type: "image_url", image_url: { url: string } }
-            const imageUrl = b.image_url as Record<string, unknown> | undefined;
-            if (typeof imageUrl?.url === "string") {
-                images.push({ url: imageUrl.url });
-            }
-        }
-    }
-
+  if (!Array.isArray(content)) {
     return images;
+  }
+
+  for (const block of content) {
+    if (typeof block !== "object" || block === null) {
+      continue;
+    }
+    const b = block as Record<string, unknown>;
+
+    if (b.type === "image") {
+      // Tool result images: { type: "image", data: string, mimeType: string }
+      if (typeof b.data === "string" && b.data) {
+        const data = b.data;
+        const mimeType = (b.mimeType as string) || "image/png";
+        const url = data.startsWith("data:")
+          ? data
+          : `data:${mimeType};base64,${data}`;
+        images.push({ url });
+        continue;
+      }
+
+      // sendChatMessage images: { source: { type: "base64", data, media_type } } or { url }
+      const source = b.source as Record<string, unknown> | undefined;
+      if (source?.type === "base64" && typeof source.data === "string") {
+        const data = source.data;
+        const mediaType = (source.media_type as string) || "image/png";
+        const url = data.startsWith("data:")
+          ? data
+          : `data:${mediaType};base64,${data}`;
+        images.push({ url });
+      } else if (typeof b.url === "string") {
+        images.push({ url: b.url });
+      }
+
+      continue;
+    }
+
+    if (b.type === "image_url") {
+      // OpenAI format: { type: "image_url", image_url: { url: string } }
+      const imageUrl = b.image_url as Record<string, unknown> | undefined;
+      if (typeof imageUrl?.url === "string") {
+        images.push({ url: imageUrl.url });
+      }
+    }
+  }
+
+  return images;
 }
 
 export function renderReadingIndicatorGroup(assistant?: AssistantIdentity) {
-    return html`
+  return html`
     <div class="chat-group assistant">
       ${renderAvatar("assistant", assistant)}
       <div class="chat-group-messages">
@@ -85,30 +92,30 @@ export function renderReadingIndicatorGroup(assistant?: AssistantIdentity) {
 }
 
 export function renderStreamingGroup(
-    text: string,
-    startedAt: number,
-    onOpenSidebar?: (content: string) => void,
-    assistant?: AssistantIdentity,
+  text: string,
+  startedAt: number,
+  onOpenSidebar?: (content: string) => void,
+  assistant?: AssistantIdentity,
 ) {
-    const timestamp = new Date(startedAt).toLocaleTimeString([], {
-        hour: "numeric",
-        minute: "2-digit",
-    });
-    const name = assistant?.name ?? "Assistant";
+  const timestamp = new Date(startedAt).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  const name = assistant?.name ?? "Assistant";
 
-    return html`
+  return html`
     <div class="chat-group assistant">
       ${renderAvatar("assistant", assistant)}
       <div class="chat-group-messages">
         ${renderGroupedMessage(
-        {
+          {
             role: "assistant",
             content: [{ type: "text", text }],
             timestamp: startedAt,
-        },
-        { isStreaming: true, showReasoning: false },
-        onOpenSidebar,
-    )}
+          },
+          { isStreaming: true, showReasoning: false },
+          onOpenSidebar,
+        )}
         <div class="chat-group-footer">
           <span class="chat-sender-name">${name}</span>
           <span class="chat-group-timestamp">${timestamp}</span>
@@ -119,46 +126,51 @@ export function renderStreamingGroup(
 }
 
 export function renderMessageGroup(
-    group: MessageGroup,
-    opts: {
-        onOpenSidebar?: (content: string) => void;
-        showReasoning: boolean;
-        assistantName?: string;
-        assistantAvatar?: string | null;
-    },
+  group: MessageGroup,
+  opts: {
+    onOpenSidebar?: (content: string) => void;
+    showReasoning: boolean;
+    assistantName?: string;
+    assistantAvatar?: string | null;
+  },
 ) {
-    const normalizedRole = normalizeRoleForGrouping(group.role);
-    const assistantName = opts.assistantName ?? "Assistant";
-    const who =
-        normalizedRole === "user"
-            ? "You"
-            : normalizedRole === "assistant"
-                ? assistantName
-                : normalizedRole;
-    const roleClass =
-        normalizedRole === "user" ? "user" : normalizedRole === "assistant" ? "assistant" : "other";
-    const timestamp = new Date(group.timestamp).toLocaleTimeString([], {
-        hour: "numeric",
-        minute: "2-digit",
-    });
+  const normalizedRole = normalizeRoleForGrouping(group.role);
+  const assistantName = opts.assistantName ?? "Assistant";
+  const who =
+    normalizedRole === "user"
+      ? "You"
+      : normalizedRole === "assistant"
+        ? assistantName
+        : normalizedRole;
+  const roleClass =
+    normalizedRole === "user"
+      ? "user"
+      : normalizedRole === "assistant"
+        ? "assistant"
+        : "other";
+  const timestamp = new Date(group.timestamp).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 
-    return html`
+  return html`
     <div class="chat-group ${roleClass}">
       ${renderAvatar(group.role, {
         name: assistantName,
         avatar: opts.assistantAvatar ?? null,
-    })}
+      })}
       <div class="chat-group-messages">
         ${group.messages.map((item, index) =>
-        renderGroupedMessage(
+          renderGroupedMessage(
             item.message,
             {
-                isStreaming: group.isStreaming && index === group.messages.length - 1,
-                showReasoning: opts.showReasoning,
+              isStreaming:
+                group.isStreaming && index === group.messages.length - 1,
+              showReasoning: opts.showReasoning,
             },
             opts.onOpenSidebar,
-        ),
-    )}
+          ),
+        )}
         <div class="chat-group-footer">
           <span class="chat-sender-name">${who}</span>
           <span class="chat-group-timestamp">${timestamp}</span>
@@ -168,53 +180,58 @@ export function renderMessageGroup(
   `;
 }
 
-function renderAvatar(role: string, assistant?: Pick<AssistantIdentity, "name" | "avatar">) {
-    const normalized = normalizeRoleForGrouping(role);
-    const assistantName = assistant?.name?.trim() || "Assistant";
-    const assistantAvatar = assistant?.avatar?.trim() || "";
-    const initial =
-        normalized === "user"
-            ? "U"
-            : normalized === "assistant"
-                ? assistantName.charAt(0).toUpperCase() || "A"
-                : normalized === "tool"
-                    ? "⚙"
-                    : "?";
-    const className =
-        normalized === "user"
-            ? "user"
-            : normalized === "assistant"
-                ? "assistant"
-                : normalized === "tool"
-                    ? "tool"
-                    : "other";
+function renderAvatar(
+  role: string,
+  assistant?: Pick<AssistantIdentity, "name" | "avatar">,
+) {
+  const normalized = normalizeRoleForGrouping(role);
+  const assistantName = assistant?.name?.trim() || "Assistant";
+  const assistantAvatar = assistant?.avatar?.trim() || "";
+  const initial =
+    normalized === "user"
+      ? "U"
+      : normalized === "assistant"
+        ? assistantName.charAt(0).toUpperCase() || "A"
+        : normalized === "tool"
+          ? "⚙"
+          : "?";
+  const className =
+    normalized === "user"
+      ? "user"
+      : normalized === "assistant"
+        ? "assistant"
+        : normalized === "tool"
+          ? "tool"
+          : "other";
 
-    if (assistantAvatar && normalized === "assistant") {
-        if (isAvatarUrl(assistantAvatar)) {
-            return html`<img
+  if (assistantAvatar && normalized === "assistant") {
+    if (isAvatarUrl(assistantAvatar)) {
+      return html`<img
         class="chat-avatar ${className}"
         src="${assistantAvatar}"
         alt="${assistantName}"
       />`;
-        }
-        return html`<div class="chat-avatar ${className}">${assistantAvatar}</div>`;
     }
+    return html`<div class="chat-avatar ${className}">${assistantAvatar}</div>`;
+  }
 
-    return html`<div class="chat-avatar ${className}">${initial}</div>`;
+  return html`<div class="chat-avatar ${className}">${initial}</div>`;
 }
 
 function isAvatarUrl(value: string): boolean {
-    return (
-        /^https?:\/\//i.test(value) || /^data:image\//i.test(value) || value.startsWith("/") // Relative paths from avatar endpoint
-    );
+  return (
+    /^https?:\/\//i.test(value) ||
+    /^data:image\//i.test(value) ||
+    value.startsWith("/") // Relative paths from avatar endpoint
+  );
 }
 
 function renderMessageImages(images: ImageBlock[]) {
-    if (images.length === 0) {
-        return nothing;
-    }
+  if (images.length === 0) {
+    return nothing;
+  }
 
-    return html`
+  return html`
     <div class="chat-message-images">
       ${images.map(
         (img) => html`
@@ -225,73 +242,76 @@ function renderMessageImages(images: ImageBlock[]) {
             @click=${() => window.open(img.url, "_blank")}
           />
         `,
-    )}
+      )}
     </div>
   `;
 }
 
 function renderGroupedMessage(
-    message: unknown,
-    opts: { isStreaming: boolean; showReasoning: boolean },
-    onOpenSidebar?: (content: string) => void,
+  message: unknown,
+  opts: { isStreaming: boolean; showReasoning: boolean },
+  onOpenSidebar?: (content: string) => void,
 ) {
-    const m = message as Record<string, unknown>;
-    const role = typeof m.role === "string" ? m.role : "unknown";
-    const isToolResult =
-        isToolResultMessage(message) ||
-        role.toLowerCase() === "toolresult" ||
-        role.toLowerCase() === "tool_result" ||
-        typeof m.toolCallId === "string" ||
-        typeof m.tool_call_id === "string";
+  const m = message as Record<string, unknown>;
+  const role = typeof m.role === "string" ? m.role : "unknown";
+  const isToolResult =
+    isToolResultMessage(message) ||
+    role.toLowerCase() === "toolresult" ||
+    role.toLowerCase() === "tool_result" ||
+    typeof m.toolCallId === "string" ||
+    typeof m.tool_call_id === "string";
 
-    const toolCards = extractToolCards(message);
-    const hasToolCards = toolCards.length > 0;
-    const images = extractImages(message);
-    const hasImages = images.length > 0;
+  const toolCards = extractToolCards(message);
+  const hasToolCards = toolCards.length > 0;
+  const images = extractImages(message);
+  const hasImages = images.length > 0;
 
-    const extractedText = extractTextCached(message);
-    const extractedThinking =
-        opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
-    const markdownBase = extractedText?.trim() ? extractedText : null;
-    const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
-    const markdown = markdownBase;
-    const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
+  const extractedText = extractTextCached(message);
+  const extractedThinking =
+    opts.showReasoning && role === "assistant"
+      ? extractThinkingCached(message)
+      : null;
+  const markdownBase = extractedText?.trim() ? extractedText : null;
+  const reasoningMarkdown = extractedThinking
+    ? formatReasoningMarkdown(extractedThinking)
+    : null;
+  const markdown = markdownBase;
+  const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
 
-    const bubbleClasses = [
-        "chat-bubble",
-        canCopyMarkdown ? "has-copy" : "",
-        opts.isStreaming ? "streaming" : "",
-        "fade-in",
-    ]
-        .filter(Boolean)
-        .join(" ");
+  const bubbleClasses = [
+    "chat-bubble",
+    canCopyMarkdown ? "has-copy" : "",
+    opts.isStreaming ? "streaming" : "",
+    "fade-in",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
-    if (!markdown && hasToolCards && isToolResult) {
-        return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
-    }
+  if (!markdown && hasToolCards && isToolResult) {
+    return html`${toolCards.map((card) =>
+      renderToolCardSidebar(card, onOpenSidebar),
+    )}`;
+  }
 
-    if (!markdown && !hasToolCards && !hasImages) {
-        return nothing;
-    }
+  if (!markdown && !hasToolCards && !hasImages) {
+    return nothing;
+  }
 
-    return html`
+  return html`
     <div class="${bubbleClasses}">
       ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
       ${renderMessageImages(images)}
       ${reasoningMarkdown
-            ? html`<div class="chat-thinking">${unsafeHTML(
-                toSanitizedMarkdownHtml(reasoningMarkdown),
-            )}</div>`
-            : nothing
-        }
+        ? html`<div class="chat-thinking">
+            ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+          </div>`
+        : nothing}
       ${markdown
-            ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(
-                toSanitizedMarkdownHtml(markdown),
-            )}</div>`
-            : nothing
-        }
+        ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+            ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
+          </div>`
+        : nothing}
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}
     </div>
   `;
 }
-

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -42,6 +42,9 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
       text: item.text as string | undefined,
       name: item.name as string | undefined,
       args: item.args || item.arguments,
+      data: item.data as string | undefined,
+      mimeType: item.mimeType as string | undefined,
+      source: item.source as MessageContentItem["source"],
     }));
   } else if (typeof m.text === "string") {
     content = [{ type: "text", text: m.text }];
@@ -53,9 +56,6 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   return { role, content, timestamp, id };
 }
 
-/**
- * Normalize role for grouping purposes.
- */
 export function normalizeRoleForGrouping(role: string): string {
   const lower = role.toLowerCase();
   // Preserve original casing when it's already a core role.

--- a/ui/src/ui/types/chat-types.ts
+++ b/ui/src/ui/types/chat-types.ts
@@ -21,10 +21,13 @@ export type MessageGroup = {
 
 /** Content item types in a normalized message */
 export type MessageContentItem = {
-  type: "text" | "tool_call" | "tool_result";
+  type: "text" | "image" | "tool_call" | "tool_result";
   text?: string;
   name?: string;
   args?: unknown;
+  data?: string;
+  mimeType?: string;
+  source?: { type?: string; media_type?: string; data?: string };
 };
 
 /** Normalized message structure for rendering */


### PR DESCRIPTION
## Problem
Webchat UI does not render images returned in tool result content blocks. The content mapper in message-normalizer.ts drops data/mimeType/source fields, and extractToolOutputText in app-tool-stream.ts silently ignores image blocks.

Related to #21025

## Fix
- Updated chat-types.ts to include image type and fields (data, mimeType, source)
- Updated message-normalizer.ts to preserve data/mimeType/source fields in content mapping
- Updated app-tool-stream.ts to handle image content blocks in extractToolOutputText

## AI Disclosure
This PR was AI-assisted using Twin (twin.so). Testing depth: untested (no local build environment).

## Checklist
- [x] No unrelated changes
- [x] AI-assisted disclosure included

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds type definitions and field preservation for image content in tool results, but **the UI rendering logic is incomplete** - images won't actually display because `extractImages()` doesn't handle the new `data`/`mimeType` fields.

**Changes:**
- Added `image` type and `data`/`mimeType`/`source` fields to `MessageContentItem` type definition
- Preserved image fields in `normalizeMessage()` content mapping
- Added placeholder text `[image: {mimeType}]` in `extractToolOutputText()` for tool stream output

**Critical issue:**
- `extractImages()` in `grouped-render.ts` only handles `source` object and `url` formats, not the `data`/`mimeType` format that tool results actually use (see `src/agents/tool-images.ts:35`)

<h3>Confidence Score: 1/5</h3>

- This PR has a critical logical gap that prevents the stated functionality from working
- The PR adds type definitions and preserves image fields through the message normalizer, but the actual rendering function (`extractImages` in `grouped-render.ts`) doesn't handle the new field format. Tool result images use `{data, mimeType}` directly on the image block, but `extractImages` only checks for `source.data` or `url` fields. Without the comment fix, images in tool results won't render.
- Pay close attention to `ui/src/ui/chat/grouped-render.ts` - the `extractImages` function needs to handle the `data`/`mimeType` fields

<sub>Last reviewed commit: e481441</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->