### PR TITLE
runner: sanitize invalid UTF-16 surrogates in session/prompt payloads

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -335,6 +335,14 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
     expect(classifyFailoverReason("string should match pattern")).toBe("format");
+    expect(
+      classifyFailoverReason(
+        "request body is not valid JSON: no low surrogate in string: line 1 column 123",
+      ),
+    ).toBe("format");
+    expect(classifyFailoverReason("invalid request payload: lone surrogate in string")).toBe(
+      "format",
+    );
     expect(classifyFailoverReason("bad request")).toBeNull();
     expect(
       classifyFailoverReason(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -630,6 +630,9 @@ const ERROR_PATTERNS = {
     "tool_use_id",
     "messages.1.content.1.tool_use.id",
     "invalid request format",
+    "request body is not valid json",
+    "no low surrogate",
+    "lone surrogate",
   ],
 } as const;
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -14,6 +14,7 @@ import {
   sanitizeWithOpenAIResponses,
   TEST_SESSION_ID,
 } from "./pi-embedded-runner.sanitize-session-history.test-harness.js";
+import { hasUnpairedSurrogates } from "./pi-embedded-runner/unicode-safety.js";
 
 let sanitizeSessionHistory: SanitizeSessionHistoryFn;
 
@@ -283,5 +284,36 @@ describe("sanitizeSessionHistory", () => {
           (msg as { toolCallId?: string }).toolCallId === "tool_01VihkDRptyLpX1ApUPe7ooU",
       ),
     ).toBe(false);
+  });
+
+  it("repairs invalid UTF-16 surrogate sequences in session messages", async () => {
+    const messages = [
+      { role: "user", content: "hello \ud83d world" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "bad low surrogate \udc00 here" }],
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const userText = (result[0] as { content?: unknown })?.content;
+    expect(typeof userText).toBe("string");
+    expect(userText).toContain("\uFFFD");
+    expect(hasUnpairedSurrogates(userText as string)).toBe(false);
+
+    const assistantContent = (result[1] as { content?: unknown })?.content;
+    const assistantText = Array.isArray(assistantContent)
+      ? (assistantContent[0] as { text?: unknown })?.text
+      : undefined;
+    expect(typeof assistantText).toBe("string");
+    expect(assistantText).toContain("\uFFFD");
+    expect(hasUnpairedSurrogates(assistantText as string)).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -25,6 +25,7 @@ import {
 import type { TranscriptPolicy } from "../transcript-policy.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { log } from "./logger.js";
+import { sanitizeAgentMessagesUnicode } from "./unicode-safety.js";
 import { describeUnknownError } from "./utils.js";
 
 const GOOGLE_TURN_ORDERING_CUSTOM_TYPE = "google-turn-ordering-bootstrap";
@@ -468,6 +469,13 @@ export async function sanitizeSessionHistory(params: {
   const sanitizedOpenAI = isOpenAIResponsesApi
     ? downgradeOpenAIReasoningBlocks(sanitizedToolResults)
     : sanitizedToolResults;
+  const unicodeSanitized = sanitizeAgentMessagesUnicode(sanitizedOpenAI);
+  if (unicodeSanitized.replacementCount > 0) {
+    log.warn(
+      `session unicode sanitizer repaired ${unicodeSanitized.replacementCount} invalid UTF-16 surrogate code unit(s) (sessionId=${params.sessionId})`,
+    );
+  }
+  const sanitizedUnicode = unicodeSanitized.messages;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {
@@ -479,11 +487,11 @@ export async function sanitizeSessionHistory(params: {
   }
 
   if (!policy.applyGoogleTurnOrdering) {
-    return sanitizedOpenAI;
+    return sanitizedUnicode;
   }
 
   return applyGoogleTurnOrderingFix({
-    messages: sanitizedOpenAI,
+    messages: sanitizedUnicode,
     modelApi: params.modelApi,
     sessionManager: params.sessionManager,
     sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -99,6 +99,7 @@ import {
 } from "../system-prompt.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";
 import { splitSdkTools } from "../tool-split.js";
+import { sanitizeUnpairedSurrogatesWithStats } from "../unicode-safety.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import {
@@ -931,6 +932,14 @@ export async function runEmbeddedAttempt(
               `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
             );
           }
+        }
+        const promptUnicodeResult = sanitizeUnpairedSurrogatesWithStats(effectivePrompt);
+        if (promptUnicodeResult.replacements > 0) {
+          effectivePrompt = promptUnicodeResult.value;
+          log.warn(
+            `prompt unicode sanitizer repaired ${promptUnicodeResult.replacements} invalid UTF-16 surrogate code unit(s) ` +
+              `(runId=${params.runId} sessionId=${params.sessionId})`,
+          );
         }
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);

--- a/src/agents/pi-embedded-runner/unicode-safety.test.ts
+++ b/src/agents/pi-embedded-runner/unicode-safety.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasUnpairedSurrogates,
+  sanitizeUnknownStringsDeep,
+  sanitizeUnpairedSurrogatesWithStats,
+} from "./unicode-safety.js";
+
+describe("unicode-safety", () => {
+  it("leaves valid surrogate pairs unchanged", () => {
+    const value = "emoji 😀 ok";
+    const result = sanitizeUnpairedSurrogatesWithStats(value);
+    expect(result.value).toBe(value);
+    expect(result.replacements).toBe(0);
+    expect(hasUnpairedSurrogates(result.value)).toBe(false);
+  });
+
+  it("replaces lone high surrogate", () => {
+    const value = "broken \ud83d tail";
+    const result = sanitizeUnpairedSurrogatesWithStats(value);
+    expect(result.replacements).toBe(1);
+    expect(result.value).toContain("\uFFFD");
+    expect(hasUnpairedSurrogates(result.value)).toBe(false);
+  });
+
+  it("replaces lone low surrogate", () => {
+    const value = "broken \udc00 tail";
+    const result = sanitizeUnpairedSurrogatesWithStats(value);
+    expect(result.replacements).toBe(1);
+    expect(result.value).toContain("\uFFFD");
+    expect(hasUnpairedSurrogates(result.value)).toBe(false);
+  });
+
+  it("sanitizes nested objects and arrays", () => {
+    const data = {
+      text: "x\ud83d",
+      nested: [{ note: "y\udc00" }],
+    };
+    const result = sanitizeUnknownStringsDeep(data);
+    expect(result.replacements).toBe(2);
+    expect(result.value.text).toContain("\uFFFD");
+    expect(result.value.nested[0]?.note).toContain("\uFFFD");
+  });
+});

--- a/src/agents/pi-embedded-runner/unicode-safety.ts
+++ b/src/agents/pi-embedded-runner/unicode-safety.ts
@@ -1,0 +1,187 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+const HIGH_SURROGATE_MIN = 0xd800;
+const HIGH_SURROGATE_MAX = 0xdbff;
+const LOW_SURROGATE_MIN = 0xdc00;
+const LOW_SURROGATE_MAX = 0xdfff;
+const REPLACEMENT_CHAR = "\uFFFD";
+
+type StringSanitizeResult = {
+  value: string;
+  replacements: number;
+};
+
+type DeepSanitizeResult<T> = {
+  value: T;
+  replacements: number;
+  changed: boolean;
+};
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= HIGH_SURROGATE_MIN && codeUnit <= HIGH_SURROGATE_MAX;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= LOW_SURROGATE_MIN && codeUnit <= LOW_SURROGATE_MAX;
+}
+
+function sanitizeStringInternal(input: string): StringSanitizeResult {
+  if (!input) {
+    return { value: input, replacements: 0 };
+  }
+
+  const parts: string[] = [];
+  let replacements = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    const current = input.charCodeAt(i);
+    if (isHighSurrogate(current)) {
+      if (i + 1 < input.length) {
+        const next = input.charCodeAt(i + 1);
+        if (isLowSurrogate(next)) {
+          parts.push(input[i], input[i + 1]);
+          i += 1;
+          continue;
+        }
+      }
+      replacements += 1;
+      parts.push(REPLACEMENT_CHAR);
+      continue;
+    }
+    if (isLowSurrogate(current)) {
+      replacements += 1;
+      parts.push(REPLACEMENT_CHAR);
+      continue;
+    }
+    parts.push(input[i]);
+  }
+
+  if (replacements === 0) {
+    return { value: input, replacements: 0 };
+  }
+  return { value: parts.join(""), replacements };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function sanitizeUnknownStringsDeepInternal(
+  value: unknown,
+  seen: WeakSet<object>,
+): DeepSanitizeResult<unknown> {
+  if (typeof value === "string") {
+    const sanitized = sanitizeStringInternal(value);
+    return {
+      value: sanitized.value,
+      replacements: sanitized.replacements,
+      changed: sanitized.replacements > 0,
+    };
+  }
+
+  if (Array.isArray(value)) {
+    let replacements = 0;
+    let changed = false;
+    let out: unknown[] | undefined;
+    for (let i = 0; i < value.length; i++) {
+      const next = sanitizeUnknownStringsDeepInternal(value[i], seen);
+      replacements += next.replacements;
+      if (next.changed) {
+        changed = true;
+        if (!out) {
+          out = value.slice();
+        }
+        out[i] = next.value;
+      }
+    }
+    return {
+      value: changed ? (out as unknown) : value,
+      replacements,
+      changed,
+    };
+  }
+
+  if (isPlainObject(value)) {
+    if (seen.has(value)) {
+      return { value, replacements: 0, changed: false };
+    }
+    seen.add(value);
+
+    let replacements = 0;
+    let changed = false;
+    let out: Record<string, unknown> | undefined;
+    for (const [key, child] of Object.entries(value)) {
+      const next = sanitizeUnknownStringsDeepInternal(child, seen);
+      replacements += next.replacements;
+      if (next.changed) {
+        changed = true;
+        if (!out) {
+          out = { ...value };
+        }
+        out[key] = next.value;
+      }
+    }
+    return {
+      value: changed ? (out as unknown) : value,
+      replacements,
+      changed,
+    };
+  }
+
+  return { value, replacements: 0, changed: false };
+}
+
+export function hasUnpairedSurrogates(input: string): boolean {
+  if (!input) {
+    return false;
+  }
+  for (let i = 0; i < input.length; i++) {
+    const current = input.charCodeAt(i);
+    if (isHighSurrogate(current)) {
+      if (i + 1 >= input.length) {
+        return true;
+      }
+      const next = input.charCodeAt(i + 1);
+      if (!isLowSurrogate(next)) {
+        return true;
+      }
+      i += 1;
+      continue;
+    }
+    if (isLowSurrogate(current)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function sanitizeUnpairedSurrogates(input: string): string {
+  return sanitizeStringInternal(input).value;
+}
+
+export function sanitizeUnpairedSurrogatesWithStats(input: string): StringSanitizeResult {
+  return sanitizeStringInternal(input);
+}
+
+export function sanitizeUnknownStringsDeep<T>(value: T): { value: T; replacements: number } {
+  const result = sanitizeUnknownStringsDeepInternal(value, new WeakSet<object>());
+  return {
+    value: result.value as T,
+    replacements: result.replacements,
+  };
+}
+
+export function sanitizeAgentMessagesUnicode(messages: AgentMessage[]): {
+  messages: AgentMessage[];
+  replacementCount: number;
+} {
+  const result = sanitizeUnknownStringsDeep(messages);
+  return {
+    messages: result.value,
+    replacementCount: result.replacements,
+  };
+}


### PR DESCRIPTION
## Summary

- Problem: invalid UTF-16 surrogates in session/prompt text can produce provider JSON errors like `no low surrogate`.
- Impact: a poisoned turn can repeat failures on later sends.
- Fix: sanitize invalid surrogate code units before request serialization, and classify surrogate-related malformed-JSON errors as `format`.
- Scope boundary: no usage/quota preflight behavior in this PR.
- AI-assisted disclosure: AI-assisted implementation, then manual review and manual test verification.

## Quick Review (2-3 min)

1. Check `src/agents/pi-embedded-runner/unicode-safety.ts` for surrogate repair behavior.
2. Check `src/agents/pi-embedded-runner/run/attempt.ts` and `src/agents/pi-embedded-runner/google.ts` call sites for prompt/history sanitization.
3. Check tests listed below for lone high/low surrogate handling and valid pair preservation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Invalid lone surrogates are repaired before request serialization.
- Surrogate-related malformed JSON provider errors are classified as `format`.
- Valid surrogate pairs (normal emoji text) remain unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: Node 22 / pnpm 10
- Integration/channel: N/A (runner-level tests)

### Steps

1. Feed text with lone high and lone low surrogate units through session/prompt sanitization paths.
2. Verify repaired output excludes unpaired surrogates.
3. Verify valid surrogate pairs stay unchanged.
4. Verify surrogate-malformed JSON errors classify as `format`.

### Expected

- Invalid surrogates are repaired, valid pairs remain intact, and classification is `format`.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- `corepack pnpm vitest run src/agents/pi-embedded-runner/unicode-safety.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- `corepack pnpm vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts`
- `corepack pnpm oxlint --type-aware` on touched files
- Manual spot-check: valid emoji surrogate pairs unchanged.
- Not verified here: full repo `corepack pnpm tsgo` due pre-existing unrelated TS2742 baseline failures.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert quickly: revert commit `9cba5443793b07b0a18b2123ddc3948b982d0bf5`.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/unicode-safety.ts`
  - `src/agents/pi-embedded-runner/google.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-helpers/errors.ts`

## Risks and Mitigations

- Risk: over-sanitization could alter intentionally malformed text.
- Mitigation: replacement is limited to invalid unpaired surrogate units; valid pairs are preserved and covered by tests.
