### PR TITLE
fix(tts): send voice messages as Opus bubbles on Telegram

### DIFF
--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -70,6 +70,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       messageThreadId,
       replyToMessageId,
       quoteText,
+      asVoice: payload.audioAsVoice === true,
       accountId: accountId ?? undefined,
       mediaLocalRoots,
     };

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
+import { normalizeChatChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type {
   TtsConfig,
@@ -486,7 +487,12 @@ function resolveOutputFormat(channelId?: string | null) {
 }
 
 function resolveChannelId(channel: string | undefined): ChannelId | null {
-  return channel ? normalizeChannelId(channel) : null;
+  if (!channel) {
+    return null;
+  }
+  // Try plugin registry first, fall back to static channel list.
+  // Plugin registry may not be initialized when TTS runs from tool context.
+  return normalizeChannelId(channel) ?? (normalizeChatChannelId(channel) as ChannelId | null);
 }
 
 function resolveEdgeOutputFormat(config: ResolvedTtsConfig): string {


### PR DESCRIPTION
## Summary

- Problem: TTS voice messages on Telegram arrive as MP3 document attachments instead of native voice bubbles
- Why: resolveChannelId() returns null when plugin registry is unavailable during TTS tool execution, falling back to MP3 instead of Opus format
- Fix 1 (tts.ts): resolveChannelId() falls back to normalizeChatChannelId() for static channel resolution
- Fix 2 (telegram.ts): Pass audioAsVoice through to sendVoice instead of sendDocument

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [x] Integrations

## User-visible Changes
TTS audio on Telegram now arrives as native voice bubbles (Opus) instead of MP3 file attachments

## Security Impact
No security impact. No new permissions, tokens, network calls, or execution surface changes.

## Evidence
Tested on live Telegram bot: before fix voice messages arrived as MP3 documents, after fix they arrive as Opus voice bubbles. Verified audio content via Deepgram transcription.

## Compatibility
Backward compatible. No config/env/migration changes needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed TTS voice messages on Telegram to display as native voice bubbles (Opus) instead of MP3 document attachments. The fix addresses two issues: `resolveChannelId()` in `tts.ts` now falls back to static channel resolution when the plugin registry is unavailable during TTS tool execution, and the `audioAsVoice` flag is properly passed through in `telegram.ts` to use `sendVoice` instead of `sendDocument`.

- Fixed channel ID resolution fallback in `tts.ts:489-496`
- Properly passed through `audioAsVoice` flag in `telegram.ts:73`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-targeted, and properly handle edge cases. The fallback logic in `resolveChannelId` prevents null pointer issues when the plugin registry is unavailable, and the `asVoice` parameter is correctly passed through with proper type checking. The code maintains backward compatibility and includes appropriate comments explaining the rationale.
- No files require special attention

<sub>Last reviewed commit: f3a810d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->