### PR TITLE
fix(memory): negate BM25 rank before clamping in bm25RankToScore

### DIFF
--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -44,7 +44,7 @@ export function buildFtsQuery(raw: string): string | null {
 }
 
 export function bm25RankToScore(rank: number): number {
-  const normalized = Number.isFinite(rank) ? Math.max(0, rank) : 999;
+  const normalized = Number.isFinite(rank) ? Math.max(0, -rank) : 999;
   return 1 / (1 + normalized);
 }
 


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates test expectations to match the fixed `bm25RankToScore` implementation that now correctly handles negative BM25 ranks from SQLite FTS5. The test cases were updated from positive to negative rank values and include clear documentation explaining that SQLite FTS5 returns negative ranks where more negative indicates a better match.

<h3>Confidence Score: 4/5</h3>

- Safe to merge - test update correctly reflects the fixed implementation
- Test-only changes that accurately document and verify the corrected BM25 rank handling. The updated test cases properly use negative ranks matching SQLite FTS5 output. Clear comments explain the transformation logic. Minor concern about the inverse score semantics (better matches = lower scores) being inconsistent with vector scoring conventions, but this is a pre-existing design decision not introduced by this PR.
- No files require special attention

<sub>Last reviewed commit: 65a6ec9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->