### PR TITLE
Security: reject insecure non-loopback gateway deep links

### DIFF
--- a/apps/ios/Tests/DeepLinkParserTests.swift
+++ b/apps/ios/Tests/DeepLinkParserTests.swift
@@ -85,6 +85,12 @@ import Testing
                 .init(host: "openclaw.local", port: 18789, tls: true, token: "abc", password: "def")))
     }
 
+    @Test func parseGatewayLinkRejectsInsecureNonLoopbackWs() {
+        let url = URL(
+            string: "openclaw://gateway?host=attacker.example&port=18789&tls=0&token=abc")!
+        #expect(DeepLinkParser.parse(url) == nil)
+    }
+
     @Test func parseGatewaySetupCodeParsesBase64UrlPayload() {
         let payload = #"{"url":"wss://gateway.example.com:443","token":"tok","password":"pw"}"#
         let encoded = Data(payload.utf8)
@@ -121,6 +127,36 @@ import Testing
             host: "gateway.example.com",
             port: 443,
             tls: true,
+            token: "tok",
+            password: nil))
+    }
+
+    @Test func parseGatewaySetupCodeRejectsInsecureNonLoopbackWs() {
+        let payload = #"{"url":"ws://attacker.example:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+        #expect(link == nil)
+    }
+
+    @Test func parseGatewaySetupCodeAllowsLoopbackWs() {
+        let payload = #"{"url":"ws://127.0.0.1:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+
+        #expect(link == .init(
+            host: "127.0.0.1",
+            port: 18789,
+            tls: false,
             token: "tok",
             password: nil))
     }

--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -1,6 +1,23 @@
 import Foundation
 
 enum GatewayRemoteConfig {
+    private static func isLoopbackHost(_ rawHost: String) -> Bool {
+        let host = rawHost
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        if host.isEmpty {
+            return false
+        }
+        if host == "localhost" || host == "::1" || host == "127.0.0.1" {
+            return true
+        }
+        if host.hasPrefix("127.") || host.hasPrefix("::ffff:127.") {
+            return true
+        }
+        return false
+    }
+
     static func resolveTransport(root: [String: Any]) -> AppState.RemoteTransport {
         guard let gateway = root["gateway"] as? [String: Any],
               let remote = gateway["remote"] as? [String: Any],
@@ -39,6 +56,9 @@ enum GatewayRemoteConfig {
         guard scheme == "ws" || scheme == "wss" else { return nil }
         let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !host.isEmpty else { return nil }
+        if scheme == "ws", !self.isLoopbackHost(host) {
+            return nil
+        }
         if scheme == "ws", url.port == nil {
             guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
                 return url

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -218,9 +218,14 @@ import Testing
         #expect(url.absoluteString == "https://gateway.example:443/remote-ui/")
     }
 
-    @Test func normalizeGatewayUrlAddsDefaultPortForWs() {
-        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://gateway")
+    @Test func normalizeGatewayUrlAddsDefaultPortForLoopbackWs() {
+        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://127.0.0.1")
         #expect(url?.port == 18789)
-        #expect(url?.absoluteString == "ws://gateway:18789")
+        #expect(url?.absoluteString == "ws://127.0.0.1:18789")
+    }
+
+    @Test func normalizeGatewayUrlRejectsNonLoopbackWs() {
+        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://gateway")
+        #expect(url == nil)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
@@ -1,0 +1,45 @@
+import OpenClawKit
+import Foundation
+import Testing
+
+@Suite struct DeepLinksSecurityTests {
+    @Test func gatewayDeepLinkRejectsInsecureNonLoopbackWs() {
+        let url = URL(
+            string: "openclaw://gateway?host=attacker.example&port=18789&tls=0&token=abc")!
+        #expect(DeepLinkParser.parse(url) == nil)
+    }
+
+    @Test func gatewayDeepLinkAllowsLoopbackWs() {
+        let url = URL(
+            string: "openclaw://gateway?host=127.0.0.1&port=18789&tls=0&token=abc")!
+        #expect(
+            DeepLinkParser.parse(url) == .gateway(
+                .init(host: "127.0.0.1", port: 18789, tls: false, token: "abc", password: nil)))
+    }
+
+    @Test func setupCodeRejectsInsecureNonLoopbackWs() {
+        let payload = #"{"url":"ws://attacker.example:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        #expect(GatewayConnectDeepLink.fromSetupCode(encoded) == nil)
+    }
+
+    @Test func setupCodeAllowsLoopbackWs() {
+        let payload = #"{"url":"ws://127.0.0.1:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        #expect(
+            GatewayConnectDeepLink.fromSetupCode(encoded) == .init(
+                host: "127.0.0.1",
+                port: 18789,
+                tls: false,
+                token: "tok",
+                password: nil))
+    }
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 


### PR DESCRIPTION
## Summary
- reject `openclaw://gateway` deep links that request insecure `ws://` transport for non-loopback hosts
- reject setup-code payloads with insecure non-loopback `ws://` URLs
- keep loopback `ws://` flows working for local development and same-host agent setups
- apply equivalent guardrails in macOS remote config normalization
- add iOS/macOS/OpenClawKit tests for reject/allow behavior

## Security impact
This closes a configuration/deep-link vector where users could be tricked into pairing over cleartext WebSocket to a non-loopback host, exposing gateway tokens in transit.

## Validation
- `swift test --package-path apps/shared/OpenClawKit --filter DeepLinksSecurityTests` *(fails in this environment due upstream macro plugin resolution in dependency checkout: `SwiftUIMacros` not found; unrelated to this change)*
- `swiftc apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift /tmp/deeplink_security_repro.swift -o /tmp/deeplink_security_repro && /tmp/deeplink_security_repro`
- `swiftc apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift /tmp/gateway_remote_config_repro.swift -o /tmp/gateway_remote_config_repro && /tmp/gateway_remote_config_repro`

## Notes
- scoped to avoid overlap with currently open PRs from this repo fork

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds security guardrails to prevent cleartext WebSocket (`ws://`) connections to non-loopback hosts in gateway deep links and setup codes, mitigating a social engineering vector where users could be tricked into pairing over insecure connections.

**Key changes:**
- Added `isLoopbackHost()` helper in `DeepLinks.swift` and `GatewayRemoteConfig.swift` that checks for `localhost`, `127.0.0.1`, `::1`, and `127.*` prefixes
- Modified `DeepLinkParser.parse()` to reject `openclaw://gateway` deep links with `tls=0` for non-loopback hosts
- Modified `GatewayConnectDeepLink.fromSetupCode()` to reject setup code payloads with insecure non-loopback `ws://` URLs
- Modified `GatewayRemoteConfig.normalizeGatewayUrl()` to reject non-loopback `ws://` URLs in macOS remote config
- Added comprehensive test coverage across iOS, macOS, and OpenClawKit test suites

**Security impact:**
This prevents users from being socially engineered into establishing cleartext WebSocket connections that would expose gateway authentication tokens to network eavesdropping. The change preserves local development workflows (`ws://127.0.0.1`) while blocking the attack vector (`ws://attacker.example`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it adds important security protections without affecting legitimate use cases
- The implementation is clean, well-tested, and narrowly scoped to address a specific security vulnerability. The loopback detection logic is duplicated across two files (DeepLinks.swift and GatewayRemoteConfig.swift) with identical implementations, comprehensive test coverage validates both rejection and allowance behavior, and the changes preserve backwards compatibility for legitimate local development scenarios
- No files require special attention - all changes are straightforward security improvements

<sub>Last reviewed commit: 290f1c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->