### PR TITLE
fix: correct metric name for p-tag targeting check failure in nostr-bus

### DIFF
--- a/extensions/nostr/src/metrics.ts
+++ b/extensions/nostr/src/metrics.ts
@@ -20,7 +20,8 @@ export type EventMetricName =
   | "event.rejected.oversized_ciphertext"
   | "event.rejected.oversized_plaintext"
   | "event.rejected.decrypt_failed"
-  | "event.rejected.self_message";
+  | "event.rejected.self_message"
+  | "event.rejected.not_targeted";
 
 export type RelayMetricName =
   | "relay.connect"
@@ -108,6 +109,7 @@ export interface MetricsSnapshot {
     oversizedPlaintext: number;
     decryptFailed: number;
     selfMessage: number;
+    notTargeted: number;
   };
 
   /** Relay stats by URL */
@@ -170,6 +172,7 @@ export function createMetrics(onMetric?: OnMetricCallback): NostrMetrics {
     oversizedPlaintext: 0,
     decryptFailed: 0,
     selfMessage: 0,
+    notTargeted: 0,
   };
 
   // Per-relay stats
@@ -276,6 +279,9 @@ export function createMetrics(onMetric?: OnMetricCallback): NostrMetrics {
         break;
       case "event.rejected.self_message":
         eventsRejected.selfMessage += value;
+        break;
+      case "event.rejected.not_targeted":
+        eventsRejected.notTargeted += value;
         break;
 
       // Relay metrics
@@ -410,6 +416,7 @@ export function createMetrics(onMetric?: OnMetricCallback): NostrMetrics {
       oversizedPlaintext: 0,
       decryptFailed: 0,
       selfMessage: 0,
+      notTargeted: 0,
     });
     relays.clear();
     rateLimiting.perSenderHits = 0;
@@ -442,6 +449,7 @@ export function createNoopMetrics(): NostrMetrics {
       oversizedPlaintext: 0,
       decryptFailed: 0,
       selfMessage: 0,
+      notTargeted: 0,
     },
     relays: {},
     rateLimiting: { perSenderHits: 0, globalHits: 0 },

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -431,7 +431,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         }
       }
       if (!targetsUs) {
-        metrics.emit("event.rejected.wrong_kind");
+        metrics.emit("event.rejected.not_targeted");
         return;
       }
 


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed metric name from `event.rejected.wrong_kind` to `event.rejected.not_targeted` when events lack a p-tag targeting the user. This better reflects the actual check being performed (p-tag targeting validation, not event kind validation).

However, the new metric name is not properly integrated into the metrics system - it's missing from the type definition and metrics collector, so it won't be tracked.

<h3>Confidence Score: 2/5</h3>

- This PR has a critical bug that prevents the metric from being tracked
- While the intent to fix the misleading metric name is correct, the implementation is incomplete. The new metric name `event.rejected.not_targeted` is not defined in the metrics type system and has no handler in the collector, meaning it will be silently ignored and not counted. This breaks observability for p-tag targeting failures.
- Pay close attention to `extensions/nostr/src/metrics.ts` which needs to be updated to properly support the new metric name

<sub>Last reviewed commit: 7ae1de8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->