### PR TITLE
Config: expose Pi compaction tuning values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config/Agents: expose Pi compaction tuning values `agents.defaults.compaction.reserveTokens` and `agents.defaults.compaction.keepRecentTokens` in config schema/types and apply them in embedded Pi runner settings overrides with floor enforcement via `reserveTokensFloor`. (#21568) Thanks @Takhoffman.
 - Auto-reply/WebChat: avoid defaulting inbound runtime channel labels to unrelated providers (for example `whatsapp`) for webchat sessions so channel-specific formatting guidance stays accurate. (#21534) Thanks @lbo728.
 - Status: include persisted `cacheRead`/`cacheWrite` in session summaries so compact `/status` output consistently shows cache hit percentages from real session data.
 - Heartbeat/Cron: restore interval heartbeat behavior so missing `HEARTBEAT.md` no longer suppresses runs (only effectively empty files skip), preserving prompt-driven and tagged-cron execution paths.

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -37,10 +37,7 @@ import {
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../pi-embedded-helpers.js";
-import {
-  ensurePiCompactionReserveTokens,
-  resolveCompactionReserveTokensFloor,
-} from "../pi-settings.js";
+import { applyPiCompactionSettingsFromConfig } from "../pi-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
 import { resolveSandboxContext } from "../sandbox.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
@@ -532,9 +529,9 @@ export async function compactEmbeddedPiSessionDirect(
       });
       trackSessionManagerAccess(params.sessionFile);
       const settingsManager = SettingsManager.create(effectiveWorkspace, agentDir);
-      ensurePiCompactionReserveTokens({
+      applyPiCompactionSettingsFromConfig({
         settingsManager,
-        minReserveTokens: resolveCompactionReserveTokensFloor(params.config),
+        cfg: params.config,
       });
       // Call for side effects (sets compaction/pruning runtime state)
       buildEmbeddedExtensionPaths({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -45,10 +45,7 @@ import {
   validateGeminiTurns,
 } from "../../pi-embedded-helpers.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
-import {
-  ensurePiCompactionReserveTokens,
-  resolveCompactionReserveTokensFloor,
-} from "../../pi-settings.js";
+import { applyPiCompactionSettingsFromConfig } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
 import { resolveSandboxContext } from "../../sandbox.js";
@@ -531,9 +528,9 @@ export async function runEmbeddedAttempt(
       });
 
       const settingsManager = SettingsManager.create(effectiveWorkspace, agentDir);
-      ensurePiCompactionReserveTokens({
+      applyPiCompactionSettingsFromConfig({
         settingsManager,
-        minReserveTokens: resolveCompactionReserveTokensFloor(params.config),
+        cfg: params.config,
       });
 
       // Call for side effects (sets compaction/pruning runtime state)

--- a/src/agents/pi-settings.e2e.test.ts
+++ b/src/agents/pi-settings.e2e.test.ts
@@ -1,37 +1,123 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  applyPiCompactionSettingsFromConfig,
   DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
-  ensurePiCompactionReserveTokens,
   resolveCompactionReserveTokensFloor,
 } from "./pi-settings.js";
 
-describe("ensurePiCompactionReserveTokens", () => {
+describe("applyPiCompactionSettingsFromConfig", () => {
   it("bumps reserveTokens when below floor", () => {
     const settingsManager = {
       getCompactionReserveTokens: () => 16_384,
+      getCompactionKeepRecentTokens: () => 20_000,
       applyOverrides: vi.fn(),
     };
 
-    const result = ensurePiCompactionReserveTokens({ settingsManager });
+    const result = applyPiCompactionSettingsFromConfig({ settingsManager });
 
-    expect(result).toEqual({
-      didOverride: true,
-      reserveTokens: DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
-    });
+    expect(result.didOverride).toBe(true);
+    expect(result.compaction.reserveTokens).toBe(DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR);
     expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
       compaction: { reserveTokens: DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR },
     });
   });
 
-  it("does not override when already above floor", () => {
+  it("does not override when already above floor and not in safeguard mode", () => {
     const settingsManager = {
       getCompactionReserveTokens: () => 32_000,
+      getCompactionKeepRecentTokens: () => 20_000,
       applyOverrides: vi.fn(),
     };
 
-    const result = ensurePiCompactionReserveTokens({ settingsManager });
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: { agents: { defaults: { compaction: { mode: "default" } } } },
+    });
 
-    expect(result).toEqual({ didOverride: false, reserveTokens: 32_000 });
+    expect(result.didOverride).toBe(false);
+    expect(result.compaction.reserveTokens).toBe(32_000);
+    expect(settingsManager.applyOverrides).not.toHaveBeenCalled();
+  });
+
+  it("applies explicit reserveTokens but still enforces floor", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 10_000,
+      getCompactionKeepRecentTokens: () => 20_000,
+      applyOverrides: vi.fn(),
+    };
+
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { reserveTokens: 12_000, reserveTokensFloor: 20_000 },
+          },
+        },
+      },
+    });
+
+    expect(result.compaction.reserveTokens).toBe(20_000);
+    expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
+      compaction: { reserveTokens: 20_000 },
+    });
+  });
+
+  it("applies keepRecentTokens when explicitly configured", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 20_000,
+      getCompactionKeepRecentTokens: () => 20_000,
+      applyOverrides: vi.fn(),
+    };
+
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              keepRecentTokens: 15_000,
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.compaction.keepRecentTokens).toBe(15_000);
+    expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
+      compaction: { keepRecentTokens: 15_000 },
+    });
+  });
+
+  it("preserves current keepRecentTokens when safeguard mode leaves it unset", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 25_000,
+      getCompactionKeepRecentTokens: () => 20_000,
+      applyOverrides: vi.fn(),
+    };
+
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: { agents: { defaults: { compaction: { mode: "safeguard" } } } },
+    });
+
+    expect(result.compaction.keepRecentTokens).toBe(20_000);
+    expect(settingsManager.applyOverrides).not.toHaveBeenCalled();
+  });
+
+  it("treats keepRecentTokens=0 as invalid and keeps the current setting", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 25_000,
+      getCompactionKeepRecentTokens: () => 20_000,
+      applyOverrides: vi.fn(),
+    };
+
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: { agents: { defaults: { compaction: { mode: "safeguard", keepRecentTokens: 0 } } } },
+    });
+
+    expect(result.compaction.keepRecentTokens).toBe(20_000);
     expect(settingsManager.applyOverrides).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -4,7 +4,13 @@ export const DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
 
 type PiSettingsManagerLike = {
   getCompactionReserveTokens: () => number;
-  applyOverrides: (overrides: { compaction: { reserveTokens: number } }) => void;
+  getCompactionKeepRecentTokens: () => number;
+  applyOverrides: (overrides: {
+    compaction: {
+      reserveTokens?: number;
+      keepRecentTokens?: number;
+    };
+  }) => void;
 };
 
 export function ensurePiCompactionReserveTokens(params: {
@@ -31,4 +37,61 @@ export function resolveCompactionReserveTokensFloor(cfg?: OpenClawConfig): numbe
     return Math.floor(raw);
   }
   return DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR;
+}
+
+function toNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function toPositiveInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+export function applyPiCompactionSettingsFromConfig(params: {
+  settingsManager: PiSettingsManagerLike;
+  cfg?: OpenClawConfig;
+}): {
+  didOverride: boolean;
+  compaction: { reserveTokens: number; keepRecentTokens: number };
+} {
+  const currentReserveTokens = params.settingsManager.getCompactionReserveTokens();
+  const currentKeepRecentTokens = params.settingsManager.getCompactionKeepRecentTokens();
+  const compactionCfg = params.cfg?.agents?.defaults?.compaction;
+
+  const configuredReserveTokens = toNonNegativeInt(compactionCfg?.reserveTokens);
+  const configuredKeepRecentTokens = toPositiveInt(compactionCfg?.keepRecentTokens);
+  const reserveTokensFloor = resolveCompactionReserveTokensFloor(params.cfg);
+
+  const targetReserveTokens = Math.max(
+    configuredReserveTokens ?? currentReserveTokens,
+    reserveTokensFloor,
+  );
+  const targetKeepRecentTokens = configuredKeepRecentTokens ?? currentKeepRecentTokens;
+
+  const overrides: { reserveTokens?: number; keepRecentTokens?: number } = {};
+  if (targetReserveTokens !== currentReserveTokens) {
+    overrides.reserveTokens = targetReserveTokens;
+  }
+  if (targetKeepRecentTokens !== currentKeepRecentTokens) {
+    overrides.keepRecentTokens = targetKeepRecentTokens;
+  }
+
+  const didOverride = Object.keys(overrides).length > 0;
+  if (didOverride) {
+    params.settingsManager.applyOverrides({ compaction: overrides });
+  }
+
+  return {
+    didOverride,
+    compaction: {
+      reserveTokens: targetReserveTokens,
+      keepRecentTokens: targetKeepRecentTokens,
+    },
+  };
 }

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -38,10 +38,41 @@ describe("config compaction settings", () => {
 
       expect(cfg.agents?.defaults?.compaction?.reserveTokensFloor).toBe(12_345);
       expect(cfg.agents?.defaults?.compaction?.mode).toBe("safeguard");
+      expect(cfg.agents?.defaults?.compaction?.reserveTokens).toBeUndefined();
+      expect(cfg.agents?.defaults?.compaction?.keepRecentTokens).toBeUndefined();
       expect(cfg.agents?.defaults?.compaction?.memoryFlush?.enabled).toBe(false);
       expect(cfg.agents?.defaults?.compaction?.memoryFlush?.softThresholdTokens).toBe(1234);
       expect(cfg.agents?.defaults?.compaction?.memoryFlush?.prompt).toBe("Write notes.");
       expect(cfg.agents?.defaults?.compaction?.memoryFlush?.systemPrompt).toBe("Flush memory now.");
+    });
+  });
+
+  it("preserves pi compaction override values", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            agents: {
+              defaults: {
+                compaction: {
+                  reserveTokens: 15_000,
+                  keepRecentTokens: 12_000,
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const cfg = loadConfig();
+      expect(cfg.agents?.defaults?.compaction?.reserveTokens).toBe(15_000);
+      expect(cfg.agents?.defaults?.compaction?.keepRecentTokens).toBe(12_000);
     });
   });
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -289,6 +289,10 @@ export type AgentCompactionMode = "default" | "safeguard";
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
+  /** Pi reserve tokens target before floor enforcement. */
+  reserveTokens?: number;
+  /** Pi keepRecentTokens budget used for cut-point selection. */
+  keepRecentTokens?: number;
   /** Minimum reserve tokens enforced for Pi compaction (0 disables the floor). */
   reserveTokensFloor?: number;
   /** Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -91,6 +91,8 @@ export const AgentDefaultsSchema = z
     compaction: z
       .object({
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+        reserveTokens: z.number().int().nonnegative().optional(),
+        keepRecentTokens: z.number().int().positive().optional(),
         reserveTokensFloor: z.number().int().nonnegative().optional(),
         maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
         memoryFlush: z


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw did not expose Pi compaction tuning knobs (`reserveTokens`, `keepRecentTokens`) in `agents.defaults.compaction`, so users could not centrally tune Pi compaction behavior from OpenClaw config.
- Why it matters: Tuning compaction thresholds is useful for stability and context retention, but required manual Pi-side settings changes.
- What changed: Added config schema/types for `agents.defaults.compaction.reserveTokens` and `agents.defaults.compaction.keepRecentTokens`, and wired embedded Pi runners to apply those values via `SettingsManager.applyOverrides`, while continuing to enforce `reserveTokensFloor`.
- What did NOT change (scope boundary): Did not expose `compaction.enabled`; did not change safeguard pruning logic; did not add docs/UI changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `agents.defaults.compaction.reserveTokens` is now accepted and applied to embedded Pi runs.
- `agents.defaults.compaction.keepRecentTokens` is now accepted and applied to embedded Pi runs.
- `agents.defaults.compaction.reserveTokensFloor` continues to enforce a minimum floor for applied reserve tokens.
- `agents.defaults.compaction.enabled` is intentionally not exposed in this PR.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A (config + runner wiring)
- Integration/channel (if any): Embedded Pi runner paths
- Relevant config (redacted):

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "reserveTokens": 15000,
        "keepRecentTokens": 12000,
        "reserveTokensFloor": 20000
      }
    }
  }
}
```

### Steps

1. Set compaction tuning values in `openclaw.json` under `agents.defaults.compaction`.
2. Execute embedded run/compaction paths that create `SettingsManager`.
3. Observe that applied Pi compaction settings include tuned values with floor enforcement.

### Expected

- Config parses successfully.
- Pi settings overrides include tuned `reserveTokens` / `keepRecentTokens`.
- `reserveTokens` never drops below configured/default floor.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm tsgo`
  - `pnpm test src/config/config.compaction-settings.test.ts`
  - `pnpm exec vitest run -c vitest.e2e.config.ts src/agents/pi-settings.e2e.test.ts`
- Edge cases checked:
  - `keepRecentTokens` unset preserves current Pi setting (no forced safeguard override)
  - `keepRecentTokens: 0` is treated invalid and preserves current setting
  - reserve floor enforcement still applies
- What you did **not** verify:
  - Full end-to-end live provider run

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `a1801984b`.
- Files/config to restore:
  - `src/agents/pi-settings.ts`
  - `src/agents/pi-embedded-runner/compact.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/config/types.agent-defaults.ts`
  - `src/config/zod-schema.agent-defaults.ts`
- Known bad symptoms reviewers should watch for:
  - Compaction tuning values in config not reflected in runtime behavior.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Applying config overrides could unintentionally diverge from existing Pi local settings.
  - Mitigation: Overrides are narrow (only reserve/keepRecent), and tests cover preservation/fallback behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Exposes Pi compaction tuning values (`reserveTokens` and `keepRecentTokens`) through OpenClaw config schema, enabling users to centrally tune Pi compaction behavior without manual Pi-side settings changes.

**Key changes:**
- Added config schema fields for `agents.defaults.compaction.reserveTokens` and `agents.defaults.compaction.keepRecentTokens`
- Created `applyPiCompactionSettingsFromConfig()` to handle both reserve and keepRecent token settings with proper validation
- Refactored embedded Pi runners to use the new unified settings application function
- Maintained `reserveTokensFloor` enforcement to prevent unsafe configurations
- Added comprehensive test coverage for edge cases including zero values and floor enforcement

**Validation alignment:**
- Zod schema validation matches runtime validation (`nonnegative` for reserveTokens, `positive` for keepRecentTokens)
- Invalid values (negative, non-finite, zero for keepRecentTokens) fall back to current Pi settings
- Floor enforcement correctly applies via `Math.max()` logic

**Backward compatibility:**
- Existing `ensurePiCompactionReserveTokens()` function preserved
- New config fields are optional with sensible fallback behavior
- No breaking changes to existing configuration

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper validation at multiple layers (Zod schema + runtime), comprehensive test coverage including edge cases, maintains backward compatibility, and follows established patterns in the codebase. The refactoring from `ensurePiCompactionReserveTokens` to `applyPiCompactionSettingsFromConfig` is clean and maintains the floor enforcement safety mechanism. No security concerns, no breaking changes, and the scope is tightly focused on exposing existing Pi settings through config.
- No files require special attention

<sub>Last reviewed commit: a180198</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->