### PR TITLE
feat(matrix): multi-account support

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -54,7 +54,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
     return { to };
   },
   handleAction: async (ctx: ChannelMessageActionContext) => {
-    const { action, params, cfg } = ctx;
+    const { action, params, cfg, accountId } = ctx;
     const resolveRoomId = () =>
       readStringParam(params, "roomId") ??
       readStringParam(params, "channelId") ??
@@ -77,6 +77,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyTo ?? undefined,
           threadId: threadId ?? undefined,
+          accountId,
         },
         cfg,
       );
@@ -93,6 +94,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           messageId,
           emoji,
           remove,
+          accountId,
         },
         cfg,
       );
@@ -107,6 +109,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           roomId: resolveRoomId(),
           messageId,
           limit,
+          accountId,
         },
         cfg,
       );
@@ -121,6 +124,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           limit,
           before: readStringParam(params, "before"),
           after: readStringParam(params, "after"),
+          accountId,
         },
         cfg,
       );
@@ -135,6 +139,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           roomId: resolveRoomId(),
           messageId,
           content,
+          accountId,
         },
         cfg,
       );
@@ -147,6 +152,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           action: "deleteMessage",
           roomId: resolveRoomId(),
           messageId,
+          accountId,
         },
         cfg,
       );
@@ -163,6 +169,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
             action === "pin" ? "pinMessage" : action === "unpin" ? "unpinMessage" : "listPins",
           roomId: resolveRoomId(),
           messageId,
+          accountId,
         },
         cfg,
       );
@@ -175,6 +182,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           action: "memberInfo",
           userId,
           roomId: readStringParam(params, "roomId") ?? readStringParam(params, "channelId"),
+          accountId,
         },
         cfg,
       );
@@ -185,6 +193,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
         {
           action: "channelInfo",
           roomId: resolveRoomId(),
+          accountId,
         },
         cfg,
       );

