### PR TITLE
Security/Voice Call: block signed webhook replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Voice Call: block replayed signed webhook requests (Telnyx/Plivo signatures and Twilio idempotency token + signature) before event processing to prevent duplicate inbound event execution from captured/retried payloads.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/Voice Call: block replayed signed webhook requests (Telnyx/Plivo signatures and Twilio idempotency token + signature) before event processing to prevent duplicate inbound event execution from captured/retried payloads.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -1,3 +1,5 @@
+import crypto from "node:crypto";
+import type { AddressInfo, Server } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceCallConfigSchema, type VoiceCallConfig } from "./config.js";
 import type { CallManager } from "./manager.js";
@@ -52,6 +54,27 @@ const createManager = (calls: CallRecord[]) => {
 
   return { manager, endCall };
 };
+
+function resolveListeningPort(server: VoiceCallWebhookServer): number {
+  const internalServer = (server as unknown as { server: Server | null }).server;
+  const address = internalServer?.address();
+  if (!address || typeof address === "string") {
+    throw new Error("voice-call webhook server did not expose a TCP listening address");
+  }
+  return (address as AddressInfo).port;
+}
+
+function createWebhookRequestManager() {
+  const processEvent = vi.fn();
+  return {
+    manager: {
+      getActiveCalls: () => [],
+      processEvent,
+      getCallByProviderCallId: () => undefined,
+    } as unknown as CallManager,
+    processEvent,
+  };
+}
 
 describe("VoiceCallWebhookServer stale call reaper", () => {
   beforeEach(() => {
@@ -111,6 +134,65 @@ describe("VoiceCallWebhookServer stale call reaper", () => {
       await server.start();
       await vi.advanceTimersByTimeAsync(60_000);
       expect(endCall).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe("VoiceCallWebhookServer replay protection", () => {
+  it("drops replayed signed webhook requests before event processing", async () => {
+    const { manager, processEvent } = createWebhookRequestManager();
+    const replaySensitiveProvider: VoiceCallProvider = {
+      name: "telnyx",
+      verifyWebhook: () => ({ ok: true }),
+      parseWebhookEvent: () => ({
+        events: [
+          {
+            id: crypto.randomUUID(),
+            type: "call.ringing",
+            callId: "call-1",
+            providerCallId: "provider-call-1",
+            timestamp: Date.now(),
+          },
+        ],
+      }),
+      initiateCall: async () => ({ providerCallId: "provider-call", status: "initiated" }),
+      hangupCall: async () => {},
+      playTts: async () => {},
+      startListening: async () => {},
+      stopListening: async () => {},
+    };
+
+    const config = createConfig({
+      serve: {
+        port: 0,
+        bind: "127.0.0.1",
+        path: "/voice/webhook",
+      },
+      staleCallReaperSeconds: 0,
+    });
+
+    const server = new VoiceCallWebhookServer(config, manager, replaySensitiveProvider);
+
+    try {
+      await server.start();
+      const port = resolveListeningPort(server);
+      const url = `http://127.0.0.1:${port}/voice/webhook`;
+      const headers = {
+        "content-type": "application/json",
+        "telnyx-signature-ed25519": "signature-replay-test",
+        "telnyx-timestamp": "1708041600",
+      };
+      const body = JSON.stringify({ data: { event_type: "call.ringing" } });
+
+      const first = await fetch(url, { method: "POST", headers, body });
+      expect(first.status).toBe(200);
+
+      const second = await fetch(url, { method: "POST", headers, body });
+      expect(second.status).toBe(200);
+
+      expect(processEvent).toHaveBeenCalledTimes(1);
     } finally {
       await server.stop();
     }


### PR DESCRIPTION
## Summary
- split signed-webhook replay protection out of #21203 into a dedicated voice-call security PR
- dedupe replayed signed webhook requests before event processing for Telnyx/Plivo/Twilio signature flows
- add focused replay-protection tests in `extensions/voice-call/src/webhook.test.ts`

## Scope boundaries
- intentionally excludes exact-path matching changes (tracked separately)
- intentionally excludes host-header hardening changes (tracked separately)
- intentionally excludes Control UI and non-voice webhook replay work

## Validation
- pnpm test -- extensions/voice-call/src/webhook.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds webhook replay protection for voice call webhooks from Telnyx, Plivo, and Twilio providers. The implementation creates a fingerprint from provider-specific signature headers and idempotency tokens, then tracks seen requests in a 5-minute sliding window using an in-memory Map. Replayed webhooks are dropped after signature verification but before event processing.

Key changes:
- Adds `buildReplayKey()` to construct provider-specific replay keys from signature headers and nonces/timestamps
- Implements `shouldDropReplayWebhook()` with SHA-256 fingerprinting and 5-minute window deduplication
- Maintains `recentReplayKeys` map with automatic cleanup when exceeding 5000 entries
- Test coverage for replay protection with identical Telnyx webhook requests

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper separation of concerns, comprehensive test coverage, and correct replay detection logic. The code follows the repository's patterns, includes appropriate memory management (map cleanup), and maintains security by performing replay checks after signature verification. The 5-minute window and 5000-key limit provide reasonable protection without excessive memory usage.
- No files require special attention

<sub>Last reviewed commit: e15d73d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->