### PR TITLE
test: guard test runner memory on local runs

### DIFF
--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -207,7 +207,7 @@ const WARNING_SUPPRESSION_FLAGS = [
   "--disable-warning=MaxListenersExceededWarning",
 ];
 
-const DEFAULT_CI_MAX_OLD_SPACE_SIZE_MB = 4096;
+const DEFAULT_MAX_OLD_SPACE_SIZE_MB = 4096;
 const maxOldSpaceSizeMb = (() => {
   // CI can hit Node heap limits (especially on large suites). Allow override, default to 4GB.
   const raw = process.env.OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB ?? "";
@@ -216,9 +216,10 @@ const maxOldSpaceSizeMb = (() => {
     return parsed;
   }
   if (isCI && !isWindows) {
-    return DEFAULT_CI_MAX_OLD_SPACE_SIZE_MB;
+    return DEFAULT_MAX_OLD_SPACE_SIZE_MB;
   }
-  return null;
+  // Local and Windows CI runs need the same guard to avoid hitting default 4GB V8 ceilings.
+  return DEFAULT_MAX_OLD_SPACE_SIZE_MB;
 })();
 
 function resolveReportDir() {


### PR DESCRIPTION
## Summary
- Apply a default V8 heap guard for local and non-Windows-CI test runs in `scripts/test-parallel.mjs` so `pnpm test` does not fail with default 4GB V8 OOM.
- This aligns local test execution with CI-like heap limiting behavior and reduces crashy behavior for large local suites.
- No behavior change to test selection or test content; only process-level runner options are affected.

## Testing
- node --check scripts/test-parallel.mjs
- pnpm exec vitest run src/commands/status.summary.redaction.test.ts --maxWorkers=2

## Notes
- The main `pnpm test` flow previously hit V8 OOM in this environment after long concurrent runs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Applied a default 4GB V8 heap limit to local and non-Windows CI test runs to prevent OOM failures during large test suites. The change renames the constant from `DEFAULT_CI_MAX_OLD_SPACE_SIZE_MB` to `DEFAULT_MAX_OLD_SPACE_SIZE_MB` and makes it apply universally (local + Windows CI + non-Windows CI) instead of just non-Windows CI.

- Renamed constant reflects broader applicability
- Now returns 4GB heap limit for all environments (previously returned `null` for local/Windows CI)
- Maintains override capability via `OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB` environment variable
- Missing heap guard in passthrough args code path (lines 336-376) - direct test invocations won't get the protection

<h3>Confidence Score: 3/5</h3>

- Safe to merge but has a logic gap in passthrough args path
- The main change correctly applies heap limiting to all test runs, but the passthrough args code path (used for direct test file invocations) doesn't apply the same heap guard, leaving a gap in OOM protection
- Pay attention to `scripts/test-parallel.mjs` - verify the passthrough args path applies heap limiting

<sub>Last reviewed commit: 7508444</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->