### PR TITLE
feat(cron): add direct-text flag to deliver text message directly [AI-assisted]

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -92,6 +92,7 @@ export function registerCronAddCommand(cron: Command) {
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
+      .option("--direct-text", "Deliver text payloads directly (skip announce conversion)", false)
       .option("--json", "Output JSON", false)
       .action(async (opts: GatewayRpcOpts & Record<string, unknown>, cmd?: Command) => {
         try {
@@ -259,6 +260,7 @@ export function registerCronAddCommand(cron: Command) {
                       : undefined,
                   to: typeof opts.to === "string" && opts.to.trim() ? opts.to.trim() : undefined,
                   bestEffort: opts.bestEffortDeliver ? true : undefined,
+                  directText: opts.directText ? true : undefined,
                 }
               : undefined,
           };

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -59,6 +59,7 @@ export function registerCronEditCommand(cron: Command) {
       )
       .option("--best-effort-deliver", "Do not fail job if delivery fails")
       .option("--no-best-effort-deliver", "Fail job when delivery fails")
+      .option("--direct-text", "Deliver text payloads directly (skip announce conversion)")
       .action(async (id, opts) => {
         try {
           if (opts.session === "main" && opts.message) {
@@ -199,6 +200,7 @@ export function registerCronEditCommand(cron: Command) {
           const hasDeliveryModeFlag = opts.announce || typeof opts.deliver === "boolean";
           const hasDeliveryTarget = typeof opts.channel === "string" || typeof opts.to === "string";
           const hasBestEffort = typeof opts.bestEffortDeliver === "boolean";
+          const hasDirectText = typeof opts.directText === "boolean";
           const hasAgentTurnPatch =
             typeof opts.message === "string" ||
             Boolean(model) ||
@@ -206,7 +208,8 @@ export function registerCronEditCommand(cron: Command) {
             hasTimeoutSeconds ||
             hasDeliveryModeFlag ||
             hasDeliveryTarget ||
-            hasBestEffort;
+            hasBestEffort ||
+            hasDirectText;
           if (hasSystemEventPatch && hasAgentTurnPatch) {
             throw new Error("Choose at most one payload change");
           }
@@ -224,7 +227,7 @@ export function registerCronEditCommand(cron: Command) {
             patch.payload = payload;
           }
 
-          if (hasDeliveryModeFlag || hasDeliveryTarget || hasBestEffort) {
+          if (hasDeliveryModeFlag || hasDeliveryTarget || hasBestEffort || hasDirectText) {
             const deliveryMode =
               opts.announce || opts.deliver === true
                 ? "announce"
@@ -242,6 +245,9 @@ export function registerCronEditCommand(cron: Command) {
             }
             if (typeof opts.bestEffortDeliver === "boolean") {
               delivery.bestEffort = opts.bestEffortDeliver;
+            }
+            if (typeof opts.directText === "boolean") {
+              delivery.directText = opts.directText;
             }
             patch.delivery = delivery;
           }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -101,6 +101,13 @@ function resolveCronDeliveryBestEffort(job: CronJob): boolean {
   return false;
 }
 
+function resolveCronDeliveryDirectText(job: CronJob): boolean {
+  if (typeof job.delivery?.directText === "boolean") {
+    return job.delivery.directText;
+  }
+  return false;
+}
+
 async function resolveCronAnnounceSessionKey(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -572,6 +579,7 @@ export async function runCronIsolatedAgentTurn(params: {
     (deliveryPayload?.mediaUrls?.length ?? 0) > 0 ||
     Object.keys(deliveryPayload?.channelData ?? {}).length > 0;
   const deliveryBestEffort = resolveCronDeliveryBestEffort(params.job);
+  const directTextDelivery = resolveCronDeliveryDirectText(params.job);
 
   // Skip delivery for heartbeat-only responses (HEARTBEAT_OK with no real content).
   const ackMaxChars = resolveHeartbeatAckMaxChars(agentCfg);
@@ -620,11 +628,10 @@ export async function runCronIsolatedAgentTurn(params: {
     }
     const identity = resolveAgentOutboundIdentity(cfgWithAgentDefaults, agentId);
 
-    // Route text-only cron announce output back through the main session so it
-    // follows the same system-message injection path as subagent completions.
-    // Keep direct outbound delivery only for structured payloads (media/channel
-    // data), which cannot be represented by the shared announce flow.
-    if (deliveryPayloadHasStructuredContent) {
+    // Route delivery:
+    // - Direct outbound for structured payloads OR when directTextDelivery is requested.
+    // - Otherwise use announce flow for text-only to ensure consistent user updates.
+    if (deliveryPayloadHasStructuredContent || (directTextDelivery && synthesizedText)) {
       try {
         const payloadsForDelivery =
           deliveryPayloads.length > 0

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -561,6 +561,7 @@ function mergeCronDelivery(
     channel: existing?.channel,
     to: existing?.to,
     bestEffort: existing?.bestEffort,
+    directText: existing?.directText,
   };
 
   if (typeof patch.mode === "string") {
@@ -576,6 +577,9 @@ function mergeCronDelivery(
   }
   if (typeof patch.bestEffort === "boolean") {
     next.bestEffort = patch.bestEffort;
+  }
+  if (typeof patch.directText === "boolean") {
+    next.directText = patch.directText;
   }
 
   return next;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -23,6 +23,8 @@ export type CronDelivery = {
   channel?: CronMessageChannel;
   to?: string;
   bestEffort?: boolean;
+  /** When true, deliver text payloads directly (skip announce conversion). */
+  directText?: boolean;
 };
 
 export type CronDeliveryPatch = Partial<CronDelivery>;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -100,6 +100,8 @@ export const CronPayloadPatchSchema = Type.Union([
 const CronDeliverySharedProperties = {
   channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
   bestEffort: Type.Optional(Type.Boolean()),
+  /** When true, deliver text payloads directly (skip announce conversion). */
+  directText: Type.Optional(Type.Boolean()),
 };
 
 const CronDeliveryNoopSchema = Type.Object(


### PR DESCRIPTION
## Summary

- Problem: add direct-text flag to deliver text message directly
- Why it matters: For text-only results, cron uses the subagent announce flow to deliver a user-facing update rather than raw output. This path intentionally asks the main agent to “convert the result into your normal assistant voice”, which tends to summarize.
- What changed: add direct-text flag to deliver text message directly, skip subagent announce flow
- What did NOT change (scope boundary):

## AI-assisted
- Prompt: add a flag to delivers text payloads directly without the announce conversion path

## Change Type (select all)

- [ ] Bug fix
- [x ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra


## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`No`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `directText` flag to cron delivery configuration allowing text payloads to bypass the announce conversion path and be delivered directly to messaging channels.

**Key changes:**
- Added optional `directText` boolean field to `CronDelivery` type and schema
- Implemented CLI flags `--direct-text` in both `cron add` and `cron edit` commands
- Modified delivery routing logic in `run.ts` to check `directText` flag and route accordingly
- Updated merge logic in `jobs.ts` to preserve `directText` field during job updates

**How it works:**
When `directText` is true and text content exists, the cron job delivers the raw text output directly via `deliverOutboundPayloads` instead of routing through the announce flow (which typically summarizes the output). Structured payloads (media, channel data) continue to use direct delivery regardless of this flag.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor style suggestion for consistency
- Implementation follows existing patterns (similar to `bestEffort` flag), adds proper type definitions, schema validation, and CLI integration. One minor style inconsistency exists in type casting approach compared to similar functionality. No logical errors or security concerns identified.
- No files require special attention - all changes are straightforward feature additions

<sub>Last reviewed commit: 22c044f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->