### PR TITLE
fix: show requestedHost instead of configuredHost in exec host error hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ package-lock.json
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
+openclaw-*.log

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -285,7 +285,7 @@ export function createExecTool(
       if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {
         throw new Error(
           `exec host not allowed (requested ${renderExecHostLabel(requestedHost)}; ` +
-            `configure tools.exec.host=${renderExecHostLabel(configuredHost)} to allow).`,
+            `configure tools.exec.host=${renderExecHostLabel(requestedHost)} to allow).`,
         );
       }
       if (elevatedRequested) {


### PR DESCRIPTION
## Summary

The error message for disallowed exec host showed the already-configured host in the `configure tools.exec.host=X to allow` hint, making the suggestion circular and confusing.

**Before:** `exec host not allowed (requested gateway; configure tools.exec.host=sandbox to allow)`
**After:** `exec host not allowed (requested gateway; configure tools.exec.host=gateway to allow)`

One-line fix: `configuredHost` → `requestedHost` in the error string interpolation.

Fixes #21501

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed error message to show the host the user should configure instead of the already-configured host. When an exec host request is denied, the error previously told users to configure `tools.exec.host` to the value that was already set, creating a confusing circular suggestion. The fix correctly suggests configuring the requested host instead.

- Corrected error hint in `src/agents/bash-tools.exec.ts:288` from `configuredHost` to `requestedHost`
- Added `openclaw-*.log` to `.gitignore` (unrelated cleanup)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line fix that corrects a simple variable reference in an error message. The change is logically correct (verified against test expectations), has no side effects, and improves user experience by providing accurate configuration guidance
- No files require special attention

<sub>Last reviewed commit: f3a586a</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->