### PR TITLE
fix(process-message): use combinedBody for BodyForAgent in group chats

### DIFF
--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -286,7 +286,7 @@ export async function processMessage(params: {
 
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
-    BodyForAgent: params.msg.body,
+    BodyForAgent: combinedBody,
     InboundHistory: inboundHistory,
     RawBody: params.msg.body,
     CommandBody: params.msg.body,


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `BodyForAgent` to use `combinedBody` instead of raw message body in WhatsApp group chats. In group chats with history, the agent now receives the full conversation context (including previous messages with sender information) rather than just the current message, aligning WhatsApp behavior with other channels like Telegram, Discord, and Slack.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward one-line fix that ensures consistency between `Body` and `BodyForAgent` in group chats. The fix aligns WhatsApp with the established pattern used in other channels (Telegram, Discord, Slack). The change only affects group chats when history is present, and provides agents with the proper context they need to understand the conversation flow.
- No files require special attention

<sub>Last reviewed commit: cd53762</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->