### PR TITLE
fix: guard account.token?.trim() with optional chaining in Discord gateway

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -395,7 +395,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
   gateway: {
     startAccount: async (ctx) => {
       const account = ctx.account;
-      const token = account.token.trim();
+      const token = account.token?.trim() ?? "";
       let discordBotLabel = "";
       try {
         const probe = await getDiscordRuntime().channel.discord.probeDiscord(token, 2500, {

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -178,7 +178,9 @@ async function downloadToFile(
               sniffLen += chunk.length;
             }
             if (total > MAX_BYTES) {
-              req.destroy(new Error("Media exceeds 5MB limit"));
+              req.destroy(
+                new Error(`Media exceeds ${Math.round(MAX_BYTES / (1024 * 1024))}MB limit`),
+              );
             }
           });
           pipeline(res, out)


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added defensive null checking to `account.token` access in Discord gateway and made error message dynamically reflect the actual size limit from the `MAX_BYTES` constant.

- In `extensions/discord/src/channel.ts`, changed `account.token.trim()` to `account.token?.trim() ?? ""` to prevent potential TypeError if token is undefined at runtime
- In `src/media/store.ts`, updated hardcoded "5MB" error message to dynamically calculate from `MAX_BYTES` constant for consistency

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both changes are defensive improvements that prevent potential runtime errors and improve code maintainability. The optional chaining prevents TypeError if token is unexpectedly undefined, and the dynamic error message ensures consistency with the actual MAX_BYTES value. No functional behavior is changed, only error handling is improved.
- No files require special attention

<sub>Last reviewed commit: 25f072d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->