### PR TITLE
fix(ui): quote pnpm path for Windows usernames with spaces

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -89,10 +89,14 @@ function createSpawnOptions(cmd, args, envOverride) {
   };
 }
 
+function shellQuoteCmd(cmd) {
+  return shouldUseShellForCommand(cmd) && cmd.includes(" ") ? `"${cmd}"` : cmd;
+}
+
 function run(cmd, args) {
   let child;
   try {
-    child = spawn(cmd, args, createSpawnOptions(cmd, args));
+    child = spawn(shellQuoteCmd(cmd), args, createSpawnOptions(cmd, args));
   } catch (err) {
     console.error(`Failed to launch ${cmd}:`, err);
     process.exit(1);
@@ -113,7 +117,7 @@ function run(cmd, args) {
 function runSync(cmd, args, envOverride) {
   let result;
   try {
-    result = spawnSync(cmd, args, createSpawnOptions(cmd, args, envOverride));
+    result = spawnSync(shellQuoteCmd(cmd), args, createSpawnOptions(cmd, args, envOverride));
   } catch (err) {
     console.error(`Failed to launch ${cmd}:`, err);
     process.exit(1);


### PR DESCRIPTION
## Summary
- When `shell: true` is used to spawn `.cmd` files on Windows, `cmd.exe` splits unquoted paths at spaces
- This broke the Control UI build for users whose Windows profile path contains a space (e.g. `C:\Users\jace nibarger\...\pnpm.cmd`)
- Added `shellQuoteCmd()` helper in `scripts/ui.js` to wrap the command in double quotes when shell mode is active and the path contains spaces

## Test plan
- [x] Verified `node scripts/ui.js build` succeeds on a Windows machine with a space in the username
- [ ] Confirm CI passes on Linux (no behavioral change — quoting is only applied when `shouldUseShellForCommand` returns true, which is Windows-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `shellQuoteCmd()` helper to wrap the pnpm command path in double quotes when spawning `.cmd` files on Windows with `shell: true`. This fixes build failures for users whose Windows profile path contains spaces (e.g. `C:\Users\jace nibarger\...\pnpm.cmd`). The fix only applies when `shouldUseShellForCommand()` returns true (Windows-only, for `.cmd/.bat/.com` extensions) and the path contains spaces.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal, targeted fix for Windows path handling
- Simple fix that adds quoting only when needed (Windows shell mode + spaces in path). The command path comes from trusted file system resolution via `which()`, not user input. Windows file system constraints prevent double-quote injection. No behavioral change for Linux/macOS or paths without spaces.
- No files require special attention

<sub>Last reviewed commit: 9c50640</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->