### PR TITLE
fix: elevenlabs_model TTS directive routes to elevenlabs override not OpenAI

### DIFF
--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -170,11 +170,16 @@ export function parseTtsDirectives(
               warnings.push(`invalid ElevenLabs voiceId "${rawValue}"`);
             }
             break;
+          case "elevenlabs_model":
+          case "elevenlabsmodel":
+            if (!policy.allowModelId) {
+              break;
+            }
+            overrides.elevenlabs = { ...overrides.elevenlabs, modelId: rawValue };
+            break;
           case "model":
           case "modelid":
           case "model_id":
-          case "elevenlabs_model":
-          case "elevenlabsmodel":
           case "openai_model":
           case "openaimodel":
             if (!policy.allowModelId) {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes routing of `elevenlabs_model` and `elevenlabsmodel` TTS directives to correctly set ElevenLabs overrides instead of going through OpenAI model validation first. Previously these provider-specific directives were falling through to the generic "model" case which would check OpenAI validity before setting ElevenLabs config. The fix extracts these cases to handle them directly before the generic model handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix that corrects the routing logic for provider-specific TTS directives. The fix is straightforward, maintains backward compatibility for the generic `model` directive, and follows the existing pattern used for other provider-specific directives like `openai_voice` and `elevenlabs_voice`. No logic errors or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 28c4bfe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->