### PR TITLE
fix(auto-reply): guard against empty issues in /config set error

### DIFF
--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -130,7 +130,7 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
       return {
         shouldContinue: false,
         reply: {
-          text: `⚠️ Config invalid after unset (${issue.path}: ${issue.message}).`,
+          text: `⚠️ Config invalid after unset (${issue?.path ?? "<root>"}: ${issue?.message ?? "invalid"}).`,
         },
       };
     }

--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -156,7 +156,7 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
       return {
         shouldContinue: false,
         reply: {
-          text: `⚠️ Config invalid after set (${issue.path}: ${issue.message}).`,
+          text: `⚠️ Config invalid after set (${issue?.path ?? "<root>"}: ${issue?.message ?? "invalid"}).`,
         },
       };
     }


### PR DESCRIPTION
## Summary
- `validateConfigObjectWithPlugins` can return `ok: false` with an empty `issues` array, causing `validated.issues[0]` to be `undefined`
- Accessing `.path` and `.message` on `undefined` throws `TypeError`, crashing the `/config set` handler
- Adds optional chaining (`?.`) and nullish-coalescing fallbacks, consistent with `src/gateway/openresponses-http.ts:360` which already handles this pattern correctly

## Test plan
- [ ] Send `/config set <invalid-key> <value>` and confirm the error reply is shown rather than an unhandled exception
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Guards `/config set` error handler against empty `issues` array from `validateConfigObjectWithPlugins` using optional chaining and nullish-coalescing fallbacks.

- Prevents `TypeError` when `validated.issues[0]` is `undefined`
- Matches existing pattern in `openresponses-http.ts:360`
- However, the same bug exists in the `/config unset` error handler at lines 129-133 and should be fixed too

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one additional fix needed for consistency
- The fix is correct and prevents a crash, but the PR only fixes the `/config set` branch while leaving the identical bug in the `/config unset` branch (lines 129-133). For full consistency and crash prevention, both branches should use the same defensive pattern.
- No files require special attention beyond addressing the unset branch issue

<sub>Last reviewed commit: 0496236</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->