### PR TITLE
fix: trim token and add null guard in Discord probeAccount

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -341,10 +341,15 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       probe: snapshot.probe,
       lastProbeAt: snapshot.lastProbeAt ?? null,
     }),
-    probeAccount: async ({ account, timeoutMs }) =>
-      getDiscordRuntime().channel.discord.probeDiscord(account.token, timeoutMs, {
+    probeAccount: async ({ account, timeoutMs }) => {
+      const token = account.token?.trim();
+      if (!token) {
+        return { ok: false, error: "No token configured" };
+      }
+      return getDiscordRuntime().channel.discord.probeDiscord(token, timeoutMs, {
         includeApplication: true,
-      }),
+      });
+    },
     auditAccount: async ({ account, timeoutMs, cfg }) => {
       const { channelIds, unresolvedChannels } = collectDiscordAuditChannelIds({
         cfg,

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -402,7 +402,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
   gateway: {
     startAccount: async (ctx) => {
       const account = ctx.account;
-      const token = account.token.trim();
+      const token = account.token?.trim();
       let discordBotLabel = "";
       try {
         const probe = await getDiscordRuntime().channel.discord.probeDiscord(token, 2500, {


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds defensive null/whitespace checks to Discord `probeAccount` function to prevent runtime errors when `account.token` is empty or whitespace-only.

- Trims token and returns early with error message if no token is configured
- Follows the defensive pattern used in `resolveTargets` and `auditAccount`
- Prevents `probeDiscord` from being called with invalid token values

<h3>Confidence Score: 4/5</h3>

- Safe to merge - defensive fix that prevents potential runtime errors
- The change correctly adds defensive guards following established patterns in the codebase. Minor inconsistency exists in `startAccount` (line 403) which still uses non-optional chaining, but this doesn't block the PR since `startAccount` is only called after the `isConfigured` check.
- No files require special attention

<sub>Last reviewed commit: bc0b38d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->