### PR TITLE
Security/Pairing: reject insecure non-loopback ws setup URLs

### DIFF
--- a/src/cli/qr-cli.test.ts
+++ b/src/cli/qr-cli.test.ts
@@ -79,6 +79,7 @@ describe("registerQrCli", () => {
       gateway: {
         bind: "custom",
         customBindHost: "gateway.local",
+        tls: { enabled: true },
         auth: { mode: "token", token: "tok" },
       },
     });
@@ -86,7 +87,7 @@ describe("registerQrCli", () => {
     await runQr(["--setup-code-only"]);
 
     const expected = encodePairingSetupCode({
-      url: "ws://gateway.local:18789",
+      url: "wss://gateway.local:18789",
       token: "tok",
     });
     expect(runtime.log).toHaveBeenCalledWith(expected);
@@ -98,6 +99,7 @@ describe("registerQrCli", () => {
       gateway: {
         bind: "custom",
         customBindHost: "gateway.local",
+        tls: { enabled: true },
         auth: { mode: "token", token: "tok" },
       },
     });
@@ -117,16 +119,31 @@ describe("registerQrCli", () => {
       gateway: {
         bind: "custom",
         customBindHost: "gateway.local",
+        tls: { enabled: true },
       },
     });
 
     await runQr(["--setup-code-only", "--token", "override-token"]);
 
     const expected = encodePairingSetupCode({
-      url: "ws://gateway.local:18789",
+      url: "wss://gateway.local:18789",
       token: "override-token",
     });
     expect(runtime.log).toHaveBeenCalledWith(expected);
+  });
+
+  it("exits when custom host uses insecure ws transport", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        bind: "custom",
+        customBindHost: "gateway.local",
+        auth: { mode: "token", token: "tok" },
+      },
+    });
+
+    await expectQrExit(["--setup-code-only"]);
+    const output = runtime.error.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(output).toContain("insecure ws://");
   });
 
   it("exits with error when gateway config is not pairable", async () => {

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -186,4 +186,24 @@ describe("pairing setup code", () => {
       urlSource: "gateway.remote.url",
     });
   });
+
+  it("allows IPv6 loopback ws:// URLs", async () => {
+    const resolved = await resolvePairingSetupFromConfig({
+      gateway: {
+        remote: { url: "ws://[0:0:0:0:0:0:0:1]:18789" },
+        auth: { mode: "token", token: "tok_123" },
+      },
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      payload: {
+        url: "ws://[::1]:18789",
+        token: "tok_123",
+        password: undefined,
+      },
+      authLabel: "token",
+      urlSource: "gateway.remote.url",
+    });
+  });
 });

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -28,6 +28,7 @@ describe("pairing setup code", () => {
         bind: "custom",
         customBindHost: "gateway.local",
         port: 19001,
+        tls: { enabled: true },
         auth: { mode: "token", token: "tok_123" },
       },
     });
