### PR TITLE
fix(xai): extend Grok model prefix support + add native Responses API config

### DIFF
--- a/src/agents/live-model-filter.test.ts
+++ b/src/agents/live-model-filter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isModernModelRef } from "./live-model-filter.js";
+
+describe("isModernModelRef — xAI Grok families", () => {
+  it("recognises grok-4 variants (existing)", () => {
+    expect(isModernModelRef({ provider: "xai", id: "grok-4" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-4-1-fast" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-4-fast" })).toBe(true);
+  });
+
+  it("recognises grok-3 variants (fix #15709)", () => {
+    expect(isModernModelRef({ provider: "xai", id: "grok-3" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-3-fast" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-3-mini" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-3-mini-fast" })).toBe(true);
+  });
+
+  it("recognises grok-2 variants (fix #15709)", () => {
+    expect(isModernModelRef({ provider: "xai", id: "grok-2" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-2-1212" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-2-vision-1212" })).toBe(true);
+  });
+
+  it("rejects non-xai providers", () => {
+    expect(isModernModelRef({ provider: "openai", id: "grok-3" })).toBe(false);
+    expect(isModernModelRef({ provider: "anthropic", id: "grok-4" })).toBe(false);
+  });
+
+  it("rejects empty/null refs", () => {
+    expect(isModernModelRef({ provider: "", id: "grok-3" })).toBe(false);
+    expect(isModernModelRef({ provider: "xai", id: "" })).toBe(false);
+    expect(isModernModelRef({})).toBe(false);
+  });
+
+  it("still recognises other modern providers", () => {
+    expect(isModernModelRef({ provider: "anthropic", id: "claude-sonnet-4-6" })).toBe(true);
+    expect(isModernModelRef({ provider: "google", id: "gemini-3-pro" })).toBe(true);
+  });
+});

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -23,7 +23,7 @@ const CODEX_MODELS = [
 const GOOGLE_PREFIXES = ["gemini-3"];
 const ZAI_PREFIXES = ["glm-5", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx"];
 const MINIMAX_PREFIXES = ["minimax-m2.1", "minimax-m2.5"];
-const XAI_PREFIXES = ["grok-4"];
+const XAI_PREFIXES = ["grok-2", "grok-3", "grok-4"];
 
 function matchesPrefix(id: string, prefixes: string[]): boolean {
   return prefixes.some((prefix) => id.startsWith(prefix));

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -376,6 +376,12 @@ export function applyHuggingfaceConfig(cfg: OpenClawConfig): OpenClawConfig {
   return applyAgentDefaultModelPrimary(next, HUGGINGFACE_DEFAULT_MODEL_REF);
 }
 
+/**
+ * Apply xAI provider configuration using the chat completions API mode.
+ * xAI supports two API modes:
+ * - openai-completions (default, chat completions API)
+ * - openai-responses (Responses API with native web_search, x_search, code_execution tools)
+ */
 export function applyXaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
   models[XAI_DEFAULT_MODEL_REF] = {
@@ -398,6 +404,29 @@ export function applyXaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
 export function applyXaiConfig(cfg: OpenClawConfig): OpenClawConfig {
   const next = applyXaiProviderConfig(cfg);
   return applyAgentDefaultModelPrimary(next, XAI_DEFAULT_MODEL_REF);
+}
+
+/**
+ * Apply xAI provider configuration using the Responses API mode.
+ * This enables native xAI server-side tools (web_search, x_search, code_execution).
+ */
+export function applyXaiResponsesApiConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[XAI_DEFAULT_MODEL_REF] = {
+    ...models[XAI_DEFAULT_MODEL_REF],
+    alias: models[XAI_DEFAULT_MODEL_REF]?.alias ?? "Grok",
+  };
+
+  const defaultModel = buildXaiModelDefinition();
+
+  return applyProviderConfigWithDefaultModel(cfg, {
+    agentModels: models,
+    providerId: "xai",
+    api: "openai-responses",
+    baseUrl: XAI_BASE_URL,
+    defaultModel,
+    defaultModelId: XAI_DEFAULT_MODEL_ID,
+  });
 }
 
 export function applyAuthProfileConfig(

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -59,6 +59,7 @@ import {
   buildZaiModelDefinition,
   buildMoonshotModelDefinition,
   buildXaiModelDefinition,
+  XAI_EXTRA_MODELS,
   QIANFAN_BASE_URL,
   QIANFAN_DEFAULT_MODEL_REF,
   KIMI_CODING_MODEL_REF,
@@ -381,6 +382,9 @@ export function applyHuggingfaceConfig(cfg: OpenClawConfig): OpenClawConfig {
  * xAI supports two API modes:
  * - openai-completions (default, chat completions API)
  * - openai-responses (Responses API with native web_search, x_search, code_execution tools)
+ *
+ * Registers grok-4 (default), grok-3, grok-3-fast, grok-3-mini, grok-3-mini-fast,
+ * and grok-2-1212 so all Grok generations work in sub-agents without silent crashes.
  */
 export function applyXaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
@@ -391,12 +395,12 @@ export function applyXaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
 
   const defaultModel = buildXaiModelDefinition();
 
-  return applyProviderConfigWithDefaultModel(cfg, {
+  return applyProviderConfigWithDefaultModels(cfg, {
     agentModels: models,
     providerId: "xai",
     api: "openai-completions",
     baseUrl: XAI_BASE_URL,
-    defaultModel,
+    defaultModels: [defaultModel, ...XAI_EXTRA_MODELS],
     defaultModelId: XAI_DEFAULT_MODEL_ID,
   });
 }
@@ -409,6 +413,7 @@ export function applyXaiConfig(cfg: OpenClawConfig): OpenClawConfig {
 /**
  * Apply xAI provider configuration using the Responses API mode.
  * This enables native xAI server-side tools (web_search, x_search, code_execution).
+ * Registers the same full set of Grok models as applyXaiProviderConfig.
  */
 export function applyXaiResponsesApiConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
@@ -419,12 +424,12 @@ export function applyXaiResponsesApiConfig(cfg: OpenClawConfig): OpenClawConfig 
 
   const defaultModel = buildXaiModelDefinition();
 
-  return applyProviderConfigWithDefaultModel(cfg, {
+  return applyProviderConfigWithDefaultModels(cfg, {
     agentModels: models,
     providerId: "xai",
     api: "openai-responses",
     baseUrl: XAI_BASE_URL,
-    defaultModel,
+    defaultModels: [defaultModel, ...XAI_EXTRA_MODELS],
     defaultModelId: XAI_DEFAULT_MODEL_ID,
   });
 }

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -180,3 +180,51 @@ export function buildXaiModelDefinition(): ModelDefinitionConfig {
     maxTokens: XAI_DEFAULT_MAX_TOKENS,
   };
 }
+
+export const XAI_EXTRA_MODELS: ModelDefinitionConfig[] = [
+  {
+    id: "grok-3",
+    name: "Grok 3",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "grok-3-fast",
+    name: "Grok 3 Fast",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "grok-3-mini",
+    name: "Grok 3 Mini",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "grok-3-mini-fast",
+    name: "Grok 3 Mini Fast",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "grok-2-1212",
+    name: "Grok 2",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+];

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -31,6 +31,7 @@ export {
   applyVercelAiGatewayProviderConfig,
   applyXaiConfig,
   applyXaiProviderConfig,
+  applyXaiResponsesApiConfig,
   applyXiaomiConfig,
   applyXiaomiProviderConfig,
   applyZaiConfig,


### PR DESCRIPTION
## Summary

Addresses two related xAI/Grok issues that together prevent Grok models from working reliably in OpenClaw sub-agents and limit Grok to the OpenAI-compat API path.

---

### Fix 1 — Closes #15709: Grok sub-agents crash / show `configured,missing`

**Root cause:** `XAI_PREFIXES` in `live-model-filter.ts` only contained `["grok-4"]`. Any model from the `grok-2` or `grok-3` families was not recognised as a valid xAI model, causing sub-agents spawned with `xai/grok-3`, `xai/grok-3-fast`, `xai/grok-3-mini` or `xai/grok-2` to crash or silently fall back with no diagnostic output.

**Fix:**
- Extend `XAI_PREFIXES` to `["grok-2", "grok-3", "grok-4"]` — covering all current Grok generations via prefix matching
- Add `XAI_EXTRA_MODELS` array in `onboard-auth.models.ts` defining `grok-3`, `grok-3-fast`, `grok-3-mini`, `grok-3-mini-fast`, `grok-2-1212` so they are registered in the provider config
- Switch `applyXaiProviderConfig` to `applyProviderConfigWithDefaultModels` to include the full model set
- After this fix, users with insufficient API key permissions get a **clean, diagnostic error** from xAI (e.g. `Forbidden: API key lacks permissions for grok-3-fast`) rather than a silent crash

---

### Fix 2 — Refs #6872: Native xAI Responses API support

**Context:** xAI's Responses API (`/v1/responses`) unlocks server-side tools — `web_search`, `x_search`, `code_execution` — that run autonomously on xAI's infrastructure. Currently OpenClaw hardcodes `api: 'openai-completions'` for xAI, bypassing this entirely.

**Fix:** Add `applyXaiResponsesApiConfig()` — a new exported function alongside `applyXaiConfig()` that configures the xAI provider with `api: 'openai-responses'`. Backward compatible; existing `applyXaiConfig()` unchanged. Adds JSDoc documenting both modes.

---

## Files Changed

| File | Change |
|------|--------|
| `src/agents/live-model-filter.ts` | Extend `XAI_PREFIXES` from `["grok-4"]` → `["grok-2", "grok-3", "grok-4"]` |
| `src/commands/onboard-auth.models.ts` | Add `XAI_EXTRA_MODELS` (grok-3/3-fast/3-mini/3-mini-fast/2-1212) |
| `src/commands/onboard-auth.config-core.ts` | Use `applyProviderConfigWithDefaultModels`, add `applyXaiResponsesApiConfig()`, add JSDoc |
| `src/agents/live-model-filter.test.ts` | **New:** 6 unit tests covering grok-2/3/4 prefix recognition |

## Testing

- ✅ `pnpm run check` — 0 errors, 0 warnings
- ✅ 6/6 unit tests pass (`live-model-filter.test.ts`)
- ✅ Live API test: `xai/grok-4-1-fast` confirmed working via opencode
- ✅ grok-3 now surfaces a clean API-level permissions error instead of a silent crash

## Related Issues

- Fixes #15709
- Refs #6872

---

## ☕ Support

This fix was researched and shipped by [@RonySpark](https://x.com/ronyspark) — diagnosed after 3 days of the community (and myself) hitting silent Grok sub-agent crashes. If this unblocks your setup or saves you API costs:

👉 **[buymeacoffee.com/ronyspark](https://buymeacoffee.com/ronyspark)**