### PR TITLE
fix: rename SsrFBlockedError to SsrfBlockedError for consistent casing

### DIFF
--- a/extensions/tlon/src/urbit/auth.ssrf.test.ts
+++ b/extensions/tlon/src/urbit/auth.ssrf.test.ts
@@ -1,5 +1,5 @@
 import type { LookupFn } from "openclaw/plugin-sdk";
-import { SsrFBlockedError } from "openclaw/plugin-sdk";
+import { SsrfBlockedError } from "openclaw/plugin-sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { authenticate } from "./auth.js";
 
@@ -17,7 +17,7 @@ describe("tlon urbit auth ssrf", () => {
     vi.stubGlobal("fetch", mockFetch);
 
     await expect(authenticate("http://127.0.0.1:8080", "code")).rejects.toBeInstanceOf(
-      SsrFBlockedError,
+      SsrfBlockedError,
     );
     expect(mockFetch).not.toHaveBeenCalled();
   });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,7 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
-import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
@@ -547,7 +547,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       );
     }
   } catch (error) {
-    if (error instanceof SsrFBlockedError) {
+    if (error instanceof SsrfBlockedError) {
       throw error;
     }
     const payload = await maybeFetchFirecrawlWebFetchPayload({

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type WebSocket, WebSocketServer } from "ws";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import { rawDataToString } from "../infra/ws.js";
 import { createTargetViaCdp, evaluateJavaScript, normalizeCdpWsUrl, snapshotAria } from "./cdp.js";
 
@@ -102,7 +102,7 @@ describe("cdp", () => {
           cdpUrl: "http://127.0.0.1:9222",
           url: "http://127.0.0.1:8080",
         }),
-      ).rejects.toBeInstanceOf(SsrFBlockedError);
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
       fetchSpy.mockRestore();

--- a/src/browser/navigation-guard.test.ts
+++ b/src/browser/navigation-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { SsrFBlockedError, type LookupFn } from "../infra/net/ssrf.js";
+import { SsrfBlockedError, type LookupFn } from "../infra/net/ssrf.js";
 import {
   assertBrowserNavigationAllowed,
   InvalidBrowserNavigationUrlError,
@@ -16,7 +16,7 @@ describe("browser navigation guard", () => {
       assertBrowserNavigationAllowed({
         url: "http://127.0.0.1:8080",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it("allows non-network schemes", async () => {
@@ -48,7 +48,7 @@ describe("browser navigation guard", () => {
         url: "https://example.com",
         lookupFn,
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it("allows hostnames that resolve to public addresses", async () => {

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import { fetchJson, fetchOk } from "./cdp.helpers.js";
 import { appendCdpPath, createTargetViaCdp, normalizeCdpWsUrl } from "./cdp.js";
 import {
@@ -648,7 +648,7 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
   const getDefaultContext = () => forProfile();
 
   const mapTabError = (err: unknown) => {
-    if (err instanceof SsrFBlockedError) {
+    if (err instanceof SsrfBlockedError) {
       return { status: 400, message: err.message };
     }
     if (err instanceof InvalidBrowserNavigationUrlError) {

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 
 const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatNowMock = vi.fn();
@@ -99,7 +99,7 @@ describe("buildGatewayCronService", () => {
 
     loadConfigMock.mockReturnValue(cfg);
     fetchWithSsrFGuardMock.mockRejectedValue(
-      new SsrFBlockedError("Blocked: private/internal IP address"),
+      new SsrfBlockedError("Blocked: private/internal IP address"),
     );
 
     const state = buildGatewayCronService({

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -16,7 +16,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { getChildLogger } from "../logging.js";
 import { normalizeAgentId, toAgentStoreSessionKey } from "../routing/session-key.js";
@@ -260,7 +260,7 @@ export function buildGatewayCronService(params: {
               });
               await result.release();
             } catch (err) {
-              if (err instanceof SsrFBlockedError) {
+              if (err instanceof SsrfBlockedError) {
                 cronLogger.warn(
                   {
                     reason: formatErrorMessage(err),

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -6,7 +6,7 @@ import {
   createPinnedDispatcher,
   resolvePinnedHostnameWithPolicy,
   type LookupFn,
-  SsrFBlockedError,
+  SsrfBlockedError,
   type SsrFPolicy,
 } from "./ssrf.js";
 
@@ -184,7 +184,7 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
         release: async () => release(dispatcher),
       };
     } catch (err) {
-      if (err instanceof SsrFBlockedError) {
+      if (err instanceof SsrfBlockedError) {
         const context = params.auditContext ?? "url-fetch";
         logWarn(
           `security: blocked URL fetch (${context}) target=${parsedUrl.origin}${parsedUrl.pathname} reason=${err.message}`,

--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -4,7 +4,7 @@ import {
   type LookupFn,
   resolvePinnedHostname,
   resolvePinnedHostnameWithPolicy,
-  SsrFBlockedError,
+  SsrfBlockedError,
 } from "./ssrf.js";
 
 describe("ssrf pinning", () => {
@@ -118,7 +118,7 @@ describe("ssrf pinning", () => {
       resolvePinnedHostnameWithPolicy("2001:db8:1234::5efe:127.0.0.1", {
         lookupFn: lookup,
       }),
-    ).rejects.toThrow(SsrFBlockedError);
+    ).rejects.toThrow(SsrfBlockedError);
     expect(lookup).not.toHaveBeenCalled();
   });
 
@@ -129,7 +129,7 @@ describe("ssrf pinning", () => {
 
     await expect(
       resolvePinnedHostnameWithPolicy("0177.0.0.1", { lookupFn: lookup }),
-    ).rejects.toThrow(SsrFBlockedError);
+    ).rejects.toThrow(SsrfBlockedError);
     expect(lookup).not.toHaveBeenCalled();
   });
 
@@ -139,7 +139,7 @@ describe("ssrf pinning", () => {
     ]) as unknown as LookupFn;
 
     await expect(resolvePinnedHostnameWithPolicy("8.8.2056", { lookupFn: lookup })).rejects.toThrow(
-      SsrFBlockedError,
+      SsrfBlockedError,
     );
     expect(lookup).not.toHaveBeenCalled();
   });

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -9,10 +9,10 @@ type LookupCallback = (
   family?: number,
 ) => void;
 
-export class SsrFBlockedError extends Error {
+export class SsrfBlockedError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "SsrFBlockedError";
+    this.name = "SsrfBlockedError";
   }
 }
 
@@ -481,11 +481,11 @@ export async function resolvePinnedHostnameWithPolicy(
   const isExplicitAllowed = allowedHostnames.has(normalized);
 
   if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
-    throw new SsrFBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
+    throw new SsrfBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
   }
 
   if (!allowPrivateNetwork && !isExplicitAllowed && isBlockedHostnameOrIp(normalized)) {
-    throw new SsrFBlockedError("Blocked hostname or private/internal IP address");
+    throw new SsrfBlockedError("Blocked hostname or private/internal IP address");
   }
 
   const lookupFn = params.lookupFn ?? dnsLookup;
@@ -497,7 +497,7 @@ export async function resolvePinnedHostnameWithPolicy(
   if (!allowPrivateNetwork && !isExplicitAllowed) {
     for (const entry of results) {
       if (isPrivateIpAddress(entry.address)) {
-        throw new SsrFBlockedError("Blocked: resolves to private/internal IP address");
+        throw new SsrfBlockedError("Blocked: resolves to private/internal IP address");
       }
     }
   }

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -183,7 +183,7 @@ export {
 
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export {
-  SsrFBlockedError,
+  SsrfBlockedError,
   isBlockedHostname,
   isBlockedHostnameOrIp,
   isPrivateIpAddress,


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renamed `SsrFBlockedError` to `SsrfBlockedError` for consistent casing across the codebase.

- Updated class definition in `src/infra/net/ssrf.ts`
- Updated all imports and instanceof checks across 11 files
- Updated test expectations to use the new error name
- Updated plugin SDK export

The renaming is complete and consistent. Note that other related identifiers like `SsrFPolicy` and `fetchWithSsrFGuard` still use inconsistent casing, but those are outside the scope of this PR.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a straightforward identifier rename with no logic changes. All references have been updated consistently across the codebase, including class definition, imports, exports, instanceof checks, and test expectations. The change is purely cosmetic, fixing inconsistent casing from `SsrFBlockedError` to `SsrfBlockedError`.
- No files require special attention

<sub>Last reviewed commit: 6b7768a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->