### PR TITLE
fix(discord): strip mention brackets in formatAllowFrom

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -107,9 +107,16 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       ),
     formatAllowFrom: ({ allowFrom }) =>
       allowFrom
-        .map((entry) => String(entry).trim())
-        .filter(Boolean)
-        .map((entry) => entry.toLowerCase()),
+        .map((entry) =>
+          String(entry)
+            .trim()
+            .replace(/^<@!?/, "")
+            .replace(/>$/, "")
+            .replace(/^(discord|user):/i, "")
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean),
     resolveDefaultTo: ({ cfg, accountId }) =>
       resolveDiscordAccount({ cfg, accountId }).config.defaultTo?.trim() || undefined,
   },

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -112,7 +112,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
             .trim()
             .replace(/^<@!?/, "")
             .replace(/>$/, "")
-            .replace(/^(discord|user):/i, "")
+            .replace(/^(discord|user|pk):/i, "")
             .trim()
             .toLowerCase(),
         )


### PR DESCRIPTION
## Summary
- `formatAllowFrom` in the Discord channel plugin was not stripping Discord mention format (`<@123456789>`) or `discord:`/`user:` prefixes before storing
- Entries added in mention format never matched bare numeric snowflake IDs that Discord delivers, silently breaking DM allowlist enforcement
- Aligns with canonical `formatDiscordAllowFrom` in `src/channels/dock.ts` and the plugin's own `normalizeEntry` in `resolveDmPolicy`

## Test plan
- [ ] Add a Discord user to `dm.allowFrom` using mention format (`<@123456789>`) — verify they can now DM the bot
- [ ] Verify `discord:ID` and `user:ID` prefix formats are also normalized
- [ ] Plain numeric IDs continue to work as before
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `formatAllowFrom` to strip Discord mention brackets (`<@123456789>`) and `discord:`/`user:` prefixes, aligning with canonical implementation and enabling proper DM allowlist matching.

- Correctly strips mention format `<@!?` prefix and `>` suffix
- Strips `discord:` and `user:` prefixes (case-insensitive)
- Missing `pk:` prefix handling for PluralKit members (supported in canonical implementation at `src/channels/dock.ts:95` and used throughout `src/discord/monitor/allow-list.ts`)

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor fix for PluralKit support
- The PR correctly implements the core fix for stripping Discord mention format and `discord:`/`user:` prefixes, which resolves the reported DM allowlist enforcement issue. However, it misses `pk:` prefix support that exists in the canonical implementation and is used throughout the codebase for PluralKit member IDs (a documented feature). This omission won't break existing functionality but creates inconsistency with the canonical implementation.
- extensions/discord/src/channel.ts - needs `pk:` prefix support added to line 115

<sub>Last reviewed commit: 2e057f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->