### PR TITLE
fix(context-pruning): pi-extensions never built + null lastTouch skips prune after restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ package-lock.json
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
+pi-extensions

--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,4 @@ package-lock.json
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
-pi-extensions
+/pi-extensions

--- a/src/agents/pi-extensions/context-pruning/extension.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.ts
@@ -11,11 +11,14 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
 
     if (runtime.settings.mode === "cache-ttl") {
       const ttlMs = runtime.settings.ttlMs;
-      const lastTouch = runtime.lastCacheTouchAt ?? null;
-      if (!lastTouch || ttlMs <= 0) {
+      if (ttlMs <= 0) {
         return undefined;
       }
-      if (ttlMs > 0 && Date.now() - lastTouch < ttlMs) {
+      const lastTouch = runtime.lastCacheTouchAt ?? null;
+      // If lastTouch is null (no prior Anthropic call recorded, e.g. after a gateway
+      // restart that wrote a zero-timestamp entry), allow pruning immediately — the
+      // cache is effectively cold and there is no TTL window to respect.
+      if (lastTouch !== null && Date.now() - lastTouch < ttlMs) {
         return undefined;
       }
     }

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -4,7 +4,10 @@ import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { EffectiveContextPruningSettings } from "./settings.js";
 import { makeToolPrunablePredicate } from "./tools.js";
 
-const CHARS_PER_TOKEN_ESTIMATE = 4;
+// Empirically, tool results (mostly code/JSON/shell output) average ~2.5 chars per token.
+// The previous value of 4 significantly over-estimated charWindow, causing the pruner to
+// under-estimate the actual fill ratio and skip pruning prematurely.
+const CHARS_PER_TOKEN_ESTIMATE = 2.5;
 // We currently skip pruning tool results that contain images. Still, we count them (approx.) so
 // we start trimming prunable tool results earlier when image-heavy context is consuming the window.
 const IMAGE_CHAR_ESTIMATE = 8_000;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -56,4 +56,17 @@ export default defineConfig([
     fixedExtension: false,
     platform: "node",
   },
+  {
+    // Pi embedded runner extensions — loaded dynamically at runtime via resolvePiExtensionPath().
+    // Must be built as separate entry points into pi-extensions/ (one level above dist/) so that
+    // the path resolver (path.join(distDir, "..", "pi-extensions", `${id}.js`)) can find them.
+    entry: [
+      "src/agents/pi-extensions/context-pruning.ts",
+      "src/agents/pi-extensions/compaction-safeguard.ts",
+    ],
+    outDir: "pi-extensions",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
 ]);


### PR DESCRIPTION
## 3 bugs found & fixed via live debugging on Raspberry Pi 4

---

### Bug 1 (build): `pi-extensions/` never built — pruning never ran in production

`resolvePiExtensionPath()` resolves to `<root>/pi-extensions/<id>.js` but `tsdown.config.ts` had no entry for these files. Both `context-pruning` and `compaction-safeguard` were silently never loaded.

**Fix:** Add tsdown entry → `pi-extensions/`. Add to `.gitignore` (build artifact). Fix `.gitignore` pattern to `/pi-extensions` (was incorrectly also ignoring `src/agents/pi-extensions/`).

---

### Bug 2 (logic): `!lastTouch` falsy check skips pruning after restart

After restart, `readLastCacheTtlTimestamp` returns `null` (correctly skips zero-timestamp entries). But `extension.ts` used `!lastTouch` which is `true` for both `null` and `0` → pruning skipped indefinitely after every restart.

```ts
// Before
if (!lastTouch || ttlMs <= 0) return undefined; // null treated same as 0

// After
if (ttlMs <= 0) return undefined;
if (lastTouch !== null && Date.now() - lastTouch < ttlMs) return undefined; // null = cold cache → prune immediately
```

---

### Bug 3 (estimate): `CHARS_PER_TOKEN_ESTIMATE = 4` causes pruner to under-fire

Pruner computes `charWindow = contextTokens × CHARS_PER_TOKEN`. With `= 4`, charWindow is overestimated → fill ratio underestimated → pruner stops too early.

Empirical measurement from a real session (code/JSON/shell tool results):
- `~384k chars / ~158k tokens ≈ 2.44 chars/token`

With `= 4`: ratio = `384k / 800k = 48%` → below `hardClearRatio=0.5` → no hard-clear  
With `= 2.5`: ratio = `384k / 500k = 77%` → above `hardClearRatio=0.5` → hard-clear runs ✅

Note: prose ≈ 4 chars/token, but tool results (code, JSON, shell) tokenize more efficiently at ~2.5.

---

## How it was found

Debugged live on a Raspberry Pi 4 running OpenClaw 2026.2.18 — noticed context pruning never reducing context size even after extended idle. Traced through session JSONL entries, extension loader, pruner source, and Anthropic token usage data.