### PR TITLE
fix: prevent whatsapp fallback for webchat sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/WebChat: avoid defaulting inbound runtime channel labels to unrelated providers (for example `whatsapp`) for webchat sessions so channel-specific formatting guidance stays accurate. (#21534) Thanks @lbo728.
 - Heartbeat/Cron: restore interval heartbeat behavior so missing `HEARTBEAT.md` no longer suppresses runs (only effectively empty files skip), preserving prompt-driven and tagged-cron execution paths.
 - WhatsApp/Cron/Heartbeat: enforce allowlisted routing for implicit scheduled/system delivery by merging pairing-store + configured `allowFrom` recipients, selecting authorized recipients when last-route context points to a non-allowlisted chat, and preventing heartbeat fan-out to recent unauthorized chats.
 - Heartbeat/Active hours: constrain active-hours `24` sentinel parsing to `24:00` in time validation so invalid values like `24:30` are rejected early. (#21410) thanks @adhitShet.


### PR DESCRIPTION
Fixes #21444

## Summary
When connecting via Hub Chat/webchat, the runtime channel was incorrectly defaulting to `whatsapp` instead of being omitted or set to `webchat`.

## Root Cause
The channel resolution fallback chain in `inbound-meta.ts`:
```typescript
channel: ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider
```

This would use `Provider` even for webchat sessions, where `Provider` may be unrelated (e.g., the user's default configured channel like `whatsapp`).

## Changes
- Added explicit webchat detection before falling back to `Provider`
- Skip `Provider` fallback when:
  - `Surface` is `'webchat'`
  - `Provider` is `'webchat'`
- Channel field is now `undefined` for webchat sessions (no incorrect label)

## Impact
- ✅ Webchat sessions no longer show `channel=whatsapp` in runtime label
- ✅ Agent receives correct formatting guidance (markdown enabled for webchat)
- ✅ No more WhatsApp-specific hints ("no markdown tables", "no headers") for webchat

## Testing
- All existing tests pass (`inbound-meta.test.ts`: 13/13 ✅)
- Logic handles webchat detection without breaking existing channels

## Closes
#21444

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes incorrect channel detection for webchat sessions by adding explicit webchat detection before falling back to the `Provider` field. Previously, the fallback chain `OriginatingChannel ?? Surface ?? Provider` would incorrectly use the user's default configured channel (e.g., `whatsapp`) for webchat sessions, causing the agent to receive wrong formatting guidance.

The fix adds conditional logic that only falls back to `Provider` when both the provider itself is not `webchat` AND the `Surface` is not `webchat`. This ensures webchat sessions (where `Surface = 'webchat'`) correctly use `'webchat'` as the channel value, and avoids pulling in unrelated provider values.

Key changes:
- Extracts channel resolution into a multi-step variable assignment with explicit webchat checks
- Preserves existing behavior for real messaging channels (WhatsApp, Telegram, etc.)
- All existing tests pass (13/13 in `inbound-meta.test.ts`)
- Well-documented with clear inline comments explaining the rationale

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-isolated to channel resolution logic, adds defensive checks without breaking existing behavior, includes clear documentation, and all existing tests pass. The logic is straightforward and addresses a specific bug without introducing new complexity or security concerns.
- No files require special attention

<sub>Last reviewed commit: 929233b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->