### PR TITLE
docs: clarify bind=lan non-loopback access requires wss or tunnel (#21158)

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -80,6 +80,7 @@ Shared options (where supported):
 
 Note: when you set `--url`, the CLI does not fall back to config or environment credentials.
 Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
+For non-loopback direct targets (`lan`/`tailnet`/`custom`), use `wss://` (or SSH tunnel to loopback). Plain `ws://<non-loopback>` is blocked by security checks.
 
 ### `gateway health`
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -278,11 +278,14 @@ openclaw logs --follow
 What to check:
 
 - Non-loopback binds (`lan`, `tailnet`, `custom`) need auth configured.
+- Plain `ws://` to non-loopback hosts is blocked by design. For direct LAN/tailnet/custom access, use `wss://` and enable Gateway TLS (`gateway.tls.enabled=true`) or terminate TLS upstream.
+- For local operator checks (`openclaw gateway status`, `openclaw doctor`), prefer loopback or an SSH tunnel target.
 - Old keys like `gateway.token` do not replace `gateway.auth.token`.
 
 Common signatures:
 
 - `refusing to bind gateway ... without auth` → bind+auth mismatch.
+- `SECURITY ERROR: Gateway URL "... uses plaintext ws:// to a non-loopback address."` → switch to `wss://`, or tunnel to `ws://127.0.0.1:<port>`.
 - `RPC probe: failed` while runtime is running → gateway alive but inaccessible with current auth/url.
 
 ### 3) Pairing and device identity state changed


### PR DESCRIPTION
## Summary  Refs #21158.

Add documentation guidance for the `bind=lan` / non-loopback case where direct plaintext WebSocket URLs are rejected by security checks.

## Changes
 `docs/cli/gateway.md`: clarified that direct non-loopback targets should use `wss://` (or SSH tunnel to loopback), and that plain `ws://<non-loopback>` is blocked.
- `docs/gateway/troubleshooting.md`: added explicit troubleshooting notes/signatures for:
  - plaintext non-loopback `ws://` rejection
  - when to enable `gateway.tls.enabled=true`
  - using loopback/SSH tunnel for local operator checks


Refs #21158.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds documentation clarifying that direct non-loopback WebSocket connections must use `wss://` or SSH tunneling, aligning with the security checks in `src/gateway/net.ts:isSecureWebSocketUrl()` that block plaintext `ws://` to non-loopback addresses (line 429-430). The changes accurately describe the error signature users see when the security check fails and provide correct remediation guidance.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only changes that accurately describe existing security behavior. The guidance correctly references `gateway.tls.enabled=true` (verified in `src/config/types.gateway.ts:3-13`), matches the actual error message from `src/gateway/call.ts:161`, and provides valid workarounds (wss:// or SSH tunnel) that align with the security check implementation in `src/gateway/net.ts:413-431`
- No files require special attention

<sub>Last reviewed commit: 4fbac9a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->