### PR TITLE
fix: suppress orphaned tool_use/tool_result errors after session compaction

### DIFF
--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -36,7 +36,12 @@ export type EmbeddedPiRunMeta = {
   aborted?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
   error?: {
-    kind: "context_overflow" | "compaction_failure" | "role_ordering" | "image_size";
+    kind:
+      | "context_overflow"
+      | "compaction_failure"
+      | "role_ordering"
+      | "image_size"
+      | "orphaned_tool_result";
     message: string;
   };
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */

--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -1,0 +1,203 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import {
+  enqueueDelivery,
+  ackDelivery,
+  failDelivery,
+  loadPendingDeliveries,
+  recoverPendingDeliveries,
+  isPermanentError,
+  MAX_AGE_MS,
+} from "./delivery-queue.js";
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "dq-test-"));
+}
+
+function cleanTmpDir(dir: string) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("delivery-queue", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  test("enqueue + load + ack cycle", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "telegram",
+        to: "123",
+        payloads: [{ text: "hello" }],
+      },
+      tmpDir,
+    );
+    const pending = await loadPendingDeliveries(tmpDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(id);
+
+    await ackDelivery(id, tmpDir);
+    const after = await loadPendingDeliveries(tmpDir);
+    expect(after).toHaveLength(0);
+  });
+
+  test("failDelivery increments retryCount", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "telegram",
+        to: "123",
+        payloads: [{ text: "hello" }],
+      },
+      tmpDir,
+    );
+    await failDelivery(id, "timeout", tmpDir);
+    const pending = await loadPendingDeliveries(tmpDir);
+    expect(pending[0].retryCount).toBe(1);
+    expect(pending[0].lastError).toBe("timeout");
+  });
+
+  describe("isPermanentError", () => {
+    test("detects message too long", () => {
+      expect(
+        isPermanentError("Call to 'sendMessage' failed! (400: Bad Request: message is too long)"),
+      ).toBe(true);
+    });
+
+    test("detects bot token missing", () => {
+      expect(
+        isPermanentError(
+          'Telegram bot token missing for account "default" (set channels.telegram.accounts.default.botToken)',
+        ),
+      ).toBe(true);
+    });
+
+    test("detects blocked by user", () => {
+      expect(isPermanentError("Forbidden: bot was blocked by the user")).toBe(true);
+    });
+
+    test("detects chat write forbidden", () => {
+      expect(isPermanentError("CHAT_WRITE_FORBIDDEN")).toBe(true);
+    });
+
+    test("returns false for transient errors", () => {
+      expect(isPermanentError("ETIMEDOUT")).toBe(false);
+      expect(isPermanentError("rate limit exceeded")).toBe(false);
+      expect(isPermanentError("500 Internal Server Error")).toBe(false);
+    });
+  });
+
+  test("failDelivery moves permanent errors to failed/", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "telegram",
+        to: "123",
+        payloads: [{ text: "x".repeat(5000) }],
+      },
+      tmpDir,
+    );
+    await failDelivery(id, "message is too long", tmpDir);
+    const pending = await loadPendingDeliveries(tmpDir);
+    expect(pending).toHaveLength(0);
+    // Should be in failed/
+    const failedDir = path.join(tmpDir, "delivery-queue", "failed");
+    const failedFiles = fs.readdirSync(failedDir).filter((f) => f.endsWith(".json"));
+    expect(failedFiles).toHaveLength(1);
+  });
+
+  describe("recoverPendingDeliveries", () => {
+    const noopLogger = { info: () => {}, warn: () => {}, error: () => {} };
+    const noopDelay = async () => {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const minCfg = {} as any;
+
+    test("skips entries older than MAX_AGE_MS", async () => {
+      const id = await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "123",
+          payloads: [{ text: "stale" }],
+        },
+        tmpDir,
+      );
+      // Backdate the entry
+      const queueDir = path.join(tmpDir, "delivery-queue");
+      const filePath = path.join(queueDir, `${id}.json`);
+      const entry = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      entry.enqueuedAt = Date.now() - MAX_AGE_MS - 60_000; // 1 min past max age
+      fs.writeFileSync(filePath, JSON.stringify(entry));
+
+      const result = await recoverPendingDeliveries({
+        deliver: async () => {
+          throw new Error("should not be called");
+        },
+        log: noopLogger,
+        cfg: minCfg,
+        stateDir: tmpDir,
+        delay: noopDelay,
+      });
+
+      expect(result.skipped).toBe(1);
+      expect(result.recovered).toBe(0);
+    });
+
+    test("skips entries with permanent errors", async () => {
+      const id = await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "123",
+          payloads: [{ text: "x".repeat(5000) }],
+        },
+        tmpDir,
+      );
+      // Set a permanent error
+      const queueDir = path.join(tmpDir, "delivery-queue");
+      const filePath = path.join(queueDir, `${id}.json`);
+      const entry = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      entry.lastError = "message is too long";
+      entry.retryCount = 1;
+      fs.writeFileSync(filePath, JSON.stringify(entry));
+
+      const result = await recoverPendingDeliveries({
+        deliver: async () => {
+          throw new Error("should not be called");
+        },
+        log: noopLogger,
+        cfg: minCfg,
+        stateDir: tmpDir,
+        delay: noopDelay,
+      });
+
+      expect(result.skipped).toBe(1);
+      expect(result.recovered).toBe(0);
+    });
+
+    test("recovers valid entries", async () => {
+      await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "123",
+          payloads: [{ text: "hello" }],
+        },
+        tmpDir,
+      );
+
+      const result = await recoverPendingDeliveries({
+        deliver: async () => {},
+        log: noopLogger,
+        cfg: minCfg,
+        stateDir: tmpDir,
+        delay: noopDelay,
+      });
+
+      expect(result.recovered).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Problem
When session compaction removes one half of a tool_use/tool_result pair, the next API call returns a 400 error that leaks raw to the user in chat.

**Anthropic:** `tool_use ids were found without tool_result blocks immediately after`
**OpenAI:** `No tool call found for function call output`

## Fix
Added regex pattern matching in `run.ts` to catch these orphaned tool result errors and return a friendly message instead of leaking raw API errors.

Patterns caught:
- `tool_call not found` / `tool_use_id not found`
- `function call output`
- `tool_use without tool_result`

Also includes delivery queue hardening:
- 30-min max-age for stale entries
- Permanent error detection (skip retry for non-retryable errors)
- 203 lines of tests

## Testing
Verified on 3 production instances (Mac + 2x Sofiia). Error no longer leaks to Telegram.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two production issues: (1) suppresses orphaned tool_use/tool_result 400 errors after session compaction with user-friendly message, and (2) hardens delivery queue with 30-minute stale entry detection and permanent error detection to skip non-retryable failures.

**Changes:**
- Added regex pattern matching in `run.ts` to catch orphaned tool result errors from Anthropic/OpenAI and return "Session context was refreshed mid-operation" instead of raw API errors
- Added `orphaned_tool_result` error kind to type definitions
- Delivery queue now skips entries older than 30 minutes (moved to failed/)
- Permanent errors (message too long, bot blocked, token missing, etc.) are immediately moved to failed/ without consuming retry budget
- Added 203 lines of test coverage for delivery queue hardening

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, defensive, and thoroughly tested. Error handling is conservative (catches specific patterns, logs warnings, returns user-friendly messages). Delivery queue hardening prevents wasted retry cycles on permanent errors and stale messages. The regex pattern is comprehensive and matches documented error formats from multiple providers. Test coverage is excellent with 203 new lines covering edge cases.
- No files require special attention

<sub>Last reviewed commit: 1ce7165</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->