### PR TITLE
Security/Webhooks: block signed replay for Nextcloud, Google Chat, and LINE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ Docs: https://docs.openclaw.ai
 
 - Security/Gateway Control UI: block absolute-path escape requests under `gateway.controlUi.basePath` and enforce robust root containment checks when serving static Control UI assets.
 - Security/Nextcloud Talk: block signed webhook replay by deduplicating recent `x-nextcloud-talk-random` + signature pairs before inbound processing.
+- Security/Google Chat: block replayed webhook events by deduplicating recent per-account event keys before inbound processing.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Gateway Control UI: block absolute-path escape requests under `gateway.controlUi.basePath` and enforce robust root containment checks when serving static Control UI assets.
+- Security/Nextcloud Talk: block signed webhook replay by deduplicating recent `x-nextcloud-talk-random` + signature pairs before inbound processing.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@ Docs: https://docs.openclaw.ai
 - Security/Gateway Control UI: block absolute-path escape requests under `gateway.controlUi.basePath` and enforce robust root containment checks when serving static Control UI assets.
 - Security/Nextcloud Talk: block signed webhook replay by deduplicating recent `x-nextcloud-talk-random` + signature pairs before inbound processing.
 - Security/Google Chat: block replayed webhook events by deduplicating recent per-account event keys before inbound processing.
