### PR TITLE
fix(delivery-queue): count max-retries exhausted entries as failed not skipped

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -307,7 +307,7 @@ export async function recoverPendingDeliveries(opts: {
   }
 
   opts.log.info(
-    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skipped} skipped (max retries)`,
+    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skipped} skipped`,
   );
   return { recovered, failed, skipped };
 }

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -254,7 +254,7 @@ export async function recoverPendingDeliveries(opts: {
       } catch (err) {
         opts.log.error(`Failed to move entry ${entry.id} to failed/: ${String(err)}`);
       }
-      skipped += 1;
+      failed += 1;
       continue;
     }
 

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -236,7 +236,7 @@ describe("delivery-queue", () => {
       const { result } = await runRecovery({ deliver });
 
       expect(deliver).not.toHaveBeenCalled();
-      expect(result.skipped).toBe(1);
+      expect(result.failed).toBe(1);
 
       // Entry should be in failed/ directory.
       const failedDir = path.join(tmpDir, "delivery-queue", "failed");


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed accounting bug where delivery queue entries that exhausted max retries were incorrectly counted as "skipped" instead of "failed" when moved to the `failed/` directory.

**Key changes:**
- Changed `skipped += 1` to `failed += 1` on line 257 when entries exceed `MAX_RETRIES`

**Issues found:**
- The test in `src/infra/outbound/outbound.test.ts:239` expects the old buggy behavior (`result.skipped`) and will now fail
- The log message on line 310 still refers to "skipped (max retries)" which is now misleading since max-retries-exhausted entries are counted as `failed`

<h3>Confidence Score: 2/5</h3>

- This PR fixes a semantic bug but introduces a test failure that must be resolved before merging
- The logic fix is correct (max-retries-exhausted entries should be counted as failed, not skipped), but the PR breaks an existing test that expects the old behavior. The test at `src/infra/outbound/outbound.test.ts:239` needs to be updated to expect `result.failed` instead of `result.skipped`. Additionally, the log message is now misleading.
- `src/infra/outbound/outbound.test.ts` needs to be updated - line 239 expects the old buggy behavior

<sub>Last reviewed commit: b151d8c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->