### PR TITLE
Security/Voice Call: gate skipSignatureVerification to local-dev or explicit override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Voice Call: restrict `skipSignatureVerification` to local development only (`NODE_ENV=development` + loopback/no public exposure) unless `OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION=1` is explicitly set.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/Voice Call: restrict `skipSignatureVerification` to local development only (`NODE_ENV=development` + loopback/no public exposure) unless `OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION=1` is explicitly set.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -52,6 +52,7 @@ describe("validateProviderConfig", () => {
     delete process.env.TELNYX_PUBLIC_KEY;
     delete process.env.PLIVO_AUTH_ID;
     delete process.env.PLIVO_AUTH_TOKEN;
+    delete process.env.OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION;
   };
 
   beforeEach(() => {
@@ -168,10 +169,51 @@ describe("validateProviderConfig", () => {
       const skippedVerification = createBaseConfig("telnyx");
       skippedVerification.skipSignatureVerification = true;
       skippedVerification.telnyx = { apiKey: "KEY123", connectionId: "CONN456" };
+      process.env.NODE_ENV = "development";
       expect(validateProviderConfig(skippedVerification)).toMatchObject({
         valid: true,
         errors: [],
       });
+    });
+  });
+
+  describe("skipSignatureVerification policy", () => {
+    it("rejects skipSignatureVerification outside development by default", () => {
+      process.env.NODE_ENV = "production";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((error) => error.includes("skipSignatureVerification"))).toBe(true);
+    });
+
+    it("rejects skipSignatureVerification with remote exposure even in development", () => {
+      process.env.NODE_ENV = "development";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.tunnel = { provider: "ngrok", allowNgrokFreeTierLoopbackBypass: false };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((error) => error.includes("skipSignatureVerification"))).toBe(true);
+    });
+
+    it("allows skipSignatureVerification with explicit unsafe override", () => {
+      process.env.NODE_ENV = "production";
+      process.env.OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION = "1";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.publicUrl = "https://voice.example.com/voice/webhook";
+
+      const result = validateProviderConfig(config);
+
+      expect(result).toMatchObject({ valid: true, errors: [] });
     });
   });
 

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -215,6 +215,31 @@ describe("validateProviderConfig", () => {
 
       expect(result).toMatchObject({ valid: true, errors: [] });
     });
