### PR TITLE
runner: add usage preflight guard for near-limit requests

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -2,8 +2,9 @@ import "./run.overflow-compaction.mocks.shared.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { compactEmbeddedPiSessionDirect } from "./compact.js";
 import { runEmbeddedPiAgent } from "./run.js";
-import { mockOverflowRetrySuccess } from "./run.overflow-compaction.fixture.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
+import { UsagePreflightError } from "./usage-preflight.js";
 
 const mockedRunEmbeddedAttempt = vi.mocked(runEmbeddedAttempt);
 const mockedCompactDirect = vi.mocked(compactEmbeddedPiSessionDirect);
@@ -14,9 +15,20 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
   });
 
   it("passes trigger=overflow when retrying compaction after context overflow", async () => {
-    mockOverflowRetrySuccess({
-      runEmbeddedAttempt: mockedRunEmbeddedAttempt,
-      compactDirect: mockedCompactDirect,
+    const overflowError = new Error("request_too_large: Request size exceeds model context window");
+
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "Compacted session",
+        firstKeptEntryId: "entry-5",
+        tokensBefore: 150000,
+      },
     });
 
     await runEmbeddedPiAgent({
@@ -36,5 +48,37 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         authProfileId: "test-profile",
       }),
     );
+  });
+
+  it("returns a user-facing error for usage preflight blocks without compaction", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: new UsagePreflightError(
+          {
+            providerId: "openai-codex",
+            blocked: true,
+            warning: true,
+            estimatedPromptTokens: 512,
+            remainingPercent: 1,
+            windowLabel: "3h",
+          },
+          "Usage guard: request blocked to avoid hitting openai-codex limits.",
+        ),
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace",
+      prompt: "hello",
+      timeoutMs: 30000,
+      runId: "run-preflight",
+    });
+
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("Usage guard");
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -99,6 +99,11 @@ import {
 } from "../system-prompt.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";
 import { splitSdkTools } from "../tool-split.js";
+import {
+  evaluateUsagePreflight,
+  UsagePreflightError,
+  usagePreflightDecisionMessage,
+} from "../usage-preflight.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import {
@@ -955,6 +960,31 @@ export async function runEmbeddedAttempt(
           log.warn(
             `Removed orphaned user message to prevent consecutive user turns. ` +
               `runId=${params.runId} sessionId=${params.sessionId}`,
+          );
+        }
+
+        const usagePreflightDecision = await evaluateUsagePreflight({
+          provider: params.provider,
+          prompt: effectivePrompt,
+          historyMessages: activeSession.messages,
+          timeoutMs: Math.min(2_000, Math.max(750, Math.floor(params.timeoutMs / 4))),
+        });
+        if (usagePreflightDecision.warning) {
+          const remainingLabel =
+            usagePreflightDecision.remainingPercent !== undefined
+              ? `${usagePreflightDecision.remainingPercent.toFixed(0)}%`
+              : "unknown";
+          log.warn(
+            `[usage-preflight] low remaining quota detected for ${params.provider}: ` +
+              `remaining=${remainingLabel} window=${usagePreflightDecision.windowLabel ?? "unknown"} ` +
+              `estimatedPromptTokens=${usagePreflightDecision.estimatedPromptTokens}`,
+          );
+        }
+        if (usagePreflightDecision.blocked) {
+          throw new UsagePreflightError(
+            usagePreflightDecision,
+            usagePreflightDecisionMessage(usagePreflightDecision) ??
+              "Usage guard: request blocked due to low remaining provider quota.",
           );
         }
 

