### PR TITLE
fix: use correct field for input_text content parts in openai-http

### DIFF
--- a/src/gateway/openai-http.e2e.test.ts
+++ b/src/gateway/openai-http.e2e.test.ts
@@ -214,7 +214,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
               role: "user",
               content: [
                 { type: "text", text: "hello" },
-                { type: "input_text", text: "world" },
+                { type: "input_text", input_text: "world" },
               ],
             },
           ],

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -60,8 +60,8 @@ function extractTextContent(content: unknown): string {
         if (type === "text" && typeof text === "string") {
           return text;
         }
-        if (type === "input_text" && typeof text === "string") {
-          return text;
+        if (type === "input_text" && typeof inputText === "string") {
+          return inputText;
         }
         if (typeof inputText === "string") {
           return inputText;


### PR DESCRIPTION
## Summary
- `extractTextContent` in `openai-http.ts` incorrectly read `part.text` when handling content parts with `type === "input_text"`, instead of `part.input_text` (stored as `inputText`)
- For `input_text`-typed parts, the text value lives in `part.input_text`, not `part.text`
- This caused the type-guarded branch to return wrong content or fall through to the generic fallback

## Test plan
- [ ] Send a request with an `{ type: "input_text", input_text: "hello" }` content part and verify correct extraction
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug where `extractTextContent` in `openai-http.ts` was reading the wrong field for `input_text`-typed content parts. The function was checking `part.text` instead of `part.input_text` (destructured as `inputText`), causing incorrect extraction or fallthrough to the generic handler.

- Changed line 63 to check `typeof inputText === "string"` instead of `typeof text === "string"`
- Changed line 64 to return `inputText` instead of `text`
- This ensures content from `{ type: "input_text", input_text: "..." }` parts is correctly extracted

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with a test fix needed
- The fix correctly addresses a field access bug where the wrong variable was being checked/returned for `input_text` content parts. However, the existing e2e test uses the wrong field name (`text` instead of `input_text`), so it's not properly validating the fix and should be corrected before merging.
- src/gateway/openai-http.e2e.test.ts needs test data correction to properly validate the fix

<sub>Last reviewed commit: 127edeb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->