### PR TITLE
fix: join debounced Signal messages with actual newline

### DIFF
--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -301,7 +301,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       const combinedText = entries
         .map((entry) => entry.bodyText)
         .filter(Boolean)
-        .join("\\n");
+        .join("\n");
       if (!combinedText.trim()) {
         return;
       }


### PR DESCRIPTION
## Summary
- Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug in Signal message debouncing where multiple messages were being joined with the literal string `\\n` instead of an actual newline character. When the debouncer collected multiple rapid messages from the same sender, they would display as "message1\\nmessage2" rather than appearing on separate lines.

The fix changes `src/signal/monitor/event-handler.ts:304` from `.join("\\n")` to `.join("\n")`, ensuring debounced messages are properly separated with actual newlines. This aligns with the repository guideline in AGENTS.md that states "never embed '\\n'" for multiline content.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a straightforward one-character bug fix that changes a literal escape sequence to an actual newline. The change is minimal, well-scoped, and fixes a clear text formatting bug in the Signal message debouncing logic. The fix aligns with repository guidelines and has no side effects.
- No files require special attention

<sub>Last reviewed commit: 868c2b7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->