### PR TITLE
fix(slack): prefer userToken for writes when userTokenReadOnly=false

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -46,7 +46,7 @@ function getTokenForOperation(
   if (!allowUserWrites) {
     return botToken;
   }
-  return botToken ?? userToken;
+  return userToken ?? botToken;
 }
 
 export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -117,7 +117,7 @@ export async function handleSlackAction(
     if (!allowUserWrites) {
       return botToken;
     }
-    return botToken ?? userToken;
+    return userToken ?? botToken;
   };
 
   const buildActionOpts = (operation: "read" | "write") => {


### PR DESCRIPTION
## Summary
- When `userTokenReadOnly` is `false`, user token should be used for write operations
- `getTokenForOperation` had reversed fallback: `botToken ?? userToken` always returned `botToken`, ignoring user token
- Fixed to `userToken ?? botToken` so user token takes priority when user writes are allowed

## Test plan
- [ ] Configure Slack with both tokens, set `userTokenReadOnly: false` — messages should appear as user
- [ ] Without `userToken`, `botToken` still used as fallback
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes token selection logic for Slack write operations when user token read-only mode is disabled. The nullish coalescing operator was reversed (`botToken ?? userToken`), causing bot token to always be used even when user writes were enabled. Now correctly prioritizes user token over bot token (`userToken ?? botToken`) so the user token is used when available and user writes are allowed.

- Corrects the token fallback order in `getTokenForOperation` function for write operations
- Affects three write paths: pairing approval notifications, `sendText`, and `sendMedia`
- Identical bug exists in `src/agents/tools/slack-actions.ts:120` and should be fixed in a follow-up

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one caveat - identical bug exists elsewhere
- The fix is correct and straightforward (swapping operator order), but the same bug exists in `src/agents/tools/slack-actions.ts:120` which isn't addressed in this PR
- Check `src/agents/tools/slack-actions.ts` for the same bug

<sub>Last reviewed commit: 630f6be</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->