### PR TITLE
iOS/Security: force TLS for non-loopback manual gateway sessions

### DIFF
--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -102,4 +102,27 @@ import Testing
 
         #expect(controller._test_didAutoConnect() == false)
     }
+
+    @Test @MainActor func manualConnectionsForceTLSForNonLoopbackHosts() async {
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+        #expect(controller._test_resolveManualUseTLS(host: "gateway.example.com", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "openclaw.local", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "localhost", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "127.0.0.1", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "::1", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "[::1]", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "0.0.0.0", useTLS: false) == false)
+    }
+
+    @Test @MainActor func manualDefaultPortUses443OnlyForTailnetTLSHosts() async {
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+        #expect(controller._test_resolveManualPort(host: "gateway.example.com", port: 0, useTLS: true) == 18789)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 0, useTLS: true) == 443)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net.", port: 0, useTLS: true) == 443)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 18789, useTLS: true) == 18789)
+    }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 


### PR DESCRIPTION
## Summary
- force TLS for all non-loopback iOS manual gateway sessions at runtime (controller-level fail-closed)
- keep plaintext `ws://` support only for explicit loopback development hosts (`localhost`, `127.*`, `::1`, `0.0.0.0`)
- preserve existing `.ts.net` default-port behavior (443 when TLS and no explicit port)
- add targeted security regression tests for TLS coercion and manual port defaults

## Why
Deep-link/setup-code hardening already rejects insecure non-loopback setup payloads, but manual runtime connection logic could still use plaintext transport for non-loopback hosts if TLS was toggled off. This closes that remaining path and aligns iOS behavior with Android transport hardening.

## Validation
- `./scripts/ios-configure-signing.sh` (pass)
- `xcodegen generate` in `apps/ios` (pass)
- `xcodebuild` test execution in this environment is blocked because the active developer directory is Command Line Tools (`/Library/Developer/CommandLineTools`) rather than full Xcode

## Scope / Non-duplication
- complements (does not duplicate) PR #21268, which focused on deep-link/setup-code parsing guards
- this PR enforces secure transport at the iOS runtime controller layer for manual connections

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Forces TLS encryption for all non-loopback iOS manual gateway connections at the controller level, closing a security gap where users could disable TLS for remote hosts. The change:

- Introduces `resolveManualUseTLS()` to enforce TLS based on host type (loopback vs remote)
- Extracts `isLoopbackHost()` helper to identify development hosts (`localhost`, `127.*`, `::1`, `0.0.0.0`)
- Separates TLS requirement logic (`shouldRequireTLS`) from Tailscale port-443 default logic (`shouldUseTLSDefaultPort443`)
- Applies TLS enforcement consistently across manual connections, autoconnect, and last-known reconnect paths
- Adds comprehensive test coverage for TLS coercion and port resolution behavior

This complements existing deep-link/setup-code parsing guards and aligns iOS behavior with Android transport hardening.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security hardening change with comprehensive test coverage
- The changes are well-structured, logically sound, and improve security posture. The refactoring properly separates concerns (TLS requirement vs port selection), the loopback detection logic is thorough (handles IPv4, IPv6, brackets, zones, trailing dots), and the security enforcement is applied consistently across all connection code paths. Test coverage validates both TLS coercion and port resolution behavior for various host types.
- No files require special attention

<sub>Last reviewed commit: 4b15033</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->