### PR TITLE
fix: add missing await on countRows() in MemoryDB.count()

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -152,7 +152,7 @@ class MemoryDB {
 
   async count(): Promise<number> {
     await this.ensureInitialized();
-    return this.table!.countRows();
+    return await this.table!.countRows();
   }
 }
 


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added missing `await` on `countRows()` call in `MemoryDB.count()` method. The fix ensures the Promise returned by LanceDB's `countRows()` is properly awaited, consistent with all other async table operations in the codebase (`add()`, `delete()`, `vectorSearch()`, etc.).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a straightforward bug fix that adds a missing `await` keyword to ensure proper Promise handling. All other LanceDB table operations in the file consistently use `await`, making this fix clearly correct. The method signature already returns `Promise<number>`, so the change aligns with the existing contract.
- No files require special attention

<sub>Last reviewed commit: 868d346</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->