### PR TITLE
Android: allow HTTP for LAN hosts

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -624,8 +624,10 @@ class GatewaySession(
     val port = parsed?.port ?: -1
     val scheme = parsed?.scheme?.trim().orEmpty().ifBlank { "http" }
 
-    // Detect TLS reverse proxy: endpoint on port 443, or domain-based host
-    val tls = endpoint.port == 443 || endpoint.host.contains(".")
+    // Detect TLS reverse proxy: endpoint on port 443 only.
+    // Do not force TLS for dotted LAN hosts (e.g., IPs or .local),
+    // because Android WebView cannot use plain HTTP if we auto-upgrade.
+    val tls = endpoint.port == 443
 
     // If raw URL is a non-loopback address AND we're behind TLS reverse proxy,
     // fix the port (gateway sends its internal port like 18789, but we need 443 via Caddy)


### PR DESCRIPTION
## Summary\n- Avoid forcing HTTPS for dotted LAN hosts in Android gateway canvas URLs.\n- This fixes WebView loading on LAN/IP endpoints where the gateway serves HTTP only.\n\n## Problem\nThe Android app currently treats any host containing a dot as TLS and rewrites canvas URLs to https. For LAN IPs or local DNS (e.g., 192.168.x.x, .local), this breaks A2UI loading and yields connection errors.\n\n## Fix\nOnly auto‑enable TLS when the port is 443. This keeps HTTPS for reverse proxies while allowing HTTP on LAN endpoints.\n\n## Testing\n- Built Android debug APK locally.\n- Verified A2UI endpoint loads over HTTP on LAN.\n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Android WebView loading on LAN/IP endpoints by removing the heuristic that forced HTTPS for any host containing a dot. The previous logic (`endpoint.host.contains(".")`) incorrectly treated LAN IPs like `192.168.x.x` and `.local` hostnames as TLS-enabled, breaking HTTP-only gateway connections.

The fix simplifies TLS detection to only check `endpoint.port == 443`, which resolves the immediate LAN issue. However, the `GatewayEndpoint` already has a `tlsEnabled` field populated from mDNS discovery that would be a more accurate source of truth for TLS detection.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with low risk - fixes a real Android LAN connectivity issue
- The change correctly addresses the immediate problem of LAN HTTP connections being forced to HTTPS. The simplified port-based heuristic (port 443 only) is reasonable for the common case. Minor improvement opportunity exists to use the existing `tlsEnabled` field for more accurate TLS detection, but the current fix is functionally correct for the stated use case.
- No files require special attention

<sub>Last reviewed commit: 760466f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->