### PR TITLE
fix: memory prune command to prevent unbounded MEMORY.md growth

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -212,6 +212,12 @@ Periodically (every few days), use a heartbeat to:
 
 Think of it like a human reviewing their journal and updating their mental model. Daily files are raw notes; MEMORY.md is curated wisdom.
 
+### Managing MEMORY.md size
+
+MEMORY.md is injected into context on every main session start but truncated at 20,000 characters.
+When it grows large, run `openclaw memory prune` to archive older sections to `memory/YYYY-MM-DD-archived.md`.
+Run `openclaw memory status` to check current file sizes.
+
 The goal: Be helpful without being annoying. Check in a few times a day, do useful background work, but respect quiet time.
 
 ## Make It Yours

--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -241,5 +241,9 @@ Redact sensitive host details (usernames, hostnames, IPs, serials, service names
 If there are durable preferences or decisions (risk posture, allowed ports, update policy),
 also update `MEMORY.md` (long-term memory is optional and only used in private sessions).
 
+Before writing to MEMORY.md, check its size with `openclaw memory status`. If the file exceeds the
+warning threshold (default: 15,000 chars), run `openclaw memory prune` to archive older sections
+before adding new content.
+
 If the session cannot write to the workspace, ask for permission or provide exact entries
 the user can paste into the memory files.

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -172,6 +172,10 @@ export const FIELD_HELP: Record<string, string> = {
     'Include absolute timestamps in message envelopes ("on" or "off").',
   "agents.defaults.envelopeElapsed": 'Include elapsed time in message envelopes ("on" or "off").',
   "agents.defaults.models": "Configured model catalog (keys are full provider/model IDs).",
+  "agents.defaults.memory.warnChars":
+    "Warn when MEMORY.md exceeds this many characters (default: 15000, ~75% of 20k bootstrap limit).",
+  "agents.defaults.memory.pruneKeepChars":
+    "Characters to keep in MEMORY.md after pruning (default: 10000, 50% of bootstrap limit).",
   "agents.defaults.memorySearch":
     "Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).",
   "agents.defaults.memorySearch.sources":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -134,6 +134,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.envelopeTimezone": "Envelope Timezone",
   "agents.defaults.envelopeTimestamp": "Envelope Timestamp",
   "agents.defaults.envelopeElapsed": "Envelope Elapsed",
+  "agents.defaults.memory.warnChars": "Memory Warn Chars",
+  "agents.defaults.memory.pruneKeepChars": "Memory Prune Keep Chars",
   "agents.defaults.memorySearch": "Memory Search",
   "agents.defaults.memorySearch.enabled": "Enable Memory Search",
   "agents.defaults.memorySearch.sources": "Memory Search Sources",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -162,6 +162,13 @@ export type AgentDefaultsConfig = {
   contextPruning?: AgentContextPruningConfig;
   /** Compaction tuning and pre-compaction memory flush behavior. */
   compaction?: AgentCompactionConfig;
+  /** Memory file management settings. */
+  memory?: {
+    /** Warn when MEMORY.md exceeds this many chars (default: 15000). */
+    warnChars?: number;
+    /** Chars to keep in MEMORY.md after pruning (default: 10000). */
+    pruneKeepChars?: number;
+  };
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;
   /** Default thinking level when no /think directive is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -54,6 +54,13 @@ export const AgentDefaultsSchema = z
     envelopeElapsed: z.union([z.literal("on"), z.literal("off")]).optional(),
     contextTokens: z.number().int().positive().optional(),
     cliBackends: z.record(z.string(), CliBackendSchema).optional(),
+    memory: z
+      .object({
+        warnChars: z.number().int().positive().optional(),
+        pruneKeepChars: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
     memorySearch: MemorySearchSchema,
     contextPruning: z
       .object({

--- a/src/memory/prune.test.ts
+++ b/src/memory/prune.test.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_MEMORY_WARN_CHARS, pruneMemoryFile, splitAtHeadingBoundary } from "./prune.js";
+
+describe("splitAtHeadingBoundary", () => {
+  it("returns full content when keepChars >= length", () => {
+    const content = "# Title\n\nSome text\n";
+    const [kept, archived] = splitAtHeadingBoundary(content, content.length + 100);
+    expect(kept).toBe(content);
+    expect(archived).toBe("");
+  });
+
+  it("splits at heading boundary before keepChars", () => {
+    const content =
+      "# Title\n\nFirst section\n\n## Second\n\nSecond text\n\n## Third\n\nThird text\n";
+    const [kept, archived] = splitAtHeadingBoundary(content, 35);
+    expect(kept).toBe("# Title\n\nFirst section\n\n");
+    expect(archived).toBe("## Second\n\nSecond text\n\n## Third\n\nThird text\n");
+  });
+
+  it("falls back to newline boundary when no heading before keepChars", () => {
+    const content = "Line one\nLine two\nLine three\nLine four\n";
+    const [kept, archived] = splitAtHeadingBoundary(content, 20);
+    expect(kept).toBe("Line one\nLine two\n");
+    expect(archived).toBe("Line three\nLine four\n");
+  });
+
+  it("handles keepChars <= 0", () => {
+    const content = "Some content";
+    const [kept, archived] = splitAtHeadingBoundary(content, 0);
+    expect(kept).toBe("");
+    expect(archived).toBe("Some content");
+  });
+});
+
+describe("pruneMemoryFile", () => {
+  let tmpDir: string;
+  let memoryFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "prune-test-"));
+    memoryFile = path.join(tmpDir, "MEMORY.md");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns pruned: false when file is below threshold", async () => {
+    const content = "# Small file\n\nNot much here.\n";
+    await fs.writeFile(memoryFile, content, "utf-8");
+
+    const result = await pruneMemoryFile({ filePath: memoryFile });
+    expect(result.pruned).toBe(false);
+    expect(result.originalChars).toBe(content.length);
+    expect(result.keptChars).toBe(content.length);
+    expect(result.archivedChars).toBe(0);
+  });
+
+  it("dry-run mode returns result without writing", async () => {
+    const content = "# Title\n\n" + "x".repeat(DEFAULT_MEMORY_WARN_CHARS + 100) + "\n";
+    await fs.writeFile(memoryFile, content, "utf-8");
+
+    const result = await pruneMemoryFile({ filePath: memoryFile, dryRun: true });
+    expect(result.pruned).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.archiveFilePath).toBeDefined();
+
+    const afterContent = await fs.readFile(memoryFile, "utf-8");
+    expect(afterContent).toBe(content);
+  });
+
+  it("splits at heading boundary correctly", async () => {
+    const head = "# Title\n\nImportant stuff\n\n";
+    const tail = "## Old Section\n\n" + "y".repeat(DEFAULT_MEMORY_WARN_CHARS) + "\n";
+    const content = head + tail;
+    await fs.writeFile(memoryFile, content, "utf-8");
+
+    const result = await pruneMemoryFile({
+      filePath: memoryFile,
+      keepChars: head.length + 5,
+      warnChars: 100,
+    });
+    expect(result.pruned).toBe(true);
+    expect(result.dryRun).toBe(false);
+
+    const keptContent = await fs.readFile(memoryFile, "utf-8");
+    expect(keptContent).toBe(head);
+    expect(result.archiveFilePath).toBeDefined();
+
+    const archiveContent = await fs.readFile(result.archiveFilePath!, "utf-8");
+    expect(archiveContent).toContain("## Archived from MEMORY.md on");
+    expect(archiveContent).toContain(tail);
+  });
+
+  it("falls back to newline boundary when no heading before keepChars", async () => {
+    const content = "Line one\nLine two\n" + "z".repeat(DEFAULT_MEMORY_WARN_CHARS + 100) + "\n";
+    await fs.writeFile(memoryFile, content, "utf-8");
+
+    const result = await pruneMemoryFile({
+      filePath: memoryFile,
+      keepChars: 15,
+      warnChars: 100,
+    });
+    expect(result.pruned).toBe(true);
+    const keptContent = await fs.readFile(memoryFile, "utf-8");
+    expect(keptContent).toBe("Line one\n");
+  });
+
+  it("creates memory/ directory if missing", async () => {
+    const content = "# Title\n\n## Old\n\n" + "a".repeat(200) + "\n";
+    await fs.writeFile(memoryFile, content, "utf-8");
+
+    const result = await pruneMemoryFile({
+      filePath: memoryFile,
+      keepChars: 12,
+      warnChars: 50,
+    });
+    expect(result.pruned).toBe(true);
+    expect(result.archiveFilePath).toBeDefined();
+
+    const archiveStat = await fs.stat(result.archiveFilePath!);
+    expect(archiveStat.isFile()).toBe(true);
+  });
+
+  it("appends to existing archive file", async () => {
+    const archiveDir = path.join(tmpDir, "memory");
+    await fs.mkdir(archiveDir, { recursive: true });
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const archivePath = path.join(archiveDir, `${dateStr}-archived.md`);
+    await fs.writeFile(archivePath, "## Previous archive\n\nOld stuff\n", "utf-8");
+
+    const content = "# Title\n\n## Old\n\n" + "b".repeat(200) + "\n";
+    await fs.writeFile(memoryFile, content, "utf-8");
+
+    const result = await pruneMemoryFile({
+      filePath: memoryFile,
+      keepChars: 12,
+      warnChars: 50,
+    });
+    expect(result.pruned).toBe(true);
+
+    const archiveContent = await fs.readFile(archivePath, "utf-8");
+    expect(archiveContent).toContain("## Previous archive");
+    expect(archiveContent).toContain("## Archived from MEMORY.md on");
+  });
+
+  it("handles missing file gracefully", async () => {
+    const result = await pruneMemoryFile({
+      filePath: path.join(tmpDir, "nonexistent.md"),
+    });
+    expect(result.pruned).toBe(false);
+    expect(result.originalChars).toBe(0);
+  });
+
+  it("handles empty file gracefully", async () => {
+    await fs.writeFile(memoryFile, "", "utf-8");
+    const result = await pruneMemoryFile({ filePath: memoryFile });
+    expect(result.pruned).toBe(false);
+    expect(result.originalChars).toBe(0);
+    expect(result.keptChars).toBe(0);
+  });
+});

--- a/src/memory/prune.ts
+++ b/src/memory/prune.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ensureDir } from "./internal.js";
+
+export const DEFAULT_MEMORY_WARN_CHARS = 15_000;
+export const DEFAULT_MEMORY_PRUNE_KEEP_CHARS = 10_000;
+
+export type MemoryPruneResult = {
+  pruned: boolean;
+  dryRun: boolean;
+  filePath: string;
+  originalChars: number;
+  keptChars: number;
+  archivedChars: number;
+  archiveFilePath?: string;
+};
+
+export type MemoryPruneOptions = {
+  filePath: string;
+  dryRun?: boolean;
+  keepChars?: number;
+  warnChars?: number;
+};
+
+/**
+ * Split content at the nearest `## ` or `# ` heading boundary before `keepChars`.
+ * Falls back to the nearest newline boundary. Returns `[kept, archived]`.
+ */
+export function splitAtHeadingBoundary(content: string, keepChars: number): [string, string] {
+  if (keepChars >= content.length) {
+    return [content, ""];
+  }
+  if (keepChars <= 0) {
+    return ["", content];
+  }
+
+  const region = content.slice(0, keepChars);
+
+  let splitIndex = -1;
+  for (let i = region.length - 1; i >= 0; i--) {
+    if (region[i] === "\n") {
+      const after = region.slice(i + 1);
+      if (after.startsWith("## ") || after.startsWith("# ")) {
+        splitIndex = i + 1;
+        break;
+      }
+    }
+  }
+
+  if (splitIndex === -1) {
+    const lastNewline = region.lastIndexOf("\n");
+    splitIndex = lastNewline >= 0 ? lastNewline + 1 : keepChars;
+  }
+
+  return [content.slice(0, splitIndex), content.slice(splitIndex)];
+}
+
+/**
+ * Prune MEMORY.md when it exceeds the warn threshold.
+ * Keeps the first portion and archives the rest.
+ */
+export async function pruneMemoryFile(opts: MemoryPruneOptions): Promise<MemoryPruneResult> {
+  const { filePath, dryRun = false } = opts;
+  const keepChars = opts.keepChars ?? DEFAULT_MEMORY_PRUNE_KEEP_CHARS;
+  const warnChars = opts.warnChars ?? DEFAULT_MEMORY_WARN_CHARS;
+
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return {
+        pruned: false,
+        dryRun,
+        filePath,
+        originalChars: 0,
+        keptChars: 0,
+        archivedChars: 0,
+      };
+    }
+    throw err;
+  }
+
+  const originalChars = content.length;
+
+  if (originalChars <= warnChars) {
+    return {
+      pruned: false,
+      dryRun,
+      filePath,
+      originalChars,
+      keptChars: originalChars,
+      archivedChars: 0,
+    };
+  }
+
+  const [kept, archived] = splitAtHeadingBoundary(content, keepChars);
+
+  if (archived.length === 0) {
+    return {
+      pruned: false,
+      dryRun,
+      filePath,
+      originalChars,
+      keptChars: originalChars,
+      archivedChars: 0,
+    };
+  }
+
+  const now = new Date();
+  const dateStr = now.toISOString().slice(0, 10);
+  const memoryDir = path.dirname(filePath);
+  const archiveDir = path.join(memoryDir, "memory");
+  const archiveFilePath = path.join(archiveDir, `${dateStr}-archived.md`);
+
+  if (dryRun) {
+    return {
+      pruned: true,
+      dryRun: true,
+      filePath,
+      originalChars,
+      keptChars: kept.length,
+      archivedChars: archived.length,
+      archiveFilePath,
+    };
+  }
+
+  ensureDir(archiveDir);
+
+  const archiveHeader = `\n## Archived from MEMORY.md on ${dateStr}\n\n`;
+  await fs.appendFile(archiveFilePath, archiveHeader + archived, "utf-8");
+
+  const tmpPath = filePath + ".tmp";
+  await fs.writeFile(tmpPath, kept, "utf-8");
+  await fs.rename(tmpPath, filePath);
+
+  return {
+    pruned: true,
+    dryRun: false,
+    filePath,
+    originalChars,
+    keptChars: kept.length,
+    archivedChars: archived.length,
+    archiveFilePath,
+  };
+}

--- a/src/memory/prune.ts
+++ b/src/memory/prune.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { ensureDir } from "./internal.js";
 
 export const DEFAULT_MEMORY_WARN_CHARS = 15_000;
 export const DEFAULT_MEMORY_PRUNE_KEEP_CHARS = 10_000;
@@ -126,7 +125,7 @@ export async function pruneMemoryFile(opts: MemoryPruneOptions): Promise<MemoryP
     };
   }
 
