### PR TITLE
fix: warn when thinking level xhigh falls back for unsupported models

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -492,6 +492,12 @@ export async function agentCommand(
       if (explicitThink) {
         throw new Error(`Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`);
       }
+      // Emit a warning when config-level xhigh falls back to high for unsupported models.
+      // This prevents silent downgrades that leave users confused when thinking budget is lower than expected.
+      console.warn(
+        `[openclaw] Thinking level "xhigh" is not supported for ${provider}/${model}. ` +
+          `Supported models: ${formatXHighModelHint()}. Falling back to "high".`,
+      );
       resolvedThinkLevel = "high";
       if (sessionEntry && sessionStore && sessionKey && sessionEntry.thinkingLevel === "xhigh") {
         const entry = sessionEntry;


### PR DESCRIPTION
Fixes #21582

## Summary
When `thinkingDefault: "xhigh"` is set in config for models that don't support it (e.g., Anthropic Claude), the level silently falls back to `"high"` with no warning in logs or status output.

This leaves users confused when their thinking budget is lower than expected — only discoverable by manually checking `/status` after an upgrade.

## Root Cause
In `src/commands/agent.ts`, config-level `xhigh` settings for unsupported models fall back to `high` without emitting any diagnostic:

```typescript
if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
  const explicitThink = Boolean(thinkOnce || thinkOverride);
  if (explicitThink) {
    throw new Error(...); // Explicit /thinking xhigh → error
  }
  resolvedThinkLevel = "high";  // Config xhigh → silent fallback ⚠️
}
```

## Changes
- Added `console.warn` before fallback to `"high"` for config-level `xhigh`
- Warning message includes:
  - Unsupported model (e.g., `anthropic/claude-opus-4-6`)
  - List of supported models (GPT-5.2, Codex variants)
  - Fallback action ("Falling back to 'high'")
- Explicit `/thinking xhigh` commands continue to throw errors (unchanged)

**Example warning:**
```
[openclaw] Thinking level "xhigh" is not supported for anthropic/claude-opus-4-6. 
Supported models: openai/gpt-5.2, openai-codex/gpt-5.3-codex, ... Falling back to "high".
```

## Impact
- ✅ Users see clear warning at startup instead of silent runtime downgrade
- ✅ Helps identify config issues immediately (no need to check `/status`)
- ✅ No behavior change: fallback logic remains `high` (just visible now)
- ✅ Existing tests unaffected (only added logging, no logic change)

## Testing
- All existing tests pass (`thinking.test.ts`: 14/14 ✅)
- Fallback behavior unchanged (still `"high"`)
- Warning only emitted for config-level `xhigh`, not explicit commands

## Closes
#21582

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a warning message when the `thinkingDefault: "xhigh"` config setting silently falls back to `"high"` for models that don't support extra-high thinking levels (e.g., Anthropic Claude). Previously, users would only discover this downgrade by checking `/status` output, leading to confusion about lower-than-expected thinking budgets.

The change adds a single `console.warn` call that clearly identifies the unsupported model, lists which models do support `xhigh` (GPT-5.2, Codex variants), and notifies users of the fallback to `"high"`. The warning only appears for config-level `xhigh` settings—explicit `/thinking xhigh` commands continue to throw errors as before.

The implementation is minimal, non-breaking, and improves user experience by making silent configuration issues visible at startup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change adds only a single `console.warn` statement without modifying any logic or control flow. The fallback behavior remains identical (still uses `"high"`), and the warning provides clear, actionable information. No test changes are needed since the functionality is unchanged. The implementation follows repository conventions (uses `[openclaw]` prefix), and the message accurately reflects the helper functions' output.
- No files require special attention

<sub>Last reviewed commit: 25875d2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->