### PR TITLE
fix: correct replyies pluralization typo to replies in Slack dispatch

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -423,7 +423,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   if (shouldLogVerbose()) {
     const finalCount = counts.final;
     logVerbose(
-      `slack: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${prepared.replyTarget}`,
+      `slack: delivered ${finalCount} repl${finalCount === 1 ? "y" : "ies"} to ${prepared.replyTarget}`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed typo in verbose logging message: changed "reply" → "repl" + "y"/"ies" to correctly pluralize as "reply"/"replies" instead of "replyies"

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- The change only fixes a string formatting typo in a verbose logging statement, with no impact on functionality, logic, or behavior
- No files require special attention

<sub>Last reviewed commit: 7c887d4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->