### PR TITLE
fix: replace || with ?? for token fallback in twitch resolveToken

### DIFF
--- a/extensions/twitch/src/token.ts
+++ b/extensions/twitch/src/token.ts
@@ -66,7 +66,7 @@ export function resolveTwitchToken(
   if (accountId === DEFAULT_ACCOUNT_ID) {
     // Base-level config takes precedence
     token = normalizeTwitchToken(
-      (typeof twitchCfg?.accessToken === "string" ? twitchCfg.accessToken : undefined) ||
+      (typeof twitchCfg?.accessToken === "string" ? twitchCfg.accessToken : undefined) ??
         (accountCfg?.accessToken as string | undefined),
     );
   } else {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces logical OR (`||`) with nullish coalescing (`??`) for token fallback in `resolveTwitchToken`. This ensures that an explicitly set empty string in base-level config (`twitchCfg.accessToken`) takes precedence over account-level config, which is the intended behavior per the "Base-level config takes precedence" comment on line 67.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-character operator replacement that fixes a subtle bug in fallback logic. The `??` operator correctly handles empty strings as valid values (preventing incorrect fallback), while `||` would treat them as falsy and incorrectly fall back. This aligns with the documented precedence that base-level config takes precedence over account config.
- No files require special attention

<sub>Last reviewed commit: 40e90ea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->