### PR TITLE
fix: add 5th BACKOFF_MS entry to cover all MAX_RETRIES=5 retry slots

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -699,7 +699,6 @@ export async function handleFeishuMessage(params: {
     // get a separate session from the main group chat.
     let peerId = isGroup ? ctx.chatId : ctx.senderOpenId;
     if (isGroup && ctx.rootId) {
-      const groupConfig = resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId });
       const topicSessionMode =
         groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";
       if (topicSessionMode === "enabled") {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -16,6 +16,7 @@ const BACKOFF_MS: readonly number[] = [
   25_000, // retry 2: 25s
   120_000, // retry 3: 2m
   600_000, // retry 4: 10m
+  1_800_000, // retry 5: 30m
 ];
 
 type DeliveryMirrorPayload = {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -171,7 +171,7 @@ describe("delivery-queue", () => {
       expect(computeBackoffMs(3)).toBe(120_000);
       expect(computeBackoffMs(4)).toBe(600_000);
       // Beyond defined schedule -- clamps to last value.
-      expect(computeBackoffMs(5)).toBe(600_000);
+      expect(computeBackoffMs(5)).toBe(1_800_000);
     });
   });
 

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -170,8 +170,9 @@ describe("delivery-queue", () => {
       expect(computeBackoffMs(2)).toBe(25_000);
       expect(computeBackoffMs(3)).toBe(120_000);
       expect(computeBackoffMs(4)).toBe(600_000);
-      // Beyond defined schedule -- clamps to last value.
       expect(computeBackoffMs(5)).toBe(1_800_000);
+      // Beyond defined schedule -- clamps to last value.
+      expect(computeBackoffMs(6)).toBe(1_800_000);
     });
   });
 


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two bugs: added missing 5th backoff entry (30m) to match `MAX_RETRIES=5`, and removed shadowed `groupConfig` variable in Feishu bot that was declared but never used.

- `delivery-queue.ts`: added 5th `BACKOFF_MS` entry (1,800,000ms / 30m) so all retry slots have corresponding backoff values
- `bot.ts`: removed redundant `groupConfig` declaration at line 699 (already defined at line 558-560)

<h3>Confidence Score: 3/5</h3>

- Safe to merge after updating test expectations
- The code changes are correct - adding the missing 5th backoff entry and removing dead code. However, the test in `outbound.test.ts:174` expects the old behavior and will fail, requiring an update before the tests pass.
- `src/infra/outbound/outbound.test.ts` requires test update to match new backoff behavior

<sub>Last reviewed commit: 0bb303f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->