### PR TITLE
fix: RFC 5987 filename* parsing fails for non-empty language tags

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -45,7 +45,8 @@ function parseContentDispositionFileName(header?: string | null): string | undef
   const starMatch = /filename\*\s*=\s*([^;]+)/i.exec(header);
   if (starMatch?.[1]) {
     const cleaned = stripQuotes(starMatch[1].trim());
-    const encoded = cleaned.split("''").slice(1).join("''") || cleaned;
+    const m = cleaned.match(/^[^']*'[^']*'(.+)$/);
+    const encoded = m ? m[1] : cleaned;
     try {
       return path.basename(decodeURIComponent(encoded));
     } catch {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed RFC 5987 `filename*` parameter parsing in `Content-Disposition` headers to correctly handle non-empty language tags. The old implementation used `split("''")` which only worked when the language field was empty (e.g., `UTF-8''file.pdf`), but failed for language-tagged filenames like `UTF-8'en'file.pdf`. The new regex-based approach correctly extracts the encoded filename portion regardless of whether the language tag is present or empty.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix that correctly implements RFC 5987 parsing using a regex pattern that handles both empty and non-empty language tags. The regex pattern `^[^']*'[^']*'(.+)$` properly extracts the third part of the format (charset'language'encoded-value) and gracefully falls back to the original value if the pattern doesn't match. The fix is localized to a single function with clear semantics and no side effects.
- No files require special attention

<sub>Last reviewed commit: 76601b8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->