### PR TITLE
fix(telegram): stabilize partial finalization and MEDIA dedupe (AI-assisted)

### DIFF
--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -58,4 +58,20 @@ describe("filterMessagingToolMediaDuplicates", () => {
     });
     expect(result).toBe(payloads);
   });
+
+  it("strips mediaUrl when sent media uses local path and payload uses file scheme", () => {
+    const result = filterMessagingToolMediaDuplicates({
+      payloads: [{ text: "hello", mediaUrl: "file:///tmp/photo.jpg" }],
+      sentMediaUrls: ["/tmp/photo.jpg"],
+    });
+    expect(result).toEqual([{ text: "hello", mediaUrl: undefined, mediaUrls: undefined }]);
+  });
+
+  it("filters mediaUrls array when sent media uses file scheme and payload uses local path", () => {
+    const result = filterMessagingToolMediaDuplicates({
+      payloads: [{ text: "gallery", mediaUrls: ["/tmp/a.jpg", "https://example.com/a.jpg"] }],
+      sentMediaUrls: ["file:///tmp/a.jpg"],
+    });
+    expect(result).toEqual([{ text: "gallery", mediaUrls: ["https://example.com/a.jpg"] }]);
+  });
 });

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -459,7 +459,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.forceNewMessage).toHaveBeenCalled();
   });
 
-  it("does not force new message in partial mode when reasoning ends", async () => {
+  it("does not force new message in partial mode when reasoning stream ends", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -298,6 +298,37 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.stop).toHaveBeenCalled();
   });
 
+  it("edits final in place when preview message id becomes available after stop", async () => {
+    let messageId: number | undefined;
+    const draftStream = {
+      update: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+      messageId: vi.fn(() => messageId),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(async () => {
+        await Promise.resolve();
+        messageId = 777;
+      }),
+      forceNewMessage: vi.fn(),
+    };
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Hel" });
+        await dispatcherOptions.deliver({ text: "Hello final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "777" });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(draftStream.stop).toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledWith(123, 777, "Hello final", expect.any(Object));
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("disables block streaming when streamMode is off", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver({ text: "Hello" }, { kind: "final" });
@@ -384,6 +415,25 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
   });
 
+  it("does not force new message in partial mode when assistant message restarts", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "First response" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "After tool call" });
+        await dispatcherOptions.deliver({ text: "After tool call" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+  });
+
   it("forces new message when reasoning ends after previous output", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
@@ -448,6 +498,26 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     // No previous text output, so no forceNewMessage needed
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not force new message in partial mode when reasoning ends", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Let me check" });
+        await replyOptions?.onReasoningStream?.({ text: "Analyzing..." });
+        await replyOptions?.onReasoningEnd?.();
+        await replyOptions?.onPartialReply?.({ text: "Done" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
   });
 

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -415,25 +415,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
   });
 
-  it("does not force new message in partial mode when assistant message restarts", async () => {
-    const draftStream = createDraftStream(999);
-    createTelegramDraftStream.mockReturnValue(draftStream);
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onPartialReply?.({ text: "First response" });
-        await replyOptions?.onAssistantMessageStart?.();
-        await replyOptions?.onPartialReply?.({ text: "After tool call" });
-        await dispatcherOptions.deliver({ text: "After tool call" }, { kind: "final" });
-        return { queuedFinal: true };
-      },
-    );
-    deliverReplies.mockResolvedValue({ delivered: true });
-
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
-
-    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
-  });
-
   it("forces new message when reasoning ends after previous output", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
@@ -459,7 +440,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.forceNewMessage).toHaveBeenCalled();
   });
 
-  it("does not force new message in partial mode when reasoning stream ends", async () => {
+  it("does not force new message in partial mode when reasoning ends without reasoning stream", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -501,7 +482,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
   });
 
-  it("does not force new message in partial mode when reasoning ends", async () => {
+  it("does not force new message in partial mode when reasoning stream ends", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -454,7 +454,7 @@ export const dispatchTelegramMessage = async ({
       },
     }));
   } finally {
-            // Must stop() first to flush debounced content before clear() wipes state
+    // Must stop() first to flush debounced content before clear() wipes state
     await draftStream?.stop();
     if (!finalizedViaPreviewMessage) {
       await draftStream?.clear();

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -454,7 +454,7 @@ export const dispatchTelegramMessage = async ({
       },
     }));
   } finally {
-    // Must stop() first to flush debounced content before clear() wipes state
+            // Must stop() first to flush debounced content before clear() wipes state
     await draftStream?.stop();
     if (!finalizedViaPreviewMessage) {
       await draftStream?.clear();


### PR DESCRIPTION
## Summary

- Problem: Telegram `streamMode: partial` finalization could regress/overwrite expected final behavior, and MEDIA path variants (e.g. `file://` vs local path) could be treated as different entries.
- Why it matters: Users can see unstable final message behavior and duplicate/incorrect media handling in Telegram.
- What changed: Stabilized partial-to-final ordering in Telegram draft flow, normalized MEDIA path variants for dedupe, and added/updated focused tests.
- What did NOT change (scope boundary): No provider/model behavior changes outside Telegram/media payload handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18780
- Related #18784

## User-visible / Behavior Changes

- Telegram partial streaming finalization is more stable and less likely to regress at finalization boundary.
- MEDIA path variants (`file://...` vs equivalent local path) are deduped consistently.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js + pnpm
- Model/provider: N/A (unit tests)
- Integration/channel (if any): Telegram
- Relevant config (redacted): standard local config; no new config required

### Steps

1. Run Telegram partial-stream test paths and MEDIA payload dedupe tests.
2. Compare behavior for partial/final ordering and path-variant dedupe.
3. Confirm no regressions in targeted suites.

### Expected

- Stable finalization ordering in partial stream mode.
- Equivalent MEDIA paths dedupe to one logical entry.

### Actual

- Verified via passing targeted tests after patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Telegram draft-stream, dispatch, and payload dedupe tests.
- Edge cases checked: regressive partial snapshots, file/path variant dedupe.
- What you did **not** verify: full live Telegram E2E against production bot.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commits.
- Files/config to restore: Telegram draft/payload files touched in this PR.
- Known bad symptoms reviewers should watch for: duplicate media outputs or partial/final ordering regressions.

## Risks and Mitigations

- Risk: Over-dedup in unusual path edge cases.
  - Mitigation: path-variant tests added/updated; scope limited to MEDIA dedupe logic.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Stabilizes Telegram partial finalization ordering and normalizes MEDIA path variants for deduplication. The changes address two key issues: (1) partial-to-final message ordering regressions, and (2) `file://` vs local path variants being treated as different media entries.

**Key changes:**
- Added `normalizeMediaForDedupe` function in `reply-payloads.ts` that strips `file://` prefix to normalize path variants for consistent deduplication
- Added tests for cross-variant MEDIA deduplication (`file:///tmp/photo.jpg` vs `/tmp/photo.jpg`)
- Added test coverage for draft stream finalization edge cases (message ID available after stop)
- Added tests for partial mode behavior (no force new message on assistant restart or reasoning end)

**Issues found:**
- Two duplicate test names in `bot-message-dispatch.test.ts` that will cause test framework issues (lines 418 and 504)

<h3>Confidence Score: 3/5</h3>

- safe to merge after fixing duplicate test names
- core logic changes are focused and well-tested, but duplicate test names will cause test execution issues that must be resolved before merge
- src/telegram/bot-message-dispatch.test.ts requires removing duplicate tests before merge

<sub>Last reviewed commit: 5ac94b4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->