+
+    it("accepts mapped-loopback binds in development without extra exposure", () => {
+      process.env.NODE_ENV = "development";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.serve.bind = "::ffff:127.0.0.1";
+
+      const result = validateProviderConfig(config);
+
+      expect(result).toMatchObject({ valid: true, errors: [] });
+    });
+
+    it("rejects wildcard bind in development without explicit override", () => {
+      process.env.NODE_ENV = "development";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.serve.bind = "0.0.0.0";
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((error) => error.includes("skipSignatureVerification"))).toBe(true);
+    });
   });
 
   describe("plivo provider", () => {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -3,6 +3,7 @@ import {
   TtsConfigSchema,
   TtsModeSchema,
   TtsProviderSchema,
+  isTruthyEnvValue,
 } from "openclaw/plugin-sdk";
 import { z } from "zod";
 
@@ -393,6 +394,37 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
   return resolved;
 }
 
+function normalizeBindHost(bind: string): string {
+  const normalized = bind.trim().toLowerCase();
+  if (!normalized) {
+    return "";
+  }
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+}
+
+function normalizeIPv4MappedAddress(host: string): string {
+  if (host.startsWith("::ffff:")) {
+    return host.slice("::ffff:".length);
+  }
+  return host;
+}
+
+export function isLoopbackBindAddress(bind: string | undefined): boolean {
+  if (!bind?.trim()) {
+    return false;
+  }
+  const host = normalizeBindHost(bind);
+  const withoutZone = host.split("%")[0] ?? host;
+  if (withoutZone === "localhost" || withoutZone === "::1" || withoutZone === "0:0:0:0:0:0:0:1") {
+    return true;
+  }
+  const normalized = normalizeIPv4MappedAddress(withoutZone);
+  return normalized === "127.0.0.1" || normalized.startsWith("127.");
+}
+
 /**
  * Validate that the configuration has all required fields for the selected provider.
  */
@@ -417,16 +449,8 @@ export function validateProviderConfig(config: VoiceCallConfig): {
   if (config.skipSignatureVerification) {
     const env = process.env;
     const nodeEnv = (env.NODE_ENV ?? "").trim().toLowerCase();
-    const skipVerificationOverride = (env.OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION ?? "")
-      .trim()
-      .toLowerCase();
-    const allowUnsafeSkip =
-      skipVerificationOverride === "1" ||
-      skipVerificationOverride === "true" ||
-      skipVerificationOverride === "yes" ||
-      skipVerificationOverride === "on";
-    const bind = (config.serve?.bind ?? "").trim().toLowerCase();
-    const bindIsLoopback = bind === "127.0.0.1" || bind === "::1" || bind === "localhost";
+    const allowUnsafeSkip = isTruthyEnvValue(env.OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION);
+    const bindIsLoopback = isLoopbackBindAddress(config.serve?.bind);
     const hasRemoteExposure =
       !bindIsLoopback ||
       Boolean(config.publicUrl?.trim()) ||

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -1,5 +1,5 @@
 import type { VoiceCallConfig } from "./config.js";
-import { resolveVoiceCallConfig, validateProviderConfig } from "./config.js";
+import { isLoopbackBindAddress, resolveVoiceCallConfig, validateProviderConfig } from "./config.js";
 import type { CoreConfig } from "./core-bridge.js";
 import { CallManager } from "./manager.js";
 import type { VoiceCallProvider } from "./providers/base.js";
@@ -33,17 +33,10 @@ type Logger = {
   debug?: (message: string) => void;
 };
 
-function isLoopbackBind(bind: string | undefined): boolean {
-  if (!bind) {
-    return false;
-  }
-  return bind === "127.0.0.1" || bind === "::1" || bind === "localhost";
-}
-
 function resolveProvider(config: VoiceCallConfig): VoiceCallProvider {
   const allowNgrokFreeTierLoopbackBypass =
     config.tunnel?.provider === "ngrok" &&
-    isLoopbackBind(config.serve?.bind) &&
+    isLoopbackBindAddress(config.serve?.bind) &&
     (config.tunnel?.allowNgrokFreeTierLoopbackBypass ?? false);
 
   switch (config.provider) {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -114,7 +114,8 @@ export async function createVoiceCallRuntime(params: {
 
   if (config.skipSignatureVerification) {
     log.warn(
-      "[voice-call] SECURITY WARNING: skipSignatureVerification=true disables webhook signature verification (development only). Do not use in production.",
+      "[voice-call] SECURITY WARNING: skipSignatureVerification=true disables webhook signature verification. " +
+        "This is allowed only for local development (or OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION=1).",
     );
   }
 


### PR DESCRIPTION
This PR reopens the voice-call signature verification hardening from the previously closed PR after branch-name cleanup.

Summary:
- Restrict `skipSignatureVerification` to local-dev safe contexts or explicit override.
- Add config/runtime tests for enforcement behavior.
- Include current CI-compatible test typing fix required by `pnpm check`.

Replaces: #21068

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens voice-call security by restricting `skipSignatureVerification` to safe local-dev contexts only. The change prevents accidentally disabling webhook signature verification in production or when using tunnels/public URLs. Adds comprehensive test coverage for the new policy enforcement and includes an unrelated test typing fix for `update-cli.test.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Security hardening with comprehensive test coverage and clear validation logic. The changes appropriately restrict a dangerous configuration option to safe contexts only, with an explicit override for testing. The test typing fix is a necessary cleanup. No logical errors or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 5afef25</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->