### PR TITLE
fix: remove port 3000 from STANDARD_PORTS in security skill-scanner

### DIFF
--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -105,7 +105,7 @@ const LINE_RULES: LineRule[] = [
   },
 ];
 
-const STANDARD_PORTS = new Set([80, 443, 8080, 8443, 3000]);
+const STANDARD_PORTS = new Set([80, 443, 8080, 8443]);
 
 const SOURCE_RULES: SourceRule[] = [
   {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed port 3000 from `STANDARD_PORTS` in the security skill-scanner to flag WebSocket connections to this commonly-used development port. Since port 3000 is typically associated with local development servers rather than production services, treating it as suspicious helps detect potential data exfiltration or command-and-control connections in skill/plugin code.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line modification that improves security detection by correctly classifying port 3000 as non-standard. The logic is sound, the change is well-scoped, and aligns with the security scanner's purpose of detecting suspicious network activity in skill/plugin code.
- No files require special attention

<sub>Last reviewed commit: 3009aab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->