### PR TITLE
config: support agents.list[].thinkingDefault

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -19,6 +19,7 @@ type ResolvedAgentConfig = {
   workspace?: string;
   agentDir?: string;
   model?: AgentEntry["model"];
+  thinkingDefault?: AgentEntry["thinkingDefault"];
   skills?: AgentEntry["skills"];
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
@@ -113,6 +114,7 @@ export function resolveAgentConfig(
       typeof entry.model === "string" || (entry.model && typeof entry.model === "object")
         ? entry.model
         : undefined,
+    thinkingDefault: entry.thinkingDefault,
     skills: Array.isArray(entry.skills) ? entry.skills : undefined,
     memorySearch: entry.memorySearch,
     humanDelay: entry.humanDelay,

--- a/src/agents/model-selection.e2e.test.ts
+++ b/src/agents/model-selection.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   buildModelAliasIndex,
   normalizeProviderId,
   modelKey,
+  resolveThinkingDefault,
 } from "./model-selection.js";
 
 describe("model-selection", () => {
@@ -18,6 +19,26 @@ describe("model-selection", () => {
       expect(normalizeProviderId("OpenCode-Zen")).toBe("opencode");
       expect(normalizeProviderId("qwen")).toBe("qwen-portal");
       expect(normalizeProviderId("kimi-code")).toBe("kimi-coding");
+    });
+  });
+
+  describe("resolveThinkingDefault", () => {
+    it("prefers per-agent thinkingDefault over global defaults", () => {
+      const cfg = {
+        agents: {
+          defaults: { thinkingDefault: "low" },
+          list: [{ id: "atlas", thinkingDefault: "high" }],
+        },
+      } as OpenClawConfig;
+
+      const level = resolveThinkingDefault({
+        cfg,
+        provider: "openai-codex",
+        model: "gpt-5.3-codex",
+        agentId: "atlas",
+      });
+
+      expect(level).toBe("high");
     });
   });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -501,8 +501,13 @@ export function resolveThinkingDefault(params: {
   provider: string;
   model: string;
   catalog?: ModelCatalogEntry[];
+  agentId?: string;
 }): ThinkLevel {
-  const configured = params.cfg.agents?.defaults?.thinkingDefault;
+  const perAgentConfigured =
+    typeof params.agentId === "string" && params.agentId.trim()
+      ? resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault
+      : undefined;
+  const configured = perAgentConfigured ?? params.cfg.agents?.defaults?.thinkingDefault;
   if (configured) {
     return configured;
   }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,4 +1,5 @@
 import {
+  resolveAgentConfig,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
@@ -70,7 +71,10 @@ export async function getReplyFromConfig(
   );
   const resolvedOpts =
     mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
-  const agentCfg = cfg.agents?.defaults;
+  const agentOverride = resolveAgentConfig(cfg, agentId);
+  const agentCfg = Object.assign({}, cfg.agents?.defaults, {
+    thinkingDefault: agentOverride?.thinkingDefault ?? cfg.agents?.defaults?.thinkingDefault,
+  });
   const sessionCfg = cfg.session;
   const { defaultProvider, defaultModel, aliasIndex } = resolveDefaultModel({
     cfg,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -485,6 +485,7 @@ export async function agentCommand(
         provider,
         model,
         catalog: catalogForThinking,
+        agentId: sessionAgentId,
       });
     }
     if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from "vitest";
 import { validateConfigObject } from "./config.js";
 
 describe("config schema regressions", () => {
+  it("accepts agent-level thinkingDefault overrides", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "atlas",
+            thinkingDefault: "high",
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts nested telegram groupPolicy overrides", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -25,6 +25,8 @@ export type AgentConfig = {
   workspace?: string;
   agentDir?: string;
   model?: AgentModelConfig;
+  /** Per-agent default thinking level override. */
+  thinkingDefault?: AgentDefaultsConfig["thinkingDefault"];
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];
   memorySearch?: MemorySearchConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -588,6 +588,16 @@ export const AgentEntrySchema = z
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
+    thinkingDefault: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+        z.literal("xhigh"),
+      ])
+      .optional(),
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -341,6 +341,7 @@ export async function runCronIsolatedAgentTurn(params: {
       provider,
       model,
       catalog: await loadCatalog(),
+      agentId,
     });
   }
   if (thinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -618,6 +618,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           provider,
           model,
           catalog,
+          agentId: sessionAgentId,
         });
       }
     }


### PR DESCRIPTION
## Summary
- allow `agents.list[].thinkingDefault` in config schema/types
- honor per-agent thinking defaults when resolving default think level
- apply per-agent think default in auto-reply runs
- add regression tests for schema acceptance + per-agent precedence

## Why
Users currently hit config validation errors like:

`agents.list.0: Unrecognized key: "thinkingDefault"`

when trying to set thinking defaults per agent (e.g. Atlas). This makes gateway calls fail during local config checks and is confusing because the runtime already has plumbing for agent-aware think resolution.

## Notes
- This change is focused on `thinkingDefault` only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added support for per-agent `thinkingDefault` configuration overrides. The PR extends the config schema and types to allow setting thinking defaults on a per-agent basis in `agents.list[].thinkingDefault`, and updates the resolution logic to prefer per-agent values over global defaults.

Key changes:
- Extended `AgentEntrySchema` Zod schema to accept `thinkingDefault` field
- Added `thinkingDefault` to `AgentConfig` type and `ResolvedAgentConfig`
- Updated `resolveThinkingDefault()` to accept optional `agentId` parameter and resolve per-agent overrides
- Modified call sites in gateway, commands, and cron to pass `agentId` when resolving thinking defaults
- Added workaround in `get-reply.ts` to manually construct `agentCfg` with per-agent thinking default
- Added regression test for schema acceptance and unit test for precedence logic

The implementation works correctly with proper precedence (per-agent > global > model-based > "off"), though the approach is somewhat distributed across multiple layers.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - implements a well-scoped feature addition with proper tests
- The changes are focused and implement the stated feature correctly. The implementation includes proper type definitions, schema validation, regression tests, and updates to key call sites. The logic preserves correct precedence order (per-agent > global > model defaults). However, the score is not a 5 because the implementation is somewhat distributed and could benefit from consolidation (e.g., the workaround in `get-reply.ts` and the missing `agentId` in `auto-reply/reply/model-selection.ts`). There's also incomplete coverage - some call sites like `extensions/voice-call` and `auto-reply/reply/model-selection.ts` don't pass `agentId` to `resolveThinkingDefault`, though the feature still works via fallback paths.
- No files require special attention

<sub>Last reviewed commit: 7663bae</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->