### PR TITLE
fix: check QMD backend before memory search config

### DIFF
--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -15,18 +15,20 @@ import { resolveUserPath } from "../utils.js";
 export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void> {
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
+
+  // QMD backend handles embeddings internally (e.g. embeddinggemma) — no
+  // separate embedding provider is needed. Skip the provider check entirely.
+  // Check this FIRST, before resolving memorySearch config, as QMD is independent.
+  const backendConfig = resolveMemoryBackendConfig({ cfg, agentId });
+  if (backendConfig.backend === "qmd") {
+    return;
+  }
+
   const resolved = resolveMemorySearchConfig(cfg, agentId);
   const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");
-    return;
-  }
-
-  // QMD backend handles embeddings internally (e.g. embeddinggemma) — no
-  // separate embedding provider is needed. Skip the provider check entirely.
-  const backendConfig = resolveMemoryBackendConfig({ cfg, agentId });
-  if (backendConfig.backend === "qmd") {
     return;
   }
 


### PR DESCRIPTION
Fixes #21443

## Summary
When `memory.backend` is set to `qmd`, `openclaw doctor` was still showing the embedding-provider warning, despite QMD managing embeddings internally.

## Root Cause
The QMD backend check was implemented (#17263) but ran **after** memory search config resolution, which could cause it to be skipped in certain configuration states.

## Changes
- Moved QMD backend check to the top of `noteMemorySearchHealth()`
- Now checks QMD backend **before** resolving memory search config
- Added clarifying comment explaining the check order

## Testing
- All existing tests pass (`doctor-memory-search.test.ts`)
- QMD backend check now runs first, ensuring no false warnings

## Closes
#21443

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reordered QMD backend check to run before memory search config resolution, preventing false embedding-provider warnings when using QMD. QMD handles embeddings internally and doesn't require a separate provider, so the check correctly exits early before any provider validation logic runs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple reordering fix with existing test coverage confirming QMD backend check behavior. The change is minimal (moving 6 lines earlier), logic is unchanged, and all tests pass. The fix addresses a clear bug where QMD users received false warnings.
- No files require special attention

<sub>Last reviewed commit: 05c5205</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->