### PR TITLE
fix: treat empty string env vars as valid, only throw for undefined

### DIFF
--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -97,7 +97,7 @@ function substituteString(value: string, env: NodeJS.ProcessEnv, configPath: str
     }
     if (token?.kind === "substitution") {
       const envValue = env[token.name];
-      if (envValue === undefined || envValue === "") {
+      if (envValue === undefined) {
         throw new MissingEnvVarError(token.name, configPath);
       }
       chunks.push(envValue);

--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -97,7 +97,7 @@ function substituteString(value: string, env: NodeJS.ProcessEnv, configPath: str
     }
     if (token?.kind === "substitution") {
       const envValue = env[token.name];
-      if (envValue === undefined) {
+      if (envValue === undefined || envValue === "") {
         throw new MissingEnvVarError(token.name, configPath);
       }
       chunks.push(envValue);
@@ -164,7 +164,7 @@ function substituteAny(value: unknown, env: NodeJS.ProcessEnv, path: string): un
  * @param obj - The parsed config object (after JSON5 parse and $include resolution)
  * @param env - Environment variables to use for substitution (defaults to process.env)
  * @returns The config object with env vars substituted
- * @throws {MissingEnvVarError} If a referenced env var is not set or empty
+ * @throws {MissingEnvVarError} If a referenced env var is not set
  */
 export function resolveConfigEnvVars(obj: unknown, env: NodeJS.ProcessEnv = process.env): unknown {
   return substituteAny(obj, env, "");


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes behavior to treat empty string environment variables as valid values rather than missing, only throwing `MissingEnvVarError` for truly undefined variables.

- Modified validation logic in `substituteString` to remove empty string check
- Test suite has failing test that expects old behavior (`env-substitution.test.ts:113-117`)
- JSDoc documentation on line 167 needs update to match new behavior

<h3>Confidence Score: 1/5</h3>

- This PR will break existing tests and needs test updates before merging
- Score reflects critical test failure and documentation inconsistency - the change modifies expected behavior but doesn't update the test suite that explicitly validates the old behavior
- Pay close attention to `src/config/env-substitution.test.ts` line 113-117 - this test must be updated or removed to match the new behavior

<sub>Last reviewed commit: 70cc77d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->