### PR TITLE
fix: sanitize tool call IDs at write time (#21178)

### DIFF
--- a/src/agents/session-tool-result-guard-id-normalization.test.ts
+++ b/src/agents/session-tool-result-guard-id-normalization.test.ts
@@ -1,0 +1,122 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+
+type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
+
+const asAppendMessage = (message: unknown) => message as AppendMessage;
+
+function getPersistedMessages(sm: SessionManager): AgentMessage[] {
+  return sm
+    .getEntries()
+    .filter((e) => e.type === "message")
+    .map((e) => (e as { message: AgentMessage }).message);
+}
+
+describe("tool call ID normalization at write time (#21178)", () => {
+  it("normalizes OpenAI-style tool call IDs on assistant messages", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "functions.read:0", name: "read", arguments: {} }],
+      }),
+    );
+
+    const messages = getPersistedMessages(sm);
+    expect(messages).toHaveLength(1);
+    const block = (messages[0] as { content: Array<{ id?: string }> }).content[0];
+    // Colons and dots stripped: "functions.read:0" → "functionsread0"
+    expect(block.id).toBe("functionsread0");
+  });
+
+  it("normalizes tool call IDs on toolResult messages consistently", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    // Assistant sends a tool call with OpenAI-format ID
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "functions.read:0", name: "read", arguments: {} }],
+      }),
+    );
+
+    // Tool result references the same raw ID
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "functions.read:0",
+        content: [{ type: "text", text: "file contents" }],
+        isError: false,
+      }),
+    );
+
+    const messages = getPersistedMessages(sm);
+    expect(messages).toHaveLength(2);
+    const assistantBlock = (messages[0] as { content: Array<{ id?: string }> }).content[0];
+    const toolResult = messages[1] as { toolCallId?: string };
+    // Both should be normalized to the same value
+    expect(assistantBlock.id).toBe("functionsread0");
+    expect(toolResult.toolCallId).toBe("functionsread0");
+  });
+
+  it("normalizes toolUseId on toolResult messages", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolUse", id: "call|special_chars", name: "write", arguments: {} }],
+      }),
+    );
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolUseId: "call|special_chars",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      }),
+    );
+
+    const messages = getPersistedMessages(sm);
+    expect(messages).toHaveLength(2);
+    const assistantBlock = (messages[0] as { content: Array<{ id?: string }> }).content[0];
+    const toolResult = messages[1] as { toolUseId?: string };
+    expect(assistantBlock.id).toBe("callspecialchars");
+    expect(toolResult.toolUseId).toBe("callspecialchars");
+  });
+
+  it("does not modify already-valid alphanumeric tool call IDs", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "toolu01XYZ", name: "read", arguments: {} }],
+      }),
+    );
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "toolu01XYZ",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      }),
+    );
+
+    const messages = getPersistedMessages(sm);
+    const assistantBlock = (messages[0] as { content: Array<{ id?: string }> }).content[0];
+    const toolResult = messages[1] as { toolCallId?: string };
+    // Already alphanumeric — should pass through unchanged
+    expect(assistantBlock.id).toBe("toolu01XYZ");
+    expect(toolResult.toolCallId).toBe("toolu01XYZ");
+  });
+});


### PR DESCRIPTION
## Summary
- Normalizes tool call IDs to alphanumeric format at write time in `session-tool-result-guard.ts`
- Prevents cross-provider session corruption when switching between models that generate different ID formats (e.g. OpenAI `functions.read:0` vs Anthropic `toolu_01X`)
- Both assistant tool call blocks and toolResult references are normalized consistently

Fixes #21178

## Test plan
- [x] Added `session-tool-result-guard-id-normalization.test.ts` with 4 test cases:
  - Normalizes OpenAI-style IDs on assistant messages
  - Normalizes toolCallId on toolResult messages consistently with assistant
  - Normalizes toolUseId on toolResult messages
  - Passes through already-valid alphanumeric IDs unchanged
- [x] All tests pass (`vitest run`)
- [x] Lint/format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalizes tool call IDs to alphanumeric format at write time to prevent cross-provider session corruption when switching between models with different ID formats (OpenAI `functions.read:0` vs Anthropic `toolu_01X`). Both assistant tool call blocks and toolResult references are normalized consistently using the existing `sanitizeToolCallId` function.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Well-tested fix that normalizes tool call IDs at write time using existing, proven sanitization logic. The change is minimal, focused, and covered by comprehensive tests validating both assistant and toolResult message normalization. The implementation correctly applies normalization before ID extraction, ensuring the pending map lookups work correctly.
- No files require special attention

<sub>Last reviewed commit: 85eec80</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->