### PR TITLE
fix: off-by-one in resolveStableCronOffsetMs skips valid 1ms stagger window

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -28,7 +28,7 @@ import type { CronServiceState } from "./state.js";
 const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
 
 function resolveStableCronOffsetMs(jobId: string, staggerMs: number) {
-  if (staggerMs <= 1) {
+  if (staggerMs <= 0) {
     return 0;
   }
   const digest = crypto.createHash("sha256").update(jobId).digest();


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed off-by-one error in `resolveStableCronOffsetMs` that incorrectly rejected valid 1ms stagger windows. The condition changed from `staggerMs <= 1` to `staggerMs <= 0`, allowing 1ms stagger values to be processed correctly.

- Previously, any `staggerMs` value of 1 or less would return 0, skipping the hash-based offset calculation
- With this fix, only values of 0 or less return early, allowing 1ms to be a valid stagger window
- The hash-based offset calculation `digest.readUInt32BE(0) % staggerMs` now correctly handles 1ms staggers

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix corrects a clear off-by-one bug in boundary checking. The change is minimal (single character), logically sound, and aligns with the function's purpose of handling positive stagger values. The modulo operation works correctly for staggerMs=1.
- No files require special attention

<sub>Last reviewed commit: 3957f6a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->