### PR TITLE
feat(gateway): implement control UI loopback guard

### DIFF
--- a/src/gateway/control-ui-loopback-guard.test.ts
+++ b/src/gateway/control-ui-loopback-guard.test.ts
@@ -1,0 +1,159 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoist mock before imports
+const mockWarn = vi.hoisted(() => vi.fn());
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    warn: mockWarn,
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { createControlUiLoopbackGuard } from "./control-ui-loopback-guard.js";
+
+describe("createControlUiLoopbackGuard", () => {
+  const mockLog = createSubsystemLogger("test");
+
+  beforeEach(() => {
+    mockWarn.mockClear();
+  });
+
+  function createMockReq(remoteAddress: string | undefined): IncomingMessage {
+    return {
+      socket: { remoteAddress },
+    } as unknown as IncomingMessage;
+  }
+
+  function createMockRes() {
+    const endMock = vi.fn();
+    const setHeaderMock = vi.fn();
+    const res = {
+      statusCode: 200,
+      setHeader: setHeaderMock,
+      end: endMock,
+    };
+    return res as unknown as ServerResponse & { end: typeof endMock };
+  }
+
+  describe("default mode (warn only)", () => {
+    it("allows requests from 127.0.0.1 without warning", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, false);
+      const req = createMockReq("127.0.0.1");
+      const res = createMockRes();
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(true);
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it("allows requests from ::1 without warning", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, false);
+      const req = createMockReq("::1");
+      const res = createMockRes();
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(true);
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it("allows requests from ::ffff:127.0.0.1 without warning", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, false);
+      const req = createMockReq("::ffff:127.0.0.1");
+      const res = createMockRes();
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(true);
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it("warns but allows requests from external IPs", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, false);
+      const req = createMockReq("192.168.1.100");
+      const res = createMockRes();
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(true);
+      expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining("192.168.1.100"));
+    });
+
+    it("warns but allows requests from private network IPs", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, false);
+      const req = createMockReq("10.0.0.1");
+      const res = createMockRes();
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(true);
+      expect(mockWarn).toHaveBeenCalled();
+    });
+
+    it("handles undefined remote address with warning but allows", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, false);
+      const req = createMockReq(undefined);
+      const res = createMockRes();
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(true);
+      expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining("unknown"));
+    });
+  });
+
+  describe("strict mode", () => {
+    it("allows requests from 127.0.0.1", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, true);
+      const req = createMockReq("127.0.0.1");
+      const res = createMockRes();
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("rejects requests from external IPs with 403", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, true);
+      const req = createMockReq("203.0.113.50");
+      const res = createMockRes();
+      const endFn = res.end;
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(false);
+      expect(result.statusCode).toBe(403);
+      expect(res.statusCode).toBe(403);
+      expect(endFn).toHaveBeenCalledWith(expect.stringContaining("Forbidden"));
+    });
+
+    it("rejects requests from private network IPs with 403", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, true);
+      const req = createMockReq("192.168.1.1");
+      const res = createMockRes();
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(false);
+      expect(result.statusCode).toBe(403);
+    });
+
+    it("rejects requests with undefined remote address in strict mode", () => {
+      const guard = createControlUiLoopbackGuard(mockLog, true);
+      const req = createMockReq(undefined);
+      const res = createMockRes();
+
+      const result = guard(req, res);
+
+      expect(result.allowed).toBe(false);
+      expect(result.statusCode).toBe(403);
+      expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining("unknown"));
+    });
+  });
+});

