### PR TITLE
fix: pass unresolvedGroups and hasWildcardUnmentionedGroups through audit return

### DIFF
--- a/src/telegram/audit.ts
+++ b/src/telegram/audit.ts
@@ -71,6 +71,8 @@ export async function auditTelegramGroupMembership(params: {
   groupIds: string[];
   proxyUrl?: string;
   timeoutMs: number;
+  unresolvedGroups?: number;
+  hasWildcardUnmentionedGroups?: boolean;
 }): Promise<TelegramGroupMembershipAudit> {
   const started = Date.now();
   const token = params.token?.trim() ?? "";
@@ -141,8 +143,8 @@ export async function auditTelegramGroupMembership(params: {
   return {
     ok: groups.every((g) => g.ok),
     checkedGroups: groups.length,
-    unresolvedGroups: 0,
-    hasWildcardUnmentionedGroups: false,
+    unresolvedGroups: params.unresolvedGroups ?? 0,
+    hasWildcardUnmentionedGroups: params.hasWildcardUnmentionedGroups ?? false,
     groups,
     elapsedMs: Date.now() - started,
   };


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `auditTelegramGroupMembership` to properly pass through `unresolvedGroups` and `hasWildcardUnmentionedGroups` values from the caller instead of hardcoding them to 0 and false. These values are collected by `collectTelegramUnmentionedGroupIds` and needed to be preserved in the audit return value for accurate Telegram group membership reporting.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that adds two optional parameters and uses them in the return value instead of hardcoded defaults. The fix aligns with how the function is called in `extensions/telegram/src/channel.ts:346` where the caller was already overwriting these fields. No breaking changes, no security concerns, and the existing tests continue to work (they don't pass these params, so they get the default values).
- No files require special attention

<sub>Last reviewed commit: bf67d3f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->