### PR TITLE
Draft: Accept thinkingDefault in per-agent runtime schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Config: accept `thinkingDefault` in per-agent runtime schema so `agents.list` entries can define it without validation errors. (#21097)
+
 - Gateway/WebChat: block `sessions.patch` and `sessions.delete` for WebChat clients so session-store mutations stay restricted to non-WebChat operator flows. Thanks @allsmog for reporting.
 - Security/Skills: for the next npm release, reject symlinks during skill packaging to prevent external file inclusion in distributed `.skill` archives. Thanks @aether-ai-agent for reporting.
 - Security/Config: block prototype-polluting keys (`__proto__`, `prototype`, `constructor`) in `deepMerge`, preventing prototype pollution via merged configuration objects. (#20853) Thanks @davidrudduck.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/WebChat: block `sessions.patch` and `sessions.delete` for WebChat clients so session-store mutations stay restricted to non-WebChat operator flows. Thanks @allsmog for reporting.
 - Security/Skills: for the next npm release, reject symlinks during skill packaging to prevent external file inclusion in distributed `.skill` archives. Thanks @aether-ai-agent for reporting.
+- Security/Config: block prototype-polluting keys (`__proto__`, `prototype`, `constructor`) in `deepMerge`, preventing prototype pollution via merged configuration objects. (#20853) Thanks @davidrudduck.
 - Security/iMessage: harden remote attachment SSH/SCP handling by requiring strict host-key verification, validating `channels.imessage.remoteHost` as `host`/`user@host`, and rejecting unsafe host tokens from config or auto-detection. Thanks @allsmog for reporting.
 - Security/Feishu: prevent path traversal in Feishu inbound media temp-file writes by replacing key-derived temp filenames with UUID-based names. Thanks @allsmog for reporting.
 - LINE/Security: harden inbound media temp-file naming by using UUID-based temp paths for downloaded media instead of external message IDs. (#20792) Thanks @mbelinky.

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -589,6 +589,7 @@ export const AgentEntrySchema = z
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
     skills: z.array(z.string()).optional(),
+    thinkingDefault: z.string().optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),
     heartbeat: HeartbeatSchema,


### PR DESCRIPTION
## Summary
- Add missing `thinkingDefault` property to `AgentEntrySchema` so per-agent `thinkingDefault` config validates for `agents.list` entries.

## Why
The runtime already reads per-agent `thinkingDefault`, but schema validation for agent entries currently rejects the key.

## Notes
- No behavior changes besides schema acceptance.

Fixes: #21097
