### PR TITLE
fix: avoid mutating input object in normalizeAny

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -579,16 +579,17 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         deps.logger.warn(`Config warnings:\\n${details}`);
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
-      const cfg = applyModelDefaults(
-        applyCompactionDefaults(
-          applyContextPruningDefaults(
-            applyAgentDefaults(
-              applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+      const cfg = normalizeConfigPaths(
+        applyModelDefaults(
+          applyCompactionDefaults(
+            applyContextPruningDefaults(
+              applyAgentDefaults(
+                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+              ),
             ),
           ),
         ),
       );
-      normalizeConfigPaths(cfg);
 
       const duplicates = findDuplicateAgentDirs(cfg, {
         env: deps.env,

--- a/src/config/normalize-paths.ts
+++ b/src/config/normalize-paths.ts
@@ -44,14 +44,15 @@ function normalizeAny(key: string | undefined, value: unknown): unknown {
     return value;
   }
 
-  for (const [childKey, childValue] of Object.entries(value)) {
+  const result = { ...value };
+  for (const [childKey, childValue] of Object.entries(result)) {
     const next = normalizeAny(childKey, childValue);
     if (next !== childValue) {
-      value[childKey] = next;
+      result[childKey] = next;
     }
   }
 
-  return value;
+  return result;
 }
 
 /**

--- a/src/config/normalize-paths.ts
+++ b/src/config/normalize-paths.ts
@@ -65,6 +65,5 @@ export function normalizeConfigPaths(cfg: OpenClawConfig): OpenClawConfig {
   if (!cfg || typeof cfg !== "object") {
     return cfg;
   }
-  normalizeAny(undefined, cfg);
-  return cfg;
+  return normalizeAny(undefined, cfg) as OpenClawConfig;
 }


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `normalizeConfigPaths` to return the normalized config object instead of discarding it, which was broken after `normalizeAny` was changed to return a new object rather than mutating in place.

- Correctly returns the result from `normalizeAny` instead of ignoring it
- However, `src/config/io.ts:591` still has a call site that discards the return value and needs to be fixed

<h3>Confidence Score: 3/5</h3>

- This PR fixes a critical bug but leaves another call site broken
- The change correctly fixes `normalizeConfigPaths` to use the return value from `normalizeAny`, which is necessary after the mutation fix. However, there's still a broken call site in `src/config/io.ts:591` that doesn't use the return value, which means config paths won't be normalized in that code path
- Check `src/config/io.ts:591` - it needs the same fix applied

<sub>Last reviewed commit: 5fd7819</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->