### PR TITLE
Security/Gateway: guard dangerous HTTP /tools/invoke re-enables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Gateway: fail startup when `gateway.tools.allow` re-enables dangerous HTTP `/tools/invoke` tools (`sessions_spawn`, `sessions_send`, `gateway`, `whatsapp_login`) unless `OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS=1` is explicitly set for short-lived break-glass use.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/Gateway: fail startup when `gateway.tools.allow` re-enables dangerous HTTP `/tools/invoke` tools (`sessions_spawn`, `sessions_send`, `gateway`, `whatsapp_login`) unless `OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS=1` is explicitly set for short-lived break-glass use.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -2,6 +2,63 @@ import { describe, expect, it } from "vitest";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 
 describe("resolveGatewayRuntimeConfig", () => {
+  describe("gateway HTTP dangerous tool guard", () => {
+    it("rejects dangerous HTTP tool re-enables without explicit break-glass env", async () => {
+      const cfg = {
+        gateway: {
+          auth: {
+            mode: "token" as const,
+            token: "test-token-123",
+          },
+          tools: {
+            allow: ["sessions_spawn"],
+          },
+        },
+      };
+
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        }),
+      ).rejects.toThrow(
+        "refusing to start gateway with dangerous HTTP /tools/invoke tool re-enables",
+      );
+    });
+
+    it("allows dangerous HTTP tool re-enables with explicit break-glass env", async () => {
+      const previous = process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS;
+      process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS = "1";
+      try {
+        const cfg = {
+          gateway: {
+            auth: {
+              mode: "token" as const,
+              token: "test-token-123",
+            },
+            tools: {
+              allow: ["sessions_send"],
+            },
+          },
+        };
+
+        const result = await resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        });
+
+        expect(result.authMode).toBe("token");
+        expect(result.bindHost).toBe("127.0.0.1");
+      } finally {
+        if (previous === undefined) {
+          delete process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS;
+        } else {
+          process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS = previous;
+        }
+      }
+    });
+  });
+
   describe("trusted-proxy auth mode", () => {
     // This test validates BOTH validation layers:
     // 1. CLI validation in src/cli/gateway-cli/run.ts (line 246)


### PR DESCRIPTION
## Summary
- add a startup hard guard that blocks dangerous HTTP `/tools/invoke` tool re-enables from `gateway.tools.allow`
- require explicit break-glass env (`OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS=1`) to allow these re-enables
- add runtime config regression tests for both reject and override paths

## Testing
- `pnpm test src/gateway/server-runtime-config.test.ts` *(fails in this environment: `pnpm` not found)*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added startup guard that blocks dangerous HTTP `/tools/invoke` re-enables (`sessions_spawn`, `sessions_send`, `gateway`, `whatsapp_login`) from `gateway.tools.allow` unless explicit break-glass env `OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS=1` is set. This hardens the defense-in-depth against RCE by failing fast at startup rather than just warning in security audit. The guard normalizes tool names (trim + lowercase) before checking against `DEFAULT_GATEWAY_HTTP_TOOL_DENY`, matching the runtime filter behavior in `tools-invoke-http.ts:280-281`. Test coverage includes both reject and override paths with proper env cleanup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Implementation is security-focused with proper normalization, consistent with existing runtime filter logic, comprehensive test coverage for both reject and override paths, and clear CHANGELOG entry. No logical errors or edge cases found.
- No files require special attention

<sub>Last reviewed commit: c21757b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->