### PR TITLE
Auto-reply: delay onAgentRunStart until real activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/Runner: emit `onAgentRunStart` only after agent lifecycle or tool activity begins (and only once per run), so fallback preflight errors no longer mark runs as started. (#21165) Thanks @shakkernerd.
+
 ## 2026.2.19
 
 ### Changes


### PR DESCRIPTION
## Summary
- delay `onAgentRunStart` until the run actually emits activity
- make start notification idempotent so it can only fire once per run
- add tests for no-start-on-fallback-failure and start-on-cli-run

## Testing
- `pnpm test -- src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Delays `onAgentRunStart` notification until the agent run emits real activity (instead of firing immediately when the run ID is created), and makes the notification idempotent to prevent duplicate firing. This prevents premature notifications when fallback failures occur before the agent actually starts executing.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-isolated to the agent runner execution flow, include comprehensive test coverage for both success and failure cases, and implement a straightforward idempotency pattern that prevents duplicate notifications
- No files require special attention

<sub>Last reviewed commit: 8c4aae5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->