### PR TITLE
fix: remove hidden add() side effects from has() in nostr seen-tracker

### DIFF
--- a/extensions/nostr/src/seen-tracker.ts
+++ b/extensions/nostr/src/seen-tracker.ts
@@ -207,7 +207,6 @@ export function createSeenTracker(options?: SeenTrackerOptions): SeenTracker {
   function has(id: string): boolean {
     const entry = entries.get(id);
     if (!entry) {
-      add(id);
       return false;
     }
 
@@ -215,7 +214,6 @@ export function createSeenTracker(options?: SeenTrackerOptions): SeenTracker {
     if (Date.now() - entry.seenAt > ttlMs) {
       removeFromList(id);
       entries.delete(id);
-      add(id);
       return false;
     }
 


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed hidden `add()` side effects from the `has()` method in the Nostr seen-tracker. Previously, `has()` would incorrectly call `add()` when an ID was not found or expired, violating its documented contract that it "checks if an ID has been seen (also marks it as seen if not)". The interface was misleading - the actual behavior should be a pure check. The fix removes two `add()` calls from `has()`, ensuring it only reads state and updates LRU positioning for existing valid entries, without inserting new entries. The codebase already uses `peek()` for pure checks and `add()` for explicit marking, so this fix aligns implementation with usage patterns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a clean bug fix that aligns implementation with documented behavior.
- The fix removes unintended side effects from a method that should be read-only. The interface comment is misleading (says "also marks it as seen if not") but actual usage patterns in `nostr-bus.ts` show `peek()` is used for pure checks and `add()` is called explicitly after verification. This change makes `has()` behave more like `peek()` but with LRU updates for existing entries, which is correct. No logic issues or breaking changes - the two removed `add()` calls were bugs causing duplicate insertions.
- No files require special attention

<sub>Last reviewed commit: d89d51d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->