### PR TITLE
Gateway: allow node health and throttle repeated unauthorized role retries

### DIFF
--- a/src/gateway/server-methods.control-plane-rate-limit.test.ts
+++ b/src/gateway/server-methods.control-plane-rate-limit.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __testing as controlPlaneRateLimitTesting } from "./control-plane-rate-limit.js";
-import { handleGatewayRequest } from "./server-methods.js";
+import { __testing as serverMethodsTesting, handleGatewayRequest } from "./server-methods.js";
 import type { GatewayRequestHandler } from "./server-methods/types.js";
 
 const noWebchat = () => false;
@@ -8,6 +8,7 @@ const noWebchat = () => false;
 describe("gateway control-plane write rate limit", () => {
   beforeEach(() => {
     controlPlaneRateLimitTesting.resetControlPlaneRateLimitState();
+    serverMethodsTesting.resetUnauthorizedRoleRateLimitState();
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-19T00:00:00.000Z"));
   });
@@ -15,6 +16,7 @@ describe("gateway control-plane write rate limit", () => {
   afterEach(() => {
     vi.useRealTimers();
     controlPlaneRateLimitTesting.resetControlPlaneRateLimitState();
+    serverMethodsTesting.resetUnauthorizedRoleRateLimitState();
   });
 
   function buildContext(logWarn = vi.fn()) {
@@ -41,6 +43,25 @@ describe("gateway control-plane write rate limit", () => {
       },
       connId: "conn-1",
       clientIp: "10.0.0.5",
+    } as Parameters<typeof handleGatewayRequest>[0]["client"];
+  }
+
+  function buildNodeClient() {
+    return {
+      connect: {
+        role: "node",
+        scopes: [],
+        client: {
+          id: "openclaw-node",
+          version: "1.0.0",
+          platform: "darwin",
+          mode: "node",
+        },
+        minProtocol: 1,
+        maxProtocol: 1,
+      },
+      connId: "node-conn-1",
+      clientIp: "127.0.0.1",
     } as Parameters<typeof handleGatewayRequest>[0]["client"];
   }
 
@@ -120,5 +141,49 @@ describe("gateway control-plane write rate limit", () => {
     const allowed = await runRequest({ method: "update.run", context, client, handler });
     expect(allowed).toHaveBeenCalledWith(true, undefined, undefined);
     expect(handlerCalls).toHaveBeenCalledTimes(4);
+  });
+
+  it("allows node clients to call health", async () => {
+    const handlerCalls = vi.fn();
+    const handler: GatewayRequestHandler = (opts) => {
+      handlerCalls(opts);
+      opts.respond(true, { ok: true }, undefined);
+    };
+    const context = buildContext();
+    const client = buildNodeClient();
+
+    const respond = await runRequest({ method: "health", context, client, handler });
+    expect(handlerCalls).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("rate-limits repeated unauthorized role errors for node clients", async () => {
+    const handler: GatewayRequestHandler = (opts) => {
+      opts.respond(true, { ok: true }, undefined);
+    };
+    const logWarn = vi.fn();
+    const context = buildContext(logWarn);
+    const client = buildNodeClient();
+
+    const first = await runRequest({ method: "status", context, client, handler });
+    const second = await runRequest({ method: "status", context, client, handler });
+    const third = await runRequest({ method: "status", context, client, handler });
+
+    expect(first).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST", message: "unauthorized role: node" }),
+    );
+    expect(second).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST", message: "unauthorized role: node" }),
+    );
+    expect(third).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "UNAVAILABLE", retryable: true }),
+    );
+    expect(logWarn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-methods.control-plane-rate-limit.test.ts
+++ b/src/gateway/server-methods.control-plane-rate-limit.test.ts
@@ -52,7 +52,7 @@ describe("gateway control-plane write rate limit", () => {
         role: "node",
         scopes: [],
         client: {
-          id: "openclaw-node",
+          id: "node-host",
           version: "1.0.0",
           platform: "darwin",
           mode: "node",


### PR DESCRIPTION
## Summary
- I tracked the auth loop down to post-connect method authorization: node clients were connecting successfully, then getting `unauthorized role: node` for `health` and retrying forever.
- This change allows node role clients to call `health`, which removes the main failure path behind the retry storm.
- I also added a connection-scoped guardrail: repeated unauthorized-role errors from node clients are rate-limited and return a retryable `UNAVAILABLE` with `retryAfterMs`.

## Why this matters
- The macOS app can end up in a fixed-interval retry loop that drives gateway/app CPU very high.
- Even if clients misbehave, gateway should degrade safely instead of processing endless unauthorized requests.

## What changed
- `src/gateway/server-methods.ts`
  - Added `NODE_ROLE_ALLOWED_METHODS` and included `health`.
  - Added per-connection unauthorized-role budget (`3` failures in `30s`, `30s` lockout).
  - Added test-only reset hook for rate-limit state.
- `src/gateway/server-methods.control-plane-rate-limit.test.ts`
  - Added tests for node `health` allow behavior.
  - Added tests for unauthorized-role throttling behavior.

## Verification
- `npm exec --yes pnpm -- vitest run src/gateway/server-methods.control-plane-rate-limit.test.ts`
- `npm exec --yes pnpm -- vitest run src/gateway/method-scopes.test.ts`

Fixes #21137
Related #21009

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a retry storm issue where node clients repeatedly failed authorization when calling `health`, causing high CPU usage. The solution adds `health` to the allowlist for node role clients and implements connection-scoped rate limiting for repeated unauthorized role errors (3 failures in 30s triggers a 30s lockout with `UNAVAILABLE` + `retryAfterMs`).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations around rate limit tuning
- Well-tested implementation with comprehensive test coverage. The authorization logic is sound and the rate limiting correctly prevents retry storms. The 3-failure threshold may trigger quickly but includes proper retry signaling. Only minor concern is lack of metrics/observability for monitoring rate limit hits in production.
- No files require special attention

<sub>Last reviewed commit: e905410</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->