@@ -35,7 +36,7 @@ describe("pairing setup code", () => {
     expect(resolved).toEqual({
       ok: true,
       payload: {
-        url: "ws://gateway.local:19001",
+        url: "wss://gateway.local:19001",
         token: "tok_123",
         password: undefined,
       },
@@ -50,6 +51,7 @@ describe("pairing setup code", () => {
         gateway: {
           bind: "custom",
           customBindHost: "gateway.local",
+          tls: { enabled: true },
           auth: { mode: "token", token: "old" },
         },
       },
@@ -145,5 +147,43 @@ describe("pairing setup code", () => {
       urlSource: "gateway.remote.url",
     });
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("rejects insecure remote ws:// URLs", async () => {
+    const resolved = await resolvePairingSetupFromConfig(
+      {
+        gateway: {
+          remote: { url: "ws://attacker.example:18789" },
+          auth: { mode: "token", token: "tok_123" },
+        },
+      },
+      { preferRemoteUrl: true },
+    );
+
+    expect(resolved.ok).toBe(false);
+    if (resolved.ok) {
+      throw new Error("expected setup resolution to fail");
+    }
+    expect(resolved.error).toContain("insecure ws://");
+  });
+
+  it("allows loopback ws:// URLs for local development", async () => {
+    const resolved = await resolvePairingSetupFromConfig({
+      gateway: {
+        remote: { url: "ws://127.0.0.1:18789" },
+        auth: { mode: "token", token: "tok_123" },
+      },
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      payload: {
+        url: "ws://127.0.0.1:18789",
+        token: "tok_123",
+        password: undefined,
+      },
+      authLabel: "token",
+      urlSource: "gateway.remote.url",
+    });
   });
 });

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -1,37 +1,17 @@
 import os from "node:os";
 import type { OpenClawConfig } from "../config/types.js";
+import { isSecureWebSocketUrl } from "../gateway/net.js";
 
 const DEFAULT_GATEWAY_PORT = 18789;
-
-function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname
-    .trim()
-    .toLowerCase()
-    .replace(/^\[|\]$/g, "");
-  if (!normalized) {
-    return false;
-  }
-  return (
-    normalized === "localhost" ||
-    normalized === "127.0.0.1" ||
-    normalized.startsWith("127.") ||
-    normalized === "::1" ||
-    normalized === "0:0:0:0:0:0:0:1" ||
-    normalized.startsWith("::ffff:127.")
-  );
-}
 
 function validateTransportSecurity(url: string): string | null {
   try {
     const parsed = new URL(url);
     const protocol = parsed.protocol.toLowerCase();
-    if (protocol === "wss:") {
-      return null;
-    }
-    if (protocol !== "ws:") {
+    if (protocol !== "ws:" && protocol !== "wss:") {
       return "Gateway URL must use ws:// or wss://.";
     }
-    if (isLoopbackHost(parsed.hostname)) {
+    if (isSecureWebSocketUrl(url)) {
       return null;
     }
     return "Refusing to generate setup code with insecure ws:// for non-loopback host. Use wss://.";

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -4,7 +4,10 @@ import type { OpenClawConfig } from "../config/types.js";
 const DEFAULT_GATEWAY_PORT = 18789;
 
 function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname.trim().toLowerCase();
+  const normalized = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
   if (!normalized) {
     return false;
   }
@@ -13,6 +16,7 @@ function isLoopbackHost(hostname: string): boolean {
     normalized === "127.0.0.1" ||
     normalized.startsWith("127.") ||
     normalized === "::1" ||
+    normalized === "0:0:0:0:0:0:0:1" ||
     normalized.startsWith("::ffff:127.")
   );
 }


### PR DESCRIPTION
## Summary
- reject setup-code generation when the resolved gateway URL is `ws://` on a non-loopback host
- keep loopback `ws://` support for local development
- add regression tests for rejected insecure remote URLs and allowed loopback URLs
- update existing pairing tests to use TLS where required by the new guard

## Why
Pairing setup payloads include gateway credentials. Allowing plaintext non-loopback WebSocket URLs can expose those credentials in transit.

## Testing
- `pnpm test src/pairing/setup-code.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds transport security validation to pairing setup, rejecting plaintext `ws://` connections to non-loopback hosts while preserving local development workflows. The implementation uses loopback detection covering standard patterns (`localhost`, `127.*`, `::1`, `::ffff:127.*`) and validates URLs before setup code generation.

- Implemented `isLoopbackHost()` helper to identify loopback addresses
- Added `validateTransportSecurity()` to enforce `wss://` for remote hosts
- Updated existing tests to use TLS where required by the new validation
- Added regression tests for both rejected insecure URLs and allowed loopback cases

<h3>Confidence Score: 4/5</h3>

- This security improvement is safe to merge with minor edge cases to consider
- The PR correctly implements transport security validation to prevent credential exposure over plaintext connections. The implementation has good test coverage and updates existing tests appropriately. One minor consideration is IPv6 loopback variant handling, but the current implementation covers standard cases. The security benefit significantly outweighs the small risk of edge case scenarios.
- No files require special attention - the implementation is straightforward and well-tested

<sub>Last reviewed commit: cd4268c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->