### PR TITLE
fix(voice-call): pad buffers to equal length before timingSafeEqual

### DIFF
--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -43,17 +43,12 @@ export function validateTwilioSignature(
 
 /**
  * Timing-safe string comparison to prevent timing attacks.
+ * Uses SHA-256 hashing to normalize buffer lengths, eliminating
+ * length-based side channels.
  */
 function timingSafeEqual(a: string, b: string): boolean {
-  const bufA = Buffer.from(a);
-  const bufB = Buffer.from(b);
-  const maxLen = Math.max(bufA.length, bufB.length);
-  const paddedA = Buffer.alloc(maxLen);
-  const paddedB = Buffer.alloc(maxLen);
-  bufA.copy(paddedA);
-  bufB.copy(paddedB);
-  const equal = crypto.timingSafeEqual(paddedA, paddedB);
-  return equal && bufA.length === bufB.length;
+  const hash = (s: string) => crypto.createHash("sha256").update(s).digest();
+  return crypto.timingSafeEqual(hash(a), hash(b));
 }
 
 /**
@@ -545,12 +540,8 @@ function getBaseUrlNoQuery(url: string): string {
 }
 
 function timingSafeEqualString(a: string, b: string): boolean {
-  if (a.length !== b.length) {
-    const dummy = Buffer.from(a);
-    crypto.timingSafeEqual(dummy, dummy);
-    return false;
-  }
-  return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  const hash = (s: string) => crypto.createHash("sha256").update(s).digest();
+  return crypto.timingSafeEqual(hash(a), hash(b));
 }
 
 function validatePlivoV2Signature(params: {

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -45,16 +45,15 @@ export function validateTwilioSignature(
  * Timing-safe string comparison to prevent timing attacks.
  */
 function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) {
-    // Still do comparison to maintain constant time
-    const dummy = Buffer.from(a);
-    crypto.timingSafeEqual(dummy, dummy);
-    return false;
-  }
-
   const bufA = Buffer.from(a);
   const bufB = Buffer.from(b);
-  return crypto.timingSafeEqual(bufA, bufB);
+  const maxLen = Math.max(bufA.length, bufB.length);
+  const paddedA = Buffer.alloc(maxLen);
+  const paddedB = Buffer.alloc(maxLen);
+  bufA.copy(paddedA);
+  bufB.copy(paddedB);
+  const equal = crypto.timingSafeEqual(paddedA, paddedB);
+  return equal && bufA.length === bufB.length;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to fix a timing attack vulnerability in webhook signature validation but the implementation still leaks length information. The padded buffer approach returns `equal && bufA.length === bufB.length` where the length comparison is not constant-time, allowing attackers to distinguish responses based on signature length. The file also contains `timingSafeEqualString` (line 547) with the old vulnerable early-return pattern. PR #20856 (f1e1ad73) previously fixed this exact vulnerability in `src/security/secret-equal.ts` by hashing both inputs with SHA-256 before comparison—the same approach should be applied here.

- Both `timingSafeEqual` and `timingSafeEqualString` need to hash inputs with SHA-256 before calling `crypto.timingSafeEqual`
- This ensures fixed-length buffers (32 bytes) and true constant-time comparison regardless of input lengths

<h3>Confidence Score: 1/5</h3>

- This PR contains a critical security vulnerability in webhook signature validation
- The implementation still has a timing side-channel that leaks length information, which could be exploited by attackers to bypass webhook signature validation. The non-constant-time length check defeats the purpose of the timing-safe comparison.
- Pay close attention to `extensions/voice-call/src/webhook-security.ts` - both timing-safe comparison functions need to be fixed using SHA-256 hashing

<sub>Last reviewed commit: a75015b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->