### PR TITLE
Draft: Avoid caching missing binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Plugins: avoid caching missing binary checks in `hasBinary()`, so installs made after gateway start are discovered without requiring a PATH change. (#21094)
+
 - Gateway/WebChat: block `sessions.patch` and `sessions.delete` for WebChat clients so session-store mutations stay restricted to non-WebChat operator flows. Thanks @allsmog for reporting.
 - Security/Skills: for the next npm release, reject symlinks during skill packaging to prevent external file inclusion in distributed `.skill` archives. Thanks @aether-ai-agent for reporting.
 - Security/Config: block prototype-polluting keys (`__proto__`, `prototype`, `constructor`) in `deepMerge`, preventing prototype pollution via merged configuration objects. (#20853) Thanks @davidrudduck.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/WebChat: block `sessions.patch` and `sessions.delete` for WebChat clients so session-store mutations stay restricted to non-WebChat operator flows. Thanks @allsmog for reporting.
 - Security/Skills: for the next npm release, reject symlinks during skill packaging to prevent external file inclusion in distributed `.skill` archives. Thanks @aether-ai-agent for reporting.
+- Security/Config: block prototype-polluting keys (`__proto__`, `prototype`, `constructor`) in `deepMerge`, preventing prototype pollution via merged configuration objects. (#20853) Thanks @davidrudduck.
 - Security/iMessage: harden remote attachment SSH/SCP handling by requiring strict host-key verification, validating `channels.imessage.remoteHost` as `host`/`user@host`, and rejecting unsafe host tokens from config or auto-detection. Thanks @allsmog for reporting.
 - Security/Feishu: prevent path traversal in Feishu inbound media temp-file writes by replacing key-derived temp filenames with UUID-based names. Thanks @allsmog for reporting.
 - LINE/Security: harden inbound media temp-file naming by using UUID-based temp paths for downloaded media instead of external message IDs. (#20792) Thanks @mbelinky.

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -144,6 +144,5 @@ export function hasBinary(bin: string): boolean {
       }
     }
   }
-  hasBinaryCache.set(bin, false);
   return false;
 }


### PR DESCRIPTION
## Summary
- Stop caching negative results in `hasBinary()`.

## Why
`hasBinaryCache` previously memoized `false` misses, so binaries installed after startup were ignored until cache invalidation (PATH/env changes).

## Notes
- Positive cache entries remain cached.
- This is a one-line behavioral fix.

Fixes: #21094
