### PR TITLE
Security/Gateway: harden Control UI static path containment

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -208,4 +208,36 @@ describe("handleControlUiHttpRequest", () => {
       },
     });
   });
+
+  it("rejects absolute-path escape attempts under basePath routes", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-root-"));
+    try {
+      const root = path.join(tmp, "ui");
+      const sibling = path.join(tmp, "ui-secrets");
+      await fs.mkdir(root, { recursive: true });
+      await fs.mkdir(sibling, { recursive: true });
+      await fs.writeFile(path.join(root, "index.html"), "<html>ok</html>\n");
+      const secretPath = path.join(sibling, "secret.txt");
+      await fs.writeFile(secretPath, "sensitive-data");
+
+      const secretPathUrl = secretPath.split(path.sep).join("/");
+      const absolutePathUrl = secretPathUrl.startsWith("/") ? secretPathUrl : `/${secretPathUrl}`;
+      const { res, end } = makeMockHttpResponse();
+
+      const handled = handleControlUiHttpRequest(
+        { url: `/openclaw/${absolutePathUrl}`, method: "GET" } as IncomingMessage,
+        res,
+        {
+          basePath: "/openclaw",
+          root: { kind: "resolved", path: root },
+        },
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(404);
+      expect(end).toHaveBeenCalledWith("Not Found");
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -240,4 +240,43 @@ describe("handleControlUiHttpRequest", () => {
       await fs.rm(tmp, { recursive: true, force: true });
     }
   });
+
+  it("rejects symlink escape attempts under basePath routes", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-root-"));
+    try {
+      const root = path.join(tmp, "ui");
+      const sibling = path.join(tmp, "outside");
+      await fs.mkdir(path.join(root, "assets"), { recursive: true });
+      await fs.mkdir(sibling, { recursive: true });
+      await fs.writeFile(path.join(root, "index.html"), "<html>ok</html>\n");
+      const secretPath = path.join(sibling, "secret.txt");
+      await fs.writeFile(secretPath, "sensitive-data");
+
+      const linkPath = path.join(root, "assets", "leak.txt");
+      try {
+        await fs.symlink(secretPath, linkPath, "file");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EPERM") {
+          return;
+        }
+        throw error;
+      }
+
+      const { res, end } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/openclaw/assets/leak.txt", method: "GET" } as IncomingMessage,
+        res,
+        {
+          basePath: "/openclaw",
+          root: { kind: "resolved", path: root },
+        },
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(404);
+      expect(end).toHaveBeenCalledWith("Not Found");
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveControlUiRootSync } from "../infra/control-ui-assets.js";
+import { isWithinDir } from "../infra/path-safety.js";
 import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
 import {
   CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
@@ -261,6 +262,9 @@ function isSafeRelativePath(relPath: string) {
     return false;
   }
   const normalized = path.posix.normalize(relPath);
+  if (path.posix.isAbsolute(normalized) || path.win32.isAbsolute(normalized)) {
+    return false;
+  }
   if (normalized.startsWith("../") || normalized === "..") {
     return false;
   }
@@ -396,8 +400,8 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const filePath = path.join(root, fileRel);
-  if (!filePath.startsWith(root)) {
+  const filePath = path.resolve(root, fileRel);
+  if (!isWithinDir(root, filePath)) {
     respondNotFound(res);
     return true;
   }


### PR DESCRIPTION
## Summary
- block absolute path inputs in Control UI static path resolution
- replace prefix-based `startsWith(root)` checks with robust `isWithinDir(...)` containment checks
- add regression coverage proving `/openclaw//<absolute-path>` cannot escape `gateway.controlUi.root`

## Scope boundaries
- this PR is **Control UI containment only**
- webhook replay protections were split to separate PRs (#21531, #21532)
- no voice-call webhook path/host hardening changes are included here
- no CI test-runner harness changes are included here

## Why
`handleControlUiHttpRequest` previously relied on string-prefix checks after joining user-derived paths. Crafted absolute-path requests under a configured `gateway.controlUi.basePath` could bypass intended root containment when path prefixes overlapped.

## Repro (before this patch)
1. Configure `gateway.controlUi.basePath="/openclaw"` and root `/tmp/ui`.
2. Create `/tmp/ui-secrets/secret.txt` outside the allowed root.
3. Request `GET /openclaw//tmp/ui-secrets/secret.txt`.
4. Observe leaked file contents instead of `404`.

## Validation
- `pnpm test -- src/gateway/control-ui.http.test.ts`
