### PR TITLE
fix(feishu): remove empty else block in bot.ts

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -620,7 +620,6 @@ export async function handleFeishuMessage(params: {
       }
       return;
     }
-  } else {
   }
 
   try {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed an empty `else` block that served no purpose in the Feishu message handler. The code after the conditional executes the same way with or without the empty block, making this a clean code improvement with no behavioral change.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change only removes an empty else block, which has zero behavioral impact on the code. It's a pure code cleanup that improves readability.
- No files require special attention

<sub>Last reviewed commit: 6b068b3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->