### PR TITLE
fix: use >= 0 to accept newline at index 0 in Signal formatter

### DIFF
--- a/src/signal/format.ts
+++ b/src/signal/format.ts
@@ -365,7 +365,7 @@ function findBreakIndex(window: string): number {
   }
 
   // Prefer newline break, fall back to whitespace
-  return lastNewline > 0 ? lastNewline : lastWhitespace;
+  return lastNewline >= 0 ? lastNewline : lastWhitespace;
 }
 
 export function markdownToSignalTextChunks(


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed off-by-one error in `findBreakIndex` that prevented newlines at position 0 from being recognized as valid break points. The function now correctly uses `>= 0` instead of `> 0` when checking if a newline was found, allowing it to properly prefer newline breaks at the start of text windows.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix corrects a clear off-by-one error in a boundary condition check. The change is minimal (single operator), logically sound, and addresses a specific edge case where newlines at index 0 were incorrectly ignored. The function correctly uses -1 as a sentinel value for "not found", making >= 0 the correct boundary check.
- No files require special attention

<sub>Last reviewed commit: 7d70ac6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->