### PR TITLE
Android/Security: exclude device identity from backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Android/Security: require TLS for non-loopback gateway connections, block manual non-loopback plaintext attempts with a clear status error, and keep plaintext WS limited to loopback-only development flows.
+- Android/Security: exclude `openclaw/identity` from Android cloud backup/device-transfer rules so device private identity material is not exported.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,8 +189,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Android/Security: require TLS for non-loopback gateway connections, block manual non-loopback plaintext attempts with a clear status error, and keep plaintext WS limited to loopback-only development flows.
-- Android/Security: exclude `openclaw/identity` from Android cloud backup/device-transfer rules so device private identity material is not exported.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/apps/android/app/src/main/res/xml/backup_rules.xml
+++ b/apps/android/app/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
   <include domain="file" path="." />
+  <exclude domain="file" path="openclaw/identity" />
 </full-backup-content>

--- a/apps/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/apps/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -2,8 +2,10 @@
 <data-extraction-rules>
   <cloud-backup>
     <include domain="file" path="." />
+    <exclude domain="file" path="openclaw/identity" />
   </cloud-backup>
   <device-transfer>
     <include domain="file" path="." />
+    <exclude domain="file" path="openclaw/identity" />
   </device-transfer>
 </data-extraction-rules>

--- a/apps/android/app/src/test/java/ai/openclaw/android/BackupRulesTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/BackupRulesTest.kt
@@ -1,0 +1,34 @@
+package ai.openclaw.android
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackupRulesTest {
+  @Test
+  fun backupRules_excludeIdentityDirectory() {
+    val xml = loadXml("backup_rules.xml")
+    assertTrue(xml.contains("""<exclude domain="file" path="openclaw/identity" />"""))
+  }
+
+  @Test
+  fun dataExtractionRules_excludeIdentityDirectoryForCloudAndTransfer() {
+    val xml = loadXml("data_extraction_rules.xml")
+    val marker = """<exclude domain="file" path="openclaw/identity" />"""
+    val count = Regex(Regex.escape(marker)).findAll(xml).count()
+    assertEquals(2, count)
+  }
+
+  private fun loadXml(fileName: String): String {
+    val candidates =
+      listOf(
+        File("src/main/res/xml/$fileName"),
+        File("app/src/main/res/xml/$fileName"),
+        File("apps/android/app/src/main/res/xml/$fileName"),
+      )
+    val match = candidates.firstOrNull { it.exists() }
+      ?: throw IllegalStateException("Missing XML fixture: $fileName")
+    return match.readText(Charsets.UTF_8)
+  }
+}


### PR DESCRIPTION
This PR reopens the Android backup identity exclusion work from the previously closed PR after branch-name cleanup.

Summary:
- Exclude `openclaw/identity` from Android backup/data-transfer rules.
- Add regression coverage for backup/data extraction XML rules.

Note:
- This branch currently includes the secure transport commit lineage as prepared previously.

Replaces: #21070

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Excludes `openclaw/identity` from Android cloud backup and device-transfer rules, and enforces TLS for all non-loopback gateway connections.

- Added exclusion rules to `backup_rules.xml` and `data_extraction_rules.xml` to prevent device identity material from being backed up
- Added `BackupRulesTest.kt` with regression coverage for backup exclusions
- Implemented TLS enforcement in `ConnectionManager`, `GatewaySession`, and `NodeRuntime` - non-loopback connections now require TLS
- Added `isLoopbackHost()` helper to detect localhost/127.x/::1 addresses
- Updated `ConnectionManagerTest.kt` with comprehensive test coverage for TLS enforcement logic

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Security-focused PR with proper backup exclusions and TLS enforcement. Well-tested with comprehensive unit tests covering both backup rules and TLS enforcement logic. Changes are defensive, preventing plaintext connections to non-loopback hosts and excluding sensitive identity data from backups. Only minor code duplication noted.
- No files require special attention

<sub>Last reviewed commit: b45edc4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->