### PR TITLE
fix: use HEARTBEAT_TOKEN constant instead of hardcoded string in followup-runner

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -28,7 +28,7 @@ import {
 import { stripHeartbeatToken } from "../heartbeat.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildEmbeddedRunBaseParams,
@@ -125,7 +125,7 @@ export async function runAgentTurnWithFallback(params: {
     try {
       const normalizeStreamingText = (payload: ReplyPayload): { text?: string; skip: boolean } => {
         let text = payload.text;
-        if (!params.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
+        if (!params.isHeartbeat && text?.includes(HEARTBEAT_TOKEN)) {
           const stripped = stripHeartbeatToken(text, {
             mode: "message",
           });

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -2,7 +2,7 @@ import type { ReplyToMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import type { OriginatingChannelType } from "../templating.js";
-import { SILENT_REPLY_TOKEN } from "../tokens.js";
+import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
 import { formatBunFetchSocketError, isBunFetchSocketError } from "./agent-runner-utils.js";
 import { createBlockReplyPayloadKey, type BlockReplyPipeline } from "./block-reply-pipeline.js";
@@ -45,7 +45,7 @@ export function buildReplyPayloads(params: {
           text = formatBunFetchSocketError(text);
         }
 
-        if (!text || !text.includes("HEARTBEAT_OK")) {
+        if (!text || !text.includes(HEARTBEAT_TOKEN)) {
           return [{ ...payload, text }];
         }
         const stripped = stripHeartbeatToken(text, { mode: "message" });

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -11,7 +11,7 @@ import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import type { OriginatingChannelType } from "../templating.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveRunAuthProfile } from "./agent-runner-utils.js";
 import type { FollowupRun } from "./queue.js";
@@ -222,7 +222,7 @@ export function createFollowupRunner(params: {
       }
       const sanitizedPayloads = payloadArray.flatMap((payload) => {
         const text = payload.text;
-        if (!text || !text.includes("HEARTBEAT_OK")) {
+        if (!text || !text.includes(HEARTBEAT_TOKEN)) {
           return [payload];
         }
         const stripped = stripHeartbeatToken(text, { mode: "message" });


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced hardcoded `"HEARTBEAT_OK"` string with `HEARTBEAT_TOKEN` constant in `followup-runner.ts`

- Imported `HEARTBEAT_TOKEN` from `../tokens.js` 
- Changed line 225 from `.includes("HEARTBEAT_OK")` to `.includes(HEARTBEAT_TOKEN)`
- Improves maintainability by using the centralized constant

Note: Two other files (`agent-runner-payloads.ts` and `agent-runner-execution.ts`) still have hardcoded `"HEARTBEAT_OK"` strings that could be updated for consistency.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The change correctly replaces a hardcoded string with the proper constant, improving maintainability. The logic is unchanged and the constant has the same value. Score is 4 (not 5) because there are similar instances in other files that weren't addressed, suggesting this fix is incomplete.
- No files require special attention

<sub>Last reviewed commit: 922915e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->