### PR TITLE
chore(changelog): preserve Slack streaming credit attribution for #20988

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 - Docker: pin base images to SHA256 digests in Docker builds to prevent mutable tag drift. (#7734) Thanks @coygeek.
 - Provider/HTTP: treat HTTP 503 as failover-eligible for LLM provider errors. (#21086) Thanks @Protocol-zero-0.
+- Slack: pass `recipient_team_id` / `recipient_user_id` through Slack native streaming calls so `chat.startStream`/`appendStream`/`stopStream` work reliably across DMs and Slack Connect setups, and disable block streaming when native streaming is active. (#20988) Thanks @Dithilli. Earlier recipient-ID groundwork was contributed in #20377 by @AsserAl1012.
 
 - Discord/Gateway: handle close code 4014 (missing privileged gateway intents) without crashing the gateway. Thanks @thewilloftheshadow.
 - Security/Net: strip sensitive headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Cookie2`) on cross-origin redirects in `fetchWithSsrFGuard` to prevent credential forwarding across origin boundaries. (#20313) Thanks @afurm.


### PR DESCRIPTION
## Summary

Preserve full credit attribution in CHANGELOG.md for Slack streaming recipient-ID work:
- Main implementation: @Dithilli in #20988
- Prior groundwork: @AsserAl1012 in #20377

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves full credit attribution in `CHANGELOG.md` for Slack streaming recipient-ID work. The changelog entry now properly credits `@Dithilli` for the main implementation in #20988 and acknowledges `@AsserAl1012`'s earlier groundwork in #20377. This is a documentation-only change that ensures proper contributor recognition without any functional impact.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- This is a documentation-only change that adds proper credit attribution to the CHANGELOG. The change correctly follows the repo's changelog format with proper markdown formatting (backticks around code elements, @ symbols properly handled), PR references, and contributor attribution. No code or functional changes are involved.
- No files require special attention

<sub>Last reviewed commit: da04544</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->