### PR TITLE
fix(plugins): log typed hook count in hook runner initialization

### DIFF
--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -30,7 +30,7 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
     catchErrors: true,
   });
 
-  const hookCount = registry.hooks.length;
+  const hookCount = registry.typedHooks.length;
   if (hookCount > 0) {
     log.info(`hook runner initialized with ${hookCount} registered hooks`);
   }


### PR DESCRIPTION
## Summary
- `initializeGlobalHookRunner` logged `registry.hooks.length` (legacy `registerHook()` registrations)
- `createHookRunner` exclusively reads from `registry.typedHooks` (populated by modern `api.on()` API)
- Plugins registering hooks via `api.on()` always showed `0 registered hooks` in startup logs
- Fixed to reference `registry.typedHooks.length`, matching what the hook runner actually executes

## Test plan
- [ ] Enable a plugin with typed hooks — startup logs should now show correct non-zero count
- [x] Lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed logging discrepancy in `initializeGlobalHookRunner` where the startup log incorrectly reported hook count from legacy `registry.hooks` (populated by `registerHook()`) instead of `registry.typedHooks` (populated by modern `api.on()` API). Since `createHookRunner` exclusively reads from `registry.typedHooks` when executing hooks, plugins using `api.on()` always showed "0 registered hooks" at startup despite having active hooks.

- Changed `registry.hooks.length` to `registry.typedHooks.length` in hook-runner-global.ts:33
- Log now accurately reflects the hooks that will actually be executed by the hook runner
- No behavioral changes to hook execution, only corrects the diagnostic output

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with zero risk
- The change is a trivial one-line fix correcting a logging discrepancy. The hook runner already correctly reads from `registry.typedHooks` (verified in hooks.ts:103), and this PR simply aligns the log message with the actual data source. No logic changes, no runtime behavior changes, only diagnostic output accuracy.
- No files require special attention

<sub>Last reviewed commit: 3c8a817</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->