### PR TITLE
fix: add missing Content-Type header to Gemini embeddings POST request

### DIFF
--- a/src/memory/embeddings-gemini.ts
+++ b/src/memory/embeddings-gemini.ts
@@ -70,6 +70,7 @@ export async function createGeminiEmbeddingProvider(
   const fetchWithGeminiAuth = async (apiKey: string, endpoint: string, body: unknown) => {
     const authHeaders = parseGeminiAuth(apiKey);
     const headers = {
+      "Content-Type": "application/json",
       ...authHeaders.headers,
       ...client.headers,
     };


### PR DESCRIPTION
## Summary
- `fetchWithGeminiAuth` in `src/memory/embeddings-gemini.ts` sends a JSON body via `JSON.stringify(body)` but was missing the `Content-Type: application/json` header
- Without this header some API gateways and proxies reject or misparse the request body
- Added `"Content-Type": "application/json"` as the base header, allowing `authHeaders` and `client.headers` to override it if needed

## Test plan
- [ ] Confirm that embedding requests to the Gemini API succeed with the header present
- [ ] Verify that any custom headers in `client.headers` or `authHeaders` can still override Content-Type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added explicit `Content-Type: application/json` header as base in `fetchWithGeminiAuth`, but this header is already provided by `parseGeminiAuth()` which returns it in both OAuth and traditional API key authentication modes.

- The change is functionally redundant since `authHeaders.headers` (line 74) already includes `Content-Type: application/json`
- The header merge order means the explicit base header on line 73 is immediately overridden
- No actual bug was present - the Content-Type header was already being sent correctly

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge but makes a redundant change
- The change adds an explicit Content-Type header that is already provided by the `parseGeminiAuth` function, making it functionally redundant. However, it doesn't introduce any bugs or break existing functionality - the header was already being sent correctly before this PR.
- No files require special attention

<sub>Last reviewed commit: ed1c686</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->