### PR TITLE
fix(usage-format): remove dead duplicate branch in formatUsd

### DIFF
--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -34,9 +34,6 @@ export function formatUsd(value?: number): string | undefined {
   if (value === undefined || !Number.isFinite(value)) {
     return undefined;
   }
-  if (value >= 1) {
-    return `$${value.toFixed(2)}`;
-  }
   if (value >= 0.01) {
     return `$${value.toFixed(2)}`;
   }


### PR DESCRIPTION
## Summary
- `formatUsd` contained two consecutive `if` branches that both returned `value.toFixed(2)`: one for `value >= 1` and one for `value >= 0.01`
- Since any value `>= 1` is also `>= 0.01`, the first branch was entirely dead code
- Collapsed into a single `if (value >= 0.01)` check

## Test plan
- [x] `formatUsd(1.234)` → `"$1.23"`, `formatUsd(0.5)` → `"$0.50"`, `formatUsd(0.0042)` → `"$0.0042"` all still correct
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes dead code from `formatUsd` function by eliminating redundant `value >= 1` check that was unreachable due to subsequent `value >= 0.01` condition.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - removes unreachable dead code with no behavioral changes
- The change removes genuinely dead code (the `value >= 1` check was never reachable because any value >= 1 satisfies the subsequent `value >= 0.01` condition). Function behavior remains identical for all inputs, and the author verified test cases.
- No files require special attention

<sub>Last reviewed commit: 7f4f363</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->