### PR TITLE
fix: use nullish coalescing in whatsapp deleteAccount for empty string accountId

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -61,7 +61,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     resolveAccount: (cfg, accountId) => resolveWhatsAppAccount({ cfg, accountId }),
     defaultAccountId: (cfg) => resolveDefaultWhatsAppAccountId(cfg),
     setAccountEnabled: ({ cfg, accountId, enabled }) => {
-      const accountKey = accountId || DEFAULT_ACCOUNT_ID;
+      const accountKey = accountId ?? DEFAULT_ACCOUNT_ID;
       const accounts = { ...cfg.channels?.whatsapp?.accounts };
       const existing = accounts[accountKey] ?? {};
       return {

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -82,7 +82,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       };
     },
     deleteAccount: ({ cfg, accountId }) => {
-      const accountKey = accountId || DEFAULT_ACCOUNT_ID;
+      const accountKey = accountId ?? DEFAULT_ACCOUNT_ID;
       const accounts = { ...cfg.channels?.whatsapp?.accounts };
       delete accounts[accountKey];
       return {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `deleteAccount` to use nullish coalescing (`??`) instead of logical OR (`||`) when falling back to `DEFAULT_ACCOUNT_ID`. This ensures empty string `accountId` values are preserved rather than treated as falsy.

- Fixes potential bug where empty string `accountId` would incorrectly fall back to default
- Aligns with most other channel extensions which use `??` for this pattern
- Note: `setAccountEnabled` on line 64 still uses `||` and should be updated for consistency

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor inconsistency noted
- The fix correctly addresses a potential edge case where empty string `accountId` values would be treated as falsy. The change aligns with patterns used in other channel extensions. Score reduced by 1 due to an inconsistency in the same file where `setAccountEnabled` still uses the old pattern.
- Consider updating `setAccountEnabled` (line 64) for consistency

<sub>Last reviewed commit: a2aff51</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->