### PR TITLE
fix(cron/whatsapp): route implicit delivery to allowlisted recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Heartbeat/Cron: restore interval heartbeat behavior so missing `HEARTBEAT.md` no longer suppresses runs (only effectively empty files skip), preserving prompt-driven and tagged-cron execution paths.
+- WhatsApp/Cron/Heartbeat: enforce allowlisted routing for implicit scheduled/system delivery by merging pairing-store + configured `allowFrom` recipients, selecting authorized recipients when last-route context points to a non-allowlisted chat, and preventing heartbeat fan-out to recent unauthorized chats.
 - Heartbeat/Active hours: constrain active-hours `24` sentinel parsing to `24:00` in time validation so invalid values like `24:30` are rejected early. (#21410) thanks @adhitShet.
 - Heartbeat: treat `activeHours` windows with identical `start`/`end` times as zero-width (always outside the window) instead of always-active. (#21408) thanks @adhitShet.
 - Gateway/Pairing: tolerate legacy paired devices missing `roles`/`scopes` metadata in websocket upgrade checks and backfill metadata on reconnect. (#21447, fixes #21236) Thanks @joshavant.

--- a/src/channels/plugins/whatsapp-heartbeat.test.ts
+++ b/src/channels/plugins/whatsapp-heartbeat.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(),
+  resolveStorePath: vi.fn(() => "/tmp/test-sessions.json"),
+}));
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStoreSync: vi.fn(() => []),
+}));
+
+import type { OpenClawConfig } from "../../config/config.js";
+import { loadSessionStore } from "../../config/sessions.js";
+import { readChannelAllowFromStoreSync } from "../../pairing/pairing-store.js";
+import { resolveWhatsAppHeartbeatRecipients } from "./whatsapp-heartbeat.js";
+
+function makeCfg(overrides?: Partial<OpenClawConfig>): OpenClawConfig {
+  return {
+    bindings: [],
+    channels: {},
+    ...overrides,
+  } as OpenClawConfig;
+}
+
+describe("resolveWhatsAppHeartbeatRecipients", () => {
+  beforeEach(() => {
+    vi.mocked(loadSessionStore).mockReset();
+    vi.mocked(readChannelAllowFromStoreSync).mockReset();
+    vi.mocked(readChannelAllowFromStoreSync).mockReturnValue([]);
+  });
+
+  it("uses allowFrom store recipients when session recipients are ambiguous", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      a: { lastChannel: "whatsapp", lastTo: "+15550000001", updatedAt: 2, sessionId: "a" },
+      b: { lastChannel: "whatsapp", lastTo: "+15550000002", updatedAt: 1, sessionId: "b" },
+    });
+    vi.mocked(readChannelAllowFromStoreSync).mockReturnValue(["+15550000001"]);
+
+    const cfg = makeCfg();
+    const result = resolveWhatsAppHeartbeatRecipients(cfg);
+
+    expect(result).toEqual({ recipients: ["+15550000001"], source: "session-single" });
+  });
+
+  it("falls back to allowFrom when no session recipient is authorized", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      a: { lastChannel: "whatsapp", lastTo: "+15550000099", updatedAt: 2, sessionId: "a" },
+    });
+    vi.mocked(readChannelAllowFromStoreSync).mockReturnValue(["+15550000001"]);
+
+    const cfg = makeCfg();
+    const result = resolveWhatsAppHeartbeatRecipients(cfg);
+
+    expect(result).toEqual({ recipients: ["+15550000001"], source: "allowFrom" });
+  });
+
+  it("includes both session and allowFrom recipients when --all is set", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      a: { lastChannel: "whatsapp", lastTo: "+15550000099", updatedAt: 2, sessionId: "a" },
+    });
+    vi.mocked(readChannelAllowFromStoreSync).mockReturnValue(["+15550000001"]);
+
+    const cfg = makeCfg();
+    const result = resolveWhatsAppHeartbeatRecipients(cfg, { all: true });
+
+    expect(result).toEqual({
+      recipients: ["+15550000099", "+15550000001"],
+      source: "all",
+    });
+  });
+});

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -12,8 +12,11 @@ import {
   resolveOutboundTarget,
   resolveSessionDeliveryTarget,
 } from "../../infra/outbound/targets.js";
