### PR TITLE
fix #20721: add video and audio to models.input type union

### DIFF
--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -66,7 +66,12 @@ function tryFlattenLiteralAnyOf(variants: unknown[]): { type: string; enum: unkn
       return null;
     }
 
-    const variantType = typeof v.type === "string" ? v.type : null;
+    const variantType =
+      typeof v.type === "string"
+        ? v.type
+        : Array.isArray(v.type) && v.type.length === 1
+          ? v.type[0]
+          : null;
     if (!variantType) {
       return null;
     }

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -28,7 +28,7 @@ export type ModelDefinitionConfig = {
   name: string;
   api?: ModelApi;
   reasoning: boolean;
-  input: Array<"text" | "image">;
+  input: Array<"text" | "image" | "video" | "audio">;
   cost: {
     input: number;
     output: number;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -38,7 +38,11 @@ export const ModelDefinitionSchema = z
     name: z.string().min(1),
     api: ModelApiSchema.optional(),
     reasoning: z.boolean().optional(),
-    input: z.array(z.union([z.literal("text"), z.literal("image")])).optional(),
+    input: z
+      .array(
+        z.union([z.literal("text"), z.literal("image"), z.literal("video"), z.literal("audio")]),
+      )
+      .optional(),
     cost: z
       .object({
         input: z.number().optional(),


### PR DESCRIPTION
## Summary

Model input config (`models.providers[].models[].input`) rejects `"video"` and `"audio"` values at zod validation, preventing users from declaring Gemini native multimodal capabilities.

## Changes

- `src/config/zod-schema.core.ts`: Added "video" and "audio" to input type union
- `src/config/types.models.ts`: Added "video" and "audio" to ModelDefinitionConfig.input type

## Testing

- [x] Code compiles and passes format check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `"video"` and `"audio"` to the model input type union, allowing users to declare Gemini native multimodal capabilities in model configurations. The changes update both the TypeScript type definition and the Zod validation schema to accept these new input types alongside existing `"text"` and `"image"` types.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-scoped, and follow the existing pattern. Both the TypeScript type and Zod schema are updated consistently. The new input types align with existing `MediaUnderstandingCapabilitiesSchema` that already supports video and audio, demonstrating consistency with the codebase's architecture.
- No files require special attention

<sub>Last reviewed commit: 3e12dca</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->