### PR TITLE
fix(ui): improve mixed RTL/LTR text direction in chat

### DIFF
--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -128,6 +128,7 @@
    ============================================= */
 
 .chat-text[dir="rtl"] {
+  direction: rtl;
   text-align: right;
 }
 

--- a/ui/src/ui/text-direction.test.ts
+++ b/ui/src/ui/text-direction.test.ts
@@ -21,4 +21,14 @@ describe("detectTextDirection", () => {
     expect(detectTextDirection("# مرحبا")).toBe("rtl");
     expect(detectTextDirection("- hello")).toBe("ltr");
   });
+
+  it("prefers dominant script in mixed-language text", () => {
+    expect(detectTextDirection("Hello שלום עולם")).toBe("rtl");
+    expect(detectTextDirection("שלום hello world test")).toBe("ltr");
+  });
+
+  it("ignores OpenClaw reply tags at the start", () => {
+    expect(detectTextDirection("[[reply_to_current]] שלום עם Web UI")).toBe("rtl");
+    expect(detectTextDirection("[[reply_to: 123]] hello עם קצת עברית")).toBe("ltr");
+  });
 });

--- a/ui/src/ui/text-direction.test.ts
+++ b/ui/src/ui/text-direction.test.ts
@@ -31,4 +31,12 @@ describe("detectTextDirection", () => {
     expect(detectTextDirection("[[reply_to_current]] שלום עם Web UI")).toBe("rtl");
     expect(detectTextDirection("[[reply_to: 123]] hello עם קצת עברית")).toBe("ltr");
   });
+
+  it("ignores fenced and inline code for direction inference", () => {
+    const mixed = "סגור — עשיתי.\n\n```bash\ngh auth login\ngit push\n```\n\nעוד טקסט בעברית";
+    expect(detectTextDirection(mixed)).toBe("rtl");
+
+    const mixedInline = "שלום זה `npm run build` ואז ממשיכים בעברית";
+    expect(detectTextDirection(mixedInline)).toBe("rtl");
+  });
 });

--- a/ui/src/ui/text-direction.ts
+++ b/ui/src/ui/text-direction.ts
@@ -7,11 +7,16 @@
 const RTL_CHAR_REGEX =
   /\p{Script=Hebrew}|\p{Script=Arabic}|\p{Script=Syriac}|\p{Script=Thaana}|\p{Script=Nko}|\p{Script=Samaritan}|\p{Script=Mandaic}|\p{Script=Adlam}|\p{Script=Phoenician}|\p{Script=Lydian}/u;
 
