### PR TITLE
fix(hooks): internal hooks silently broken for Telegram /new command

### DIFF
--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -416,4 +416,24 @@ describe("hooks", () => {
       expect(keys).toEqual([]);
     });
   });
+
+  describe("globalThis singleton", () => {
+    it("should store handlers map on globalThis so bundler chunks share state", () => {
+      const key = "__openclaw_internal_hook_handlers__";
+      const globalMap = (globalThis as Record<string, unknown>)[key];
+      expect(globalMap).toBeInstanceOf(Map);
+    });
+
+    it("should reuse the same map across multiple imports", () => {
+      const key = "__openclaw_internal_hook_handlers__";
+      const globalMap = (globalThis as Record<string, unknown>)[key] as Map<string, unknown>;
+
+      // Register via the module API
+      const handler = vi.fn();
+      registerInternalHook("singleton:test", handler);
+
+      // The global map should reflect the registration
+      expect(globalMap.has("singleton:test")).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`/new` from Telegram skips all internal hooks (session-memory, command-logger, etc.) while the same command from webchat works fine. Hooks register and load correctly (`openclaw hooks list` shows 4/4 ready), but `triggerInternalHook` finds zero handlers when called from the Telegram code path.

**Root cause:** tsdown produces multiple output chunks with separate copies of the `handlers` Map in `internal-hooks.ts`. In the built output:

- `gateway-cli-*.js` imports `registerInternalHook` from `reply-*.js` (has its own `const handlers = new Map()`)
- `pi-embedded-*.js` imports `triggerInternalHook` from `internal-hooks-*.js` (different `new Map()`)

Gateway startup registers hooks into the first Map. Telegram triggers against the second. Two Maps, zero overlap.

Verified by inspecting the dist output — `grep "handlers.*new Map"` shows separate Map allocations in `reply-*.js` and `internal-hooks-*.js`.

## Fix

Store the handlers Map on `globalThis` so all chunks resolve to the same instance regardless of how the bundler splits the module graph. The lazy init pattern avoids creating a new Map if one already exists from another chunk.

2 files changed, 36 insertions, 2 deletions.

Closes #20984

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed internal hooks being silently broken for Telegram `/new` command by moving the handlers registry from a module-level Map to a `globalThis` singleton. The root cause was tsdown splitting `internal-hooks.ts` across multiple output chunks (`gateway-cli-*.js` and `pi-embedded-*.js`), each with its own isolated Map instance. Hooks registered during gateway startup were stored in one Map, while Telegram triggers checked a different Map, resulting in zero handlers being found.

- Changed `handlers` from module-scoped constant to lazy-initialized `globalThis.__openclaw_internal_hook_handlers__` singleton
- Added lazy init pattern with nullish coalescing to reuse existing Map if already created by another chunk
- Added test coverage verifying Map is stored on `globalThis` and shared across registrations
- Solution ensures all chunks resolve to the same Map instance regardless of bundler code-splitting strategy

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-tested, and solves a real production bug. The globalThis singleton pattern is appropriate for this bundler edge case, the lazy initialization is thread-safe in Node.js (single-threaded event loop), and tests verify the Map is shared across imports. The change is backward compatible and doesn't affect the public API.
- No files require special attention

<sub>Last reviewed commit: 707d948</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->