### PR TITLE
fix(zalo): add missing slash in API URL path construction

### DIFF
--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -93,7 +93,7 @@ export async function callZaloApi<T = unknown>(
   body?: Record<string, unknown>,
   options?: { timeoutMs?: number; fetch?: ZaloFetch },
 ): Promise<ZaloApiResponse<T>> {
-  const url = `${ZALO_API_BASE}/bot${token}/${method}`;
+  const url = `${ZALO_API_BASE}/bot/${token}/${method}`;
   const controller = new AbortController();
   const timeoutId = options?.timeoutMs
     ? setTimeout(() => controller.abort(), options.timeoutMs)


### PR DESCRIPTION
## Summary
- `callZaloApi` constructed the URL as `` `/bot${token}/${method}` `` which concatenates "bot" directly to the token (e.g., `/botABC123/sendMessage`)
- The correct Zalo Bot API path format requires a slash separator: `/bot/<TOKEN>/method`
- Without this fix, **every** API call (probe, send message, get updates, set webhook) hits a malformed URL and returns 404, making the entire Zalo integration non-functional

## Test plan
- [ ] Configure a Zalo bot token and run `openclaw status` — probe should now succeed
- [ ] Send a test message via the Zalo extension and confirm delivery
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical URL construction bug where the token was concatenated directly to "bot" (`` `/bot${token}` ``) instead of being separated with a slash (`` `/bot/${token}` ``). This made all Zalo API calls (probe, send message, get updates, set webhook) fail with 404 errors, completely breaking the integration.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is a trivial one-character addition (adding `/` between "bot" and the token variable) that corrects a clear typo in the URL path. The change is correctly applied in the only location where the base URL is constructed (`callZaloApi` function at extensions/zalo/src/api.ts:96), and all other functions (`getMe`, `sendMessage`, `sendPhoto`, `getUpdates`, `setWebhook`, etc.) delegate to this single function, so no other code needs updating.
- No files require special attention

<sub>Last reviewed commit: c905d1a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->