### PR TITLE
fix(update): prevent double restart when refreshing service env

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -602,7 +602,8 @@ describe("update-cli", () => {
       force: true,
       json: undefined,
     });
-    expect(runRestartScript).toHaveBeenCalled();
+    // runDaemonInstall performs kickstart internally; no additional restart should fire
+    expect(runRestartScript).not.toHaveBeenCalled();
     expect(runDaemonRestart).not.toHaveBeenCalled();
   });
 
@@ -634,8 +635,28 @@ describe("update-cli", () => {
     await runRestartFallbackScenario({ daemonInstall: "fail" });
   });
 
-  it("updateCommand falls back to restart when no detached restart script is available", async () => {
-    await runRestartFallbackScenario({ daemonInstall: "ok" });
+  it("updateCommand does not fall back to runDaemonRestart when runDaemonInstall succeeds (no restart script)", async () => {
+    const mockResult: UpdateRunResult = {
+      status: "ok",
+      mode: "git",
+      steps: [],
+      durationMs: 100,
+    };
+
+    vi.mocked(runGatewayUpdate).mockResolvedValue(mockResult);
+    vi.mocked(runDaemonInstall).mockResolvedValue(undefined);
+    prepareRestartScript.mockResolvedValue(null);
+    serviceLoaded.mockResolvedValue(true);
+    vi.mocked(runDaemonRestart).mockResolvedValue(true);
+
+    await updateCommand({});
+
+    expect(runDaemonInstall).toHaveBeenCalledWith({
+      force: true,
+      json: undefined,
+    });
+    // runDaemonInstall performs kickstart internally; runDaemonRestart must not also fire
+    expect(runDaemonRestart).not.toHaveBeenCalled();
   });
 
   it("updateCommand does not refresh service env when --no-restart is set", async () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -179,7 +179,7 @@ function printDryRunPreview(preview: UpdateDryRunPreview, jsonMode: boolean): vo
 async function refreshGatewayServiceEnv(params: {
   result: UpdateRunResult;
   jsonMode: boolean;
-}): Promise<void> {
+}): Promise<boolean> {
   const args = ["gateway", "install", "--force"];
   if (params.jsonMode) {
     args.push("--json");
@@ -193,7 +193,7 @@ async function refreshGatewayServiceEnv(params: {
       timeoutMs: SERVICE_REFRESH_TIMEOUT_MS,
     });
     if (res.code === 0) {
-      return;
+      return false; // entry.js refreshed env; caller still needs to restart
     }
     throw new Error(
       `updated install refresh failed (${candidate}): ${formatCommandFailure(res.stdout, res.stderr)}`,
@@ -201,6 +201,7 @@ async function refreshGatewayServiceEnv(params: {
   }
 
   await runDaemonInstall({ force: true, json: params.jsonMode || undefined });
+  return true; // runDaemonInstall includes launchctl kickstart; restart already done
 }
 
 async function tryInstallShellCompletion(opts: {
@@ -531,10 +532,15 @@ async function maybeRestartService(params: {
       let restartInitiated = false;
       if (params.refreshServiceEnv) {
         try {
-          await refreshGatewayServiceEnv({
+          const restarted = await refreshGatewayServiceEnv({
             result: params.result,
             jsonMode: Boolean(params.opts.json),
           });
+          // If refreshGatewayServiceEnv performed an internal restart (runDaemonInstall path),
+          // mark as initiated to prevent a second restart from runRestartScript or runDaemonRestart.
+          if (restarted) {
+            restartInitiated = true;
+          }
         } catch (err) {
           if (!params.opts.json) {
             defaultRuntime.log(
@@ -545,10 +551,10 @@ async function maybeRestartService(params: {
           }
         }
       }
-      if (params.restartScriptPath) {
+      if (!restartInitiated && params.restartScriptPath) {
         await runRestartScript(params.restartScriptPath);
         restartInitiated = true;
-      } else {
+      } else if (!restartInitiated) {
         restarted = await runDaemonRestart();
       }
 


### PR DESCRIPTION
## Problem

`runDaemonInstall({ force: true })` calls `installLaunchAgent` which performs `launchctl bootout + bootstrap + kickstart -k`, restarting the service itself. The code introduced in #21071 then also ran `runRestartScript` (another `kickstart -k`) or `runDaemonRestart`, causing two competing restarts that each trigger startup hooks (e.g. `BOOT.md`).

**Observed symptoms:**
- 5 duplicate on-boot notifications after `openclaw update`
- 3 duplicate on-boot notifications after `openclaw gateway restart`
- `gateway.err.log` shows repeated `gateway already running (pid …); lock timeout after 5000ms` from launchctl racing with itself

## Root Cause

In `maybeRestartService`, after `runDaemonInstall` succeeds (which internally does `kickstart -k`), the code continued to execute `runRestartScript` (which also does `kickstart -k` after a 1 s delay). This is a regression from 20004711d which removed the `serviceRefreshed` guard that originally prevented the double-restart.

## Fix

Set `restartInitiated = true` after a successful `runDaemonInstall` so the subsequent `runRestartScript` / `runDaemonRestart` branches are skipped — the service has already been restarted by the install's `kickstart`.

```
runDaemonInstall (kickstart ✓) → skip runRestartScript → skip runDaemonRestart
```

The fallback paths still work:
- If `runDaemonInstall` **throws**, `restartInitiated` stays `false` and the existing fallback runs (`runDaemonRestart` on failure, as tested).
- If `refreshServiceEnv` is false, the restart-script / daemon-restart paths run as before.

## Testing

- Updated two tests to match the corrected behavior.
- All 44 update-cli tests pass.
- `pnpm check` format: ✅ (TS2742 errors in other files are pre-existing, unrelated to this change)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents duplicate service restarts during `openclaw update` by setting `restartInitiated = true` after successful `runDaemonInstall`.

- Fixed regression from commit 20004711d which removed the `serviceRefreshed` guard
- `runDaemonInstall` internally performs `launchctl kickstart -k` (confirmed in `src/daemon/launchd.ts:403`), making additional restarts redundant
- Adds conditional guards (`!restartInitiated &&`) to skip `runRestartScript` and `runDaemonRestart` when install already restarted the service
- Preserves fallback behavior: if `runDaemonInstall` throws, `restartInitiated` stays false and normal restart paths execute
- Updated tests correctly verify the new behavior across all paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The fix correctly addresses a clear regression with a simple, well-scoped change. The logic is sound across all code paths, the root cause analysis is accurate (verified by examining git history and the `installLaunchAgent` implementation), and comprehensive test coverage validates both the fix and fallback behavior. No security concerns or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 0d162b9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->