### PR TITLE
fix: use strict equality for wildcard hour field in cron stagger

### DIFF
--- a/src/cron/stagger.test.ts
+++ b/src/cron/stagger.test.ts
@@ -9,8 +9,8 @@ import {
 describe("cron stagger helpers", () => {
   it("detects recurring top-of-hour cron expressions for 5-field and 6-field cron", () => {
     expect(isRecurringTopOfHourCronExpr("0 * * * *")).toBe(true);
-    expect(isRecurringTopOfHourCronExpr("0 */2 * * *")).toBe(true);
-    expect(isRecurringTopOfHourCronExpr("0 0 */3 * * *")).toBe(true);
+    expect(isRecurringTopOfHourCronExpr("0 */2 * * *")).toBe(false);
+    expect(isRecurringTopOfHourCronExpr("0 0 */3 * * *")).toBe(false);
     expect(isRecurringTopOfHourCronExpr("0 7 * * *")).toBe(false);
     expect(isRecurringTopOfHourCronExpr("15 * * * *")).toBe(false);
   });

--- a/src/cron/stagger.ts
+++ b/src/cron/stagger.ts
@@ -10,11 +10,11 @@ export function isRecurringTopOfHourCronExpr(expr: string) {
   const fields = parseCronFields(expr);
   if (fields.length === 5) {
     const [minuteField, hourField] = fields;
-    return minuteField === "0" && hourField.includes("*");
+    return minuteField === "0" && hourField === "*";
   }
   if (fields.length === 6) {
     const [secondField, minuteField, hourField] = fields;
-    return secondField === "0" && minuteField === "0" && hourField.includes("*");
+    return secondField === "0" && minuteField === "0" && hourField === "*";
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed bug in cron stagger detection where step-hour patterns like `*/2` were incorrectly matched as top-of-hour schedules. Changed from substring matching to strict equality checking for the wildcard hour field.

- Changed `hourField.includes("*")` to `hourField === "*"` for both 5-field and 6-field cron expressions
- Updated test expectations to correctly expect `false` for step-hour patterns
- Updated migration tests to verify step-hour schedules don't receive default stagger timing

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix is a simple, focused bug correction with complete test coverage. The logic change is correct and all tests have been properly updated to match the new behavior
- No files require special attention

<sub>Last reviewed commit: f1efcc6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->