--- a/src/agents/pi-embedded-runner/usage-preflight.test.ts
+++ b/src/agents/pi-embedded-runner/usage-preflight.test.ts
@@ -1,0 +1,132 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetUsagePreflightCacheForTests,
+  evaluateUsagePreflight,
+  usagePreflightDecisionMessage,
+} from "./usage-preflight.js";
+
+const loadProviderUsageSummaryMock = vi.fn();
+const resolveUsageProviderIdMock = vi.fn((provider?: string | null) => {
+  if (provider === "openai-codex") {
+    return "openai-codex";
+  }
+  return undefined;
+});
+
+vi.mock("../../infra/provider-usage.js", () => ({
+  loadProviderUsageSummary: (...args: unknown[]) => loadProviderUsageSummaryMock(...args),
+  resolveUsageProviderId: (provider?: string | null) => resolveUsageProviderIdMock(provider),
+}));
+
+const emptyHistory: AgentMessage[] = [];
+
+describe("usage preflight", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetUsagePreflightCacheForTests();
+  });
+
+  it("hard-blocks when remaining usage is <= 1%", async () => {
+    loadProviderUsageSummaryMock.mockResolvedValue({
+      updatedAt: Date.now(),
+      providers: [
+        {
+          provider: "openai-codex",
+          displayName: "Codex",
+          windows: [{ label: "3h", usedPercent: 99 }],
+        },
+      ],
+    });
+
+    const decision = await evaluateUsagePreflight({
+      provider: "openai-codex",
+      prompt: "short",
+      historyMessages: emptyHistory,
+    });
+
+    expect(decision.blocked).toBe(true);
+    expect(decision.warning).toBe(true);
+    expect(decision.remainingPercent).toBe(1);
+  });
+
+  it("blocks when remaining usage is <= 2% for non-trivial prompt size", async () => {
+    loadProviderUsageSummaryMock.mockResolvedValue({
+      updatedAt: Date.now(),
+      providers: [
+        {
+          provider: "openai-codex",
+          displayName: "Codex",
+          windows: [{ label: "day", usedPercent: 98 }],
+        },
+      ],
+    });
+
+    const decision = await evaluateUsagePreflight({
+      provider: "openai-codex",
+      prompt: "x".repeat(1_200),
+      historyMessages: emptyHistory,
+    });
+
+    expect(decision.estimatedPromptTokens).toBeGreaterThanOrEqual(256);
+    expect(decision.blocked).toBe(true);
+    expect(decision.warning).toBe(true);
+  });
+
+  it("warns without blocking when near limit but prompt estimate is small", async () => {
+    loadProviderUsageSummaryMock.mockResolvedValue({
+      updatedAt: Date.now(),
+      providers: [
+        {
+          provider: "openai-codex",
+          displayName: "Codex",
+          windows: [{ label: "day", usedPercent: 98 }],
+        },
+      ],
+    });
+
+    const decision = await evaluateUsagePreflight({
+      provider: "openai-codex",
+      prompt: "tiny",
+      historyMessages: emptyHistory,
+    });
+
+    expect(decision.blocked).toBe(false);
+    expect(decision.warning).toBe(true);
+    expect(decision.remainingPercent).toBe(2);
+  });
+
+  it("fails open when provider usage data is unavailable", async () => {
+    loadProviderUsageSummaryMock.mockResolvedValue({
+      updatedAt: Date.now(),
+      providers: [],
+    });
+
+    const decision = await evaluateUsagePreflight({
+      provider: "openai-codex",
+      prompt: "hello",
+      historyMessages: emptyHistory,
+    });
+
+    expect(decision.blocked).toBe(false);
+    expect(decision.warning).toBe(false);
+  });
+
+  it("formats a user-facing block message", () => {
+    const message = usagePreflightDecisionMessage(
+      {
+        providerId: "openai-codex",
+        blocked: true,
+        warning: true,
+        estimatedPromptTokens: 512,
+        remainingPercent: 1,
+        windowLabel: "3h",
+        resetAt: Date.now() + 30 * 60 * 1000,
+      },
+      Date.now(),
+    );
+
+    expect(message).toContain("Usage guard");
+    expect(message).toContain("openai-codex");
+  });
+});

