### PR TITLE
fix: group/channel sessions never reset daily (#21161)

### DIFF
--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -108,7 +108,7 @@ export function mergeSessionEntry(
   patch: Partial<SessionEntry>,
 ): SessionEntry {
   const sessionId = patch.sessionId ?? existing?.sessionId ?? crypto.randomUUID();
-  const updatedAt = Math.max(existing?.updatedAt ?? 0, patch.updatedAt ?? 0, Date.now());
+  const updatedAt = patch.updatedAt ?? existing?.updatedAt ?? Date.now();
   if (!existing) {
     return { ...patch, sessionId, updatedAt };
   }


### PR DESCRIPTION
## Summary

- **Bug:** `mergeSessionEntry` unconditionally set `updatedAt = Math.max(existing, patch, Date.now())`, causing metadata-only merges (from `recordSessionMetaFromInbound`) to always bump the timestamp to now. This made daily reset freshness checks always see group/channel sessions as "fresh", so the 4am daily reset never triggered.
- **Fix:** Change `updatedAt` resolution to `patch.updatedAt ?? existing?.updatedAt ?? Date.now()` — callers that explicitly provide `updatedAt` are unaffected, but metadata-only merges no longer silently advance the timestamp.
- **Scope:** 1-line fix in `src/config/sessions/types.ts`, 4 regression tests in `sessions.test.ts`

## Root Cause

`recordSessionMetaFromInbound` calls `mergeSessionEntry` with a metadata patch (chatType, groupId, etc.) that does **not** include `updatedAt`. The old `Math.max(...)` always included `Date.now()`, so every inbound message bumped `updatedAt` before `initSessionState` could check freshness. Since `evaluateSessionFreshness` compares `updatedAt < dailyResetAt`, and `updatedAt` was always "now" (after 4am), the session was never stale.

## Test plan

- [x] `mergeSessionEntry` does not auto-bump `updatedAt` on metadata-only patch
- [x] `mergeSessionEntry` advances `updatedAt` when patch explicitly provides it
- [x] `mergeSessionEntry` defaults to `Date.now()` for brand-new entries
- [x] End-to-end: session updated at 3am is correctly detected as stale after 4am boundary
- [x] `pnpm build && pnpm check && pnpm test` — all pass (454 config/session tests, 0 failures)

## AI Disclosure

This PR was fully AI-assisted (identified, coded, and tested by Claude Opus 4.6). The contributor understands the code and the fix. Session logs available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `mergeSessionEntry` to stop auto-bumping `updatedAt` on metadata-only merges, fixing a bug where group/channel sessions never reset at the daily 4am boundary. The old `Math.max` logic always included `Date.now()`, causing `recordSessionMetaFromInbound` to inadvertently advance timestamps when updating chatType/groupId metadata, making sessions appear perpetually fresh to the reset checker.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted bug fix with comprehensive test coverage
- The PR makes a surgical 1-line change to fix a specific bug with clear root cause analysis. The new logic (`patch.updatedAt ?? existing?.updatedAt ?? Date.now()`) is semantically correct - it preserves existing timestamps when no explicit update is provided, which is the intended behavior. Four regression tests comprehensively cover the three behavioral requirements (metadata-only merge, explicit update, new entry) plus an end-to-end freshness scenario. All call sites verified - explicit `updatedAt` patches (like `updateLastRoute`) continue to work correctly since patch takes precedence in the nullish coalescing chain.
- No files require special attention

<sub>Last reviewed commit: 2ff9685</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->