### PR TITLE
fix: re-resolve skill paths at runtime for cross-machine portability

### DIFF
--- a/src/agents/skills.resolveskillspromptforrun.e2e.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.e2e.test.ts
@@ -1,15 +1,48 @@
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { SkillEntry, SkillSnapshot } from "./skills/types.js";
 import { resolveSkillsPromptForRun } from "./skills.js";
-import type { SkillEntry } from "./skills/types.js";
 
 describe("resolveSkillsPromptForRun", () => {
-  it("prefers snapshot prompt when available", () => {
+  it("re-generates prompt from resolvedSkills when available (portability fix)", () => {
+    const home = os.homedir();
+    // Simulate a snapshot created on a *different* machine with a foreign home dir baked in.
+    const foreignHome = "/Users/alice";
+    const foreignPath = `${foreignHome}/.openclaw/skills/demo-skill/SKILL.md`;
+    const snapshot: SkillSnapshot = {
+      // The cached prompt contains the foreign machine's absolute path.
+      prompt: `<available_skills>\n<skill name="demo-skill" file_path="${foreignPath}">\nDemo\n</skill>\n</available_skills>`,
+      skills: [{ name: "demo-skill" }],
+      resolvedSkills: [
+        {
+          name: "demo-skill",
+          description: "Demo",
+          // The resolvedSkills store the *actual* absolute path on the current machine.
+          filePath: path.join(home, ".openclaw/skills/demo-skill/SKILL.md"),
+          baseDir: path.join(home, ".openclaw/skills/demo-skill"),
+          source: "openclaw-managed",
+          disableModelInvocation: false,
+        },
+      ],
+    };
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: snapshot,
+      workspaceDir: "/tmp/openclaw",
+    });
+    // The prompt should use `~/` (compacted from current home), NOT the foreign path.
+    expect(prompt).toContain("~/.openclaw/skills/demo-skill/SKILL.md");
+    expect(prompt).not.toContain(foreignHome);
+  });
+
+  it("falls back to cached prompt for legacy snapshots without resolvedSkills", () => {
     const prompt = resolveSkillsPromptForRun({
       skillsSnapshot: { prompt: "SNAPSHOT", skills: [] },
       workspaceDir: "/tmp/openclaw",
     });
     expect(prompt).toBe("SNAPSHOT");
   });
+
   it("builds prompt from entries when snapshot is missing", () => {
     const entry: SkillEntry = {
       skill: {


### PR DESCRIPTION
## Summary

- When a session is created on machine A and later loaded on machine B, the cached `skillsSnapshot.prompt` contains absolute paths from machine A (e.g. `/Users/alice/...`) that are meaningless on machine B
- Modified `resolveSkillsPromptForRun()` to re-generate the prompt from `resolvedSkills` at runtime using `compactSkillPaths()` against the current machine's home directory, instead of blindly returning the cached prompt
- Legacy snapshots without `resolvedSkills` still fall back to the cached prompt for backward compatibility

Fixes #21508

## Test plan

- [x] Existing e2e tests updated and passing (3 tests)
- [x] New test verifies that a snapshot with a foreign home path produces correct `~/` paths on the current machine
- [x] All `src/agents/skills/` unit tests passing (7 tests)
- [ ] Manual: create a session on machine A, move state to machine B, verify skill paths resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cross-machine portability issue where skill paths cached in session snapshots from one machine (e.g., `/Users/alice/...`) were not updated when the session was loaded on a different machine (e.g., `/home/node/...`). The fix modifies `resolveSkillsPromptForRun()` to re-generate the prompt at runtime using `compactSkillPaths()` against the current machine's home directory when `resolvedSkills` is available, while maintaining backward compatibility by falling back to the cached prompt for legacy snapshots.

Key changes:
- Re-generates skill prompts at runtime from `resolvedSkills` instead of blindly returning cached prompt
- Uses `compactSkillPaths()` to convert absolute paths to `~/` relative paths based on current machine's home directory
- Preserves backward compatibility for legacy snapshots without `resolvedSkills`
- Adds comprehensive test coverage for the portability fix

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The implementation is clean, well-tested, and maintains backward compatibility. The logic correctly re-generates prompts at runtime using the existing `compactSkillPaths()` helper, which has its own test coverage. The new test validates the portability fix scenario. The change is narrowly scoped to fix a specific portability issue without affecting other functionality. One point deducted only because tests couldn't be executed in this environment to verify they pass.
- No files require special attention

<sub>Last reviewed commit: e6126c7</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->