### PR TITLE
fix: exec host error message shows configuredHost instead of requestedHost

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -285,7 +285,7 @@ export function createExecTool(
       if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {
         throw new Error(
           `exec host not allowed (requested ${renderExecHostLabel(requestedHost)}; ` +
-            `configure tools.exec.host=${renderExecHostLabel(configuredHost)} to allow).`,
+            `configure tools.exec.host=${renderExecHostLabel(requestedHost)} to allow).`,
         );
       }
       if (elevatedRequested) {


### PR DESCRIPTION
## Summary

One-character fix: change `configuredHost` → `requestedHost` in the exec host error message hint.

## Problem

When an LLM agent requests an exec host that differs from the configured host, the error message suggests configuring the *already-configured* value, making the hint self-referential and useless.

**Before:**
```
exec host not allowed (requested node; configure tools.exec.host=sandbox to allow)
```

**After:**
```
exec host not allowed (requested node; configure tools.exec.host=node to allow)
```

## Files Changed

- `src/agents/bash-tools.exec.ts` — line 288

Fixes #21501

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a self-referential error message in the exec host validation logic. When an agent requests a different exec host than configured, the error message now correctly suggests configuring the *requested* host value instead of the already-configured value.

- Changed `src/agents/bash-tools.exec.ts:288` from `configuredHost` to `requestedHost` in the error message hint
- The fix transforms unhelpful messages like "configure tools.exec.host=sandbox to allow" (when sandbox is already configured) into actionable ones like "configure tools.exec.host=node to allow" (when node was requested)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a trivial one-character fix that corrects a logic error in an error message. The fix changes which variable is referenced in the error message from `configuredHost` (already configured) to `requestedHost` (the value needed). This makes the error message actionable. The test suite only checks that the error is thrown, not the exact message content, so no test updates are needed. The change is isolated, well-understood, and fixes a clear bug.
- No files require special attention

<sub>Last reviewed commit: 33d0d65</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->