### PR TITLE
fix(twitch): remove leading space in disconnectAll log message

### DIFF
--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -226,7 +226,7 @@ export class TwitchClientManager {
     this.clients.forEach((client) => client.quit());
     this.clients.clear();
     this.messageHandlers.clear();
-    this.logger.info(" Disconnected all clients");
+    this.logger.info("Disconnected all clients");
   }
 
   /**


### PR DESCRIPTION
## Summary
- Removes a spurious leading space from the `logger.info` call in `TwitchClientManager.disconnectAll()`
- `" Disconnected all clients"` was inconsistent with every other log call in the file which use no leading space

## Test plan
- [ ] Confirm log output no longer starts with a blank character
- [x] No logic change — string-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes spurious leading space from log message in `TwitchClientManager.disconnectAll()` for consistency with other log calls in the file. Also changes WhatsApp's `deleteAccount` to use nullish coalescing operator (`??`) instead of logical OR (`||`).

- Twitch log fix is correct and improves consistency (verified all other logger calls use no leading space)
- WhatsApp operator change is unrelated and not mentioned in PR title/description
- WhatsApp change creates inconsistency within the same file (`setAccountEnabled` on line 64 still uses `||`)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge - changes are cosmetic/style-only with no logic impact
- Score reflects that both changes are low-risk (string formatting and operator preference), but mixing unrelated changes and creating internal inconsistency in WhatsApp file are style concerns that should be addressed
- Consider addressing the inconsistency in `extensions/whatsapp/src/channel.ts` where both `||` and `??` are now used for the same pattern

<sub>Last reviewed commit: c49258a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->