### PR TITLE
Security/Voice Call: require trusted proxy IPs for forwarded-header trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/Voice Call: require `webhookSecurity.trustedProxyIPs` whenever forwarded-header trust paths are enabled (`allowedHosts` or `trustForwardingHeaders`) so webhook URL reconstruction only trusts proxy headers from explicitly trusted source IPs.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Voice Call: require `webhookSecurity.trustedProxyIPs` whenever forwarded-header trust paths are enabled (`allowedHosts` or `trustForwardingHeaders`) so webhook URL reconstruction only trusts proxy headers from explicitly trusted source IPs.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -113,7 +113,9 @@ describe("validateProviderConfig", () => {
 
       expect(result.valid).toBe(false);
       expect(
-        result.errors.some((error) => error.includes("webhookSecurity.trustedProxyIPs is required")),
+        result.errors.some((error) =>
+          error.includes("webhookSecurity.trustedProxyIPs is required"),
+        ),
       ).toBe(true);
     });
 
@@ -130,7 +132,9 @@ describe("validateProviderConfig", () => {
 
       expect(result.valid).toBe(false);
       expect(
-        result.errors.some((error) => error.includes("webhookSecurity.trustedProxyIPs is required")),
+        result.errors.some((error) =>
+          error.includes("webhookSecurity.trustedProxyIPs is required"),
+        ),
       ).toBe(true);
     });
 

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -99,6 +99,56 @@ describe("validateProviderConfig", () => {
     });
   });
 
