### PR TITLE
iOS/Gateway: stabilize background wake and reconnect behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- iOS/Gateway: stabilize background wake and reconnect behavior with background reconnect suppression/lease windows, BGAppRefresh wake fallback, location wake hook throttling, and APNs wake retry+nudge instrumentation. (#21226) thanks @mbelinky.
+
 ### Fixes
 
 - Discord/Gateway: handle close code 4014 (missing privileged gateway intents) without crashing the gateway. Thanks @thewilloftheshadow.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -67,6 +67,37 @@ pnpm ios:open
 - iPhone node commands in foreground: camera snap/clip, canvas present/navigate/eval/snapshot, screen record, location, contacts, calendar, reminders, photos, motion, local notifications.
 - Share extension deep-link forwarding into the connected gateway session.
 
+## Location Automation Use Case (Testing)
+
+Use this for automation signals ("I moved", "I arrived", "I left"), not as a keep-awake mechanism.
+
+- Product intent:
+  - movement-aware automations driven by iOS location events
+  - example: arrival/exit geofence, significant movement, visit detection
+- Non-goal:
+  - continuous GPS polling just to keep the app alive
+
+Test path to include in QA runs:
+
+1. Enable location permission in app:
+   - set `Always` permission
+   - verify background location capability is enabled in the build profile
+2. Background the app and trigger movement:
+   - walk/drive enough for a significant location update, or cross a configured geofence
+3. Validate gateway side effects:
+   - node reconnect/wake if needed
+   - expected location/movement event arrives at gateway
+   - automation trigger executes once (no duplicate storm)
+4. Validate resource impact:
+   - no sustained high thermal state
+   - no excessive background battery drain over a short observation window
+
+Pass criteria:
+
+- movement events are delivered reliably enough for automation UX
+- no location-driven reconnect spam loops
+- app remains stable after repeated background/foreground transitions
+
 ## Known Issues / Limitations / Problems
 
 - Foreground-first: iOS can suspend sockets in background; reconnect recovery is still being tuned.

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -64,6 +64,10 @@
 		<string>audio</string>
 		<string>remote-notification</string>
 	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>ai.openclaw.ios.bgrefresh</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/apps/ios/Sources/Location/SignificantLocationMonitor.swift
+++ b/apps/ios/Sources/Location/SignificantLocationMonitor.swift
@@ -10,7 +10,8 @@ enum SignificantLocationMonitor {
     static func startIfNeeded(
         locationService: any LocationServicing,
         locationMode: OpenClawLocationMode,
-        gateway: GatewayNodeSession
+        gateway: GatewayNodeSession,
+        beforeSend: (@MainActor @Sendable () async -> Void)? = nil
     ) {
         guard locationMode == .always else { return }
         let status = locationService.authorizationStatus()
@@ -31,6 +32,9 @@ enum SignificantLocationMonitor {
                   let json = String(data: data, encoding: .utf8)
             else { return }
             Task { @MainActor in
+                if let beforeSend {
+                    await beforeSend()
+                }
                 await gateway.sendEvent(event: "location.update", payloadJSON: json)
             }
         }

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -42,6 +42,7 @@ private final class NotificationInvokeLatch<T: Sendable>: @unchecked Sendable {
 final class NodeAppModel {
     private let deepLinkLogger = Logger(subsystem: "ai.openclaw.ios", category: "DeepLink")
     private let pushWakeLogger = Logger(subsystem: "ai.openclaw.ios", category: "PushWake")
+    private let locationWakeLogger = Logger(subsystem: "ai.openclaw.ios", category: "LocationWake")
     enum CameraHUDKind {
         case photo
         case recording
@@ -103,6 +104,11 @@ final class NodeAppModel {
     private var backgroundTalkKeptActive = false
     private var backgroundedAt: Date?
     private var reconnectAfterBackgroundArmed = false
+    private var backgroundGraceTaskID: UIBackgroundTaskIdentifier = .invalid
+    @ObservationIgnored private var backgroundGraceTaskTimer: Task<Void, Never>?
+    private var backgroundReconnectSuppressed = false
+    private var backgroundReconnectLeaseUntil: Date?
+    private var lastSignificantLocationWakeAt: Date?
 
     private var gatewayConnected = false
     private var operatorConnected = false
@@ -271,6 +277,7 @@ final class NodeAppModel {
             self.stopGatewayHealthMonitor()
             self.backgroundedAt = Date()
             self.reconnectAfterBackgroundArmed = true
+            self.beginBackgroundConnectionGracePeriod()
             // Release voice wake mic in background.
             self.backgroundVoiceWakeSuspended = self.voiceWake.suspendForExternalAudioCapture()
             let shouldKeepTalkActive = keepTalkActive && self.talkMode.isEnabled
@@ -278,6 +285,8 @@ final class NodeAppModel {
             self.backgroundTalkSuspended = self.talkMode.suspendForBackground(keepActive: shouldKeepTalkActive)
         case .active, .inactive:
             self.isBackgrounded = false
+            self.endBackgroundConnectionGracePeriod(reason: "scene_foreground")
+            self.clearBackgroundReconnectSuppression(reason: "scene_foreground")
             if self.operatorConnected {
                 self.startGatewayHealthMonitor()
             }
@@ -329,7 +338,96 @@ final class NodeAppModel {
             }
         @unknown default:
             self.isBackgrounded = false
+            self.endBackgroundConnectionGracePeriod(reason: "scene_unknown")
+            self.clearBackgroundReconnectSuppression(reason: "scene_unknown")
         }
+    }
+
+    private func beginBackgroundConnectionGracePeriod(seconds: TimeInterval = 25) {
+        self.grantBackgroundReconnectLease(seconds: seconds, reason: "scene_background_grace")
+        self.endBackgroundConnectionGracePeriod(reason: "restart")
+        let taskID = UIApplication.shared.beginBackgroundTask(withName: "gateway-background-grace") { [weak self] in
+            Task { @MainActor in
+                self?.suppressBackgroundReconnect(
+                    reason: "background_grace_expired",
+                    disconnectIfNeeded: true)
+                self?.endBackgroundConnectionGracePeriod(reason: "expired")
+            }
+        }
+        guard taskID != .invalid else {
+            self.pushWakeLogger.info("Background grace unavailable: beginBackgroundTask returned invalid")
+            return
+        }
+        self.backgroundGraceTaskID = taskID
+        self.pushWakeLogger.info("Background grace started seconds=\(seconds, privacy: .public)")
+        self.backgroundGraceTaskTimer = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: UInt64(max(1, seconds) * 1_000_000_000))
+            await MainActor.run {
+                self.suppressBackgroundReconnect(reason: "background_grace_timer", disconnectIfNeeded: true)
+                self.endBackgroundConnectionGracePeriod(reason: "timer")
+            }
+        }
+    }
+
+    private func endBackgroundConnectionGracePeriod(reason: String) {
+        self.backgroundGraceTaskTimer?.cancel()
+        self.backgroundGraceTaskTimer = nil
+        guard self.backgroundGraceTaskID != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(self.backgroundGraceTaskID)
+        self.backgroundGraceTaskID = .invalid
+        self.pushWakeLogger.info("Background grace ended reason=\(reason, privacy: .public)")
+    }
+
+    private func grantBackgroundReconnectLease(seconds: TimeInterval, reason: String) {
+        guard self.isBackgrounded else { return }
+        let leaseSeconds = max(5, seconds)
+        let leaseUntil = Date().addingTimeInterval(leaseSeconds)
+        if let existing = self.backgroundReconnectLeaseUntil, existing > leaseUntil {
+            // Keep the longer lease if one is already active.
+        } else {
+            self.backgroundReconnectLeaseUntil = leaseUntil
+        }
+        let wasSuppressed = self.backgroundReconnectSuppressed
+        self.backgroundReconnectSuppressed = false
+        self.pushWakeLogger.info(
+            "Background reconnect lease reason=\(reason, privacy: .public) seconds=\(leaseSeconds, privacy: .public) wasSuppressed=\(wasSuppressed, privacy: .public)")
+    }
+
+    private func suppressBackgroundReconnect(reason: String, disconnectIfNeeded: Bool) {
+        guard self.isBackgrounded else { return }
+        let hadLease = self.backgroundReconnectLeaseUntil != nil
+        let changed = hadLease || !self.backgroundReconnectSuppressed
+        self.backgroundReconnectLeaseUntil = nil
+        self.backgroundReconnectSuppressed = true
+        guard changed else { return }
+        self.pushWakeLogger.info(
+            "Background reconnect suppressed reason=\(reason, privacy: .public) disconnect=\(disconnectIfNeeded, privacy: .public)")
+        guard disconnectIfNeeded else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            await self.operatorGateway.disconnect()
+            await self.nodeGateway.disconnect()
+            await MainActor.run {
+                self.operatorConnected = false
+                self.gatewayConnected = false
+                self.talkMode.updateGatewayConnected(false)
+                if self.isBackgrounded {
+                    self.gatewayStatusText = "Background idle"
+                    self.gatewayServerName = nil
+                    self.gatewayRemoteAddress = nil
+                    self.showLocalCanvasOnDisconnect()
+                }
+            }
+        }
+    }
+
+    private func clearBackgroundReconnectSuppression(reason: String) {
+        let changed = self.backgroundReconnectSuppressed || self.backgroundReconnectLeaseUntil != nil
+        self.backgroundReconnectSuppressed = false
+        self.backgroundReconnectLeaseUntil = nil
+        guard changed else { return }
+        self.pushWakeLogger.info("Background reconnect cleared reason=\(reason, privacy: .public)")
     }
 
     func setVoiceWakeEnabled(_ enabled: Bool) {
@@ -568,7 +666,7 @@ final class NodeAppModel {
                 } catch {
                     if let gatewayError = error as? GatewayResponseError {
                         let lower = gatewayError.message.lowercased()
-                        if lower.contains("unauthorized role") {
+                        if lower.contains("unauthorized role") || lower.contains("missing scope") {
                             await self.setGatewayHealthMonitorDisabled(true)
                             return true
                         }
@@ -601,7 +699,7 @@ final class NodeAppModel {
         } catch {
             if let gatewayError = error as? GatewayResponseError {
                 let lower = gatewayError.message.lowercased()
-                if lower.contains("unauthorized role") {
+                if lower.contains("unauthorized role") || lower.contains("missing scope") {
                     await self.setGatewayHealthMonitorDisabled(true)
                     return
                 }
@@ -1725,6 +1823,23 @@ private extension NodeAppModel {
         self.apnsLastRegisteredTokenHex = nil
     }
 
+    func refreshBackgroundReconnectSuppressionIfNeeded(source: String) {
+        guard self.isBackgrounded else { return }
+        guard !self.backgroundReconnectSuppressed else { return }
+        guard let leaseUntil = self.backgroundReconnectLeaseUntil else {
+            self.suppressBackgroundReconnect(reason: "\(source):no_lease", disconnectIfNeeded: true)
+            return
+        }
+        if Date() >= leaseUntil {
+            self.suppressBackgroundReconnect(reason: "\(source):lease_expired", disconnectIfNeeded: true)
+        }
+    }
+
+    func shouldPauseReconnectLoopInBackground(source: String) -> Bool {
+        self.refreshBackgroundReconnectSuppressionIfNeeded(source: source)
+        return self.isBackgrounded && self.backgroundReconnectSuppressed
+    }
+
     func startOperatorGatewayLoop(
         url: URL,
         stableID: String,
@@ -1747,6 +1862,7 @@ private extension NodeAppModel {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     continue
                 }
+                if self.shouldPauseReconnectLoopInBackground(source: "operator_loop") { try? await Task.sleep(nanoseconds: 2_000_000_000); continue }
                 if await self.isOperatorConnected() {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     continue
@@ -1834,6 +1950,7 @@ private extension NodeAppModel {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     continue
                 }
+                if self.shouldPauseReconnectLoopInBackground(source: "node_loop") { try? await Task.sleep(nanoseconds: 2_000_000_000); continue }
                 if await self.isGatewayConnected() {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     continue
@@ -1883,7 +2000,15 @@ private extension NodeAppModel {
                             }
                             await self.showA2UIOnConnectIfNeeded()
                             await self.onNodeGatewayConnected()
-                            await MainActor.run { SignificantLocationMonitor.startIfNeeded(locationService: self.locationService, locationMode: self.locationMode(), gateway: self.nodeGateway) }
+                            await MainActor.run {
+                                SignificantLocationMonitor.startIfNeeded(
+                                    locationService: self.locationService,
+                                    locationMode: self.locationMode(),
+                                    gateway: self.nodeGateway,
+                                    beforeSend: { [weak self] in
+                                        await self?.handleSignificantLocationWakeIfNeeded()
+                                    })
+                            }
                         },
                         onDisconnected: { [weak self] reason in
                             guard let self else { return }
@@ -2135,12 +2260,59 @@ extension NodeAppModel {
     }
 
     func handleSilentPushWake(_ userInfo: [AnyHashable: Any]) async -> Bool {
+        let wakeId = Self.makePushWakeAttemptID()
         guard Self.isSilentPushPayload(userInfo) else {
-            self.pushWakeLogger.info("Ignored APNs payload: not silent push")
+            self.pushWakeLogger.info("Ignored APNs payload wakeId=\(wakeId, privacy: .public): not silent push")
             return false
         }
-        self.pushWakeLogger.info("Silent push received; attempting reconnect if needed")
-        return await self.reconnectGatewaySessionsForSilentPushIfNeeded()
+        let pushKind = Self.openclawPushKind(userInfo)
+        self.pushWakeLogger.info(
+            "Silent push received wakeId=\(wakeId, privacy: .public) kind=\(pushKind, privacy: .public) backgrounded=\(self.isBackgrounded, privacy: .public) autoReconnect=\(self.gatewayAutoReconnectEnabled, privacy: .public)")
+        let result = await self.reconnectGatewaySessionsForSilentPushIfNeeded(wakeId: wakeId)
+        self.pushWakeLogger.info(
+            "Silent push outcome wakeId=\(wakeId, privacy: .public) applied=\(result.applied, privacy: .public) reason=\(result.reason, privacy: .public) durationMs=\(result.durationMs, privacy: .public)")
+        return result.applied
+    }
+
+    func handleBackgroundRefreshWake(trigger: String = "bg_app_refresh") async -> Bool {
+        let wakeId = Self.makePushWakeAttemptID()
+        self.pushWakeLogger.info(
+            "Background refresh wake received wakeId=\(wakeId, privacy: .public) trigger=\(trigger, privacy: .public) backgrounded=\(self.isBackgrounded, privacy: .public) autoReconnect=\(self.gatewayAutoReconnectEnabled, privacy: .public)")
+        let result = await self.reconnectGatewaySessionsForSilentPushIfNeeded(wakeId: wakeId)
+        self.pushWakeLogger.info(
+            "Background refresh wake outcome wakeId=\(wakeId, privacy: .public) applied=\(result.applied, privacy: .public) reason=\(result.reason, privacy: .public) durationMs=\(result.durationMs, privacy: .public)")
+        return result.applied
+    }
+
+    func handleSignificantLocationWakeIfNeeded() async {
+        let wakeId = Self.makePushWakeAttemptID()
+        let now = Date()
+        let throttleWindowSeconds: TimeInterval = 180
+
+        if await self.isGatewayConnected() {
+            self.locationWakeLogger.info(
+                "Location wake no-op wakeId=\(wakeId, privacy: .public): already connected")
+            return
+        }
+        if let last = self.lastSignificantLocationWakeAt,
+           now.timeIntervalSince(last) < throttleWindowSeconds
+        {
+            self.locationWakeLogger.info(
+                "Location wake throttled wakeId=\(wakeId, privacy: .public) elapsedSec=\(now.timeIntervalSince(last), privacy: .public)")
+            return
+        }
+        self.lastSignificantLocationWakeAt = now
+
+        self.locationWakeLogger.info(
+            "Location wake begin wakeId=\(wakeId, privacy: .public) backgrounded=\(self.isBackgrounded, privacy: .public) autoReconnect=\(self.gatewayAutoReconnectEnabled, privacy: .public)")
+        let result = await self.reconnectGatewaySessionsForSilentPushIfNeeded(wakeId: wakeId)
+        self.locationWakeLogger.info(
+            "Location wake trigger wakeId=\(wakeId, privacy: .public) applied=\(result.applied, privacy: .public) reason=\(result.reason, privacy: .public) durationMs=\(result.durationMs, privacy: .public)")
+
+        guard result.applied else { return }
+        let connected = await self.waitForGatewayConnection(timeoutMs: 5000, pollMs: 250)
+        self.locationWakeLogger.info(
+            "Location wake post-check wakeId=\(wakeId, privacy: .public) connected=\(connected, privacy: .public)")
     }
 
     func updateAPNsDeviceToken(_ tokenData: Data) {
@@ -2210,28 +2382,83 @@ extension NodeAppModel {
         return false
     }
 
-    private func reconnectGatewaySessionsForSilentPushIfNeeded() async -> Bool {
-        guard self.isBackgrounded else {
-            self.pushWakeLogger.info("Wake no-op: app not backgrounded")
-            return false
+    private static func makePushWakeAttemptID() -> String {
+        let raw = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        return String(raw.prefix(8))
+    }
+
+    private static func openclawPushKind(_ userInfo: [AnyHashable: Any]) -> String {
+        if let payload = userInfo["openclaw"] as? [String: Any],
+           let kind = payload["kind"] as? String
+        {
+            let trimmed = kind.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
         }
-        guard self.gatewayAutoReconnectEnabled else {
-            self.pushWakeLogger.info("Wake no-op: auto reconnect disabled")
-            return false
+        if let payload = userInfo["openclaw"] as? [AnyHashable: Any],
+           let kind = payload["kind"] as? String
+        {
+            let trimmed = kind.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
         }
-        guard self.activeGatewayConnectConfig != nil else {
-            self.pushWakeLogger.info("Wake no-op: no active gateway config")
-            return false
+        return "unknown"
+    }
+
+    private struct SilentPushWakeAttemptResult {
+        var applied: Bool
+        var reason: String
+        var durationMs: Int
+    }
+
+    private func waitForGatewayConnection(timeoutMs: Int, pollMs: Int) async -> Bool {
+        let clampedTimeoutMs = max(0, timeoutMs)
+        let pollIntervalNs = UInt64(max(50, pollMs)) * 1_000_000
+        let deadline = Date().addingTimeInterval(Double(clampedTimeoutMs) / 1000.0)
+        while Date() < deadline {
+            if await self.isGatewayConnected() {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: pollIntervalNs)
+        }
+        return await self.isGatewayConnected()
+    }
+
+    private func reconnectGatewaySessionsForSilentPushIfNeeded(
+        wakeId: String
+    ) async -> SilentPushWakeAttemptResult {
+        let startedAt = Date()
+        let makeResult: (Bool, String) -> SilentPushWakeAttemptResult = { applied, reason in
+            let durationMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+            return SilentPushWakeAttemptResult(
+                applied: applied,
+                reason: reason,
+                durationMs: max(0, durationMs))
         }
 
+        guard self.isBackgrounded else {
+            self.pushWakeLogger.info("Wake no-op wakeId=\(wakeId, privacy: .public): app not backgrounded")
+            return makeResult(false, "not_backgrounded")
+        }
+        guard self.gatewayAutoReconnectEnabled else {
+            self.pushWakeLogger.info("Wake no-op wakeId=\(wakeId, privacy: .public): auto reconnect disabled")
+            return makeResult(false, "auto_reconnect_disabled")
+        }
+        guard let cfg = self.activeGatewayConnectConfig else {
+            self.pushWakeLogger.info("Wake no-op wakeId=\(wakeId, privacy: .public): no active gateway config")
+            return makeResult(false, "no_active_gateway_config")
+        }
+
+        self.pushWakeLogger.info(
+            "Wake reconnect begin wakeId=\(wakeId, privacy: .public) stableID=\(cfg.stableID, privacy: .public)")
+        self.grantBackgroundReconnectLease(seconds: 30, reason: "wake_\(wakeId)")
         await self.operatorGateway.disconnect()
         await self.nodeGateway.disconnect()
         self.operatorConnected = false
         self.gatewayConnected = false
         self.gatewayStatusText = "Reconnecting…"
         self.talkMode.updateGatewayConnected(false)
-        self.pushWakeLogger.info("Wake reconnect trigger applied")
-        return true
+        self.applyGatewayConnectConfig(cfg)
+        self.pushWakeLogger.info("Wake reconnect trigger applied wakeId=\(wakeId, privacy: .public)")
+        return makeResult(true, "reconnect_triggered")
     }
 }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -75,6 +75,10 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         }
     }
 
+    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
+        pongReceiveHandler(nil)
+    }
+
     func receive() async throws -> URLSessionWebSocketTask.Message {
         let phase = self.lock.withLock { () -> Int in
             let current = self.receivePhase


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: iOS node background behavior was unstable (reconnect churn/heat) and wake-on-demand paths were not robust enough across silent push/background/location triggers.
- Why it matters: users need predictable background idle behavior with reliable explicit wake for `node.invoke`.
- What changed: added iOS background reconnect suppression + lease windows, BGAppRefresh fallback wake scheduling/handling, location wake hook/throttle, websocket ping keepalive, and gateway APNs wake retry+nudge instrumentation.
- What did NOT change (scope boundary): no Android changes, no TestFlight/release distribution changes, no protocol breaking changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- iOS app now enters explicit background-idle mode after a short grace period instead of reconnecting continuously.
- Silent push / background refresh / significant location updates can trigger controlled reconnect windows.
- Gateway wake flow for disconnected iOS nodes now includes richer wake lifecycle logging and one retry path.
- `apps/ios/README.md` now documents location-automation QA use case and pass criteria.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes (BG task identifier usage)
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes (ping keepalive behavior)
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  - Risk: more wake-related background activity.
  - Mitigation: explicit suppression + lease windows + throttles; wake remains best-effort and bounded.

## Repro + Verification

### Environment

- OS: macOS (dev host) + physical iPhone 15 Pro Max
- Runtime/container: local dev + gateway on `mb-server`
- Model/provider: N/A
- Integration/channel (if any): APNs sandbox
- Relevant config (redacted): APNs team/key configured on gateway host

### Steps

1. Build/deploy iOS app to physical device.
2. Background app and sample node connection state over ~1 minute.
3. Send APNs push wake and then `nodes invoke device.status`.

### Expected

- Background idle remains disconnected without reconnect churn.
- Push wake restores invoke path within a few seconds.

### Actual

- Idle: stable disconnected state, no transitions.
- Wake: invoke success on first attempt (~4.6s in probe run).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: foreground invoke works; background idle stability sampling; push->invoke wake end-to-end on physical iPhone.
- Edge cases checked: reconnect suppression lease expiry, wake retry path test coverage.
- What you did **not** verify: long-duration battery drain profiling, outdoor location-distance wake scenario beyond short-range constraints.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No (uses existing APNs env if present)
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR, or disable push wake usage and rely on foreground reconnect.
- Files/config to restore: revert `apps/ios/Sources/Model/NodeAppModel.swift`, `apps/ios/Sources/OpenClawApp.swift`, and `src/gateway/server-methods/nodes.ts`.
- Known bad symptoms reviewers should watch for: missed wake invokes, excessive background reconnecting, repeated APNs wake spam.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: wake retry/nudge logic could be noisy on flaky APNs delivery.
  - Mitigation: throttles (`NODE_WAKE_THROTTLE_MS`, `NODE_WAKE_NUDGE_THROTTLE_MS`) and best-effort behavior.
- Risk: background suppression could hide transient reconnect opportunities.
  - Mitigation: explicit lease grants on wake triggers + foreground reconnection path remains intact.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes iOS background wake behavior by introducing controlled reconnect suppression with lease-based windows, APNs wake retry logic with user nudges, and websocket ping-based keepalive.

The changes successfully address the problem of iOS reconnect churn in the background by implementing an explicit idle mode after a 25-second grace period. Wake paths are now more robust with retry logic and better instrumentation on both iOS and gateway sides.

Key improvements:
- Background reconnect suppression prevents continuous reconnect loops when idle
- Wake lease windows (30s) provide controlled reconnect opportunities for APNs push, background refresh, and location triggers
- Gateway now performs two wake attempts (3s + 12s waits) before sending user notification nudge
- Websocket keepalive switched from RPC `health` calls to lightweight ping frames
- Comprehensive logging across wake lifecycle stages for debugging

The implementation includes proper throttling (15s for wake attempts, 10min for user nudges, 3min for location wakes), graceful cleanup with weak references, and updated test coverage for the retry behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor monitoring needed for production battery impact
- Score reflects solid implementation with proper resource management (weak refs, throttles, bounded tasks), comprehensive logging, and test coverage. The wake retry logic is well-structured with fallback paths. Minor deduction for the untested long-duration battery impact noted by the author and the complexity of coordinating multiple wake paths that could interact in unexpected ways under edge conditions.
- Monitor `NodeAppModel.swift` and `nodes.ts` in production for wake behavior - check logs for excessive nudges or missed wakes

<sub>Last reviewed commit: 667772b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->