+const LETTER_CHAR_REGEX = /\p{L}/u;
+const LEADING_REPLY_TAG_REGEX = /^\s*\[\[\s*reply_to(?:_current|\s*:\s*[^\]]+)?\s*\]\]\s*/iu;
+
 /**
- * Detect text direction from the first significant character.
- * @param text - The text to check
- * @param skipPattern - Characters to skip when looking for the first significant char.
- *   Defaults to whitespace and Unicode punctuation/symbols.
+ * Detect text direction from significant letters in the message.
+ *
+ * Uses a light-weight heuristic:
+ * - skip whitespace/punctuation/symbols
+ * - count RTL vs non-RTL letters
+ * - fall back to the first significant strong character on ties
  */
 export function detectTextDirection(
   text: string | null,
@@ -20,11 +25,36 @@ export function detectTextDirection(
   if (!text) {
     return "ltr";
   }
-  for (const char of text) {
+
+  // Ignore OpenClaw reply tags when inferring direction, e.g. [[reply_to_current]].
+  const normalized = text.replace(LEADING_REPLY_TAG_REGEX, "");
+
+  let rtlCount = 0;
+  let ltrCount = 0;
+  let firstStrong: "rtl" | "ltr" | null = null;
+
+  for (const char of normalized) {
     if (skipPattern.test(char)) {
       continue;
     }
-    return RTL_CHAR_REGEX.test(char) ? "rtl" : "ltr";
+
+    if (RTL_CHAR_REGEX.test(char)) {
+      rtlCount++;
+      firstStrong ??= "rtl";
+      continue;
+    }
+
+    if (LETTER_CHAR_REGEX.test(char)) {
+      ltrCount++;
+      firstStrong ??= "ltr";
+    }
   }
-  return "ltr";
+
+  if (rtlCount === 0 && ltrCount === 0) {
+    return "ltr";
+  }
+  if (rtlCount === ltrCount) {
+    return firstStrong ?? "ltr";
+  }
+  return rtlCount > ltrCount ? "rtl" : "ltr";
 }

--- a/ui/src/ui/text-direction.ts
+++ b/ui/src/ui/text-direction.ts
@@ -9,6 +9,8 @@ const RTL_CHAR_REGEX =
 
 const LETTER_CHAR_REGEX = /\p{L}/u;
 const LEADING_REPLY_TAG_REGEX = /^\s*\[\[\s*reply_to(?:_current|\s*:\s*[^\]]+)?\s*\]\]\s*/iu;
+const FENCED_CODE_BLOCK_REGEX = /```[\s\S]*?```/g;
+const INLINE_CODE_REGEX = /`[^`\n]+`/g;
 
 /**
  * Detect text direction from significant letters in the message.
@@ -26,8 +28,12 @@ export function detectTextDirection(
     return "ltr";
   }
 
-  // Ignore OpenClaw reply tags when inferring direction, e.g. [[reply_to_current]].
-  const normalized = text.replace(LEADING_REPLY_TAG_REGEX, "");
+  // Ignore OpenClaw reply tags and code snippets when inferring direction.
+  // Code blocks are often English-heavy and can skew base direction.
+  const normalized = text
+    .replace(LEADING_REPLY_TAG_REGEX, "")
+    .replace(FENCED_CODE_BLOCK_REGEX, " ")
+    .replace(INLINE_CODE_REGEX, " ");
 
   let rtlCount = 0;
   let ltrCount = 0;


### PR DESCRIPTION
## Summary
- infer chat text direction by dominant script (RTL vs non-RTL letters), not only first significant char
- ignore leading OpenClaw reply tags (e.g. `[[reply_to_current]]`) during direction inference
- ignore fenced and inline code snippets for direction inference (prevents English-heavy code from skewing base direction)
- apply `direction: rtl` for RTL chat text rendering
- add tests for mixed-language, reply-tag-prefixed, and code-containing messages

## Why
Mixed RTL/LTR messages in Control UI could render with confusing base direction, especially when messages start with metadata-like tags or include large code snippets.

## Testing
- `pnpm -C ui build` passes
- added/updated unit tests in `ui/src/ui/text-direction.test.ts`

## Notes
This is a heuristic improvement (not a full bidi engine), but significantly improves common mixed-language chat cases.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves RTL/LTR text direction detection by counting dominant script characters rather than relying only on the first significant character. Filters out OpenClaw reply tags and code blocks (both fenced and inline) to prevent English-heavy metadata from skewing direction inference. Adds `direction: rtl` CSS property for proper RTL rendering.

- Enhanced `detectTextDirection` to count RTL vs LTR letters across the entire message
- Strips `[[reply_to_current]]` and `[[reply_to: ID]]` tags before analysis
- Removes code blocks (fenced ``` and inline `) to avoid skewing toward English
- Falls back to first strong character when RTL and LTR counts are equal
- Comprehensive test coverage for mixed-language, reply-prefixed, and code-containing messages

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured improvement with thorough test coverage. The heuristic approach is appropriate for the use case. All changes are localized to text direction detection with no side effects. Tests cover edge cases including mixed-language text, reply tags, and code blocks.
- No files require special attention

<sub>Last reviewed commit: fd4cb0d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->