### PR TITLE
fix: throw on null output_file_id before empty string reaches fetch in batch-openai

### DIFF
--- a/src/memory/batch-openai.ts
+++ b/src/memory/batch-openai.ts
@@ -216,10 +216,15 @@ export async function runOpenAiEmbeddingBatches(params: {
 
       const completed =
         batchInfo.status === "completed"
-          ? {
-              outputFileId: batchInfo.output_file_id ?? "",
-              errorFileId: batchInfo.error_file_id ?? undefined,
-            }
+          ? (() => {
+              if (!batchInfo.output_file_id) {
+                throw new Error(`openai batch ${batchInfo.id} completed without output file id`);
+              }
+              return {
+                outputFileId: batchInfo.output_file_id,
+                errorFileId: batchInfo.error_file_id ?? undefined,
+              };
+            })()
           : await waitForOpenAiBatch({
               openAi: params.openAi,
               batchId: batchInfo.id,

--- a/src/memory/batch-voyage.ts
+++ b/src/memory/batch-voyage.ts
@@ -210,10 +210,15 @@ export async function runVoyageEmbeddingBatches(params: {
 
       const completed =
         batchInfo.status === "completed"
-          ? {
-              outputFileId: batchInfo.output_file_id ?? "",
-              errorFileId: batchInfo.error_file_id ?? undefined,
-            }
+          ? (() => {
+              if (!batchInfo.output_file_id) {
+                throw new Error(`voyage batch ${batchInfo.id} completed without output file id`);
+              }
+              return {
+                outputFileId: batchInfo.output_file_id,
+                errorFileId: batchInfo.error_file_id ?? undefined,
+              };
+            })()
           : await waitForVoyageBatch({
               client: params.client,
               batchId: batchInfo.id,


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

prevented null `output_file_id` from being coerced to empty string before reaching fetch call

- wraps the early-return object literal in an IIFE to validate `output_file_id` before constructing the `completed` object
- throws immediately with a clear error message if `output_file_id` is null or undefined when status is "completed"
- same vulnerability exists in `batch-voyage.ts:214` which still uses `?? ""` pattern

<h3>Confidence Score: 3/5</h3>

- Fix is correct but incomplete - same bug exists in batch-voyage.ts
- The fix correctly prevents null `output_file_id` from being coerced to empty string in batch-openai.ts, but the exact same vulnerability pattern exists in batch-voyage.ts:214 which still uses `batchInfo.output_file_id ?? ""`. The incomplete fix means the bug is only partially addressed.
- batch-voyage.ts needs the same fix applied (line 214)

<sub>Last reviewed commit: 9c90fbc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->