### PR TITLE
Security/Voice Call: enforce exact webhook path matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Voice Call: require exact webhook path matching (with trailing-slash normalization) so prefixed paths like `/voice/webhook-attacker` are rejected before webhook verification and event parsing.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/Voice Call: require exact webhook path matching (with trailing-slash normalization) so prefixed paths like `/voice/webhook-attacker` are rejected before webhook verification and event parsing.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.


### PR DESCRIPTION
## Summary

- enforce exact webhook route matching in `VoiceCallWebhookServer` instead of `startsWith`
- normalize trailing slashes to preserve compatibility for `/voice/webhook` and `/voice/webhook/`
- add regression coverage that reproduces and blocks `/voice/webhook-attacker` route acceptance
- add changelog entry under `2026.2.19 (Unreleased)`

## Why

This is route-hardening and correctness: `extensions/voice-call/src/webhook.ts` currently accepts any pathname that starts with the configured webhook path, so lookalike routes like `/voice/webhook-attacker` are handled by the webhook pipeline instead of being rejected at routing.

This PR does **not** claim signature-bypass. Provider signature checks still run. The fix narrows request handling to the exact configured endpoint and reduces unnecessary attack surface.

## Repro (before this patch)

1. Configure voice-call webhook path as `/voice/webhook`.
2. Send a POST request to `/voice/webhook-attacker`.
3. Observe that the request is handled by webhook logic (instead of immediate `404 Not Found`).

## Validation

- `pnpm format:check CHANGELOG.md extensions/voice-call/src/webhook.ts extensions/voice-call/src/webhook.test.ts`
- `pnpm test -- extensions/voice-call/src/webhook.test.ts`

## Supersedes

- Replaces #21194 to use a non-`codex/` branch name.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Patches a security vulnerability in the voice-call webhook server by replacing prefix matching (`startsWith`) with exact path matching. The fix prevents attackers from reaching webhook verification and event parsing via prefixed routes like `/voice/webhook-attacker`. Includes trailing-slash normalization to maintain backward compatibility for both `/voice/webhook` and `/voice/webhook/` requests, plus regression tests that validate the fix blocks the exploit path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a focused security fix with comprehensive test coverage
- The change is well-scoped, addresses a real security vulnerability, includes proper normalization logic for backward compatibility, and adds regression tests that reproduce and validate the fix. The implementation is straightforward with no complex logic or side effects.
- No files require special attention

<sub>Last reviewed commit: 3d0f4db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
