### PR TITLE
fix: always mask API keys regardless of length, show at most first 4 chars

### DIFF
--- a/src/utils/mask-api-key.test.ts
+++ b/src/utils/mask-api-key.test.ts
@@ -7,12 +7,9 @@ describe("maskApiKey", () => {
     expect(maskApiKey("   ")).toBe("missing");
   });
 
-  it("returns trimmed value when length is 16 chars or less", () => {
-    expect(maskApiKey(" abcdefghijklmnop ")).toBe("abcdefghijklmnop");
-    expect(maskApiKey(" short ")).toBe("short");
-  });
-
-  it("masks long values with first and last 8 chars", () => {
-    expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("12345678...ijklmnop");
+  it("always masks keys showing only first 4 chars", () => {
+    expect(maskApiKey(" abcdefghijklmnop ")).toBe("abcd****");
+    expect(maskApiKey(" short ")).toBe("shor****");
+    expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("1234****");
   });
 });

--- a/src/utils/mask-api-key.ts
+++ b/src/utils/mask-api-key.ts
@@ -3,8 +3,6 @@ export const maskApiKey = (value: string): string => {
   if (!trimmed) {
     return "missing";
   }
-  if (trimmed.length <= 16) {
-    return trimmed;
-  }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
+  const prefix = trimmed.slice(0, 4);
+  return `${prefix}****`;
 };


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves API key masking security by always masking keys regardless of length, showing only the first 4 characters followed by `****` instead of the previous behavior that exposed short keys (≤16 chars) completely.

- Changed from conditional masking (8 chars...8 chars for long keys, full exposure for short keys) to uniform masking (4 chars + `****`)
- Tests need updating to match new behavior

<h3>Confidence Score: 3/5</h3>

- This PR improves security but breaks existing tests
- The implementation change is correct and improves security, but the tests are outdated and will fail, preventing this from being merged without additional fixes
- The test file `src/utils/mask-api-key.test.ts` requires updates to match the new implementation

<sub>Last reviewed commit: 242fd0c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->