--- a/src/agents/pi-embedded-runner/usage-preflight.ts
+++ b/src/agents/pi-embedded-runner/usage-preflight.ts
@@ -1,0 +1,295 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { estimateTokens } from "@mariozechner/pi-coding-agent";
+import {
+  loadProviderUsageSummary,
+  resolveUsageProviderId,
+  type ProviderUsageSnapshot,
+  type UsageProviderId,
+  type UsageWindow,
+} from "../../infra/provider-usage.js";
+
+type UsagePreflightSnapshot = {
+  providerId: UsageProviderId;
+  window: UsageWindow;
+  remainingPercent: number;
+};
+
+export type UsagePreflightDecision = {
+  providerId?: UsageProviderId;
+  blocked: boolean;
+  warning: boolean;
+  estimatedPromptTokens: number;
+  remainingPercent?: number;
+  windowLabel?: string;
+  resetAt?: number;
+};
+
+const USAGE_PREFLIGHT_CACHE_TTL_MS = 60_000;
+const WARN_REMAINING_PERCENT = 10;
+const BLOCK_REMAINING_PERCENT = 2;
+const ALWAYS_BLOCK_REMAINING_PERCENT = 1;
+const BLOCK_MIN_ESTIMATED_PROMPT_TOKENS = 256;
+
+const usageSnapshotCache = new Map<
+  UsageProviderId,
+  {
+    snapshot: ProviderUsageSnapshot | null;
+    expiresAt: number;
+  }
+>();
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, value));
+}
+
+function textTokenHeuristic(text: string): number {
+  if (!text) {
+    return 0;
+  }
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function messageTextChars(message: AgentMessage): number {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content.length;
+  }
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const text = (block as { text?: unknown }).text;
+    if (typeof text === "string") {
+      total += text.length;
+      continue;
+    }
+    if ((block as { type?: unknown }).type === "image") {
+      total += 1_024;
+    }
+  }
+  return total;
+}
+
+function estimateMessageTokens(message: AgentMessage): number {
+  try {
+    const estimated = estimateTokens(message);
+    if (Number.isFinite(estimated) && estimated > 0) {
+      return Math.ceil(estimated);
+    }
+  } catch {
+    // Fall back to char heuristics below.
+  }
+  return textTokenHeuristicByCharCount(messageTextChars(message));
+}
+
+function textTokenHeuristicByCharCount(charCount: number): number {
+  if (!(charCount > 0)) {
+    return 0;
+  }
+  return Math.max(1, Math.ceil(charCount / 4));
+}
+
+export function estimatePromptTokensForPreflight(params: {
+  historyMessages: AgentMessage[];
+  prompt: string;
+}): number {
+  let total = textTokenHeuristic(params.prompt);
+  for (const message of params.historyMessages) {
+    total += estimateMessageTokens(message);
+  }
+  return Math.max(1, total);
+}
+
+function pickMostExhaustedWindow(snapshot: ProviderUsageSnapshot): UsagePreflightSnapshot | null {
+  if (snapshot.windows.length === 0) {
+    return null;
+  }
+  let best: UsageWindow | undefined;
+  let bestRemaining = Number.POSITIVE_INFINITY;
+  for (const window of snapshot.windows) {
+    const remaining = clampPercent(100 - window.usedPercent);
+    if (!best || remaining < bestRemaining) {
+      best = window;
+      bestRemaining = remaining;
+    }
+  }
+  if (!best) {
+    return null;
+  }
+  return {
+    providerId: snapshot.provider,
+    window: best,
+    remainingPercent: bestRemaining,
+  };
+}
+
+async function loadSnapshotForProvider(params: {
+  providerId: UsageProviderId;
+  now: number;
+  timeoutMs: number;
+}): Promise<ProviderUsageSnapshot | null> {
+  const cached = usageSnapshotCache.get(params.providerId);
+  if (cached && cached.expiresAt > params.now) {
+    return cached.snapshot;
+  }
+
+  try {
+    const summary = await loadProviderUsageSummary({
+      providers: [params.providerId],
+      timeoutMs: params.timeoutMs,
+      now: params.now,
+    });
+    const snapshot =
+      summary.providers.find((entry) => entry.provider === params.providerId) ?? null;
+    usageSnapshotCache.set(params.providerId, {
+      snapshot,
+      expiresAt: params.now + USAGE_PREFLIGHT_CACHE_TTL_MS,
+    });
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+function formatResetHint(resetAt?: number, now: number = Date.now()): string | undefined {
+  if (!resetAt || !Number.isFinite(resetAt)) {
+    return undefined;
+  }
+  const diffMs = Math.max(0, resetAt - now);
+  if (diffMs <= 0) {
+    return "resets now";
+  }
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 60) {
+    return `resets in ${diffMin}m`;
+  }
+  const hours = Math.floor(diffMin / 60);
+  const minutes = diffMin % 60;
+  if (hours < 24) {
+    return minutes > 0 ? `resets in ${hours}h ${minutes}m` : `resets in ${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  return `resets in ${days}d`;
+}
+
+function buildUserMessage(params: {
+  providerId: UsageProviderId;
+  remainingPercent: number;
+  windowLabel: string;
+  resetAt?: number;
+  now: number;
+}): string {
+  const resetHint = formatResetHint(params.resetAt, params.now);
+  const resetSuffix = resetHint ? ` (${resetHint})` : "";
+  return (
+    `Usage guard: request blocked to avoid hitting ${params.providerId} limits. ` +
+    `About ${params.remainingPercent.toFixed(0)}% remains in the ${params.windowLabel} window${resetSuffix}. ` +
+    "Switch model/provider/auth profile or wait for reset, then try again."
+  );
+}
+
+export class UsagePreflightError extends Error {
+  readonly details: UsagePreflightDecision;
+  readonly userMessage: string;
+
+  constructor(details: UsagePreflightDecision, userMessage: string) {
+    super(userMessage);
+    this.name = "UsagePreflightError";
+    this.details = details;
+    this.userMessage = userMessage;
+  }
+}
+
+export function isUsagePreflightError(error: unknown): error is UsagePreflightError {
+  return error instanceof UsagePreflightError;
+}
+
+export async function evaluateUsagePreflight(params: {
+  provider?: string;
+  prompt: string;
+  historyMessages: AgentMessage[];
+  now?: number;
+  timeoutMs?: number;
+}): Promise<UsagePreflightDecision> {
+  const now = params.now ?? Date.now();
+  const providerId = resolveUsageProviderId(params.provider);
+  const estimatedPromptTokens = estimatePromptTokensForPreflight({
+    historyMessages: params.historyMessages,
+    prompt: params.prompt,
+  });
+
+  if (!providerId) {
+    return {
+      blocked: false,
+      warning: false,
+      estimatedPromptTokens,
+    };
+  }
+
+  const timeoutMs =
+    typeof params.timeoutMs === "number" && params.timeoutMs > 0 ? params.timeoutMs : 1_500;
+  const snapshot = await loadSnapshotForProvider({ providerId, now, timeoutMs });
+  if (!snapshot || snapshot.error) {
+    return {
+      providerId,
+      blocked: false,
+      warning: false,
+      estimatedPromptTokens,
+    };
+  }
+
+  const exhausted = pickMostExhaustedWindow(snapshot);
+  if (!exhausted) {
+    return {
+      providerId,
+      blocked: false,
+      warning: false,
+      estimatedPromptTokens,
+    };
+  }
+
+  const remaining = exhausted.remainingPercent;
+  const warning = remaining <= WARN_REMAINING_PERCENT;
+  const blocked =
+    remaining <= ALWAYS_BLOCK_REMAINING_PERCENT ||
+    (remaining <= BLOCK_REMAINING_PERCENT &&
+      estimatedPromptTokens >= BLOCK_MIN_ESTIMATED_PROMPT_TOKENS);
+
+  return {
+    providerId,
+    blocked,
+    warning,
+    estimatedPromptTokens,
+    remainingPercent: remaining,
+    windowLabel: exhausted.window.label,
+    resetAt: exhausted.window.resetAt,
+  };
+}
+
+export function usagePreflightDecisionMessage(
+  decision: UsagePreflightDecision,
+  now: number = Date.now(),
+): string | undefined {
+  if (!decision.providerId || decision.remainingPercent === undefined || !decision.windowLabel) {
+    return undefined;
+  }
+  return buildUserMessage({
+    providerId: decision.providerId,
+    remainingPercent: decision.remainingPercent,
+    windowLabel: decision.windowLabel,
+    resetAt: decision.resetAt,
+    now,
+  });
+}
+
+export function _resetUsagePreflightCacheForTests(): void {
+  usageSnapshotCache.clear();
+}


### PR DESCRIPTION
## Summary

- Problem: near-quota requests can fail late and create poor UX.
- Fix: add a fail-open usage preflight guard (warn/block thresholds) before prompt send.
- Runner behavior: blocked preflight returns user-facing `payloads[].isError=true` and skips overflow-compaction fallback.
- Scope boundary: no surrogate sanitization changes in this PR; no public contract expansion for `EmbeddedPiRunMeta.error.kind`.
- AI-assisted disclosure: AI-assisted implementation, then manual review and manual test verification.

## Quick Review (3-5 min)

1. `src/agents/pi-embedded-runner/usage-preflight.ts`: threshold logic + fail-open cache/timeout behavior.
2. `src/agents/pi-embedded-runner/run/attempt.ts`: where preflight is invoked.
3. `src/agents/pi-embedded-runner/run.ts`: early return for `UsagePreflightError` as user-facing error payload.
4. Tests: warning-only, hard-block, fail-open, and no compaction fallback on preflight block.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #21557

## User-visible / Behavior Changes

- Low remaining quota can emit warning logs.
- Critically low remaining quota can proactively block a request before provider call.
- If usage telemetry is unavailable/unreliable, guard fails open (no proactive block).
- Blocked preflight returns explicit error payload and does not enter overflow-compaction retry path.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - Risk: pre-send usage fetch adds dependency/latency.
  - Mitigation: short timeout, small TTL cache, and fail-open semantics.

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: Node 22 / pnpm 10
- Integration/channel: N/A (runner-level tests with usage mocks)

### Steps

1. Mock remaining quota windows at warning and critical thresholds.
2. Run preflight evaluation and runner flow.
3. Verify warn-only behavior, hard-block behavior, and fail-open when usage API data is unavailable.
4. Verify blocked preflight does not continue into overflow-compaction fallback.

### Expected

- Warn near low quota.
- Block only at critical conditions.
- Fail open on telemetry outage.
- Return clear user-facing blocked payload.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- `corepack pnpm vitest run src/agents/pi-embedded-runner/usage-preflight.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`
- `corepack pnpm oxlint --type-aware` on touched files
- Manual verification after follow-up patch to keep existing error-context formatting behavior in `run.ts`.
- Not verified here: full repo `corepack pnpm tsgo` due pre-existing unrelated TS2742 baseline failures.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert quickly: revert commits `61eac88536b9cf976d08d780419f6d59d36d0027` and `5c759c117d9852dbe1e5cd07ab826b8d635d4af2`.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/usage-preflight.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-runner/run.ts`

## Risks and Mitigations

- Risk: threshold heuristics may be too strict or too lenient per provider/account.
- Mitigation: bounded heuristics, fail-open behavior, focused boundary tests, and linked policy issue #21557 for maintainer tuning.
