### PR TITLE
fix: remove early break that prevented 3+ target ambiguity detection in bluebubbles

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -477,9 +477,6 @@ export async function handleBlueBubblesWebhookRequest(
     }
     if (safeEqualSecret(guid, token)) {
       strictMatches.push(target);
-      if (strictMatches.length > 1) {
-        break;
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed early loop break that prevented detection of 3+ ambiguous webhook targets with matching passwords. The break statement stopped collecting matches after finding 2 targets, causing the ambiguity check to miss cases where 3 or more targets shared the same password token.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that removes a premature optimization. The early break prevented the loop from collecting all matching targets, which broke the ambiguity detection logic for 3+ targets. Removing it ensures all matches are found and properly rejected by the existing validation at line 499-503. The fix is minimal, clearly correct, and restores the intended behavior without introducing new logic or side effects.
- No files require special attention

<sub>Last reviewed commit: 946d112</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->