### PR TITLE
Security/Browser: fail closed when control server has no auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Browser: fail closed when browser control would start without gateway auth, unless `OPENCLAW_UNSAFE_ALLOW_BROWSER_CONTROL_NO_AUTH=1` is explicitly set for short-lived break-glass use.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.


### PR DESCRIPTION
## Summary
- fail closed in browser control startup when no gateway auth is resolved
- require explicit break-glass env (`OPENCLAW_UNSAFE_ALLOW_BROWSER_CONTROL_NO_AUTH=1`) to allow unauthenticated browser control outside test-like environments
- add unit coverage for the new no-auth override policy helper

## Testing
- `pnpm test src/browser/control-auth.auto-token.test.ts` *(fails in this environment: `pnpm` not found)*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented fail-closed security policy for browser control server startup when no authentication is configured. The server now refuses to start without credentials unless an explicit break-glass environment variable is set, with automatic allowance for test environments.

**Key changes:**
- Added `shouldAllowUnsafeBrowserControlNoAuth` helper that checks for test-like environments or explicit unsafe override
- Modified `startBrowserControlServerFromConfig` to fail and return `null` when no auth is present and the unsafe override isn't set
- Comprehensive test coverage for the new policy logic covering production, test, and break-glass scenarios
- Updated CHANGELOG with security fix description

**Code quality notes:**
- The `isTestLikeEnv` function duplicates logic already present in `shouldAutoGenerateBrowserAuth`, but this is acceptable since they serve different purposes and may diverge in the future
- Security logging appropriately distinguishes between error (refused startup) and warning (unsafe override used) levels

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with only a minor grammatical fix needed
- The security hardening is well-implemented with proper fail-closed behavior, comprehensive test coverage, and appropriate handling of test vs production environments. The only issue found is a minor grammatical error in an error message that doesn't affect functionality.
- No files require special attention - all changes are straightforward and well-tested

<sub>Last reviewed commit: 6cef266</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->