### PR TITLE
fix: use parts[1] index check instead of parts.includes for chatType in qmd-scope

### DIFF
--- a/src/memory/qmd-scope.ts
+++ b/src/memory/qmd-scope.ts
@@ -69,9 +69,9 @@ function parseQmdSessionScope(key?: string): ParsedQmdSessionScope {
     parts.length >= 2 &&
     (parts[1] === "group" || parts[1] === "channel" || parts[1] === "direct" || parts[1] === "dm")
   ) {
-    if (parts.includes("group")) {
+    if (parts[1] === "group") {
       chatType = "group";
-    } else if (parts.includes("channel")) {
+    } else if (parts[1] === "channel") {
       chatType = "channel";
     }
     return {


### PR DESCRIPTION
## Summary
- `parseQmdSessionScope` used `parts.includes("group")` and `parts.includes("channel")` to determine `chatType`, but `Array.includes` searches the entire array
- A session key whose channel name (at `parts[0]`) happened to be `"group"` or `"channel"` would be misclassified — the check must be positional, only looking at `parts[1]`
- The outer guard already verifies `parts[1]` is one of the expected values, so the inner check must match that same index
- Fix: replaced `parts.includes("group")` with `parts[1] === "group"` and `parts.includes("channel")` with `parts[1] === "channel"`

## File changed
`src/memory/qmd-scope.ts` — `parseQmdSessionScope` function (~line 72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug in `parseQmdSessionScope` where `chatType` detection used `Array.includes()` instead of positional index checks. A session key like `"group:direct:123"` would be misclassified as `"group"` instead of `"direct"` because the channel name matched. The fix correctly checks `parts[1]` to match the outer guard logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - fixes a clear logic bug with minimal risk
- The fix addresses a specific bug where positional logic was incorrectly using array search. The change is minimal (2 lines), matches the guard condition on line 70, and all existing tests pass. The logic is straightforward and correct.
- No files require special attention

<sub>Last reviewed commit: ebbd77c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->