### PR TITLE
fix: use || instead of && in formatResponseUsageLine early-return guard

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -89,7 +89,7 @@ export const formatResponseUsageLine = (params: {
   }
   const input = usage.input;
   const output = usage.output;
-  if (typeof input !== "number" && typeof output !== "number") {
+  if (typeof input !== "number" || typeof output !== "number") {
     return null;
   }
   const inputLabel = typeof input === "number" ? formatTokenCount(input) : "?";

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -313,7 +313,7 @@ export function registerConfigCli(program: Command) {
     .description("Set a config value by dot path")
     .argument("<path>", "Config path (dot or bracket notation)")
     .argument("<value>", "Value (JSON5 or raw string)")
-    .option("--json", "Parse value as JSON5 (required)", false)
+    .option("--json", "Strict JSON5 parsing (error instead of raw string fallback)", false)
     .action(async (path: string, value: string, opts) => {
       try {
         const parsedPath = parsePath(path);

--- a/src/signal/send.ts
+++ b/src/signal/send.ts
@@ -53,7 +53,7 @@ function parseTarget(raw: string): SignalTarget {
     };
   }
   if (normalized.startsWith("u:")) {
-    return { type: "username", username: value.trim() };
+    return { type: "username", username: value.slice("u:".length).trim() };
   }
   return { type: "recipient", recipient: value };
 }

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -404,7 +404,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
   }
 
-  const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
+  const anyReplyDelivered =
+    queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0 || (counts.tool ?? 0) > 0;
 
   if (!anyReplyDelivered) {
     await draftStream.clear();


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed multiple logical bugs across the codebase:
- Corrected early-return guard in `formatResponseUsageLine` to use `||` instead of `&&`, ensuring null is returned when either input or output token count is missing
- Added missing tool count check in Slack dispatch to prevent tool-only replies from being incorrectly cleared
- Fixed Signal username shorthand parser to properly strip the `u:` prefix
- Updated config CLI help text for clarity

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- All changes are straightforward bug fixes with clear logical improvements. The `||` vs `&&` fix corrects an obvious logical error, the Signal parser fix properly strips the prefix, the dispatch fix includes tool counts appropriately, and the help text update improves clarity without changing behavior
- No files require special attention

<sub>Last reviewed commit: e349618</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->