### PR TITLE
fix: check equal-length arrays in isDroppedBoundaryTextBlockSubset

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -339,10 +339,15 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       probe: snapshot.probe,
       lastProbeAt: snapshot.lastProbeAt ?? null,
     }),
-    probeAccount: async ({ account, timeoutMs }) =>
-      getDiscordRuntime().channel.discord.probeDiscord(account.token, timeoutMs, {
+    probeAccount: async ({ account, timeoutMs }) => {
+      const token = account.token?.trim();
+      if (!token) {
+        return { ok: false, error: "No token configured" };
+      }
+      return getDiscordRuntime().channel.discord.probeDiscord(token, timeoutMs, {
         includeApplication: true,
-      }),
+      });
+    },
     auditAccount: async ({ account, timeoutMs, cfg }) => {
       const { channelIds, unresolvedChannels } = collectDiscordAuditChannelIds({
         cfg,

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -60,7 +60,7 @@ function isDroppedBoundaryTextBlockSubset(params: {
   finalTextBlocks: string[];
 }): boolean {
   const { streamedTextBlocks, finalTextBlocks } = params;
-  if (finalTextBlocks.length === 0 || finalTextBlocks.length >= streamedTextBlocks.length) {
+  if (finalTextBlocks.length === 0 || finalTextBlocks.length > streamedTextBlocks.length) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two defensive programming issues: corrected array length comparison logic in `isDroppedBoundaryTextBlockSubset` to allow equal-length arrays to proceed to content comparison, and added token trimming with null guard in Discord `probeAccount` to match existing patterns in the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both changes are small, well-contained defensive improvements: the array comparison fix corrects a logical error that prevented equal-length arrays from being compared, and the Discord token guard follows existing patterns in the codebase
- No files require special attention

<sub>Last reviewed commit: 3e81bb0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->