### PR TITLE
fix(feishu): schedule deferred flush for pending streaming card text

### DIFF
--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -182,6 +182,10 @@ export class FeishuStreamingSession {
       return;
     }
     this.closed = true;
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = undefined;
+    }
     await this.queue;
 
     // Use finalText, or pending throttled text, or current text

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -140,6 +140,11 @@ export class FeishuStreamingSession {
     const now = Date.now();
     if (now - this.lastUpdateTime < this.updateThrottleMs) {
       this.pendingText = text;
+      setTimeout(() => {
+        if (this.pendingText !== null && !this.closed) {
+          void this.update(this.pendingText);
+        }
+      }, this.updateThrottleMs);
       return;
     }
     this.pendingText = null;


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds deferred flush scheduling when throttle skips updates, preventing pending text from being lost until `close()` is called. However, the implementation has a critical bug where multiple rapid `update()` calls within the throttle window schedule overlapping timeouts without canceling previous ones.

- schedules `setTimeout` to flush pending text after throttle expires
- missing guard to prevent multiple overlapping timeouts (see `draft-stream-loop.ts:54-56` for correct pattern)

<h3>Confidence Score: 2/5</h3>

- This PR has a logic bug that will cause redundant scheduled updates
- The intent is correct (schedule deferred flush for throttled updates), but the implementation is missing a critical guard to prevent multiple overlapping timeouts. Each rapid call to `update()` within the throttle window schedules a new timeout without clearing previous ones, leading to redundant update attempts. The codebase already has the correct pattern in `draft-stream-loop.ts` which prevents this issue.
- extensions/feishu/src/streaming-card.ts requires a fix to prevent multiple overlapping timeout scheduling

<sub>Last reviewed commit: cce135d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->