### PR TITLE
fix: trim token before passing to probeTelegram in Telegram probeAccount

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -341,7 +341,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         };
       }
       const audit = await getTelegramRuntime().channel.telegram.auditGroupMembership({
-        token: account.token,
+        token: account.token.trim(),
         botId,
         groupIds,
         proxyUrl: account.config.proxy,

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -316,7 +316,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
     }),
     probeAccount: async ({ account, timeoutMs }) =>
       getTelegramRuntime().channel.telegram.probeTelegram(
-        account.token,
+        account.token.trim(),
         timeoutMs,
         account.config.proxy,
       ),


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Defensive fix that trims whitespace from token before passing to `probeTelegram` in the `probeAccount` method.

- The token resolution in `src/telegram/token.ts` already trims tokens at the source, so this is a safety measure
- Ensures consistency with line 380 where the token is also trimmed in `startAccount`
- Consider applying the same defensive trim to line 340 (`auditGroupMembership`) for consistency

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple defensive fix that adds token trimming. Since tokens are already trimmed at the source, this change has no functional impact on correct configurations but protects against potential edge cases where whitespace might be present. The change is minimal, well-scoped, and follows existing patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: dccacbe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->