### PR TITLE
fix(heartbeat): constrain 24-hour sentinel to 24:00 only in regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Heartbeat/Cron: restore interval heartbeat behavior so missing `HEARTBEAT.md` no longer suppresses runs (only effectively empty files skip), preserving prompt-driven and tagged-cron execution paths.
+- Heartbeat/Active hours: constrain active-hours `24` sentinel parsing to `24:00` in time validation so invalid values like `24:30` are rejected early. (#21410) thanks @adhitShet.
 - Gateway/Pairing: tolerate legacy paired devices missing `roles`/`scopes` metadata in websocket upgrade checks and backfill metadata on reconnect. (#21447, fixes #21236) Thanks @joshavant.
 - Docker: pin base images to SHA256 digests in Docker builds to prevent mutable tag drift. (#7734) Thanks @coygeek.
 - Provider/HTTP: treat HTTP 503 as failover-eligible for LLM provider errors. (#21086) Thanks @Protocol-zero-0.

--- a/src/infra/heartbeat-active-hours.ts
+++ b/src/infra/heartbeat-active-hours.ts
@@ -4,7 +4,7 @@ import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 
 type HeartbeatConfig = AgentDefaultsConfig["heartbeat"];
 
-const ACTIVE_HOURS_TIME_PATTERN = /^([01]\d|2[0-3]|24):([0-5]\d)$/;
+const ACTIVE_HOURS_TIME_PATTERN = /^(?:([01]\d|2[0-3]):([0-5]\d)|24:00)$/;
 
 function resolveActiveHoursTimezone(cfg: OpenClawConfig, raw?: string): string {
   const trimmed = raw?.trim();


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed regex pattern to only accept `24:00` as the end-of-day sentinel value. The previous pattern incorrectly matched `24:01` through `24:59` because the alternation allowed the `24` hour with any valid minute pattern `[0-5]\d`. The new pattern uses top-level alternation to treat `24:00` as a literal special case, correctly restricting 24-hour time to exactly `24:00`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a regex bug that allowed invalid times like 24:01-24:59. The change is surgical, affects only the regex pattern, and the parsing logic at line 36-38 already validates that hour 24 requires minute 0. The fix aligns the regex validation with the parsing validation and documented behavior.
- No files require special attention

<sub>Last reviewed commit: bcc75c5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->