### PR TITLE
fix(dedupe): prune entries at exact TTL cutoff boundary

### DIFF
--- a/src/infra/dedupe.ts
+++ b/src/infra/dedupe.ts
@@ -25,7 +25,7 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
     const cutoff = ttlMs > 0 ? now - ttlMs : undefined;
     if (cutoff !== undefined) {
       for (const [entryKey, entryTs] of cache) {
-        if (entryTs < cutoff) {
+        if (entryTs <= cutoff) {
           cache.delete(entryKey);
         }
       }


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed the TTL boundary check in the dedupe cache pruning logic from strict less-than (`<`) to less-than-or-equal (`<=`), ensuring entries are correctly pruned when they reach exactly the TTL cutoff time. This aligns the pruning behavior with the validity check on line 46 which uses `now - existing < ttlMs` (strict less-than), meaning an entry at exactly the TTL boundary is considered expired and should be removed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-character fix that corrects an off-by-one boundary condition in TTL pruning logic. The fix aligns the pruning behavior with the validity check, ensuring consistent semantics throughout the dedupe cache. The change is well-contained, logically sound, and addresses a precise edge case without introducing new complexity or side effects.
- No files require special attention

<sub>Last reviewed commit: 3eca747</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->