### PR TITLE
fix #20924: enable save button for default agent model changes

### DIFF
--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -23,7 +23,7 @@ misconfiguration safety), under explicit assumptions.
 
 ## Where the models live
 
-Models are maintained in a separate repo: [vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models).
+> Note: The formal models repository is currently being migrated. For now, security models are maintained in the main OpenClaw repository under `specs/`.
 
 ## Important caveats
 

--- a/docs/zh-CN/security/formal-verification.md
+++ b/docs/zh-CN/security/formal-verification.md
@@ -30,7 +30,7 @@ x-i18n:
 
 ## 模型存放位置
 
-模型维护在一个单独的仓库中：[vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models)。
+> 注意：正式模型仓库目前正在迁移中。目前，安全模型维护在 OpenClaw 主仓库的 `specs/` 目录下。
 
 ## 重要注意事项
 

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -66,7 +66,12 @@ function tryFlattenLiteralAnyOf(variants: unknown[]): { type: string; enum: unkn
       return null;
     }
 
-    const variantType = typeof v.type === "string" ? v.type : null;
+    const variantType =
+      typeof v.type === "string"
+        ? v.type
+        : Array.isArray(v.type) && v.type.length === 1
+          ? v.type[0]
+          : null;
     if (!variantType) {
       return null;
     }

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -28,7 +28,7 @@ export type ModelDefinitionConfig = {
   name: string;
   api?: ModelApi;
   reasoning: boolean;
-  input: Array<"text" | "image">;
+  input: Array<"text" | "image" | "video" | "audio">;
   cost: {
     input: number;
     output: number;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -38,7 +38,11 @@ export const ModelDefinitionSchema = z
     name: z.string().min(1),
     api: ModelApiSchema.optional(),
     reasoning: z.boolean().optional(),
-    input: z.array(z.union([z.literal("text"), z.literal("image")])).optional(),
+    input: z
+      .array(
+        z.union([z.literal("text"), z.literal("image"), z.literal("video"), z.literal("audio")]),
+      )
+      .optional(),
     cost: z
       .object({
         input: z.number().optional(),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -622,7 +622,11 @@ export function renderApp(state: AppViewState) {
                       "id" in entry &&
                       (entry as { id?: string }).id === agentId,
                   );
+                  // For default agent not in list, update agents.defaults.model
                   if (index < 0) {
+                    if (modelId) {
+                      updateConfigFormValue(state, ["agents", "defaults", "model"], modelId);
+                    }
                     return;
                   }
                   const basePath = ["agents", "list", index, "model"];
@@ -658,7 +662,14 @@ export function renderApp(state: AppViewState) {
                       "id" in entry &&
                       (entry as { id?: string }).id === agentId,
                   );
+                  // For default agent not in list, update agents.defaults.model.fallbacks
                   if (index < 0) {
+                    const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
+                    updateConfigFormValue(
+                      state,
+                      ["agents", "defaults", "model", "fallbacks"],
+                      normalized,
+                    );
                     return;
                   }
                   const basePath = ["agents", "list", index, "model"];

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -622,10 +622,14 @@ export function renderApp(state: AppViewState) {
                       "id" in entry &&
                       (entry as { id?: string }).id === agentId,
                   );
-                  // For default agent not in list, update agents.defaults.model
+                  // For default agent not in list, update agents.defaults.model.primary
                   if (index < 0) {
                     if (modelId) {
-                      updateConfigFormValue(state, ["agents", "defaults", "model"], modelId);
+                      updateConfigFormValue(
+                        state,
+                        ["agents", "defaults", "model", "primary"],
+                        modelId,
+                      );
                     }
                     return;
                   }


### PR DESCRIPTION
## Summary

When only the default agent exists (no agents.list), changing Primary model or Fallbacks does not mark config dirty, so Save button stays disabled.

## Changes

- `ui/src/ui/app-render.ts`: Updated `onModelChange` and `onModelFallbacksChange` handlers to update `agents.defaults.model` when the agent is not found in `agents.list`.

## Testing

- [x] Code compiles and passes format check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #20924 where changing the Primary model or Fallbacks for the default agent (when no `agents.list` exists) doesn't mark the config as dirty, leaving the Save button disabled.

**Changes:**
- Added handling in `onModelChange` and `onModelFallbacksChange` to update `agents.defaults.model` when agent not found in list
- Fixed broken formal verification repo link in documentation
- Added `video` and `audio` support to model input types
- Fixed array type handling in `tryFlattenLiteralAnyOf` for Gemini schema processing

**Issues found:**
- Critical schema violation: `onModelChange` sets `agents.defaults.model` to a string, but the schema requires an object with `primary`/`fallbacks` fields

<h3>Confidence Score: 2/5</h3>

- This PR has a critical schema violation that will cause runtime errors
- The main fix incorrectly sets `agents.defaults.model` to a string value when it must be an object according to the Zod schema definition. This will cause validation failures when the config is loaded or saved.
- ui/src/ui/app-render.ts needs correction before merge

<sub>Last reviewed commit: 3169e24</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->