### PR TITLE
Security/Gateway: require explicit break-glass env for Control UI bypass flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/Gateway: fail startup when `gateway.controlUi.dangerouslyDisableDeviceAuth` is set unless `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1` is explicitly provided, while keeping `allowInsecureAuth` compatibility without re-enabling Control UI auth bypass.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Gateway: fail startup when `gateway.controlUi.dangerouslyDisableDeviceAuth` is set unless `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1` is explicitly provided, while keeping `allowInsecureAuth` compatibility without re-enabling Control UI auth bypass.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -42,7 +42,7 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.controlUi.allowInsecureAuth":
     "Insecure-auth toggle; Control UI still enforces secure context + device identity unless dangerouslyDisableDeviceAuth is enabled.",
   "gateway.controlUi.dangerouslyDisableDeviceAuth":
-    "DANGEROUS. Disable Control UI device identity checks (token/password only).",
+    "DANGEROUS. Disable Control UI device identity checks (token/password only). Requires OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1 at startup.",
   "gateway.http.endpoints.chatCompletions.enabled":
     "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
   "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -4,12 +4,12 @@ import type {
   GatewayTailscaleConfig,
   loadConfig,
 } from "../config/config.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import {
   assertGatewayAuthConfigured,
   type ResolvedGatewayAuth,
   resolveGatewayAuth,
 } from "./auth.js";
-import { isTruthyEnvValue } from "../infra/env.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import { resolveHooksConfig } from "./hooks.js";
 import {

--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -851,6 +851,7 @@ describe("gateway server auth/connect", () => {
           });
           expect(res.ok).toBe(false);
           expect(res.error?.message ?? "").toContain("pairing required");
+          await approvePendingPairingIfNeeded();
           ws.close();
         });
       } finally {

--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -760,131 +760,139 @@ describe("gateway server auth/connect", () => {
   });
 
   test("rejects control ui without device identity even when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    const { server, ws, prevToken } = await startServerWithClient("secret", {
-      wsHeaders: { origin: "http://127.0.0.1" },
-    });
-    const res = await connectReq(ws, {
-      token: "secret",
-      device: null,
-      client: {
-        id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-        version: "1.0.0",
-        platform: "web",
-        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-      },
-    });
-    expect(res.ok).toBe(false);
-    expect(res.error?.message ?? "").toContain("secure context");
-    ws.close();
-    await server.close();
-    restoreGatewayToken(prevToken);
-  });
-
-  test("rejects control ui password-only auth when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    testState.gatewayAuth = { mode: "password", password: "secret" };
-    await withGatewayServer(async ({ port }) => {
-      const ws = await openWs(port, { origin: originForPort(port) });
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      const { server, ws, prevToken } = await startServerWithClient("secret", {
+        wsHeaders: { origin: "http://127.0.0.1" },
+      });
       const res = await connectReq(ws, {
-        password: "secret",
+        token: "secret",
         device: null,
         client: {
-          ...CONTROL_UI_CLIENT,
+          id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+          version: "1.0.0",
+          platform: "web",
+          mode: GATEWAY_CLIENT_MODES.WEBCHAT,
         },
       });
       expect(res.ok).toBe(false);
       expect(res.error?.message ?? "").toContain("secure context");
       ws.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
     });
   });
 
