### PR TITLE
fix: include tool count in anyReplyDelivered check

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -211,7 +211,6 @@ function getTextStats(text: string): { printableRatio: number; wordishRatio: num
     const code = char.codePointAt(0) ?? 0;
     if (code === 9 || code === 10 || code === 13 || code === 32) {
       printable += 1;
-      wordish += 1;
       continue;
     }
     if (code < 32 || (code >= 0x7f && code <= 0x9f)) {

--- a/src/signal/send.ts
+++ b/src/signal/send.ts
@@ -53,7 +53,7 @@ function parseTarget(raw: string): SignalTarget {
     };
   }
   if (normalized.startsWith("u:")) {
-    return { type: "username", username: value.trim() };
+    return { type: "username", username: value.slice("u:".length).trim() };
   }
   return { type: "recipient", recipient: value };
 }

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -404,7 +404,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
   }
 
-  const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
+  const anyReplyDelivered =
+    queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0 || (counts.tool ?? 0) > 0;
 
   if (!anyReplyDelivered) {
     await draftStream.clear();


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR contains three separate bug fixes: includes tool count in reply delivery check to prevent incorrect draft clearing, fixes Signal username parsing to strip the `u:` prefix, and corrects whitespace handling in text statistics to prevent binary content misclassification.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All three bug fixes are well-isolated, logically correct, and follow existing code patterns. The changes fix real bugs without introducing side effects or breaking changes.
- No files require special attention

<sub>Last reviewed commit: 47c2d0b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->