### PR TITLE
fix(telegram): quoted replies silently drop quote in delivery path

### DIFF
--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -245,14 +245,10 @@ describe("deliverReplies", () => {
       "123",
       expect.any(String),
       expect.objectContaining({
-        reply_to_message_id: 500,
-      }),
-    );
-    expect(sendMessage).toHaveBeenCalledWith(
-      "123",
-      expect.any(String),
-      expect.not.objectContaining({
-        reply_parameters: expect.anything(),
+        reply_parameters: {
+          message_id: 500,
+          quote: "quoted text",
+        },
       }),
     );
   });

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -178,6 +178,7 @@ export async function deliverReplies(params: {
         ...(shouldAttachButtonsToMedia ? { reply_markup: replyMarkup } : {}),
         ...buildTelegramSendParams({
           replyToMessageId,
+          replyQuoteText,
           thread,
         }),
       };

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -508,12 +508,20 @@ async function sendTelegramVoiceFallbackText(opts: {
 
 function buildTelegramSendParams(opts?: {
   replyToMessageId?: number;
+  replyQuoteText?: string;
   thread?: TelegramThreadSpec | null;
 }): Record<string, unknown> {
   const threadParams = buildTelegramThreadParams(opts?.thread);
   const params: Record<string, unknown> = {};
   if (opts?.replyToMessageId) {
-    params.reply_to_message_id = opts.replyToMessageId;
+    if (opts.replyQuoteText?.trim()) {
+      params.reply_parameters = {
+        message_id: opts.replyToMessageId,
+        quote: opts.replyQuoteText.trim(),
+      };
+    } else {
+      params.reply_to_message_id = opts.replyToMessageId;
+    }
   }
   if (threadParams) {
     params.message_thread_id = threadParams.message_thread_id;
@@ -538,6 +546,7 @@ async function sendTelegramText(
 ): Promise<number | undefined> {
   const baseParams = buildTelegramSendParams({
     replyToMessageId: opts?.replyToMessageId,
+    replyQuoteText: opts?.replyQuoteText,
     thread: opts?.thread,
   });
   // Add link_preview_options when link preview is disabled.


### PR DESCRIPTION
## Summary
- `buildTelegramSendParams` in `bot/delivery.ts` did not accept or forward `replyQuoteText`, so any quote text passed via `sendTelegramText` was silently ignored
- `sendTelegramText` accepted `replyQuoteText` but only passed `replyToMessageId` and `thread` to `buildTelegramSendParams`
- Fix adds `replyQuoteText` param and emits `reply_parameters: { message_id, quote }` when present, matching the existing behavior in `send.ts`

## Test plan
- [ ] Send a reply with a quoted excerpt via Telegram bot — verify the quote bubble appears
- [ ] Send a plain reply (no quote) — verify `reply_to_message_id` still works
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `buildTelegramSendParams` to properly forward `replyQuoteText` and emit `reply_parameters` with quoted text, matching the pattern in `send.ts`

**Issues found:**
- Media messages (photos, videos, animations, documents) at delivery.ts:179 don't pass `replyQuoteText` to `buildTelegramSendParams`, so quoted replies will be silently dropped when sending media. The `replyQuoteText` variable is available in scope but isn't being forwarded.
- The existing test "uses reply_to_message_id when quote text is provided" (delivery.test.ts:228) expects the old behavior and will now fail. It should be updated to expect `reply_parameters` with `message_id` and `quote` fields when `replyQuoteText` is provided.

<h3>Confidence Score: 3/5</h3>

- This PR fixes a valid bug but introduces a logic issue in media message handling and will break an existing test
- The fix correctly implements the `reply_parameters` pattern for text messages, but the media message path at line 179 is missing the same fix, so quoted replies on media will still be silently dropped. Additionally, an existing test explicitly validates the old (buggy) behavior and will now fail.
- src/telegram/bot/delivery.ts:179 (missing `replyQuoteText` for media) and src/telegram/bot/delivery.test.ts:228 (test expects old behavior)

<sub>Last reviewed commit: 5d1ab6a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->