-  ensureDir(archiveDir);
+  await fs.mkdir(archiveDir, { recursive: true }).catch(() => {});
 
   const archiveHeader = `\n## Archived from MEMORY.md on ${dateStr}\n\n`;
   await fs.appendFile(archiveFilePath, archiveHeader + archived, "utf-8");


### PR DESCRIPTION
## Summary

Closes #20720

- Add `openclaw memory prune` command that archives older MEMORY.md sections to `memory/YYYY-MM-DD-archived.md` when the file exceeds a configurable threshold
- Surface MEMORY.md file size in `openclaw memory status` with warnings when approaching the 20k bootstrap truncation limit
- Add `agents.defaults.memory.warnChars` and `agents.defaults.memory.pruneKeepChars` config options
- Update AGENTS.md and healthcheck skill docs with size management guidance

## Test plan

- Unit tests pass (12/12) — `pnpm test src/memory/prune.test.ts`
- Build passes — `pnpm build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a memory pruning command to prevent `MEMORY.md` from growing beyond the 20k character bootstrap truncation limit. The implementation adds a `openclaw memory prune` CLI command that archives older sections to dated files in the `memory/` directory while keeping the most recent content. The `memory status` command now displays file size with warnings when approaching limits.

Key changes:
- Added `pruneMemoryFile()` function with smart heading-boundary splitting to preserve markdown structure
- CLI command supports `--dry-run`, configurable thresholds, and JSON output
- Config schema adds `agents.defaults.memory.warnChars` (default: 15k) and `agents.defaults.memory.pruneKeepChars` (default: 10k)
- Updated docs to guide users on memory management
- Comprehensive unit tests (12/12 passing) cover edge cases including dry-run, heading splits, appending to existing archives, and error handling

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The implementation is well-tested (12/12 unit tests passing), follows existing codebase patterns, handles edge cases properly (missing files, empty files, existing archives), and includes comprehensive documentation. The atomic file write pattern (write to `.tmp`, then rename) prevents data loss. The feature addresses a real need (preventing unbounded MEMORY.md growth) without breaking changes.
- No files require special attention

<sub>Last reviewed commit: 6678ce7</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->