--- a/src/gateway/control-ui-loopback-guard.ts
+++ b/src/gateway/control-ui-loopback-guard.ts
@@ -1,0 +1,57 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { createSubsystemLogger } from "../logging/subsystem.js";
+import { isLoopbackAddress } from "./net.js";
+
+type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+
+export type LoopbackGuardResult = {
+  allowed: boolean;
+  statusCode?: number;
+  message?: string;
+};
+
+/**
+ * Creates a loopback guard for Control UI requests.
+ *
+ * Behavior:
+ * - Loopback addresses (127.0.0.1, ::1, ::ffff:127.0.0.1) are always allowed.
+ * - Non-loopback addresses trigger a warning in default mode but are allowed.
+ * - In strict mode, non-loopback addresses are rejected with HTTP 403.
+ * - **Undefined remote addresses**: In strict mode, rejected with 403.
+ *   In default mode, allowed with a warning (security trade-off for edge cases).
+ *
+ * @param log - Subsystem logger for warnings
+ * @param strictLoopback - If true, reject non-loopback requests with 403
+ */
+export function createControlUiLoopbackGuard(
+  log: SubsystemLogger,
+  strictLoopback: boolean = false,
+): (req: IncomingMessage, res: ServerResponse) => LoopbackGuardResult {
+  return (req: IncomingMessage, res: ServerResponse): LoopbackGuardResult => {
+    const remoteAddress = req.socket.remoteAddress;
+
+    // Check if address is loopback
+    if (remoteAddress && isLoopbackAddress(remoteAddress)) {
+      return { allowed: true };
+    }
+
+    // Non-loopback or undefined address
+    const addressDisplay = remoteAddress ?? "unknown";
+
+    if (strictLoopback) {
+      // Strict mode: reject with 403
+      log.warn(`Control UI access rejected from non-loopback address: ${addressDisplay}`);
+      res.statusCode = 403;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Forbidden: Control UI is only accessible from localhost");
+      return { allowed: false, statusCode: 403, message: "Forbidden" };
+    }
+
+    // Default mode: warn but allow
+    log.warn(
+      `Control UI accessed from non-loopback address: ${addressDisplay}. ` +
+        `Consider binding to loopback only or enabling strictLoopback.`,
+    );
+    return { allowed: true };
+  };
+}


### PR DESCRIPTION
## Summary
Implements a loopback guard for the Control UI to prevent accidental exposure when the gateway is bound to non-localhost interfaces.

## Changes
- **NEW**: `src/gateway/control-ui-loopback-guard.ts`: Middleware to check remote address.
- **NEW**: `src/gateway/control-ui-loopback-guard.test.ts`: Unit tests.
- **MODIFY**: `src/gateway/server-http.ts`: Apply guard to Control UI routes.

## Motivation
This replaces the remaining valid part of PR #6590. It ensures that even if `--bind=0.0.0.0` is used, the sensitive Control UI remains restricted to localhost by default, unless `strictLoopback` is explicitly disabled or configured otherwise (current implementation warns in default mode, blocks in strict mode).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

implements loopback guard middleware to restrict Control UI access to localhost connections, with configurable strict mode that blocks non-loopback requests

**Major changes:**
- added `createControlUiLoopbackGuard` middleware that checks `req.socket.remoteAddress` against loopback addresses (127.0.0.1, ::1, ::ffff:127.0.0.1)
- integrated guard into `createGatewayHttpServer` to protect Control UI routes
- default mode warns but allows non-loopback access; strict mode returns 403
- comprehensive unit tests covering both modes and various IP addresses

**Issue found:**
- guard is applied to all requests when `controlUiEnabled` is true, not just Control UI requests. this happens because the guard runs before path validation, so any request reaching that section will be checked. in strict mode, this incorrectly rejects legitimate non-Control-UI requests from non-loopback addresses.

<h3>Confidence Score: 2/5</h3>

- this PR has a critical logic bug that breaks non-Control-UI requests in strict mode
- the loopback guard incorrectly applies to all requests when Control UI is enabled, not just Control UI requests. this causes strict mode to reject legitimate non-Control-UI traffic from non-loopback addresses. the implementation is otherwise well-tested and the security concept is sound, but the guard placement needs to be fixed before merging
- `src/gateway/server-http.ts` requires fixing the guard placement logic to check request paths before applying the loopback guard

<sub>Last reviewed commit: 17f0281</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->