### PR TITLE
fix: add recursive depth guard to attemptReconnect() to prevent stack overflow

### DIFF
--- a/extensions/tlon/src/urbit/sse-client.ts
+++ b/extensions/tlon/src/urbit/sse-client.ts
@@ -317,6 +317,13 @@ export class UrbitSSEClient {
     );
   }
 
+  // Two separate reconnection limits are maintained intentionally:
+  // - MAX_RECONNECT_DEPTH (50): a safety guard against unbounded call-stack growth during
+  //   rapid synchronous failures (e.g. connect() throws immediately every time). Without
+  //   this limit a tight retry loop would overflow the stack before maxReconnectAttempts
+  //   is ever reached.
+  // - maxReconnectAttempts (default 10): the user-facing policy limit on how many total
+  //   reconnection attempts are made under normal backoff conditions.
   private static readonly MAX_RECONNECT_DEPTH = 50;
 
   async attemptReconnect(depth = 0) {

--- a/src/plugin-sdk/json-store.ts
+++ b/src/plugin-sdk/json-store.ts
@@ -16,8 +16,8 @@ export async function readJsonFileWithFallback<T>(
     return { value: parsed, exists: true };
   } catch (err) {
     const code = (err as { code?: string }).code;
-    if (code === "ENOENT") {
-      return { value: fallback, exists: false };
+    if (code !== "ENOENT") {
+      throw err;
     }
     return { value: fallback, exists: false };
   }

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -60,7 +60,7 @@ function isDroppedBoundaryTextBlockSubset(params: {
   finalTextBlocks: string[];
 }): boolean {
   const { streamedTextBlocks, finalTextBlocks } = params;
-  if (finalTextBlocks.length === 0 || finalTextBlocks.length >= streamedTextBlocks.length) {
+  if (finalTextBlocks.length === 0 || finalTextBlocks.length > streamedTextBlocks.length) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three bugs: prevents stack overflow in SSE reconnection logic, corrects error handling in JSON file reads, and fixes an edge case in stream text block comparison.

**Key changes:**
- Added recursive depth guard (max 50) to `UrbitSSEClient.attemptReconnect()` to prevent stack overflow when reconnection failures occur synchronously
- Fixed `readJsonFileWithFallback()` to properly rethrow non-ENOENT errors (permission errors, corrupt files, etc.) instead of silently returning fallback
- Corrected boundary check in `isDroppedBoundaryTextBlockSubset()` to handle equal-length text block arrays

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - fixes real bugs without introducing new issues
- All three changes are valid bug fixes addressing stack overflow, error handling, and edge case logic. The depth guard prevents infinite recursion, the JSON error handling fix properly propagates non-ENOENT errors, and the boundary condition fix handles equal-length arrays correctly. One minor suggestion about code clarity (dual reconnection limits), but no blocking issues.
- No files require special attention - all changes are straightforward bug fixes

<sub>Last reviewed commit: 6e341a8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->