### PR TITLE
fix(discord): defer own-mode fetch until thread allow checks pass

### DIFF
--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -338,10 +338,9 @@ async function handleDiscordReactionEvent(params: {
         return;
       }
 
-      // For "own" mode, we need to fetch the message to check the author
-      const messagePromise = data.message.fetch().catch(() => null);
-
-      const [channelInfo, message] = await Promise.all([channelInfoPromise, messagePromise]);
+      // For "own" mode, resolve allowlist/channel gates first, then fetch message author
+      // only when needed.
+      const channelInfo = await channelInfoPromise;
       parentId = channelInfo?.parentId;
       await loadThreadParentInfo();
 
@@ -350,6 +349,7 @@ async function handleDiscordReactionEvent(params: {
         return;
       }
 
+      const message = await data.message.fetch().catch(() => null);
       const messageAuthorId = message?.author?.id ?? undefined;
       if (!shouldNotifyReaction({ mode: reactionMode, messageAuthorId })) {
         return;


### PR DESCRIPTION
## Summary

- Restore this PR to its original scope: defer Discord reaction own-mode message fetch until allowlist/channel gates pass.
- Avoid unnecessary `message.fetch()` when notifications are blocked by channel/thread policy.
- Keep behavior unchanged for allowed notifications; only reorder gate evaluation.

## Why

In own reaction mode, we should not fetch message author metadata before we know the thread/channel is eligible for notification. This reduces unnecessary API calls and aligns with gate-first logic.

## Files

- `src/discord/monitor/listeners.ts`

## Commit

- `28769a794bfc2ba8d9a2c2b62da6bfc2b32eaa33`
