### PR TITLE
Security/Voice Call: enforce exact webhook path matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Voice Call: require exact webhook path matching (with trailing-slash normalization) so prefixed paths like `/voice/webhook-attacker` are rejected before webhook verification and event parsing.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.


### PR DESCRIPTION
## Summary

- enforce exact webhook route matching in `VoiceCallWebhookServer` instead of `startsWith`
- normalize trailing slashes to preserve compatibility for `/voice/webhook` and `/voice/webhook/`
- add regression coverage that reproduces and blocks `/voice/webhook-attacker` prefix-path acceptance
- add changelog entry under `2026.2.19 (Unreleased)`

## Why

`extensions/voice-call/src/webhook.ts` currently accepts any pathname that starts with the configured webhook path. That allows prefixed routes like `/voice/webhook-attacker` to reach webhook verification and event parsing.

## Repro (before this patch)

1. Configure voice-call webhook path as `/voice/webhook`.
2. Send a POST request to `/voice/webhook-attacker`.
3. Observe `200 OK` instead of `404 Not Found`.

## Validation

- `pnpm format:check CHANGELOG.md extensions/voice-call/src/webhook.ts extensions/voice-call/src/webhook.test.ts`
- `pnpm test -- extensions/voice-call/src/webhook.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced vulnerable prefix-based path matching (`startsWith`) with exact path matching in the voice-call webhook server. Added `normalizeWebhookPath` helper to handle trailing slashes consistently (e.g., `/voice/webhook` and `/voice/webhook/` both match). This prevents unauthorized access to webhook verification and event parsing via prefixed paths like `/voice/webhook-attacker`.

- Introduced `normalizeWebhookPath` function to strip trailing slashes and ensure leading slashes
- Changed path check from `url.pathname.startsWith(webhookPath)` to exact equality after normalization
- Added regression test that verifies `/voice/webhook-attacker` returns 404 instead of 200
- Added test confirming legitimate requests to `/voice/webhook` still work
- Updated CHANGELOG.md with security fix entry

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix is straightforward and well-implemented. The normalization function correctly handles edge cases (leading/trailing slashes), the exact-match comparison prevents the prefix-path vulnerability, and comprehensive regression tests verify both the fix and backward compatibility. The change is minimal, focused, and follows the existing code patterns.
- No files require special attention

<sub>Last reviewed commit: 3d0f4db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->