### PR TITLE
fix: remove duplicate comment in orderProfilesByMode

### DIFF
--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -144,7 +144,7 @@ function orderProfilesByMode(order: string[], store: AuthProfileStore): string[]
     }
   }
 
-  // Sort available profiles by lastUsed (oldest first = round-robin)
+  // Sort available profiles by type preference, then by lastUsed (oldest first = round-robin within type)
   const scored = available.map((profileId) => {
     const type = store.profiles[profileId]?.type;
     const typeScore = type === "oauth" ? 0 : type === "token" ? 1 : type === "api_key" ? 2 : 3;

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -145,7 +145,6 @@ function orderProfilesByMode(order: string[], store: AuthProfileStore): string[]
   }
 
   // Sort available profiles by lastUsed (oldest first = round-robin)
-  // Then by lastUsed (oldest first = round-robin within type)
   const scored = available.map((profileId) => {
     const type = store.profiles[profileId]?.type;
     const typeScore = type === "oauth" ? 0 : type === "token" ? 1 : type === "api_key" ? 2 : 3;


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

removed duplicate comment on line 148 that redundantly described the sorting behavior already explained on lines 155-156

- the deletion itself is correct and improves code clarity
- comment on line 147 could be updated to better reflect that type-based sorting is the primary sort criterion

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Score reflects that this is a simple comment deletion with no functional changes - removes a redundant comment that duplicated information already present elsewhere in the code
- No files require special attention

<sub>Last reviewed commit: 0a9fbd1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->