### PR TITLE
fix: remove dead isFirstTurnInSession inner condition in session-updates

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -164,7 +164,7 @@ export async function ensureSkillSnapshot(params: {
         updatedAt: Date.now(),
       };
     const skillSnapshot =
-      isFirstTurnInSession || !current.skillsSnapshot || shouldRefreshSnapshot
+      !current.skillsSnapshot || shouldRefreshSnapshot
         ? buildWorkspaceSkillSnapshot(workspaceDir, {
             config: cfg,
             skillFilter,


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed redundant `isFirstTurnInSession` check from skill snapshot conditional at line 167. This check was already guaranteed to be true by the outer condition at line 160, making it dead code.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change removes dead code that had no effect on behavior. The `isFirstTurnInSession` check at line 167 was redundant because it was already inside a block that only executes when `isFirstTurnInSession` is true (line 160). The change simplifies the logic without altering functionality.
- No files require special attention

<sub>Last reviewed commit: b45d8d1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->