### PR TITLE
fix: support multiple --media flags in send command

### DIFF
--- a/src/cli/program/message/register.send.ts
+++ b/src/cli/program/message/register.send.ts
@@ -13,7 +13,9 @@ export function registerMessageSendCommand(message: Command, helpers: MessageCli
         )
         .option(
           "--media <path-or-url>",
-          "Attach media (image/audio/video/document). Accepts local paths or URLs.",
+          "Attach media (image/audio/video/document). Accepts local paths or URLs. Repeatable for multiple attachments.",
+          (val: string, acc: string[]) => [...acc, val],
+          [] as string[],
         )
         .option(
           "--buttons <json>",

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -399,10 +399,16 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     : typeof mediaParam === "string" && mediaParam.trim()
       ? [mediaParam]
       : [];
-  const mediaHint =
-    mediaHints[0] ??
-    readStringParam(params, "path", { trim: false }) ??
-    readStringParam(params, "filePath", { trim: false });
+  // Include path/filePath fallbacks if no --media flags were provided
+  if (mediaHints.length === 0) {
+    const pathHint =
+      readStringParam(params, "path", { trim: false }) ??
+      readStringParam(params, "filePath", { trim: false });
+    if (pathHint) {
+      mediaHints.push(pathHint);
+    }
+  }
+  const mediaHint = mediaHints[0];
   const hasCard = params.card != null && typeof params.card === "object";
   const hasComponents = params.components != null && typeof params.components === "object";
   const caption = readStringParam(params, "caption", { allowEmpty: true }) ?? "";


### PR DESCRIPTION
## Problem

Passing `--media` multiple times to `openclaw message send` silently did the wrong thing — only one attachment was sent (or sometimes none), with no error or warning.

This was confusing in practice. An agent was sending batches of images believing they were all arriving, but only the last one was. Discovered when trying to send multiple frames from a particle simulation — the user only ever saw one image per send, not four.

The root cause was two separate issues:

1. **CLI layer**: `--media` was defined as a plain Commander `.option()`, so repeated flags were last-wins. `opts.media` was always a single string.

2. **Discord plugin handler**: Even if the array had been collected, `handle-action.ts` only read `params.media` (singular). Discord uses `tryHandleWithPluginAction` which bypasses the delivery layer (`deliver.ts`) entirely — and `deliver.ts` already correctly iterates `mediaUrls[]`.

The silent failure is the core issue. It would be better to error, but supporting multiple attachments seemed like the right fix since the underlying infrastructure already handles it.

## Changes

**`src/cli/program/message/register.send.ts`**
- Make `--media` repeatable using Commander's accumulator pattern
- `opts.media` is now `string[]` when the flag is repeated

**`src/infra/outbound/message-action-runner.ts`**
- Read `params.media` as `string | string[]` (handles both CLI array and API/tool string)
- Merge all values into `mergedMediaUrls` (already deduplicated)
- Normalize `params.media` to first URL string for downstream compat
- Expose full array as `params.mediaUrls` for plugin handlers

**`src/channels/plugins/actions/discord/handle-action.ts`**
- Read `params.mediaUrls` array, fall back to single `media` param
- When multiple URLs present, send one Discord message per attachment (caption on first only)

## Behavior

- Single `--media`: unchanged
- Multiple `--media`: sends one message per attachment (sequentially)
- Mixed types (images + text files): works
- Other channels: unchanged — the non-plugin delivery path (`deliver.ts`) already iterated `mediaUrls[]` correctly. Channels using the plugin action path would need their own handler updates; they will silently send only the first attachment until then (same behavior as before this PR).

## Known limitations

- No native multi-attachment in a single Discord message (would require multipart REST changes to the channel plugin interface — out of scope)
- Non-Discord plugin-path channels silently send only the first attachment when multiple `--media` flags are used (future work)
- If a later attachment in a multi-send fails, earlier ones have already been sent (no rollback)

## Testing

- Manually tested on Discord: single image ✅, 3 images ✅, 2 images + 1 text file ✅
- 2 new unit tests: multi-media string array input, path/filePath fallback preservation
- 30 unit tests pass across all affected files
- Pre-existing network-dependent test failures (bluebubbles, feishu, matrix) are unrelated to these changes

## Future work

Native multi-attachment in a single Discord message (via multipart REST) would be cleaner UX but is a larger change to the channel plugin interface.