### PR TITLE
fix: remove whitespace from wordish count in getTextStats

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -211,7 +211,6 @@ function getTextStats(text: string): { printableRatio: number; wordishRatio: num
     const code = char.codePointAt(0) ?? 0;
     if (code === 9 || code === 10 || code === 13 || code === 32) {
       printable += 1;
-      wordish += 1;
       continue;
     }
     if (code < 32 || (code >= 0x7f && code <= 0x9f)) {


### PR DESCRIPTION
## Summary
- Whitespace characters (space `0x20`, tab `0x09`, CR `0x0D`, LF `0x0A`) were counted as wordish in `getTextStats`, inflating `wordishRatio`
- This caused binary or punctuation-heavy content to appear more word-like than it actually is, skewing text classification decisions
- Fix: removed `wordish += 1` from the whitespace branch — only `\p{L}` and `\p{N}` characters (matched by `WORDISH_CHAR`) should count

## File changed
`src/media-understanding/apply.ts` — `getTextStats` function (~line 213)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects `wordishRatio` calculation in `getTextStats` by excluding whitespace characters from the wordish count. Previously, whitespace (space, tab, CR, LF) was incorrectly counted as wordish alongside letters and numbers, inflating the ratio and causing binary or punctuation-heavy content to appear more word-like than it actually is. The fix ensures only Unicode letters (`\p{L}`) and numbers (`\p{N}`) are counted as wordish, aligning with the `WORDISH_CHAR` regex definition.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple one-line removal that corrects a clear logical bug in the wordishRatio calculation. The change aligns perfectly with the documented intent (only counting `\p{L}` and `\p{N}` characters as wordish) and the existing `WORDISH_CHAR` regex. The impact is localized to text classification logic, and the fix makes the behavior more accurate without introducing any new complexity or dependencies.
- No files require special attention

<sub>Last reviewed commit: 1db1df9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->