### PR TITLE
fix(memory): add token budget limits for memory tools (#21187)

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -228,6 +228,10 @@ export const FIELD_HELP: Record<string, string> = {
   memory: "Memory backend configuration (global).",
   "memory.backend": 'Memory backend ("builtin" for OpenClaw embeddings, "qmd" for QMD sidecar).',
   "memory.citations": 'Default citation behavior ("auto", "on", or "off").',
+  "memory.limits.maxSearchInjectedTokens":
+    "Max tokens injected into the model context from memory_search results (default: 800).",
+  "memory.limits.maxGetInjectedTokens":
+    "Max tokens injected into the model context from memory_get reads (default: 1600).",
   "memory.qmd.command": "Path to the qmd binary (default: resolves from PATH).",
   "memory.qmd.includeDefaultMemory":
     "Whether to automatically index MEMORY.md + memory/**/*.md (default: true).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -176,6 +176,8 @@ export const FIELD_LABELS: Record<string, string> = {
   memory: "Memory",
   "memory.backend": "Memory Backend",
   "memory.citations": "Memory Citations Mode",
+  "memory.limits.maxSearchInjectedTokens": "Memory Search Max Injected Tokens",
+  "memory.limits.maxGetInjectedTokens": "Memory Get Max Injected Tokens",
   "memory.qmd.command": "QMD Binary",
   "memory.qmd.includeDefaultMemory": "QMD Include Default Memory",
   "memory.qmd.paths": "QMD Extra Paths",

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -8,6 +8,14 @@ export type MemoryConfig = {
   backend?: MemoryBackend;
   citations?: MemoryCitationsMode;
   qmd?: MemoryQmdConfig;
+  limits?: MemoryLimitsConfig;
+};
+
+export type MemoryLimitsConfig = {
+  /** Token budget for memory_search tool results injected into the model context. */
+  maxSearchInjectedTokens?: number;
+  /** Token budget for memory_get tool results injected into the model context. */
+  maxGetInjectedTokens?: number;
 };
 
 export type MemoryQmdConfig = {


### PR DESCRIPTION
Fixes openclaw/openclaw#21187.

Adds token-budget clamping for memory tool outputs to prevent context overflow:
- memory.limits.maxSearchInjectedTokens (default 800)
- memory.limits.maxGetInjectedTokens (default 1600)

AI-assisted: yes.

Testing:
- pnpm vitest run --config vitest.e2e.config.ts src/agents/tools/memory-tool.e2e.test.ts
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds token budget limits (`memory.limits.maxSearchInjectedTokens` and `memory.limits.maxGetInjectedTokens`) to prevent memory tool outputs from overflowing context windows. The implementation includes:

- New `MemoryLimitsConfig` type with two configurable token budgets (defaults: 800 for search, 1600 for get)
- `clampTextByInjectedTokens()` function that estimates tokens and truncates text with a safety margin
- `clampResultsByInjectedTokens()` function that processes search results within the budget
- Comprehensive test coverage for both search and get clamping behavior
- Proper integration with existing QMD character-based clamping

The token estimation uses a mocked `estimateTokens()` function in tests with a simple character-to-token ratio (1:10), ensuring deterministic test behavior. The implementation correctly handles edge cases like zero/negative budgets and applies a 1.2x safety margin to prevent overshoot.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor documentation improvements recommended
- The implementation is well-tested with comprehensive e2e tests covering edge cases, follows existing patterns, and includes proper type definitions. The token budget logic is sound with appropriate safety margins. Only minor documentation gaps in schema help/labels files prevent a perfect score.
- Consider updating `src/config/schema.help.ts` and `src/config/schema.labels.ts` to document the new config options

<sub>Last reviewed commit: ff3e400</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->