### PR TITLE
fix(security): harden data exposure controls

### DIFF
--- a/scripts/sandbox-browser-entrypoint.sh
+++ b/scripts/sandbox-browser-entrypoint.sh
@@ -56,7 +56,7 @@ for _ in $(seq 1 50); do
 done
 
 socat \
-  TCP-LISTEN:"${CDP_PORT}",fork,reuseaddr,bind=0.0.0.0 \
+  TCP-LISTEN:"${CDP_PORT}",fork,reuseaddr,bind=127.0.0.1 \
   TCP:127.0.0.1:"${CHROME_CDP_PORT}" &
 
 if [[ "${ENABLE_NOVNC}" == "1" && "${HEADLESS}" != "1" ]]; then

--- a/src/agents/anthropic-payload-log.ts
+++ b/src/agents/anthropic-payload-log.ts
@@ -135,11 +135,13 @@ export function createAnthropicPayloadLogger(params: {
         return streamFn(model, context, options);
       }
       const nextOnPayload = (payload: unknown) => {
+        // SECURITY: Log only the digest and metadata, not the full payload.
+        // Full payloads contain complete conversation context, system prompts,
+        // and user messages that should not accumulate on disk in plaintext.
         record({
           ...base,
           ts: new Date().toISOString(),
           stage: "request",
-          payload,
           payloadDigest: digest(payload),
         });
         options?.onPayload?.(payload);

--- a/src/agents/cache-trace.ts
+++ b/src/agents/cache-trace.ts
@@ -92,9 +92,9 @@ function resolveCacheTraceConfig(params: CacheTraceInit): CacheTraceConfig {
   return {
     enabled,
     filePath,
-    includeMessages: includeMessages ?? true,
-    includePrompt: includePrompt ?? true,
-    includeSystem: includeSystem ?? true,
+    includeMessages: includeMessages ?? false,
+    includePrompt: includePrompt ?? false,
+    includeSystem: includeSystem ?? false,
   };
 }
 

--- a/src/agents/queued-file-writer.ts
+++ b/src/agents/queued-file-writer.ts
@@ -19,12 +19,25 @@ export function getQueuedFileWriter(
   const ready = fs.mkdir(dir, { recursive: true }).catch(() => undefined);
   let queue = Promise.resolve();
 
+  // SECURITY: Ensure the log file is created with owner-only permissions (0o600)
+  // to prevent other users on the system from reading sensitive diagnostic data.
+  const ensurePermissions = ready.then(async () => {
+    try {
+      await fs.writeFile(filePath, "", { flag: "a", mode: 0o600 });
+      if (process.platform !== "win32") {
+        await fs.chmod(filePath, 0o600);
+      }
+    } catch {
+      // Best-effort: file may not exist yet or permissions may not be supported
+    }
+  });
+
   const writer: QueuedFileWriter = {
     filePath,
     write: (line: string) => {
       queue = queue
-        .then(() => ready)
-        .then(() => fs.appendFile(filePath, line, "utf8"))
+        .then(() => ensurePermissions)
+        .then(() => fs.appendFile(filePath, line, { encoding: "utf8", mode: 0o600 }))
         .catch(() => undefined);
     },
   };

--- a/src/agents/queued-file-writer.ts
+++ b/src/agents/queued-file-writer.ts
@@ -37,7 +37,7 @@ export function getQueuedFileWriter(
     write: (line: string) => {
       queue = queue
         .then(() => ensurePermissions)
-        .then(() => fs.appendFile(filePath, line, { encoding: "utf8", mode: 0o600 }))
+        .then(() => fs.appendFile(filePath, line, { encoding: "utf8" }))
         .catch(() => undefined);
     },
   };


### PR DESCRIPTION
## Summary

- **Bind CDP socat proxy to 127.0.0.1** — The socat proxy for Chrome DevTools Protocol was bound to `0.0.0.0`, exposing the CDP port to the network. Any reachable attacker could connect and gain full Chromium control. Now restricted to loopback only.
- **Default cache trace to exclude message content** — `includeMessages`, `includePrompt`, and `includeSystem` defaulted to `true`, causing full conversation content (including proprietary system prompts) to accumulate on disk indefinitely. Defaults changed to `false`; operators can opt-in via config.
- **Restrict log file permissions and redact payload content** — `QueuedFileWriter` now creates files with mode `0o600` (owner-only). Anthropic payload logger records only the SHA-256 digest instead of the full API request body containing conversation context and user messages.

## Test plan

- [x] Build succeeds with no type errors
- [x] All existing tests pass (no dedicated tests for these modules)
- [ ] Verify `sandbox-browser-entrypoint.sh` socat binds to `127.0.0.1` on container start
- [ ] Verify cache-trace JSONL excludes messages by default, includes when opted-in
- [ ] Verify payload log files created with `0o600` permissions on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tightens data exposure controls across multiple security surfaces: restricts CDP proxy to loopback, defaults cache trace to exclude sensitive content, and hardens log file permissions.

- Bound socat CDP proxy to `127.0.0.1` instead of `0.0.0.0` to prevent network exposure of Chrome DevTools Protocol
- Changed cache trace defaults from opt-out to opt-in for `includeMessages`, `includePrompt`, and `includeSystem` to prevent accumulation of sensitive conversation data
- Added file permission restrictions (`0o600`) in `QueuedFileWriter` to prevent other system users from reading diagnostic logs
- Switched anthropic payload logger to record only SHA-256 digests instead of full API request bodies

The security improvements are sound and address real exposure risks. The implementation correctly uses `chmod` to enforce permissions on existing files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it hardens security controls without breaking existing functionality
- All changes are defensive security improvements that reduce data exposure. The CDP binding change prevents network access to browser debugging. The cache trace defaults prevent inadvertent logging of sensitive content. The file permissions restrict access to diagnostic data. The payload digest change prevents full conversation content from accumulating on disk. No breaking changes to existing functionality.
- No files require special attention

<sub>Last reviewed commit: 897a608</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->