### PR TITLE
fix: use exit(1) for force-exit timeout to indicate abnormal termination

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -51,7 +51,7 @@ export async function runGatewayLoop(params: {
     const forceExitTimer = setTimeout(() => {
       gatewayLog.error("shutdown timed out; exiting without full cleanup");
       cleanupSignals();
-      params.runtime.exit(0);
+      params.runtime.exit(1);
     }, forceExitMs);
 
     void (async () => {

--- a/src/macos/gateway-daemon.ts
+++ b/src/macos/gateway-daemon.ts
@@ -147,7 +147,7 @@ async function main() {
     forceExitTimer = setTimeout(() => {
       defaultRuntime.error("gateway: shutdown timed out; exiting without full cleanup");
       cleanupSignals();
-      process.exit(0);
+      process.exit(1);
     }, forceExitMs);
 
     void (async () => {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed force-exit timeout to use `exit(1)` instead of `exit(0)` to correctly indicate abnormal termination when shutdown times out.

- Fixed exit code in `run-loop.ts:54` from 0 to 1 for timeout scenario
- Inconsistency: `src/macos/gateway-daemon.ts:150` has identical timeout logic but still uses `exit(0)`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one inconsistency to address
- The change correctly uses exit code 1 for abnormal termination when shutdown times out. However, there's an inconsistent pattern in `gateway-daemon.ts` that should be addressed for consistency
- Check `src/macos/gateway-daemon.ts` for similar timeout handling

<sub>Last reviewed commit: a52002a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->