-  test("does not bypass pairing for control ui device identity when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    testState.gatewayAuth = { mode: "token", token: "secret" };
-    const { writeConfigFile } = await import("../config/config.js");
-    await writeConfigFile({
-      gateway: {
-        trustedProxies: ["127.0.0.1"],
-      },
-      // oxlint-disable-next-line typescript/no-explicit-any
-    } as any);
-    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
-    try {
+  test("rejects control ui password-only auth when insecure auth is enabled", async () => {
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      testState.gatewayAuth = { mode: "password", password: "secret" };
       await withGatewayServer(async ({ port }) => {
-        const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
-          headers: {
-            origin: "https://localhost",
-            "x-forwarded-for": "203.0.113.10",
-          },
-        });
-        const challengePromise = onceMessage<{
-          type?: string;
-          event?: string;
-          payload?: Record<string, unknown> | null;
-        }>(ws, (o) => o.type === "event" && o.event === "connect.challenge");
-        await new Promise<void>((resolve) => ws.once("open", resolve));
-        const challenge = await challengePromise;
-        const nonce = (challenge.payload as { nonce?: unknown } | undefined)?.nonce;
-        expect(typeof nonce).toBe("string");
-        const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
-        const { device } = await createSignedDevice({
-          token: "secret",
-          scopes,
-          clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          nonce: String(nonce),
-        });
+        const ws = await openWs(port, { origin: originForPort(port) });
         const res = await connectReq(ws, {
-          token: "secret",
-          scopes,
-          device,
+          password: "secret",
+          device: null,
           client: {
             ...CONTROL_UI_CLIENT,
           },
         });
         expect(res.ok).toBe(false);
-        expect(res.error?.message ?? "").toContain("pairing required");
+        expect(res.error?.message ?? "").toContain("secure context");
         ws.close();
       });
-    } finally {
-      restoreGatewayToken(prevToken);
-    }
+    });
+  });
+
+  test("does not bypass pairing for control ui device identity when insecure auth is enabled", async () => {
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const { writeConfigFile } = await import("../config/config.js");
+      await writeConfigFile({
+        gateway: {
+          trustedProxies: ["127.0.0.1"],
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+      } as any);
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await withGatewayServer(async ({ port }) => {
+          const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+            headers: {
+              origin: "https://localhost",
+              "x-forwarded-for": "203.0.113.10",
+            },
+          });
+          const challengePromise = onceMessage<{
+            type?: string;
+            event?: string;
+            payload?: Record<string, unknown> | null;
+          }>(ws, (o) => o.type === "event" && o.event === "connect.challenge");
+          await new Promise<void>((resolve) => ws.once("open", resolve));
+          const challenge = await challengePromise;
+          const nonce = (challenge.payload as { nonce?: unknown } | undefined)?.nonce;
+          expect(typeof nonce).toBe("string");
+          const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+          const { device } = await createSignedDevice({
+            token: "secret",
+            scopes,
+            clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+            clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            nonce: String(nonce),
+          });
+          const res = await connectReq(ws, {
+            token: "secret",
+            scopes,
+            device,
+            client: {
+              ...CONTROL_UI_CLIENT,
+            },
+          });
+          expect(res.ok).toBe(false);
+          expect(res.error?.message ?? "").toContain("pairing required");
+          ws.close();
+        });
+      } finally {
+        restoreGatewayToken(prevToken);
+      }
+    });
   });
 
   test("allows control ui with stale device identity when device auth is disabled", async () => {
-    testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
-    testState.gatewayAuth = { mode: "token", token: "secret" };
-    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
-    try {
-      await withGatewayServer(async ({ port }) => {
-        const ws = await openWs(port, { origin: originForPort(port) });
-        const { device } = await createSignedDevice({
-          token: "secret",
-          scopes: [],
-          clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          signedAtMs: Date.now() - 60 * 60 * 1000,
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await withGatewayServer(async ({ port }) => {
+          const ws = await openWs(port, { origin: originForPort(port) });
+          const { device } = await createSignedDevice({
+            token: "secret",
+            scopes: [],
+            clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+            clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            signedAtMs: Date.now() - 60 * 60 * 1000,
+          });
+          const res = await connectReq(ws, {
+            token: "secret",
+            scopes: ["operator.read"],
+            device,
+            client: {
+              ...CONTROL_UI_CLIENT,
+            },
+          });
+          expect(res.ok).toBe(true);
+          expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+          const health = await rpcReq(ws, "health");
+          expect(health.ok).toBe(true);
+          ws.close();
         });
-        const res = await connectReq(ws, {
-          token: "secret",
-          scopes: ["operator.read"],
-          device,
-          client: {
-            ...CONTROL_UI_CLIENT,
-          },
-        });
-        expect(res.ok).toBe(true);
-        expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
-        const health = await rpcReq(ws, "health");
-        expect(health.ok).toBe(true);
-        ws.close();
-      });
-    } finally {
-      restoreGatewayToken(prevToken);
-    }
+      } finally {
+        restoreGatewayToken(prevToken);
+      }
+    });
   });
 
   test("accepts device token auth for paired device", async () => {


### PR DESCRIPTION
This PR reopens the gateway hardening change from the previously closed PR after branch-name cleanup.

Summary:
- Enforce explicit break-glass env for Control UI bypass flags.
- Add runtime/config tests and e2e coverage for the guard.
- Include current CI-compatible test typing fix required by `pnpm check`.

Replaces: #21059

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a security hardening change that requires an explicit break-glass environment variable (`OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1`) to enable Control UI bypass flags (`gateway.controlUi.allowInsecureAuth` and `gateway.controlUi.dangerouslyDisableDeviceAuth`). The gateway will now fail at startup if these flags are set without the environment variable.

Key changes:
- Added startup validation in `src/gateway/server-runtime-config.ts:109-119` that enforces the break-glass requirement
- Updated config help text for both bypass flags to document the new requirement
- Added comprehensive test coverage in runtime config tests (2 new tests)
- Wrapped existing e2e tests that use bypass flags with `withEnvAsync` to set the required env var
- Included a typing fix for the CLI test suite (`runDaemonInstall` mock) to resolve `pnpm check` failures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it adds a security hardening measure with comprehensive test coverage
- The change enforces a security guard that prevents accidental use of insecure Control UI bypass flags. The implementation is clean, follows existing patterns (`isTruthyEnvValue`), has thorough test coverage at both unit and e2e levels, and includes proper documentation updates. The typing fix is a straightforward addition of a missing mock declaration.
- No files require special attention

<sub>Last reviewed commit: 739736f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->