### PR TITLE
fix: process supervisor leaks timers and adapter when run already settled

### DIFF
--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -192,6 +192,8 @@ export function createProcessSupervisor(): ProcessSupervisor {
 
       const waitPromise = (async (): Promise<RunExit> => {
         const result = await adapter.wait();
+        clearTimers();
+        adapter.dispose();
         if (settled) {
           return {
             reason: forcedReason ?? "exit",
@@ -205,8 +207,6 @@ export function createProcessSupervisor(): ProcessSupervisor {
           };
         }
         settled = true;
-        clearTimers();
-        adapter.dispose();
         active.delete(runId);
 
         const reason: TerminationReason =


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moved `clearTimers()` and `adapter.dispose()` calls before the `settled` guard check in the `waitPromise` handler to prevent resource leaks when a run is already settled at the time `adapter.wait()` completes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward defensive fix that ensures cleanup operations (`clearTimers()` and `adapter.dispose()`) always execute when `adapter.wait()` completes, regardless of whether the run is already settled. Both operations are idempotent and safe to call multiple times. The fix prevents a resource leak in edge cases without introducing any new risks.
- No files require special attention

<sub>Last reviewed commit: 910fe77</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->