### PR TITLE
fix: replace truthiness check with explicit null/undefined guard for setUnset

### DIFF
--- a/src/auto-reply/reply/commands-setunset.ts
+++ b/src/auto-reply/reply/commands-setunset.ts
@@ -90,7 +90,7 @@ export function parseSlashCommandWithSetUnset<T>(params: {
     onUnset: params.onUnset,
     onError: params.onError,
   });
-  if (setUnset) {
+  if (setUnset !== null && setUnset !== undefined) {
     return setUnset;
   }
   const knownAction = params.onKnownAction(action, args);


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced truthiness check with explicit null/undefined guard for the `setUnset` variable in `parseSlashCommandWithSetUnset`.

- Prevents incorrect fall-through behavior when callbacks return falsy but valid values like `false`, `0`, or `""`
- Makes the code more robust and type-safe by explicitly checking for null/undefined rather than relying on truthiness

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The change is a straightforward bug fix that makes the code more defensive and correct. It replaces a truthiness check with an explicit null/undefined guard, which prevents incorrect behavior when callbacks return falsy values. The change is minimal, well-targeted, and has no negative side effects.
- No files require special attention

<sub>Last reviewed commit: 9fc0f7e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->