### PR TITLE
fix: rethrow non-ENOENT errors in readJsonFileWithFallback

### DIFF
--- a/src/plugin-sdk/json-store.ts
+++ b/src/plugin-sdk/json-store.ts
@@ -16,8 +16,8 @@ export async function readJsonFileWithFallback<T>(
     return { value: parsed, exists: true };
   } catch (err) {
     const code = (err as { code?: string }).code;
-    if (code === "ENOENT") {
-      return { value: fallback, exists: false };
+    if (code !== "ENOENT") {
+      throw err;
     }
     return { value: fallback, exists: false };
   }


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed error handling in `readJsonFileWithFallback` to properly rethrow non-ENOENT filesystem errors (like EACCES or EISDIR) instead of silently treating them as missing files. This prevents masking real filesystem problems behind successful fallback returns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a straightforward bug fix that corrects error handling logic. It inverts a condition from `===` to `!==` to properly rethrow non-ENOENT errors instead of silently swallowing them. The fix aligns with the function's documented purpose and improves error visibility for callers.
- No files require special attention

<sub>Last reviewed commit: 7542e61</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->