### PR TITLE
fix: remove duplicate "before" from STOP_WORDS_EN in query-expansion

### DIFF
--- a/src/memory/query-expansion.ts
+++ b/src/memory/query-expansion.ts
@@ -96,7 +96,6 @@ const STOP_WORDS_EN = new Set([
   "earlier",
   "later",
   "recently",
-  "before",
   "ago",
   "just",
   "now",


### PR DESCRIPTION
## Summary
- `STOP_WORDS_EN` in `src/memory/query-expansion.ts` contained `"before"` twice: once in the prepositions group (line ~69) and again in the time references group (line ~99)
- Duplicate entries in a `Set` are harmless at runtime but the redundancy is misleading and flags as a code smell
- Removed the duplicate `"before"` from the time references section, keeping the canonical prepositions entry

## Test plan
- [ ] Confirm `STOP_WORDS_EN` no longer contains a duplicate `"before"` entry
- [ ] Verify `extractKeywords("before yesterday")` still filters out both words

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed duplicate `"before"` entry from `STOP_WORDS_EN` set in `src/memory/query-expansion.ts:99`. The word appeared twice: once correctly in the prepositions section (line 69) and redundantly in the time references section (line 99).

- Clean code improvement that eliminates redundancy
- No functional impact since `Set` automatically deduplicates entries
- Improves code clarity and maintainability

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- The change removes a duplicate string literal from a Set constant. Since Sets automatically deduplicate, this has zero functional impact on runtime behavior. The change improves code clarity by removing a misleading redundancy.
- No files require special attention

<sub>Last reviewed commit: b6b0c6f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->