### PR TITLE
BugFix: Anthropic compatible Custom Provider Fix to Match Anthropic Client Behavior

### DIFF
--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -313,8 +313,14 @@ async function requestAnthropicVerification(params: {
   apiKey: string;
   modelId: string;
 }): Promise<VerificationResult> {
+  // Use a base URL with /v1 injected for this raw fetch only. The rest of the app uses the
+  // Anthropic client, which appends /v1 itself; config should store the base URL
+  // without /v1 to avoid /v1/v1/messages at runtime. See docs/gateway/configuration-reference.md.
+  const baseUrlForRequest = /\/v1\/?$/.test(params.baseUrl.trim())
+    ? params.baseUrl.trim()
+    : params.baseUrl.trim().replace(/\/?$/, "") + "/v1";
   const endpoint = resolveVerificationEndpoint({
-    baseUrl: params.baseUrl,
+    baseUrl: baseUrlForRequest,
     modelId: params.modelId,
     endpointPath: "messages",
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Anthropic compatible endpoints would not work after setup.
- Why it matters: Some of us want to run models locally!
- What changed: The onboarding wizard differs from the rest of the application, in that it uses a raw fetch call rather than the anthropic client to contact the LLM server. The onboarding wizard now injects a v1 for making the raw fetch call to verify the endpoint. The rest of the application uses the anthropic client, which does this automatically.
- What did NOT change (scope boundary): nothing else changed. This will only affect onboarding, so existing configs will not be touched. 

## Change Type (select all)

- [ x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # https://github.com/openclaw/openclaw/issues/21261
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes, fixes calls to Anthropic compatible APIs.
- Command/tool execution surface changed? (`Yes/No`) No.
- Data access scope changed? (`Yes/No`) No.
- If any `Yes`, explain risk + mitigation:

Tiny change to onboarding wizard only to match behavior of the rest of the application, which uses the anthropic client. The onboarding wizard uses a raw fetch, requiring us to manually inject /v1. 

## Repro + Verification

If you run locally, should be straightforward to test it works. Just add a custom provider with anthropic compatible selected, and see if works right off the bat. 

### Environment

- OS: MacOS
- Runtime/container:
- Model/provider: Ollama
- Integration/channel (if any):
- Relevant config (redacted):

### Steps to reproduce

1. Configure something like Ollama manually as a custom provider, selecting Anthropic compatible. The onboarding wizard will happily confirm that something like localhost:1234/v1 is a very valid and successful endpoint.
2. Try using OpenClaw tui, you'll get a 404 not found error since it's hitting an invalid endpoint of /v1/v1/messages. Manually removing the /v1 from the config file will fix it.

### Expected behavior

The setup script and regular usage of anthropic compatible providers should have identical behavior for calling models. 

### Actual behavior

Instead it appears they are different.


## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)


Logs from attaching a listener between Ollama and OpenClaw:

```shell
..z7Q:..POST /v1/v1/messages HTTP/1.1
```


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify: Still need to run locally and confirm it works.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Kind of? Tiny tweak for onboarding wizard of custom providers.
- Migration needed? (`Yes/No`) No.
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Contributors can easily rollback, and users can manually go into their config files to adjust custom provider URLs.
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Anthropic-compatible endpoint configuration in onboarding wizard. The wizard now conditionally appends `/v1` to the base URL when making verification requests, matching the behavior of the Anthropic client used in the rest of the application. This prevents double `/v1/v1/messages` paths that caused 404 errors when using Anthropic-compatible providers like Ollama. The fix only affects the onboarding wizard verification step; existing configurations are not modified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix that adds conditional `/v1` path handling only for the onboarding verification step. The fix is well-documented with an inline comment referencing the configuration docs, uses a simple regex pattern to check for existing `/v1` suffix, and aligns with the documented behavior that base URLs should omit `/v1` since the Anthropic client appends it automatically. The scope is limited to the verification function used during onboarding, leaving existing configurations untouched.
- No files require special attention

<sub>Last reviewed commit: b7fb46f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->