### PR TITLE
fix: sanitize Telegram menu commands before setMyCommands

### DIFF
--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -36,7 +36,12 @@ export type EmbeddedPiRunMeta = {
   aborted?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
   error?: {
-    kind: "context_overflow" | "compaction_failure" | "role_ordering" | "image_size";
+    kind:
+      | "context_overflow"
+      | "compaction_failure"
+      | "role_ordering"
+      | "image_size"
+      | "orphaned_tool_result";
     message: string;
   };
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */

--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -1,0 +1,203 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import {
+  enqueueDelivery,
+  ackDelivery,
+  failDelivery,
+  loadPendingDeliveries,
+  recoverPendingDeliveries,
+  isPermanentError,
+  MAX_AGE_MS,
+} from "./delivery-queue.js";
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "dq-test-"));
+}
+
+function cleanTmpDir(dir: string) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("delivery-queue", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  test("enqueue + load + ack cycle", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "telegram",
+        to: "123",
+        payloads: [{ text: "hello" }],
+      },
+      tmpDir,
+    );
+    const pending = await loadPendingDeliveries(tmpDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(id);
+
+    await ackDelivery(id, tmpDir);
+    const after = await loadPendingDeliveries(tmpDir);
+    expect(after).toHaveLength(0);
+  });
+
+  test("failDelivery increments retryCount", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "telegram",
+        to: "123",
+        payloads: [{ text: "hello" }],
+      },
+      tmpDir,
+    );
+    await failDelivery(id, "timeout", tmpDir);
+    const pending = await loadPendingDeliveries(tmpDir);
+    expect(pending[0].retryCount).toBe(1);
+    expect(pending[0].lastError).toBe("timeout");
+  });
+
+  describe("isPermanentError", () => {
+    test("detects message too long", () => {
+      expect(
+        isPermanentError("Call to 'sendMessage' failed! (400: Bad Request: message is too long)"),
+      ).toBe(true);
+    });
+
+    test("detects bot token missing", () => {
+      expect(
+        isPermanentError(
+          'Telegram bot token missing for account "default" (set channels.telegram.accounts.default.botToken)',
+        ),
+      ).toBe(true);
+    });
+
+    test("detects blocked by user", () => {
+      expect(isPermanentError("Forbidden: bot was blocked by the user")).toBe(true);
+    });
+
+    test("detects chat write forbidden", () => {
+      expect(isPermanentError("CHAT_WRITE_FORBIDDEN")).toBe(true);
+    });
+
+    test("returns false for transient errors", () => {
+      expect(isPermanentError("ETIMEDOUT")).toBe(false);
+      expect(isPermanentError("rate limit exceeded")).toBe(false);
+      expect(isPermanentError("500 Internal Server Error")).toBe(false);
+    });
+  });
+
+  test("failDelivery moves permanent errors to failed/", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "telegram",
+        to: "123",
+        payloads: [{ text: "x".repeat(5000) }],
+      },
+      tmpDir,
+    );
+    await failDelivery(id, "message is too long", tmpDir);
+    const pending = await loadPendingDeliveries(tmpDir);
+    expect(pending).toHaveLength(0);
+    // Should be in failed/
+    const failedDir = path.join(tmpDir, "delivery-queue", "failed");
+    const failedFiles = fs.readdirSync(failedDir).filter((f) => f.endsWith(".json"));
+    expect(failedFiles).toHaveLength(1);
+  });
+
+  describe("recoverPendingDeliveries", () => {
+    const noopLogger = { info: () => {}, warn: () => {}, error: () => {} };
+    const noopDelay = async () => {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const minCfg = {} as any;
+
+    test("skips entries older than MAX_AGE_MS", async () => {
+      const id = await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "123",
+          payloads: [{ text: "stale" }],
+        },
+        tmpDir,
+      );
+      // Backdate the entry
+      const queueDir = path.join(tmpDir, "delivery-queue");
+      const filePath = path.join(queueDir, `${id}.json`);
+      const entry = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      entry.enqueuedAt = Date.now() - MAX_AGE_MS - 60_000; // 1 min past max age
+      fs.writeFileSync(filePath, JSON.stringify(entry));
+
+      const result = await recoverPendingDeliveries({
+        deliver: async () => {
+          throw new Error("should not be called");
+        },
+        log: noopLogger,
+        cfg: minCfg,
+        stateDir: tmpDir,
+        delay: noopDelay,
+      });
+
+      expect(result.skipped).toBe(1);
+      expect(result.recovered).toBe(0);
+    });
+
+    test("skips entries with permanent errors", async () => {
+      const id = await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "123",
+          payloads: [{ text: "x".repeat(5000) }],
+        },
+        tmpDir,
+      );
+      // Set a permanent error
+      const queueDir = path.join(tmpDir, "delivery-queue");
+      const filePath = path.join(queueDir, `${id}.json`);
+      const entry = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      entry.lastError = "message is too long";
+      entry.retryCount = 1;
+      fs.writeFileSync(filePath, JSON.stringify(entry));
+
+      const result = await recoverPendingDeliveries({
+        deliver: async () => {
+          throw new Error("should not be called");
+        },
+        log: noopLogger,
+        cfg: minCfg,
+        stateDir: tmpDir,
+        delay: noopDelay,
+      });
+
+      expect(result.skipped).toBe(1);
+      expect(result.recovered).toBe(0);
+    });
+
+    test("recovers valid entries", async () => {
+      await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "123",
+          payloads: [{ text: "hello" }],
+        },
+        tmpDir,
+      );
+
+      const result = await recoverPendingDeliveries({
+        deliver: async () => {},
+        log: noopLogger,
+        cfg: minCfg,
+        stateDir: tmpDir,
+        delay: noopDelay,
+      });
+
+      expect(result.recovered).toBe(1);
+    });
+  });
+});

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -73,7 +73,8 @@ function sanitizeTelegramMenuCommands(params: {
 
   for (const cmd of params.commands) {
     const commandRaw = typeof cmd.command === "string" ? cmd.command.trim() : "";
-    const descriptionRaw = typeof cmd.description === "string" ? cmd.description.trim() : "";
+    const descriptionRaw = typeof cmd.description === "string" ? cmd.description : "";
+    const descriptionNormalized = descriptionRaw.replace(/\s+/g, " ").trim();
 
     // Telegram Bot API constraints:
     // - command: 1-32 chars, [a-z0-9_]+ (no leading slash)
@@ -93,7 +94,7 @@ function sanitizeTelegramMenuCommands(params: {
       continue;
     }
 
-    if (descriptionRaw.length < 3) {
+    if (descriptionNormalized.length < 3) {
       dropped += 1;
       params.runtime.error?.(
         danger(`Telegram menu command "/${command}" has missing/short description; skipping.`),
@@ -102,7 +103,9 @@ function sanitizeTelegramMenuCommands(params: {
     }
 
     const description =
-      descriptionRaw.length > 256 ? descriptionRaw.substring(0, 253) + "..." : descriptionRaw;
+      descriptionNormalized.length > 256
+        ? descriptionNormalized.substring(0, 253) + "..."
+        : descriptionNormalized;
 
     out.push({ command, description });
     seen.add(command);


### PR DESCRIPTION
## Problem
`setMyCommands` fails with `400 BOT_COMMAND_INVALID` when commands contain hyphens or descriptions exceed 256 chars. Telegram requires command names to match `[a-z0-9_]{1,32}`.

Example: `/export-session` has a hyphen → Telegram rejects the entire batch.

## Fix
Added `sanitizeTelegramMenuCommands()` that:
- Validates command names against `[a-z0-9_]{1,32}`
- Truncates descriptions to 256 chars
- Strips newlines and control whitespace from descriptions
- Deduplicates entries
- Logs dropped invalid commands for debugging

Applied to all command sources: built-in, plugin catalog, and custom commands.

## Testing
Verified on 2 production instances. Log output: `menu command sanitization: dropped 1/48 invalid entries` — the `/export-session` command is cleanly filtered, all others pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `sanitizeTelegramMenuCommands()` to validate and normalize Telegram bot menu commands before registration, preventing `400 BOT_COMMAND_INVALID` errors from malformed commands.

- Validates command names against Telegram's `[a-z0-9_]{1,32}` pattern
- Truncates descriptions exceeding 256 chars and normalizes whitespace
- Filters invalid entries with detailed error logging
- Deduplicates commands silently

**Note**: This PR also includes unrelated changes:
- Delivery queue improvements (permanent error detection, stale entry handling, comprehensive test coverage)
- Pi-embedded-runner error handling for orphaned tool results

These additional changes are not mentioned in the PR title/description but appear to be intentional merged commits.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with only minor style considerations
- The Telegram sanitization logic correctly implements validation against Telegram's API constraints, the delivery queue changes include comprehensive test coverage and sound error handling logic, and the pi-embedded-runner changes appropriately catch orphaned tool result errors. The only concern is a minor inconsistency in duplicate command tracking that doesn't affect functionality.
- No files require special attention — all changes are well-implemented with appropriate error handling

<sub>Last reviewed commit: 358eab1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->