### PR TITLE
fix(heartbeat): preserve real delivery target in session context

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -666,6 +666,14 @@ export async function runHeartbeatOnce(opts: {
     Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
     From: sender,
     To: sender,
+    // Preserve the real delivery target so that reply/session.ts records it as
+    // lastTo instead of the synthetic sender id (which may be "heartbeat").
+    // Without this, forum-topic sessions get lastTo="heartbeat" and subsequent
+    // announce delivery fails because it can't resolve a valid chat target.
+    OriginatingChannel: delivery.channel !== "none" ? delivery.channel : undefined,
+    OriginatingTo: delivery.to,
+    AccountId: delivery.accountId,
+    MessageThreadId: delivery.threadId,
     Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",
     SessionKey: sessionKey,
   };


### PR DESCRIPTION
## Problem

Heartbeat runner sets `ctx.To = sender`, where `sender` is resolved by `resolveHeartbeatSenderId`. When no allowFrom candidates match, sender falls back to the literal string `"heartbeat"`.

`reply/session.ts` then persists this as `lastTo` in the session store:
```typescript
const lastToRaw = ctx.OriginatingTo || ctx.To || baseEntry?.lastTo;
```

For **forum-topic sessions**, this corrupts the delivery context: `lastTo` becomes `"heartbeat"` instead of the real Telegram chat id. Subsequent cron announce delivery fails because `resolveDeliveryTarget` cannot resolve a valid outbound target.

Fixes #21235

## Fix

Set `OriginatingChannel`, `OriginatingTo`, `AccountId`, and `MessageThreadId` on the heartbeat message context from the resolved delivery target. `reply/session.ts` already prefers `OriginatingTo` over `ctx.To`, so the real chat id is now preserved across heartbeat runs.

## Changes

- `src/infra/heartbeat-runner.ts`: Add originating delivery fields to heartbeat message context