### PR TITLE
fix: remove dead null check after requireRef in dragViaPlaywright

### DIFF
--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -89,9 +89,6 @@ export async function dragViaPlaywright(opts: {
 }): Promise<void> {
   const startRef = requireRef(opts.startRef);
   const endRef = requireRef(opts.endRef);
-  if (!startRef || !endRef) {
-    throw new Error("startRef and endRef are required");
-  }
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed unreachable null check in `dragViaPlaywright` function. The check tested `startRef` and `endRef` for falsy values after calling `requireRef()`, which always throws an error for invalid refs and never returns null/undefined. This cleanup brings the function in line with other similar functions in the file that also use `requireRef()` without subsequent null checks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change removes genuinely unreachable code - `requireRef()` throws an error for falsy values, making the subsequent null check impossible to reach. The pattern matches other similar functions in the same file that also call `requireRef()` without null checks
- No files require special attention

<sub>Last reviewed commit: 1b37119</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->