### PR TITLE
fix(test): resolve vi.mock hoisting failures on macOS runners

### DIFF
--- a/extensions/bluebubbles/src/test-mocks.ts
+++ b/extensions/bluebubbles/src/test-mocks.ts
@@ -1,11 +1,22 @@
 import { vi } from "vitest";
 
-vi.mock("./accounts.js", async () => {
-  const { createBlueBubblesAccountsMockModule } = await import("./test-harness.js");
-  return createBlueBubblesAccountsMockModule();
-});
+vi.mock("./accounts.js", () => ({
+  resolveBlueBubblesAccount: vi.fn(
+    (params: {
+      cfg?: { channels?: { bluebubbles?: Record<string, unknown> } };
+      accountId?: string;
+    }) => {
+      const config = params.cfg?.channels?.bluebubbles ?? {};
+      return {
+        accountId: params.accountId ?? "default",
+        enabled: config.enabled !== false,
+        configured: Boolean(config.serverUrl && config.password),
+        config,
+      };
+    },
+  ),
+}));
 
-vi.mock("./probe.js", async () => {
-  const { createBlueBubblesProbeMockModule } = await import("./test-harness.js");
-  return createBlueBubblesProbeMockModule();
-});
+vi.mock("./probe.js", () => ({
+  getCachedBlueBubblesPrivateApiStatus: vi.fn().mockReturnValue(null),
+}));

--- a/extensions/bluebubbles/src/test-mocks.ts
+++ b/extensions/bluebubbles/src/test-mocks.ts
@@ -19,4 +19,5 @@ vi.mock("./accounts.js", () => ({
 
 vi.mock("./probe.js", () => ({
   getCachedBlueBubblesPrivateApiStatus: vi.fn().mockReturnValue(null),
+  isBlueBubblesPrivateApiStatusEnabled: vi.fn((status: boolean | null) => status === true),
 }));

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 
-const handleDiscordAction = vi.fn(async (..._args: unknown[]) => ({ details: { ok: true } }));
-const handleTelegramAction = vi.fn(async (..._args: unknown[]) => ({ ok: true }));
-const sendReactionSignal = vi.fn(async (..._args: unknown[]) => ({ ok: true }));
-const removeReactionSignal = vi.fn(async (..._args: unknown[]) => ({ ok: true }));
-const handleSlackAction = vi.fn(async (..._args: unknown[]) => ({ details: { ok: true } }));
+const handleDiscordAction = vi.hoisted(() =>
+  vi.fn(async (..._args: unknown[]) => ({ details: { ok: true } })),
+);
+const handleTelegramAction = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => ({ ok: true })));
+const sendReactionSignal = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => ({ ok: true })));
+const removeReactionSignal = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => ({ ok: true })));
+const handleSlackAction = vi.hoisted(() =>
+  vi.fn(async (..._args: unknown[]) => ({ details: { ok: true } })),
+);
 
 vi.mock("../../../agents/tools/discord-actions.js", () => ({
   handleDiscordAction,

--- a/src/discord/monitor/exec-approvals.test.ts
+++ b/src/discord/monitor/exec-approvals.test.ts
@@ -61,20 +61,18 @@ const gatewayClientParams = vi.hoisted(() => [] as Array<Record<string, unknown>
 const mockGatewayClientCtor = vi.hoisted(() => vi.fn());
 const mockResolveGatewayConnectionAuth = vi.hoisted(() => vi.fn());
 
-vi.mock("../send.shared.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../send.shared.js")>();
-  return {
-    ...actual,
-    createDiscordClient: () => ({
-      rest: {
-        post: mockRestPost,
-        patch: mockRestPatch,
-        delete: mockRestDelete,
-      },
-      request: (_fn: () => Promise<unknown>, _label: string) => _fn(),
-    }),
-  };
-});
+vi.mock("../send.shared.js", () => ({
+  createDiscordClient: () => ({
+    rest: {
+      post: mockRestPost,
+      patch: mockRestPatch,
+      delete: mockRestDelete,
+    },
+    request: (_fn: () => Promise<unknown>, _label: string) => _fn(),
+  }),
+  stripUndefinedFields: <T extends object>(value: T): T =>
+    Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T,
+}));
 
 vi.mock("../../gateway/client.js", () => ({
   GatewayClient: class {

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -15,13 +15,11 @@ import { loadWebMedia } from "../../web/media.js";
 import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
 import { runMessageAction } from "./message-action-runner.js";
 
-vi.mock("../../web/media.js", async () => {
-  const actual = await vi.importActual<typeof import("../../web/media.js")>("../../web/media.js");
-  return {
-    ...actual,
-    loadWebMedia: vi.fn(actual.loadWebMedia),
-  };
-});
+const loadWebMediaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../web/media.js", () => ({
+  loadWebMedia: loadWebMediaMock,
+}));
 
 const slackConfig = {
   channels: {


### PR DESCRIPTION
Fix macOS-specific vi.mock hoisting failures (pre-existing, unrelated to any open feature PR).

On macOS Vitest runners, module-scope vi.fn() in vi.mock factories can be undefined after hoisting. Wrapping with vi.hoisted() ensures correct initialization order.

Files changed: actions.test.ts, media-send.test.ts, test-mocks.ts, feishu/media.test.ts, exec-approvals.test.ts, message-action-runner.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps module-scope `vi.fn()` calls in `vi.hoisted()` to fix macOS-specific Vitest hoisting failures where mocks could be undefined after hoisting. The changes update 4 test files to use the correct initialization order for mock factories.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal, focused test-only fixes that follow established patterns used extensively throughout the codebase (172 other files use `vi.hoisted`). The fixes address a real macOS-specific testing issue without touching production code.
- No files require special attention

<sub>Last reviewed commit: 8b6c3b6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->