### PR TITLE
feat(models): add apiKeyHelper for dynamic API key resolution

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1639,6 +1639,7 @@ OpenClaw uses the pi-coding-agent model catalog. Add custom providers via `model
 ```
 
 - Use `authHeader: true` + `headers` for custom auth needs.
+- Use `apiKeyHelper` instead of `apiKey` to run a shell command that returns the API key at runtime (e.g. `"echo '-'"` for gateway proxies, or `"op read 'op://Vault/Key'"` for secret managers). The command runs via the system shell (`/bin/sh` on Unix, `cmd.exe` on Windows) with a 10-second timeout. Falls through to `apiKey` on failure.
 - Override agent config root with `OPENCLAW_AGENT_DIR` (or `PI_CODING_AGENT_DIR`).
 
 ### Provider examples

--- a/docs/zh-CN/concepts/model-providers.md
+++ b/docs/zh-CN/concepts/model-providers.md
@@ -130,6 +130,42 @@ OpenClaw 附带 pi-ai 目录。这些提供商**不需要** `models.providers` �
 
 使用 `models.providers`（或 `models.json`）添加**自定义**提供商或 OpenAI/Anthropic 兼容的代理。
 
+### `apiKeyHelper` — 动态 API 密钥解析
+
+除了使用静态 `apiKey`，您还可以使用 `apiKeyHelper` 运行一个在运行时返回 API 密钥的
+Shell 命令。适用场景包括：
+
+- **AI 网关代理**（如 Tailscale Aperture）— 只需一个占位密钥
+- **密钥管理器**（1Password CLI、HashiCorp Vault、AWS Secrets Manager）
+- **动态密钥轮换** — 任何需要在运行时获取密钥的场景
+
+命令通过系统 Shell 执行（Unix 上为 `/bin/sh`，Windows 上为 `cmd.exe`），超时时间为 10 秒。如果命令失败，将回退到内联 `apiKey`。
+
+**优先级顺序：** 认证配置文件 → 环境变量 → `apiKeyHelper` → 内联 `apiKey`
+
+```json5
+{
+  models: {
+    providers: {
+      // Tailscale Aperture — 代理处理认证，只需一个占位密钥
+      anthropic: {
+        baseUrl: "http://ai-proxy.example.ts.net",
+        apiKeyHelper: "echo '-'",
+        api: "anthropic-messages",
+        models: [{ id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }],
+      },
+      // 1Password — 从保险库获取 API 密钥
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        apiKeyHelper: "op read 'op://Vault/OpenAI/api-key'",
+        api: "openai-completions",
+        models: [{ id: "gpt-5.1", name: "GPT 5.1" }],
+      },
+    },
+  },
+}
+```
+
 ### Moonshot AI (Kimi)
 
 Moonshot 使用 OpenAI 兼容端点，因此将其配置为自定义提供商：

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -5,7 +5,11 @@ import {
   resolveAuthProfileDisplayLabel,
   resolveAuthProfileOrder,
 } from "./auth-profiles.js";
