### PR TITLE
fix: auto-initialize agent sessions.json on agent creation

### DIFF
--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -309,7 +309,7 @@ export async function ensureWorkspaceAndSessions(
     } catch {
       // File doesn't exist, create it with empty structure
       await fs.mkdir(agentStateSessionsDir, { recursive: true });
-      const emptySessions = { sessions: [] };
+      const emptySessions = {};
       await fs.writeFile(sessionsFile, JSON.stringify(emptySessions, null, 2));
       runtime.log(`Agent state initialized: ${shortenHomePath(sessionsFile)}`);
     }

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -298,6 +298,22 @@ export async function ensureWorkspaceAndSessions(
   const sessionsDir = resolveSessionTranscriptsDirForAgent(options?.agentId);
   await fs.mkdir(sessionsDir, { recursive: true });
   runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);
+
+  // Initialize agent state sessions directory with empty sessions.json if it doesn't exist
+  if (options?.agentId) {
+    const agentStateSessionsDir = path.join(CONFIG_DIR, "agents", options.agentId, "sessions");
+    const sessionsFile = path.join(agentStateSessionsDir, "sessions.json");
+    
+    try {
+      await fs.stat(sessionsFile);
+    } catch {
+      // File doesn't exist, create it with empty structure
+      await fs.mkdir(agentStateSessionsDir, { recursive: true });
+      const emptySessions = { sessions: [] };
+      await fs.writeFile(sessionsFile, JSON.stringify(emptySessions, null, 2));
+      runtime.log(`Agent state initialized: ${shortenHomePath(sessionsFile)}`);
+    }
+  }
 }
 
 export function resolveNodeManagerOptions(): Array<{


### PR DESCRIPTION
When creating a new agent, the agent state directory (e.g., ~/.openclaw/agents/<agentId>/sessions/) was not initialized with a sessions.json file. This caused the agent to not appear in the web UI dropdown even after the agent was created.

Now, ensureWorkspaceAndSessions() automatically creates an empty sessions.json when initializing an agent, ensuring the agent appears in the UI selector immediately.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

adds auto-initialization of `sessions.json` when creating a new agent to ensure agents appear in the UI dropdown immediately after creation

**Critical Issue Found:**
- the initialization creates `{ sessions: [] }` but the session store expects an empty object `{}` (a `Record<string, SessionEntry>`). this will cause JSON parsing to succeed but the structure will be incompatible with the session loading logic in `loadSessionStore()` which expects a plain object mapping session keys to session entries

**Major changes:**
- adds new logic in `ensureWorkspaceAndSessions()` to create `~/.openclaw/agents/<agentId>/sessions/sessions.json` if it doesn't exist
- uses try/catch around `fs.stat()` to check if file exists
- creates the directory and file with initial structure when missing

<h3>Confidence Score: 1/5</h3>

- critical bug will prevent agents from appearing in UI despite initialization
- the code creates `{ sessions: [] }` but the session store expects `{}` (empty object), causing a structural mismatch. while JSON parsing won't fail, the session loading logic expects a `Record<string, SessionEntry>` and will not handle the `sessions` array property correctly. this defeats the purpose of the PR
- pay close attention to `src/commands/onboard-helpers.ts:312` - the data structure must match the session store format

<sub>Last reviewed commit: 73f0c69</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->