### PR TITLE
fix: keep local gateway probes on loopback for bind=lan (#21158)

### DIFF
--- a/src/cli/daemon-cli/shared.test.ts
+++ b/src/cli/daemon-cli/shared.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { theme } from "../../terminal/theme.js";
-import { resolveRuntimeStatusColor } from "./shared.js";
+import { pickProbeHostForBind, resolveRuntimeStatusColor } from "./shared.js";
 
 describe("resolveRuntimeStatusColor", () => {
   it("maps known runtime states to expected theme colors", () => {
@@ -12,5 +12,19 @@ describe("resolveRuntimeStatusColor", () => {
   it("falls back to warning color for unexpected states", () => {
     expect(resolveRuntimeStatusColor("degraded")).toBe(theme.warn);
     expect(resolveRuntimeStatusColor(undefined)).toBe(theme.muted);
+  });
+});
+
+describe("pickProbeHostForBind", () => {
+  it("uses loopback for lan probes", () => {
+    expect(pickProbeHostForBind("lan", "100.64.0.1")).toBe("127.0.0.1");
+  });
+
+  it("uses custom bind host when provided", () => {
+    expect(pickProbeHostForBind("custom", undefined, "10.1.2.3")).toBe("10.1.2.3");
+  });
+
+  it("uses tailnet IP for tailnet bind when available", () => {
+    expect(pickProbeHostForBind("tailnet", "100.64.0.1")).toBe("100.64.0.1");
   });
 });

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -5,7 +5,6 @@ import {
 } from "../../daemon/constants.js";
 import { resolveGatewayLogPaths } from "../../daemon/launchd.js";
 import { formatRuntimeStatus } from "../../daemon/runtime-format.js";
-import { pickPrimaryLanIPv4 } from "../../gateway/net.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
 import { colorize, isRich, theme } from "../../terminal/theme.js";
 import { formatCliCommand } from "../command-format.js";

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -73,7 +73,7 @@ export function pickProbeHostForBind(
     return tailnetIPv4 ?? "127.0.0.1";
   }
   if (bindMode === "lan") {
-    return pickPrimaryLanIPv4() ?? "127.0.0.1";
+    return "127.0.0.1";
   }
   return "127.0.0.1";
 }

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -185,7 +185,7 @@ export async function gatherDaemonStatus(
   const probeUrl = probeUrlOverride ?? `ws://${probeHost}:${daemonPort}`;
   const probeNote =
     !probeUrlOverride && bindMode === "lan"
-      ? `bind=lan listens on 0.0.0.0 (all interfaces); probing via ${probeHost}.`
+      ? "bind=lan listens on 0.0.0.0 (all interfaces); probing local loopback for secure local status checks."
       : !probeUrlOverride && bindMode === "loopback"
         ? "Loopback-only gateway; only local clients can connect."
         : undefined;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -125,9 +125,7 @@ export function buildGatewayConnectionDetails(
   const localUrl =
     preferTailnet && tailnetIPv4
       ? `${scheme}://${tailnetIPv4}:${localPort}`
-      : preferLan && lanIPv4
-        ? `${scheme}://${lanIPv4}:${localPort}`
-        : `${scheme}://127.0.0.1:${localPort}`;
+      : `${scheme}://127.0.0.1:${localPort}`;
   const urlOverride =
     typeof options.url === "string" && options.url.trim().length > 0
       ? options.url.trim()
@@ -144,8 +142,10 @@ export function buildGatewayConnectionDetails(
         ? "missing gateway.remote.url (fallback local)"
         : preferTailnet && tailnetIPv4
           ? `local tailnet ${tailnetIPv4}`
-          : preferLan && lanIPv4
-            ? `local lan ${lanIPv4}`
+          : preferLan
+            ? lanIPv4
+              ? `local loopback (bind=lan, lan=${lanIPv4})`
+              : "local loopback (bind=lan)"
             : "local loopback";
   const remoteFallbackNote = remoteMisconfigured
     ? "Warn: gateway.mode=remote but gateway.remote.url is missing; set gateway.remote.url or switch gateway.mode=local."

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -103,13 +103,13 @@ describe("resolveGatewayConnection", () => {
     expect(result.url).toBe("ws://100.64.0.1:18800");
   });
 
-  it("uses lan host when local bind is lan", () => {
+  it("uses loopback when local bind is lan", () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryLanIPv4.mockReturnValue("192.168.1.42");
 
     const result = resolveGatewayConnection({});
 
-    expect(result.url).toBe("ws://192.168.1.42:18800");
+    expect(result.url).toBe("ws://127.0.0.1:18800");
   });
 });


### PR DESCRIPTION
## Summary

Fixes a regression where local CLI probe paths could fail under `gateway.bind=lan` with:

`SECURITY ERROR: Gateway URL "ws://<lan-ip>:18789" uses plaintext ws:// to a non-loopback address.`

## Root cause

`gateway status` and doctor probe paths selected LAN IP for `bind=lan` and built a `ws://<lan-ip>` target.
After ws non-loopback hardening, this is correctly rejected as insecure, but it also broke local status/doctor flow.

## Fix

- Keep local probe/client targets on loopback for local management paths.
- Preserve existing bind behavior (`bind=lan` still listens on `0.0.0.0`).
- Update tests for the new expected behavior.

## Why this is safe

- No breaking API changes.
- Does not weaken security checks for remote non-loopback `ws://` URLs.
- Only changes local management target selection to deterministic loopback.

Closes #21158.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression where `gateway status` and doctor commands failed under `bind=lan` configuration after WebSocket security hardening. The fix ensures local CLI probe paths always use loopback (`127.0.0.1`) for connection targets, while the gateway server continues to bind to `0.0.0.0` (all interfaces) as expected. The security hardening that blocks plaintext `ws://` connections to non-loopback addresses remains intact.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix correctly addresses the regression without weakening security checks. The changes are minimal, well-tested, and preserve the intended behavior where the gateway binds to all interfaces but local management commands connect via secure loopback. All test updates align with the new behavior.
- No files require special attention

<sub>Last reviewed commit: 14d725b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->