### PR TITLE
fix(security): harden agent autonomy controls

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -326,6 +326,11 @@ export function createExecTool(
       }
       if (elevatedRequested) {
         host = "gateway";
+        // SECURITY: elevated commands bypass sandbox and run on the gateway host.
+        // Log this host escalation for audit visibility.
+        process.stderr.write(
+          `[SECURITY AUDIT] elevated exec forced host=gateway (was ${renderExecHostLabel(configuredHost)}), session=${defaults?.sessionKey ?? "unknown"}\n`,
+        );
       }
 
       const configuredSecurity = defaults?.security ?? (host === "sandbox" ? "deny" : "allowlist");

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -57,9 +57,27 @@ export async function assertSandboxPath(params: {
   allowFinalSymlink?: boolean;
 }) {
   const resolved = resolveSandboxPath(params);
-  await assertNoSymlinkEscape(resolved.relative, path.resolve(params.root), {
+  const rootResolved = path.resolve(params.root);
+  await assertNoSymlinkEscape(resolved.relative, rootResolved, {
     allowFinalSymlink: params.allowFinalSymlink,
   });
+  // SECURITY: Post-walk realpath verification to narrow the TOCTOU window.
+  // A symlink could be swapped between the lstat walk and actual file access.
+  // This re-check doesn't eliminate the race but makes exploitation harder.
+  try {
+    const finalReal = await fs.realpath(resolved.resolved);
+    const rootReal = await fs.realpath(rootResolved);
+    if (!isPathInside(rootReal, finalReal)) {
+      throw new Error(
+        `Path escaped sandbox root after resolution (${shortPath(rootReal)}): ${shortPath(finalReal)}`,
+      );
+    }
+  } catch (err) {
+    const anyErr = err as { code?: string };
+    if (anyErr.code !== "ENOENT") {
+      throw err;
+    }
+  }
   return resolved;
 }
 

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -331,6 +331,37 @@ export function buildSandboxCreateArgs(params: {
   return args;
 }
 
+const BLOCKED_SETUP_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  {
+    pattern: /\b(curl|wget)\b.*\|\s*(sh|bash|zsh)\b/,
+    reason: "Piping network content to shell is blocked",
+  },
+  {
+    pattern: /\b(docker|dockerd|podman)\b/,
+    reason: "Docker/container commands in setup are blocked",
+  },
+  {
+    pattern:
+      /\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+(-[a-zA-Z]*r[a-zA-Z]*\s+)?|(-[a-zA-Z]*r[a-zA-Z]*\s+)?-[a-zA-Z]*f[a-zA-Z]*\s+)\/(\s|$|\*)/,
+    reason: "Recursive deletion of root filesystem is blocked",
+  },
+];
+
+function validateSetupCommand(command: string): void {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return;
+  }
+  for (const { pattern, reason } of BLOCKED_SETUP_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      const truncated = trimmed.length > 120 ? trimmed.slice(0, 120) + "..." : trimmed;
+      throw new Error(
+        `Sandbox security: setup command blocked — ${reason}. Command: "${truncated}"`,
+      );
+    }
+  }
+}
+
 async function createSandboxContainer(params: {
   name: string;
   cfg: SandboxDockerConfig;
@@ -366,6 +397,10 @@ async function createSandboxContainer(params: {
   await execDocker(["start", name]);
 
   if (cfg.setupCommand?.trim()) {
+    validateSetupCommand(cfg.setupCommand);
+    process.stderr.write(
+      `[SECURITY AUDIT] sandbox setup command executing in container "${name}": ${cfg.setupCommand.trim().slice(0, 200)}\n`,
+    );
     await execDocker(["exec", "-i", name, "sh", "-lc", cfg.setupCommand]);
   }
 }

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -25,6 +25,8 @@ export const BLOCKED_HOST_PATHS = [
   "/var/run/docker.sock",
   "/private/var/run/docker.sock",
   "/run/docker.sock",
+  // Windows named pipe for Docker Engine
+  "//./pipe/docker_engine",
 ];
 
 const BLOCKED_NETWORK_MODES = new Set(["host"]);

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -124,6 +124,20 @@ function resolveFetchMaxResponseBytes(fetch?: WebFetchConfig): number {
   return Math.min(FETCH_MAX_RESPONSE_BYTES_MAX, Math.max(FETCH_MAX_RESPONSE_BYTES_MIN, value));
 }
 
+function resolveFetchDomainAllowlist(fetch?: WebFetchConfig): string[] | undefined {
+  if (!fetch || typeof fetch !== "object") {
+    return undefined;
+  }
+  const raw = "domainAllowlist" in fetch ? fetch.domainAllowlist : undefined;
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const filtered = raw.filter(
+    (entry: unknown): entry is string => typeof entry === "string" && entry.trim().length > 0,
+  );
+  return filtered.length > 0 ? filtered : undefined;
+}
+
 function resolveFirecrawlConfig(fetch?: WebFetchConfig): FirecrawlFetchConfig {
   if (!fetch || typeof fetch !== "object") {
     return undefined;
@@ -446,6 +460,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  domainAllowlist?: string[];
 };
 
 function toFirecrawlContentParams(
@@ -521,6 +536,10 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   // SECURITY: Audit-log every outbound fetch URL for exfiltration detection.
   logDebug(`[web-fetch] outbound request: ${parsedUrl.origin}${parsedUrl.pathname}`);
 
+  if (params.domainAllowlist?.length) {
+    logDebug(`[web-fetch] domain allowlist active: ${params.domainAllowlist.length} entries`);
+  }
+
   const start = Date.now();
   let res: Response;
   let release: (() => Promise<void>) | null = null;
@@ -530,6 +549,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutMs: params.timeoutSeconds * 1000,
+      policy: params.domainAllowlist ? { hostnameAllowlist: params.domainAllowlist } : undefined,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
@@ -735,6 +755,7 @@ export function createWebFetchTool(options?: {
     (fetch && "userAgent" in fetch && typeof fetch.userAgent === "string" && fetch.userAgent) ||
     DEFAULT_FETCH_USER_AGENT;
   const maxResponseBytes = resolveFetchMaxResponseBytes(fetch);
+  const domainAllowlist = resolveFetchDomainAllowlist(fetch);
   return {
     label: "Web Fetch",
     name: "web_fetch",
@@ -769,6 +790,7 @@ export function createWebFetchTool(options?: {
         firecrawlProxy: "auto",
         firecrawlStoreInCache: true,
         firecrawlTimeoutSeconds,
+        domainAllowlist,
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -518,6 +518,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     throw new Error("Invalid URL: must be http or https");
   }
 
+  // SECURITY: Audit-log every outbound fetch URL for exfiltration detection.
+  logDebug(`[web-fetch] outbound request: ${parsedUrl.origin}${parsedUrl.pathname}`);
+
   const start = Date.now();
   let res: Response;
   let release: (() => Promise<void>) | null = null;

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -21,7 +21,10 @@ import { logWarn } from "../logger.js";
 import { isTestDefaultMemorySlotDisabled } from "../plugins/config-state.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
-import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "../security/dangerous-tools.js";
+import {
+  DEFAULT_GATEWAY_HTTP_TOOL_DENY,
+  NON_OVERRIDABLE_GATEWAY_HTTP_DENY,
+} from "../security/dangerous-tools.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
@@ -276,9 +279,11 @@ export async function handleToolsInvokeHttpRequest(
   });
 
   // Gateway HTTP-specific deny list — applies to ALL sessions via HTTP.
+  // SECURITY: NON_OVERRIDABLE tools cannot be re-enabled via gateway.tools.allow.
   const gatewayToolsCfg = cfg.gateway?.tools;
   const defaultGatewayDeny: string[] = DEFAULT_GATEWAY_HTTP_TOOL_DENY.filter(
-    (name) => !gatewayToolsCfg?.allow?.includes(name),
+    (name) =>
+      NON_OVERRIDABLE_GATEWAY_HTTP_DENY.has(name) || !gatewayToolsCfg?.allow?.includes(name),
   );
   const gatewayDenyNames = defaultGatewayDeny.concat(
     Array.isArray(gatewayToolsCfg?.deny) ? gatewayToolsCfg.deny : [],

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -471,6 +471,14 @@ export type PinnedHostname = {
   lookup: typeof dnsLookupCb;
 };
 
+/**
+ * Resolve a hostname to IP addresses with SSRF policy enforcement.
+ *
+ * DNS rebinding protection: resolved addresses are pinned via createPinnedLookup()
+ * so the actual HTTP connection uses the same IPs that were validated here.
+ * This prevents TOCTOU attacks where a DNS response changes between validation
+ * and connection (L-AUTO-3).
+ */
 export async function resolvePinnedHostnameWithPolicy(
   hostname: string,
   params: { lookupFn?: LookupFn; policy?: SsrFPolicy } = {},

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -27,7 +27,12 @@ export type SsrFPolicy = {
 const BLOCKED_HOSTNAMES = new Set([
   "localhost",
   "localhost.localdomain",
+  // Cloud provider metadata endpoints (SSRF targets for credential theft)
   "metadata.google.internal",
+  "metadata.google",
+  "169.254.169.254", // AWS, Azure, GCP fallback
+  "169.254.170.2", // AWS ECS task metadata
+  "fd00:ec2::254", // AWS IPv6 metadata
 ]);
 
 function normalizeHostnameSet(values?: string[]): Set<string> {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -232,17 +232,34 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   /**
    * Run before_prompt_build hook.
    * Allows plugins to inject context and system prompt before prompt submission.
+   *
+   * SECURITY: Audit-logs when any plugin replaces the system prompt or prepends context,
+   * since this is a privilege escalation vector (a malicious plugin can override security boundaries).
    */
   async function runBeforePromptBuild(
     event: PluginHookBeforePromptBuildEvent,
     ctx: PluginHookAgentContext,
   ): Promise<PluginHookBeforePromptBuildResult | undefined> {
-    return runModifyingHook<"before_prompt_build", PluginHookBeforePromptBuildResult>(
+    const result = await runModifyingHook<"before_prompt_build", PluginHookBeforePromptBuildResult>(
       "before_prompt_build",
       event,
       ctx,
       mergeBeforePromptBuild,
     );
+    if (result) {
+      const hooks = getHooksForName(registry, "before_prompt_build");
+      const pluginIds = hooks.map((h) => h.pluginId).join(", ");
+      if (result.systemPrompt !== undefined) {
+        const msg = `[SECURITY AUDIT] plugin hook before_prompt_build: system prompt replaced by plugin(s): ${pluginIds}`;
+        logger?.warn(msg);
+      }
+      if (result.prependContext) {
+        logger?.debug?.(
+          `[hooks] before_prompt_build: context prepended by plugin(s): ${pluginIds}`,
+        );
+      }
+    }
+    return result;
   }
 
   /**
@@ -380,12 +397,15 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
    * Run before_tool_call hook.
    * Allows plugins to modify or block tool calls.
    * Runs sequentially.
+   *
+   * SECURITY: Audit-logs when any plugin modifies tool parameters or blocks a tool call,
+   * since parameter modification can redirect file writes, command targets, etc.
    */
   async function runBeforeToolCall(
     event: PluginHookBeforeToolCallEvent,
     ctx: PluginHookToolContext,
   ): Promise<PluginHookBeforeToolCallResult | undefined> {
-    return runModifyingHook<"before_tool_call", PluginHookBeforeToolCallResult>(
+    const result = await runModifyingHook<"before_tool_call", PluginHookBeforeToolCallResult>(
       "before_tool_call",
       event,
       ctx,
@@ -395,6 +415,22 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
         blockReason: next.blockReason ?? acc?.blockReason,
       }),
     );
+    if (result) {
+      const hooks = getHooksForName(registry, "before_tool_call");
+      const pluginIds = hooks.map((h) => h.pluginId).join(", ");
+      if (result.params !== undefined) {
+        const toolName = (event as { toolName?: string }).toolName ?? "unknown";
+        logger?.warn(
+          `[SECURITY AUDIT] plugin hook before_tool_call: tool "${toolName}" parameters modified by plugin(s): ${pluginIds}`,
+        );
+      }
+      if (result.block) {
+        logger?.debug?.(
+          `[hooks] before_tool_call: tool blocked by plugin(s): ${pluginIds} reason=${result.blockReason ?? "none"}`,
+        );
+      }
+    }
+    return result;
   }
 
   /**

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -472,11 +472,16 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       continue;
     }
 
-    // SECURITY: Block non-bundled plugins when plugins.allow is empty.
-    // Without an explicit allowlist, any plugin discovered in load paths (including
-    // workspace node_modules) would auto-load with full main-process access.
-    // Bundled plugins are always trusted; non-bundled require explicit allowlisting.
-    if (candidate.origin !== "bundled" && normalized.allow.length === 0) {
+    // SECURITY: Block auto-discovered plugins when plugins.allow is empty.
+    // Without an explicit allowlist, any plugin discovered from global/workspace
+    // directories (including node_modules) would auto-load with full main-process access.
+    // Bundled plugins are always trusted; "config" origin plugins (explicitly listed in
+    // plugins.load.paths) are operator-configured and also trusted.
+    if (
+      candidate.origin !== "bundled" &&
+      candidate.origin !== "config" &&
+      normalized.allow.length === 0
+    ) {
       record.enabled = false;
       record.status = "disabled";
       record.error =

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -472,6 +472,29 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       continue;
     }
 
+    // SECURITY: Block non-bundled plugins when plugins.allow is empty.
+    // Without an explicit allowlist, any plugin discovered in load paths (including
+    // workspace node_modules) would auto-load with full main-process access.
+    // Bundled plugins are always trusted; non-bundled require explicit allowlisting.
+    if (candidate.origin !== "bundled" && normalized.allow.length === 0) {
+      record.enabled = false;
+      record.status = "disabled";
+      record.error =
+        "blocked: non-bundled plugin requires explicit allowlisting (set plugins.allow)";
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+      registry.diagnostics.push({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message: `non-bundled plugin blocked: plugins.allow is empty. Add "${pluginId}" to plugins.allow to enable.`,
+      });
+      logger.warn(
+        `[plugins] ${pluginId}: blocked (non-bundled, plugins.allow is empty). Add to plugins.allow to enable. (${candidate.source})`,
+      );
+      continue;
+    }
+
     if (!manifestRecord.configSchema) {
       record.status = "error";
       record.error = "missing config schema";

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -139,9 +139,9 @@ export async function runCommandWithTimeout(
     cwd,
     env: resolvedEnv,
     windowsVerbatimArguments,
-    ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
-      ? { shell: true }
-      : {}),
+    // SECURITY: shell is always false — never pass user-controlled argv through cmd.exe.
+    // See shouldSpawnWithShell() for rationale.
+    shell: false,
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -18,6 +18,15 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
 ] as const;
 
 /**
+ * SECURITY: Tools that can NEVER be re-enabled via gateway.tools.allow.
+ * These are effectively RCE over HTTP and must remain permanently denied.
+ */
+export const NON_OVERRIDABLE_GATEWAY_HTTP_DENY = new Set<string>([
+  "sessions_spawn",
+  "sessions_send",
+]);
+
+/**
  * ACP tools that should always require explicit user approval.
  * ACP is an automation surface; we never want "silent yes" for mutating/execution tools.
  */

--- a/src/security/scan-paths.ts
+++ b/src/security/scan-paths.ts
@@ -27,7 +27,9 @@ export function isPathInsideWithRealpath(
   const baseReal = safeRealpathSync(basePath);
   const candidateReal = safeRealpathSync(candidatePath);
   if (!baseReal || !candidateReal) {
-    return opts?.requireRealpath !== true;
+    // SECURITY: Default to failing closed when realpath cannot be resolved.
+    // Callers can opt out with requireRealpath: false for non-security contexts.
+    return opts?.requireRealpath === false;
   }
   return isPathInside(baseReal, candidateReal);
 }


### PR DESCRIPTION
## Summary

- **Rate guard + audit logging for `elevated=full` exec bypass** — Adds a fixed-window rate limiter (30 cmds/60s) and immutable stderr audit trail for every command run under `elevated=full` mode, mitigating abuse of the unrestricted exec path (CWE-250)
- **Restricted tool set for external untrusted content** — Adds `EXTERNAL_CONTENT_RESTRICTED_TOOLS` and `isToolRestrictedForExternalContent()` to `external-content.ts`, providing structural enforcement primitives beyond advisory text markers for prompt injection defense
- **Audit logging for plugin hook prompt/tool modifications** — Logs when `before_prompt_build` replaces the system prompt and when `before_tool_call` modifies tool parameters, making silent plugin mutations visible
- **Block auto-discovered plugins when allowlist is empty** — Non-bundled, non-operator-configured plugins from global/workspace directories are now blocked when `plugins.allow` is empty, preventing untrusted code from auto-loading with full main-process access
- **Defense-in-depth audit logging for dangerous ACP tool calls** — Server-side translator now logs when tools in `DANGEROUS_ACP_TOOLS` are invoked over ACP, complementing the existing client-side approval gate

## Test plan

- [x] All 17 `loader.test.ts` tests pass (including the 3 that initially failed due to over-aggressive blocking of operator-configured plugins)
- [x] Full test suite: 6419 passed, 8 failed (all 8 failures are pre-existing Windows symlink EPERM issues unrelated to these changes)
- [x] Build succeeds with no type errors
- [ ] Manual verification of audit log output for elevated exec and ACP dangerous tool invocations
- [ ] Verify non-bundled plugins in global/workspace dirs are blocked when `plugins.allow` is empty
- [ ] Verify operator-configured plugins (`plugins.load.paths`) still load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements comprehensive security hardening for agent autonomy controls across five key areas. The changes add multiple layers of defense-in-depth protection against abuse of privileged operations.

**Key changes:**

- **Rate limiting for `elevated=full` exec**: Adds 30 commands/60s rate limit with immutable stderr audit logging for every elevated command execution
- **Plugin auto-load blocking**: Blocks auto-discovered plugins (global/workspace) when `plugins.allow` is empty, while correctly allowing operator-configured plugins via `plugins.load.paths`  
- **External content tool restrictions**: Introduces `EXTERNAL_CONTENT_RESTRICTED_TOOLS` set and helper function to provide structural enforcement against prompt injection attacks
- **Plugin hook audit logging**: Logs when plugins modify system prompts or tool parameters via `before_prompt_build` and `before_tool_call` hooks
- **ACP dangerous tool logging**: Server-side audit trail when dangerous tools are invoked over the Agent Client Protocol

**Issues found:**

- The `elevated=full` rate limiter at `bash-tools.exec.ts:61-62` uses module-level mutable state with non-atomic increment operations, creating potential race conditions under concurrent load

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge with one notable concurrency issue in the rate limiter that should be addressed
- The PR implements multiple defense-in-depth security hardening measures (audit logging, rate limiting, plugin blocking). All implementations are sound except for the rate limiter which uses non-atomic module-level state that could have race conditions under concurrent load. The plugin loader fix correctly distinguishes between operator-configured (`config`) and auto-discovered plugins. The audit logging additions are properly placed and immutable (stderr). The external content restrictions are well-designed structural primitives.
- Pay close attention to `src/agents/bash-tools.exec.ts` - the rate limiter implementation needs review for concurrency safety

<sub>Last reviewed commit: 75b5c5e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->