+- Security/LINE: block replayed signed webhook payloads by deduplicating recent webhook event IDs (fallback to signature+body hash) before event dispatch to prevent duplicate inbound command/message execution.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,10 +189,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/Gateway Control UI: block absolute-path escape requests under `gateway.controlUi.basePath` and enforce robust root containment checks when serving static Control UI assets.
-- Security/Nextcloud Talk: block signed webhook replay by deduplicating recent `x-nextcloud-talk-random` + signature pairs before inbound processing.
-- Security/Google Chat: block replayed webhook events by deduplicating recent per-account event keys before inbound processing.
-- Security/LINE: block replayed signed webhook payloads by deduplicating recent webhook event IDs (fallback to signature+body hash) before event dispatch to prevent duplicate inbound command/message execution.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/extensions/nextcloud-talk/src/monitor.webhook-security.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.webhook-security.test.ts
@@ -1,0 +1,59 @@
+import type { AddressInfo } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import { createNextcloudTalkWebhookServer } from "./monitor.js";
+import { generateNextcloudTalkSignature } from "./signature.js";
+
+const SECRET = "test-secret";
+const WEBHOOK_PATH = "/nextcloud-talk-webhook";
+
+const VALID_PAYLOAD = {
+  type: "Create",
+  actor: { type: "Person", id: "user-1", name: "Alice" },
+  object: { type: "Note", id: "message-1", content: "hello" },
+  target: { type: "Room", id: "room-1", name: "General" },
+};
+
+describe("createNextcloudTalkWebhookServer replay protection", () => {
+  it("processes a valid signed payload only once when replayed", async () => {
+    const body = JSON.stringify(VALID_PAYLOAD);
+    const { random, signature } = generateNextcloudTalkSignature({
+      body,
+      secret: SECRET,
+    });
+
+    const onMessage = vi.fn(async () => {});
+    const serverState = createNextcloudTalkWebhookServer({
+      port: 0,
+      host: "127.0.0.1",
+      path: WEBHOOK_PATH,
+      secret: SECRET,
+      onMessage,
+    });
+
+    await serverState.start();
+    const address = serverState.server.address() as AddressInfo | null;
+    if (!address) {
+      serverState.stop();
+      throw new Error("missing server address");
+    }
+
+    try {
+      const url = `http://127.0.0.1:${address.port}${WEBHOOK_PATH}`;
+      const headers = {
+        "content-type": "application/json",
+        "x-nextcloud-talk-random": random,
+        "x-nextcloud-talk-signature": signature,
+        "x-nextcloud-talk-backend": "https://nextcloud.example",
+      };
+
+      const first = await fetch(url, { method: "POST", headers, body });
+      const second = await fetch(url, { method: "POST", headers, body });
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(onMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      serverState.stop();
+    }
+  });
+});

--- a/src/line/webhook-utils.ts
+++ b/src/line/webhook-utils.ts
@@ -1,4 +1,8 @@
+import crypto from "node:crypto";
 import type { WebhookRequestBody } from "@line/bot-sdk";
+
+const LINE_WEBHOOK_REPLAY_WINDOW_MS = 5 * 60_000;
+const LINE_WEBHOOK_REPLAY_MAX_KEYS = 5_000;
 
 export function parseLineWebhookBody(rawBody: string): WebhookRequestBody | null {
   try {
@@ -12,4 +16,54 @@ export function isLineWebhookVerificationRequest(
   body: WebhookRequestBody | null | undefined,
 ): boolean {
   return !!body && Array.isArray(body.events) && body.events.length === 0;
+}
+
+function stableLineEventIds(body: WebhookRequestBody): string[] {
+  const ids = new Set<string>();
+  for (const evt of body.events ?? []) {
+    const candidate =
+      evt && typeof evt === "object" && "webhookEventId" in evt
+        ? (evt as { webhookEventId?: unknown }).webhookEventId
+        : undefined;
+    if (typeof candidate === "string" && candidate.trim()) {
+      ids.add(candidate.trim());
+    }
+  }
+  return [...ids].toSorted();
+}
+
+export function buildLineWebhookReplayKey(params: {
+  signature: string;
+  rawBody: string;
+  body: WebhookRequestBody;
+}): string {
+  const eventIds = stableLineEventIds(params.body);
+  if (eventIds.length > 0) {
+    return `line:event:${eventIds.join(",")}`;
+  }
+  const bodyHash = crypto.createHash("sha256").update(params.rawBody).digest("hex");
+  return `line:sig:${params.signature}:body:${bodyHash}`;
+}
+
+export function shouldDropReplayLineWebhookEvent(
+  recentReplayKeys: Map<string, number>,
+  replayKey: string,
+  nowMs: number,
+): boolean {
+  const seenAt = recentReplayKeys.get(replayKey);
+  recentReplayKeys.set(replayKey, nowMs);
+
+  if (typeof seenAt === "number" && nowMs - seenAt < LINE_WEBHOOK_REPLAY_WINDOW_MS) {
+    return true;
+  }
+
+  if (recentReplayKeys.size > LINE_WEBHOOK_REPLAY_MAX_KEYS) {
+    for (const [key, timestamp] of recentReplayKeys) {
+      if (nowMs - timestamp >= LINE_WEBHOOK_REPLAY_WINDOW_MS) {
+        recentReplayKeys.delete(key);
+      }
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Summary
- split replay-deduping work out of #21203 into a focused webhook replay PR
- block signed webhook replay for Nextcloud Talk
- dedupe replayed webhook events for Google Chat
- block replayed signed payloads for LINE webhook handlers

## Scope boundaries
- intentionally excludes voice-call webhook changes
- intentionally excludes Control UI containment changes
- intentionally excludes test-runner CI harness changes

## Validation
- pnpm test -- extensions/nextcloud-talk/src/monitor.webhook-security.test.ts extensions/googlechat/src/monitor.webhook-routing.test.ts src/line/webhook-node.test.ts src/line/webhook.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds replay protection to webhook handlers for Nextcloud Talk, Google Chat, and LINE by deduplicating webhook events within a 5-minute window. Each implementation uses an in-memory cache with cleanup logic to prevent unbounded memory growth (max 5,000 keys). Nextcloud Talk uses `random:signature` pairs, Google Chat uses account-scoped event keys built from message/space metadata, and LINE uses webhook event IDs (falling back to `signature:bodyhash` when IDs are unavailable).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Focused security improvement with solid test coverage. The replay protection implementations follow consistent patterns across all three integrations, use proper constant-time signature validation, include appropriate bounds checks for memory management, and are thoroughly tested. The changes are additive (no breaking modifications to existing behavior) and all validation/rejection occurs before event processing.
- No files require special attention

<sub>Last reviewed commit: 04ad8fc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->