### PR TITLE
fix: watermark at-most-once → at-least-once message delivery

### DIFF
--- a/src/slack/monitor/catchup.ts
+++ b/src/slack/monitor/catchup.ts
@@ -1,0 +1,424 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { SlackMessageEvent } from "../types.js";
+import type { SlackMonitorContext } from "./context.js";
+import type { SlackMessageHandler } from "./message-handler.js";
+import { resolveSlackChannelConfig } from "./channel-config.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SlackCatchupState = {
+  version: 1;
+  channels: Record<string, string>; // channelId -> latest processed ts
+  globalTs: string; // fallback watermark
+  updatedAt: string; // ISO timestamp
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CATCHUP_WINDOW_SEC = 30 * 60; // 30 minutes max lookback
+const CATCHUP_PER_CHANNEL_LIMIT = 20; // max messages per channel
+const CATCHUP_INTER_CHANNEL_DELAY_MS = 200; // pause between channels
+const WATERMARK_FLUSH_INTERVAL_MS = 30_000; // 30 seconds
+
+// ---------------------------------------------------------------------------
+// State file path helper
+// ---------------------------------------------------------------------------
+
+function resolveStateFilePath(accountId: string): string {
+  const homeDir = os.homedir();
+  return path.join(homeDir, ".openclaw", `slack-catchup-${accountId}.json`);
+}
+
+// ---------------------------------------------------------------------------
+// Load / Save state
+// ---------------------------------------------------------------------------
+
+export async function loadCatchupState(accountId: string): Promise<SlackCatchupState | null> {
+  const filePath = resolveStateFilePath(accountId);
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as SlackCatchupState;
+    if (parsed.version !== 1) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCatchupState(
+  accountId: string,
+  state: SlackCatchupState,
+): Promise<void> {
+  const filePath = resolveStateFilePath(accountId);
+  const dir = path.dirname(filePath);
+  await fs.promises.mkdir(dir, { recursive: true });
+  const tmpPath = `${filePath}.tmp`;
+  await fs.promises.writeFile(tmpPath, JSON.stringify(state, null, 2), "utf-8");
+  await fs.promises.rename(tmpPath, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Watermark buffer (in-memory, flushed periodically)
+// ---------------------------------------------------------------------------
+
+/** Per-account in-memory watermark buffers. */
+const watermarkBuffers = new Map<string, Record<string, string>>();
+
+/** Active flush interval timers per account. */
+const flushTimers = new Map<string, ReturnType<typeof setInterval>>();
+
+/**
+ * Update the in-memory watermark for a channel.
+ * Only advances the watermark (never goes backwards).
+ */
+export function updateCatchupWatermark(channelId: string, ts: string, accountId: string): void {
+  if (!channelId || !ts) {
+    return;
+  }
+  let buffer = watermarkBuffers.get(accountId);
+  if (!buffer) {
+    buffer = {};
+    watermarkBuffers.set(accountId, buffer);
+  }
+  const existing = buffer[channelId];
+  if (!existing || ts > existing) {
+    buffer[channelId] = ts;
+  }
+}
+
+/**
+ * Flush the in-memory watermark buffer to disk for a given account.
+ * Merges with any existing on-disk state so concurrent flushes are safe.
+ */
+export async function flushCatchupWatermark(accountId: string): Promise<void> {
+  const buffer = watermarkBuffers.get(accountId);
+  if (!buffer || Object.keys(buffer).length === 0) {
+    return;
+  }
+
+  // Take a snapshot and clear the buffer
+  const snapshot = { ...buffer };
+  for (const key of Object.keys(snapshot)) {
+    delete buffer[key];
+  }
+
+  const existing = await loadCatchupState(accountId);
+  const channels = existing?.channels ?? {};
+  let globalTs = existing?.globalTs ?? "0";
+
+  for (const [channelId, ts] of Object.entries(snapshot)) {
+    const current = channels[channelId];
+    if (!current || ts > current) {
+      channels[channelId] = ts;
+    }
+    if (ts > globalTs) {
+      globalTs = ts;
+    }
+  }
+
+  const state: SlackCatchupState = {
+    version: 1,
+    channels,
+    globalTs,
+    updatedAt: new Date().toISOString(),
+  };
+  await saveCatchupState(accountId, state);
+}
+
+/**
+ * Start a periodic flush timer for the given account.
+ * Returns a cleanup function that stops the timer and flushes one last time.
+ */
+export function startWatermarkFlushTimer(accountId: string): () => Promise<void> {
+  // Avoid duplicate timers
+  const existingTimer = flushTimers.get(accountId);
+  if (existingTimer) {
+    clearInterval(existingTimer);
+  }
+
+  const timer = setInterval(() => {
+    void flushCatchupWatermark(accountId).catch(() => {
+      // silently ignore periodic flush errors
+    });
+  }, WATERMARK_FLUSH_INTERVAL_MS);
+
+  // Ensure the timer does not prevent process exit
+  if (typeof timer === "object" && "unref" in timer) {
+    timer.unref();
+  }
+  flushTimers.set(accountId, timer);
+
+  return async () => {
+    clearInterval(timer);
+    flushTimers.delete(accountId);
+    await flushCatchupWatermark(accountId);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Startup catch-up
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the list of channel IDs to scan for catch-up.
+ * Uses the resolved channelsConfig from the monitor context (already resolved
+ * from names to IDs by the time provider.ts calls us).
+ */
+function resolveChannelIdsToScan(ctx: SlackMonitorContext): string[] {
+  const channels = ctx.channelsConfig;
+  if (!channels) {
+    return [];
+  }
+  const ids: string[] = [];
+  for (const key of Object.keys(channels)) {
+    if (key === "*") {
+      continue;
+    }
+    // Only include keys that look like Slack channel IDs (C... or G...)
+    if (/^[CG][A-Z0-9]+$/i.test(key)) {
+      ids.push(key);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Compute the "oldest" timestamp for the Slack API query.
+ * Uses the per-channel watermark if available, falls back to globalTs,
+ * then clamps to CATCHUP_WINDOW_SEC from now.
+ */
+function resolveOldestTs(
+  channelId: string,
+  state: SlackCatchupState | null,
+): string {
+  const now = Date.now() / 1000;
+  const windowFloor = String(now - CATCHUP_WINDOW_SEC);
+
+  if (!state) {
+    return windowFloor;
+  }
+
+  const channelTs = state.channels[channelId];
+  const candidate = channelTs ?? state.globalTs;
+
+  if (!candidate || candidate === "0") {
+    return windowFloor;
+  }
+
+  // Clamp: never look back further than the window
+  return candidate < windowFloor ? windowFloor : candidate;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export type PerformStartupCatchUpParams = {
+  ctx: SlackMonitorContext;
+  handleSlackMessage: SlackMessageHandler;
+  abortSignal?: AbortSignal;
+};
+
+export async function performStartupCatchUp(
+  params: PerformStartupCatchUpParams,
+): Promise<void> {
+  const { ctx, handleSlackMessage, abortSignal } = params;
+  const runtime = ctx.runtime;
+  const accountId = ctx.accountId;
+
+  const state = await loadCatchupState(accountId);
+  if (!state) {
+    runtime.log?.(`slack catch-up [${accountId}]: no previous state found, skipping catch-up`);
+    // Initialize state file so next restart has a baseline
+    const now = String(Date.now() / 1000);
+    await saveCatchupState(accountId, {
+      version: 1,
+      channels: {},
+      globalTs: now,
+      updatedAt: new Date().toISOString(),
+    });
+    return;
+  }
+
+  const channelIds = resolveChannelIdsToScan(ctx);
+  if (channelIds.length === 0) {
+    runtime.log?.(`slack catch-up [${accountId}]: no channels configured, skipping`);
+    return;
+  }
+
+  // Also include DM channels: list open IMs
+  const dmChannelIds: string[] = [];
+  if (ctx.dmEnabled) {
+    try {
+      const dmResult = await ctx.app.client.conversations.list({
+        token: ctx.botToken,
+        types: "im",
+        limit: 200,
+      });
+      for (const ch of (dmResult as { channels?: Array<{ id?: string; is_open?: boolean }> })
+        .channels ?? []) {
+        if (ch.id) {
+          dmChannelIds.push(ch.id);
+        }
+      }
+    } catch (err) {
+      runtime.error?.(`slack catch-up [${accountId}]: failed to list DM channels: ${String(err)}`);
+    }
+  }
+
+  const allChannelIds = [...channelIds, ...dmChannelIds];
+  let totalMessages = 0;
+  let channelsScanned = 0;
+  let channelsWithMessages = 0;
+
+  runtime.log?.(
+    `slack catch-up [${accountId}]: scanning ${allChannelIds.length} channels (${channelIds.length} group + ${dmChannelIds.length} DM)`,
+  );
+
+  for (const channelId of allChannelIds) {
+    if (abortSignal?.aborted) {
+      runtime.log?.(`slack catch-up [${accountId}]: aborted`);
+      break;
+    }
+
+    const oldest = resolveOldestTs(channelId, state);
+    channelsScanned++;
+
+    try {
+      const result = await ctx.app.client.conversations.history({
+        token: ctx.botToken,
+        channel: channelId,
+        oldest,
+        limit: CATCHUP_PER_CHANNEL_LIMIT,
+        inclusive: false, // exclude the watermark message itself
+      });
+
+      const messages = (result.messages ?? []) as Array<{
+        type?: string;
+        user?: string;
+        bot_id?: string;
+        subtype?: string;
+        text?: string;
+        ts?: string;
+        thread_ts?: string;
+        event_ts?: string;
+        channel?: string;
+        channel_type?: string;
+        files?: unknown[];
+      }>;
+
+      if (messages.length === 0) {
+        continue;
+      }
+
+      // Determine channel type and requireMention for filtering
+      const channelInfo = await ctx.resolveChannelName(channelId);
+      const channelType = channelInfo?.type ?? (channelId.startsWith("D") ? "im" : "channel");
+      const isDm = channelType === "im";
+      const channelConfig = resolveSlackChannelConfig({
+        channelId,
+        channelName: channelInfo?.name,
+        channels: ctx.channelsConfig,
+        defaultRequireMention: ctx.defaultRequireMention,
+      });
+      const requireMention = !isDm && (channelConfig?.requireMention ?? true);
+
+      // Sort oldest first (Slack returns newest first)
+      const sorted = [...messages].sort((a, b) => {
+        const tsA = a.ts ?? "0";
+        const tsB = b.ts ?? "0";
+        return tsA < tsB ? -1 : tsA > tsB ? 1 : 0;
+      });
+
+      let channelCount = 0;
+      for (const msg of sorted) {
+        // Skip bot's own messages
+        if (msg.user === ctx.botUserId) {
+          continue;
+        }
+        if (msg.bot_id && msg.user === ctx.botUserId) {
+          continue;
+        }
+
+        // Skip subtypes except file_share
+        if (msg.subtype && msg.subtype !== "file_share") {
+          continue;
+        }
+
+        // For requireMention channels, only catch up messages that mention the bot
+        if (requireMention && ctx.botUserId) {
+          const text = msg.text ?? "";
+          if (!text.includes(`<@${ctx.botUserId}>`)) {
+            continue;
+          }
+        }
+
+        // Build a SlackMessageEvent from the history message
+        const event: SlackMessageEvent = {
+          type: "message",
+          user: msg.user,
+          bot_id: msg.bot_id,
+          subtype: msg.subtype,
+          text: msg.text,
+          ts: msg.ts,
+          thread_ts: msg.thread_ts,
+          event_ts: msg.event_ts ?? msg.ts,
+          channel: channelId,
+          channel_type: channelType,
+          files: msg.files as SlackMessageEvent["files"],
+        };
+
+        // Determine if the message was a mention
+        const wasMentioned = ctx.botUserId
+          ? Boolean(event.text?.includes(`<@${ctx.botUserId}>`))
+          : false;
+
+        try {
+          await handleSlackMessage(event, {
+            source: "message",
+            wasMentioned,
+          });
+          channelCount++;
+          totalMessages++;
+
+          // Update watermark immediately for each processed message
+          if (msg.ts) {
+            updateCatchupWatermark(channelId, msg.ts, accountId);
+          }
+        } catch (err) {
+          runtime.error?.(
+            `slack catch-up [${accountId}]: failed to process message ${msg.ts} in ${channelId}: ${String(err)}`,
+          );
+        }
+      }
+
+      if (channelCount > 0) {
+        channelsWithMessages++;
+      }
+    } catch (err) {
+      runtime.error?.(
+        `slack catch-up [${accountId}]: failed to fetch history for ${channelId}: ${String(err)}`,
+      );
+    }
+
+    // Delay between channels to avoid rate limits
+    if (channelsScanned < allChannelIds.length) {
+      await sleep(CATCHUP_INTER_CHANNEL_DELAY_MS);
+    }
+  }
+
+  // Flush watermarks after catch-up completes
+  await flushCatchupWatermark(accountId);
+
+  runtime.log?.(
+    `slack catch-up [${accountId}]: completed — scanned ${channelsScanned} channels, dispatched ${totalMessages} messages from ${channelsWithMessages} channels`,
+  );
+}

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -19,7 +19,7 @@ import {
 import type { SlackStreamSession } from "../../streaming.js";
 import { appendSlackStream, startSlackStream, stopSlackStream } from "../../streaming.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
-import { updateCatchupWatermark } from "../catchup.js";
+import { completeInflightMessage, registerInflightMessage, updateCatchupWatermark } from "../catchup.js";
 import { createSlackReplyDeliveryPlan, deliverReplies, resolveSlackThreadTs } from "../replies.js";
 import type { PreparedSlackMessage } from "./types.js";
 
@@ -348,50 +348,84 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     hasStreamedMessage = true;
   };
 
-  const { queuedFinal, counts } = await dispatchInboundMessage({
-    ctx: prepared.ctxPayload,
-    cfg,
-    dispatcher,
-    replyOptions: {
-      ...replyOptions,
-      skillFilter: prepared.channelConfig?.skills,
-      hasRepliedRef,
-      disableBlockStreaming: useStreaming
-        ? true
-        : typeof account.config.blockStreaming === "boolean"
-          ? !account.config.blockStreaming
-          : undefined,
-      onModelSelected,
-      onPartialReply: useStreaming
-        ? undefined
-        : async (payload) => {
-            updateDraftFromPartial(payload.text);
-          },
-      onAssistantMessageStart: useStreaming
-        ? undefined
-        : async () => {
-            if (hasStreamedMessage) {
-              draftStream.forceNewMessage();
-              hasStreamedMessage = false;
-              appendRenderedText = "";
-              appendSourceText = "";
-              statusUpdateCount = 0;
-            }
-          },
-      onReasoningEnd: useStreaming
-        ? undefined
-        : async () => {
-            if (hasStreamedMessage) {
-              draftStream.forceNewMessage();
-              hasStreamedMessage = false;
-              appendRenderedText = "";
-              appendSourceText = "";
-              statusUpdateCount = 0;
-            }
-          },
-    },
-  });
-  await draftStream.flush();
+  // -----------------------------------------------------------------------
+  // At-least-once watermark: register this message as in-flight so the
+  // watermark cannot advance past it until processing completes.
+  // -----------------------------------------------------------------------
+  const watermarkTs = message.ts ?? message.event_ts;
+  if (watermarkTs) {
+    registerInflightMessage(message.channel, watermarkTs, account.accountId);
+  }
+
+  let queuedFinal = false;
+  let counts = { tool: 0, block: 0, final: 0 };
+  let processingFailed = false;
+
+  try {
+    const result = await dispatchInboundMessage({
+      ctx: prepared.ctxPayload,
+      cfg,
+      dispatcher,
+      replyOptions: {
+        ...replyOptions,
+        skillFilter: prepared.channelConfig?.skills,
+        hasRepliedRef,
+        disableBlockStreaming: useStreaming
+          ? true
+          : typeof account.config.blockStreaming === "boolean"
+            ? !account.config.blockStreaming
+            : undefined,
+        onModelSelected,
+        onPartialReply: useStreaming
+          ? undefined
+          : async (payload) => {
+              updateDraftFromPartial(payload.text);
+            },
+        onAssistantMessageStart: useStreaming
+          ? undefined
+          : async () => {
+              if (hasStreamedMessage) {
+                draftStream.forceNewMessage();
+                hasStreamedMessage = false;
+                appendRenderedText = "";
+                appendSourceText = "";
+                statusUpdateCount = 0;
+              }
+            },
+        onReasoningEnd: useStreaming
+          ? undefined
+          : async () => {
+              if (hasStreamedMessage) {
+                draftStream.forceNewMessage();
+                hasStreamedMessage = false;
+                appendRenderedText = "";
+                appendSourceText = "";
+                statusUpdateCount = 0;
+              }
+            },
+      },
+    });
+    queuedFinal = result.queuedFinal;
+    counts = result.counts;
+  } catch (err) {
+    processingFailed = true;
+    runtime.error?.(
+      danger(`slack: dispatch failed for ${message.channel}/${watermarkTs ?? message.ts}: ${String(err)}`),
+    );
+  } finally {
+    // Complete in-flight tracking regardless of outcome so deferred
+    // watermarks from other concurrent dispatches can drain.
+    if (watermarkTs) {
+      completeInflightMessage(message.channel, watermarkTs, account.accountId, !processingFailed);
+    }
+  }
+
+  // Best-effort cleanup (runs regardless of processing outcome)
+  try {
+    await draftStream.flush();
+  } catch {
+    // Draft stream flush is best-effort; reply delivery already complete.
+  }
   draftStream.stop();
   markDispatchIdle();
 
@@ -407,8 +441,18 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
   }
 
-  // Advance the catch-up watermark so this message is not re-processed on restart
-  const watermarkTs = message.ts ?? message.event_ts;
+  // On processing failure, do not advance watermark — the message will be
+  // re-processed via catch-up on next restart (at-least-once semantics).
+  if (processingFailed) {
+    try {
+      await draftStream.clear();
+    } catch {
+      // ignore
+    }
+    return;
+  }
+
+  // Advance the catch-up watermark (respects in-flight safety)
   if (watermarkTs) {
     updateCatchupWatermark(message.channel, watermarkTs, account.accountId);
   }


### PR DESCRIPTION
## Summary

The current watermark implementation has an at-most-once delivery bug when messages in the same channel are dispatched concurrently.

**Problem**: If message ts=101 completes before ts=100, the watermark advances to 101. If ts=100 then fails, it will not be re-processed on restart because the watermark is already past it.

**Fix**: Add in-flight message tracking to the watermark system:

1. **`registerInflightMessage()`** — called before dispatch begins, marks the message as in-flight so the watermark cannot advance past it
2. **`completeInflightMessage(success)`** — called in `finally` block after dispatch completes; on failure, the ts is added to a failed set that permanently blocks watermark advancement until process restart
3. **`updateCatchupWatermark()`** — now checks for unresolved messages (in-flight or failed) with lower timestamps; defers the watermark update if any exist
4. **`drainDeferredWatermarks()`** — flushes deferred watermarks that become safe after in-flight messages complete

The dispatch function in `dispatch.ts` is wrapped in try-catch-finally:
- On success: watermark advances normally (respecting in-flight safety)
- On failure: watermark is NOT advanced; message will be re-processed on restart
- Draft stream flush is best-effort (runs regardless of outcome)

On process restart, all in-memory tracking is cleared and catch-up replays from the last safely flushed watermark — guaranteeing **at-least-once** delivery.

> **Stacked PR**: This depends on #21563 and #21564 and should be merged last.

## Test plan
- [ ] Simulate concurrent messages: send 2 messages rapidly to same channel
- [ ] Verify watermark only advances after both complete
- [ ] Simulate failure: mock `dispatchInboundMessage` to throw for one message
- [ ] Verify failed message's ts blocks watermark advancement
- [ ] Restart gateway and verify the failed message is re-processed
- [ ] Verify deferred watermarks drain correctly after in-flight messages complete
- [ ] Load test: send 10+ messages rapidly, verify no message loss
- [ ] Verify draft stream flush failure does not affect watermark tracking

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds in-flight message tracking to fix an at-most-once bug in the Slack watermark system, ensuring at-least-once message delivery guarantees.

The PR implements a deferred watermark mechanism that prevents the watermark from advancing past messages that are still being processed or have failed. When messages complete out-of-order (e.g., ts=101 before ts=100), the watermark advancement is deferred until all earlier messages complete successfully. Failed messages permanently block watermark advancement until process restart, when catch-up replays from the last safe watermark.

Key changes:
- `registerInflightMessage()` marks messages before dispatch to prevent watermark advancement
- `completeInflightMessage()` removes messages from in-flight tracking; failures block watermark until restart
- `updateCatchupWatermark()` defers updates when lower-timestamp messages are unresolved
- `drainDeferredWatermarks()` applies safe watermarks after in-flight messages complete
- dispatch.ts wraps message processing in try-catch-finally with proper tracking
- Watermarks flush periodically (30s) and on shutdown via atomic file writes

<h3>Confidence Score: 4/5</h3>

- Implementation is sound with correct at-least-once semantics and proper concurrency handling
- The in-flight tracking logic correctly handles out-of-order completion and maintains watermark safety. The deferred watermark mechanism properly blocks advancement when lower-timestamp messages are unresolved. String comparison works for Slack's Unix timestamp format (10 digits + decimal). Atomic file writes and JavaScript's single-threaded nature prevent race conditions. One minor point: the catch-up error handling could benefit from explicit tests, but the logic is correct.
- No files require special attention

<sub>Last reviewed commit: e3fd7ab</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->