### PR TITLE
fix: replace escaped \n with real newlines in logger calls (io.ts)

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -565,7 +565,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           .join("\n");
         if (!loggedInvalidConfigs.has(configPath)) {
           loggedInvalidConfigs.add(configPath);
-          deps.logger.error(`Invalid config at ${configPath}:\\n${details}`);
+          deps.logger.error(`Invalid config at ${configPath}:\n${details}`);
         }
         const error = new Error("Invalid config");
         (error as { code?: string; details?: string }).code = "INVALID_CONFIG";
@@ -576,7 +576,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         const details = validated.warnings
           .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
           .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
+        deps.logger.warn(`Config warnings:\n${details}`);
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = applyModelDefaults(


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed logger calls to use actual newlines instead of escaped `\\n` sequences. Template literals on lines 568 and 579 were incorrectly using `:\\n` which produced literal backslash-n in log output rather than line breaks. This aligns with the repository's style guide (AGENTS.md line 4) which explicitly states "never embed `\\n`" in output strings.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a trivial string literal fix that corrects logging output formatting. It replaces escaped `\\n` with actual newlines in two template literals (lines 568 and 579), fixing a clear bug where log messages would display literal `\n` instead of line breaks. The fix is isolated, syntactically correct, and aligns with the repository's documented style guidelines in AGENTS.md.
- No files require special attention

<sub>Last reviewed commit: be21447</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->