### PR TITLE
iOS: use dedicated session key for chat sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
+- iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -1603,6 +1603,14 @@ extension NodeAppModel {
         return SessionKey.makeAgentSessionKey(agentId: agentId, baseKey: base)
     }
 
+    var chatSessionKey: String {
+        let base = "ios"
+        let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if agentId.isEmpty || (!defaultId.isEmpty && agentId == defaultId) { return base }
+        return SessionKey.makeAgentSessionKey(agentId: agentId, baseKey: base)
+    }
+
     var activeAgentName: String {
         let agentId = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -99,7 +99,7 @@ struct RootCanvas: View {
                 ChatSheet(
                     // Chat RPCs run on the operator session (read/write scopes).
                     gateway: self.appModel.operatorSession,
-                    sessionKey: self.appModel.mainSessionKey,
+                    sessionKey: self.appModel.chatSessionKey,
                     agentName: self.appModel.activeAgentName,
                     userAccent: self.appModel.seamColor)
             case .quickSetup:

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -77,6 +77,19 @@ private final class MockWatchMessagingService: WatchMessagingServicing, @uncheck
         #expect(json.contains("\"value\""))
     }
 
+    @Test @MainActor func chatSessionKeyDefaultsToIOSBase() {
+        let appModel = NodeAppModel()
+        #expect(appModel.chatSessionKey == "ios")
+    }
+
+    @Test @MainActor func chatSessionKeyUsesAgentScopedKeyForNonDefaultAgent() {
+        let appModel = NodeAppModel()
+        appModel.gatewayDefaultAgentId = "main"
+        appModel.setSelectedAgentId("agent-123")
+        #expect(appModel.chatSessionKey == SessionKey.makeAgentSessionKey(agentId: "agent-123", baseKey: "ios"))
+        #expect(appModel.mainSessionKey == "agent:agent-123:main")
+    }
+
     @Test @MainActor func handleInvokeRejectsBackgroundCommands() async {
         let appModel = NodeAppModel()
         appModel.setScenePhase(.background)


### PR DESCRIPTION
## Summary
- add `chatSessionKey` to `NodeAppModel`, using `ios` as the base key and preserving agent scoping
- route iOS `ChatSheet` to `chatSessionKey` instead of `mainSessionKey` to avoid cross-client session collisions
- add NodeAppModel tests covering default and agent-scoped `chatSessionKey` behavior

## Testing
- iOS test target was not executed in this environment because the generated Xcode project is not present in-repo (`apps/ios/project.yml` is present, `.xcodeproj` is generated out-of-band)

## Attribution
- intent and prior exploration came from https://github.com/openclaw/openclaw/pull/18658 by @kbadinger; this PR keeps only the dedicated chat-session-key slice.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a dedicated `chatSessionKey` property to prevent iOS chat sessions from colliding with the main session key used by other app functionality. The new property uses `"ios"` as the base key (rather than `"main"`) while preserving agent-scoping behavior, ensuring iOS chat sessions are isolated from cross-client session collisions.

Key changes:
- Added `chatSessionKey` computed property in `NodeAppModel` that mirrors `mainSessionKey` logic but uses `"ios"` as base
- Updated `ChatSheet` initialization in `RootCanvas` to use `chatSessionKey` instead of `mainSessionKey`
- Added unit tests verifying default behavior (`"ios"`) and agent-scoped behavior (`"agent:{agentId}:ios"`)

The implementation correctly follows the existing session key patterns and maintains consistency with agent scoping.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows established patterns. The new `chatSessionKey` property duplicates the logic of `mainSessionKey` with only the base key changed from normalized main to `"ios"`. Tests thoroughly cover both default and agent-scoped scenarios. The change is isolated to chat functionality and addresses a legitimate cross-client collision issue.
- No files require special attention

<sub>Last reviewed commit: cda4c20</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->