### PR TITLE
fix(whatsapp): strip + prefix from E.164 in mention strip patterns

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -210,7 +210,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
   },
   mentions: {
     stripPatterns: ({ ctx }) => {
-      const selfE164 = (ctx.To ?? "").replace(/^whatsapp:/, "");
+      const selfE164 = (ctx.To ?? "").replace(/^whatsapp:/, "").replace(/^\+/, "");
       if (!selfE164) {
         return [];
       }

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -236,7 +236,7 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     },
     mentions: {
       stripPatterns: ({ ctx }) => {
-        const selfE164 = (ctx.To ?? "").replace(/^whatsapp:/, "");
+        const selfE164 = (ctx.To ?? "").replace(/^whatsapp:/, "").replace(/^\+/, "");
         if (!selfE164) {
           return [];
         }


### PR DESCRIPTION
## Summary
- `mentions.stripPatterns` built regex patterns using the E.164 number with `+` prefix (e.g., `@+14155552671`)
- WhatsApp group messages tag participants as `@14155552671` (no `+`), so the pattern never matched
- Fix adds `.replace(/^\+/, "")` after the scheme strip, matching how tests normalize the same value

## Test plan
- [ ] In a WhatsApp group, mention the bot — verify the mention is stripped from inbound text
- [ ] DMs still work (stripPatterns returns empty when selfE164 is falsy)
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where WhatsApp group mentions were not being stripped from inbound messages. The issue was that `mentions.stripPatterns` was building regex patterns using E.164 numbers with the `+` prefix (e.g., `@+14155552671`), but WhatsApp actually tags group participants without the `+` (e.g., `@14155552671`), causing the pattern to never match.

The fix adds `.replace(/^\+/, "")` to strip the leading `+` after removing the `whatsapp:` scheme prefix. This aligns with how the E.164 number is normalized elsewhere in the codebase and ensures mention patterns correctly match actual WhatsApp mention tags in group messages.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it's a targeted bug fix with clear reasoning
- The change is minimal (single line), well-explained, and fixes a clear bug where WhatsApp group mentions weren't being stripped. The logic is sound - WhatsApp uses bare numbers in mentions (`@14155552671`) not E.164 format with `+`. Score is 4 rather than 5 because there may be similar code in `src/channels/dock.ts` that needs the same fix for consistency.
- No files require special attention - the change is straightforward and isolated

<sub>Last reviewed commit: e2d29ee</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->