### PR TITLE
fix: use media.url and media.urls in iMessage inbound processing

### DIFF
--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -452,13 +452,12 @@ export function buildIMessageInboundContext(params: {
     Timestamp: decision.createdAt,
     MediaPath: params.media?.path,
     MediaType: params.media?.type,
-    MediaUrl: params.media?.path,
+    MediaUrl: params.media?.url,
     MediaPaths:
       params.media?.paths && params.media.paths.length > 0 ? params.media.paths : undefined,
     MediaTypes:
       params.media?.types && params.media.types.length > 0 ? params.media.types : undefined,
-    MediaUrls:
-      params.media?.paths && params.media.paths.length > 0 ? params.media.paths : undefined,
+    MediaUrls: params.media?.urls && params.media.urls.length > 0 ? params.media.urls : undefined,
     MediaRemoteHost: params.remoteHost,
     WasMentioned: decision.effectiveWasMentioned,
     CommandAuthorized: decision.commandAuthorized,

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -349,8 +349,10 @@ export function buildIMessageInboundContext(params: {
   media?: {
     path?: string;
     type?: string;
+    url?: string;
     paths?: string[];
     types?: Array<string | undefined>;
+    urls?: string[];
   };
   historyLimit: number;
   groupHistories: Map<string, HistoryEntry[]>;


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two copy-paste bugs in iMessage inbound processing where media path values were incorrectly assigned to URL fields. Line 455 now correctly assigns `media.url` to `MediaUrl` (was using `media.path`), and line 460 now correctly assigns `media.urls` to `MediaUrls` (was using `media.paths`).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge - fixes clear copy-paste errors in media field assignments
- The changes correct obvious bugs where path values were assigned to URL fields. However, the TypeScript type definition for the `media` parameter (lines 349-354) is missing the `url` and `urls` properties that are now being used, which means TypeScript won't catch if these fields are undefined at runtime.
- Check that callers of `buildIMessageInboundContext` actually provide `media.url` and `media.urls` fields

<sub>Last reviewed commit: f3b7f55</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->