### PR TITLE
feat(slack): support chat:write.customize for custom bot name/avatar

### DIFF
--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -142,3 +142,54 @@ Message context lines include `slack message id` and `channel` fields you can re
 
 - React with ✅ to mark completed tasks.
 - Pin key decisions or weekly status updates.
+
+---
+
+## Custom bot name and avatar (`chat:write.customize`)
+
+By default, OpenClaw posts to Slack under the app's display name and icon set in
+[api.slack.com](https://api.slack.com). You can override this per-message so the
+bot appears with your configured assistant name and avatar instead.
+
+### What it does
+
+When the bot token includes the `chat:write.customize` scope, OpenClaw
+automatically adds `username` and `icon_emoji` (or `icon_url`) to every
+`chat.postMessage` call made by the monitor (inbound-reply) path, so the bot
+shows up in Slack channels with its configured identity.
+
+The feature is **backward-compatible**: if the scope is absent, the message is
+retried without the custom identity fields — no error is surfaced and delivery
+is unaffected.
+
+### Step 1 — Add the scope in api.slack.com
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and open your app.
+2. Navigate to **OAuth & Permissions → Scopes → Bot Token Scopes**.
+3. Click **Add an OAuth Scope** and add `chat:write.customize`.
+4. Scroll to the top of the page and click **Reinstall to Workspace** (required
+   after any scope change).
+
+### Step 2 — Configure in openclaw.json
+
+Set `ui.assistant.name` and optionally `ui.assistant.avatar`:
+
+```json
+{
+  "ui": {
+    "assistant": {
+      "name": "Bernard",
+      "avatar": "https://example.com/bernard-avatar.png"
+    }
+  }
+}
+```
+
+| Field                | Effect in Slack                                                                                  |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| `ui.assistant.name`  | Sets the `username` field — overrides the app's display name for this message.                  |
+| `ui.assistant.avatar`| If an `https://` URL, sets `icon_url`. Otherwise `:robot_face:` is used as `icon_emoji` fallback.|
+
+You can also configure identity at the agent level via `agents.<id>.identity.name`,
+`agents.<id>.identity.avatar`, and `agents.<id>.identity.emoji`. `ui.assistant.*`
+takes precedence over per-agent identity when both are set.

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -1,4 +1,4 @@
-import { resolveHumanDelayConfig } from "../../../agents/identity.js";
+import { resolveAgentIdentity, resolveHumanDelayConfig } from "../../../agents/identity.js";
 import { dispatchInboundMessage } from "../../../auto-reply/dispatch.js";
 import { clearHistoryEntriesIfEnabled } from "../../../auto-reply/reply/history.js";
 import { createReplyDispatcherWithTyping } from "../../../auto-reply/reply/reply-dispatcher.js";
@@ -19,6 +19,7 @@ import {
 import type { SlackStreamSession } from "../../streaming.js";
 import { appendSlackStream, startSlackStream, stopSlackStream } from "../../streaming.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
+import type { SlackSendIdentity } from "../../send.js";
 import { createSlackReplyDeliveryPlan, deliverReplies, resolveSlackThreadTs } from "../replies.js";
 import type { PreparedSlackMessage } from "./types.js";
 
@@ -57,10 +58,55 @@ function shouldUseStreaming(params: {
   return true;
 }
 
+/**
+ * Build a Slack custom identity payload for chat:write.customize.
+ *
+ * Reads `ui.assistant.name` / `ui.assistant.avatar` from config (with fallback
+ * to the per-agent identity). Only returns a value when a name has been
+ * explicitly configured; otherwise the bot posts under its default app name.
+ *
+ * The returned identity is passed to sendMessageSlack which handles the
+ * chat:write.customize scope gracefully: if the bot token lacks the scope,
+ * the message is retried without custom identity fields so no error surfaces.
+ */
+function buildSlackCustomIdentity(
+  cfg: PreparedSlackMessage["ctx"]["cfg"],
+  agentId: string,
+): SlackSendIdentity | undefined {
+  // Prefer ui.assistant.* (user-facing UI config) then fall back to agent identity.
+  const uiName = cfg.ui?.assistant?.name?.trim() || undefined;
+  const uiAvatar = cfg.ui?.assistant?.avatar?.trim() || undefined;
+  const agentIdentity = resolveAgentIdentity(cfg, agentId);
+  const name = uiName ?? agentIdentity?.name?.trim() ?? undefined;
+
+  // Only customise when a name is explicitly configured.
+  if (!name) {
+    return undefined;
+  }
+
+  // Resolve icon: prefer HTTP(S) avatar URL, otherwise fall back to emoji or :robot_face:.
+  const avatarCandidate = uiAvatar ?? agentIdentity?.avatar?.trim() ?? undefined;
+  const isUrl = (v?: string) => Boolean(v && /^https?:\/\//i.test(v));
+
+  if (isUrl(avatarCandidate)) {
+    return { username: name, iconUrl: avatarCandidate };
+  }
+
+  const emojiCandidate = agentIdentity?.emoji?.trim() ?? undefined;
+  const iconEmoji =
+    emojiCandidate && /^:[^:\s]+:$/.test(emojiCandidate) ? emojiCandidate : ":robot_face:";
+
+  return { username: name, iconEmoji };
+}
+
 export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessage) {
   const { ctx, account, message, route } = prepared;
   const cfg = ctx.cfg;
   const runtime = ctx.runtime;
+
+  // Resolve custom bot identity for chat:write.customize (username + icon).
+  // Falls back gracefully when the scope is absent — no error is surfaced.
+  const botIdentity = buildSlackCustomIdentity(cfg, route.agentId);
 
   if (prepared.isDirectMessage) {
     const sessionCfg = cfg.session;
@@ -169,6 +215,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       runtime,
       textLimit: ctx.textLimit,
       replyThreadTs,
+      ...(botIdentity ? { identity: botIdentity } : {}),
     });
     replyPlan.markSent();
   };
@@ -283,6 +330,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         runtime,
         textLimit: ctx.textLimit,
         replyThreadTs,
+        ...(botIdentity ? { identity: botIdentity } : {}),
       });
       replyPlan.markSent();
     },

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -6,7 +6,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
-import { sendMessageSlack } from "../send.js";
+import { sendMessageSlack, type SlackSendIdentity } from "../send.js";
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
@@ -16,6 +16,8 @@ export async function deliverReplies(params: {
   runtime: RuntimeEnv;
   textLimit: number;
   replyThreadTs?: string;
+  /** Optional bot identity for chat:write.customize (username / icon). */
+  identity?: SlackSendIdentity;
 }) {
   for (const payload of params.replies) {
     const threadTs = payload.replyToId ?? params.replyThreadTs;
@@ -34,6 +36,7 @@ export async function deliverReplies(params: {
         token: params.token,
         threadTs,
         accountId: params.accountId,
+        ...(params.identity ? { identity: params.identity } : {}),
       });
     } else {
       let first = true;
@@ -45,6 +48,7 @@ export async function deliverReplies(params: {
           mediaUrl,
           threadTs,
           accountId: params.accountId,
+          ...(params.identity ? { identity: params.identity } : {}),
         });
       }
     }


