### PR TITLE
fix(models): add gemini-3.1-pro-preview forward-compat for google-gemini-cli provider

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -27,6 +27,10 @@ const ANTIGRAVITY_OPUS_THINKING_TEMPLATE_MODEL_IDS = [
   "claude-opus-4.5-thinking",
 ] as const;
 
+// gemini-3.1-pro-preview: launched 2026-02-19; forward-compat until pi-ai catalog is updated.
+const GEMINI_CLI_31_PRO_PREVIEW_MODEL_ID = "gemini-3.1-pro-preview";
+const GEMINI_CLI_31_PRO_TEMPLATE_MODEL_IDS = ["gemini-3-pro-preview"] as const;
+
 export const ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES = [
   {
     id: ANTIGRAVITY_OPUS_46_THINKING_MODEL_ID,
@@ -278,6 +282,31 @@ function resolveAntigravityOpus46ForwardCompatModel(
   });
 }
 
+// gemini-3.1-pro-preview launched 2026-02-19 and is available via the Gemini CLI
+// (`gemini -m gemini-3.1-pro-preview`) but pi-ai's built-in model catalog does not
+// yet include it. Clone gemini-3-pro-preview as a forward-compat entry until the
+// catalog is updated upstream.
+// See: https://github.com/openclaw/openclaw/issues/21176
+function resolveGeminiCli31ProPreviewForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+    return undefined;
+  }
+  if (modelId.trim().toLowerCase() !== GEMINI_CLI_31_PRO_PREVIEW_MODEL_ID) {
+    return undefined;
+  }
+
+  return cloneFirstTemplateModel({
+    normalizedProvider: "google-gemini-cli",
+    trimmedModelId: GEMINI_CLI_31_PRO_PREVIEW_MODEL_ID,
+    templateIds: [...GEMINI_CLI_31_PRO_TEMPLATE_MODEL_IDS],
+    modelRegistry,
+  });
+}
+
 export function resolveForwardCompatModel(
   provider: string,
   modelId: string,
@@ -288,6 +317,7 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveAntigravityOpus46ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveAntigravityOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
+    resolveGeminiCli31ProPreviewForwardCompatModel(provider, modelId, modelRegistry)
   );
 }


### PR DESCRIPTION
## Summary

- **Problem:** `gemini-3.1-pro-preview` launched 2026-02-19 and works via the standalone Gemini CLI (`gemini -m gemini-3.1-pro-preview`), but OpenClaw rejects it with `Unknown model: google-gemini-cli/gemini-3.1-pro-preview` because pi-ai's built-in model catalog doesn't include it yet.
- **Why it matters:** Users on `google-gemini-cli` cannot use the new model until the catalog is updated.
- **What changed:** Added a `resolveGeminiCli31ProPreviewForwardCompatModel` forward-compat resolver in `src/agents/model-forward-compat.ts` that clones `gemini-3-pro-preview` as `gemini-3.1-pro-preview` — the same pattern used for `claude-opus-4-6`, `glm-5`, and `gemini-3-pro-image` in the existing codebase.
- **What did NOT change:** No behavioral changes for any other provider or model.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

- `google-gemini-cli/gemini-3.1-pro-preview` now resolves to a cloned `gemini-3-pro-preview` model definition, unblocking users who upgraded the Gemini CLI and set the new model in their config.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

1. Set an agent's model to `google-gemini-cli/gemini-3.1-pro-preview`
2. Send a message
3. Before fix: `Unknown model: google-gemini-cli/gemini-3.1-pro-preview`
4. After fix: routes to Gemini CLI using `gemini-3-pro-preview` metadata as template

## Compatibility / Migration

- Backward compatible? Yes
- No config or migration changes required.

## Closes

Closes #21176

🤖 AI-Assisted: Yes (via OpenClaw)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds forward-compatibility support for `gemini-3.1-pro-preview` model in the `google-gemini-cli` provider. The model launched on 2026-02-19 and works via the standalone Gemini CLI but isn't yet in pi-ai's built-in catalog. The implementation clones `gemini-3-pro-preview` as a template using the same pattern established for other forward-compat models (`claude-opus-4-6`, `glm-5`). The change is minimal, isolated, and follows existing architectural patterns correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows an established pattern used for multiple other forward-compat models in the same file. The change is isolated to a single function that only affects the specific `google-gemini-cli/gemini-3.1-pro-preview` model combination. The template model (`gemini-3-pro-preview`) exists and is referenced throughout the codebase. No behavioral changes for other models or providers.
- No files require special attention

<sub>Last reviewed commit: d54bce3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->