### PR TITLE
Android/Security: require TLS for non-loopback gateway sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Android/Security: require TLS for non-loopback gateway connections, block manual non-loopback plaintext attempts with a clear status error, and keep plaintext WS limited to loopback-only development flows.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Android/Security: require TLS for non-loopback gateway connections, block manual non-loopback plaintext attempts with a clear status error, and keep plaintext WS limited to loopback-only development flows.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -593,6 +593,10 @@ class NodeRuntime(context: Context) {
       _statusText.value = "Failed: invalid manual host/port"
       return
     }
+    if (!manualTls.value && !ConnectionManager.isLoopbackHost(host)) {
+      _statusText.value = "Failed: non-loopback manual gateway requires TLS"
+      return
+    }
     connect(GatewayEndpoint.manual(host = host, port = port))
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.android.gateway
 
 import android.util.Log
+import ai.openclaw.android.node.ConnectionManager
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -658,14 +659,7 @@ class GatewaySession(
     return "$fallbackScheme://$formattedHost$portSuffix"
   }
 
-  private fun isLoopbackHost(raw: String?): Boolean {
-    val host = raw?.trim()?.lowercase().orEmpty()
-    if (host.isEmpty()) return false
-    if (host == "localhost") return true
-    if (host == "::1") return true
-    if (host == "0.0.0.0" || host == "::") return true
-    return host.startsWith("127.")
-  }
+  private fun isLoopbackHost(raw: String?): Boolean = ConnectionManager.isLoopbackHost(raw)
 }
 
 private fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -191,6 +191,9 @@ class GatewaySession(
       }
 
     suspend fun connect() {
+      if (tls == null && !isLoopbackHost(endpoint.host)) {
+        throw IllegalStateException("non-loopback gateway connections require TLS")
+      }
       val scheme = if (tls != null) "wss" else "ws"
       val url = "$scheme://${endpoint.host}:${endpoint.port}"
       val httpScheme = if (tls != null) "https" else "http"

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
@@ -28,11 +28,18 @@ class ConnectionManager(
 ) {
   companion object {
     internal fun isLoopbackHost(rawHost: String?): Boolean {
-      val host = rawHost?.trim()?.lowercase().orEmpty()
+      val host =
+        rawHost
+          ?.trim()
+          ?.lowercase()
+          ?.removePrefix("[")
+          ?.removeSuffix("]")
+          .orEmpty()
       if (host.isEmpty()) return false
       if (host == "localhost") return true
       if (host == "::1") return true
-      if (host == "0.0.0.0" || host == "::") return true
+      if (host == "0.0.0.0" || host == "::") return false
+      if (host.startsWith("::ffff:127.")) return true
       return host.startsWith("127.")
     }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
@@ -27,6 +27,15 @@ class ConnectionManager(
   private val manualTls: () -> Boolean,
 ) {
   companion object {
+    internal fun isLoopbackHost(rawHost: String?): Boolean {
+      val host = rawHost?.trim()?.lowercase().orEmpty()
+      if (host.isEmpty()) return false
+      if (host == "localhost") return true
+      if (host == "::1") return true
+      if (host == "0.0.0.0" || host == "::") return true
+      return host.startsWith("127.")
+    }
+
     internal fun resolveTlsParamsForEndpoint(
       endpoint: GatewayEndpoint,
       storedFingerprint: String?,
@@ -35,9 +44,19 @@ class ConnectionManager(
       val stableId = endpoint.stableId
       val stored = storedFingerprint?.trim().takeIf { !it.isNullOrEmpty() }
       val isManual = stableId.startsWith("manual|")
+      val loopbackHost = isLoopbackHost(endpoint.host)
 
       if (isManual) {
-        if (!manualTlsEnabled) return null
+        if (!manualTlsEnabled) {
+          if (loopbackHost) return null
+          // Never allow non-loopback manual connections to downgrade to plaintext.
+          return GatewayTlsParams(
+            required = true,
+            expectedFingerprint = null,
+            allowTOFU = false,
+            stableId = stableId,
+          )
+        }
         if (!stored.isNullOrBlank()) {
           return GatewayTlsParams(
             required = true,
@@ -67,6 +86,16 @@ class ConnectionManager(
       val hinted = endpoint.tlsEnabled || !endpoint.tlsFingerprintSha256.isNullOrBlank()
       if (hinted) {
         // TXT is unauthenticated. Do not treat the advertised fingerprint as authoritative.
+        return GatewayTlsParams(
+          required = true,
+          expectedFingerprint = null,
+          allowTOFU = false,
+          stableId = stableId,
+        )
+      }
+
+      if (!loopbackHost) {
+        // Discovery TXT is unauthenticated; require TLS for any non-loopback endpoint.
         return GatewayTlsParams(
           required = true,
           expectedFingerprint = null,

--- a/apps/android/app/src/test/java/ai/openclaw/android/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/node/ConnectionManagerTest.kt
@@ -136,4 +136,26 @@ class ConnectionManagerTest {
 
     assertNull(params)
   }
+
+  @Test
+  fun isLoopbackHost_doesNotTreatWildcardBindsAsLoopback() {
+    assertEquals(false, ConnectionManager.isLoopbackHost("0.0.0.0"))
+    assertEquals(false, ConnectionManager.isLoopbackHost("::"))
+  }
+
+  @Test
+  fun resolveTlsParamsForEndpoint_manualWildcardRequiresTlsWhenManualTlsDisabled() {
+    val endpoint = GatewayEndpoint.manual(host = "0.0.0.0", port = 18789)
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertNotNull(params)
+    assertEquals(true, params?.required)
+    assertEquals(null, params?.expectedFingerprint)
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/android/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/node/ConnectionManagerTest.kt
@@ -2,6 +2,7 @@ package ai.openclaw.android.node
 
 import ai.openclaw.android.gateway.GatewayEndpoint
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -62,7 +63,9 @@ class ConnectionManagerTest {
         storedFingerprint = null,
         manualTlsEnabled = false,
       )
-    assertNull(off)
+    assertNotNull(off)
+    assertEquals(true, off?.required)
+    assertEquals(null, off?.expectedFingerprint)
 
     val on =
       ConnectionManager.resolveTlsParamsForEndpoint(
@@ -72,5 +75,65 @@ class ConnectionManagerTest {
       )
     assertNull(on?.expectedFingerprint)
     assertEquals(false, on?.allowTOFU)
+  }
+
+  @Test
+  fun resolveTlsParamsForEndpoint_manualLoopbackAllowsPlaintextWhenTlsDisabled() {
+    val endpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 18789)
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertNull(params)
+  }
+
+  @Test
+  fun resolveTlsParamsForEndpoint_nonLoopbackWithoutHintsStillRequiresTls() {
+    val endpoint =
+      GatewayEndpoint(
+        stableId = "_openclaw-gw._tcp.|local.|Test",
+        name = "Test",
+        host = "10.0.0.2",
+        port = 18789,
+        tlsEnabled = false,
+        tlsFingerprintSha256 = null,
+      )
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertNotNull(params)
+    assertEquals(true, params?.required)
+    assertEquals(null, params?.expectedFingerprint)
+  }
+
+  @Test
+  fun resolveTlsParamsForEndpoint_loopbackWithoutHintsMayRemainPlaintext() {
+    val endpoint =
+      GatewayEndpoint(
+        stableId = "_openclaw-gw._tcp.|local.|Test",
+        name = "Test",
+        host = "127.0.0.1",
+        port = 18789,
+        tlsEnabled = false,
+        tlsFingerprintSha256 = null,
+      )
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertNull(params)
   }
 }


### PR DESCRIPTION
This PR reopens the Android transport hardening from the previously closed PR after branch-name cleanup.

Summary:
- Require TLS for non-loopback Android gateway sessions.
- Keep plaintext WS limited to loopback development flows.
- Add/retain unit tests for transport-policy behavior.

Replaces: #21069

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces TLS for non-loopback Android gateway connections by blocking plaintext WebSocket connections to remote hosts while preserving plaintext for loopback development flows.

**Key changes:**
- Added `isLoopbackHost` helper to detect localhost/127.x.x.x/::1/0.0.0.0/:: addresses
- `GatewaySession.connect()` now throws `IllegalStateException` if attempting non-loopback plaintext connection
- `ConnectionManager.resolveTlsParamsForEndpoint` enforces TLS requirements for manual and discovered non-loopback endpoints
- `NodeRuntime.connectManual()` validates TLS requirement before attempting connection
- Added comprehensive test coverage for loopback vs non-loopback TLS enforcement scenarios

**Minor issue:**
- The `isLoopbackHost` function is duplicated in both `GatewaySession.kt` and `ConnectionManager.kt` with identical implementations

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security hardening logic is straightforward and well-tested. The PR includes comprehensive unit tests covering all critical scenarios (loopback vs non-loopback, manual vs discovered endpoints). The only issue is a minor code duplication that doesn't affect functionality or security.
- No files require special attention

<sub>Last reviewed commit: 920af39</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->