### PR TITLE
Gateway/CLI: recover pairing bootstrap deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/Pairing: tolerate legacy paired devices missing `roles`/`scopes` metadata in websocket upgrade checks and backfill metadata on reconnect. (#21447, fixes #21236) Thanks @joshavant.
+- Gateway/Pairing/CLI: align read-scope compatibility in pairing/device-token checks and add local `openclaw devices` fallback recovery for loopback `pairing required` deadlocks, with explicit fallback notice to unblock approval bootstrap flows. (#21616) Thanks @shakkernerd.
 - Docker: pin base images to SHA256 digests in Docker builds to prevent mutable tag drift. (#7734) Thanks @coygeek.
 - Provider/HTTP: treat HTTP 503 as failover-eligible for LLM provider errors. (#21086) Thanks @Protocol-zero-0.
 - Slack: pass `recipient_team_id` / `recipient_user_id` through Slack native streaming calls so `chat.startStream`/`appendStream`/`stopStream` work reliably across DMs and Slack Connect setups, and disable block streaming when native streaming is active. (#20988) Thanks @Dithilli. Earlier recipient-ID groundwork was contributed in #20377 by @AsserAl1012.

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -2,6 +2,14 @@ import { Command } from "commander";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 const callGateway = vi.fn();
+const buildGatewayConnectionDetails = vi.fn(() => ({
+  url: "ws://127.0.0.1:18789",
+  urlSource: "local loopback",
+  message: "",
+}));
+const listDevicePairing = vi.fn();
+const approveDevicePairing = vi.fn();
+const summarizeDeviceTokens = vi.fn();
 const withProgress = vi.fn(async (_opts: unknown, fn: () => Promise<unknown>) => await fn());
 const runtime = {
   log: vi.fn(),
@@ -11,10 +19,17 @@ const runtime = {
 
 vi.mock("../gateway/call.js", () => ({
   callGateway,
+  buildGatewayConnectionDetails,
 }));
 
 vi.mock("./progress.js", () => ({
   withProgress,
+}));
+
+vi.mock("../infra/device-pairing.js", () => ({
+  listDevicePairing,
+  approveDevicePairing,
+  summarizeDeviceTokens,
 }));
 
 vi.mock("../runtime.js", () => ({
@@ -216,8 +231,73 @@ describe("devices cli tokens", () => {
   });
 });
 
+describe("devices cli local fallback", () => {
+  const fallbackNotice = "Direct scope access failed; using local fallback.";
+
+  it("falls back to local pairing list when gateway returns pairing required on loopback", async () => {
+    callGateway.mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-1", deviceId: "device-1", publicKey: "pk", ts: 1 }],
+      paired: [],
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesCommand(["list"]);
+
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "device.pair.list" }),
+    );
+    expect(listDevicePairing).toHaveBeenCalledTimes(1);
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
+  });
+
+  it("falls back to local approve when gateway returns pairing required on loopback", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"))
+      .mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-latest", deviceId: "device-1", publicKey: "pk", ts: 2 }],
+      paired: [],
+    });
+    approveDevicePairing.mockResolvedValueOnce({
+      requestId: "req-latest",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+      },
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesApprove(["--latest"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-latest");
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
+  });
+
+  it("does not use local fallback when an explicit --url is provided", async () => {
+    callGateway.mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+
+    await expect(
+      runDevicesCommand(["list", "--json", "--url", "ws://127.0.0.1:18789"]),
+    ).rejects.toThrow("pairing required");
+    expect(listDevicePairing).not.toHaveBeenCalled();
+  });
+});
+
 afterEach(() => {
   callGateway.mockReset();
+  buildGatewayConnectionDetails.mockReset();
+  buildGatewayConnectionDetails.mockReturnValue({
+    url: "ws://127.0.0.1:18789",
+    urlSource: "local loopback",
+    message: "",
+  });
+  listDevicePairing.mockReset();
+  approveDevicePairing.mockReset();
+  summarizeDeviceTokens.mockReset();
   withProgress.mockClear();
   runtime.log.mockReset();
   runtime.error.mockReset();

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+const gatewayClientState = vi.hoisted(() => ({
+  options: null as Record<string, unknown> | null,
+}));
+
+class MockGatewayClient {
+  private readonly opts: Record<string, unknown>;
+
+  constructor(opts: Record<string, unknown>) {
+    this.opts = opts;
+    gatewayClientState.options = opts;
+  }
+
+  start(): void {
+    void Promise.resolve()
+      .then(async () => {
+        const onHelloOk = this.opts.onHelloOk;
+        if (typeof onHelloOk === "function") {
+          await onHelloOk();
+        }
+      })
+      .catch(() => {});
+  }
+
+  stop(): void {}
+
+  async request(method: string): Promise<unknown> {
+    if (method === "system-presence") {
+      return [];
+    }
+    return {};
+  }
+}
+
+vi.mock("./client.js", () => ({
+  GatewayClient: MockGatewayClient,
+}));
+
+const { probeGateway } = await import("./probe.js");
+
+describe("probeGateway", () => {
+  it("connects with operator.read scope", async () => {
+    const result = await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+    });
+
+    expect(gatewayClientState.options?.scopes).toEqual(["operator.read"]);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import type { SystemPresence } from "../infra/system-presence.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
+import { READ_SCOPE } from "./method-scopes.js";
 
 export type GatewayProbeAuth = {
   token?: string;
@@ -54,6 +55,7 @@ export async function probeGateway(opts: {
       url: opts.url,
       token: opts.auth?.token,
       password: opts.auth?.password,
+      scopes: [READ_SCOPE],
       clientName: GATEWAY_CLIENT_NAMES.CLI,
       clientVersion: "dev",
       mode: GATEWAY_CLIENT_MODES.PROBE,

--- a/src/shared/operator-scope-compat.test.ts
+++ b/src/shared/operator-scope-compat.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { roleScopesAllow } from "./operator-scope-compat.js";
+
+describe("roleScopesAllow", () => {
+  it("treats operator.read as satisfied by read/write/admin scopes", () => {
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.read"],
+        allowedScopes: ["operator.read"],
+      }),
+    ).toBe(true);
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.read"],
+        allowedScopes: ["operator.write"],
+      }),
+    ).toBe(true);
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.read"],
+        allowedScopes: ["operator.admin"],
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps non-read operator scopes explicit", () => {
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.write"],
+        allowedScopes: ["operator.admin"],
+      }),
+    ).toBe(false);
+  });
+
+  it("uses strict matching for non-operator roles", () => {
+    expect(
+      roleScopesAllow({
+        role: "node",
+        requestedScopes: ["system.run"],
+        allowedScopes: ["operator.admin", "system.run"],
+      }),
+    ).toBe(true);
+    expect(
+      roleScopesAllow({
+        role: "node",
+        requestedScopes: ["system.run"],
+        allowedScopes: ["operator.admin"],
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/shared/operator-scope-compat.ts
+++ b/src/shared/operator-scope-compat.ts
@@ -1,0 +1,46 @@
+const OPERATOR_ROLE = "operator";
+const OPERATOR_ADMIN_SCOPE = "operator.admin";
+const OPERATOR_READ_SCOPE = "operator.read";
+const OPERATOR_WRITE_SCOPE = "operator.write";
+
+function normalizeScopeList(scopes: readonly string[]): string[] {
+  const out = new Set<string>();
+  for (const scope of scopes) {
+    const trimmed = scope.trim();
+    if (trimmed) {
+      out.add(trimmed);
+    }
+  }
+  return [...out];
+}
+
+function operatorScopeSatisfied(requestedScope: string, granted: Set<string>): boolean {
+  if (requestedScope === OPERATOR_READ_SCOPE) {
+    return (
+      granted.has(OPERATOR_READ_SCOPE) ||
+      granted.has(OPERATOR_WRITE_SCOPE) ||
+      granted.has(OPERATOR_ADMIN_SCOPE)
+    );
+  }
+  return granted.has(requestedScope);
+}
+
+export function roleScopesAllow(params: {
+  role: string;
+  requestedScopes: readonly string[];
+  allowedScopes: readonly string[];
+}): boolean {
+  const requested = normalizeScopeList(params.requestedScopes);
+  if (requested.length === 0) {
+    return true;
+  }
+  const allowed = normalizeScopeList(params.allowedScopes);
+  if (allowed.length === 0) {
+    return false;
+  }
+  const allowedSet = new Set(allowed);
+  if (params.role.trim() !== OPERATOR_ROLE) {
+    return requested.every((scope) => allowedSet.has(scope));
+  }
+  return requested.every((scope) => operatorScopeSatisfied(scope, allowedSet));
+}


### PR DESCRIPTION
## Summary
This PR fixes the pairing/bootstrap deadlock where read-only commands could work, but `devices` commands could not recover pending scope upgrades.

## Problem
After resetting/repairing pairing state, users could hit this sequence:
1. `openclaw health` succeeds (read path).
2. `openclaw devices list` fails with `gateway closed (1008): pairing required`.
3. A pending scope-upgrade request is created in pairing files.
4. `openclaw devices approve --latest` also fails with `pairing required`, so the same client cannot self-recover.

Contributors/debugging reports showed this as a recurring confusion around #21236 / #21447 behavior.

## Root Causes
- Pairing/device-token scope checks used strict scope-set membership during connect/token validation.
- Read semantics (`operator.read` satisfied by stronger operator scopes) were applied at method authorization, but not consistently in handshake/token checks.
- Probe client used implicit default scopes, making initial pairing states noisier than necessary.
- `devices` CLI depended on gateway scope access even in the exact scenario where scope-upgrade pending prevents that access.

## What changed
### 1) Scope compatibility is centralized for connect/token checks
- Added `roleScopesAllow` for role-aware scope compatibility.
- For operator role: `operator.read` is satisfied by `operator.read`, `operator.write`, or `operator.admin`.
- Non-read operator scopes remain explicit.
- Non-operator roles keep strict matching.

### 2) Probe least-privilege scope
- Probe client now explicitly requests `operator.read`.

### 3) Devices CLI bootstrap recovery fallback
- `devices list` and `devices approve` now fallback to local pairing files when:
  - gateway returns `pairing required`
  - target is local loopback
  - no explicit `--url` override
- Added explicit user-facing notice:
  - `Direct scope access failed; using local fallback.`
- This unblocks `openclaw devices approve --latest` in bootstrap deadlock scenarios.

## Safety guards
- No fallback for explicit `--url` (avoid silently crossing trust boundaries).
- Fallback path redacts token data using existing summary helpers.

## Tests added/updated
- `src/shared/operator-scope-compat.test.ts`
- `src/infra/device-pairing.test.ts`
- `src/gateway/probe.test.ts`
- `src/gateway/server.auth.e2e.test.ts`
- `src/cli/devices-cli.test.ts`

## Verification run
- `pnpm test -- src/shared/operator-scope-compat.test.ts src/infra/device-pairing.test.ts src/gateway/probe.test.ts src/cli/devices-cli.test.ts`
- `pnpm check`
- Targeted e2e auth test:
  - `vitest run --config vitest.e2e.config.ts src/gateway/server.auth.e2e.test.ts -t "allows operator.read connect when device is paired with operator.admin"`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves a critical deadlock where `openclaw devices` commands could not recover from scope-upgrade-pending states after pairing resets. The fix introduces role-aware scope compatibility checks and local pairing fallbacks for bootstrap scenarios.

Key changes:
- **Scope compatibility logic**: New `roleScopesAllow` function treats `operator.read` as satisfied by stronger operator scopes (`operator.write`, `operator.admin`), matching the existing method authorization semantics
- **Gateway/pairing integration**: Replaced strict set-membership checks with role-aware scope compatibility in WebSocket message handler and device pairing token verification
- **Probe scope optimization**: Probe client now explicitly requests `operator.read` instead of relying on implicit defaults, reducing scope-upgrade noise
- **CLI fallback recovery**: `devices list` and `devices approve` commands fallback to local pairing files when gateway returns "pairing required" on loopback connections without explicit `--url` override
- **Test coverage**: Comprehensive unit and e2e tests validate scope compatibility rules, fallback behavior, and security boundaries

The implementation is well-scoped and maintains security boundaries by only enabling fallback for local loopback connections without explicit URL overrides.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor areas requiring attention around edge cases
- Score reflects solid implementation with comprehensive test coverage covering unit, integration, and e2e scenarios. The scope compatibility logic is well-isolated and follows clear semantics. The CLI fallback includes appropriate security guards (no fallback for explicit `--url`, loopback-only). However, the empty requested scopes case returning true deserves verification, and the URL parsing error handling in fallback logic silently returns false which could mask issues.
- Pay close attention to `src/shared/operator-scope-compat.ts:34` (empty scopes behavior) and `src/cli/devices-cli.ts:115` (silent URL parsing error handling)

<sub>Last reviewed commit: d9eab50</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->