### PR TITLE
docs(ollama): add prominent warnings about /v1 breaking tool calling

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -10,6 +10,10 @@ title: "Ollama"
 
 Ollama is a local LLM runtime that makes it easy to run open-source models on your machine. OpenClaw integrates with Ollama's native API (`/api/chat`), supporting streaming and tool calling, and can **auto-discover tool-capable models** when you opt in with `OLLAMA_API_KEY` (or an auth profile) and do not define an explicit `models.providers.ollama` entry.
 
+<Warning>
+**Remote Ollama users**: Do not use the `/v1` OpenAI-compatible URL (`http://host:11434/v1`) with OpenClaw. This breaks tool calling — your model will output raw JSON instead of executing tools. Use the native Ollama API: `baseUrl: "http://host:11434"` with `api: "ollama"` (the default).
+</Warning>
+
 ## Quick start
 
 1. Install Ollama: [https://ollama.ai](https://ollama.ai)
@@ -133,12 +137,17 @@ If Ollama is running on a different host or port (explicit config disables auto-
     providers: {
       ollama: {
         apiKey: "ollama-local",
-        baseUrl: "http://ollama-host:11434",
+        baseUrl: "http://ollama-host:11434",  // No /v1 — use the native Ollama API
+        api: "ollama",  // Required for tool calling to work
       },
     },
   },
 }
 ```
+
+<Warning>
+Do not add `/v1` to the URL. The `/v1` path uses OpenAI-compatible mode which breaks tool calling. Use the base Ollama URL without any path suffix.
+</Warning>
 
 ### Model selection
 
@@ -177,7 +186,11 @@ OpenClaw's Ollama integration uses the **native Ollama API** (`/api/chat`) by de
 
 #### Legacy OpenAI-Compatible Mode
 
-If you need to use the OpenAI-compatible endpoint instead (e.g., behind a proxy that only supports OpenAI format), set `api: "openai-completions"` explicitly:
+<Warning>
+**Tool calling does not work with OpenAI-compatible mode.** The model will output tool call JSON as plain text instead of executing tools. Only use this mode if you specifically need OpenAI format for a proxy and do not need tools.
+</Warning>
+
+If you need to use the OpenAI-compatible endpoint (e.g., behind a proxy that only supports OpenAI format), set `api: "openai-completions"` explicitly:
 
 ```json5
 {
@@ -194,7 +207,7 @@ If you need to use the OpenAI-compatible endpoint instead (e.g., behind a proxy 
 }
 ```
 
-Note: The OpenAI-compatible endpoint may not support streaming + tool calling simultaneously. You may need to disable streaming with `params: { streaming: false }` in model config.
+This mode also does not support streaming + tool calling simultaneously. You may need to disable streaming with `params: { streaming: false }` in model config.
 
 ### Context windows
 


### PR DESCRIPTION
## Summary

- **Problem:** Users running Ollama on a remote host naturally configure `baseUrl: "http://host:11434/v1"` with `api: "openai-responses"`, which silently breaks tool calling
- **Why it matters:** Model outputs raw JSON as plain text instead of executing tools—no error surfaced, confusing UX
- **What changed:** Added prominent `<Warning>` callouts at top of doc, in custom URL section, and in legacy mode section
- **What did NOT change:** No code changes, docs-only

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21243

## User-visible / Behavior Changes

None (docs-only). Users will now see clear warnings before misconfiguring Ollama.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime/container: N/A (docs change)
- Model/provider: Ollama
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. View docs/providers/ollama.md before change
2. Note warning about /v1 is buried in Advanced section
3. View docs/providers/ollama.md after change
4. Note prominent warning at top and in custom URL section

### Expected

- Clear warning visible before user configures remote Ollama incorrectly

### Actual

- Warning now appears at top of doc and in relevant config sections

## Evidence

- [x] Diff shows `<Warning>` callouts added in three locations
- Renders correctly in Mintlify (standard component)

## Human Verification (required)

- Verified scenarios: Read through doc flow as a new user setting up remote Ollama
- Edge cases checked: Ensured warning appears before any config example that could mislead
- What I did NOT verify: Live Mintlify rendering (no local Mintlify instance)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert commit
- Files/config to restore: docs/providers/ollama.md
- Known bad symptoms: N/A (docs-only)

## Risks and Mitigations

None. Docs-only change adding warnings.