### PR TITLE
fix: reset isFinal flag in forceNewMessage in telegram draft-stream

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -82,7 +82,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       };
     },
     deleteAccount: ({ cfg, accountId }) => {
-      const accountKey = accountId || DEFAULT_ACCOUNT_ID;
+      const accountKey = accountId ?? DEFAULT_ACCOUNT_ID;
       const accounts = { ...cfg.channels?.whatsapp?.accounts };
       delete accounts[accountKey];
       return {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -565,7 +565,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           .join("\n");
         if (!loggedInvalidConfigs.has(configPath)) {
           loggedInvalidConfigs.add(configPath);
-          deps.logger.error(`Invalid config at ${configPath}:\\n${details}`);
+          deps.logger.error(`Invalid config at ${configPath}:\n${details}`);
         }
         const error = new Error("Invalid config");
         (error as { code?: string; details?: string }).code = "INVALID_CONFIG";
@@ -576,7 +576,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         const details = validated.warnings
           .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
           .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
+        deps.logger.warn(`Config warnings:\n${details}`);
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = applyModelDefaults(

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -135,6 +135,7 @@ export function createTelegramDraftStream(params: {
   };
 
   const forceNewMessage = () => {
+    isFinal = false;
     streamMessageId = undefined;
     lastSentText = "";
     loop.resetPending();


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles three small but important bug fixes: properly resets the `isFinal` flag when forcing new Telegram messages, fixes empty string handling in WhatsApp account deletion, and corrects escaped newlines in config error messages.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward bug fixes with clear logic improvements
- All three changes are focused bug fixes with clear intent. The telegram draft-stream fix addresses a state management issue, the WhatsApp fix prevents incorrect account deletion, and the config logging fix improves error message readability. No breaking changes or risky refactoring.
- No files require special attention

<sub>Last reviewed commit: cadfefc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->