### PR TITLE
fix: use kind direct for DM peer in zalouser monitor ternary else branch

### DIFF
--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -277,7 +277,7 @@ async function processMessage(
 
   const peer = isGroup
     ? { kind: "group" as const, id: chatId }
-    : { kind: "group" as const, id: senderId };
+    : { kind: "direct" as const, id: senderId };
 
   const route = core.channel.routing.resolveAgentRoute({
     cfg: config,


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a critical bug in the zalouser monitor where direct messages (DMs) were incorrectly assigned `kind: "group"` instead of `kind: "direct"` in the peer object. This caused DM session routing to bypass the intended `dmScope=main` behavior, preventing DMs from properly collapsing into the main agent session.

- Corrected the ternary operator else branch on line 280 to use `kind: "direct"` for non-group messages
- Ensures DM messages are properly routed through the session key logic that respects `dmScope` configuration
- Aligns with the comment on line 287 explaining the session routing behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is a straightforward one-line correction of an obvious logic error where the else branch incorrectly duplicated the if branch condition. The change aligns with the documented intent (comment on line 287) and the surrounding code structure. No additional side effects or edge cases introduced.
- No files require special attention

<sub>Last reviewed commit: 43af80c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->