### PR TITLE
fix: call onEose per-relay inside loop instead of once with all relays joined

### DIFF
--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -239,8 +239,8 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
         onDisconnect: (relay) => {
           ctx.log?.debug?.(`[${account.accountId}] Disconnected from relay: ${relay}`);
         },
-        onEose: (relays) => {
-          ctx.log?.debug?.(`[${account.accountId}] EOSE received from relays: ${relays}`);
+        onEose: (relay) => {
+          ctx.log?.debug?.(`[${account.accountId}] EOSE received from relay: ${relay}`);
         },
         onMetric: (event: MetricEvent) => {
           // Log significant metrics at appropriate levels

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -497,8 +497,8 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         // EOSE handler - called when all stored events have been received
         for (const relay of relays) {
           metrics.emit("relay.message.eose", 1, { relay });
+          onEose?.(relay);
         }
-        onEose?.(relays.join(", "));
       },
       onclose: (reason) => {
         // Handle subscription close


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `onEose` callback to match its interface contract - now called once per relay instead of once with all relays joined as a comma-separated string. The interface defines `onEose?: (relay: string) => void` expecting a single relay, and this change aligns the implementation with that contract, matching the behavior of `onConnect` and `onDisconnect` callbacks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that corrects the callback behavior to match the interface contract. The fix is minimal (3 lines changed), logically sound, and improves consistency with other callback handlers. While channel.ts has a misleading variable name that should be updated for clarity, this doesn't affect functionality
- No files require special attention

<sub>Last reviewed commit: 8ff106e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->