### PR TITLE
fix: guard sandbox policy push with null check in resolveToolPolicies

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -249,7 +249,9 @@ function resolveToolPolicies(params: {
 
   if (params.sandboxMode === "all") {
     const sandboxPolicy = resolveSandboxToolPolicyForAgent(params.cfg, params.agentId ?? undefined);
-    policies.push(sandboxPolicy);
+    if (sandboxPolicy != null) {
+      policies.push(sandboxPolicy);
+    }
   }
 
   return policies;


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a defensive null check before pushing `sandboxPolicy` to the `policies` array in `resolveToolPolicies`. This prevents potential runtime errors if `resolveSandboxToolPolicyForAgent` returns a nullish value, though according to its type signature it should always return a valid `SandboxToolPolicyResolved` object.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change adds a defensive null check which can only improve safety. The fix is minimal, focused, and follows defensive programming practices. Even though the type signature suggests the value should never be null, the guard prevents potential runtime errors without introducing any side effects.
- No files require special attention

<sub>Last reviewed commit: 5e3d899</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->