### PR TITLE
fix(msteams): enforce allowlist checks on redirect hops (SSRF) (#11811)

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -521,6 +521,7 @@ Teams recently introduced two channel UI styles over the same underlying data mo
 
 Without Graph permissions, channel messages with images will be received as text-only (the image content is not accessible to the bot).
 By default, OpenClaw only downloads media from Microsoft/Teams hostnames. Override with `channels.msteams.mediaAllowHosts` (use `["*"]` to allow any host).
+Redirects are handled in **manual** mode and every redirect hop is validated against `channels.msteams.mediaAllowHosts` (HTTPS-only) to prevent SSRF via allowlisted URL → disallowed redirect.
 Authorization headers are only attached for hosts in `channels.msteams.mediaAuthAllowHosts` (defaults to Graph + Bot Framework hosts). Keep this list strict (avoid multi-tenant suffixes).
 
 ## Sending files in group chats

--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -104,7 +104,7 @@ describe("msteams attachments", () => {
   describe("downloadMSTeamsAttachments", () => {
     it("downloads and stores image contentUrl attachments", async () => {
       const { downloadMSTeamsAttachments } = await load();
-      const fetchMock = vi.fn(async () => {
+      const fetchMock = vi.fn(async (_url: string, _opts?: RequestInit) => {
         return new Response(Buffer.from("png"), {
           status: 200,
           headers: { "content-type": "image/png" },
@@ -118,7 +118,7 @@ describe("msteams attachments", () => {
         fetchFn: fetchMock as unknown as typeof fetch,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith("https://x/img");
+      expect(fetchMock).toHaveBeenCalledWith("https://x/img", { redirect: "manual" });
       expect(saveMediaBufferMock).toHaveBeenCalled();
       expect(media).toHaveLength(1);
       expect(media[0]?.path).toBe("/tmp/saved.png");
@@ -126,7 +126,7 @@ describe("msteams attachments", () => {
 
     it("supports Teams file.download.info downloadUrl attachments", async () => {
       const { downloadMSTeamsAttachments } = await load();
-      const fetchMock = vi.fn(async () => {
+      const fetchMock = vi.fn(async (_url: string, _opts?: RequestInit) => {
         return new Response(Buffer.from("png"), {
           status: 200,
           headers: { "content-type": "image/png" },
@@ -145,13 +145,13 @@ describe("msteams attachments", () => {
         fetchFn: fetchMock as unknown as typeof fetch,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith("https://x/dl");
+      expect(fetchMock).toHaveBeenCalledWith("https://x/dl", { redirect: "manual" });
       expect(media).toHaveLength(1);
     });
 
     it("downloads non-image file attachments (PDF)", async () => {
       const { downloadMSTeamsAttachments } = await load();
-      const fetchMock = vi.fn(async () => {
+      const fetchMock = vi.fn(async (_url: string, _opts?: RequestInit) => {
         return new Response(Buffer.from("pdf"), {
           status: 200,
           headers: { "content-type": "application/pdf" },
@@ -170,7 +170,7 @@ describe("msteams attachments", () => {
         fetchFn: fetchMock as unknown as typeof fetch,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith("https://x/doc.pdf");
+      expect(fetchMock).toHaveBeenCalledWith("https://x/doc.pdf", { redirect: "manual" });
       expect(media).toHaveLength(1);
       expect(media[0]?.path).toBe("/tmp/saved.pdf");
       expect(media[0]?.placeholder).toBe("<media:document>");
@@ -178,7 +178,7 @@ describe("msteams attachments", () => {
 
     it("downloads inline image URLs from html attachments", async () => {
       const { downloadMSTeamsAttachments } = await load();
-      const fetchMock = vi.fn(async () => {
+      const fetchMock = vi.fn(async (_url: string, _opts?: RequestInit) => {
         return new Response(Buffer.from("png"), {
           status: 200,
           headers: { "content-type": "image/png" },
@@ -198,7 +198,7 @@ describe("msteams attachments", () => {
       });
 
       expect(media).toHaveLength(1);
-      expect(fetchMock).toHaveBeenCalledWith("https://x/inline.png");
+      expect(fetchMock).toHaveBeenCalledWith("https://x/inline.png", { redirect: "manual" });
     });
 
     it("stores inline data:image base64 payloads", async () => {
@@ -248,6 +248,7 @@ describe("msteams attachments", () => {
 
       expect(fetchMock).toHaveBeenCalled();
       expect(media).toHaveLength(1);
+      // First attempt unauthenticated + retry with Authorization.
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
@@ -298,6 +299,112 @@ describe("msteams attachments", () => {
 
       expect(media).toHaveLength(0);
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("does not auto-follow redirects to disallowed hosts before allowlist checks", async () => {
+      const { downloadMSTeamsAttachments } = await load();
+      const fetchMock = vi.fn(async (url: string, _opts?: RequestInit) => {
+        if (url === "https://attacker.example/file") {
+          return new Response("redirect", {
+            status: 302,
+            headers: { location: "https://internal.service.local/secret" },
+          });
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      });
+
+      const media = await downloadMSTeamsAttachments({
+        attachments: [
+          { contentType: "application/pdf", contentUrl: "https://attacker.example/file" },
+        ],
+        maxBytes: 1024 * 1024,
+        allowHosts: ["attacker.example"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+      });
+
+      // Should not follow the redirect, so nothing is downloaded.
+      expect(media).toHaveLength(0);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith("https://attacker.example/file", {
+        redirect: "manual",
+      });
+    });
+
+    it("follows redirects when every hop is allowlisted", async () => {
+      const { downloadMSTeamsAttachments } = await load();
+      const fetchMock = vi.fn(async (url: string, _opts?: RequestInit) => {
+        if (url === "https://x/start") {
+          return new Response("redirect", {
+            status: 302,
+            headers: { location: "/final" },
+          });
+        }
+        if (url === "https://x/final") {
+          return new Response(Buffer.from("png"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          });
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      });
+
+      const media = await downloadMSTeamsAttachments({
+        attachments: [{ contentType: "image/png", contentUrl: "https://x/start" }],
+        maxBytes: 1024 * 1024,
+        allowHosts: ["x"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+      });
+
+      expect(media).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not forward auth headers to redirect destinations outside auth allowlist", async () => {
+      const { downloadMSTeamsAttachments } = await load();
+
+      const calls: Array<{ url: string; auth?: string }> = [];
+      const fetchMock = vi.fn(async (url: string, opts?: RequestInit) => {
+        const auth =
+          opts && typeof opts === "object" && "headers" in opts
+            ? (opts.headers as Record<string, string>)?.Authorization
+            : undefined;
+        calls.push({ url, auth });
+
+        if (url === "https://graph.microsoft.com/file") {
+          // Unauth first, auth retry will happen.
+          if (!auth) {
+            return new Response("unauthorized", { status: 401 });
+          }
+          // Auth retry redirects to a different allowlisted host.
+          return new Response("redirect", {
+            status: 302,
+            headers: { location: "https://files.example/final" },
+          });
+        }
+
+        if (url === "https://files.example/final") {
+          return new Response(Buffer.from("png"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          });
+        }
+
+        throw new Error(`unexpected fetch: ${url}`);
+      });
+
+      const media = await downloadMSTeamsAttachments({
+        attachments: [{ contentType: "image/png", contentUrl: "https://graph.microsoft.com/file" }],
+        maxBytes: 1024 * 1024,
+        tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+        allowHosts: ["graph.microsoft.com", "files.example"],
+        authAllowHosts: ["graph.microsoft.com"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+      });
+
+      expect(media).toHaveLength(1);
+
+      const redirectCall = calls.find((c) => c.url === "https://files.example/final");
+      expect(redirectCall?.auth).toBeUndefined();
     });
   });
 

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -82,6 +82,51 @@ function scopeCandidatesForUrl(url: string): string[] {
   }
 }
 
+const MAX_REDIRECTS = 5;
+
+async function fetchWithManualRedirects(params: {
+  url: string;
+  fetchFn: typeof fetch;
+  allowHosts: string[];
+  resolveRequestInit?: (url: string) => RequestInit;
+}): Promise<Response> {
+  let currentUrl = params.url;
+
+  for (let i = 0; i <= MAX_REDIRECTS; i++) {
+    const init = params.resolveRequestInit?.(currentUrl);
+    const res = await params.fetchFn(currentUrl, { ...init, redirect: "manual" });
+
+    if (res.ok) {
+      return res;
+    }
+
+    const redirectUrl = readRedirectUrl(currentUrl, res);
+    if (!redirectUrl) {
+      return res;
+    }
+
+    // Allowlist is checked for every hop.
+    if (!isUrlAllowed(redirectUrl, params.allowHosts)) {
+      return res;
+    }
+
+    // Only follow HTTPS redirects.
+    try {
+      const parsed = new URL(redirectUrl);
+      if (parsed.protocol !== "https:") {
+        return res;
+      }
+    } catch {
+      return res;
+    }
+
+    currentUrl = redirectUrl;
+  }
+
+  // Too many redirects. Return the last response.
+  return await params.fetchFn(currentUrl, { redirect: "manual" });
+}
+
 async function fetchWithAuthFallback(params: {
   url: string;
   tokenProvider?: MSTeamsAccessTokenProvider;
@@ -90,7 +135,13 @@ async function fetchWithAuthFallback(params: {
   authAllowHosts: string[];
 }): Promise<Response> {
   const fetchFn = params.fetchFn ?? fetch;
-  const firstAttempt = await fetchFn(params.url);
+
+  // SECURITY: never let the fetch client auto-follow redirects before allowlist checks.
+  const firstAttempt = await fetchWithManualRedirects({
+    url: params.url,
+    fetchFn,
+    allowHosts: params.allowHosts,
+  });
   if (firstAttempt.ok) {
     return firstAttempt;
   }
@@ -108,31 +159,23 @@ async function fetchWithAuthFallback(params: {
   for (const scope of scopes) {
     try {
       const token = await params.tokenProvider.getAccessToken(scope);
-      const res = await fetchFn(params.url, {
-        headers: { Authorization: `Bearer ${token}` },
-        redirect: "manual",
+      const res = await fetchWithManualRedirects({
+        url: params.url,
+        fetchFn,
+        allowHosts: params.allowHosts,
+        resolveRequestInit: (url) => {
+          // Only attach Authorization on hosts explicitly allowlisted for auth.
+          if (!isUrlAllowed(url, params.authAllowHosts)) {
+            return {};
+          }
+          return {
+            headers: { Authorization: `Bearer ${token}` },
+          };
+        },
       });
+
       if (res.ok) {
         return res;
-      }
-      const redirectUrl = readRedirectUrl(params.url, res);
-      if (redirectUrl && isUrlAllowed(redirectUrl, params.allowHosts)) {
-        const redirectRes = await fetchFn(redirectUrl);
-        if (redirectRes.ok) {
-          return redirectRes;
-        }
-        if (
-          (redirectRes.status === 401 || redirectRes.status === 403) &&
-          isUrlAllowed(redirectUrl, params.authAllowHosts)
-        ) {
-          const redirectAuthRes = await fetchFn(redirectUrl, {
-            headers: { Authorization: `Bearer ${token}` },
-            redirect: "manual",
-          });
-          if (redirectAuthRes.ok) {
-            return redirectAuthRes;
-          }
-        }
       }
     } catch {
       // Try the next scope.


### PR DESCRIPTION
Fixes openclaw/openclaw#11811.

Security fix: MSTeams attachment downloads now use manual redirect handling and validate every redirect hop against the allowlist (HTTPS-only) before following, preventing SSRF via allowlisted URL -> disallowed redirect.

Also ensures Authorization headers are only attached for hosts in channels.msteams.mediaAuthAllowHosts (no token forwarding to redirect destinations).

Docs:
- docs/channels/msteams.md: note manual redirect + per-hop allowlist behavior.

AI-assisted: yes.

Testing:
- pnpm vitest run extensions/msteams/src/attachments.test.ts
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an SSRF vulnerability in MSTeams attachment downloads by implementing manual redirect handling with per-hop allowlist validation.

**Key Changes:**
- Added `fetchWithManualRedirects` function that validates every redirect hop against the allowlist before following (HTTPS-only)
- Authorization headers are now only attached to hosts in the `authAllowHosts` list, preventing token forwarding to redirect destinations
- All fetch calls now use `redirect: "manual"` to prevent automatic redirect following before security checks
- Comprehensive test coverage for the SSRF prevention scenarios
- Documentation updated to describe the manual redirect and per-hop allowlist behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix is well-implemented with proper validation at every redirect hop, comprehensive test coverage for all edge cases (SSRF prevention, auth header stripping, multi-hop redirects), and clear documentation. The implementation correctly enforces HTTPS-only redirects and prevents credential leakage.
- No files require special attention

<sub>Last reviewed commit: d30269f</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->