### PR TITLE
fix #20898: handle array type in tryFlattenLiteralAnyOf

### DIFF
--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -66,7 +66,12 @@ function tryFlattenLiteralAnyOf(variants: unknown[]): { type: string; enum: unkn
       return null;
     }
 
-    const variantType = typeof v.type === "string" ? v.type : null;
+    const variantType =
+      typeof v.type === "string"
+        ? v.type
+        : Array.isArray(v.type) && v.type.length === 1
+          ? v.type[0]
+          : null;
     if (!variantType) {
       return null;
     }

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -69,7 +69,7 @@ function tryFlattenLiteralAnyOf(variants: unknown[]): { type: string; enum: unkn
     const variantType =
       typeof v.type === "string"
         ? v.type
-        : Array.isArray(v.type) && v.type.length === 1
+        : Array.isArray(v.type) && v.type.length === 1 && typeof v.type[0] === "string"
           ? v.type[0]
           : null;
     if (!variantType) {


### PR DESCRIPTION
## Summary

`tryFlattenLiteralAnyOf` silently fails when a schema variant uses `type: ["string"]` instead of `type: "string"`, even though both are valid JSON Schema.

## Changes

- `src/agents/schema/clean-for-gemini.ts`: Handle array type (e.g., `type: ["string"]`) in addition to string type.

## Testing

- [x] Code compiles and passes format check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended `tryFlattenLiteralAnyOf` to handle array type syntax (e.g., `type: ["string"]`) in addition to string type syntax (e.g., `type: "string"`), both valid per JSON Schema spec. This prevents silent failures when flattening literal anyOf variants.

- handled single-element array types in `tryFlattenLiteralAnyOf` logic
- aligns with existing `isNullSchema` pattern which already handles array types
- missing type validation: array element should be verified as string (see comment)

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe but has a minor type safety gap that should be addressed
- The change correctly handles array type syntax and aligns with JSON Schema spec and existing patterns in the file (like `isNullSchema`). However, missing type validation for the array element at line 72 creates a potential runtime issue - if `v.type[0]` is not a string, the subsequent type comparison logic could behave unexpectedly. This is a logical error that needs to be fixed.
- src/agents/schema/clean-for-gemini.ts requires attention for the type validation issue

<sub>Last reviewed commit: 2e8be7a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->