### PR TITLE
fix: resolve workspace template dir in bundled dist/ layout

### DIFF
--- a/src/agents/workspace-templates.ancestor-walk.test.ts
+++ b/src/agents/workspace-templates.ancestor-walk.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  resetWorkspaceTemplateDirCache,
+  resolveWorkspaceTemplateDir,
+} from "./workspace-templates.js";
+
+async function makeTempRoot(): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tpl-ancestor-"));
+}
+
+describe("resolveWorkspaceTemplateDir ancestor walk", () => {
+  it("finds templates when module is nested one level deep (dist/)", async () => {
+    resetWorkspaceTemplateDirCache();
+    const root = await makeTempRoot();
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+
+    const templatesDir = path.join(root, "docs", "reference", "templates");
+    await fs.mkdir(templatesDir, { recursive: true });
+    await fs.writeFile(path.join(templatesDir, "TOOLS.md"), "# tools\n");
+
+    const distDir = path.join(root, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    const moduleUrl = pathToFileURL(path.join(distDir, "workspace.js")).toString();
+
+    const resolved = await resolveWorkspaceTemplateDir({ cwd: root, moduleUrl });
+    expect(resolved).toBe(templatesDir);
+  });
+
+  it("finds templates when module is nested two levels deep (src/agents/)", async () => {
+    resetWorkspaceTemplateDirCache();
+    const root = await makeTempRoot();
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+
+    const templatesDir = path.join(root, "docs", "reference", "templates");
+    await fs.mkdir(templatesDir, { recursive: true });
+    await fs.writeFile(path.join(templatesDir, "TOOLS.md"), "# tools\n");
+
+    const srcDir = path.join(root, "src", "agents");
+    await fs.mkdir(srcDir, { recursive: true });
+    const moduleUrl = pathToFileURL(path.join(srcDir, "workspace-templates.ts")).toString();
+
+    const resolved = await resolveWorkspaceTemplateDir({ cwd: root, moduleUrl });
+    expect(resolved).toBe(templatesDir);
+  });
+
+  it("finds templates when cwd is the workspace (not package root)", async () => {
+    resetWorkspaceTemplateDirCache();
+    const root = await makeTempRoot();
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+
+    const templatesDir = path.join(root, "docs", "reference", "templates");
+    await fs.mkdir(templatesDir, { recursive: true });
+    await fs.writeFile(path.join(templatesDir, "TOOLS.md"), "# tools\n");
+
+    const distDir = path.join(root, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    const moduleUrl = pathToFileURL(path.join(distDir, "workspace.js")).toString();
+
+    // cwd is a completely different directory (simulates cron isolated session)
+    const fakeCwd = await makeTempRoot();
+    const resolved = await resolveWorkspaceTemplateDir({ cwd: fakeCwd, moduleUrl });
+    expect(resolved).toBe(templatesDir);
+  });
+});


### PR DESCRIPTION
## Problem

Cron isolated sessions fail with:

```
Error: Missing workspace template: TOOLS.md (/usr/lib/node_modules/docs/reference/templates/TOOLS.md).
Ensure docs/reference/templates are packaged.
```

The template file exists at `/usr/lib/node_modules/openclaw/docs/reference/templates/TOOLS.md`, but the fallback path resolves incorrectly.

## Root Cause

`FALLBACK_TEMPLATE_DIR` in `workspace-templates.ts` uses a hardcoded relative path:

```typescript
path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../docs/reference/templates')
```

This assumes the source layout where the file lives at `src/agents/workspace-templates.ts` (2 levels deep). In the bundled `dist/` layout (1 level deep), this resolves to:

- Expected: `/usr/lib/node_modules/openclaw/docs/reference/templates`
- Actual: `/usr/lib/node_modules/docs/reference/templates` ❌

When `resolveOpenClawPackageRoot()` also returns `null` (because cwd is the workspace dir in cron isolated sessions, not the package dir), no candidate path is valid.

## Fix

Replace the hardcoded `../../` relative path with `findTemplateDirFromAncestors()` — a small helper that walks up from `import.meta.url` to find the nearest parent directory containing `docs/reference/templates/`. This works for both:

- Source layout: `src/agents/` (2 levels up)
- Bundled layout: `dist/` (1 level up)
- Any future restructuring

## Changes

- **`src/agents/workspace-templates.ts`** — Replace hardcoded relative fallback with ancestor directory walk
- **`src/agents/workspace-templates.ancestor-walk.test.ts`** — 3 test cases:
  - Module nested 1 level deep (`dist/`) ✅
  - Module nested 2 levels deep (`src/agents/`) ✅
  - cwd is workspace dir, not package root (cron isolated session scenario) ✅

## Testing

```
✓ finds templates when module is nested one level deep (dist/)
✓ finds templates when module is nested two levels deep (src/agents/)
✓ finds templates when cwd is the workspace (not package root)

Test Files  1 passed (1)
Tests       3 passed (3)
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces hardcoded relative path fallback with ancestor directory walk to correctly resolve workspace template directory in both source (`src/agents/`) and bundled (`dist/`) layouts.

- Introduces `findTemplateDirFromAncestors()` helper that walks up from `import.meta.url` to find `docs/reference/templates/`
- Fixes cron isolated session failures where the old hardcoded `../../` path resolved to incorrect location in bundled layout
- Adds comprehensive test coverage for 1-level deep (dist), 2-level deep (src/agents), and cwd-mismatch scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-designed with proper fallback handling, comprehensive test coverage for all scenarios, and directly addresses the root cause. The ancestor walk approach is more robust than hardcoded relative paths and handles both current and future directory structures
- No files require special attention

<sub>Last reviewed commit: f8cab06</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->