### PR TITLE
fix(status): show 'active (not configured)' when Tailscale is running but mode=off

### DIFF
--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -46,7 +46,7 @@ export async function statusAllCommand(
     const tailscale = await (async () => {
       try {
         const parsed = await readTailscaleStatusJson(runExec, {
-          timeoutMs: 1200,
+          timeoutMs: 3000,
         });
         const backendState = typeof parsed.BackendState === "string" ? parsed.BackendState : null;
         const self =
@@ -273,7 +273,9 @@ export async function statusAllCommand(
         Item: "Tailscale",
         Value:
           tailscaleMode === "off"
-            ? `off${tailscale.backendState ? ` · ${tailscale.backendState}` : ""}${tailscale.dnsName ? ` · ${tailscale.dnsName}` : ""}`
+            ? tailscale.backendState === "Running"
+              ? `active (not configured)${tailscale.dnsName ? ` · ${tailscale.dnsName}` : ""}`
+              : `off${tailscale.backendState ? ` · ${tailscale.backendState}` : ""}`
             : tailscale.dnsName && tailscaleHttpsUrl
               ? `${tailscaleMode} · ${tailscale.backendState ?? "unknown"} · ${tailscale.dnsName} · ${tailscaleHttpsUrl}`
               : `${tailscaleMode} · ${tailscale.backendState ?? "unknown"} · magicdns unknown`,

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -136,7 +136,9 @@ export async function appendStatusAllDiagnosis(params: {
     const hasDns = Boolean(params.tailscale.dnsName);
     const label =
       params.tailscaleMode === "off"
-        ? `Tailscale: off · ${backend}${params.tailscale.dnsName ? ` · ${params.tailscale.dnsName}` : ""}`
+        ? params.tailscale.backendState === "Running"
+          ? `Tailscale: active (not configured for OpenClaw)${params.tailscale.dnsName ? ` · ${params.tailscale.dnsName}` : ""}`
+          : `Tailscale: off · ${backend}${params.tailscale.dnsName ? ` · ${params.tailscale.dnsName}` : ""}`
         : `Tailscale: ${params.tailscaleMode} · ${backend}${params.tailscale.dnsName ? ` · ${params.tailscale.dnsName}` : ""}`;
     emitCheck(label, okBackend && (params.tailscaleMode === "off" || hasDns) ? "ok" : "warn");
     if (params.tailscale.error) {

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -359,7 +359,9 @@ export async function statusCommand(
       Item: "Tailscale",
       Value:
         tailscaleMode === "off"
-          ? muted("off")
+          ? tailscaleDns
+            ? muted(`active (not configured) · ${tailscaleDns}`)
+            : muted("off")
           : tailscaleDns && tailscaleHttpsUrl
             ? `${tailscaleMode} · ${tailscaleDns} · ${tailscaleHttpsUrl}`
             : warn(`${tailscaleMode} · magicdns unknown`),

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -81,12 +81,11 @@ export async function scanStatus(
 
       progress.setLabel("Checking Tailscale…");
       const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
-      const tailscaleDns =
-        tailscaleMode === "off"
-          ? null
-          : await getTailnetHostname((cmd, args) =>
-              runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
-            ).catch(() => null);
+      // Always probe Tailscale state, even when mode="off", so we can surface
+      // that Tailscale is running but not yet configured for OpenClaw.
+      const tailscaleDns = await getTailnetHostname((cmd, args) =>
+        runExec(cmd, args, { timeoutMs: 1500, maxBuffer: 200_000 }),
+      ).catch(() => null);
       const tailscaleHttpsUrl =
         tailscaleMode !== "off" && tailscaleDns
           ? `https://${tailscaleDns}${normalizeControlUiBasePath(cfg.gateway?.controlUi?.basePath)}`


### PR DESCRIPTION
## Summary

- Problem: `openclaw status --deep` displays "Tailscale off" on hosts where Tailscale is active but not configured in `openclaw.json` (`gateway.tailscale.mode` defaults to `"off"`)
- Why it matters: misleading — suggests Tailscale is unavailable when it's working fine
- What changed: three small display-layer fixes (no behavior changes)
- What did NOT change: Tailscale setup/config logic, auth, gateway behavior, existing behavior when `tailscaleMode !== "off"`

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Linked Issue/PR

- Closes #21131

## User-visible / Behavior Changes

When Tailscale is running but `gateway.tailscale.mode` is not set (defaults to `"off"`):

- `openclaw status` now shows `active (not configured) · <dns>` instead of `off`
- `openclaw status --deep` overview shows `active (not configured) · <dns>` instead of `off · Running · <dns>`
- `openclaw status --deep` diagnosis shows `Tailscale: active (not configured for OpenClaw)` instead of `Tailscale: off · Running`

No changes when `tailscaleMode !== "off"`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same probe, broader conditions + higher timeout)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux 6.x arm64 (matches reporter's env)

### Steps

1. Have Tailscale running (`tailscale status` shows active)
2. Do NOT configure `gateway.tailscale.mode` in `openclaw.json`
3. Run `openclaw status` and `openclaw status --deep`

### Expected

Status reflects Tailscale is running

### Actual (before fix)

Both show `Tailscale   off`

## Evidence

Three root causes identified in code:

**1. 1200ms probe timeout fails on ARM64** — `status-all.ts` ran `tailscale status --json` with `timeoutMs: 1200`. On ARM64, `findTailscaleBinary` runs `which tailscale` + `tailscale --version` before the actual call; combined latency can exceed 1200ms. When it times out, `backendState` and `dnsName` are both null → shows bare `off`. Fixed: increased to 3000ms.

**2. Simple status never probed when mode=off** — `status.scan.ts` short-circuited to `null` without calling `getTailnetHostname`. Fixed: always probe (1500ms timeout).

**3. Misleading label even when probe succeeded** — `off · Running` starts with "off" when Tailscale IS active. Fixed: show `active (not configured)` instead.

## Human Verification

- Traced all four files manually (`status.scan.ts`, `status.command.ts`, `status-all.ts`, `status-all/diagnosis.ts`)
- Confirmed changes are isolated to the `tailscaleMode === "off"` + `backendState === "Running"` branch
- Edge cases: Tailscale not installed → probe throws → caught → null → unchanged "off"; Tailscale stopped → `backendState !== "Running"` → unchanged display
- Did not verify on live ARM64 hardware

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

Revert is safe — display-only, no state mutations.

## Risks and Mitigations

- Risk: on hosts with no Tailscale binary, `openclaw status` takes ~1.5s longer (probe runs and fails instead of being skipped)
  - Mitigation: probe is wrapped in `.catch(() => null)` with a 1500ms timeout