### PR TITLE
fix(agents): use resolved workspaceDir instead of process.cwd() in post-compaction audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Heartbeat/Cron: restore interval heartbeat behavior so missing `HEARTBEAT.md` no longer suppresses runs (only effectively empty files skip), preserving prompt-driven and tagged-cron execution paths.
+- Agents/Compaction: fix post-compaction audit and context injection using `process.cwd()` instead of the agent's configured workspace directory. Thanks @mattemoon.
 - Gateway/Pairing: tolerate legacy paired devices missing `roles`/`scopes` metadata in websocket upgrade checks and backfill metadata on reconnect. (#21447, fixes #21236) Thanks @joshavant.
 - Docker: pin base images to SHA256 digests in Docker builds to prevent mutable tag drift. (#7734) Thanks @coygeek.
 - Provider/HTTP: treat HTTP 503 as failover-eligible for LLM provider errors. (#21086) Thanks @Protocol-zero-0.

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -159,6 +159,7 @@ describe("runReplyAgent onAgentRunStart", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
   }
 
@@ -286,6 +287,7 @@ describe("runReplyAgent authProfileId fallback scoping", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
 
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
@@ -428,6 +430,7 @@ describe("runReplyAgent auto-compaction token update", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
@@ -489,6 +492,7 @@ describe("runReplyAgent auto-compaction token update", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
@@ -579,6 +583,7 @@ describe("runReplyAgent block streaming", () => {
       resolvedBlockStreamingBreak: "text_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
@@ -681,6 +686,7 @@ describe("runReplyAgent block streaming", () => {
       resolvedBlockStreamingBreak: "text_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
 
     await vi.advanceTimersByTimeAsync(5);
@@ -746,6 +752,7 @@ describe("runReplyAgent claude-cli routing", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
   }
 
@@ -847,6 +854,7 @@ describe("runReplyAgent messaging tool suppression", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
   }
 
@@ -1019,6 +1027,7 @@ describe("runReplyAgent reminder commitment guard", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
   }
 
@@ -1119,6 +1128,7 @@ describe("runReplyAgent fallback reasoning tags", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
   }
 
@@ -1239,6 +1249,7 @@ describe("runReplyAgent response usage footer", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
   }
 
@@ -1346,6 +1357,7 @@ describe("runReplyAgent transient HTTP retry", () => {
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
+      workspaceDir: "/tmp",
     });
 
     await vi.advanceTimersByTimeAsync(2_500);

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -158,6 +158,7 @@ function createMinimalRun(params?: {
         resolvedBlockStreamingBreak: "message_end",
         shouldInjectGroupIntro: false,
         typingMode: params?.typingMode ?? "instant",
+        workspaceDir: "/tmp",
       });
     },
   };
@@ -265,6 +266,7 @@ async function runReplyAgentWithBase(params: {
     resolvedBlockStreamingBreak: "message_end",
     shouldInjectGroupIntro: false,
     typingMode: params.typingMode ?? "instant",
+    workspaceDir: "/tmp",
   });
 }
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -125,6 +125,7 @@ export async function runReplyAgent(params: {
   sessionCtx: TemplateContext;
   shouldInjectGroupIntro: boolean;
   typingMode: TypingMode;
+  workspaceDir: string;
 }): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const {
     commandBody,
@@ -151,6 +152,7 @@ export async function runReplyAgent(params: {
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    workspaceDir,
   } = params;
 
   let activeSessionEntry = sessionEntry;
@@ -672,7 +674,6 @@ export async function runReplyAgent(params: {
 
       // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {
-        const workspaceDir = process.cwd();
         readPostCompactionContext(workspaceDir)
           .then((contextContent) => {
             if (contextContent) {
@@ -707,7 +708,6 @@ export async function runReplyAgent(params: {
         if (sessionFile) {
           const messages = readSessionMessages(sessionFile);
           const readPaths = extractReadPaths(messages);
-          const workspaceDir = process.cwd();
           const audit = auditPostCompactionReads(readPaths, workspaceDir);
           if (!audit.passed) {
             enqueueSystemEvent(formatAuditWarning(audit.missingPatterns), { sessionKey });

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -460,5 +460,6 @@ export async function runPreparedReply(
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    workspaceDir,
   });
 }


### PR DESCRIPTION

## Summary

- **Problem:** The post-compaction audit and AGENTS.md context injection both called `process.cwd()` to locate the workspace directory, rather than using the agent's configured workspace path.
- **How it was found:** During code review of the post-compaction audit feature, while investigating a spurious "required startup files not read" warning after a compaction. In that specific case the gateway cwd happened to match the workspace, so the bug didn't directly cause the warning — the warning was from a missing `WORKFLOW_AUTO.md` file. But inspecting the source revealed the audit uses `process.cwd()` rather than the resolved workspace path, which is fragile regardless.
- **Why it matters:** The workspace directory is configurable (`agents.defaults.workspace`, per-agent `workspace` override, `~` expansion). Using `process.cwd()` only works when the gateway happens to launch from the workspace directory — a coincidence of default deployment, not a guarantee. Any non-default workspace path causes the audit to look in the wrong directory, silently failing to find `WORKFLOW_AUTO.md` and daily memory files, and firing spurious post-compaction warnings on every compaction. The correct value is already resolved earlier in the call chain and simply wasn't threaded through.
- **What changed:** `workspaceDir` (already resolved correctly in `get-reply-run.ts`) is now threaded into `runReplyAgent` as an explicit param and used in both compaction code paths.
- **What did NOT change:** The audit logic, context injection logic, `resolveWorkspaceRoot()`, and all other call sites are untouched. Behavior is identical for the common case where cwd == workspace.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Related: introduced alongside post-compaction-audit.ts without threading the resolved workspaceDir through to the runner

## User-visible / Behavior Changes

Post-compaction audit now correctly checks the configured workspace directory instead of the process working directory. Users with non-default workspace paths will no longer receive spurious "required startup files were not read" warnings after every compaction.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 25.3 (arm64)
- Runtime: Node 22.22.0
- Gateway running with default workspace at ~/.openclaw/workspace

### Steps

1. Configure workspace at any path (default or custom)
2. Trigger a context compaction
3. Observe post-compaction audit behaviour in next agent turn

### Expected

Audit checks the configured workspace, finds required files if present, passes silently.

### Actual (before fix)

Audit checks `process.cwd()`. If that differs from workspace, required files are not found and a spurious warning fires on every post-compaction turn.

## Evidence

- [x] 78 tests passing across 4 files (agent-runner, post-compaction-audit, post-compaction-context)
- [x] `pnpm tsgo` clean on changed files
- [x] `pnpm build` clean
- [x] `pnpm lint` clean (0 warnings, 0 errors via scripts/committer)
- [x] Verified on live gateway instance — audit now resolves correctly after reading WORKFLOW_AUTO.md

## Human Verification (required)

- Verified: compaction audit fires and passes correctly on live macOS gateway (default workspace config)
- Verified: `process.cwd()` no longer present in agent-runner.ts compaction paths
- Edge cases checked: default workspace path, `~`-prefixed path (expanded before reaching runReplyAgent)
- What I did not verify: non-macOS platforms, sandboxed workspace configs

## Compatibility / Migration

- Backward compatible? Yes — identical behaviour when cwd == workspace (the common/default case)
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit; the two `process.cwd()` calls restore prior behaviour
- Files: `src/auto-reply/reply/agent-runner.ts`, `src/auto-reply/reply/get-reply-run.ts`
- Bad symptoms: TypeScript errors on `workspaceDir` if new callers of `runReplyAgent` are added without the field

## Risks and Mitigations

- Risk: future callers of `runReplyAgent` must supply `workspaceDir`
  - Mitigation: TypeScript enforces this at compile time

---

AI-assisted (Claude Sonnet via OpenClaw). Fully tested locally against a live instance. Author understands what the code does.
