### PR TITLE
fix: correct article "an user" → "a user" in subagent spawn note

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -41,7 +41,7 @@ export type SpawnSubagentContext = {
 };
 
 export const SUBAGENT_SPAWN_ACCEPTED_NOTE =
-  "auto-announces on completion, do not poll/sleep. The response will be sent back as an user message.";
+  "auto-announces on completion, do not poll/sleep. The response will be sent back as a user message.";
 
 export type SpawnSubagentResult = {
   status: "accepted" | "forbidden" | "error";


### PR DESCRIPTION
## Summary
- Fixes grammatical error in `SUBAGENT_SPAWN_ACCEPTED_NOTE` in `src/agents/subagent-spawn.ts`
- "user" starts with a consonant sound, so the correct article is "a", not "an"
- This string is returned as the `note` field in `SpawnSubagentResult` and visible to agents/users

## Test plan
- [x] Grep confirmed no tests assert the exact old string — the constant is imported directly
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects grammatical error in `SUBAGENT_SPAWN_ACCEPTED_NOTE` constant from "an user" to "a user". The word "user" begins with a consonant sound (/ju:/), so the correct indefinite article is "a" rather than "an".

- Fixed grammar in `src/agents/subagent-spawn.ts:44`
- The constant is used in `SpawnSubagentResult` and returned to agents/users in the `note` field
- Test file imports the constant directly, so no test assertion updates needed

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a trivial grammatical fix that corrects a single article in a user-facing string constant. The change is purely cosmetic with zero behavioral impact, and the test suite correctly imports the constant rather than asserting on the literal string value.
- No files require special attention

<sub>Last reviewed commit: 8c35991</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->