### PR TITLE
fix: remove inner groupConfig shadow, reuse outer variable in feishu bot

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -699,7 +699,6 @@ export async function handleFeishuMessage(params: {
     // get a separate session from the main group chat.
     let peerId = isGroup ? ctx.chatId : ctx.senderOpenId;
     if (isGroup && ctx.rootId) {
-      const groupConfig = resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId });
       const topicSessionMode =
         groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";
       if (topicSessionMode === "enabled") {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed variable shadowing bug in Feishu bot where `groupConfig` was redundantly declared inside the topic session routing block, creating a shadow variable instead of reusing the outer `groupConfig` declared at line 558.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that removes redundant variable shadowing. The outer `groupConfig` was already correctly declared and this fix ensures it's properly reused. No logical changes to behavior, all usages verified to be correct.
- No files require special attention

<sub>Last reviewed commit: 1df3efe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->