### PR TITLE
fix: add leading newline to code block closing fence in Slack format

### DIFF
--- a/src/slack/format.ts
+++ b/src/slack/format.ts
@@ -101,7 +101,7 @@ function buildSlackRenderOptions() {
       italic: { open: "_", close: "_" },
       strikethrough: { open: "~", close: "~" },
       code: { open: "`", close: "`" },
-      code_block: { open: "```\n", close: "```" },
+      code_block: { open: "```\n", close: "\n```" },
     },
     escapeText: escapeSlackMrkdwnText,
     buildLink: buildSlackLink,


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a formatting bug in Slack code blocks where the closing fence (```) was incorrectly concatenated with the last line of code instead of appearing on its own line. The change adds a leading newline (`\n`) to the closing fence marker in `src/slack/format.ts:104`, changing from `close: "```"` to `close: "\n```"`. This ensures proper Slack mrkdwn rendering where code blocks display correctly with the closing backticks on a separate line.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a minimal one-character fix to a string constant that corrects a clear formatting bug. The modification aligns with Slack's mrkdwn syntax requirements for code blocks, where the closing fence must be on its own line. The change is isolated to Slack formatting and does not affect other channels or core logic.
- No files require special attention

<sub>Last reviewed commit: 75f9d39</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->