### PR TITLE
fix: remove "D" (delete) from canWrite check in windows-acl

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -97,13 +97,13 @@ Successfully processed 1 files`;
       // F = Full control (read + write)
       // M = Modify (read + write)
       // W = Write
-      // D = Delete (considered write)
+      // D = Delete only (not write)
       // R = Read only
       const testCases = [
         { rights: "(F)", canWrite: true, canRead: true },
         { rights: "(M)", canWrite: true, canRead: true },
         { rights: "(W)", canWrite: true, canRead: false },
-        { rights: "(D)", canWrite: true, canRead: false },
+        { rights: "(D)", canWrite: false, canRead: false },
         { rights: "(R)", canWrite: false, canRead: true },
         { rights: "(RX)", canWrite: false, canRead: true },
       ];

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -80,7 +80,7 @@ function classifyPrincipal(
 function rightsFromTokens(tokens: string[]): { canRead: boolean; canWrite: boolean } {
   const upper = tokens.join("").toUpperCase();
   const canWrite =
-    upper.includes("F") || upper.includes("M") || upper.includes("W") || upper.includes("D");
+    upper.includes("F") || upper.includes("M") || upper.includes("W");
   const canRead = upper.includes("F") || upper.includes("M") || upper.includes("R");
   return { canRead, canWrite };
 }

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -79,8 +79,7 @@ function classifyPrincipal(
 
 function rightsFromTokens(tokens: string[]): { canRead: boolean; canWrite: boolean } {
   const upper = tokens.join("").toUpperCase();
-  const canWrite =
-    upper.includes("F") || upper.includes("M") || upper.includes("W");
+  const canWrite = upper.includes("F") || upper.includes("M") || upper.includes("W");
   const canRead = upper.includes("F") || upper.includes("M") || upper.includes("R");
   return { canRead, canWrite };
 }


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes "D" (Delete) from the `canWrite` check in Windows ACL permission classification. The change correctly distinguishes Delete permission from Write permission - they represent different Windows ACL capabilities (deleting files vs modifying contents). Test expectations updated to match: `(D)` rights now yield `canWrite: false` instead of `true`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change correctly implements a semantic distinction between Delete and Write permissions in Windows ACLs. Both the implementation and corresponding tests are updated consistently. The fix improves accuracy of security audits by not inflating write permission surface with delete-only entries.
- No files require special attention

<sub>Last reviewed commit: e65847f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->