### PR DESCRIPTION
## Summary

Closes #21133

When `ui.assistant.name` is configured and the bot token includes the `chat:write.customize` scope, OpenClaw now passes `username` and `icon_emoji` (or `icon_url`) to `chat.postMessage` so the bot appears in Slack with the configured assistant identity instead of the default app name.

## Changes

### `src/slack/monitor/replies.ts`
- Added optional `identity?: SlackSendIdentity` parameter to `deliverReplies`
- Forwarded it to both `sendMessageSlack` call sites (text and media paths)

### `src/slack/monitor/message-handler/dispatch.ts`
- Added `buildSlackCustomIdentity(cfg, agentId)` helper that reads `ui.assistant.name` / `ui.assistant.avatar` (with per-agent identity fallback via `resolveAgentIdentity`)
- Resolves identity once at start of `dispatchPreparedSlackMessage` and passes it through `deliverNormally` and the inline `deliverReplies` call
- The lower-level `send.ts` already had `chat:write.customize` scope-error fallback (retries without custom identity if scope is absent)

### `skills/slack/SKILL.md`
- Added new **Custom bot name and avatar (`chat:write.customize`)** section
- Documents what it does, how to add the scope in api.slack.com, and how to configure `ui.assistant.name` / `ui.assistant.avatar` in openclaw.json

## Behavior

- **When `ui.assistant.name` is set**: Slack messages from the bot show the configured name and `:robot_face:` emoji (or `icon_url` if avatar is an `https://` URL)
- **When scope is absent**: Message is silently retried without custom identity — no error, no breakage
- **When no name is configured**: Identity customization is skipped entirely

## Testing

- No name configured → identity is `undefined` → `sendMessageSlack` called without identity → no change in behavior ✅
- Name configured, scope present → `username` + `icon_emoji`/`icon_url` sent ✅
- Name configured, scope absent → Slack returns `missing_scope` → `isSlackCustomizeScopeError` detects it → retry without identity → message delivered ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for `chat:write.customize` scope to customize bot name and avatar in Slack messages. When `ui.assistant.name` is configured, the bot posts with custom identity (name + emoji/avatar) instead of default app name. Implementation includes graceful fallback when scope is missing - messages retry without custom identity on scope errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean implementation with proper error handling, graceful fallback for missing scope, backward compatibility, clear documentation, and follows existing patterns in the codebase
- No files require special attention

<sub>Last reviewed commit: e203f73</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->