### PR TITLE
feat(onboard): add Cencori provider.

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1054,6 +1054,7 @@
                   "providers/openai",
                   "providers/openrouter",
                   "providers/litellm",
+                  "providers/cencori",
                   "providers/bedrock",
                   "providers/vercel-ai-gateway",
                   "providers/moonshot",

--- a/docs/providers/cencori.md
+++ b/docs/providers/cencori.md
@@ -1,0 +1,76 @@
+---
+title: "Cencori"
+summary: "Cencori setup (auth + model selection)"
+read_when:
+  - You want to use Cencori with OpenClaw
+  - You need the API key env var or CLI auth choice
+---
+
+# Cencori
+
+[Cencori](https://cencori.com) is a **Cloud Intelligence Provider (CIP)** — the unified infrastructure layer for the AI-first world.
+
+- Provider: `cencori`
+- Auth: `CENCORI_API_KEY`
+- Base URL: `https://cencori.com/api/v1`
+- API: OpenAI-compatible chat/completions
+- Default model: `cencori/gpt-4o`
+
+## Before you begin
+
+To get the most out of Cencori, we recommend having the following ready:
+
+- A [Cencori account](https://cencori.com/signup) to access your project dashboard.
+- An API key for at least one AI provider (OpenAI, Anthropic, or Google).
+- A basic understanding of [AI Gateway concepts](/docs/ai/gateway).
+
+## Quick start
+
+1. Set the API key (recommended: store it for the Gateway):
+
+```bash
+openclaw onboard --auth-choice cencori-api-key
+```
+
+2. Set a default model:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "cencori/gpt-4o" },
+    },
+  },
+}
+```
+
+## Non-interactive example
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice cencori-api-key \
+  --cencori-api-key "$CENCORI_API_KEY"
+```
+
+## Products
+
+Cencori is built on products that handle the heavy lifting of AI infrastructure:
+
+1. **AI Gateway**: A single, secure endpoint for all your model routing.
+2. **Compute**: Secure, ephemeral execution for AI agents and logic.
+3. **Workflow**: Visual orchestration for multi-step AI pipelines.
+4. **Data Storage**: AI-native storage for context, vector sync, and integrity.
+5. **Integration**: Pre-built connectors to external tools and databases.
+
+## SDKs & Integrations
+
+Cencori is designed to work where your code already lives. We provide three primary integration paths:
+
+- **Official SDKs**: Dedicated, feature-rich libraries for **TypeScript**, **Python**, and **Go**.
+- **Framework Adapters**: Deep integrations for **Vercel AI SDK**, **TanStack AI**, and **LangChain**.
+- **Universal Proxy**: Use your existing OpenAI or Anthropic SDKs by simply changing the `base_url`. We are 100% compatible with the native ecosystem.
+
+## Environment note
+
+If the Gateway runs as a daemon (launchd/systemd), make sure `CENCORI_API_KEY` is available to that process (for example, in `~/.openclaw/.env` or via `env.shellEnv`).

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -40,6 +40,7 @@ See [Venice AI](/providers/venice).
 - [Qwen (OAuth)](/providers/qwen)
 - [OpenRouter](/providers/openrouter)
 - [LiteLLM (unified gateway)](/providers/litellm)
