### PR TITLE
fix: strip u: prefix when parsing Signal username shorthand

### DIFF
--- a/src/signal/send.ts
+++ b/src/signal/send.ts
@@ -53,7 +53,7 @@ function parseTarget(raw: string): SignalTarget {
     };
   }
   if (normalized.startsWith("u:")) {
-    return { type: "username", username: value.trim() };
+    return { type: "username", username: value.slice("u:".length).trim() };
   }
   return { type: "recipient", recipient: value };
 }


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed bug in Signal username shorthand parsing where the `u:` prefix wasn't stripped from the username value.

- Before: `u:alice` would incorrectly pass `u:alice` as the username
- After: `u:alice` correctly passes `alice` as the username
- Consistent with how other prefixes (`group:`, `username:`, `signal:`) are handled in the same function

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- Single-line bug fix that correctly strips the `u:` prefix to match the documented behavior and align with how other prefixes are handled in the same function. The change is minimal, self-contained, and follows the existing pattern established for `group:` and `username:` prefix handling.
- No files require special attention

<sub>Last reviewed commit: 6686ead</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->