### PR TITLE
fix(cron): handle sessions list cron model override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .
 - Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runWithModelFallback } from "../../agents/model-fallback.js";
+
+// ---------- mocks ----------
+
+const resolveAgentConfigMock = vi.fn();
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentConfig: resolveAgentConfigMock,
+  resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
+  resolveAgentModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
+  resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
+  resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
+  resolveAgentSkillsFilter: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../agents/skills.js", () => ({
+  buildWorkspaceSkillSnapshot: vi.fn().mockReturnValue({
+    prompt: "<available_skills></available_skills>",
+    resolvedSkills: [],
+    version: 42,
+  }),
+}));
+
+vi.mock("../../agents/skills/refresh.js", () => ({
+  getSkillsSnapshotVersion: vi.fn().mockReturnValue(42),
+}));
+
+vi.mock("../../agents/workspace.js", () => ({
+  ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
+}));
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn().mockResolvedValue({ models: [] }),
+}));
+
+const resolveAllowedModelRefMock = vi.fn();
+const resolveConfiguredModelRefMock = vi.fn();
+
+vi.mock("../../agents/model-selection.js", () => ({
+  getModelRefStatus: vi.fn().mockReturnValue({ allowed: false }),
+  isCliProvider: vi.fn().mockReturnValue(false),
+  resolveAllowedModelRef: resolveAllowedModelRefMock,
+  resolveConfiguredModelRef: resolveConfiguredModelRefMock,
+  resolveHooksGmailModel: vi.fn().mockReturnValue(null),
+  resolveThinkingDefault: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: vi.fn(),
+}));
+
+const runWithModelFallbackMock = vi.mocked(runWithModelFallback);
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: vi.fn(),
+}));
+
+vi.mock("../../agents/context.js", () => ({
+  lookupContextTokens: vi.fn().mockReturnValue(128000),
+}));
+
+vi.mock("../../agents/date-time.js", () => ({
+  formatUserTime: vi.fn().mockReturnValue("2026-02-10 12:00"),
+  resolveUserTimeFormat: vi.fn().mockReturnValue("24h"),
+  resolveUserTimezone: vi.fn().mockReturnValue("UTC"),
+}));
+
+vi.mock("../../agents/timeout.js", () => ({
+  resolveAgentTimeoutMs: vi.fn().mockReturnValue(60_000),
+}));
+
+vi.mock("../../agents/usage.js", () => ({
+  deriveSessionTotalTokens: vi.fn().mockReturnValue(30),
+  hasNonzeroUsage: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: vi.fn(),
+}));
+
+vi.mock("../../agents/cli-session.js", () => ({
+  getCliSessionId: vi.fn().mockReturnValue(undefined),
+  setCliSessionId: vi.fn(),
+}));
+
+vi.mock("../../auto-reply/thinking.js", () => ({
+  normalizeThinkLevel: vi.fn().mockReturnValue(undefined),
+  normalizeVerboseLevel: vi.fn().mockReturnValue("off"),
+  supportsXHighThinking: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../../cli/outbound-send-deps.js", () => ({
+  createOutboundSendDeps: vi.fn().mockReturnValue({}),
+}));
+
+const updateSessionStoreMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
+  resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  updateSessionStore: updateSessionStoreMock,
+}));
+
+vi.mock("../../routing/session-key.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../routing/session-key.js")>();
+  return {
+    ...actual,
+    buildAgentMainSessionKey: vi.fn().mockReturnValue("agent:default:cron:test"),
+    normalizeAgentId: vi.fn((id: string) => id),
+  };
+});
+
+vi.mock("../../infra/agent-events.js", () => ({
+  registerAgentRunContext: vi.fn(),
+}));
+
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+vi.mock("../../security/external-content.js", () => ({
+  buildSafeExternalPrompt: vi.fn().mockReturnValue("safe prompt"),
+  detectSuspiciousPatterns: vi.fn().mockReturnValue([]),
+  getHookType: vi.fn().mockReturnValue("unknown"),
+  isExternalHookSession: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../delivery.js", () => ({
+  resolveCronDeliveryPlan: vi.fn().mockReturnValue({ requested: false }),
+}));
+
+vi.mock("./delivery-target.js", () => ({
+  resolveDeliveryTarget: vi.fn().mockResolvedValue({
+    channel: "discord",
+    to: undefined,
+    accountId: undefined,
+    error: undefined,
+  }),
+}));
+
+vi.mock("./helpers.js", () => ({
+  isHeartbeatOnlyResponse: vi.fn().mockReturnValue(false),
+  pickLastDeliverablePayload: vi.fn().mockReturnValue(undefined),
+  pickLastNonEmptyTextFromPayloads: vi.fn().mockReturnValue("test output"),
+  pickSummaryFromOutput: vi.fn().mockReturnValue("summary"),
+  pickSummaryFromPayloads: vi.fn().mockReturnValue("summary"),
+  resolveHeartbeatAckMaxChars: vi.fn().mockReturnValue(100),
+}));
+
+const resolveCronSessionMock = vi.fn();
+vi.mock("./session.js", () => ({
+  resolveCronSession: resolveCronSessionMock,
+}));
+
+vi.mock("../../agents/defaults.js", () => ({
+  DEFAULT_CONTEXT_TOKENS: 128000,
+  DEFAULT_MODEL: "gpt-4",
+  DEFAULT_PROVIDER: "openai",
+}));
+
+const { runCronIsolatedAgentTurn } = await import("./run.js");
+
+// ---------- helpers ----------
+
+function makeJob(overrides?: Record<string, unknown>) {
+  return {
+    id: "digest-job",
+    name: "Daily Digest",
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    payload: {
+      kind: "agentTurn",
+      message: "run daily digest",
+      model: "anthropic/claude-sonnet-4-6",
+    },
+    ...overrides,
+  } as never;
+}
+
+function makeParams(overrides?: Record<string, unknown>) {
+  return {
+    cfg: {},
+    deps: {} as never,
+    job: makeJob(),
+    message: "run daily digest",
+    sessionKey: "cron:digest",
+    ...overrides,
+  };
+}
+
+function makeFreshSessionEntry() {
+  return {
+    sessionId: "test-session-id",
+    updatedAt: 0,
+    systemSent: false,
+    skillsSnapshot: undefined,
+    // Crucially: no model or modelProvider — simulates a brand-new session
+    model: undefined as string | undefined,
+    modelProvider: undefined as string | undefined,
+  };
+}
+
+// ---------- tests ----------
+
+describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
+  let previousFastTestEnv: string | undefined;
+  let sessionEntry: ReturnType<typeof makeFreshSessionEntry>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    previousFastTestEnv = process.env.OPENCLAW_TEST_FAST;
+    delete process.env.OPENCLAW_TEST_FAST;
+
+    // Agent default model is Opus
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    // Cron payload model override resolves to Sonnet
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "anthropic", model: "claude-sonnet-4-6" },
+    });
+
+    resolveAgentConfigMock.mockReturnValue(undefined);
+
+    sessionEntry = makeFreshSessionEntry();
+    resolveCronSessionMock.mockReturnValue({
+      storePath: "/tmp/store.json",
+      store: {},
+      sessionEntry,
+      systemSent: false,
+      isNewSession: true,
+    });
+  });
+
+  afterEach(() => {
+    if (previousFastTestEnv == null) {
+      delete process.env.OPENCLAW_TEST_FAST;
+      return;
+    }
+    process.env.OPENCLAW_TEST_FAST = previousFastTestEnv;
+  });
+
+  it("persists cron payload model on session entry even when the run throws", async () => {
+    // Simulate the agent run throwing (e.g. LLM provider timeout)
+    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
+
+    const result = await runCronIsolatedAgentTurn(makeParams());
+
+    expect(result.status).toBe("error");
+
+    // The session entry should record the intended cron model override (Sonnet)
+    // so that sessions_list does not fall back to the agent default (Opus).
+    //
+    // BUG (#21057): the model is only written AFTER a successful run (line 520),
+    // so it remains undefined when the run throws at the catch on line 502.
+    expect(sessionEntry.model).toBe("claude-sonnet-4-6");
+    expect(sessionEntry.modelProvider).toBe("anthropic");
+  });
+
+  it("persists cron payload model before the run starts (pre-run persist)", async () => {
+    // Simulate a successful run
+    runWithModelFallbackMock.mockResolvedValueOnce({
+      result: {
+        payloads: [{ text: "digest complete" }],
+        meta: {
+          agentMeta: {
+            model: "claude-sonnet-4-6",
+            provider: "anthropic",
+            usage: { input: 100, output: 50 },
+          },
+        },
+      },
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    // The pre-run persist (line 432) should already include the cron model
+    // override so that even a concurrent sessions_list call sees Sonnet, not
+    // the agent default Opus.
+    //
+    // Inspect the updateSessionStore calls: the pre-run persist happens before
+    // the run, and the post-run persist happens after.  Both should carry the
+    // cron override model — not undefined.
+    const preRunCalls = updateSessionStoreMock.mock.calls;
+    expect(preRunCalls.length).toBeGreaterThanOrEqual(2);
+
+    // Execute the pre-run persist callback (second call — first is skills snapshot)
+    // against a fresh store to capture what it would write.
+    const preRunStore: Record<string, unknown> = {};
+    const preRunCallback = preRunCalls[1][1] as (store: Record<string, unknown>) => void;
+    preRunCallback(preRunStore);
+
+    const preRunEntry = Object.values(preRunStore)[0] as {
+      model?: string;
+      modelProvider?: string;
+    };
+    expect(preRunEntry.model).toBe("claude-sonnet-4-6");
+    expect(preRunEntry.modelProvider).toBe("anthropic");
+  });
+});

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -229,6 +229,7 @@ function makeSuccessfulRunResult(overrides?: Record<string, unknown>) {
     },
     provider: "anthropic",
     model: "claude-sonnet-4-6",
