### PR TITLE
fix(gateway): tolerate legacy paired device metadata in ws upgrade checks

### DIFF
--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -980,6 +980,9 @@ describe("gateway server auth/connect", () => {
         {};
       const legacy = paired[deviceId];
       expect(legacy).toBeDefined();
+      if (!legacy) {
+        throw new Error(`Expected paired metadata for deviceId=${deviceId}`);
+      }
       expect(legacy?.roles).toBeUndefined();
       expect(legacy?.scopes).toBeUndefined();
       delete legacy.roles;


### PR DESCRIPTION
## Summary

- Fixes pairing regression introduced by stricter websocket handshake scope/role upgrades by tolerating pre-existing paired devices that were created without `roles`/`scopes` metadata.
- For legacy paired metadata, skip manual repair pairing for role/scope checks and allow the existing pair to complete while updating metadata in place.
- Add regression coverage for this scenario in auth E2E tests.

## Problem

- Recent WS handshake hardening required role/scope repair approval whenever a paired device record lacked role/scope metadata fields.
- Older paired records can be missing these fields, causing existing clients to fail with `pairing required` until they are manually re-paired.

## What changed

### Changes
- Add legacy metadata detection in `src/gateway/server/ws-connection/message-handler.ts`.
- Gate role/scope upgrade pairing requirements behind presence of upgrade metadata (`roles` and `scopes`).
- Add e2e test `allows legacy paired devices without role/scope metadata` in `src/gateway/server.auth.e2e.test.ts`.

### Fixes
- Restore backwards compatibility for already paired devices created before `roles`/`scopes` metadata was introduced.

## Linked Issue

- Fixes: #21236

## Human Verification

- Not run.
