### PR TITLE
Gateway: include diagnostics state in sessions.list

### DIFF
--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -177,6 +177,7 @@ Runtime override (owner only):
 - `openclaw status` — shows store path and recent sessions.
 - `openclaw sessions --json` — dumps every entry (filter with `--active <minutes>`).
 - `openclaw gateway call sessions.list --params '{}'` — fetch sessions from the running gateway (use `--url`/`--token` for remote gateway access).
+  - `sessions.list` rows may include best-effort diagnostics fields: `diagnosticsState`, `diagnosticsStateTs`, `processingConfirmed`, and (when available) `diagnosticsQueueDepth`/`diagnosticsReason`.
 - Send `/status` as a standalone message in chat to see whether the agent is reachable, how much of the session context is used, current thinking/verbose toggles, and when your WhatsApp web creds were last refreshed (helps spot relink needs).
 - Send `/context list` or `/context detail` to see what’s in the system prompt and injected workspace files (and the biggest context contributors).
 - Send `/stop` as a standalone message to abort the current run, clear queued followups for that session, and stop any sub-agent runs spawned from it (the reply includes the stopped count).

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -21,6 +21,7 @@ import {
   type SessionEntry,
   type SessionScope,
 } from "../config/sessions.js";
+import { peekDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import {
   normalizeAgentId,
   normalizeMainKey,
@@ -788,6 +789,12 @@ export function listSessionsFromStore(params: {
       const resolvedModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
       const modelProvider = resolvedModel.provider ?? DEFAULT_PROVIDER;
       const model = resolvedModel.model ?? DEFAULT_MODEL;
+      const diagState = peekDiagnosticSessionState({
+        sessionKey: key,
+        sessionId: entry?.sessionId,
+      });
+      const diagnosticsState = diagState?.state;
+      const processingConfirmed = diagnosticsState === "processing";
       return {
         key,
         entry,
@@ -804,6 +811,11 @@ export function listSessionsFromStore(params: {
         sessionId: entry?.sessionId,
         systemSent: entry?.systemSent,
         abortedLastRun: entry?.abortedLastRun,
+        diagnosticsState,
+        diagnosticsStateTs: diagState?.lastActivity,
+        processingConfirmed,
+        diagnosticsQueueDepth: diagState?.queueDepth,
+        diagnosticsReason: diagState?.lastReason,
         thinkingLevel: entry?.thinkingLevel,
         verboseLevel: entry?.verboseLevel,
         reasoningLevel: entry?.reasoningLevel,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -25,6 +25,16 @@ export type GatewaySessionRow = {
   sessionId?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
+  /** Best-effort diagnostics-derived state (only present when the gateway observed activity for this session). */
+  diagnosticsState?: "idle" | "waiting" | "processing";
+  /** Epoch ms timestamp for the diagnostics state sample (usually last activity). */
+  diagnosticsStateTs?: number;
+  /** Convenience boolean for UIs: true when diagnosticsState==="processing". */
+  processingConfirmed?: boolean;
+  /** Diagnostics queue depth (if tracked). */
+  diagnosticsQueueDepth?: number;
+  /** Most recent diagnostics reason (if known). */
+  diagnosticsReason?: string;
   thinkingLevel?: string;
   verboseLevel?: string;
   reasoningLevel?: string;

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -6,6 +6,7 @@ export type SessionState = {
   lastActivity: number;
   state: SessionStateValue;
   queueDepth: number;
+  lastReason?: string;
   toolCallHistory?: ToolCallRecord[];
   toolLoopWarningBuckets?: Map<string, number>;
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
@@ -74,6 +75,22 @@ function findStateBySessionId(sessionId: string): SessionState | undefined {
     }
   }
   return undefined;
+}
+
+export function peekDiagnosticSessionState(ref: SessionRef): SessionState | undefined {
+  pruneDiagnosticSessionStates();
+  const key = resolveSessionKey(ref);
+  const existing =
+    diagnosticSessionStates.get(key) ?? (ref.sessionId && findStateBySessionId(ref.sessionId));
+  if (existing) {
+    if (ref.sessionId) {
+      existing.sessionId = ref.sessionId;
+    }
+    if (ref.sessionKey) {
+      existing.sessionKey = ref.sessionKey;
+    }
+  }
+  return existing;
 }
 
 export function getDiagnosticSessionState(ref: SessionRef): SessionState {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -176,6 +176,7 @@ export function logSessionStateChange(
   const isProbeSession = state.sessionId?.startsWith("probe-") ?? false;
   const prevState = state.state;
   state.state = params.state;
+  state.lastReason = params.reason;
   state.lastActivity = Date.now();
   if (params.state === "idle") {
     state.queueDepth = Math.max(0, state.queueDepth - 1);

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -392,6 +392,11 @@ export type GatewaySessionRow = {
   sessionId?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
+  diagnosticsState?: "idle" | "waiting" | "processing";
+  diagnosticsStateTs?: number;
+  processingConfirmed?: boolean;
+  diagnosticsQueueDepth?: number;
+  diagnosticsReason?: string;
   thinkingLevel?: string;
   verboseLevel?: string;
   reasoningLevel?: string;


### PR DESCRIPTION
Closes #21537.

### What
- Extends `sessions.list` rows with best-effort diagnostics-derived fields:
  - `diagnosticsState`: `idle|waiting|processing`
  - `diagnosticsStateTs`: epoch ms
  - `processingConfirmed`: boolean convenience (`diagnosticsState === "processing"`)
  - `diagnosticsQueueDepth` + `diagnosticsReason` when available
- Does **not** create diagnostic entries as a side-effect of listing sessions.

### Tests
- `OPENCLAW_PROFILE= OPENCLAW_GATEWAY_TOKEN= pnpm vitest run --config vitest.gateway.config.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended `sessions.list` to include diagnostics-derived fields (`diagnosticsState`, `diagnosticsStateTs`, `processingConfirmed`, `diagnosticsQueueDepth`, `diagnosticsReason`) by introducing `peekDiagnosticSessionState` which reads existing diagnostic state without creating new entries.

- Added `peekDiagnosticSessionState` function in `src/logging/diagnostic-session-state.ts:80` that looks up existing diagnostic state without side-effect creation
- Modified `listSessionsFromStore` in `src/gateway/session-utils.ts:792-818` to call `peekDiagnosticSessionState` and populate new fields
- Updated type definitions in both `src/gateway/session-utils.types.ts:28-37` and `ui/src/ui/types.ts:395-399` with matching field types
- Added `lastReason` tracking to `SessionState` type and `logSessionStateChange` function
- Included comprehensive test coverage for all scenarios (state present, absent, sessionId-only lookup)
- Updated documentation to describe the new best-effort fields

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows the stated goal of not creating diagnostic entries as a side-effect. The new `peekDiagnosticSessionState` function correctly returns undefined for non-existent states rather than creating them. Type definitions are consistently updated across both gateway and UI. Comprehensive tests cover all key scenarios including the critical behavior of not creating entries when none exist.
- No files require special attention

<sub>Last reviewed commit: de25216</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->