+- [Cencori](/providers/cencori)
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)
 - [Together AI](/providers/together)
 - [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -36,6 +36,7 @@ See [Venice AI](/providers/venice).
 - [OpenAI (API + Codex)](/providers/openai)
 - [Anthropic (API + Claude Code CLI)](/providers/anthropic)
 - [OpenRouter](/providers/openrouter)
+- [Cencori](/providers/cencori)
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)
 - [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
 - [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -40,6 +40,8 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     - **API key**: stores the key for you.
     - **Vercel AI Gateway (multi-model proxy)**: prompts for `AI_GATEWAY_API_KEY`.
     - More detail: [Vercel AI Gateway](/providers/vercel-ai-gateway)
+    - **Cencori (AI Infrastructure)**: prompts for `CENCORI_API_KEY`.
+    - More detail: [Cencori](/providers/cencori)
     - **Cloudflare AI Gateway**: prompts for Account ID, Gateway ID, and `CLOUDFLARE_AI_GATEWAY_API_KEY`.
     - More detail: [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
     - **MiniMax M2.1**: config is auto-written.
@@ -158,6 +160,16 @@ Add `--json` for a machine‑readable summary.
       --mode local \
       --auth-choice ai-gateway-api-key \
       --ai-gateway-api-key "$AI_GATEWAY_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  <Accordion title="Cencori example">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice cencori-api-key \
+      --cencori-api-key "$CENCORI_API_KEY" \
       --gateway-port 18789 \
       --gateway-bind loopback
     ```

--- a/docs/start/wizard-cli-automation.md
+++ b/docs/start/wizard-cli-automation.md
@@ -64,6 +64,16 @@ Add `--json` for a machine-readable summary.
       --gateway-bind loopback
     ```
   </Accordion>
+  <Accordion title="Cencori example">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice cencori-api-key \
+      --cencori-api-key "$CENCORI_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
   <Accordion title="Cloudflare AI Gateway example">
     ```bash
     openclaw onboard --non-interactive \

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -159,6 +159,10 @@ What you set:
     Prompts for `AI_GATEWAY_API_KEY`.
     More detail: [Vercel AI Gateway](/providers/vercel-ai-gateway).
   </Accordion>
+  <Accordion title="Cencori">
+    Prompts for `CENCORI_API_KEY`.
+    More detail: [Cencori](/providers/cencori).
+  </Accordion>
   <Accordion title="Cloudflare AI Gateway">
     Prompts for account ID, gateway ID, and `CLOUDFLARE_AI_GATEWAY_API_KEY`.
     More detail: [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway).

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -301,6 +301,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     xai: "XAI_API_KEY",
     openrouter: "OPENROUTER_API_KEY",
     litellm: "LITELLM_API_KEY",
+    cencori: "CENCORI_API_KEY",
     "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
     "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
     moonshot: "MOONSHOT_API_KEY",

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -132,6 +132,7 @@ export function registerOnboardCommand(program: Command) {
           anthropicApiKey: opts.anthropicApiKey as string | undefined,
           openaiApiKey: opts.openaiApiKey as string | undefined,
           openrouterApiKey: opts.openrouterApiKey as string | undefined,
+          cencoriApiKey: opts.cencoriApiKey as string | undefined,
           aiGatewayApiKey: opts.aiGatewayApiKey as string | undefined,
           cloudflareAiGatewayAccountId: opts.cloudflareAiGatewayAccountId as string | undefined,
           cloudflareAiGatewayGatewayId: opts.cloudflareAiGatewayGatewayId as string | undefined,

--- a/src/commands/auth-choice-options.e2e.test.ts
+++ b/src/commands/auth-choice-options.e2e.test.ts
@@ -37,6 +37,7 @@ describe("buildAuthChoiceOptions", () => {
       ["moonshot-api-key", "moonshot-api-key-cn", "kimi-code-api-key", "together-api-key"],
     ],
     ["Vercel AI Gateway auth choice", ["ai-gateway-api-key"]],
+    ["Cencori auth choice", ["cencori-api-key"]],
     ["Cloudflare AI Gateway auth choice", ["cloudflare-ai-gateway-api-key"]],
     ["Together AI auth choice", ["together-api-key"]],
     ["Synthetic auth choice", ["synthetic-api-key"]],

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -149,6 +149,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     choices: ["litellm-api-key"],
   },
   {
+    value: "cencori",
+    label: "Cencori",
+    hint: "AI Infrastructure",
+    choices: ["cencori-api-key"],
+  },
+  {
     value: "cloudflare-ai-gateway",
     label: "Cloudflare AI Gateway",
     hint: "Account ID + Gateway ID + API key",
@@ -189,6 +195,11 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     value: "litellm-api-key",
     label: "LiteLLM API key",
     hint: "Unified gateway for 100+ LLM providers",
+  },
+  {
+    value: "cencori-api-key",
+    label: "Cencori API key",
+    hint: "OpenAI-compatible AI gateway with built-in security",
   },
   {
     value: "ai-gateway-api-key",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -12,6 +12,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   chutes: "chutes",
   "openai-api-key": "openai",
   "openrouter-api-key": "openrouter",
+  "cencori-api-key": "cencori",
   "ai-gateway-api-key": "vercel-ai-gateway",
   "cloudflare-ai-gateway-api-key": "cloudflare-ai-gateway",
   "moonshot-api-key": "moonshot",

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -37,6 +37,8 @@ import {
   XAI_DEFAULT_MODEL_REF,
 } from "./onboard-auth.credentials.js";
 export {
+  applyCencoriConfig,
+  applyCencoriProviderConfig,
   applyCloudflareAiGatewayConfig,
   applyCloudflareAiGatewayProviderConfig,
   applyVercelAiGatewayConfig,

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -126,6 +126,7 @@ export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
 export const HUGGINGFACE_DEFAULT_MODEL_REF = "huggingface/deepseek-ai/DeepSeek-R1";
 export const TOGETHER_DEFAULT_MODEL_REF = "together/moonshotai/Kimi-K2.5";
 export const LITELLM_DEFAULT_MODEL_REF = "litellm/claude-opus-4-6";
+export const CENCORI_DEFAULT_MODEL_REF = "cencori/gpt-4o";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.6";
 
 export async function setZaiApiKey(key: string, agentDir?: string) {
@@ -197,6 +198,18 @@ export async function setLitellmApiKey(key: string, agentDir?: string) {
     credential: {
       type: "api_key",
       provider: "litellm",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
+export async function setCencoriApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "cencori:default",
+    credential: {
+      type: "api_key",
+      provider: "cencori",
       key,
     },
     agentDir: resolveAuthAgentDir(agentDir),

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -5,6 +5,8 @@ export {
 export { VENICE_DEFAULT_MODEL_ID, VENICE_DEFAULT_MODEL_REF } from "../agents/venice-models.js";
 export {
   applyAuthProfileConfig,
+  applyCencoriConfig,
+  applyCencoriProviderConfig,
   applyCloudflareAiGatewayConfig,
   applyCloudflareAiGatewayProviderConfig,
   applyHuggingfaceConfig,
@@ -52,11 +54,13 @@ export {
   applyOpencodeZenProviderConfig,
 } from "./onboard-auth.config-opencode.js";
 export {
+  CENCORI_DEFAULT_MODEL_REF,
   CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
   LITELLM_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
   setCloudflareAiGatewayConfig,
+  setCencoriApiKey,
   setQianfanApiKey,
   setGeminiApiKey,
   setLitellmApiKey,

--- a/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
@@ -13,6 +13,7 @@ type AuthChoiceFlagOptions = Pick<
   | "geminiApiKey"
   | "openaiApiKey"
   | "openrouterApiKey"
+  | "cencoriApiKey"
   | "aiGatewayApiKey"
   | "cloudflareAiGatewayApiKey"
   | "moonshotApiKey"

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -10,6 +10,7 @@ import { buildTokenProfileId, validateAnthropicSetupToken } from "../../auth-tok
 import { applyGoogleGeminiModelDefault } from "../../google-gemini-model-default.js";
 import {
   applyAuthProfileConfig,
+  applyCencoriConfig,
   applyCloudflareAiGatewayConfig,
   applyQianfanConfig,
   applyKimiCodeConfig,
@@ -31,6 +32,7 @@ import {
   applyZaiConfig,
   setAnthropicApiKey,
   setCloudflareAiGatewayConfig,
+  setCencoriApiKey,
   setQianfanApiKey,
   setGeminiApiKey,
   setKimiCodingApiKey,
@@ -413,6 +415,29 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     return applyVercelAiGatewayConfig(nextConfig);
+  }
+
+  if (authChoice === "cencori-api-key") {
+    const resolved = await resolveNonInteractiveApiKey({
+      provider: "cencori",
+      cfg: baseConfig,
+      flagValue: opts.cencoriApiKey,
+      flagName: "--cencori-api-key",
+      envVar: "CENCORI_API_KEY",
+      runtime,
+    });
+    if (!resolved) {
+      return null;
+    }
+    if (resolved.source !== "profile") {
+      await setCencoriApiKey(resolved.key);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "cencori:default",
+      provider: "cencori",
+      mode: "api_key",
+    });
+    return applyCencoriConfig(nextConfig);
   }
 
   if (authChoice === "cloudflare-ai-gateway-api-key") {

--- a/src/commands/onboard-provider-auth-flags.ts
+++ b/src/commands/onboard-provider-auth-flags.ts
@@ -6,6 +6,7 @@ type OnboardProviderAuthOptionKey = keyof Pick<
   | "openaiApiKey"
   | "openrouterApiKey"
   | "aiGatewayApiKey"
+  | "cencoriApiKey"
   | "cloudflareAiGatewayApiKey"
   | "moonshotApiKey"
   | "kimiCodeApiKey"
@@ -53,6 +54,13 @@ export const ONBOARD_PROVIDER_AUTH_FLAGS: ReadonlyArray<OnboardProviderAuthFlag>
     cliFlag: "--openrouter-api-key",
     cliOption: "--openrouter-api-key <key>",
     description: "OpenRouter API key",
+  },
+  {
+    optionKey: "cencoriApiKey",
+    authChoice: "cencori-api-key",
+    cliFlag: "--cencori-api-key",
+    cliOption: "--cencori-api-key <key>",
+    description: "Cencori API key",
   },
   {
     optionKey: "aiGatewayApiKey",

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -14,6 +14,7 @@ export type AuthChoice =
   | "openai-api-key"
   | "openrouter-api-key"
   | "litellm-api-key"
+  | "cencori-api-key"
   | "ai-gateway-api-key"
   | "cloudflare-ai-gateway-api-key"
   | "moonshot-api-key"
@@ -57,6 +58,7 @@ export type AuthChoiceGroupId =
   | "copilot"
   | "openrouter"
   | "litellm"
+  | "cencori"
   | "ai-gateway"
   | "cloudflare-ai-gateway"
   | "moonshot"
@@ -103,6 +105,7 @@ export type OnboardOptions = {
   openaiApiKey?: string;
   openrouterApiKey?: string;
   litellmApiKey?: string;
+  cencoriApiKey?: string;
   aiGatewayApiKey?: string;
   cloudflareAiGatewayAccountId?: string;
   cloudflareAiGatewayGatewayId?: string;


### PR DESCRIPTION
## Summary

- Problem: OpenClaw onboarding does not currently support Cencori as a first-class provider/auth option.
- Why it matters: Users can route through Cencori manually, but setup is inconsistent vs other providers and harder to automate.
- What changed: Added `cencori-api-key` across interactive and non-interactive onboarding, wired `CENCORI_API_KEY` + `--cencori-api-key`, applied default provider/model config (`cencori/gpt-4o`), and added docs + e2e coverage.
- What did NOT change (scope boundary): No changes to runtime inference logic for other providers, no UI redesign, no unrelated auth flow refactors.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none)
- Related # (none)

## User-visible / Behavior Changes

- `openclaw onboard` now includes Cencori (`cencori-api-key`) in model/auth selection.
- Non-interactive onboarding now supports Cencori via `--auth-choice cencori-api-key` + `--cencori-api-key` or `CENCORI_API_KEY`.
- Cencori provider docs are now available and linked in provider/wizard docs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: New token path (`CENCORI_API_KEY`) could be mishandled if not normalized/validated.
  - Mitigation: Reused existing key validation/normalization patterns and existing auth profile persistence flow.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node
- Model/provider: Cencori onboarding path
- Integration/channel (if any): N/A
- Relevant config (redacted): `CENCORI_API_KEY=***`

### Steps

1. Run `openclaw onboard` and select `cencori-api-key`.
2. Confirm existing `CENCORI_API_KEY` or enter key when prompted.
3. Run non-interactive path with `--auth-choice cencori-api-key` and key/env.

### Expected

- Cencori credentials are stored via auth profile.
- Default/provider model config is applied correctly.
- Docs point to Cencori provider setup.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Notes: targeted e2e tests passed after fix:
- `src/commands/auth-choice-options.e2e.test.ts`
- `src/commands/auth-choice.e2e.test.ts`

## Human Verification (required)

- Verified scenarios:
  - Interactive Cencori auth choice path
  - Existing `CENCORI_API_KEY` reuse path
  - Non-interactive option inference/flag wiring
  - Docs navigation entries
- Edge cases checked:
  - Env-key path without manual prompt entry
  - `setDefaultModel` behavior via shared default-model helper
- What you did **not** verify:
  - Full end-to-end live request execution against Cencori API endpoint

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Avoid selecting `cencori-api-key`, or revert this PR commit.
- Files/config to restore:
  - Revert onboarding/auth files and docs touched by this PR.
- Known bad symptoms reviewers should watch for:
  - `cencori-api-key` selection errors in onboarding
  - Missing default model/provider mapping for Cencori

## Risks and Mitigations

- Risk: Provider config drift (base URL/model ref mismatch).
  - Mitigation: Single-source constants + e2e coverage + docs alignment.
- Risk: Auth-choice mapping regressions with legacy `apiKey` + `tokenProvider`.
  - Mitigation: Added explicit mapping and test coverage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Cencori as a first-class provider to OpenClaw's onboarding flow. The implementation follows established patterns for API key-based providers (similar to LiteLLM, Vercel AI Gateway, etc.) and includes comprehensive coverage across interactive/non-interactive flows, tests, and documentation.

**Key changes:**
- Added `cencori-api-key` auth choice with `CENCORI_API_KEY` environment variable support
- Wired Cencori through all onboarding paths (interactive prompts, CLI flags, env detection)
- Applied default provider config (`cencori/gpt-4o` via OpenAI-compatible API at `https://cencori.com/api/v1`)
- Added comprehensive e2e test coverage matching existing provider test patterns
- Created provider documentation and updated all relevant docs navigation

**Code quality:**
- Consistently reuses existing auth/validation patterns (`normalizeApiKeyInput`, `validateApiKeyInput`, `resolveEnvApiKey`)
- Follows the same structure as other API key providers (LiteLLM, Vercel AI Gateway)
- Type definitions are properly extended across all relevant files
- Test coverage includes both environment key detection and manual entry paths

**Minor issue:**
- One broken documentation link in `cencori.md` (line 25) - references non-existent `/docs/ai/gateway` path

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with only one minor documentation fix needed
- The implementation follows well-established patterns throughout the codebase, reuses existing validation/security helpers, includes comprehensive test coverage, and makes no changes to runtime inference logic. The only issue is a broken documentation link that should be fixed before merge. Score is 4 (not 5) due to the doc link issue.
- Only `docs/providers/cencori.md` needs attention - fix the broken `/docs/ai/gateway` link on line 25

<sub>Last reviewed commit: f128f3b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->