### PR TITLE
test(security): add regression test for claude-opus-4-6 audit

### DIFF
--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3532,4 +3532,27 @@ description: test skill
       expect(warning?.detail).toContain("gateway.auth.token");
     });
   });
+
+  it("identifies claude-opus-4-6 as a strong model (>= 4.5)", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+          },
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    const weakFinding = res.findings.find(
+      (f) => f.checkId === "models.hygiene" && f.detail.includes("Below Claude 4.5"),
+    );
+    expect(weakFinding).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Fixes #10521.

## Description
This PR adds a regression test to `src/security/audit.test.ts` to ensure that `anthropic/claude-opus-4-6` is correctly identified as a strong/safe model in security audits.

## Verification
- Verified manually with `pnpm test src/security/audit.test.ts`.
- Confirmed existing regex handles the version string correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds regression test verifying that `anthropic/claude-opus-4-6` is correctly recognized as a strong model (>= Claude 4.5) by the security audit system. The test confirms that the existing regex pattern in `src/security/audit-extra.sync.ts:162` properly matches the `claude-opus-4-6` version format and doesn't flag it with a "Below Claude 4.5" warning in the `models.hygiene` check.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a pure test addition that adds regression coverage for `claude-opus-4-6` model detection. The test follows existing patterns in the file, uses the same test structure as similar tests (lines 1189-1214), and verifies expected behavior without modifying any production code. The regex pattern in `audit-extra.sync.ts` already correctly handles the version format.
- No files require special attention

<sub>Last reviewed commit: bd7990e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->