### PR TITLE
feat(doctor): validate fallback model providers are defined (#20909)

### DIFF
--- a/src/commands/doctor-fallback-models.test.ts
+++ b/src/commands/doctor-fallback-models.test.ts
@@ -60,6 +60,7 @@ describe("noteFallbackModelHealth", () => {
           "kimi-coding": {
             baseUrl: "https://api.kimi.example.com",
             apiKey: "test-key",
+            models: [{ id: "k2p5", name: "K2P5" }],
           },
         },
       },

--- a/src/commands/doctor-fallback-models.test.ts
+++ b/src/commands/doctor-fallback-models.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the model catalog before importing the module under test.
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn().mockResolvedValue([
+    { id: "claude-opus-4-6", name: "Claude Opus 4.6", provider: "anthropic" },
+    { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", provider: "anthropic" },
+    { id: "gpt-5.3", name: "GPT-5.3", provider: "openai" },
+    { id: "gemini-3-flash-preview", name: "Gemini 3 Flash", provider: "google" },
+  ]),
+}));
+
+// Capture note() calls to verify output.
+const noteCalls: Array<{ message: string; title: string }> = [];
+vi.mock("../terminal/note.js", () => ({
+  note: (message: string, title: string) => {
+    noteCalls.push({ message, title });
+  },
+}));
+
+import type { OpenClawConfig } from "../config/config.js";
+import { noteFallbackModelHealth } from "./doctor-fallback-models.js";
+
+describe("noteFallbackModelHealth", () => {
+  beforeEach(() => {
+    noteCalls.length = 0;
+  });
+
+  it("emits no note when there are no fallbacks configured", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+        },
+      },
+    };
+    await noteFallbackModelHealth(cfg);
+    expect(noteCalls).toHaveLength(0);
+  });
+
+  it("emits no note when all fallback providers are in the catalog", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["openai/gpt-5.3", "google/gemini-3-flash-preview"],
+          },
+        },
+      },
+    };
+    await noteFallbackModelHealth(cfg);
+    expect(noteCalls).toHaveLength(0);
+  });
+
+  it("emits no note when fallback provider is in models.providers", async () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "kimi-coding": {
+            baseUrl: "https://api.kimi.example.com",
+            apiKey: "test-key",
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["kimi-coding/k2p5"],
+          },
+        },
+      },
+    };
+    await noteFallbackModelHealth(cfg);
+    expect(noteCalls).toHaveLength(0);
+  });
+
+  it("emits a warning when fallback provider is undefined", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["kimi-coding/k2p5"],
+          },
+        },
+      },
+    };
+    await noteFallbackModelHealth(cfg);
+    expect(noteCalls).toHaveLength(1);
+    expect(noteCalls[0].title).toBe("Fallback models");
+    expect(noteCalls[0].message).toContain("kimi-coding");
+    expect(noteCalls[0].message).toContain("agents.defaults.model.fallbacks");
+  });
+
+  it("reports multiple undefined providers", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["kimi-coding/k2p5", "deepseek/chat-v3"],
+          },
+        },
+      },
+    };
+    await noteFallbackModelHealth(cfg);
+    expect(noteCalls).toHaveLength(1);
+    expect(noteCalls[0].message).toContain("kimi-coding");
+    expect(noteCalls[0].message).toContain("deepseek");
+  });
+
+  it("checks imageModel fallbacks", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "openai/gpt-5.3",
+            fallbacks: ["unknown-provider/some-model"],
+          },
+        },
+      },
+    };
+    await noteFallbackModelHealth(cfg);
+    expect(noteCalls).toHaveLength(1);
+    expect(noteCalls[0].message).toContain("unknown-provider");
+    expect(noteCalls[0].message).toContain("agents.defaults.imageModel.fallbacks");
+  });
+
+  it("checks per-agent fallbacks", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "my-agent",
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["missing-provider/model-x"],
+            },
+          },
+        ],
+      },
+    };
+    await noteFallbackModelHealth(cfg);
+    expect(noteCalls).toHaveLength(1);
+    expect(noteCalls[0].message).toContain("missing-provider");
+    expect(noteCalls[0].message).toContain("my-agent");
+  });
+
+  it("deduplicates identical fallback refs", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["unknown/model-a"],
+          },
+          imageModel: {
+            primary: "openai/gpt-5.3",
+            fallbacks: ["unknown/model-a"],
+          },
+        },
+      },
+    };
+    await noteFallbackModelHealth(cfg);
+    expect(noteCalls).toHaveLength(1);
+    // Should only report once despite appearing in two places
+    const warningLines = noteCalls[0].message.split("\n").filter((l) => l.startsWith("- "));
+    expect(warningLines).toHaveLength(1);
+  });
+
+  it("recognizes CLI backends as valid providers", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "my-cli": { command: "my-cli-agent" },
+          },
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["my-cli/default"],
+          },
+        },
+      },
+    };
+    await noteFallbackModelHealth(cfg);
+    expect(noteCalls).toHaveLength(0);
+  });
+});

