### PR TITLE
Apple PIM CLI — Native macOS Calendar, Reminders, Contacts, and Mail.app tools via Swift CLIs

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -42,3 +42,10 @@ Use this format when adding entries:
   npm: `@scope/package`
   repo: `https://github.com/org/repo`
   install: `openclaw plugins install @scope/package`
+
+## Plugins
+
+- **Apple PIM CLI** — Native macOS Calendar, Reminders, Contacts, and Mail.app tools via Swift CLIs
+  npm: `apple-pim-cli`
+  repo: `https://github.com/omarshahine/Apple-PIM-Agent-Plugin`
+  install: `openclaw plugins install apple-pim-cli`


### PR DESCRIPTION
## Summary

Adds [Apple PIM CLI](https://github.com/omarshahine/Apple-PIM-Agent-Plugin) to the community plugins page.

**Apple PIM CLI** — Native macOS Calendar, Reminders, Contacts, and Mail.app tools via Swift CLIs

- **npm**: [`apple-pim-cli`](https://www.npmjs.com/package/apple-pim-cli)
- **repo**: https://github.com/omarshahine/Apple-PIM-Agent-Plugin
- **install**: `openclaw plugins install apple-pim-cli`

### What it does

Registers 5 OpenClaw tools (`apple_pim_calendar`, `apple_pim_reminder`, `apple_pim_contact`, `apple_pim_mail`, `apple_pim_system`) that spawn native Swift CLIs using EventKit, Contacts framework, and JXA (Mail.app). Supports per-call workspace isolation via `configDir`/`profile` parameters for multi-agent setups.

### Checklist

- [x] Published on npmjs
- [x] Public GitHub repository
- [x] Setup docs and issue tracker
- [x] macOS-only (`os: ["darwin"]` in package.json)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Apple PIM CLI to the community plugins page. The entry follows the required format with plugin name, npm package, GitHub repository, one-line description, and install command. The formatting (2-space indentation, em dash separator) matches the template exactly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple documentation-only change that adds a single plugin entry following the exact template format. No code changes, no logic modifications, no security implications.
- No files require special attention

<sub>Last reviewed commit: 4f872a6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->