+    attempts: [],
     ...overrides,
   };
 }

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -127,8 +127,9 @@ vi.mock("../../infra/skills-remote.js", () => ({
   getRemoteSkillEligibility: vi.fn().mockReturnValue({}),
 }));
 
+const logWarnMock = vi.fn();
 vi.mock("../../logger.js", () => ({
-  logWarn: vi.fn(),
+  logWarn: logWarnMock,
 }));
 
 vi.mock("../../security/external-content.js", () => ({
@@ -201,7 +202,7 @@ function makeParams(overrides?: Record<string, unknown>) {
   };
 }
 
-function makeFreshSessionEntry() {
+function makeFreshSessionEntry(overrides?: Record<string, unknown>) {
   return {
     sessionId: "test-session-id",
     updatedAt: 0,
@@ -210,6 +211,25 @@ function makeFreshSessionEntry() {
     // Crucially: no model or modelProvider — simulates a brand-new session
     model: undefined as string | undefined,
     modelProvider: undefined as string | undefined,
+    ...overrides,
+  };
+}
+
+function makeSuccessfulRunResult(overrides?: Record<string, unknown>) {
+  return {
+    result: {
+      payloads: [{ text: "digest complete" }],
+      meta: {
+        agentMeta: {
+          model: "claude-sonnet-4-6",
+          provider: "anthropic",
+          usage: { input: 100, output: 50 },
+        },
+      },
+    },
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    ...overrides,
   };
 }
 
@@ -239,6 +259,7 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     });
 
     resolveAgentConfigMock.mockReturnValue(undefined);
+    updateSessionStoreMock.mockResolvedValue(undefined);
 
     cronSession = {
       storePath: "/tmp/store.json",
@@ -269,23 +290,29 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     // The session entry should record the intended cron model override (Sonnet)
     // so that sessions_list does not fall back to the agent default (Opus).
     //
-    // BUG (#21057): the model is only written AFTER a successful run (line 520),
-    // so it remains undefined when the run throws at the catch on line 502.
+    // BUG (#21057): before the fix, the model was only written to the session
+    // entry AFTER a successful run (in the post-run telemetry block), so it
+    // remained undefined when the run threw in the catch block.
     expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+    expect(cronSession.sessionEntry.systemSent).toBe(true);
   });
 
   it("session entry already carries cron model at pre-run persist time (race condition)", async () => {
     // Capture a deep snapshot of the session entry at each persist call so we
     // can inspect what sessions_list would see mid-run — before the post-run
     // persist overwrites the entry with the actual model from agentMeta.
-    const persistedSnapshots: Array<{ model?: string; modelProvider?: string }> = [];
+    const persistedSnapshots: Array<{
+      model?: string;
+      modelProvider?: string;
+      systemSent?: boolean;
+    }> = [];
     updateSessionStoreMock.mockImplementation(
       async (_path: string, cb: (s: Record<string, unknown>) => void) => {
         const store: Record<string, unknown> = {};
         cb(store);
         const entry = Object.values(store)[0] as
-          | { model?: string; modelProvider?: string }
+          | { model?: string; modelProvider?: string; systemSent?: boolean }
           | undefined;
         if (entry) {
           persistedSnapshots.push(JSON.parse(JSON.stringify(entry)));
@@ -293,30 +320,102 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
       },
     );
 
-    // Simulate a successful run
-    runWithModelFallbackMock.mockResolvedValueOnce({
-      result: {
-        payloads: [{ text: "digest complete" }],
-        meta: {
-          agentMeta: {
-            model: "claude-sonnet-4-6",
-            provider: "anthropic",
-            usage: { input: 100, output: 50 },
-          },
-        },
-      },
-      provider: "anthropic",
-      model: "claude-sonnet-4-6",
-    });
+    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
 
     await runCronIsolatedAgentTurn(makeParams());
 
-    // There are at least 3 persists: skills snapshot, pre-run, post-run.
-    // The pre-run persist (index 1) is the one a concurrent sessions_list
+    // Persist ordering: [0] skills snapshot, [1] pre-run model+systemSent,
+    // [2] post-run telemetry.  Index 1 is what a concurrent sessions_list
     // would read while the agent run is in flight.
-    expect(persistedSnapshots.length).toBeGreaterThanOrEqual(2);
+    expect(persistedSnapshots.length).toBeGreaterThanOrEqual(3);
     const preRunSnapshot = persistedSnapshots[1];
     expect(preRunSnapshot.model).toBe("claude-sonnet-4-6");
     expect(preRunSnapshot.modelProvider).toBe("anthropic");
+    expect(preRunSnapshot.systemSent).toBe(true);
+  });
+
+  it("returns error without persisting model when payload model is disallowed", async () => {
+    resolveAllowedModelRefMock.mockReturnValueOnce({
+      error: "Model not allowed: anthropic/claude-sonnet-4-6",
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeParams());
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("Model not allowed");
+    // Model should remain undefined — the early return happens before the
+    // pre-run persist block, so neither the session entry nor the store
+    // should be touched with a rejected model.
+    expect(cronSession.sessionEntry.model).toBeUndefined();
+    expect(cronSession.sessionEntry.modelProvider).toBeUndefined();
+  });
+
+  it("persists session-level /model override on session entry before the run", async () => {
+    // No cron payload model — the job has no model field
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "run daily digest" },
+    });
+
+    // Session-level /model override set by user (e.g. via /model command)
+    cronSession.sessionEntry = makeFreshSessionEntry({
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    });
+    resolveCronSessionMock.mockReturnValue(cronSession);
+
+    // resolveAllowedModelRef is called for the session override path too
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "anthropic", model: "claude-haiku-4-5" },
+    });
+
+    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
+
+    expect(result.status).toBe("error");
+    // Even though the run failed, the session-level model override should
+    // be persisted on the entry — not the agent default (Opus).
+    expect(cronSession.sessionEntry.model).toBe("claude-haiku-4-5");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+  });
+
+  it("logs warning and continues when pre-run persist fails", async () => {
+    // Persist ordering: [1] skills snapshot, [2] pre-run, [3] post-run.
+    // Only the pre-run persist (call 2) should fail — the skills snapshot
+    // persist is pre-existing code without a try-catch guard.
+    let callCount = 0;
+    updateSessionStoreMock.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 2) {
+        throw new Error("ENOSPC: no space left on device");
+      }
+    });
+
+    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
+
+    const result = await runCronIsolatedAgentTurn(makeParams());
+
+    // The run should still complete successfully despite the persist failure
+    expect(result.status).toBe("ok");
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to persist pre-run session entry"),
+    );
+  });
+
+  it("persists default model pre-run when no payload override is present", async () => {
+    // No cron payload model override
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "run daily digest" },
+    });
+
+    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
+
+    expect(result.status).toBe("error");
+    // With no override, the default model (Opus) should still be persisted
+    // on the session entry rather than left undefined.
+    expect(cronSession.sessionEntry.model).toBe("claude-opus-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });
 });

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -37,14 +37,18 @@ vi.mock("../../agents/model-catalog.js", () => ({
 const resolveAllowedModelRefMock = vi.fn();
 const resolveConfiguredModelRefMock = vi.fn();
 
-vi.mock("../../agents/model-selection.js", () => ({
-  getModelRefStatus: vi.fn().mockReturnValue({ allowed: false }),
-  isCliProvider: vi.fn().mockReturnValue(false),
-  resolveAllowedModelRef: resolveAllowedModelRefMock,
-  resolveConfiguredModelRef: resolveConfiguredModelRefMock,
-  resolveHooksGmailModel: vi.fn().mockReturnValue(null),
-  resolveThinkingDefault: vi.fn().mockReturnValue(undefined),
-}));
+vi.mock("../../agents/model-selection.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/model-selection.js")>();
+  return {
+    ...actual,
+    getModelRefStatus: vi.fn().mockReturnValue({ allowed: false }),
+    isCliProvider: vi.fn().mockReturnValue(false),
+    resolveAllowedModelRef: resolveAllowedModelRefMock,
+    resolveConfiguredModelRef: resolveConfiguredModelRefMock,
+    resolveHooksGmailModel: vi.fn().mockReturnValue(null),
+    resolveThinkingDefault: vi.fn().mockReturnValue(undefined),
+  };
+});
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: vi.fn(),

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -107,6 +107,7 @@ const updateSessionStoreMock = vi.fn().mockResolvedValue(undefined);
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn(),
   updateSessionStore: updateSessionStoreMock,
 }));
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -384,11 +384,16 @@ export async function runCronIsolatedAgentTurn(params: {
 
   // Persist the intended model and systemSent before the run so that
   // sessions_list reflects the cron override even if the run fails or is
-  // still in progress (#21057).
+  // still in progress (#21057).  Best-effort: a filesystem error here
+  // must not prevent the actual agent run from executing.
   cronSession.sessionEntry.modelProvider = provider;
   cronSession.sessionEntry.model = model;
   cronSession.sessionEntry.systemSent = true;
-  await persistSessionEntry();
+  try {
+    await persistSessionEntry();
+  } catch (err) {
+    logWarn(`[cron:${params.job.id}] Failed to persist pre-run session entry: ${String(err)}`);
+  }
 
   // Resolve auth profile for the session, mirroring the inbound auto-reply path
   // (get-reply-run.ts). Without this, isolated cron sessions fall back to env-var

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -382,7 +382,11 @@ export async function runCronIsolatedAgentTurn(params: {
     await persistSessionEntry();
   }
 
-  // Persist systemSent before the run, mirroring the inbound auto-reply behavior.
+  // Persist the intended model and systemSent before the run so that
+  // sessions_list reflects the cron override even if the run fails or is
+  // still in progress (#21057).
+  cronSession.sessionEntry.modelProvider = provider;
+  cronSession.sessionEntry.model = model;
   cronSession.sessionEntry.systemSent = true;
   await persistSessionEntry();
 


### PR DESCRIPTION
## Summary

- Problem: `sessions_list` shows the agent default model (e.g. Opus) instead of the actual cron payload model override (e.g. Sonnet), making cost tracking unreliable
- Why it matters: Users running cron jobs on cheaper models see inflated cost estimates because the wrong model is reported
- What changed: Set `model`/`modelProvider` on the session entry **before** the agent run (not only after), wrapped in best-effort try-catch
- What did NOT change (scope boundary): Post-run model persistence is untouched — it still overwrites with the actual model used (e.g. if fallback kicked in)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21057

## User-visible / Behavior Changes

`sessions_list` now correctly reflects the cron payload model override for failed and in-progress runs, instead of falling back to the agent default model.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node.js
- Model/provider: Any agent with a cron job that overrides `payload.model`
- Integration/channel (if any): Cron / isolated agent
- Relevant config (redacted): Agent defaulting to Opus with cron job specifying `model: "anthropic/claude-sonnet-4-6"`

### Steps

1. Configure an agent with default model `claude-opus-4-6`
2. Add a cron job with `payload.model: "anthropic/claude-sonnet-4-6"`
3. Trigger the cron job and call `sessions.list` while it runs or after it fails

### Expected

- `sessions_list` shows `claude-sonnet-4-6` for the cron session

### Actual

- `sessions_list` shows `claude-opus-4-6` (the agent default)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

6 test cases covering: error path, race condition (point-in-time persist snapshots), disallowed model rejection, session-level `/model` override, persist failure resilience, and default model (no override).

## Human Verification (required)

- Verified scenarios: All 28 `src/cron/isolated-agent/` tests pass; new tests confirmed failing before fix and passing after
- Edge cases checked: Filesystem error on persist (best-effort), disallowed payload model early-return, session-level `/model` override, no payload override
- What you did **not** verify: End-to-end with a live cron job and real `sessions.list` call

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 2-line addition in `src/cron/isolated-agent/run.ts` (lines 433-434)
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms reviewers should watch for: Model field on cron sessions showing unexpected values in `sessions_list`

## Risks and Mitigations

- Risk: Pre-run persist writes a model that differs from the actual model used (e.g. if fallback triggers)
  - Mitigation: The post-run persist at line 523-524 overwrites with the actual model from `agentMeta` on success; the pre-run value is only visible during the run or after a failure

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed race condition where `sessions_list` showed incorrect model for cron jobs when the run failed or was still in progress. The model override is now persisted to the session entry before the agent run executes, ensuring it reflects the intended cron model rather than falling back to the agent default.

- Moved model and provider persistence from post-run telemetry block to pre-run, immediately after model resolution
- Added try-catch wrapper around pre-run persist to make it best-effort (filesystem errors shouldn't block the agent run)
- Added comprehensive test coverage for edge cases: run failures, race conditions during mid-run reads, disallowed models, session-level overrides, and persist failures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-isolated to cron model persistence logic with comprehensive test coverage. The best-effort error handling ensures the change cannot break existing functionality. All 6 test cases pass and cover critical scenarios including failures, race conditions, and edge cases.
- No files require special attention

<sub>Last reviewed commit: 8eb6b13</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->