### PR TITLE
fix: correct ACP session-creation rate-limit window from 10s to 60s

### DIFF
--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -59,7 +59,7 @@ type AcpGatewayAgentOptions = AcpServerOptions & {
 };
 
 const SESSION_CREATE_RATE_LIMIT_DEFAULT_MAX_REQUESTS = 120;
-const SESSION_CREATE_RATE_LIMIT_DEFAULT_WINDOW_MS = 10_000;
+const SESSION_CREATE_RATE_LIMIT_DEFAULT_WINDOW_MS = 60_000;
 
 export class AcpGatewayAgent implements Agent {
   private connection: AgentSideConnection;


### PR DESCRIPTION
## Summary
- The default rate-limit window for ACP session creation was `10_000` ms (10 seconds), allowing up to 120 sessions per 10 seconds (12/sec)
- Session creation is expensive (spawns a CLI process), so the window should be 60 seconds, capping sustained creation at 120/min (2/sec)
- Every existing test for this rate limiter already uses `windowMs: 60_000`, confirming the intended value
- Aligns the production default with test-documented expectations and provides 6x stronger burst protection

## Test plan
- [x] Existing `acp/translator.session-rate-limit.test.ts` tests pass (they supply their own `windowMs`)
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects the default ACP session-creation rate-limit window from 10 seconds to 60 seconds, aligning production defaults with test expectations.

- Changes `SESSION_CREATE_RATE_LIMIT_DEFAULT_WINDOW_MS` from `10_000` to `60_000` in `src/acp/translator.ts:62`
- Reduces sustained session-creation rate from 12/sec to 2/sec (120 per window)
- All existing tests in `acp/translator.session-rate-limit.test.ts` already use `windowMs: 60_000`, confirming this is the intended value
- Session creation spawns expensive CLI processes, so the 6x stronger burst protection is appropriate

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single constant change that aligns production code with test expectations, fixing an obvious configuration bug. The fix has strong supporting evidence (all tests use 60s window) and no negative side effects
- No files require special attention

<sub>Last reviewed commit: 237e0f6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->