+import { readChannelAllowFromStoreSync } from "../../pairing/pairing-store.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { resolveWhatsAppAccount } from "../../web/accounts.js";
+import { normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
@@ -76,7 +79,7 @@ export async function resolveDeliveryTarget(
 
   const channel = resolved.channel ?? fallbackChannel ?? DEFAULT_CHAT_CHANNEL;
   const mode = resolved.mode as "explicit" | "implicit";
-  const toCandidate = resolved.to;
+  let toCandidate = resolved.to;
 
   // When the session has no lastAccountId (e.g. first-run isolated cron
   // session), fall back to the agent's bound account from bindings config.
@@ -112,12 +115,34 @@ export async function resolveDeliveryTarget(
     };
   }
 
+  let allowFromOverride: string[] | undefined;
+  if (channel === "whatsapp") {
+    const configuredAllowFromRaw = resolveWhatsAppAccount({ cfg, accountId }).allowFrom ?? [];
+    const configuredAllowFrom = configuredAllowFromRaw
+      .map((entry) => String(entry).trim())
+      .filter((entry) => entry && entry !== "*")
+      .map((entry) => normalizeWhatsAppTarget(entry))
+      .filter((entry): entry is string => Boolean(entry));
+    const storeAllowFrom = readChannelAllowFromStoreSync("whatsapp", process.env, accountId)
+      .map((entry) => normalizeWhatsAppTarget(entry))
+      .filter((entry): entry is string => Boolean(entry));
+    allowFromOverride = [...new Set([...configuredAllowFrom, ...storeAllowFrom])];
+
+    if (mode === "implicit" && allowFromOverride.length > 0) {
+      const normalizedCurrentTarget = normalizeWhatsAppTarget(toCandidate);
+      if (!normalizedCurrentTarget || !allowFromOverride.includes(normalizedCurrentTarget)) {
+        toCandidate = allowFromOverride[0];
+      }
+    }
+  }
+
   const docked = resolveOutboundTarget({
     channel,
     to: toCandidate,
     cfg,
     accountId,
     mode,
+    allowFrom: allowFromOverride,
   });
   return {
     channel,


### PR DESCRIPTION
Fixes #19701

## Summary
- add synchronous pairing-store allowFrom reader for runtime target resolution paths
- enforce allowlisted recipient selection for implicit WhatsApp cron delivery when last-route points to a non-allowlisted chat
- constrain WhatsApp heartbeat recipient resolution to allowlisted recipients when allowFrom exists (configured + pairing-store)
- add focused regression tests for heartbeat recipient filtering and implicit cron reroute behavior

## Validation
- pnpm install --frozen-lockfile
- pnpm build
- pnpm check
- pnpm test:macmini

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces allowlisted recipient routing for implicit WhatsApp delivery in cron jobs and heartbeats by merging configured and pairing-store `allowFrom` entries, preventing scheduled messages from being sent to unauthorized recipients when session history points to non-allowlisted chats.

**Key changes:**
- Added `readChannelAllowFromStoreSync` function in `pairing-store.ts:354-370` to synchronously read allowFrom entries from both scoped and legacy storage paths
- Modified `resolveWhatsAppHeartbeatRecipients` in `whatsapp-heartbeat.ts:46-94` to merge configured and pairing-store allowFrom lists, then filter session recipients against this merged allowlist before selecting a target
- Updated `resolveDeliveryTarget` in `delivery-target.ts:118-137` to reroute implicit WhatsApp deliveries to the first allowlisted recipient when the session's last target is not in the merged allowFrom list
- Added comprehensive test coverage for both heartbeat recipient filtering and cron delivery rerouting scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-tested with focused regression tests covering both heartbeat and cron delivery scenarios, follows existing patterns for allowFrom handling, properly handles edge cases (no allowFrom, empty lists, unauthorized recipients), and the synchronous file reading approach is appropriate for the runtime context where these functions are called
- No files require special attention

<sub>Last reviewed commit: c0ddbab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->