### PR TITLE
fix(tts): deliver audio via structured mediaUrl instead of MEDIA: text tokens

### DIFF
--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -94,7 +94,11 @@ export type RunEmbeddedPiAgentParams = {
   blockReplyChunking?: BlockReplyChunking;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onReasoningEnd?: () => void | Promise<void>;
-  onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  onToolResult?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  }) => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
   lane?: string;
   enqueue?: typeof enqueueCommand;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -11,6 +11,7 @@ import type {
 import {
   extractMessagingToolSend,
   extractToolErrorMessage,
+  extractToolResultAudioAsVoice,
   extractToolResultMediaPaths,
   extractToolResultText,
   filterToolResultMediaUrls,
@@ -147,21 +148,32 @@ function emitToolResultOutput(params: {
     if (outputText) {
       ctx.emitToolOutput(toolName, meta, outputText);
     }
-    return;
+    // Fall through to deliver structured media (e.g. TTS details.mediaUrl)
+    // even in verbose mode — MEDIA: text tokens are already handled by emitToolOutput.
   }
 
   if (isToolError) {
     return;
   }
 
-  // emitToolOutput() already handles MEDIA: directives when enabled; this path
-  // only sends raw media URLs for non-verbose delivery mode.
-  const mediaPaths = filterToolResultMediaUrls(toolName, extractToolResultMediaPaths(result));
+  // When shouldEmitToolOutput() is true, MEDIA: text tokens are already delivered
+  // via emitToolOutput → parseReplyDirectives. Only extract from details to avoid
+  // duplicates. When false, extract from all sources.
+  const mediaPaths = filterToolResultMediaUrls(
+    toolName,
+    extractToolResultMediaPaths(result, {
+      detailsOnly: ctx.shouldEmitToolOutput(),
+    }),
+  );
   if (mediaPaths.length === 0) {
     return;
   }
+  const audioAsVoice = extractToolResultAudioAsVoice(result);
   try {
-    void ctx.params.onToolResult({ mediaUrls: mediaPaths });
+    void ctx.params.onToolResult({
+      mediaUrls: mediaPaths,
+      ...(audioAsVoice ? { audioAsVoice } : undefined),
+    });
   } catch {
     // ignore delivery failures
   }

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -186,25 +186,58 @@ export function filterToolResultMediaUrls(
  * Extract media file paths from a tool result.
  *
  * Strategy (first match wins):
+ * 0. Read structured `details.mediaUrl` / `details.mediaUrls` (TTS and future tools).
  * 1. Parse `MEDIA:` tokens from text content blocks (all OpenClaw tools).
  * 2. Fall back to `details.path` when image content exists (OpenClaw imageResult).
  *
  * Returns an empty array when no media is found (e.g. Pi SDK `read` tool
  * returns base64 image data but no file path; those need a different delivery
  * path like saving to a temp file).
+ *
+ * When `options.detailsOnly` is true, only Strategy 0 is checked — this avoids
+ * double-delivering MEDIA: text tokens that were already forwarded via
+ * `emitToolOutput` in verbose mode.
  */
-export function extractToolResultMediaPaths(result: unknown): string[] {
+export function extractToolResultMediaPaths(
+  result: unknown,
+  options?: { detailsOnly?: boolean },
+): string[] {
   if (!result || typeof result !== "object") {
     return [];
   }
   const record = result as Record<string, unknown>;
+
+  // Strategy 0: structured details.mediaUrl / details.mediaUrls
+  const details = record.details as Record<string, unknown> | undefined;
+  if (details) {
+    const detailsPaths: string[] = [];
+    if (typeof details.mediaUrl === "string" && details.mediaUrl.trim()) {
+      detailsPaths.push(details.mediaUrl.trim());
+    }
+    if (Array.isArray(details.mediaUrls)) {
+      for (const u of details.mediaUrls) {
+        if (typeof u === "string" && u.trim()) {
+          detailsPaths.push(u.trim());
+        }
+      }
+    }
+    if (detailsPaths.length > 0) {
+      return detailsPaths;
+    }
+  }
+
+  if (options?.detailsOnly) {
+    return [];
+  }
+
   const content = Array.isArray(record.content) ? record.content : null;
   if (!content) {
     return [];
   }
 
-  // Extract MEDIA: paths from text content blocks using the shared parser so
-  // directive matching and validation stay in sync with outbound reply parsing.
+  // Strategy 1: Extract MEDIA: paths from text content blocks using the shared
+  // parser so directive matching and validation stay in sync with outbound
+  // reply parsing.
   const paths: string[] = [];
   let hasImageContent = false;
   for (const item of content) {
@@ -228,9 +261,8 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     return paths;
   }
 
-  // Fall back to details.path when image content exists but no MEDIA: text.
+  // Strategy 2: Fall back to details.path when image content exists but no MEDIA: text.
   if (hasImageContent) {
-    const details = record.details as Record<string, unknown> | undefined;
     const p = typeof details?.path === "string" ? details.path.trim() : "";
     if (p) {
       return [p];
@@ -238,6 +270,21 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
   }
 
   return [];
+}
+
+/**
+ * Extract the `audioAsVoice` flag from a tool result details.
+ * Used alongside extractToolResultMediaPaths to propagate voice-bubble
+ * metadata from tools like TTS.
+ */
+export function extractToolResultAudioAsVoice(result: unknown): boolean {
+  if (!result || typeof result !== "object") {
+    return false;
+  }
+  const details = (result as Record<string, unknown>).details as
+    | Record<string, unknown>
+    | undefined;
+  return details?.audioAsVoice === true;
 }
 
 export function isToolResultError(result: unknown): boolean {

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -16,7 +16,11 @@ export type SubscribeEmbeddedPiSessionParams = {
   toolResultFormat?: ToolResultFormat;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
-  onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  onToolResult?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  }) => void | Promise<void>;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */
   onReasoningEnd?: () => void | Promise<void>;

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -35,15 +35,17 @@ export function createTtsTool(opts?: {
       });
 
       if (result.success && result.audioPath) {
-        const lines: string[] = [];
-        // Tag Telegram Opus output as a voice bubble instead of a file attachment.
-        if (result.voiceCompatible) {
-          lines.push("[[audio_as_voice]]");
-        }
-        lines.push(`MEDIA:${result.audioPath}`);
         return {
-          content: [{ type: "text", text: lines.join("\n") }],
-          details: { audioPath: result.audioPath, provider: result.provider },
+          content: [{ type: "text", text: SILENT_REPLY_TOKEN }],
+          details: {
+            audioPath: result.audioPath,
+            provider: result.provider,
+            // Structured media URL bypasses text-based MEDIA: parsing, which is
+            // subject to sandbox security policy that blocks absolute paths.
+            mediaUrl: result.audioPath,
+            // Tag Telegram Opus output as a voice bubble instead of a file attachment.
+            audioAsVoice: result.voiceCompatible === true,
+          },
         };
       }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -410,6 +410,7 @@ export async function runAgentTurnWithFallback(params: {
                         await onToolResult({
                           text,
                           mediaUrls: payload.mediaUrls,
+                          audioAsVoice: payload.audioAsVoice,
                         });
                       })
                       .catch((err) => {


### PR DESCRIPTION
## Problem

The built-in `tts` tool generates audio to absolute paths (`/tmp/tts-xxx/voice-xxx.opus`) and returns them as `MEDIA:/tmp/...` text tokens. The media parser security policy in `splitMediaFromOutput` blocks absolute paths, so users see raw file paths as text instead of receiving voice messages.

The `/tts audio` slash command works fine because it sets `mediaUrl` directly on the reply payload, bypassing text-based parsing entirely.

Fixes #14174.

## Solution

Option A from the issue: deliver audio through structured tool result fields instead of `MEDIA:` text tokens.

### Changes

**Core fix — `tts-tool.ts`:**
- Replaced `MEDIA:${audioPath}` text token with `details.mediaUrl` and `details.audioAsVoice` fields
- Content text returns `SILENT_REPLY_TOKEN` instead of a `MEDIA:` token that gets blocked

**Media extraction — `pi-embedded-subscribe.tools.ts`:**
- Added strategy 0 (highest priority): check `details.mediaUrl` / `details.mediaUrls` before falling back to text-based `MEDIA:` parsing
- Added `detailsOnly` option to skip text-based extraction when `emitToolOutput` already handles it (prevents duplicates)
- New `extractToolResultAudioAsVoice()` helper

**Handler — `pi-embedded-subscribe.handlers.tools.ts`:**
- Media delivery runs regardless of `shouldEmitToolOutput()`, using `detailsOnly: true` when emit is on
- Extracts and passes `audioAsVoice` through the callback

**Type + propagation:**
- `audioAsVoice?: boolean` added to `onToolResult` callback type
- Forwarded through `pi-embedded-subscribe.ts` and `agent-runner-execution.ts`

## Why not just allow /tmp/ in the security policy?

Punching holes in the path security policy for specific directories would weaken the sandbox model. The structured approach is cleaner: trusted built-in tools deliver media through typed fields, untrusted LLM text output stays sandboxed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes TTS audio delivery by replacing text-based `MEDIA:` tokens with structured `details.mediaUrl` fields, bypassing security policies that block absolute paths. The changes successfully implement Option A from issue #14174.

**Key changes:**
- `tts-tool.ts`: Returns `details.mediaUrl` and `details.audioAsVoice` instead of `MEDIA:${audioPath}` text tokens
- Media extraction: Added strategy 0 (highest priority) to check `details.mediaUrl`/`details.mediaUrls` before text parsing
- `detailsOnly` option prevents duplicate extraction when `emitToolOutput` already handles text-based `MEDIA:` parsing
- `audioAsVoice` flag propagated through callback chain to preserve voice-bubble metadata

**Note:** This PR also includes an unrelated security commit (31b12562) that strips hidden content from `web_fetch` to prevent prompt injection attacks (#8027). This security fix adds comprehensive HTML sanitization and invisible Unicode stripping.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations about scope
- The TTS fix is well-structured and follows a clean pattern of delivering media through typed fields instead of text tokens. The implementation correctly propagates `audioAsVoice` through the callback chain and uses the `detailsOnly` option to avoid duplicate media extraction. The web-fetch security fix is comprehensive with thorough test coverage. However, the PR combines two unrelated features (TTS fix + web-fetch security), which slightly reduces confidence as they should ideally be separate PRs.
- No files require special attention - the implementation is clean and follows existing patterns

<sub>Last reviewed commit: 663f98e</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->