### PR TITLE
fix(thinking): include openai-codex/gpt-5.2 in xhigh hint (#21284)

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
@@ -57,7 +57,7 @@ describe("directive behavior", () => {
     await withTempHome(async (home) => {
       const texts = await runThinkingDirective(home, "openai/gpt-4.1-mini");
       expect(texts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
+        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
       );
     });
   });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -46,6 +46,10 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("openai", "gpt-5.2")).toContain("xhigh");
   });
 
+  it("includes xhigh for openai-codex gpt-5.2", () => {
+    expect(listThinkingLevels("openai-codex", "gpt-5.2")).toContain("xhigh");
+  });
+
   it("includes xhigh for github-copilot gpt-5.2 refs", () => {
     expect(listThinkingLevels("github-copilot", "gpt-5.2")).toContain("xhigh");
     expect(listThinkingLevels("github-copilot", "gpt-5.2-codex")).toContain("xhigh");

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -23,6 +23,7 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 
 export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.2",
+  "openai-codex/gpt-5.2",
   "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",


### PR DESCRIPTION
## Summary

  - Problem: The xhigh thinking-level validation/hint omitted openai-codex/gpt-5.2, so users saw an incomplete supported-model list and openai-codex/gpt-5.2 was
    not treated as xhigh-capable.
  - Why it matters: It blocks a valid model/thinking combination and gives misleading guidance.
  - What changed: Added openai-codex/gpt-5.2 to the single source-of-truth allowlist (XHIGH_MODEL_REFS), updated the directive e2e expected error text, and added
    a unit test for supports/listThinkingLevels coverage.
  - What did NOT change (scope boundary): No gateway/auth/storage/network/tool-execution behavior changed; no config/env schema changes.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #21284
  - Related #None

  ## User-visible / Behavior Changes

  - /thinking xhigh now works for openai-codex/gpt-5.2.
  - Unsupported-model error hint for xhigh now includes openai-codex/gpt-5.2.

  ## Security Impact (required)

  - New permissions/capabilities? (No)
  - Secrets/tokens handling changed? (No)
  - New/changed network calls? (No)
  - Command/tool execution surface changed? (No)
  - Data access scope changed? (No)
  - If any Yes, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: macOS (Darwin arm64)
  - Runtime/container: Node v23.11.0, pnpm 10.23.0
  - Model/provider: openai-codex/gpt-5.2, openai/gpt-4.1-mini (test fixtures)
  - Integration/channel (if any): Auto-reply directive handling tests
  - Relevant config (redacted): Test harness defaults

  ### Steps

  1. Set a non-supported model (example: openai/gpt-4.1-mini) and run /thinking xhigh.
  2. Observe the rejection hint text.
  3. Set model to openai-codex/gpt-5.2 and run /thinking xhigh again.

  ### Expected

  - Step 1: Rejection message includes all supported models, including openai-codex/gpt-5.2.
  - Step 3: xhigh is accepted for openai-codex/gpt-5.2.

  ### Actual

  - Matches expected after this fix.

  ## Evidence

  - [ ] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  Trace/log snippets:

  - pnpm vitest run src/auto-reply/thinking.test.ts → 15 passed
  - pnpm vitest run --config vitest.e2e.config.ts src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts → 8 passed

  ## Human Verification (required)

  - Verified scenarios: xhigh support list now includes openai-codex/gpt-5.2; non-supported model still rejects with corrected hint; targeted unit + e2e tests
    pass.
  - Edge cases checked: Existing openai/gpt-5.2 and github-copilot/* xhigh paths remain covered by tests.
  - What you did not verify: Live external provider call from Codex CLI UI with real credentials.

  ## Compatibility / Migration

  - Backward compatible? (Yes)
  - Config/env changes? (No)
  - Migration needed? (No)
  - If yes, exact upgrade steps: N/A

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: git revert 09a4c2311
  - Files/config to restore:
      - src/auto-reply/thinking.ts
      - src/auto-reply/thinking.test.ts
      - src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
  - Known bad symptoms reviewers should watch for:
      - openai-codex/gpt-5.2 still rejected for /thinking xhigh
      - Supported-model hint text missing openai-codex/gpt-5.2

  ## Risks and Mitigations

  - Risk: Future model support updates may drift between allowlist and expected message text in tests.
  - Mitigation: Keep allowlist centralized in XHIGH_MODEL_REFS; tests explicitly assert both support behavior and user-facing hint text.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `openai-codex/gpt-5.2` to the xhigh thinking level allowlist and updated corresponding tests.

- Added `openai-codex/gpt-5.2` to `XHIGH_MODEL_REFS` array in `thinking.ts:26`
- Added unit test coverage for `openai-codex/gpt-5.2` xhigh support in `thinking.test.ts:49-51`
- Updated e2e test expected error message to include `openai-codex/gpt-5.2` in the supported models list in `reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts:60`

The change maintains the single-source-of-truth pattern where the allowlist drives both runtime validation and user-facing error messages via `formatXHighModelHint()`. All changes are internally consistent.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-contained bug fix that adds one missing model identifier to an allowlist. The implementation correctly updates the single source of truth (`XHIGH_MODEL_REFS`), which automatically propagates to all dependent logic through existing functions (`supportsXHighThinking`, `formatXHighModelHint`). Test coverage is comprehensive with both unit tests and e2e tests. No breaking changes, no security implications, and no architectural modifications.
- No files require special attention

<sub>Last reviewed commit: 09a4c23</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->