### PR TITLE
fix(gateway): plaintext ws:// blocked for Docker bind=lan (SECURITY ERROR on private network)

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -172,6 +172,18 @@ describe("callGateway url resolution", () => {
     expect(result).toEqual({ ok: true });
   });
 
+  it("blocks user-provided ws:// to private network even when bind=lan", async () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryLanIPv4.mockReturnValue("192.168.1.42");
+
+    // User-provided URL override bypasses locally-resolved exemption —
+    // private network ws:// is only safe when locally resolved.
+    await expect(
+      callGateway({ method: "health", url: "ws://192.168.1.100:18789", token: "t" }),
+    ).rejects.toThrow("SECURITY ERROR");
+  });
+
   it("falls back to loopback when bind is lan but no LAN IP found", async () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
     resolveGatewayPort.mockReturnValue(18800);

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -122,7 +122,10 @@ export function buildGatewayConnectionDetails(
   const preferLan = bindMode === "lan";
   const lanIPv4 = preferLan ? pickPrimaryLanIPv4() : undefined;
   const scheme = tlsEnabled ? "wss" : "ws";
-  const localUrl = preferLan && lanIPv4 ? `${scheme}://${lanIPv4}:${localPort}` : `${scheme}://127.0.0.1:${localPort}`;
+  const localUrl =
+    preferLan && lanIPv4
+      ? `${scheme}://${lanIPv4}:${localPort}`
+      : `${scheme}://127.0.0.1:${localPort}`;
   const urlOverride =
     typeof options.url === "string" && options.url.trim().length > 0
       ? options.url.trim()

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -42,6 +42,8 @@ type Pending = {
 
 export type GatewayClientOptions = {
   url?: string; // ws://127.0.0.1:18789
+  /** When true, allow plaintext ws:// to private network addresses (e.g. Docker bridge). */
+  allowPrivateNetwork?: boolean;
   connectDelayMs?: number;
   tickWatchMinIntervalMs?: number;
   token?: string;
@@ -117,7 +119,7 @@ export class GatewayClient {
     // Security check: block ALL plaintext ws:// to non-loopback addresses (CWE-319, CVSS 9.8)
     // This protects both credentials AND chat/conversation data from MITM attacks.
     // Device tokens may be loaded later in sendConnect(), so we block regardless of hasCredentials.
-    if (!isSecureWebSocketUrl(url)) {
+    if (!isSecureWebSocketUrl(url, { allowPrivateNetwork: this.opts.allowPrivateNetwork })) {
       // Safe hostname extraction - avoid throwing on malformed URLs in error path
       let displayHost = url;
       try {

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -374,4 +374,28 @@ describe("isSecureWebSocketUrl", () => {
       expect(isSecureWebSocketUrl(testCase.input), testCase.input).toBe(testCase.expected);
     }
   });
+
+  describe("allowPrivateNetwork option (Docker bind=lan)", () => {
+    const opts = { allowPrivateNetwork: true };
+
+    it("returns true for ws:// to RFC1918 private addresses", () => {
+      expect(isSecureWebSocketUrl("ws://172.18.0.2:18789", opts)).toBe(true);
+      expect(isSecureWebSocketUrl("ws://192.168.1.100:18789", opts)).toBe(true);
+      expect(isSecureWebSocketUrl("ws://10.0.0.5:18789", opts)).toBe(true);
+    });
+
+    it("returns true for ws:// to CGNAT addresses (Tailscale)", () => {
+      expect(isSecureWebSocketUrl("ws://100.64.0.1:18789", opts)).toBe(true);
+    });
+
+    it("still returns false for ws:// to public addresses", () => {
+      expect(isSecureWebSocketUrl("ws://remote.example.com:18789", opts)).toBe(false);
+      expect(isSecureWebSocketUrl("ws://8.8.8.8:18789", opts)).toBe(false);
+    });
+
+    it("still returns true for loopback regardless of option", () => {
+      expect(isSecureWebSocketUrl("ws://127.0.0.1:18789", opts)).toBe(true);
+      expect(isSecureWebSocketUrl("ws://localhost:18789", opts)).toBe(true);
+    });
+  });
 });

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -62,25 +62,24 @@ describe("resolveGatewayConnection", () => {
     });
   });
 
-  it.each([
-    {
-      label: "tailnet",
-      bind: "tailnet",
-      setup: () => pickPrimaryTailnetIPv4.mockReturnValue("100.64.0.1"),
-    },
-    {
-      label: "lan",
-      bind: "lan",
-      setup: () => pickPrimaryLanIPv4.mockReturnValue("192.168.1.42"),
-    },
-  ])("uses loopback host when local bind is $label", ({ bind, setup }) => {
-    loadConfig.mockReturnValue({ gateway: { mode: "local", bind } });
+  it("uses loopback host when local bind is tailnet", () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "tailnet" } });
     resolveGatewayPort.mockReturnValue(18800);
-    setup();
+    pickPrimaryTailnetIPv4.mockReturnValue("100.64.0.1");
 
     const result = resolveGatewayConnection({});
 
     expect(result.url).toBe("ws://127.0.0.1:18800");
+  });
+
+  it("uses LAN host when local bind is lan", () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryLanIPv4.mockReturnValue("192.168.1.42");
+
+    const result = resolveGatewayConnection({});
+
+    expect(result.url).toBe("ws://192.168.1.42:18800");
   });
 
   it("uses OPENCLAW_GATEWAY_TOKEN for local mode", () => {


### PR DESCRIPTION
## Problem

After 2026.2.18, `isSecureWebSocketUrl` rejects `ws://` to any non-loopback address. When `bind: lan` is configured (the documented Docker setup), the gateway URL resolves to a Docker bridge IP like `ws://172.18.0.2:18789`, which gets blocked:

```
SECURITY ERROR: Gateway URL "ws://172.18.0.2:18789" uses plaintext ws://
to a non-loopback address.
```

This breaks cron jobs, sub-agents, and config patches for all Docker deployments using `bind: lan`. Existing cron jobs still fire but cannot be modified. No workaround exists — switching to `bind: loopback` kills external connectivity since Docker maps ports to the container LAN IP.

## Root cause

`isSecureWebSocketUrl` only allows `ws://` for loopback. Docker bridge IPs (172.16.0.0/12) are private addresses that never leave the host, but the check does not distinguish locally-resolved URLs from user-provided ones.

## Fix

Add `allowPrivateNetwork` option to `isSecureWebSocketUrl`. When the URL was locally resolved from `bind=lan` config (not from a user override or remote URL), RFC1918 and CGNAT addresses are accepted for `ws://`. The existing `isPrivateOrLoopbackAddress` helper already covers these ranges.

User-provided URLs (`--url`, `gateway.remote.url`) still require `wss://` regardless.

5 files changed, 68 insertions(+), 12 deletions.

Closes #21065

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `allowPrivateNetwork` option to `isSecureWebSocketUrl()` to allow plaintext `ws://` connections to RFC1918 and CGNAT private network addresses when the gateway URL is locally resolved from `bind=lan` configuration (common in Docker deployments). User-provided URLs via `--url` or `gateway.remote.url` still require `wss://` regardless of bind mode.

**Key changes:**
- `isSecureWebSocketUrl()` now accepts `allowPrivateNetwork` option that permits `ws://` to private addresses detected by `isPrivateOrLoopbackAddress()` (172.16.0.0/12, 192.168.0.0/16, 10.0.0.0/8, 100.64.0.0/10)
- `buildGatewayConnectionDetails()` sets `allowPrivateNetwork: true` only when URL is locally resolved AND `bind=lan` is configured
- `GatewayClient` passes through the `allowPrivateNetwork` option to its security check
- Tests updated to verify `ws://` to LAN IPs is allowed for locally-resolved `bind=lan` URLs
- Tests verify that `ws://` to public addresses remains blocked even with `allowPrivateNetwork: true`

**Security-critical behavior verified:**
- User-provided URLs (`--url`, `gateway.remote.url`) never get the private network exemption because `isLocallyResolved` is false when these are present
- `bind=tailnet` still requires TLS (no exemption) since Tailscale IPs can be accessed from other devices on the Tailnet

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor test coverage gap
- The implementation correctly addresses the Docker `bind=lan` issue by adding `allowPrivateNetwork` option that only applies to locally-resolved URLs. Security-critical logic (user-provided URLs still require TLS) is correctly implemented via the `isLocallyResolved` check. Tests verify the main use case, but missing one edge case test for user-provided URLs with `bind=lan`.
- src/gateway/call.test.ts could benefit from additional test coverage for the user-provided URL + bind=lan scenario

<sub>Last reviewed commit: 96f42af</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->