### PR TITLE
fix: invert copyString guard to check next[field] not payload[field]

### DIFF
--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -223,7 +223,7 @@ function copyTopLevelAgentTurnFields(next: UnknownRecord, payload: UnknownRecord
     if (typeof next[field] !== "string" || !next[field].trim()) {
       return;
     }
-    payload[field] = (next[field] as string).trim();
+    payload[field] = next[field].trim();
   };
   copyString("model");
   copyString("thinking");

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -220,13 +220,10 @@ function normalizeWakeMode(raw: unknown) {
 
 function copyTopLevelAgentTurnFields(next: UnknownRecord, payload: UnknownRecord) {
   const copyString = (field: "model" | "thinking") => {
-    if (typeof payload[field] === "string" && payload[field].trim()) {
+    if (typeof next[field] !== "string" || !next[field].trim()) {
       return;
     }
-    const value = next[field];
-    if (typeof value === "string" && value.trim()) {
-      payload[field] = value.trim();
-    }
+    payload[field] = (next[field] as string).trim();
   };
   copyString("model");
   copyString("thinking");


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a critical logic bug in `copyTopLevelAgentTurnFields` that prevented top-level `model` and `thinking` fields from being copied into the nested `payload` object during cron job normalization. The old guard checked `payload[field]` and returned early if the destination already had a value, preventing overwrites. The fix inverts the guard to check `next[field]` instead, only returning early when the source has no value to copy.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix correctly inverts a logic error that prevented proper field copying. The change is minimal (inverts guard condition and simplifies assignment), follows the pattern in existing tests (line 320-336), and aligns with the commit message's description of the bug. The refactored code is clearer and more efficient.
- No files require special attention

<sub>Last reviewed commit: 4bfa2bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->