--- a/src/commands/doctor-fallback-models.ts
+++ b/src/commands/doctor-fallback-models.ts
@@ -54,7 +54,7 @@ function collectFallbackRefs(cfg: OpenClawConfig): FallbackRef[] {
     );
   }
 
-  // Per-agent fallbacks: agents.list[].model.fallbacks
+  // Per-agent fallbacks: agents.list[].model.fallbacks and agents.list[].subagents.model.fallbacks
   const agentList = cfg.agents?.list ?? [];
   for (const agent of agentList) {
     const agentId = agent.id ?? "unknown";
@@ -63,6 +63,13 @@ function collectFallbackRefs(cfg: OpenClawConfig): FallbackRef[] {
       addRefs(
         (agentModel as { fallbacks?: string[] }).fallbacks,
         `agents.list[${agentId}].model.fallbacks`,
+      );
+    }
+    const agentSubagentModel = agent.subagents?.model;
+    if (agentSubagentModel && typeof agentSubagentModel === "object") {
+      addRefs(
+        (agentSubagentModel as { fallbacks?: string[] }).fallbacks,
+        `agents.list[${agentId}].subagents.model.fallbacks`,
       );
     }
   }

--- a/src/commands/doctor-fallback-models.ts
+++ b/src/commands/doctor-fallback-models.ts
@@ -1,0 +1,161 @@
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { modelKey, normalizeProviderId, parseModelRef } from "../agents/model-selection.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { note } from "../terminal/note.js";
+
+type FallbackRef = {
+  raw: string;
+  provider: string;
+  model: string;
+  source: string;
+};
+
+/**
+ * Collect all fallback model references from config.
+ */
+function collectFallbackRefs(cfg: OpenClawConfig): FallbackRef[] {
+  const refs: FallbackRef[] = [];
+  const defaultProvider = DEFAULT_PROVIDER;
+
+  const addRefs = (fallbacks: unknown, source: string) => {
+    if (!Array.isArray(fallbacks)) {
+      return;
+    }
+    for (const raw of fallbacks) {
+      if (typeof raw !== "string" || !raw.trim()) {
+        continue;
+      }
+      const parsed = parseModelRef(raw, defaultProvider);
+      if (!parsed) {
+        continue;
+      }
+      refs.push({
+        raw,
+        provider: parsed.provider,
+        model: parsed.model,
+        source,
+      });
+    }
+  };
+
+  // agents.defaults.model.fallbacks
+  const modelConfig = cfg.agents?.defaults?.model;
+  if (modelConfig && typeof modelConfig === "object") {
+    addRefs((modelConfig as { fallbacks?: string[] }).fallbacks, "agents.defaults.model.fallbacks");
+  }
+
+  // agents.defaults.imageModel.fallbacks
+  const imageModelConfig = cfg.agents?.defaults?.imageModel;
+  if (imageModelConfig && typeof imageModelConfig === "object") {
+    addRefs(
+      (imageModelConfig as { fallbacks?: string[] }).fallbacks,
+      "agents.defaults.imageModel.fallbacks",
+    );
+  }
+
+  // Per-agent fallbacks: agents.list[].model.fallbacks
+  const agentList = cfg.agents?.list ?? [];
+  for (const agent of agentList) {
+    const agentId = agent.id ?? "unknown";
+    const agentModel = agent.model;
+    if (agentModel && typeof agentModel === "object") {
+      addRefs(
+        (agentModel as { fallbacks?: string[] }).fallbacks,
+        `agents.list[${agentId}].model.fallbacks`,
+      );
+    }
+  }
+
+  // agents.defaults.subagents.model.fallbacks
+  const subagentModel = cfg.agents?.defaults?.subagents?.model;
+  if (subagentModel && typeof subagentModel === "object") {
+    addRefs(
+      (subagentModel as { fallbacks?: string[] }).fallbacks,
+      "agents.defaults.subagents.model.fallbacks",
+    );
+  }
+
+  return refs;
+}
+
+/**
+ * Build a set of provider IDs that are known to be available:
+ * - Providers in the model catalog (built-in + discovered)
+ * - Providers explicitly configured in models.providers
+ * - CLI backends
+ */
+async function buildKnownProviderIds(cfg: OpenClawConfig): Promise<Set<string>> {
+  const known = new Set<string>();
+
+  // From model catalog (includes built-in providers like anthropic, google, openai, etc.)
+  try {
+    const catalog = await loadModelCatalog({ config: cfg });
+    for (const entry of catalog) {
+      known.add(normalizeProviderId(entry.provider));
+    }
+  } catch {
+    // If catalog loading fails, continue with explicit providers only.
+  }
+
+  // From explicit models.providers config
+  const providers = cfg.models?.providers ?? {};
+  for (const key of Object.keys(providers)) {
+    known.add(normalizeProviderId(key));
+  }
+
+  // CLI backends
+  const cliBackends = cfg.agents?.defaults?.cliBackends ?? {};
+  for (const key of Object.keys(cliBackends)) {
+    known.add(normalizeProviderId(key));
+  }
+
+  return known;
+}
+
+/**
+ * Validate that all fallback model providers are resolvable.
+ * Emits doctor notes for any misconfigured fallback references.
+ */
+export async function noteFallbackModelHealth(cfg: OpenClawConfig): Promise<void> {
+  const refs = collectFallbackRefs(cfg);
+  if (refs.length === 0) {
+    return;
+  }
+
+  const knownProviders = await buildKnownProviderIds(cfg);
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+
+  for (const ref of refs) {
+    const key = modelKey(ref.provider, ref.model);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+
+    const normalizedProvider = normalizeProviderId(ref.provider);
+    if (!knownProviders.has(normalizedProvider)) {
+      warnings.push(
+        `- "${ref.raw}" in ${ref.source}: provider "${ref.provider}" is not defined in models.providers and not found in the model catalog.`,
+      );
+    }
+  }
+
+  if (warnings.length === 0) {
+    return;
+  }
+
+  note(
+    [
+      "Fallback model chain references undefined providers.",
+      "These fallbacks will fail at runtime when the primary model is unavailable.",
+      "",
+      ...warnings,
+      "",
+      "Fix: add the missing provider to models.providers in your config,",
+      "or run: openclaw auth add --provider <provider-name>",
+    ].join("\n"),
+    "Fallback models",
+  );
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -28,6 +28,7 @@ import {
 } from "./doctor-auth.js";
 import { doctorShellCompletion } from "./doctor-completion.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+import { noteFallbackModelHealth } from "./doctor-fallback-models.js";
 import { maybeRepairGatewayDaemon } from "./doctor-gateway-daemon-flow.js";
 import { checkGatewayHealth } from "./doctor-gateway-health.js";
 import {
@@ -265,6 +266,7 @@ export async function doctorCommand(
 
   noteWorkspaceStatus(cfg);
   await noteMemorySearchHealth(cfg);
+  await noteFallbackModelHealth(cfg);
 
   // Check and fix shell completion
   await doctorShellCompletion(runtime, prompter, {


### PR DESCRIPTION
## Problem

`openclaw doctor scan` does not validate that fallback models have their providers properly defined. This leads to silent configuration errors that only surface at runtime when the primary model is unavailable and the fallback chain is triggered.

For example, configuring `kimi-coding/k2p5` as a fallback without defining `kimi-coding` in `models.providers` passes doctor validation but fails when Claude goes down.

## Fix

Add a new `noteFallbackModelHealth()` check to `openclaw doctor` that:

1. **Collects all fallback model references** from:
   - `agents.defaults.model.fallbacks`
   - `agents.defaults.imageModel.fallbacks`
   - Per-agent `model.fallbacks` in `agents.list[]`
   - `agents.defaults.subagents.model.fallbacks`

2. **Validates each provider** against known sources:
   - Model catalog (built-in providers: anthropic, openai, google, etc.)
   - Explicit `models.providers` config entries
   - CLI backends (`agents.defaults.cliBackends`)

3. **Reports actionable warnings** with the exact config path and provider name.

Example output:
```
╭ Fallback models
│ Fallback model chain references undefined providers.
│ These fallbacks will fail at runtime when the primary model is unavailable.
│
│ - "kimi-coding/k2p5" in agents.defaults.model.fallbacks: provider "kimi-coding" is not defined
│   in models.providers and not found in the model catalog.
│
│ Fix: add the missing provider to models.providers in your config,
│ or run: openclaw auth add --provider <provider-name>
╰
```

## Changes

- **`src/commands/doctor-fallback-models.ts`** — New validation module
- **`src/commands/doctor-fallback-models.test.ts`** — 9 test cases covering:
  - No fallbacks configured (no-op)
  - All providers in catalog (pass)
  - Provider in explicit `models.providers` (pass)
  - Undefined provider (warning)
  - Multiple undefined providers
  - imageModel fallbacks
  - Per-agent fallbacks
  - Deduplication of identical refs
  - CLI backends recognized as valid
- **`src/commands/doctor.ts`** — Wire up the new check after `noteMemorySearchHealth`

## Testing

```
✓ emits no note when there are no fallbacks configured
✓ emits no note when all fallback providers are in the catalog
✓ emits no note when fallback provider is in models.providers
✓ emits a warning when fallback provider is undefined
✓ reports multiple undefined providers
✓ checks imageModel fallbacks
✓ checks per-agent fallbacks
✓ deduplicates identical fallback refs
✓ recognizes CLI backends as valid providers

Test Files  1 passed (1)
Tests       9 passed (9)
```

Closes #20909

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds validation for fallback model providers in `openclaw doctor scan`. The implementation correctly validates fallback models from multiple config locations and provides actionable error messages when providers are undefined.

**Key changes:**
- New `noteFallbackModelHealth()` function validates fallback providers against known sources (model catalog, explicit config, CLI backends)
- Comprehensive test coverage (9 test cases covering all major scenarios)
- Properly integrated into doctor command flow

**Issue found:**
- Missing validation for per-agent subagent model fallbacks (`agents.list[].subagents.model.fallbacks`). The code validates `agents.defaults.subagents.model.fallbacks` but doesn't check the per-agent override. This is a minor gap since per-agent subagent models are supported and used at runtime (confirmed in `src/agents/model-selection.ts:325`).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor gap in validation coverage
- The implementation is well-structured with strong test coverage and correctly handles the main fallback validation scenarios. However, it's missing validation for per-agent subagent model fallbacks, which reduces the score from 5 to 4. The missing case is an edge scenario that's unlikely to be commonly used, but it should be included for completeness since the config schema supports it and it's used at runtime.
- src/commands/doctor-fallback-models.ts requires a minor addition to validate per-agent subagent model fallbacks

<sub>Last reviewed commit: d543412</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->