-import { getCustomProviderApiKey, resolveEnvApiKey } from "./model-auth.js";
+import {
+  getCustomProviderApiKey,
+  getCustomProviderApiKeyHelper,
+  resolveEnvApiKey,
+} from "./model-auth.js";
 import { normalizeProviderId } from "./model-selection.js";
 
 function formatApiKeySnippet(apiKey: string): string {
@@ -68,6 +72,10 @@ export function resolveModelAuthLabel(params: {
       return `oauth (${envKey.source})`;
     }
     return `api-key ${formatApiKeySnippet(envKey.apiKey)} (${envKey.source})`;
+  }
+
+  if (getCustomProviderApiKeyHelper(params.cfg, providerKey)) {
+    return "api-key (apiKeyHelper)";
   }
 
   const customKey = getCustomProviderApiKey(params.cfg, providerKey);

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildNodeShellCommand } from "../infra/node-shell.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
-import { requireApiKey, resolveAwsSdkEnvVarName, resolveModelAuthMode } from "./model-auth.js";
+import {
+  requireApiKey,
+  resolveApiKeyHelper,
+  resolveAwsSdkEnvVarName,
+  resolveModelAuthMode,
+} from "./model-auth.js";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFile: vi.fn() };
+});
+
+const mockedExecFile = vi.mocked(execFile);
 
 describe("resolveAwsSdkEnvVarName", () => {
   it("prefers bearer token over access keys and profile", () => {
@@ -103,5 +117,135 @@ describe("requireApiKey", () => {
         "openai",
       ),
     ).toThrow('No API key resolved for provider "openai"');
+  });
+});
+
+describe("resolveApiKeyHelper", () => {
+  beforeEach(() => {
+    mockedExecFile.mockReset();
+  });
+
+  const makeCfg = (apiKeyHelper?: string, apiKey?: string) => ({
+    models: {
+      providers: {
+        "test-provider": {
+          baseUrl: "http://localhost",
+          models: [],
+          ...(apiKeyHelper !== undefined ? { apiKeyHelper } : {}),
+          ...(apiKey !== undefined ? { apiKey } : {}),
+        },
+      },
+    },
+  });
+
+  /** Helper to make mockedExecFile invoke its callback with stdout. */
+  const mockExecFileSuccess = (stdout: string) => {
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      (cb as Function)(null, stdout, "");
+      return {} as ReturnType<typeof execFile>;
+    });
+  };
+
+  /** Helper to make mockedExecFile invoke its callback with an error. */
+  const mockExecFileError = (err: Error) => {
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      (cb as Function)(err, "", "");
+      return {} as ReturnType<typeof execFile>;
+    });
+  };
+
+  it("resolves API key from helper command", async () => {
+    mockExecFileSuccess("sk-from-helper");
+    const result = await resolveApiKeyHelper(makeCfg("echo 'sk-from-helper'"), "test-provider");
+    expect(result).toBe("sk-from-helper");
+    const [expectedShell, ...expectedArgs] = buildNodeShellCommand(
+      "echo 'sk-from-helper'",
+      process.platform,
+    );
+    expect(mockedExecFile).toHaveBeenCalledWith(
+      expectedShell,
+      expectedArgs,
+      { timeout: 10_000 },
+      expect.any(Function),
+    );
+  });
+
+  it("trims whitespace from command output", async () => {
+    mockExecFileSuccess("  sk-trimmed  \n");
+    const result = await resolveApiKeyHelper(makeCfg("some-command"), "test-provider");
+    expect(result).toBe("sk-trimmed");
+  });
+
+  it("returns null when no apiKeyHelper is configured", async () => {
+    const result = await resolveApiKeyHelper(makeCfg(), "test-provider");
+    expect(result).toBeNull();
+    expect(mockedExecFile).not.toHaveBeenCalled();
+  });
+
+  it("returns null when helper command fails", async () => {
+    mockExecFileError(new Error("command failed"));
+    const result = await resolveApiKeyHelper(makeCfg("bad-command"), "test-provider");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when helper command returns empty output", async () => {
+    mockExecFileSuccess("  \n  ");
+    const result = await resolveApiKeyHelper(makeCfg("empty-output"), "test-provider");
+    expect(result).toBeNull();
+  });
+
+  it("resolves a dummy dash key (Tailscale Aperture pattern)", async () => {
+    mockExecFileSuccess("-\n");
+    const result = await resolveApiKeyHelper(makeCfg("echo '-'"), "test-provider");
+    expect(result).toBe("-");
+  });
+
+  it("returns null on timeout (command throws)", async () => {
+    const err = new Error("ETIMEDOUT");
+    (err as NodeJS.ErrnoException).code = "ETIMEDOUT";
+    mockExecFileError(err);
+    const result = await resolveApiKeyHelper(makeCfg("slow-command"), "test-provider");
+    expect(result).toBeNull();
+  });
+});
+
+describe("resolveModelAuthMode with apiKeyHelper", () => {
+  it("returns api-key when apiKeyHelper is configured", () => {
+    const result = resolveModelAuthMode(
+      "test-provider",
+      {
+        models: {
+          providers: {
+            "test-provider": {
+              baseUrl: "http://localhost",
+              apiKeyHelper: "echo 'key'",
+              models: [],
+            },
+          },
+        },
+      },
+      { version: 1, profiles: {} },
+    );
+    expect(result).toBe("api-key");
+  });
+
+  it("apiKeyHelper takes precedence over inline apiKey in auth mode", () => {
+    const result = resolveModelAuthMode(
+      "test-provider",
+      {
+        models: {
+          providers: {
+            "test-provider": {
+              baseUrl: "http://localhost",
+              apiKeyHelper: "echo 'helper-key'",
+              apiKey: "inline-key",
+              models: [],
+            },
+          },
+        },
+      },
+      { version: 1, profiles: {} },
+    );
+    expect(result).toBe("api-key");
   });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1,8 +1,10 @@
+import { execFile } from "node:child_process";
 import path from "node:path";
 import { type Api, getEnvApiKey, type Model } from "@mariozechner/pi-ai";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
+import { buildNodeShellCommand } from "../infra/node-shell.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import {
   normalizeOptionalSecretInput,
@@ -53,6 +55,40 @@ export function getCustomProviderApiKey(
 ): string | undefined {
   const entry = resolveProviderConfig(cfg, provider);
   return normalizeOptionalSecretInput(entry?.apiKey);
+}
+
+export function getCustomProviderApiKeyHelper(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): string | undefined {
+  const entry = resolveProviderConfig(cfg, provider);
+  return entry?.apiKeyHelper?.trim() || undefined;
+}
+
+/**
+ * Resolve an API key by running the user-configured `apiKeyHelper` shell command.
+ * The command string comes from the user's own config file (not untrusted input),
+ * so shell execution is intentional and required (e.g. `echo '-'`, `op read ...`).
+ */
+export function resolveApiKeyHelper(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): Promise<string | null> {
+  const helper = getCustomProviderApiKeyHelper(cfg, provider);
+  if (!helper) {
+    return Promise.resolve(null);
+  }
+  const [shell, ...args] = buildNodeShellCommand(helper, process.platform);
+  return new Promise((resolve) => {
+    execFile(shell, args, { timeout: 10_000 }, (err, stdout) => {
+      if (err) {
+        resolve(null);
+        return;
+      }
+      const key = String(stdout).trim();
+      resolve(key || null);
+    });
+  });
 }
 
 function resolveProviderAuthOverride(
@@ -200,6 +236,11 @@ export async function resolveApiKeyForProvider(params: {
       source: envResolved.source,
       mode: envResolved.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key",
     };
+  }
+
+  const helperKey = await resolveApiKeyHelper(cfg, provider);
+  if (helperKey) {
+    return { apiKey: helperKey, source: "apiKeyHelper", mode: "api-key" };
   }
 
   const customKey = getCustomProviderApiKey(cfg, provider);
@@ -370,6 +411,10 @@ export function resolveModelAuthMode(
   const envKey = resolveEnvApiKey(resolved);
   if (envKey?.apiKey) {
     return envKey.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key";
+  }
+
+  if (getCustomProviderApiKeyHelper(cfg, resolved)) {
+    return "api-key";
   }
 
   if (getCustomProviderApiKey(cfg, resolved)) {

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -6,7 +6,11 @@ import {
   resolveAuthStorePathForDisplay,
   resolveProfileUnusableUntilForDisplay,
 } from "../../agents/auth-profiles.js";
-import { getCustomProviderApiKey, resolveEnvApiKey } from "../../agents/model-auth.js";
+import {
+  getCustomProviderApiKey,
+  getCustomProviderApiKeyHelper,
+  resolveEnvApiKey,
+} from "../../agents/model-auth.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { shortenHomePath } from "../../utils.js";
 import { maskApiKey } from "./list.format.js";
@@ -60,6 +64,7 @@ export function resolveProviderAuthOverview(params: {
   const apiKeyCount = profiles.filter((id) => store.profiles[id]?.type === "api_key").length;
 
   const envKey = resolveEnvApiKey(provider);
+  const helperCmd = getCustomProviderApiKeyHelper(cfg, provider);
   const customKey = getCustomProviderApiKey(cfg, provider);
 
   const effective: ProviderAuthOverview["effective"] = (() => {
@@ -76,6 +81,9 @@ export function resolveProviderAuthOverview(params: {
         kind: "env",
         detail: isOAuthEnv ? "OAuth (env)" : maskApiKey(envKey.apiKey),
       };
+    }
+    if (helperCmd) {
+      return { kind: "apiKeyHelper", detail: "apiKeyHelper" };
     }
     if (customKey) {
       return { kind: "models.json", detail: maskApiKey(customKey) };
@@ -104,6 +112,7 @@ export function resolveProviderAuthOverview(params: {
           },
         }
       : {}),
+    ...(helperCmd ? { apiKeyHelper: { source: "apiKeyHelper" } } : {}),
     ...(customKey
       ? {
           modelsJson: {

--- a/src/commands/models/list.probe.test.ts
+++ b/src/commands/models/list.probe.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AuthProbeResult } from "./list.probe.js";
+
+// Mock heavy dependencies so we can test probe target selection without side effects.
+vi.mock("../../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStore: () => ({ version: 1, profiles: {} }),
+  listProfilesForProvider: () => [],
+  resolveAuthProfileDisplayLabel: () => "",
+  resolveAuthProfileOrder: () => [],
+}));
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: () =>
+    Promise.resolve([
+      { provider: "test-helper", id: "test-model" },
+      { provider: "test-env", id: "env-model" },
+      { provider: "test-inline", id: "inline-model" },
+      { provider: "test-none", id: "none-model" },
+    ]),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../agents/agent-paths.js", () => ({
+  resolveOpenClawAgentDir: () => "/tmp/test-agent",
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "test",
+  resolveAgentWorkspaceDir: () => "/tmp/test-workspace",
+}));
+
+vi.mock("../../agents/workspace.js", () => ({
+  resolveDefaultAgentWorkspaceDir: () => "/tmp/test-workspace",
+}));
+
+vi.mock("../../config/sessions/paths.js", () => ({
+  resolveSessionTranscriptPath: () => "/tmp/test-session.json",
+  resolveSessionTranscriptsDirForAgent: () => "/tmp/test-sessions",
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: { mkdir: vi.fn().mockResolvedValue(undefined) },
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Must import after mocks are set up.
+const { runAuthProbes } = await import("./list.probe.js");
+
+const baseOpts = {
+  timeoutMs: 5000,
+  concurrency: 1,
+  maxTokens: 10,
+};
+
+describe("probe target selection with apiKeyHelper", () => {
+  it("includes apiKeyHelper provider as a probe target", async () => {
+    const cfg = {
+      models: {
+        providers: {
+          "test-helper": {
+            baseUrl: "http://localhost",
+            apiKeyHelper: "echo 'key'",
+            models: [{ id: "test-model", name: "Test" }],
+          },
+        },
+      },
+    };
+
+    const summary = await runAuthProbes({
+      cfg: cfg as unknown as Parameters<typeof runAuthProbes>[0]["cfg"],
+      providers: ["test-helper"],
+      modelCandidates: ["test-helper/test-model"],
+      options: baseOpts,
+    });
+
+    const result = summary.results.find((r: AuthProbeResult) => r.provider === "test-helper");
+    expect(result).toBeDefined();
+    expect(result!.source).toBe("apiKeyHelper");
+  });
+
+  it("prefers env over apiKeyHelper for source label", async () => {
+    const originalEnv = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "sk-test-env-key";
+
+    try {
+      const cfg = {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "http://localhost",
+              apiKeyHelper: "echo 'helper-key'",
+              models: [{ id: "gpt-5.1", name: "GPT" }],
+            },
+          },
+        },
+      };
+
+      const summary = await runAuthProbes({
+        cfg: cfg as unknown as Parameters<typeof runAuthProbes>[0]["cfg"],
+        providers: ["openai"],
+        modelCandidates: ["openai/gpt-5.1"],
+        options: baseOpts,
+      });
+
+      const result = summary.results.find((r: AuthProbeResult) => r.provider === "openai");
+      expect(result).toBeDefined();
+      expect(result!.source).toBe("env");
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env.OPENAI_API_KEY = originalEnv;
+      } else {
+        delete process.env.OPENAI_API_KEY;
+      }
+    }
+  });
+
+  it("skips provider with no auth configured", async () => {
+    const cfg = {
+      models: {
+        providers: {
+          "test-none": {
+            baseUrl: "http://localhost",
+            models: [{ id: "none-model", name: "No Auth" }],
+          },
+        },
+      },
+    };
+
+    const summary = await runAuthProbes({
+      cfg: cfg as unknown as Parameters<typeof runAuthProbes>[0]["cfg"],
+      providers: ["test-none"],
+      modelCandidates: ["test-none/none-model"],
+      options: baseOpts,
+    });
+
+    const result = summary.results.find((r: AuthProbeResult) => r.provider === "test-none");
+    expect(result).toBeUndefined();
+  });
+
+  it("reports no_model for apiKeyHelper provider without catalog match", async () => {
+    const cfg = {
+      models: {
+        providers: {
+          "unknown-provider": {
+            baseUrl: "http://localhost",
+            apiKeyHelper: "echo 'key'",
+            models: [{ id: "some-model", name: "Some" }],
+          },
+        },
+      },
+    };
+
+    const summary = await runAuthProbes({
+      cfg: cfg as unknown as Parameters<typeof runAuthProbes>[0]["cfg"],
+      providers: ["unknown-provider"],
+      modelCandidates: [],
+      options: baseOpts,
+    });
+
+    const result = summary.results.find((r: AuthProbeResult) => r.provider === "unknown-provider");
+    expect(result).toBeDefined();
+    expect(result!.source).toBe("apiKeyHelper");
+    expect(result!.status).toBe("no_model");
+  });
+});

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -187,7 +187,11 @@ export async function modelsStatusCommand(
   const providerAuth = providers
     .map((provider) => resolveProviderAuthOverview({ provider, cfg, store, modelsPath }))
     .filter((entry) => {
-      const hasAny = entry.profiles.count > 0 || Boolean(entry.env) || Boolean(entry.modelsJson);
+      const hasAny =
+        entry.profiles.count > 0 ||
+        Boolean(entry.env) ||
+        Boolean(entry.apiKeyHelper) ||
+        Boolean(entry.modelsJson);
       return hasAny;
     });
   const providerAuthMap = new Map(providerAuth.map((entry) => [entry.provider, entry]));

--- a/src/commands/models/list.types.ts
+++ b/src/commands/models/list.types.ts
@@ -19,7 +19,7 @@ export type ModelRow = {
 export type ProviderAuthOverview = {
   provider: string;
   effective: {
-    kind: "profiles" | "env" | "models.json" | "missing";
+    kind: "profiles" | "env" | "apiKeyHelper" | "models.json" | "missing";
     detail: string;
   };
   profiles: {
@@ -30,5 +30,6 @@ export type ProviderAuthOverview = {
     labels: string[];
   };
   env?: { value: string; source: string };
+  apiKeyHelper?: { source: string };
   modelsJson?: { value: string; source: string };
 };

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -44,6 +44,7 @@ export type ModelDefinitionConfig = {
 export type ModelProviderConfig = {
   baseUrl: string;
   apiKey?: string;
+  apiKeyHelper?: string;
   auth?: ModelProviderAuthMode;
   api?: ModelApi;
   headers?: Record<string, string>;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -59,6 +59,7 @@ export const ModelProviderSchema = z
   .object({
     baseUrl: z.string().min(1),
     apiKey: z.string().optional().register(sensitive),
+    apiKeyHelper: z.string().optional().register(sensitive),
     auth: z
       .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token")])
       .optional(),


### PR DESCRIPTION
## Summary

- Adds `apiKeyHelper` field to model provider config, allowing a shell command to resolve API keys at runtime (secret managers, gateway proxies, dynamic rotation)
- Uses cross-platform shell via `buildNodeShellCommand` (`/bin/sh -lc` on Unix, `cmd.exe` on Windows)
- Async `execFile` with 10s timeout — non-blocking for gateway request flow
- Auth label rendering uses config-only check (no command execution in `/status`)
- Surfaces `apiKeyHelper` providers in `models status --json` and probe targets
- Marks `apiKeyHelper` as sensitive in Zod schema (consistent with `apiKey`)

## Review issue fixes

1. **Cross-platform shell** — replaced hardcoded `/bin/sh` with `buildNodeShellCommand()` from `src/infra/node-shell.ts`
2. **Sensitive marking** — `apiKeyHelper` now uses `.register(sensitive)` in Zod schema
3. **No side effects in label rendering** — auth label checks config presence only, never runs the command
4. **Async execution** — converted from blocking `execFileSync` to async `execFile` callback pattern (Codex P1)
5. **Probe target support** — `apiKeyHelper` providers are now included in auth probe targets (Codex P2)

## Testing

### Automated
- 761 test files, 6121 tests all passing
- New test coverage: `model-auth.test.ts` (7 new tests), `list.probe.test.ts` (4 new tests)
- Tests cover: key resolution, whitespace trimming, timeout handling, empty output, Tailscale Aperture `echo '-'` pattern, probe target selection, env priority over helper

### Manual (end-to-end)
- **Tailscale Aperture**: Configured `apiKeyHelper: "echo '-'"` proxying to Anthropic — verified dummy key flows through gateway, model responds correctly
- **1Password CLI**: Configured `apiKeyHelper: "op read 'op://Personal/ANTHROPIC_API_KEY/license key'"` — verified vault key retrieval, model responds correctly
- **`models status --json`**: Verified `apiKeyHelper` providers appear in status output with correct `effective.kind`
- **Sensitive data audit**: Confirmed no secrets, tokens, or vault paths leak in diff

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm format:check` passes
- [ ] `pnpm lint` — 0 warnings, 0 errors
- [ ] `pnpm test` — 6121/6121 tests pass
- [ ] Verify cross-platform shell on Windows (uses `cmd.exe /d /s /c`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `apiKeyHelper` field to model provider config for dynamic API key resolution via shell commands at runtime. Key changes:

- **Core implementation**: New `resolveApiKeyHelper()` in `src/agents/model-auth.ts:73-92` runs user-configured shell commands with 10s timeout using cross-platform `buildNodeShellCommand()` (Unix: `/bin/sh -lc`, Windows: `cmd.exe /d /s /c`)
- **Auth priority**: Profiles → env vars → `apiKeyHelper` → inline `apiKey` (lines 232-248)
- **Zod schema**: Marks `apiKeyHelper` as sensitive in `src/config/zod-schema.core.ts:62`
- **Status/probe support**: Providers with `apiKeyHelper` correctly surface in `models status --json` and probe targets
- **No side effects in labels**: Auth label rendering checks config presence only (line 77), never executes command
- **Comprehensive tests**: 7 new tests in `model-auth.test.ts` (key resolution, whitespace, timeout, empty output, Tailscale `-` pattern) + 4 probe tests

Documentation updated for English and zh-CN with examples for Tailscale Aperture and 1Password CLI.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is production-ready: uses async non-blocking `execFile` with timeout protection, properly handles cross-platform shells, maintains correct auth priority order, includes comprehensive test coverage (11 new tests), and follows the project's conventions. The shell command execution is intentional for user-configured commands from their own config file (not untrusted input), with proper error handling and fallback to inline `apiKey` on failure.
- No files require special attention

<sub>Last reviewed commit: b457fa7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->