### PR TITLE
fix: remove dead duplicate subagent branch in toAgentStoreSessionKey

### DIFF
--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -51,9 +51,6 @@ export function toAgentStoreSessionKey(params: {
   if (lowered.startsWith("agent:")) {
     return lowered;
   }
-  if (lowered.startsWith("subagent:")) {
-    return `agent:${normalizeAgentId(params.agentId)}:${lowered}`;
-  }
   return `agent:${normalizeAgentId(params.agentId)}:${lowered}`;
 }
 


### PR DESCRIPTION
## Summary
- `toAgentStoreSessionKey` in `src/routing/session-key.ts` had an `if (lowered.startsWith("subagent:"))` branch with a body identical to the unconditional return below it
- Unreachable dead code that falsely implied subagent keys get special handling
- Removing it clarifies intent without altering behavior

## Test plan
- [x] All existing tests pass — `toAgentStoreSessionKey` still returns correct keys for subagent requests
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes a duplicate conditional branch in `toAgentStoreSessionKey` that was unreachable dead code. The removed `if (lowered.startsWith("subagent:"))` check had an identical body to the unconditional return statement that follows it, meaning subagent keys never received special handling despite what the code implied.

- The removed branch returned: `` `agent:${normalizeAgentId(params.agentId)}:${lowered}` ``
- The unconditional fallback returns the exact same thing
- All test usages confirm subagent keys follow the format `agent:main:subagent:*`, not `subagent:*`
- This cleanup improves code clarity without changing behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The removed code was provably unreachable dead code - the conditional branch had an identical body to the unconditional return below it. Test evidence confirms all subagent keys use the `agent:*:subagent:*` format, never the standalone `subagent:*` format that would have triggered the removed branch. This is a pure cleanup with zero behavioral change.
- No files require special attention

<sub>Last reviewed commit: 13cbe20</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->