### PR TITLE
fix: use isBrowserEnabled(cfg) instead of direct cfg.browser?.enabled in attack surface summary

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -332,7 +332,7 @@ export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): Securi
   const elevated = cfg.tools?.elevated?.enabled !== false;
   const webhooksEnabled = cfg.hooks?.enabled === true;
   const internalHooksEnabled = cfg.hooks?.internal?.enabled === true;
-  const browserEnabled = cfg.browser?.enabled ?? true;
+  const browserEnabled = isBrowserEnabled(cfg);
 
   const detail =
     `groups: open=${group.open}, allowlist=${group.allowlist}` +


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced direct `cfg.browser?.enabled ?? true` access with `isBrowserEnabled(cfg)` helper function in attack surface summary collection. This ensures consistent browser enabled status resolution across the codebase by using the centralized helper that calls `resolveBrowserConfig`, which includes proper error handling via try/catch.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line refactoring that replaces inline logic with an existing helper function. The change maintains identical behavior while improving code consistency. The helper function `isBrowserEnabled` uses the same default value (true) and includes additional error handling via try/catch that makes the code more robust.
- No files require special attention

<sub>Last reviewed commit: 2d4ed0c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->