### PR TITLE
fix: remove always-false needsFullReindex from shouldSyncMemory expression

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -881,8 +881,7 @@ export abstract class MemoryManagerSyncOps {
         return;
       }
 
-      const shouldSyncMemory =
-        this.sources.has("memory") && (params?.force || needsFullReindex || this.dirty);
+      const shouldSyncMemory = this.sources.has("memory") && (params?.force || this.dirty);
       const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
 
       if (shouldSyncMemory) {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes redundant `needsFullReindex` check from `shouldSyncMemory` expression (line 875 is unreachable when `needsFullReindex` is true due to early return on line 872), and strengthens API key masking to always show only first 4 chars regardless of length

- Fixed logic bug where `needsFullReindex` was checked after already returning when true
- Changed `maskApiKey` to mask all keys uniformly (`prefix****`) instead of exposing keys ≤16 chars
- Test file needs update to match new masking behavior

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing test failures
- The logic changes are correct and improve code quality, but the PR has failing tests that must be fixed before merging. The `manager-sync-ops.ts` change correctly removes dead code. The `mask-api-key.ts` change improves security by masking all keys, but the test file was not updated to match the new behavior.
- src/utils/mask-api-key.test.ts requires test updates to match new masking behavior

<sub>Last reviewed commit: e9e8d71</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->