### PR TITLE
fix: guard mention regex against replacing @name inside URLs in msteams

### DIFF
--- a/extensions/msteams/src/mentions.test.ts
+++ b/extensions/msteams/src/mentions.test.ts
@@ -232,4 +232,33 @@ describe("formatMentionText", () => {
 
     expect(result).toBe("Hey <at>John(Test)</at> and <at>Alice.Smith</at>");
   });
+
+  it("does not replace @name inside a URL", () => {
+    const text = "See https://github.com/@Alice for the profile";
+    const mentions = [{ id: "28:aaa", name: "Alice" }];
+
+    const result = formatMentionText(text, mentions);
+
+    // @Alice inside the URL path must remain untouched
+    expect(result).toBe("See https://github.com/@Alice for the profile");
+  });
+
+  it("replaces standalone @name but leaves @name inside URLs untouched", () => {
+    const text = "Hey @Alice, see https://github.com/@Alice for the profile";
+    const mentions = [{ id: "28:aaa", name: "Alice" }];
+
+    const result = formatMentionText(text, mentions);
+
+    expect(result).toBe("Hey <at>Alice</at>, see https://github.com/@Alice for the profile");
+  });
+
+  it("does not replace @name inside URLs with unicode names", () => {
+    const text = "参照: https://example.com/@田中 そして @田中 さんへ";
+    const mentions = [{ id: "28:aaa", name: "田中" }];
+
+    const result = formatMentionText(text, mentions);
+
+    // @田中 in the URL must be untouched; standalone @田中 followed by space should be replaced
+    expect(result).toBe("参照: https://example.com/@田中 そして <at>田中</at> さんへ");
+  });
 });

--- a/extensions/msteams/src/mentions.ts
+++ b/extensions/msteams/src/mentions.ts
@@ -107,7 +107,7 @@ export function formatMentionText(text: string, mentions: MentionInfo[]): string
   for (const mention of mentions) {
     // Replace @Name or @name with <at>Name</at>
     const escapedName = mention.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const namePattern = new RegExp(`@${escapedName}`, "gi");
+    const namePattern = new RegExp(`(?<![/\\w])@${escapedName}\\b`, "gi");
     formatted = formatted.replace(namePattern, `<at>${mention.name}</at>`);
   }
   return formatted;

--- a/extensions/msteams/src/mentions.ts
+++ b/extensions/msteams/src/mentions.ts
@@ -107,7 +107,7 @@ export function formatMentionText(text: string, mentions: MentionInfo[]): string
   for (const mention of mentions) {
     // Replace @Name or @name with <at>Name</at>
     const escapedName = mention.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const namePattern = new RegExp(`(?<![/\\w])@${escapedName}\\b`, "gi");
+    const namePattern = new RegExp(`(?<![/\\w])@${escapedName}(?=\\s|[.,!?;:]|$)`, "giu");
     formatted = formatted.replace(namePattern, `<at>${mention.name}</at>`);
   }
   return formatted;


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds negative lookbehind `(?<![/\\w])` and word boundary `\\b` to the mention regex in `formatMentionText()` to prevent replacing `@name` patterns inside URLs.

**Key Issues Found:**
- The `\\b` word boundary doesn't work correctly with Unicode names (Japanese, Chinese, etc.) because JavaScript's word boundary only recognizes ASCII characters. This means the fix may not work for users with non-ASCII names like `@タナカ` or `@张伟`.
- No test coverage for the URL protection scenario that this PR aims to fix.

**Recommendation:** Add the `u` flag and replace `\\b` with an explicit boundary pattern like `(?=\\s|[.,!?;:]|$)` that explicitly matches whitespace, punctuation, or end-of-string. Also add test cases verifying URL protection works and Unicode names are handled correctly.

<h3>Confidence Score: 3/5</h3>

- This PR has a critical bug with Unicode name handling that could break mentions for international users
- The negative lookbehind for URL protection is correct, but the `\\b` word boundary will fail with Unicode names (Japanese, Chinese, etc.) because JavaScript regex word boundaries only work with ASCII characters. The PR also lacks test coverage for the specific URL scenario it aims to fix. These issues need to be addressed before merging.
- extensions/msteams/src/mentions.ts requires fixes for Unicode support, and extensions/msteams/src/mentions.test.ts needs additional test coverage for URL protection

<sub>Last reviewed commit: a24af88</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->