### PR TITLE
docs: mission control v1 proposal (read-only scope)

### DIFF
--- a/docs/proposals/mission-control-v1.md
+++ b/docs/proposals/mission-control-v1.md
@@ -1,0 +1,38 @@
+# Mission Control v1 Proposal
+
+Related issue: https://github.com/openclaw/openclaw/issues/21600
+Prototype repository: https://github.com/frank8ai/openclaw-mission-control
+
+## Problem
+
+Operators need a fast operational view of what OpenClaw is currently doing across cron jobs, sessions, and subagents. Existing workflows require jumping across multiple commands/logs.
+
+## v1 Scope (read-only, merge-friendly)
+
+- Runtime overview for tasks + cron + sessions + subagents
+- Runs history and failed-run aggregation
+- Filter/search/time-range controls
+- Explicit fallback/source signaling for observability
+
+## Non-goals for v1
+
+- No direct runtime control actions in v1
+- No kill/run-now/enable-disable actions in v1 UI
+
+## v2 Follow-up (separate track)
+
+- run-now / enable-disable / kill actions
+- with permissions, second confirmation, audit trail, secure-default-off
+
+## Why this shape
+
+- Low risk to core runtime
+- Useful immediately for operators
+- Enables incremental PR split (API -> data aggregation -> UI)
+
+## Suggested PR split
+
+1. Runtime aggregation API (read-only)
+2. History/failure rollups + filtering params
+3. UI pages/components wired to those APIs
+4. Optional docs/examples


### PR DESCRIPTION
## Summary
This PR adds a short proposal document for Mission Control v1.

- Related issue: #21600
- Prototype implementation: https://github.com/frank8ai/openclaw-mission-control

## Scope
- read-only operational overview
- runs/failure aggregation
- filtering/search/time-range
- v2 control actions intentionally deferred

No runtime behavior is changed in this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a proposal document for Mission Control v1, a read-only operational dashboard for OpenClaw. The proposal outlines a low-risk, incremental approach focusing on runtime visibility (tasks, cron, sessions, subagents) and failure aggregation, while explicitly deferring control actions to v2. No code changes included.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - documentation only with no runtime changes
- This is a documentation-only PR adding a proposal document. No code is modified, no runtime behavior is affected. The proposal itself is well-structured, clearly scoped, and follows a sensible incremental approach by deferring risky control actions to v2.
- No files require special attention

<sub>Last reviewed commit: f911ad3</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->