### PR TITLE
feat(compaction): notify on start + idle-triggered proactive compaction (extends #18049)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1028,6 +1028,8 @@ Docs: https://docs.openclaw.ai
 - Infra/fs-safe: sanitize directory-read failures so raw `EISDIR` text never leaks to messaging surfaces, with regression tests for both root-scoped and direct safe reads. Landed from contributor PR #31205 by @polooooo. Thanks @polooooo.
 
 ## Unreleased
+- Sessions/Resilience: ignore invalid persisted `sessionFile` metadata and fall back to the derived safe transcript path instead of aborting session resolution for handlers and tooling. (#16061) Thanks @haoyifan and @vincentkoc.
+- Sessions/Paths: resolve symlinked state-dir aliases during transcript-path validation while preserving safe cross-agent/state-root compatibility for valid `agents/<id>/sessions/**` paths. (#18593) Thanks @EpaL and @vincentkoc.
 
 ### Changes
 
@@ -1560,8 +1562,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Sessions/Resilience: ignore invalid persisted `sessionFile` metadata and fall back to the derived safe transcript path instead of aborting session resolution for handlers and tooling. (#16061) Thanks @haoyifan and @vincentkoc.
-- Sessions/Paths: resolve symlinked state-dir aliases during transcript-path validation while preserving safe cross-agent/state-root compatibility for valid `agents/<id>/sessions/**` paths. (#18593) Thanks @EpaL and @vincentkoc.
+- Gateway/Compaction: notify users when compaction starts and trigger proactive compaction on idle sessions, extending the triple-layer post-compaction context enforcement (#18049). (#21117) Thanks @irchelper.
 - Agents/Compaction: count auto-compactions only after a non-retry `auto_compaction_end`, keeping session `compactionCount` aligned to completed compactions.
 - Security/CLI: redact sensitive values in `openclaw config get` output before printing config paths, preventing credential leakage to terminal output/history. (#13683) Thanks @SleuthCo.
 - Agents/Moonshot: force `supportsDeveloperRole=false` for Moonshot-compatible `openai-completions` models (provider `moonshot` and Moonshot base URLs), so initial runs no longer send unsupported `developer` roles that trigger `ROLE_UNSPECIFIED` errors. (#21060, #22194) Thanks @ShengFuC.

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -17,7 +17,7 @@ Compaction **summarizes older conversation** into a compact summary entry and ke
 - The compaction summary
 - Recent messages after the compaction point
 
-Compaction **persists** in the session’s JSONL history.
+Compaction **persists** in the session's JSONL history.
 
 ## Configuration
 
@@ -56,15 +56,37 @@ When unset, compaction uses the agent's primary model.
 
 ## Auto-compaction (default on)
 
-When a session nears or exceeds the model’s context window, OpenClaw triggers auto-compaction and may retry the original request using the compacted context.
+When a session nears or exceeds the model's context window, OpenClaw triggers auto-compaction and may retry the original request using the compacted context.
 
-You’ll see:
+You'll see:
 
 - `🧹 Auto-compaction complete` in verbose mode
 - `/status` showing `🧹 Compactions: <count>`
 
 Before compaction, OpenClaw can run a **silent memory flush** turn to store
 durable notes to disk. See [Memory](/concepts/memory) for details and config.
+
+### Compaction start notification
+
+By default, users see no feedback while compaction is running, which can cause
+confusion (the model is briefly unresponsive). Enable a user-facing notification
+with `agents.defaults.compaction.notifyOnStart`:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "compaction": {
+        "notifyOnStart": true,
+        "notifyOnStartText": "🧹 Context compacting, back in a moment…"
+      }
+    }
+  }
+}
+```
+
+- `notifyOnStart` — `boolean`, default `false`. When `true`, a message is sent to the user as soon as compaction starts.
+- `notifyOnStartText` — `string`, default `"🧹 Context compacting, back in a moment…"`. Custom notification text.
 
 ## Manual compaction
 

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -300,6 +300,27 @@ Config (`agents.defaults.compaction.memoryFlush`):
 - `prompt` (user message for the flush turn)
 - `systemPrompt` (extra system prompt appended for the flush turn)
 
+---
+
+## Compaction start notification (implemented)
+
+Goal: let the user know compaction is in progress so they aren't confused by a
+temporary lack of responses or red UI state during the compaction pass.
+
+When `agents.defaults.compaction.notifyOnStart` is `true`, OpenClaw delivers a
+message via the block-reply path as soon as the Pi runtime emits a
+`compaction:start` event.
+
+Config (`agents.defaults.compaction`):
+
+- `notifyOnStart` (default: `false`) — enable the notification
+- `notifyOnStartText` (default: `"🧹 Context compacting, back in a moment…"`) — notification text
+
+Implementation: the callback is created in `src/auto-reply/reply/agent-runner.ts`
+and invoked from the `onAgentEvent` handler in
+`src/auto-reply/reply/agent-runner-execution.ts` when `stream === "compaction"` and
+`phase === "start"`.
+
 Notes:
 
 - The default prompt/system prompt include a `NO_REPLY` hint to suppress delivery.

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -629,7 +629,6 @@ describe("Agent-specific tool filtering", () => {
 
     const result = await execTool?.execute("call1", {
       command: "echo done",
-
     });
 
     const resultDetails = result?.details as { status?: string } | undefined;

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -629,7 +629,7 @@ describe("Agent-specific tool filtering", () => {
 
     const result = await execTool?.execute("call1", {
       command: "echo done",
-      yieldMs: 10,
+
     });
 
     const resultDetails = result?.details as { status?: string } | undefined;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -95,6 +95,7 @@ export async function runAgentTurnWithFallback(params: {
   pendingToolTasks: Set<Promise<void>>;
   resetSessionAfterCompactionFailure: (reason: string) => Promise<boolean>;
   resetSessionAfterRoleOrderingConflict: (reason: string) => Promise<boolean>;
+  onCompactionStart?: () => Promise<void> | void;
   isHeartbeat: boolean;
   sessionKey?: string;
   getActiveSessionEntry: () => SessionEntry | undefined;

--- a/src/auto-reply/reply/agent-runner.compaction-notify.test.ts
+++ b/src/auto-reply/reply/agent-runner.compaction-notify.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for compaction start notification (notifyOnStart / notifyOnStartText config).
+ *
+ * Verifies the full config → schema → callback → delivery chain.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TypingMode } from "../../config/types.js";
+import type { TemplateContext } from "../templating.js";
+import type { GetReplyOptions } from "../types.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+type AgentRunParams = {
+  onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
+};
+
+const state = vi.hoisted(() => ({
+  runEmbeddedPiAgentMock: vi.fn(),
+}));
+
+let runReplyAgentPromise:
+  | Promise<(typeof import("./agent-runner.js"))["runReplyAgent"]>
+  | undefined;
+
+async function getRunReplyAgent() {
+  if (!runReplyAgentPromise) {
+    runReplyAgentPromise = import("./agent-runner.js").then((m) => m.runReplyAgent);
+  }
+  return await runReplyAgentPromise;
+}
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: async ({
+    provider,
+    model,
+    run,
+  }: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => ({
+    result: await run(provider, model),
+    provider,
+    model,
+    attempts: [],
+  }),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: (params: unknown) => state.runEmbeddedPiAgentMock(params),
+}));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: vi.fn(),
+}));
+
+vi.mock("./queue.js", () => ({
+  enqueueFollowupRun: vi.fn(),
+  scheduleFollowupDrain: vi.fn(),
+}));
+
+beforeEach(() => {
+  state.runEmbeddedPiAgentMock.mockReset();
+  vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+});
+
+function createCompactionRun(params?: {
+  opts?: GetReplyOptions;
+  config?: Record<string, unknown>;
+  typingMode?: TypingMode;
+}) {
+  const typing = createMockTypingController();
+  const opts = params?.opts;
+  const sessionCtx = {
+    Provider: "whatsapp",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+  const sessionKey = "main";
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey,
+      messageProvider: "whatsapp",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: params?.config ?? {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return {
+    typing,
+    opts,
+    run: async () => {
+      const runReplyAgent = await getRunReplyAgent();
+      return runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: "main",
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: false,
+        isActive: false,
+        isStreaming: false,
+        opts,
+        typing,
+        sessionCtx,
+        defaultModel: "anthropic/claude-opus-4-5",
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: params?.typingMode ?? "instant",
+      });
+    },
+  };
+}
+
+describe("compaction start notification", () => {
+  it("calls onBlockReply with default text when notifyOnStart is true and compaction starts", async () => {
+    const onBlockReply = vi.fn();
+
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
+      return { payloads: [{ text: "done" }], meta: {} };
+    });
+
+    const { run } = createCompactionRun({
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              notifyOnStart: true,
+              memoryFlush: { enabled: false },
+            },
+          },
+        },
+      },
+      opts: { onBlockReply },
+    });
+
+    await run();
+
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "🧹 Context compacting, back in a moment…" }),
+    );
+  });
+
+  it("calls onBlockReply with custom text when notifyOnStartText is set", async () => {
+    const onBlockReply = vi.fn();
+
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
+      return { payloads: [{ text: "done" }], meta: {} };
+    });
+
+    const { run } = createCompactionRun({
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              notifyOnStart: true,
+              notifyOnStartText: "⏳ Compressing history…",
+              memoryFlush: { enabled: false },
+            },
+          },
+        },
+      },
+      opts: { onBlockReply },
+    });
+
+    await run();
+
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "⏳ Compressing history…" }),
+    );
+  });
+
+  it("does NOT call onBlockReply when notifyOnStart is false", async () => {
+    const onBlockReply = vi.fn();
+
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
+      return { payloads: [{ text: "done" }], meta: {} };
+    });
+
+    const { run } = createCompactionRun({
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              notifyOnStart: false,
+              memoryFlush: { enabled: false },
+            },
+          },
+        },
+      },
+      opts: { onBlockReply },
+    });
+
+    await run();
+
+    // onBlockReply should not have been called for the compaction notification
+    const compactionCalls = onBlockReply.mock.calls.filter((call) => {
+      const payload = call[0] as { text?: string };
+      return payload?.text?.includes("compacting") || payload?.text?.includes("Compressing");
+    });
+    expect(compactionCalls).toHaveLength(0);
+  });
+
+  it("does NOT call onBlockReply when notifyOnStart is undefined (default off)", async () => {
+    const onBlockReply = vi.fn();
+
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
+      return { payloads: [{ text: "done" }], meta: {} };
+    });
+
+    const { run } = createCompactionRun({
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: { enabled: false },
+            },
+          },
+        },
+      },
+      opts: { onBlockReply },
+    });
+
+    await run();
+
+    const compactionCalls = onBlockReply.mock.calls.filter((call) => {
+      const payload = call[0] as { text?: string };
+      return payload?.text?.includes("compacting") || payload?.text?.includes("Compressing");
+    });
+    expect(compactionCalls).toHaveLength(0);
+  });
+
+  it("does NOT call onBlockReply for compaction end events even when notifyOnStart is true", async () => {
+    const onBlockReply = vi.fn();
+
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      // Only fire end, not start
+      params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "end", willRetry: false },
+      });
+      return { payloads: [{ text: "done" }], meta: {} };
+    });
+
+    const { run } = createCompactionRun({
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              notifyOnStart: true,
+              memoryFlush: { enabled: false },
+            },
+          },
+        },
+      },
+      opts: { onBlockReply },
+    });
+
+    await run();
+
+    const compactionCalls = onBlockReply.mock.calls.filter((call) => {
+      const payload = call[0] as { text?: string };
+      return payload?.text?.includes("compacting") || payload?.text?.includes("Compressing");
+    });
+    expect(compactionCalls).toHaveLength(0);
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -15,7 +15,8 @@ import {
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
-import { emitAgentEvent } from "../../infra/agent-events.js";import type { OriginatingChannelType, TemplateContext } from "../templating.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";
+import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runAgentTurnWithFallback } from "./agent-runner-execution.js";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -47,6 +47,7 @@ import {
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
+import { cancelIdleCompaction, scheduleIdleCompaction } from "./idle-compaction.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
@@ -223,6 +224,11 @@ export async function runReplyAgent(params: {
   }
 
   await typingSignals.signalRunStart();
+
+  // A new inbound turn has started — cancel any pending idle compaction timer.
+  if (sessionKey) {
+    cancelIdleCompaction(sessionKey);
+  }
 
   activeSessionEntry = await runMemoryFlushIfNeeded({
     cfg,
@@ -488,6 +494,31 @@ export async function runReplyAgent(params: {
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,
     });
+
+    // Schedule proactive idle compaction if the context is above threshold and
+    // the user goes quiet for `idleTriggerMinutes`.
+    if (sessionKey && followupRun.run.sessionFile && followupRun.run.workspaceDir) {
+      const actualTokensUsed =
+        promptTokens ??
+        (usage
+          ? (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0)
+          : 0);
+      scheduleIdleCompaction({
+        sessionKey,
+        sessionId: followupRun.run.sessionId,
+        contextTokensUsed: actualTokensUsed,
+        contextTokensMax: contextTokensUsed,
+        cfg,
+        sessionFile: followupRun.run.sessionFile,
+        workspaceDir: followupRun.run.workspaceDir,
+        provider: followupRun.run.provider,
+        model: modelUsed,
+        thinkLevel: followupRun.run.thinkLevel,
+        bashElevated: followupRun.run.bashElevated,
+        skillsSnapshot: followupRun.run.skillsSnapshot,
+        ownerNumbers: followupRun.run.ownerNumbers,
+      });
+    }
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -344,6 +344,16 @@ export async function runReplyAgent(params: {
     });
   try {
     const runStartedAt = Date.now();
+    const compactionCfg = cfg?.agents?.defaults?.compaction;
+    const onCompactionStart =
+      compactionCfg?.notifyOnStart === true
+        ? async () => {
+            const text =
+              compactionCfg.notifyOnStartText ?? "🧹 Context compacting, back in a moment…";
+            await opts?.onBlockReply?.({ text });
+          }
+        : undefined;
+
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,
       followupRun,
@@ -360,6 +370,7 @@ export async function runReplyAgent(params: {
       pendingToolTasks,
       resetSessionAfterCompactionFailure,
       resetSessionAfterRoleOrderingConflict,
+      onCompactionStart,
       isHeartbeat,
       sessionKey,
       getActiveSessionEntry: () => activeSessionEntry,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -15,18 +15,7 @@ import {
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
-import { emitAgentEvent } from "../../infra/agent-events.js";
-import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
-import { generateSecureUuid } from "../../infra/secure-random.js";
-import { enqueueSystemEvent } from "../../infra/system-events.js";
-import { defaultRuntime } from "../../runtime.js";
-import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
-import {
-  buildFallbackClearedNotice,
-  buildFallbackNotice,
-  resolveFallbackTransition,
-} from "../fallback-state.js";
-import type { OriginatingChannelType, TemplateContext } from "../templating.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
@@ -500,9 +489,7 @@ export async function runReplyAgent(params: {
     if (sessionKey && followupRun.run.sessionFile && followupRun.run.workspaceDir) {
       const actualTokensUsed =
         promptTokens ??
-        (usage
-          ? (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0)
-          : 0);
+        (usage ? (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0) : 0);
       scheduleIdleCompaction({
         sessionKey,
         sessionId: followupRun.run.sessionId,

--- a/src/auto-reply/reply/idle-compaction.test.ts
+++ b/src/auto-reply/reply/idle-compaction.test.ts
@@ -27,9 +27,9 @@ vi.mock("../../runtime.js", () => ({
   },
 }));
 
+import { AgentDefaultsSchema } from "../../config/zod-schema.agent-defaults.js";
 import { cancelIdleCompaction, scheduleIdleCompaction } from "./idle-compaction.js";
 import type { ScheduleIdleCompactionParams } from "./idle-compaction.js";
-import { AgentDefaultsSchema } from "../../config/zod-schema.agent-defaults.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -39,11 +39,7 @@ function makeParams(
     idleTriggerPercent?: number;
   } = {},
 ): ScheduleIdleCompactionParams {
-  const {
-    idleTriggerMinutes,
-    idleTriggerPercent,
-    ...rest
-  } = overrides;
+  const { idleTriggerMinutes, idleTriggerPercent, ...rest } = overrides;
 
   return {
     sessionKey: "test-session",

--- a/src/auto-reply/reply/idle-compaction.test.ts
+++ b/src/auto-reply/reply/idle-compaction.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for idle-triggered proactive compaction.
+ *
+ * Covers:
+ * - idleTriggerMinutes not configured → no timer
+ * - context below threshold → no timer
+ * - context >= threshold with idleTriggerMinutes → timer fires → compactEmbeddedPiSession called
+ * - new message (cancelIdleCompaction) → timer cleared, compact not called
+ * - schema validation: invalid values rejected
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks (must be hoisted before imports that trigger module load) ──────────
+
+const state = vi.hoisted(() => ({
+  compactMock: vi.fn(),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  compactEmbeddedPiSession: (params: unknown) => state.compactMock(params),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { cancelIdleCompaction, scheduleIdleCompaction } from "./idle-compaction.js";
+import type { ScheduleIdleCompactionParams } from "./idle-compaction.js";
+import { AgentDefaultsSchema } from "../../config/zod-schema.agent-defaults.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeParams(
+  overrides: Partial<ScheduleIdleCompactionParams> & {
+    idleTriggerMinutes?: number;
+    idleTriggerPercent?: number;
+  } = {},
+): ScheduleIdleCompactionParams {
+  const {
+    idleTriggerMinutes,
+    idleTriggerPercent,
+    ...rest
+  } = overrides;
+
+  return {
+    sessionKey: "test-session",
+    sessionId: "session-uuid-1",
+    contextTokensUsed: 80_000,
+    contextTokensMax: 100_000,
+    sessionFile: "/tmp/session.jsonl",
+    workspaceDir: "/tmp/workspace",
+    provider: "anthropic",
+    model: "claude",
+    cfg: {
+      agents: {
+        defaults: {
+          compaction: {
+            ...(idleTriggerMinutes !== undefined ? { idleTriggerMinutes } : {}),
+            ...(idleTriggerPercent !== undefined ? { idleTriggerPercent } : {}),
+          },
+        },
+      },
+    } as unknown as ScheduleIdleCompactionParams["cfg"],
+    ...rest,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("scheduleIdleCompaction", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    state.compactMock.mockReset();
+    state.compactMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    // Clean up any lingering timers.
+    cancelIdleCompaction("test-session");
+    cancelIdleCompaction("other-session");
+    vi.useRealTimers();
+  });
+
+  it("does NOT set a timer when idleTriggerMinutes is not configured", async () => {
+    scheduleIdleCompaction(makeParams()); // no idleTriggerMinutes
+
+    await vi.runAllTimersAsync();
+
+    expect(state.compactMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT set a timer when context is below threshold (default 0.7)", async () => {
+    scheduleIdleCompaction(
+      makeParams({
+        idleTriggerMinutes: 5,
+        contextTokensUsed: 60_000, // 60% — below default 70%
+        contextTokensMax: 100_000,
+      }),
+    );
+
+    await vi.runAllTimersAsync();
+
+    expect(state.compactMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT set a timer when context is below a custom threshold", async () => {
+    scheduleIdleCompaction(
+      makeParams({
+        idleTriggerMinutes: 5,
+        idleTriggerPercent: 0.9,
+        contextTokensUsed: 80_000, // 80% — below custom 90%
+        contextTokensMax: 100_000,
+      }),
+    );
+
+    await vi.runAllTimersAsync();
+
+    expect(state.compactMock).not.toHaveBeenCalled();
+  });
+
+  it("fires compactEmbeddedPiSession after the timer when context >= threshold", async () => {
+    scheduleIdleCompaction(
+      makeParams({
+        idleTriggerMinutes: 5,
+        contextTokensUsed: 75_000, // 75% — above default 70%
+        contextTokensMax: 100_000,
+      }),
+    );
+
+    // Timer should not have fired yet.
+    expect(state.compactMock).not.toHaveBeenCalled();
+
+    // Advance by exactly 5 minutes.
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    expect(state.compactMock).toHaveBeenCalledOnce();
+    expect(state.compactMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-uuid-1",
+        sessionKey: "test-session",
+        trigger: "manual",
+      }),
+    );
+  });
+
+  it("fires at exactly the custom threshold boundary (>=)", async () => {
+    scheduleIdleCompaction(
+      makeParams({
+        idleTriggerMinutes: 2,
+        idleTriggerPercent: 0.8,
+        contextTokensUsed: 80_000, // exactly 80%
+        contextTokensMax: 100_000,
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+
+    expect(state.compactMock).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT fire when timer is cancelled before it expires", async () => {
+    scheduleIdleCompaction(
+      makeParams({
+        idleTriggerMinutes: 5,
+        contextTokensUsed: 80_000,
+        contextTokensMax: 100_000,
+      }),
+    );
+
+    // Simulate a new inbound message arriving — cancel the timer.
+    cancelIdleCompaction("test-session");
+
+    await vi.runAllTimersAsync();
+
+    expect(state.compactMock).not.toHaveBeenCalled();
+  });
+
+  it("replaces an earlier timer when called again before the first fires", async () => {
+    // First schedule
+    scheduleIdleCompaction(
+      makeParams({
+        idleTriggerMinutes: 5,
+        sessionId: "session-uuid-1",
+        contextTokensUsed: 80_000,
+        contextTokensMax: 100_000,
+      }),
+    );
+
+    // Advance partway.
+    await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+
+    // Second schedule (context still above threshold)
+    scheduleIdleCompaction(
+      makeParams({
+        idleTriggerMinutes: 5,
+        sessionId: "session-uuid-2", // different session id to verify which one fires
+        contextTokensUsed: 85_000,
+        contextTokensMax: 100_000,
+      }),
+    );
+
+    // Let the second timer fire.
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    // Only one compaction should have run (the second).
+    expect(state.compactMock).toHaveBeenCalledOnce();
+    expect(state.compactMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "session-uuid-2" }),
+    );
+  });
+
+  it("silently catches errors from compactEmbeddedPiSession (best-effort)", async () => {
+    state.compactMock.mockRejectedValueOnce(new Error("compact failed"));
+
+    scheduleIdleCompaction(
+      makeParams({
+        idleTriggerMinutes: 1,
+        contextTokensUsed: 80_000,
+        contextTokensMax: 100_000,
+      }),
+    );
+
+    // Should not throw even when compactEmbeddedPiSession rejects.
+    await expect(vi.runAllTimersAsync()).resolves.not.toThrow();
+    expect(state.compactMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe("cancelIdleCompaction", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    state.compactMock.mockReset();
+    state.compactMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cancelIdleCompaction("test-session");
+    vi.useRealTimers();
+  });
+
+  it("is a no-op when no timer is pending", () => {
+    expect(() => cancelIdleCompaction("no-such-session")).not.toThrow();
+  });
+});
+
+// ── Zod schema validation ────────────────────────────────────────────────────
+
+describe("AgentDefaultsSchema — compaction.idleTrigger* validation", () => {
+  function parseCompaction(compaction: Record<string, unknown>) {
+    return AgentDefaultsSchema?.safeParse({ compaction });
+  }
+
+  it("accepts valid idleTriggerMinutes (positive integer)", () => {
+    const result = parseCompaction({ idleTriggerMinutes: 5 });
+    expect(result?.success).toBe(true);
+  });
+
+  it("rejects idleTriggerMinutes = 0", () => {
+    const result = parseCompaction({ idleTriggerMinutes: 0 });
+    expect(result?.success).toBe(false);
+  });
+
+  it("rejects negative idleTriggerMinutes", () => {
+    const result = parseCompaction({ idleTriggerMinutes: -1 });
+    expect(result?.success).toBe(false);
+  });
+
+  it("rejects non-integer idleTriggerMinutes", () => {
+    const result = parseCompaction({ idleTriggerMinutes: 1.5 });
+    expect(result?.success).toBe(false);
+  });
+
+  it("accepts valid idleTriggerPercent (0.1–0.95)", () => {
+    const result = parseCompaction({ idleTriggerPercent: 0.75 });
+    expect(result?.success).toBe(true);
+  });
+
+  it("accepts idleTriggerPercent at min boundary (0.1)", () => {
+    const result = parseCompaction({ idleTriggerPercent: 0.1 });
+    expect(result?.success).toBe(true);
+  });
+
+  it("accepts idleTriggerPercent at max boundary (0.95)", () => {
+    const result = parseCompaction({ idleTriggerPercent: 0.95 });
+    expect(result?.success).toBe(true);
+  });
+
+  it("rejects idleTriggerPercent < 0.1", () => {
+    const result = parseCompaction({ idleTriggerPercent: 0.05 });
+    expect(result?.success).toBe(false);
+  });
+
+  it("rejects idleTriggerPercent > 0.95", () => {
+    const result = parseCompaction({ idleTriggerPercent: 0.96 });
+    expect(result?.success).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/idle-compaction.ts
+++ b/src/auto-reply/reply/idle-compaction.ts
@@ -19,7 +19,9 @@ const pendingIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
 let exitHandlerRegistered = false;
 
 function ensureExitHandler() {
-  if (exitHandlerRegistered) return;
+  if (exitHandlerRegistered) {
+    return;
+  }
   exitHandlerRegistered = true;
   process.on("exit", () => {
     for (const timer of pendingIdleTimers.values()) {

--- a/src/auto-reply/reply/idle-compaction.ts
+++ b/src/auto-reply/reply/idle-compaction.ts
@@ -1,3 +1,5 @@
+import type { CompactEmbeddedPiSessionParams } from "../../agents/pi-embedded-runner/compact.js";
+import { compactEmbeddedPiSession } from "../../agents/pi-embedded.js";
 /**
  * Idle-triggered proactive compaction.
  *
@@ -9,8 +11,6 @@
  * The timer is cancelled whenever a new inbound message is received.
  */
 import type { OpenClawConfig } from "../../config/config.js";
-import type { CompactEmbeddedPiSessionParams } from "../../agents/pi-embedded-runner/compact.js";
-import { compactEmbeddedPiSession } from "../../agents/pi-embedded.js";
 import { defaultRuntime } from "../../runtime.js";
 
 /** Map<sessionKey, NodeJS.Timeout> */
@@ -101,9 +101,7 @@ export function scheduleIdleCompaction(params: ScheduleIdleCompactionParams): vo
         ownerNumbers: params.ownerNumbers,
         trigger: "manual",
       });
-      defaultRuntime.log(
-        `[idle-compaction] Idle compaction completed for session ${sessionKey}`,
-      );
+      defaultRuntime.log(`[idle-compaction] Idle compaction completed for session ${sessionKey}`);
     } catch (err) {
       // Best-effort: errors must not affect the main reply flow.
       defaultRuntime.error(

--- a/src/auto-reply/reply/idle-compaction.ts
+++ b/src/auto-reply/reply/idle-compaction.ts
@@ -1,0 +1,128 @@
+/**
+ * Idle-triggered proactive compaction.
+ *
+ * After each agent turn, if context usage exceeds `idleTriggerPercent` and
+ * `idleTriggerMinutes` is configured, we schedule a timer. If no new message
+ * arrives before the timer fires, compaction runs proactively rather than
+ * waiting for the context window to overflow.
+ *
+ * The timer is cancelled whenever a new inbound message is received.
+ */
+import type { OpenClawConfig } from "../../config/config.js";
+import type { CompactEmbeddedPiSessionParams } from "../../agents/pi-embedded-runner/compact.js";
+import { compactEmbeddedPiSession } from "../../agents/pi-embedded.js";
+import { defaultRuntime } from "../../runtime.js";
+
+/** Map<sessionKey, NodeJS.Timeout> */
+const pendingIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+let exitHandlerRegistered = false;
+
+function ensureExitHandler() {
+  if (exitHandlerRegistered) return;
+  exitHandlerRegistered = true;
+  process.on("exit", () => {
+    for (const timer of pendingIdleTimers.values()) {
+      clearTimeout(timer);
+    }
+    pendingIdleTimers.clear();
+  });
+}
+
+export type ScheduleIdleCompactionParams = {
+  /** Session key (routing key used as timer map key). */
+  sessionKey: string;
+  /** Session id passed to compactEmbeddedPiSession. */
+  sessionId: string;
+  /** Actual prompt tokens consumed this turn. */
+  contextTokensUsed: number;
+  /** Session's max context window size. */
+  contextTokensMax: number;
+  /** Full OpenClaw config (for reading compaction settings). */
+  cfg: OpenClawConfig;
+  // Additional fields forwarded to compactEmbeddedPiSession
+  sessionFile: string;
+  workspaceDir: string;
+  provider?: string;
+  model?: string;
+  thinkLevel?: CompactEmbeddedPiSessionParams["thinkLevel"];
+  bashElevated?: CompactEmbeddedPiSessionParams["bashElevated"];
+  skillsSnapshot?: CompactEmbeddedPiSessionParams["skillsSnapshot"];
+  ownerNumbers?: string[];
+};
+
+/**
+ * Schedule a proactive idle compaction for `sessionKey`.
+ *
+ * No-ops when:
+ * - `idleTriggerMinutes` is not configured
+ * - `contextTokensUsed / contextTokensMax` is below `idleTriggerPercent`
+ *
+ * Replaces any previously scheduled timer for this session.
+ */
+export function scheduleIdleCompaction(params: ScheduleIdleCompactionParams): void {
+  const { cfg, sessionKey, sessionId, contextTokensUsed, contextTokensMax } = params;
+
+  const compactionCfg = cfg?.agents?.defaults?.compaction;
+  const idleTriggerMinutes = compactionCfg?.idleTriggerMinutes;
+  const idleTriggerPercent = compactionCfg?.idleTriggerPercent ?? 0.7;
+
+  // Feature disabled — nothing to do.
+  if (!idleTriggerMinutes) {
+    return;
+  }
+
+  // Check whether we're above the threshold.
+  const percent = contextTokensMax > 0 ? contextTokensUsed / contextTokensMax : 0;
+  if (percent < idleTriggerPercent) {
+    return;
+  }
+
+  // Replace any stale timer.
+  cancelIdleCompaction(sessionKey);
+  ensureExitHandler();
+
+  const delayMs = idleTriggerMinutes * 60 * 1000;
+
+  const timer = setTimeout(async () => {
+    pendingIdleTimers.delete(sessionKey);
+    try {
+      await compactEmbeddedPiSession({
+        sessionId,
+        sessionKey,
+        sessionFile: params.sessionFile,
+        workspaceDir: params.workspaceDir,
+        config: params.cfg,
+        provider: params.provider,
+        model: params.model,
+        thinkLevel: params.thinkLevel,
+        bashElevated: params.bashElevated,
+        skillsSnapshot: params.skillsSnapshot,
+        ownerNumbers: params.ownerNumbers,
+        trigger: "manual",
+      });
+      defaultRuntime.log(
+        `[idle-compaction] Idle compaction completed for session ${sessionKey}`,
+      );
+    } catch (err) {
+      // Best-effort: errors must not affect the main reply flow.
+      defaultRuntime.error(
+        `[idle-compaction] Idle compaction failed for session ${sessionKey}: ${String(err)}`,
+      );
+    }
+  }, delayMs);
+
+  pendingIdleTimers.set(sessionKey, timer);
+}
+
+/**
+ * Cancel a pending idle compaction timer for `sessionKey` (e.g. when a new
+ * inbound message arrives).
+ */
+export function cancelIdleCompaction(sessionKey: string): void {
+  const timer = pendingIdleTimers.get(sessionKey);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    pendingIdleTimers.delete(sessionKey);
+  }
+}

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -1,6 +1,8 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { loadConfig } from "./config.js";
-import { withTempHomeConfig } from "./test-helpers.js";
+import { loadConfig, validateConfigObject } from "./config.js";
+import { withTempHome, withTempHomeConfig } from "./test-helpers.js";
 
 describe("config compaction settings", () => {
   it("preserves memory flush config values", async () => {
@@ -127,5 +129,89 @@ describe("config compaction settings", () => {
         expect(cfg.agents?.defaults?.compaction?.qualityGuard?.maxRetries).toBe(99);
       },
     );
+  });
+
+  it("preserves notifyOnStart and notifyOnStartText config values", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            agents: {
+              defaults: {
+                compaction: {
+                  notifyOnStart: true,
+                  notifyOnStartText: "⏳ Compacting context…",
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const cfg = loadConfig();
+
+      expect(cfg.agents?.defaults?.compaction?.notifyOnStart).toBe(true);
+      expect(cfg.agents?.defaults?.compaction?.notifyOnStartText).toBe("⏳ Compacting context…");
+    });
+  });
+
+  it("accepts notifyOnStart: false without errors", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            agents: {
+              defaults: {
+                compaction: {
+                  notifyOnStart: false,
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const cfg = loadConfig();
+
+      expect(cfg.agents?.defaults?.compaction?.notifyOnStart).toBe(false);
+    });
+  });
+
+  it("rejects non-boolean notifyOnStart", () => {
+    const result = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            notifyOnStart: "yes",
+          },
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects non-string notifyOnStartText", () => {
+    const result = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            notifyOnStartText: 42,
+          },
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
   });
 });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -329,6 +329,10 @@ export type AgentCompactionConfig = {
    * When set, compaction uses this model instead of the agent's primary model.
    * Falls back to the primary model when unset. */
   model?: string;
+  /** Send a notification message to the user when compaction starts. Default: false. */
+  notifyOnStart?: boolean;
+  /** Notification text sent when compaction starts. Default: "🧹 Context compacting, back in a moment…" */
+  notifyOnStartText?: string;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -333,6 +333,16 @@ export type AgentCompactionConfig = {
   notifyOnStart?: boolean;
   /** Notification text sent when compaction starts. Default: "🧹 Context compacting, back in a moment…" */
   notifyOnStartText?: string;
+  /**
+   * Proactive idle compaction: trigger compaction after this many minutes of user
+   * inactivity when context usage exceeds `idleTriggerPercent`. Default: disabled.
+   */
+  idleTriggerMinutes?: number;
+  /**
+   * Context usage threshold (0.0–1.0) above which idle compaction may trigger.
+   * Only applies when `idleTriggerMinutes` is set. Default: 0.7 (70%).
+   */
+  idleTriggerPercent?: number;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -125,6 +125,8 @@ export const AgentDefaultsSchema = z
           .optional(),
         notifyOnStart: z.boolean().optional(),
         notifyOnStartText: z.string().optional(),
+        idleTriggerMinutes: z.number().int().positive().optional(),
+        idleTriggerPercent: z.number().min(0.1).max(0.95).optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -123,6 +123,8 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        notifyOnStart: z.boolean().optional(),
+        notifyOnStartText: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Extends #18049 (triple-layer post-compaction context enforcement).

## Summary

Two complementary improvements to the compaction subsystem:

1. **`notifyOnStart`** — send a message to the user the moment auto-compaction begins, eliminating the confusing silent period where the agent is unresponsive.
2. **Idle-triggered proactive compaction** (`idleTriggerMinutes` / `idleTriggerPercent`) — when the user goes quiet and context usage is above a configurable threshold, compact proactively while there is no active turn, rather than waiting for the window to overflow mid-conversation.

Both features are **opt-in**; existing deployments see zero behaviour change.

---

## Problem

### Silent compaction window

During auto-compaction the Pi agent is busy re-summarising history. From the user's perspective the assistant simply stops responding. Clients that surface error indicators (red dots, timeout warnings) show them even when nothing is actually wrong, leaving non-technical users confused.

### Reactive-only compaction causes latency spikes

The default compaction policy fires only when the context is near-full — typically right when a new user message arrives. The compaction turn adds latency exactly at the worst moment. A proactive idle trigger can perform the same work during quiet periods, so the next user message starts with a freshly compacted context.

---

## Solution

New optional config fields under `agents.defaults.compaction`:

| Field | Type | Default | Description |
|---|---|---|---|
| `notifyOnStart` | `boolean` | `false` | Deliver a message when compaction starts |
| `notifyOnStartText` | `string` | `"🧹 Context compacting, back in a moment…"` | Notification text |
| `idleTriggerMinutes` | `number` (positive int) | `undefined` (disabled) | Idle duration before proactive compaction fires |
| `idleTriggerPercent` | `number` (0.1 – 0.95) | `0.7` | Minimum context usage ratio for idle trigger to engage |

### Example config

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "notifyOnStart": true,
        "notifyOnStartText": "🧹 Context compacting, back in a moment…",
        "idleTriggerMinutes": 10,
        "idleTriggerPercent": 0.7
      }
    }
  }
}
```

---

## Design

### Feature 1 — Compaction start notification

**Full delivery chain (every link typed):**

```
AgentCompactionConfig.notifyOnStart / notifyOnStartText   (types.agent-defaults.ts)
  → AgentDefaultsSchema.compaction.notifyOnStart/Text     (zod-schema.agent-defaults.ts, .strict())
  → cfg.agents.defaults.compaction resolved at runtime    (agent-runner.ts)
  → onCompactionStart: (() => Promise<void>) | undefined  (agent-runner-execution.ts param type)
  → opts.onBlockReply({ text })                           (inline callback, same path as streaming)
```

Key decisions:

- **Bypass the block pipeline** — the callback calls `opts.onBlockReply` directly, with no chunking or coalescing delay. The notification reaches the client before the model goes quiet.
- **Callback isolation** — `onCompactionStart` is declared on `runAgentTurnWithFallback` params only (not on the public `GetReplyOptions`), keeping the external API surface clean.
- **Default text is user-friendly** — the fallback string is hardcoded so deployments that set `notifyOnStart: true` without specifying text still get a sensible message.

### Feature 2 — Idle-triggered proactive compaction

**Full delivery chain (every link typed):**

```
AgentCompactionConfig.idleTriggerMinutes / idleTriggerPercent  (types.agent-defaults.ts)
  → AgentDefaultsSchema.compaction.idleTriggerMinutes/Percent  (zod-schema.agent-defaults.ts, .strict())
  → cfg.agents.defaults.compaction resolved at runtime         (agent-runner.ts)
  → scheduleIdleCompaction(ScheduleIdleCompactionParams)        (idle-compaction.ts)
  → Map<sessionKey, NodeJS.Timeout>                            (module-level timer map)
  → compactEmbeddedPiSession(CompactEmbeddedPiSessionParams)   (pi-embedded.ts re-export)
```

Key decisions:

- **Threshold guard prevents premature compaction** — `scheduleIdleCompaction` computes `ratio = contextTokensUsed / contextTokensMax` and returns early if `ratio < idleTriggerPercent` (default 0.7). Sessions well below 70% context usage are never touched by idle compaction.
- **`contextTokensUsed` is actual prompt tokens** — resolved from `runResult.meta.agentMeta?.promptTokens`, falling back to `usage.input + usage.cacheRead + usage.cacheWrite`. This is distinct from `contextTokensMax` (the window cap, confusingly named `contextTokensUsed` in the pre-existing code).
- **Per-session timer map, replace semantics** — `pendingIdleTimers: Map<sessionKey, NodeJS.Timeout>` holds at most one timer per session. Each call to `scheduleIdleCompaction` cancels any previous timer before setting a new one, so the clock always resets to the last message.
- **Inbound cancel on every turn** — `cancelIdleCompaction(sessionKey)` is called unconditionally at turn start (just before `runMemoryFlushIfNeeded`). A new user message always aborts any pending idle compaction.
- **Concurrent-run safety** — if `compactEmbeddedPiSession` is called while a Pi agent run is active for the same session, the call is serialised through the existing per-session `enqueueCommandInLane` queue inside `compactEmbeddedPiSession` itself. No additional locking is needed here.
- **Best-effort error handling** — errors from `compactEmbeddedPiSession` are caught and logged via `defaultRuntime.error`; they never propagate to the caller. Idle compaction is a background optimisation, not a correctness requirement.
- **No timer leak** — a `process.on("exit")` handler (registered exactly once via a module-level `exitHandlerRegistered` flag) calls `clearTimeout` on all pending timers before the process exits.
- **`trigger: "manual"`** — reuses the existing `/compact` command code path end-to-end, including session-lane queuing, safety timeout, and post-compaction token-count persistence.

### Boundary behaviour

| Situation | Behaviour |
|---|---|
| `idleTriggerMinutes` not set | `scheduleIdleCompaction` returns immediately; no timer is ever created |
| Context ratio exactly at `idleTriggerPercent` | Timer is scheduled (condition is `>=`) |
| New user message arrives before timer fires | `cancelIdleCompaction` clears timer; compact is never called |
| Pi agent run is active when timer fires | Call is serialised behind the active run via `enqueueCommandInLane` |
| `compactEmbeddedPiSession` throws | Error silently caught and logged; next turn proceeds normally |
| Process exits with pending timer | `process.on("exit")` handler clears all pending timers |

---

## Testing

### `src/config/config.compaction-settings.test.ts` (6 tests)
- Preserves `notifyOnStart: true` and `notifyOnStartText` round-trip
- Accepts `notifyOnStart: false`
- Rejects non-boolean `notifyOnStart`
- Rejects non-string `notifyOnStartText`

### `src/auto-reply/reply/agent-runner.compaction-notify.test.ts` (5 tests)
- `notifyOnStart: true` → `onBlockReply` called with default text
- `notifyOnStart: true` + custom text → custom text delivered
- `notifyOnStart: false` → no notification
- `notifyOnStart: undefined` (default) → no notification
- Only `phase: "end"` fires (no start event) → no notification

### `src/auto-reply/reply/idle-compaction.test.ts` (18 tests)

**No-op paths:**
- `idleTriggerMinutes` not configured → no timer
- Context below threshold (default 70%) → no timer
- Context below custom threshold → no timer

**Happy path:**
- Context ≥ threshold + `idleTriggerMinutes` set → timer fires → `compactEmbeddedPiSession` called with correct `sessionId`, `sessionKey`, `trigger: "manual"`
- Fires at exactly the threshold boundary (≥, not >)

**Cancellation:**
- `cancelIdleCompaction` before timer fires → compact not called
- Re-schedule replaces previous timer; only latest sessionId fires
- `cancelIdleCompaction` on unknown key → no-op, no throw

**Error handling:**
- `compactEmbeddedPiSession` rejects → silently caught, no throw from timer callback

**Schema validation (boundary values):**
- `idleTriggerMinutes: 0` → rejected (must be positive)
- `idleTriggerMinutes: -1` → rejected
- `idleTriggerMinutes: 1.5` → rejected (must be integer)
- `idleTriggerPercent: 0.1` → accepted (min boundary)
- `idleTriggerPercent: 0.95` → accepted (max boundary)
- `idleTriggerPercent: 0.05` → rejected (< 0.1)
- `idleTriggerPercent: 0.96` → rejected (> 0.95)

---

## Files Changed

| File | Status | Description |
|---|---|---|
| `src/config/types.agent-defaults.ts` | modified | `AgentCompactionConfig` — adds `notifyOnStart`, `notifyOnStartText`, `idleTriggerMinutes`, `idleTriggerPercent` |
| `src/config/zod-schema.agent-defaults.ts` | modified | Zod schema for all four new fields; `.strict()` preserved |
| `src/auto-reply/reply/agent-runner-execution.ts` | modified | `onCompactionStart` param + invocation on `compaction:phase=start` |
| `src/auto-reply/reply/agent-runner.ts` | modified | `onCompactionStart` callback wiring; `cancelIdleCompaction` on turn start; `scheduleIdleCompaction` after `persistRunSessionUsage` |
| `src/auto-reply/reply/idle-compaction.ts` | **new** | Per-session idle compaction timer module (`scheduleIdleCompaction`, `cancelIdleCompaction`) |
| `src/auto-reply/reply/idle-compaction.test.ts` | **new** | 18 tests for idle compaction logic and schema validation |
| `src/config/config.compaction-settings.test.ts` | modified | Schema tests for `notifyOnStart` / `notifyOnStartText` |
| `src/auto-reply/reply/agent-runner.compaction-notify.test.ts` | **new** | 5 integration tests for compaction start notification |
| `docs/concepts/compaction.md` | modified | User-facing documentation for both features |
| `docs/reference/session-management-compaction.md` | modified | Implementation reference for both features |