### PR TITLE
fix(open-prose): import OpenClawPluginApi from openclaw/plugin-sdk

### DIFF
--- a/extensions/open-prose/index.ts
+++ b/extensions/open-prose/index.ts
@@ -1,4 +1,4 @@
-import type { OpenClawPluginApi } from "../../src/plugins/types.js";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
 export default function register(_api: OpenClawPluginApi) {
   // OpenProse is delivered via plugin-shipped skills.


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces fragile relative path import (`../../src/plugins/types.js`) with the proper package export (`openclaw/plugin-sdk`) for the `OpenClawPluginApi` type. This ensures the extension works correctly when used as a standalone plugin outside the monorepo, as the package export path is stable and published, while relative paths into `src/` would break.

Note: Two other extensions (`llm-task` and `lobster`) still use the old import pattern and should be migrated similarly.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - this is a straightforward import path correction with no behavioral changes
- The change is minimal, correct, and follows the established pattern used by other extensions in the codebase. The package.json exports configuration confirms `openclaw/plugin-sdk` is properly configured, and the type is correctly exported from the plugin SDK.
- No files require special attention

<sub>Last reviewed commit: e6cea2d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->