### PR TITLE
fix: use monotonic counter for subscription IDs to prevent collision

### DIFF
--- a/extensions/tlon/src/urbit/sse-client.ts
+++ b/extensions/tlon/src/urbit/sse-client.ts
@@ -53,6 +53,7 @@ export class UrbitSSEClient {
   lookupFn?: LookupFn;
   fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   streamRelease: (() => Promise<void>) | null = null;
+  private nextSubId = 1;
 
   constructor(url: string, cookie: string, options: UrbitSseOptions = {}) {
     const ctx = getUrbitContext(url, options.ship);
@@ -79,7 +80,7 @@ export class UrbitSSEClient {
     err?: (error: unknown) => void;
     quit?: () => void;
   }) {
-    const subId = this.subscriptions.length + 1;
+    const subId = this.nextSubId++;
     const subscription = {
       id: subId,
       action: "subscribe",


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced array-length-based subscription ID generation with a monotonic counter to prevent ID collisions. Previously, `subscribe()` used `this.subscriptions.length + 1` which could reuse IDs if subscriptions were removed or during reconnection scenarios, causing event handlers to be mapped incorrectly. The new `nextSubId` counter guarantees unique IDs across the client lifetime.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix is straightforward, correctly addresses a real bug, and introduces no new complexity or side effects. The monotonic counter pattern is a standard solution for ID generation and is well-suited for this use case.
- No files require special attention

<sub>Last reviewed commit: a5bb50d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->