### PR TITLE
fix: return false from mark() for undefined/null/empty message IDs

### DIFF
--- a/extensions/tlon/src/monitor/processed-messages.test.ts
+++ b/extensions/tlon/src/monitor/processed-messages.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from "vitest";
 import { createProcessedMessageTracker } from "./processed-messages.js";
 
 describe("createProcessedMessageTracker", () => {
+  it("returns false for undefined, null, and empty message IDs", () => {
+    const tracker = createProcessedMessageTracker(10);
+    expect(tracker.mark(undefined)).toBe(false);
+    expect(tracker.mark(null)).toBe(false);
+    expect(tracker.mark("")).toBe(false);
+    expect(tracker.mark("   ")).toBe(false);
+    expect(tracker.size()).toBe(0);
+  });
+
   it("dedupes and evicts oldest entries", () => {
     const tracker = createProcessedMessageTracker(3);
 

--- a/extensions/tlon/src/monitor/processed-messages.ts
+++ b/extensions/tlon/src/monitor/processed-messages.ts
@@ -11,7 +11,7 @@ export function createProcessedMessageTracker(limit = 2000): ProcessedMessageTra
   const mark = (id?: string | null) => {
     const trimmed = id?.trim();
     if (!trimmed) {
-      return true;
+      return false;
     }
     if (seen.has(trimmed)) {
       return false;

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -16,6 +16,7 @@ const BACKOFF_MS: readonly number[] = [
   25_000, // retry 2: 25s
   120_000, // retry 3: 2m
   600_000, // retry 4: 10m
+  1_800_000, // retry 5: 30m
 ];
 
 type DeliveryMirrorPayload = {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -170,8 +170,9 @@ describe("delivery-queue", () => {
       expect(computeBackoffMs(2)).toBe(25_000);
       expect(computeBackoffMs(3)).toBe(120_000);
       expect(computeBackoffMs(4)).toBe(600_000);
+      expect(computeBackoffMs(5)).toBe(1_800_000);
       // Beyond defined schedule -- clamps to last value.
-      expect(computeBackoffMs(5)).toBe(600_000);
+      expect(computeBackoffMs(6)).toBe(1_800_000);
     });
   });
 

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -872,8 +872,7 @@ export abstract class MemoryManagerSyncOps {
         return;
       }
 
-      const shouldSyncMemory =
-        this.sources.has("memory") && (params?.force || needsFullReindex || this.dirty);
+      const shouldSyncMemory = this.sources.has("memory") && (params?.force || this.dirty);
       const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
 
       if (shouldSyncMemory) {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR contains three distinct bug fixes addressing message tracking, delivery retry resilience, and memory sync logic:

- Fixed `mark()` to return `false` for undefined/null/empty message IDs, preventing duplicate processing of messages without valid IDs
- Added a 5th retry attempt with 30-minute backoff to the delivery queue for improved resilience
- Removed redundant `needsFullReindex` check from `shouldSyncMemory` expression since the code already returns early when `needsFullReindex` is true (line 855-872)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All three changes are straightforward bug fixes with clear intent: the `mark()` fix corrects return semantics for invalid inputs, the delivery queue change adds resilience, and the memory sync fix removes dead code. No breaking changes or security concerns.
- No files require special attention

<sub>Last reviewed commit: 2be3a02</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->