### PR TITLE
fix(slack): pass recipient_team_id and recipient_user_id to chatStream

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -199,6 +199,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           channel: message.channel,
           threadTs: streamThreadTs,
           text,
+          teamId: ctx.teamId || undefined,
+          botUserId: ctx.botUserId || undefined,
         });
         replyPlan.markSent();
         return;

--- a/src/slack/streaming.ts
+++ b/src/slack/streaming.ts
@@ -36,6 +36,10 @@ export type StartSlackStreamParams = {
   threadTs: string;
   /** Optional initial markdown text to include in the stream start. */
   text?: string;
+  /** Team ID — required by the Slack API for streaming outside of DMs. */
+  teamId?: string;
+  /** Bot user ID — required by the Slack API for streaming outside of DMs. */
+  botUserId?: string;
 };
 
 export type AppendSlackStreamParams = {
@@ -64,13 +68,15 @@ export type StopSlackStreamParams = {
 export async function startSlackStream(
   params: StartSlackStreamParams,
 ): Promise<SlackStreamSession> {
-  const { client, channel, threadTs, text } = params;
+  const { client, channel, threadTs, text, teamId, botUserId } = params;
 
   logVerbose(`slack-stream: starting stream in ${channel} thread=${threadTs}`);
 
   const streamer = client.chatStream({
     channel,
     thread_ts: threadTs,
+    ...(teamId ? { recipient_team_id: teamId } : undefined),
+    ...(botUserId ? { recipient_user_id: botUserId } : undefined),
   });
 
   const session: SlackStreamSession = {


### PR DESCRIPTION
## Summary

- Problem: `startSlackStream()` calls `client.chatStream()` without `recipient_team_id` and `recipient_user_id`, causing `missing_recipient_team_id` errors in all non-DM channels (private channels, public channels, groups).
- Why it matters: Slack streaming is enabled by default since 2026.2.17. Every non-DM channel message fails to deliver — the agent response is silently lost.
- What changed: Added optional `teamId` and `botUserId` params to `StartSlackStreamParams` and spread them as `recipient_team_id` / `recipient_user_id` into the `chatStream()` call. The caller in `dispatch.ts` passes `ctx.teamId` and `ctx.botUserId` which are already available in context.
- What did NOT change (scope boundary): No changes to append/stop lifecycle, fallback behavior, config schema, or non-streaming paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #21213
- Related #9972, #18555

## User-visible / Behavior Changes

Slack native text streaming now works in channels and groups, not just DMs. No config changes required.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same Slack API calls, just with required parameters now included
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Integration/channel: Slack (socket mode)
- Relevant config: `channels.slack.streaming: true` (default)

### Steps

1. Enable Slack streaming (default since 2026.2.17)
2. Send a message that triggers a bot reply in any non-DM channel (private channel, public channel, or group)

### Expected

- Agent reply is delivered via streaming

### Actual

- `missing_recipient_team_id` error — no reply delivered. Fallback to non-streaming delivery may or may not trigger depending on error path.

## Evidence

- [x] Trace/log snippets

```
slack-stream: failed to stop stream: Error: An API error occurred: missing_recipient_team_id
```

100% failure rate for channel messages after enabling streaming. DMs unaffected.

## Human Verification (required)

- Live end-to-end verified in Slack: DM, grouped DM, private channel, and public channel all work correctly with streaming enabled.
- TypeScript type check (`pnpm tsgo`) passes, all 229 Slack tests pass.
- Edge cases checked: `teamId`/`botUserId` are optional — when empty/falsy they are omitted (DM behavior unchanged)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `channels.slack.streaming: false` in `openclaw.json`
- Files/config to restore: `src/slack/streaming.ts`, `src/slack/monitor/message-handler/dispatch.ts`
- Known bad symptoms reviewers should watch for: Streaming errors in logs, messages not delivered in channels

## Risks and Mitigations

- Risk: Slack SDK `chatStream()` type might not include `recipient_team_id`/`recipient_user_id` in older SDK versions
  - Mitigation: Verified the fields exist in the bundled `@slack/web-api` types (`ChatStartStreamArguments`). They are spread conditionally so missing fields are simply omitted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `recipient_team_id` and `recipient_user_id` parameters to Slack streaming API calls to fix `missing_recipient_team_id` errors in non-DM channels (public channels, private channels, groups).

The fix threads two optional parameters through `StartSlackStreamParams` and conditionally spreads them into the `client.chatStream()` call. The caller in `dispatch.ts` passes `ctx.teamId` and `ctx.botUserId` which are populated from Slack's `auth.test` API and can be empty strings if auth fails (non-fatal). The `|| undefined` conversion ensures empty strings are omitted from the API call.

The implementation correctly handles edge cases where these IDs might be unavailable (DM contexts or auth test failures) by using conditional spreading with the ternary operator.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted bug fix that adds required Slack API parameters. The implementation correctly handles edge cases (empty strings converted to undefined via `|| undefined`, conditional spreading via ternary operator). The parameters come from authenticated context that's already validated. All existing tests pass, and the author reports successful end-to-end verification across all channel types (DM, grouped DM, private channel, public channel). The change is backward compatible and minimal in scope.
- No files require special attention

<sub>Last reviewed commit: d2806a7</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->