+  describe("webhook security forwarding trust", () => {
+    it("requires trustedProxyIPs when allowedHosts are configured", () => {
+      const config = createBaseConfig("twilio");
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.webhookSecurity = {
+        allowedHosts: ["voice.example.com"],
+        trustForwardingHeaders: false,
+        trustedProxyIPs: [],
+      };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((error) => error.includes("webhookSecurity.trustedProxyIPs is required")),
+      ).toBe(true);
+    });
+
+    it("requires trustedProxyIPs when trustForwardingHeaders=true", () => {
+      const config = createBaseConfig("twilio");
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.webhookSecurity = {
+        allowedHosts: [],
+        trustForwardingHeaders: true,
+        trustedProxyIPs: [],
+      };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((error) => error.includes("webhookSecurity.trustedProxyIPs is required")),
+      ).toBe(true);
+    });
+
+    it("passes when forwarding trust paths include trusted proxy IPs", () => {
+      const config = createBaseConfig("twilio");
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.webhookSecurity = {
+        allowedHosts: ["voice.example.com"],
+        trustForwardingHeaders: false,
+        trustedProxyIPs: ["203.0.113.10"],
+      };
+
+      const result = validateProviderConfig(config);
+
+      expect(result).toMatchObject({ valid: true, errors: [] });
+    });
+  });
+
   describe("twilio provider", () => {
     it("passes validation with mixed config and env vars", () => {
       process.env.TWILIO_AUTH_TOKEN = "secret";

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -414,6 +414,16 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     errors.push("plugins.entries.voice-call.config.fromNumber is required");
   }
 
+  const allowedWebhookHosts = config.webhookSecurity?.allowedHosts ?? [];
+  const trustForwardingHeaders = config.webhookSecurity?.trustForwardingHeaders ?? false;
+  const trustedProxyIPs = config.webhookSecurity?.trustedProxyIPs ?? [];
+  if ((trustForwardingHeaders || allowedWebhookHosts.length > 0) && trustedProxyIPs.length === 0) {
+    errors.push(
+      "plugins.entries.voice-call.config.webhookSecurity.trustedProxyIPs is required when " +
+        "webhookSecurity.allowedHosts or webhookSecurity.trustForwardingHeaders is set",
+    );
+  }
+
   if (config.provider === "telnyx") {
     if (!config.telnyx?.apiKey) {
       errors.push(

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -194,7 +194,8 @@ export function reconstructWebhookUrl(ctx: WebhookContext, options?: WebhookUrlO
   const trustedProxyIPs = options?.trustedProxyIPs?.filter(Boolean) ?? [];
   const hasTrustedProxyIPs = trustedProxyIPs.length > 0;
   const remoteIP = options?.remoteIP ?? ctx.remoteAddress;
-  const fromTrustedProxy = hasTrustedProxyIPs && (remoteIP ? trustedProxyIPs.includes(remoteIP) : false);
+  const fromTrustedProxy =
+    hasTrustedProxyIPs && (remoteIP ? trustedProxyIPs.includes(remoteIP) : false);
 
   // Only trust forwarding headers if: (has whitelist OR explicitly trusted) AND from trusted proxy
   const shouldTrustForwardingHeaders = (hasAllowedHosts || explicitlyTrusted) && fromTrustedProxy;

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -489,12 +489,21 @@ export function verifyTwilioWebhook(
 
   const isLoopback = isLoopbackAddress(options?.remoteIP ?? ctx.remoteAddress);
   const allowLoopbackForwarding = options?.allowNgrokFreeTierLoopbackBypass && isLoopback;
+  const trustedProxyIPs = options?.trustedProxyIPs?.filter(Boolean);
+  // Keep ngrok loopback compatibility mode functional without opening non-loopback trust.
+  // In this explicit mode, only loopback proxy sources are trusted for forwarding headers.
+  const effectiveTrustedProxyIPs =
+    trustedProxyIPs && trustedProxyIPs.length > 0
+      ? trustedProxyIPs
+      : allowLoopbackForwarding
+        ? ["127.0.0.1", "::1", "::ffff:127.0.0.1"]
+        : undefined;
 
   // Reconstruct the URL Twilio used
   const verificationUrl = buildTwilioVerificationUrl(ctx, options?.publicUrl, {
     allowedHosts: options?.allowedHosts,
     trustForwardingHeaders: options?.trustForwardingHeaders || allowLoopbackForwarding,
-    trustedProxyIPs: options?.trustedProxyIPs,
+    trustedProxyIPs: effectiveTrustedProxyIPs,
     remoteIP: options?.remoteIP,
   });
 

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -194,8 +194,7 @@ export function reconstructWebhookUrl(ctx: WebhookContext, options?: WebhookUrlO
   const trustedProxyIPs = options?.trustedProxyIPs?.filter(Boolean) ?? [];
   const hasTrustedProxyIPs = trustedProxyIPs.length > 0;
   const remoteIP = options?.remoteIP ?? ctx.remoteAddress;
-  const fromTrustedProxy =
-    !hasTrustedProxyIPs || (remoteIP ? trustedProxyIPs.includes(remoteIP) : false);
+  const fromTrustedProxy = hasTrustedProxyIPs && (remoteIP ? trustedProxyIPs.includes(remoteIP) : false);
 
   // Only trust forwarding headers if: (has whitelist OR explicitly trusted) AND from trusted proxy
   const shouldTrustForwardingHeaders = (hasAllowedHosts || explicitlyTrusted) && fromTrustedProxy;


### PR DESCRIPTION
## Summary
- require trusted proxy IPs whenever voice-call webhook forwarding-header trust paths are enabled (`allowedHosts` or `trustForwardingHeaders`)
- tighten webhook URL reconstruction so forwarded headers are only trusted from explicitly configured trusted proxy IPs
- add config validation + regression tests covering reject/allow/fallback behavior

## Testing
- `pnpm test extensions/voice-call/src/config.test.ts`
- `pnpm test extensions/voice-call/src/webhook-security.test.ts`

*(in this environment these commands cannot run because `pnpm` is not installed on PATH)*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tightened webhook security by requiring explicit `trustedProxyIPs` configuration whenever forwarded-header trust is enabled through `allowedHosts` or `trustForwardingHeaders`. The critical security fix changes line 197 in `webhook-security.ts` from `!hasTrustedProxyIPs ||` to `hasTrustedProxyIPs &&`, preventing forwarded headers from being trusted by default when no proxy IPs are configured.

**Key changes:**
- Config validation enforces `trustedProxyIPs` must be non-empty when using `allowedHosts` or `trustForwardingHeaders`
- Webhook URL reconstruction now requires both forwarding-trust enablement AND request from trusted proxy IP
- Test coverage validates the reject/allow/fallback behavior
- CHANGELOG entry documents the security fix

**Minor gap:** Test coverage could include an explicit case for requests from untrusted proxy IPs (IP present but not in trusted list).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - addresses a legitimate security concern with proper validation
- The change correctly fixes a security issue where forwarded headers could be trusted without verifying the request source. The logic change is simple and correct (changing OR to AND), config validation prevents misconfiguration, and tests cover the main scenarios. Score is 4 (not 5) due to minor test coverage gap for the untrusted-proxy-IP scenario.
- No files require special attention

<sub>Last reviewed commit: cb024eb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->