--- a/extensions/matrix/src/config-schema.test.ts
+++ b/extensions/matrix/src/config-schema.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { MatrixConfigSchema } from "./config-schema.js";
+
+describe("MatrixConfigSchema", () => {
+  it("parses legacy config without accounts", () => {
+    const result = MatrixConfigSchema.safeParse({
+      markdown: {},
+      homeserver: "https://matrix.example.org",
+      userId: "@bot:example.org",
+      accessToken: "token",
+      dm: {
+        enabled: true,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("parses multi-account config with accounts", () => {
+    const result = MatrixConfigSchema.safeParse({
+      markdown: {},
+      accounts: {
+        primary: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "token",
+        },
+        secondary: {
+          homeserver: "https://matrix2.example.org",
+          userId: "@bot2:example.org",
+          accessToken: "token2",
+          dm: {
+            policy: "allowlist",
+            allowFrom: ["@alice:example.org"],
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid config", () => {
+    const result = MatrixConfigSchema.safeParse({
+      markdown: {},
+      dm: {
+        policy: "not-a-policy",
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -34,10 +34,9 @@ const matrixRoomSchema = z
   })
   .optional();
 
-export const MatrixConfigSchema = z.object({
+const MatrixAccountConfigSchema = z.object({
   name: z.string().optional(),
   enabled: z.boolean().optional(),
-  markdown: MarkdownConfigSchema,
   homeserver: z.string().optional(),
   userId: z.string().optional(),
   accessToken: z.string().optional(),
@@ -60,4 +59,14 @@ export const MatrixConfigSchema = z.object({
   groups: z.object({}).catchall(matrixRoomSchema).optional(),
   rooms: z.object({}).catchall(matrixRoomSchema).optional(),
   actions: matrixActionSchema,
+});
+
+export const MatrixConfigSchema = z.object({
+  markdown: MarkdownConfigSchema,
+
+  // Backward-compatible top-level account fields
+  ...MatrixAccountConfigSchema.shape,
+
+  // Multi-account configuration; each key is an account id.
+  accounts: z.record(z.string(), MatrixAccountConfigSchema).optional(),
 });

--- a/extensions/matrix/src/matrix/accounts.ts
+++ b/extensions/matrix/src/matrix/accounts.ts
@@ -1,6 +1,10 @@
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
 import type { CoreConfig, MatrixConfig } from "../types.js";
-import { resolveMatrixConfig } from "./client.js";
+import {
+  listMatrixAccountIds as listAccountIdsFromConfig,
+  resolveMatrixAccount as resolveAccountConfig,
+  resolveMatrixConfig,
+} from "./client.js";
 import { credentialsMatchConfig, loadMatrixCredentials } from "./credentials.js";
 
 export type ResolvedMatrixAccount = {
@@ -13,8 +17,8 @@ export type ResolvedMatrixAccount = {
   config: MatrixConfig;
 };
 
-export function listMatrixAccountIds(_cfg: CoreConfig): string[] {
-  return [DEFAULT_ACCOUNT_ID];
+export function listMatrixAccountIds(cfg: CoreConfig): string[] {
+  return listAccountIdsFromConfig(cfg);
 }
 
 export function resolveDefaultMatrixAccountId(cfg: CoreConfig): string {
@@ -30,9 +34,9 @@ export function resolveMatrixAccount(params: {
   accountId?: string | null;
 }): ResolvedMatrixAccount {
   const accountId = normalizeAccountId(params.accountId);
-  const base = params.cfg.channels?.matrix ?? {};
+  const base = resolveAccountConfig({ cfg: params.cfg, accountId });
   const enabled = base.enabled !== false;
-  const resolved = resolveMatrixConfig(params.cfg, process.env);
+  const resolved = resolveMatrixConfig(params.cfg, process.env, accountId);
   const hasHomeserver = Boolean(resolved.homeserver);
   const hasUserId = Boolean(resolved.userId);
   const hasAccessToken = Boolean(resolved.accessToken);

--- a/extensions/matrix/src/matrix/actions/client.ts
+++ b/extensions/matrix/src/matrix/actions/client.ts
@@ -22,7 +22,7 @@ export async function resolveActionClient(
   if (opts.client) {
     return { client: opts.client, stopOnDone: false };
   }
-  const active = getActiveMatrixClient();
+  const active = opts.accountId ? getActiveMatrixClient(opts.accountId) : null;
   if (active) {
     return { client: active, stopOnDone: false };
   }
@@ -31,11 +31,13 @@ export async function resolveActionClient(
     const client = await resolveSharedMatrixClient({
       cfg: getMatrixRuntime().config.loadConfig() as CoreConfig,
       timeoutMs: opts.timeoutMs,
+      accountId: opts.accountId,
     });
     return { client, stopOnDone: false };
   }
   const auth = await resolveMatrixAuth({
     cfg: getMatrixRuntime().config.loadConfig() as CoreConfig,
+    accountId: opts.accountId,
   });
   const client = await createMatrixClient({
     homeserver: auth.homeserver,
@@ -43,6 +45,7 @@ export async function resolveActionClient(
     accessToken: auth.accessToken,
     encryption: auth.encryption,
     localTimeoutMs: opts.timeoutMs,
+    accountId: opts.accountId,
   });
   if (auth.encryption && client.crypto) {
     try {

--- a/extensions/matrix/src/matrix/actions/types.ts
+++ b/extensions/matrix/src/matrix/actions/types.ts
@@ -57,6 +57,7 @@ export type MatrixRawEvent = {
 export type MatrixActionClientOpts = {
   client?: MatrixClient;
   timeoutMs?: number;
+  accountId?: string | null;
 };
 
 export type MatrixMessageSummary = {

--- a/extensions/matrix/src/matrix/active-client.test.ts
+++ b/extensions/matrix/src/matrix/active-client.test.ts
@@ -1,0 +1,45 @@
+import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearActiveMatrixClient,
+  getActiveMatrixClient,
+  setActiveMatrixClient,
+} from "./active-client.js";
+
+describe("active matrix client registry", () => {
+  beforeEach(() => {
+    clearActiveMatrixClient("acct-1");
+    clearActiveMatrixClient("acct-2");
+  });
+
+  it("returns the client that was set for an account", () => {
+    const client = { stop: vi.fn() } as unknown as MatrixClient;
+
+    setActiveMatrixClient("acct-1", client);
+
+    expect(getActiveMatrixClient("acct-1")).toBe(client);
+  });
+
+  it("keeps account clients isolated", () => {
+    const client1 = { stop: vi.fn() } as unknown as MatrixClient;
+    const client2 = { stop: vi.fn() } as unknown as MatrixClient;
+
+    setActiveMatrixClient("acct-1", client1);
+    setActiveMatrixClient("acct-2", client2);
+
+    expect(getActiveMatrixClient("acct-1")).toBe(client1);
+    expect(getActiveMatrixClient("acct-2")).toBe(client2);
+  });
+
+  it("clear removes only the targeted account", () => {
+    const client1 = { stop: vi.fn() } as unknown as MatrixClient;
+    const client2 = { stop: vi.fn() } as unknown as MatrixClient;
+
+    setActiveMatrixClient("acct-1", client1);
+    setActiveMatrixClient("acct-2", client2);
+    clearActiveMatrixClient("acct-1");
+
+    expect(getActiveMatrixClient("acct-1")).toBeNull();
+    expect(getActiveMatrixClient("acct-2")).toBe(client2);
+  });
+});

--- a/extensions/matrix/src/matrix/active-client.ts
+++ b/extensions/matrix/src/matrix/active-client.ts
@@ -1,11 +1,20 @@
 import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 
-let activeClient: MatrixClient | null = null;
+const activeClients = new Map<string, MatrixClient>();
 
-export function setActiveMatrixClient(client: MatrixClient | null): void {
-  activeClient = client;
+export function setActiveMatrixClient(accountId: string, client: MatrixClient | null): void {
+  if (client) {
+    activeClients.set(accountId, client);
+    return;
+  }
+
+  activeClients.delete(accountId);
 }
 
-export function getActiveMatrixClient(): MatrixClient | null {
-  return activeClient;
+export function getActiveMatrixClient(accountId: string): MatrixClient | null {
+  return activeClients.get(accountId) ?? null;
+}
+
+export function clearActiveMatrixClient(accountId: string): void {
+  activeClients.delete(accountId);
 }

--- a/extensions/matrix/src/matrix/client.ts
+++ b/extensions/matrix/src/matrix/client.ts
@@ -1,5 +1,10 @@
 export type { MatrixAuth, MatrixResolvedConfig } from "./client/types.js";
 export { isBunRuntime } from "./client/runtime.js";
-export { resolveMatrixConfig, resolveMatrixAuth } from "./client/config.js";
+export {
+  listMatrixAccountIds,
+  resolveMatrixAccount,
+  resolveMatrixConfig,
+  resolveMatrixAuth,
+} from "./client/config.js";
 export { createMatrixClient } from "./client/create-client.js";
 export { resolveSharedMatrixClient, waitForMatrixSync, stopSharedClient } from "./client/shared.js";

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -74,6 +74,7 @@ export type MatrixMonitorHandlerParams = {
   mediaMaxBytes: number;
   startupMs: number;
   startupGraceMs: number;
+  accountId?: string | null;
   directTracker: {
     isDirectMessage: (params: {
       roomId: string;
@@ -107,6 +108,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     mediaMaxBytes,
     startupMs,
     startupGraceMs,
+    accountId,
     directTracker,
     getRoomInfo,
     getMemberDisplayName,
@@ -456,6 +458,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           kind: isDirectMessage ? "dm" : "channel",
           id: isDirectMessage ? senderId : roomId,
         },
+        accountId,
       });
       const envelopeFrom = isDirectMessage ? senderName : (roomName ?? roomId);
       const textWithId = `${bodyText}\n[matrix event id: ${messageId} room: ${roomId}]`;

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -45,6 +45,7 @@ export async function sendMessageMatrix(
   const { client, stopOnDone } = await resolveMatrixClient({
     client: opts.client,
     timeoutMs: opts.timeoutMs,
+    accountId: opts.accountId,
   });
   try {
     const roomId = await resolveMatrixRoomId(client, to);
@@ -166,6 +167,7 @@ export async function sendPollMatrix(
   const { client, stopOnDone } = await resolveMatrixClient({
     client: opts.client,
     timeoutMs: opts.timeoutMs,
+    accountId: opts.accountId,
   });
 
   try {
@@ -194,10 +196,12 @@ export async function sendTypingMatrix(
   typing: boolean,
   timeoutMs?: number,
   client?: MatrixClient,
+  accountId?: string | null,
 ): Promise<void> {
   const { client: resolved, stopOnDone } = await resolveMatrixClient({
     client,
     timeoutMs,
+    accountId,
   });
   try {
     const resolvedTimeoutMs = typeof timeoutMs === "number" ? timeoutMs : 30_000;
@@ -213,12 +217,14 @@ export async function sendReadReceiptMatrix(
   roomId: string,
   eventId: string,
   client?: MatrixClient,
+  accountId?: string | null,
 ): Promise<void> {
   if (!eventId?.trim()) {
     return;
   }
   const { client: resolved, stopOnDone } = await resolveMatrixClient({
     client,
+    accountId,
   });
   try {
     const resolvedRoom = await resolveMatrixRoomId(resolved, roomId);
@@ -235,12 +241,14 @@ export async function reactMatrixMessage(
   messageId: string,
   emoji: string,
   client?: MatrixClient,
+  accountId?: string | null,
 ): Promise<void> {
   if (!emoji.trim()) {
     throw new Error("Matrix reaction requires an emoji");
   }
   const { client: resolved, stopOnDone } = await resolveMatrixClient({
     client,
+    accountId,
   });
   try {
     const resolvedRoom = await resolveMatrixRoomId(resolved, roomId);

--- a/extensions/matrix/src/matrix/send/client.ts
+++ b/extensions/matrix/src/matrix/send/client.ts
@@ -28,12 +28,13 @@ export function resolveMediaMaxBytes(): number | undefined {
 export async function resolveMatrixClient(opts: {
   client?: MatrixClient;
   timeoutMs?: number;
+  accountId?: string | null;
 }): Promise<{ client: MatrixClient; stopOnDone: boolean }> {
   ensureNodeRuntime();
   if (opts.client) {
     return { client: opts.client, stopOnDone: false };
   }
-  const active = getActiveMatrixClient();
+  const active = opts.accountId ? getActiveMatrixClient(opts.accountId) : null;
   if (active) {
     return { client: active, stopOnDone: false };
   }
@@ -41,16 +42,18 @@ export async function resolveMatrixClient(opts: {
   if (shouldShareClient) {
     const client = await resolveSharedMatrixClient({
       timeoutMs: opts.timeoutMs,
+      accountId: opts.accountId,
     });
     return { client, stopOnDone: false };
   }
-  const auth = await resolveMatrixAuth();
+  const auth = await resolveMatrixAuth({ accountId: opts.accountId });
   const client = await createMatrixClient({
     homeserver: auth.homeserver,
     userId: auth.userId,
     accessToken: auth.accessToken,
     encryption: auth.encryption,
     localTimeoutMs: opts.timeoutMs,
+    accountId: opts.accountId,
   });
   if (auth.encryption && client.crypto) {
     try {

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -7,13 +7,14 @@ export const matrixOutbound: ChannelOutboundAdapter = {
   chunker: (text, limit) => getMatrixRuntime().channel.text.chunkMarkdownText(text, limit),
   chunkerMode: "markdown",
   textChunkLimit: 4000,
-  sendText: async ({ to, text, deps, replyToId, threadId }) => {
+  sendText: async ({ to, text, deps, replyToId, threadId, accountId }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
     const result = await send(to, text, {
       replyToId: replyToId ?? undefined,
       threadId: resolvedThreadId,
+      accountId,
     });
     return {
       channel: "matrix",
@@ -21,7 +22,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendMedia: async ({ to, text, mediaUrl, deps, replyToId, threadId }) => {
+  sendMedia: async ({ to, text, mediaUrl, deps, replyToId, threadId, accountId }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
@@ -29,6 +30,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       replyToId: replyToId ?? undefined,
       threadId: resolvedThreadId,
+      accountId,
     });
     return {
       channel: "matrix",
@@ -36,11 +38,12 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendPoll: async ({ to, poll, threadId }) => {
+  sendPoll: async ({ to, poll, threadId, accountId }) => {
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
     const result = await sendPollMatrix(to, poll, {
       threadId: resolvedThreadId,
+      accountId,
     });
     return {
       channel: "matrix",

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -42,6 +42,7 @@ export async function handleMatrixAction(
   cfg: CoreConfig,
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
+  const accountId = readStringParam(params, "accountId");
   const isActionEnabled = createActionGate(cfg.channels?.matrix?.actions);
 
   if (reactionActions.has(action)) {
@@ -57,13 +58,14 @@ export async function handleMatrixAction(
       if (remove || isEmpty) {
         const result = await removeMatrixReactions(roomId, messageId, {
           emoji: remove ? emoji : undefined,
+          accountId,
         });
         return jsonResult({ ok: true, removed: result.removed });
       }
-      await reactMatrixMessage(roomId, messageId, emoji);
+      await reactMatrixMessage(roomId, messageId, emoji, undefined, accountId);
       return jsonResult({ ok: true, added: emoji });
     }
-    const reactions = await listMatrixReactions(roomId, messageId);
+    const reactions = await listMatrixReactions(roomId, messageId, { accountId });
     return jsonResult({ ok: true, reactions });
   }
 
@@ -86,6 +88,7 @@ export async function handleMatrixAction(
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          accountId,
         });
         return jsonResult({ ok: true, result });
       }
@@ -93,14 +96,14 @@ export async function handleMatrixAction(
         const roomId = readRoomId(params);
         const messageId = readStringParam(params, "messageId", { required: true });
         const content = readStringParam(params, "content", { required: true });
-        const result = await editMatrixMessage(roomId, messageId, content);
+        const result = await editMatrixMessage(roomId, messageId, content, { accountId });
         return jsonResult({ ok: true, result });
       }
       case "deleteMessage": {
         const roomId = readRoomId(params);
         const messageId = readStringParam(params, "messageId", { required: true });
         const reason = readStringParam(params, "reason");
-        await deleteMatrixMessage(roomId, messageId, { reason: reason ?? undefined });
+        await deleteMatrixMessage(roomId, messageId, { reason: reason ?? undefined, accountId });
         return jsonResult({ ok: true, deleted: true });
       }
       case "readMessages": {
@@ -112,6 +115,7 @@ export async function handleMatrixAction(
           limit: limit ?? undefined,
           before: before ?? undefined,
           after: after ?? undefined,
+          accountId,
         });
         return jsonResult({ ok: true, ...result });
       }
@@ -127,15 +131,15 @@ export async function handleMatrixAction(
     const roomId = readRoomId(params);
     if (action === "pinMessage") {
       const messageId = readStringParam(params, "messageId", { required: true });
-      const result = await pinMatrixMessage(roomId, messageId);
+      const result = await pinMatrixMessage(roomId, messageId, { accountId });
       return jsonResult({ ok: true, pinned: result.pinned });
     }
     if (action === "unpinMessage") {
       const messageId = readStringParam(params, "messageId", { required: true });
-      const result = await unpinMatrixMessage(roomId, messageId);
+      const result = await unpinMatrixMessage(roomId, messageId, { accountId });
       return jsonResult({ ok: true, pinned: result.pinned });
     }
-    const result = await listMatrixPins(roomId);
+    const result = await listMatrixPins(roomId, { accountId });
     return jsonResult({ ok: true, pinned: result.pinned, events: result.events });
   }
 
@@ -147,6 +151,7 @@ export async function handleMatrixAction(
     const roomId = readStringParam(params, "roomId") ?? readStringParam(params, "channelId");
     const result = await getMatrixMemberInfo(userId, {
       roomId: roomId ?? undefined,
+      accountId,
     });
     return jsonResult({ ok: true, member: result });
   }
@@ -156,7 +161,7 @@ export async function handleMatrixAction(
       throw new Error("Matrix room info is disabled.");
     }
     const roomId = readRoomId(params);
-    const result = await getMatrixRoomInfo(roomId);
+    const result = await getMatrixRoomInfo(roomId, { accountId });
     return jsonResult({ ok: true, room: result });
   }
 


### PR DESCRIPTION
## Summary
This PR adds first-class multi-account support to the Matrix extension by introducing an `accounts` map in the Matrix config and threading `accountId` through client resolution, monitoring, and outbound/actions. It also adds an active-client registry keyed by account so outbound actions can reuse the correct running client, while keeping the shared client lifecycle safe across concurrent starts.

## Backward compatibility
Legacy single-account configuration remains supported: existing top-level Matrix fields (`homeserver`, `userId`, `accessToken`, etc.) still parse and continue to work without an `accounts` section. When no explicit `accountId` is provided, the default account key is used.

## Test coverage
- Unit tests added for Matrix config schema parsing (legacy + multi-account + invalid policy cases).
- Unit tests added for the per-account active-client registry behavior.

Note: local integration/e2ee tests that depend on the `matrix-sdk-crypto` native module cannot be exercised here because the native dependency is not installed in this environment; unit tests and build pass.

## Files changed
- `extensions/matrix/src/config-schema.ts`
- `extensions/matrix/src/matrix/client/shared.ts`
- `extensions/matrix/src/matrix/active-client.ts`
- `extensions/matrix/src/matrix/monitor/index.ts`
- `extensions/matrix/src/matrix/monitor/handler.ts`

New tests:
- `extensions/matrix/src/config-schema.test.ts`
- `extensions/matrix/src/matrix/active-client.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduced multi-account support for Matrix by adding an `accounts` map to the config schema while preserving backward compatibility with legacy single-account configuration. The implementation threads `accountId` through client resolution, monitoring, actions, and outbound handlers. Storage paths are now account-scoped to prevent conflicts between multiple accounts on the same homeserver. An active-client registry keyed by account ID enables concurrent operation of multiple Matrix accounts while maintaining safe shared client lifecycle management.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows clean patterns with comprehensive test coverage for config parsing and active-client registry. Backward compatibility is properly maintained through fallback logic, and the accountId threading is consistently applied across all components
- No files require special attention

<sub>Last reviewed commit: 9a98922</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->