### PR TITLE
fix: correct off-by-one in resolveThreadParentSessionKey

### DIFF
--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -91,7 +91,7 @@ export function resolveThreadParentSessionKey(
       idx = candidate;
     }
   }
-  if (idx <= 0) {
+  if (idx < 0) {
     return null;
   }
   const parent = raw.slice(0, idx).trim();


### PR DESCRIPTION
## Summary
- `resolveThreadParentSessionKey` in `src/sessions/session-key-utils.ts` used `idx <= 0` to bail out when no thread marker was found, which incorrectly returns `null` when the marker appears at position `0` (a valid position at the start of the string)
- Changed to `idx < 0` so only the sentinel value of `-1` (no match found) triggers the early return

## Test plan
- [ ] Verify that a session key starting with `:thread:` (marker at index 0) correctly returns the parent key
- [ ] Confirm that a session key with no thread marker still returns `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed off-by-one error in `resolveThreadParentSessionKey` where `idx <= 0` incorrectly rejected valid session keys with thread markers at position 0. Changed to `idx < 0` to only bail on the `-1` sentinel value from `lastIndexOf`.

- Correctly handles the edge case where a session key starts with `:thread:` or `:topic:` at index 0
- No logic changes for existing use cases (thread markers in middle/end of string, or no markers)
- The fix ensures `lastIndexOf` return value of `0` (valid position) is distinguished from `-1` (not found)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple, correct fix for edge case bug
- Single-line fix that corrects a clear off-by-one error. The change from `<= 0` to `< 0` properly handles the `lastIndexOf` return values: `-1` (not found) vs `0` (found at position 0). No behavioral changes for existing valid cases, only fixes the edge case bug.
- No files require special attention

<sub>Last reviewed commit: 156b364</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->