### PR TITLE
Security/Voice: reject malformed Host headers in webhook+WS server

### DIFF
--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -26,11 +26,23 @@ function firstHeaderValue(value: string | string[] | undefined): string | undefi
   return value;
 }
 
+function isMalformedHostHeaderValue(hostHeader: string): boolean {
+  return (
+    hostHeader.includes("@") ||
+    hostHeader.includes("\r") ||
+    hostHeader.includes("\n") ||
+    /\s/.test(hostHeader)
+  );
+}
+
 function parseHttpRequestUrl(params: {
   requestUrl: string | undefined;
   hostHeader: string | string[] | undefined;
 }): URL | null {
   const hostHeader = firstHeaderValue(params.hostHeader)?.trim();
+  if (hostHeader && isMalformedHostHeaderValue(hostHeader)) {
+    return null;
+  }
   const host = hostHeader || "localhost";
   try {
     return new URL(params.requestUrl || "/", `http://${host}`);


### PR DESCRIPTION
## Summary
- harden `VoiceCallWebhookServer` URL parsing for both HTTP webhooks and WebSocket upgrades
- reject malformed explicit `Host` headers with `400` instead of allowing uncaught URL parse exceptions
- add regression coverage proving malformed upgrade requests do not terminate the server

## Security impact
Malformed `Host` headers on upgrade/webhook paths could trigger an unhandled `Invalid URL` exception path, causing process instability/DoS in streaming-enabled deployments. This change fails closed and preserves service availability.

## Validation
- `pnpm vitest extensions/voice-call/src/webhook.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens webhook server against malformed `Host` header DoS by wrapping URL parsing in `parseHttpRequestUrl`, which returns `null` on parse failures with explicit host headers and falls back to localhost when no host is provided. Both HTTP webhooks and WebSocket upgrades now fail closed with `400 Bad Request` instead of throwing unhandled exceptions.

- Added `parseHttpRequestUrl` helper with safe URL construction and fallback logic
- Updated upgrade handler (`webhook.ts:224`) to reject malformed upgrades with `400 Bad Request` 
- Updated request handler (`webhook.ts:318`) to reject malformed requests with `400 Bad Request`
- Added regression test verifying server stability after malformed upgrade attempts

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused security hardening fix that adds proper error handling for malformed Host headers. The implementation uses defensive programming (fail closed), includes comprehensive test coverage proving the server remains stable after malformed requests, and follows the existing code patterns. No breaking changes, no uncovered edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 3373ab6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->