### PR TITLE
fix: use correct 5000ms slow_down backoff in GitHub Device Flow

### DIFF
--- a/src/providers/github-copilot-auth.ts
+++ b/src/providers/github-copilot-auth.ts
@@ -99,7 +99,7 @@ async function pollForAccessToken(params: {
       continue;
     }
     if (err === "slow_down") {
-      await new Promise((r) => setTimeout(r, params.intervalMs + 2000));
+      await new Promise((r) => setTimeout(r, params.intervalMs + 5000));
       continue;
     }
     if (err === "expired_token") {


### PR DESCRIPTION
## Summary
- `pollForAccessToken` in `src/providers/github-copilot-auth.ts` added only 2000ms on a `slow_down` error, but the [GitHub Device Flow specification](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#step-3-app-polls-github-to-check-if-the-user-authorized-the-device) requires the polling interval to increase by **5 seconds** on each `slow_down` response
- Changed the additive delay from `2000` to `5000` to comply with the spec and avoid continued rate-limiting

## Test plan
- [ ] Simulate a `slow_down` response and verify the next poll fires at least 5 seconds later than the base interval
- [ ] Confirm `authorization_pending` still uses the base interval unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed the `slow_down` backoff delay from 2000ms to 5000ms in GitHub Device Flow polling to comply with the [GitHub OAuth specification](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#step-3-app-polls-github-to-check-if-the-user-authorized-the-device), which requires a 5-second increase when rate-limited.

- Fixed spec compliance issue in `pollForAccessToken` function
- The PR correctly implements the required 5-second additive delay per the GitHub specification
- Note: This change is not yet reflected in `CHANGELOG.md` under the 2026.2.20 (Unreleased) section

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line fix that corrects a specification compliance issue. The implementation is straightforward, changing only the delay constant from 2000ms to 5000ms to match GitHub's documented Device Flow requirements. No logic changes, no new dependencies, and the fix follows the existing error-handling pattern.
- No files require special attention

<sub>Last reviewed commit: 662217a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->