### PR TITLE
fix(exec): reflect configured exec host in tool schema default (#11150)

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -98,53 +98,60 @@ export const DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS = 130_000;
 const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
 
-export const execSchema = Type.Object({
-  command: Type.String({ description: "Shell command to execute" }),
-  workdir: Type.Optional(Type.String({ description: "Working directory (defaults to cwd)" })),
-  env: Type.Optional(Type.Record(Type.String(), Type.String())),
-  yieldMs: Type.Optional(
-    Type.Number({
-      description: "Milliseconds to wait before backgrounding (default 10000)",
-    }),
-  ),
-  background: Type.Optional(Type.Boolean({ description: "Run in background immediately" })),
-  timeout: Type.Optional(
-    Type.Number({
-      description: "Timeout in seconds (optional, kills process on expiry)",
-    }),
-  ),
-  pty: Type.Optional(
-    Type.Boolean({
-      description:
-        "Run in a pseudo-terminal (PTY) when available (TTY-required CLIs, coding agents)",
-    }),
-  ),
-  elevated: Type.Optional(
-    Type.Boolean({
-      description: "Run on the host with elevated permissions (if allowed)",
-    }),
-  ),
-  host: Type.Optional(
-    Type.String({
-      description: "Exec host (sandbox|gateway|node).",
-    }),
-  ),
-  security: Type.Optional(
-    Type.String({
-      description: "Exec security mode (deny|allowlist|full).",
-    }),
-  ),
-  ask: Type.Optional(
-    Type.String({
-      description: "Exec ask mode (off|on-miss|always).",
-    }),
-  ),
-  node: Type.Optional(
-    Type.String({
-      description: "Node id/name for host=node.",
-    }),
-  ),
-});
+export function createExecSchema(options?: { defaultHost?: ExecHost }) {
+  return Type.Object({
+    command: Type.String({ description: "Shell command to execute" }),
+    workdir: Type.Optional(Type.String({ description: "Working directory (defaults to cwd)" })),
+    env: Type.Optional(Type.Record(Type.String(), Type.String())),
+    yieldMs: Type.Optional(
+      Type.Number({
+        description: "Milliseconds to wait before backgrounding (default 10000)",
+      }),
+    ),
+    background: Type.Optional(Type.Boolean({ description: "Run in background immediately" })),
+    timeout: Type.Optional(
+      Type.Number({
+        description: "Timeout in seconds (optional, kills process on expiry)",
+      }),
+    ),
+    pty: Type.Optional(
+      Type.Boolean({
+        description:
+          "Run in a pseudo-terminal (PTY) when available (TTY-required CLIs, coding agents)",
+      }),
+    ),
+    elevated: Type.Optional(
+      Type.Boolean({
+        description: "Run on the host with elevated permissions (if allowed)",
+      }),
+    ),
+    host: Type.Optional(
+      Type.String({
+        description: "Exec host (sandbox|gateway|node).",
+        // When tools.exec.host is configured, reflect it as the tool schema default so
+        // parameter-filling models don't repeatedly request a disallowed host.
+        default: options?.defaultHost ?? "sandbox",
+      }),
+    ),
+    security: Type.Optional(
+      Type.String({
+        description: "Exec security mode (deny|allowlist|full).",
+      }),
+    ),
+    ask: Type.Optional(
+      Type.String({
+        description: "Exec ask mode (off|on-miss|always).",
+      }),
+    ),
+    node: Type.Optional(
+      Type.String({
+        description: "Node id/name for host=node.",
+      }),
+    ),
+  });
+}
+
+export const execSchema = createExecSchema();
 
 export type ExecProcessOutcome = {
   status: "completed" | "failed";

--- a/src/agents/bash-tools.exec.schema.test.ts
+++ b/src/agents/bash-tools.exec.schema.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { createExecTool } from "./bash-tools.exec.js";
+
+describe("exec tool schema defaults", () => {
+  it("reflects configured tools.exec.host as host default", () => {
+    const tool = createExecTool({ host: "gateway" });
+    const schema = tool.parameters as {
+      properties?: Record<string, { default?: unknown }>;
+    };
+
+    expect(schema.properties?.host?.default).toBe("gateway");
+  });
+
+  it("defaults host to sandbox when not configured", () => {
+    const tool = createExecTool(undefined);
+    const schema = tool.parameters as {
+      properties?: Record<string, { default?: unknown }>;
+    };
+
+    expect(schema.properties?.host?.default).toBe("sandbox");
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -25,7 +25,7 @@ import {
   renderExecHostLabel,
   resolveApprovalRunningNoticeMs,
   runExecProcess,
-  execSchema,
+  createExecSchema,
   validateHostEnv,
 } from "./bash-tools.exec-runtime.js";
 import type {
@@ -180,7 +180,7 @@ export function createExecTool(
     label: "exec",
     description:
       "Execute shell commands with background continuation. Use yieldMs/background to continue later via process tool. Use pty=true for TTY-required commands (terminal UIs, coding agents).",
-    parameters: execSchema,
+    parameters: createExecSchema({ defaultHost: defaults?.host ?? "sandbox" }),
     execute: async (_toolCallId, args, signal, onUpdate) => {
       const params = args as {
         command: string;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -84,6 +84,11 @@ export const FIELD_HELP: Record<string, string> = {
     "When true (default), backgrounded exec sessions enqueue a system event and request a heartbeat on exit.",
   "tools.exec.notifyOnExitEmptySuccess":
     "When true, successful backgrounded exec exits with empty output still enqueue a completion system event (default: false).",
+  "tools.exec.host":
+    'Default exec host routing ("sandbox"|"gateway"|"node"). This is also reflected as the default in the exec tool schema shown to the model (default: "sandbox").',
+  "tools.exec.security":
+    'Default exec security mode ("deny"|"allowlist"|"full"). Default: "deny" (or "allowlist" on non-sandbox hosts).',
+  "tools.exec.ask": 'Default exec approval mode ("off"|"on-miss"|"always"). Default: "on-miss".',
   "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",
   "tools.exec.safeBins":
     "Allow stdin-only safe binaries to run without explicit allowlist entries.",


### PR DESCRIPTION
Fixes openclaw/openclaw#11150.

When 	ools.exec.host is configured (e.g. "gateway"), parameter-filling models often send host: "sandbox" because the exec tool schema default was static. This causes avoidable failed tool calls.

Changes:
- Make exec schema default host dynamic and derived from effective config.
- Add regression test for schema defaults.
- Document tools.exec host/security/ask defaults in schema help.

AI-assisted: yes.

Testing:
- pnpm check
- pnpm vitest run src/agents/bash-tools.exec.schema.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed parameter-filling models sending disallowed `host` values by making the exec tool schema default dynamic based on effective configuration. When `tools.exec.host` is configured (e.g., "gateway"), the schema now reflects this as the default instead of hardcoding "sandbox", preventing unnecessary failed tool calls.

**Changes:**
- Converted static `execSchema` to `createExecSchema()` function that accepts `defaultHost` parameter
- Updated `createExecTool` to pass configured host value to schema generator
- Maintained backward compatibility by exporting default `execSchema` instance
- Added regression tests verifying schema defaults match configuration
- Documented `tools.exec.host`, `tools.exec.security`, and `tools.exec.ask` defaults in schema help

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and maintains backward compatibility. The change only affects the tool schema default value shown to models, making it align with the actual configuration. The old `execSchema` export is preserved, tests cover both configured and unconfigured cases, and the documentation accurately describes the new behavior.
- No files require special attention

<sub>Last reviewed commit: 1c9a4c9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->