### PR TITLE
chore(changelog): add unreleased fixes for #7734 and #21086

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker: pin base images to SHA256 digests in Docker builds to prevent mutable tag drift. (#7734) Thanks @coygeek.
+- Provider/HTTP: treat HTTP 503 as failover-eligible for LLM provider errors. (#21086) Thanks @Protocol-zero-0.
+
 - Discord/Gateway: handle close code 4014 (missing privileged gateway intents) without crashing the gateway. Thanks @thewilloftheshadow.
 - Security/Net: strip sensitive headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Cookie2`) on cross-origin redirects in `fetchWithSsrFGuard` to prevent credential forwarding across origin boundaries. (#20313) Thanks @afurm.
 - Auto-reply/Runner: emit `onAgentRunStart` only after agent lifecycle or tool activity begins (and only once per run), so fallback preflight errors no longer mark runs as started. (#21165) Thanks @shakkernerd.


### PR DESCRIPTION
## Summary

This changelog update adds the two newly merged upstream fixes to the Unreleased section:

- #7734 by @coygeek: Docker base images are now pinned to SHA256 digests.
- #21086 by @Protocol-zero-0: HTTP 503 provider errors are now treated as failover-eligible.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two recently merged fixes to the Unreleased section of `CHANGELOG.md`. The entries follow the established formatting conventions and correctly reference the merged PRs #7734 and #21086 with proper attribution to the respective contributors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are purely documentation updates that add two changelog entries for already-merged PRs. The formatting follows existing conventions, the PR references are accurate, and the authors are correctly attributed. No functional code changes are introduced.
- No files require special attention

<sub>Last reviewed commit: 4030772</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->