### PR TITLE
fix: killProcessTree grace-period check uses process group instead of process

### DIFF
--- a/src/process/kill-tree.ts
+++ b/src/process/kill-tree.ts
@@ -59,7 +59,7 @@ function killProcessTreeUnix(pid: number, graceMs: number): void {
 
   // Step 2: Wait grace period, then SIGKILL if still alive
   setTimeout(() => {
-    if (isProcessAlive(-pid)) {
+    if (isProcessAlive(pid)) {
       try {
         process.kill(-pid, "SIGKILL");
         return;


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a critical bug in Unix process tree termination where the grace-period liveness check was incorrectly checking the process group (`-pid`) instead of the actual process (`pid`). This caused premature exits when the process group leader died but other processes in the group were still alive, preventing proper SIGKILL cleanup of remaining processes after the grace period.

**Key changes:**
- Changed `isProcessAlive(-pid)` to `isProcessAlive(pid)` on line 62
- The `isProcessAlive` helper uses `process.kill(pid, 0)` which only works with positive PIDs (not process groups)
- After the grace period, the code now correctly checks if the main process is alive before attempting SIGKILL

**Impact:**
- Fixes edge case where child processes could survive termination if the group leader died during the grace period
- Ensures SIGKILL is properly sent when needed
- Aligns with Windows implementation which also checks the main PID

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused one-line bug fix with clear semantics
- The fix is a simple, well-justified one-line change that corrects an obvious logic error. The `isProcessAlive` function uses `process.kill(pid, 0)` to check liveness, which only works with positive PIDs (individual processes), not negative PIDs (process groups). The previous code was checking `-pid` which would always throw/fail on Unix since signal 0 doesn't work on process groups, causing the function to incorrectly conclude the process group was dead. The fix properly checks the main process PID, which is what the Windows implementation does and what the test suite expects (see test line 94-98 which mocks checks for positive PIDs only).
- No files require special attention

<sub>Last reviewed commit: 74bb37a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->