### PR TITLE
fix(compaction): repair tool_use/tool_result pairing after compaction

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -643,6 +643,17 @@ export async function compactEmbeddedPiSessionDirect(
         const result = await compactWithSafetyTimeout(() =>
           session.compact(params.customInstructions),
         );
+
+        // Post-compaction safety: compaction can drop/move toolResult blocks or
+        // leave tool_use blocks without their matching tool results.
+        // Re-run pairing repair to avoid strict-provider 400s on the next run.
+        if (transcriptPolicy.repairToolUseResultPairing) {
+          const repaired = sanitizeToolUseResultPairing(session.messages);
+          if (repaired !== session.messages && repaired.length > 0) {
+            session.agent.replaceMessages(repaired);
+          }
+        }
+
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
         try {


### PR DESCRIPTION
## Problem
Session compaction can drop or move toolResult messages in ways that leave `tool_use` blocks without matching `tool_result` blocks (or leave free-floating tool results). Strict providers (Anthropic-compatible APIs, Cloud Code Assist) reject the next request with a 400.

## Fix
After `session.compact()` completes, re-run `sanitizeToolUseResultPairing(session.messages)` (when transcript policy enables it) and replace session messages with the repaired transcript.

This is a post-compaction safety net that complements pre-compaction truncation/repair.

## Testing
- Compiles clean
- Verified logic is a pure transcript transformation already used in other truncation paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds post-compaction tool pairing repair to prevent 400 errors from strict providers when `tool_use` blocks are left without matching `tool_result` blocks after compaction. The fix applies the existing `sanitizeToolUseResultPairing` function (already used pre-compaction at line 594) to repair the transcript after `session.compact()` completes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix reuses an existing, well-tested transcript repair function that's already applied pre-compaction. The conditional check matches the existing pattern (line 593-595), and the implementation is defensive (checks length > 0 before replacing). No new logic is introduced, only applying an existing safety net at an additional point in the flow.
- No files require special attention

<sub>Last reviewed commit: 2102876</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->