### PR TITLE
fix: add ?? 0 fallback for reconnectAttempts in WhatsApp channel summary

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -390,7 +390,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
         connected: snapshot.connected ?? false,
         lastConnectedAt: snapshot.lastConnectedAt ?? null,
         lastDisconnect: snapshot.lastDisconnect ?? null,
-        reconnectAttempts: snapshot.reconnectAttempts,
+        reconnectAttempts: snapshot.reconnectAttempts ?? 0,
         lastMessageAt: snapshot.lastMessageAt ?? null,
         lastEventAt: snapshot.lastEventAt ?? null,
         lastError: snapshot.lastError ?? null,

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -406,7 +406,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
         linked,
         running: runtime?.running ?? false,
         connected: runtime?.connected ?? false,
-        reconnectAttempts: runtime?.reconnectAttempts,
+        reconnectAttempts: runtime?.reconnectAttempts ?? 0,
         lastConnectedAt: runtime?.lastConnectedAt ?? null,
         lastDisconnect: runtime?.lastDisconnect ?? null,
         lastMessageAt: runtime?.lastMessageAt ?? null,


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `?? 0` fallback for `reconnectAttempts` in the `buildChannelSummary` function to prevent `undefined` values when `snapshot.reconnectAttempts` is not set.

- Fixed `buildChannelSummary` to use nullish coalescing for `reconnectAttempts` (line 387)
- Inconsistency found: `buildAccountSnapshot` at line 403 still lacks the same fallback and should be fixed

<h3>Confidence Score: 3/5</h3>

- This PR fixes a real issue but is incomplete - the same fix needs to be applied in one more location
- The fix correctly adds a `?? 0` fallback for `reconnectAttempts` in `buildChannelSummary`, which prevents `undefined` from being assigned when `snapshot.reconnectAttempts` is not set (since `ChannelAccountSnapshot` expects `reconnectAttempts?: number`). However, the same issue exists in `buildAccountSnapshot` at line 403 where `runtime?.reconnectAttempts` is used without a fallback. This inconsistency means the bug is only partially fixed.
- The changed file `extensions/whatsapp/src/channel.ts` needs one additional fix at line 403 to be complete

<sub>Last reviewed commit: 6a25a5a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->