### PR TITLE
Add DeepSeek embeddings provider for memory search

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -77,6 +77,7 @@ runs:
         which node
         node -v
         pnpm -v
+        FROZEN_LOCKFILE="${FROZEN_LOCKFILE:-true}"
         case "$FROZEN_LOCKFILE" in
           true) LOCKFILE_FLAG="--frozen-lockfile" ;;
           false) LOCKFILE_FLAG="" ;;

--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -18,6 +18,7 @@ runs:
         PNPM_VERSION: ${{ inputs.pnpm-version }}
       run: |
         set -euo pipefail
+        PNPM_VERSION="${PNPM_VERSION:-10.23.0}"
         if [[ ! "$PNPM_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}([.-][0-9A-Za-z.-]+)?$ ]]; then
           echo "::error::Invalid pnpm-version input: '$PNPM_VERSION'"
           exit 2

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -317,7 +317,7 @@ If you don't want to set an API key, use `memorySearch.provider = "local"` or se
 
 Fallbacks:
 
-- `memorySearch.fallback` can be `openai`, `gemini`, `local`, or `none`.
+- `memorySearch.fallback` can be `openai`, `gemini`, `voyage`, `deepseek`, `local`, or `none`.
 - The fallback provider is only used when the primary embedding provider fails.
 
 Batch indexing (OpenAI + Gemini + Voyage):
@@ -327,6 +327,7 @@ Batch indexing (OpenAI + Gemini + Voyage):
 - Set `remote.batch.concurrency` to control how many batch jobs we submit in parallel (default: 2).
 - Batch mode applies when `memorySearch.provider = "openai"` or `"gemini"` and uses the corresponding API key.
 - Gemini batch jobs use the async embeddings batch endpoint and require Gemini Batch API availability.
+- DeepSeek does not currently have a batch embeddings path wired here, so it uses synchronous embedding calls.
 
 Why OpenAI batch is fast + cheap:
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -92,7 +92,8 @@ Defaults:
   2. `openai` if an OpenAI key can be resolved.
   3. `gemini` if a Gemini key can be resolved.
   4. `voyage` if a Voyage key can be resolved.
-  5. Otherwise memory search stays disabled until configured.
+  5. `deepseek` if a DeepSeek key can be resolved.
+  6. Otherwise memory search stays disabled until configured.
 - Local mode uses node-llama-cpp and may require `pnpm approve-builds`.
 - Uses sqlite-vec (when available) to accelerate vector search inside SQLite.
 
@@ -101,7 +102,8 @@ resolves keys from auth profiles, `models.providers.*.apiKey`, or environment
 variables. Codex OAuth only covers chat/completions and does **not** satisfy
 embeddings for memory search. For Gemini, use `GEMINI_API_KEY` or
 `models.providers.google.apiKey`. For Voyage, use `VOYAGE_API_KEY` or
-`models.providers.voyage.apiKey`. When using a custom OpenAI-compatible endpoint,
+`models.providers.voyage.apiKey`. For DeepSeek, use `DEEPSEEK_API_KEY` or
+`models.providers.deepseek.apiKey`. When using a custom OpenAI-compatible endpoint,
 set `memorySearch.remote.apiKey` (and optional `memorySearch.remote.headers`).
 
 ### QMD backend (experimental)

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -67,6 +67,7 @@ Semantic memory search uses **embedding APIs** when configured for remote provid
 - `memorySearch.provider = "openai"` → OpenAI embeddings
 - `memorySearch.provider = "gemini"` → Gemini embeddings
 - `memorySearch.provider = "voyage"` → Voyage embeddings
+- `memorySearch.provider = "deepseek"` → DeepSeek embeddings
 - Optional fallback to a remote provider if local embeddings fail
 
 You can keep it local with `memorySearch.provider = "local"` (no API usage).

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -9,7 +9,7 @@ export type ResolvedMemorySearchConfig = {
   enabled: boolean;
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
-  provider: "openai" | "local" | "gemini" | "voyage" | "auto";
+  provider: "openai" | "local" | "gemini" | "voyage" | "deepseek" | "auto";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -25,7 +25,7 @@ export type ResolvedMemorySearchConfig = {
   experimental: {
     sessionMemory: boolean;
   };
-  fallback: "openai" | "gemini" | "local" | "voyage" | "none";
+  fallback: "openai" | "gemini" | "local" | "voyage" | "deepseek" | "none";
   model: string;
   local: {
     modelPath?: string;
@@ -81,6 +81,7 @@ export type ResolvedMemorySearchConfig = {
 const DEFAULT_OPENAI_MODEL = "text-embedding-3-small";
 const DEFAULT_GEMINI_MODEL = "gemini-embedding-001";
 const DEFAULT_VOYAGE_MODEL = "voyage-4-large";
+const DEFAULT_DEEPSEEK_MODEL = "deepseek-embedding";
 const DEFAULT_CHUNK_TOKENS = 400;
 const DEFAULT_CHUNK_OVERLAP = 80;
 const DEFAULT_WATCH_DEBOUNCE_MS = 1500;
@@ -153,6 +154,7 @@ function mergeConfig(
     provider === "openai" ||
     provider === "gemini" ||
     provider === "voyage" ||
+    provider === "deepseek" ||
     provider === "auto";
   const batch = {
     enabled: overrideRemote?.batch?.enabled ?? defaultRemote?.batch?.enabled ?? false,
@@ -182,7 +184,9 @@ function mergeConfig(
         ? DEFAULT_OPENAI_MODEL
         : provider === "voyage"
           ? DEFAULT_VOYAGE_MODEL
-          : undefined;
+          : provider === "deepseek"
+            ? DEFAULT_DEEPSEEK_MODEL
+            : undefined;
   const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -315,6 +315,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     qianfan: "QIANFAN_API_KEY",
     ollama: "OLLAMA_API_KEY",
     vllm: "VLLM_API_KEY",
+    deepseek: "DEEPSEEK_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -76,7 +76,7 @@ export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void>
   if (hasLocalEmbeddings(resolved.local)) {
     return;
   }
-  for (const provider of ["openai", "gemini", "voyage"] as const) {
+  for (const provider of ["openai", "gemini", "voyage", "deepseek"] as const) {
     if (hasRemoteApiKey || (await hasApiKeyForProvider(provider, cfg, agentDir))) {
       return;
     }
@@ -119,7 +119,7 @@ function hasLocalEmbeddings(local: { modelPath?: string }): boolean {
 }
 
 async function hasApiKeyForProvider(
-  provider: "openai" | "gemini" | "voyage",
+  provider: "openai" | "gemini" | "voyage" | "deepseek",
   cfg: OpenClawConfig,
   agentDir: string,
 ): Promise<boolean> {
@@ -141,6 +141,8 @@ function providerEnvVar(provider: string): string {
       return "GEMINI_API_KEY";
     case "voyage":
       return "VOYAGE_API_KEY";
+    case "deepseek":
+      return "DEEPSEEK_API_KEY";
     default:
       return `${provider.toUpperCase()}_API_KEY`;
   }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -181,7 +181,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.experimental.sessionMemory":
     "Enable experimental session transcript indexing for memory search (default: false).",
   "agents.defaults.memorySearch.provider":
-    'Embedding provider ("openai", "gemini", "voyage", or "local").',
+    'Embedding provider ("openai", "gemini", "voyage", "deepseek", or "local").',
   "agents.defaults.memorySearch.remote.baseUrl":
     "Custom base URL for remote embeddings (OpenAI-compatible proxies or Gemini overrides).",
   "agents.defaults.memorySearch.remote.apiKey": "Custom API key for the remote embedding provider.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -273,7 +273,7 @@ export type MemorySearchConfig = {
     sessionMemory?: boolean;
   };
   /** Embedding provider mode. */
-  provider?: "openai" | "gemini" | "local" | "voyage";
+  provider?: "openai" | "gemini" | "local" | "voyage" | "deepseek";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -292,7 +292,7 @@ export type MemorySearchConfig = {
     };
   };
   /** Fallback behavior when embeddings fail. */
-  fallback?: "openai" | "gemini" | "local" | "voyage" | "none";
+  fallback?: "openai" | "gemini" | "local" | "voyage" | "deepseek" | "none";
   /** Embedding model id (remote) or alias (local). */
   model?: string;
   /** Local embedding settings (node-llama-cpp). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -464,7 +464,13 @@ export const MemorySearchSchema = z
       .strict()
       .optional(),
     provider: z
-      .union([z.literal("openai"), z.literal("local"), z.literal("gemini"), z.literal("voyage")])
+      .union([
+        z.literal("openai"),
+        z.literal("local"),
+        z.literal("gemini"),
+        z.literal("voyage"),
+        z.literal("deepseek"),
+      ])
       .optional(),
     remote: z
       .object({
@@ -490,6 +496,7 @@ export const MemorySearchSchema = z
         z.literal("gemini"),
         z.literal("local"),
         z.literal("voyage"),
+        z.literal("deepseek"),
         z.literal("none"),
       ])
       .optional(),

--- a/src/memory/embeddings-deepseek.test.ts
+++ b/src/memory/embeddings-deepseek.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as authModule from "../agents/model-auth.js";
+import { type FetchMock, withFetchPreconnect } from "../test-utils/fetch-mock.js";
+import { createDeepseekEmbeddingProvider, normalizeDeepseekModel } from "./embeddings-deepseek.js";
+
+vi.mock("../agents/model-auth.js", async () => {
+  const { createModelAuthMockModule } = await import("../test-utils/model-auth-mock.js");
+  return createModelAuthMockModule();
+});
+
+const createFetchMock = () => {
+  const fetchMock = vi.fn<FetchMock>(
+    async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+  return withFetchPreconnect(fetchMock);
+};
+
+function mockDeepseekApiKey() {
+  vi.mocked(authModule.resolveApiKeyForProvider).mockResolvedValue({
+    apiKey: "deepseek-key-123",
+    mode: "api-key",
+    source: "test",
+  });
+}
+
+async function createDefaultDeepseekProvider(
+  model: string,
+  fetchMock: ReturnType<typeof createFetchMock>,
+) {
+  vi.stubGlobal("fetch", fetchMock);
+  mockDeepseekApiKey();
+  return createDeepseekEmbeddingProvider({
+    config: {} as never,
+    provider: "deepseek",
+    model,
+    fallback: "none",
+  });
+}
+
+describe("deepseek embedding provider", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("configures client with correct defaults and headers", async () => {
+    const fetchMock = createFetchMock();
+    const result = await createDefaultDeepseekProvider("deepseek-embedding", fetchMock);
+
+    await result.provider.embedQuery("test query");
+
+    expect(authModule.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "deepseek" }),
+    );
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    expect(url).toBe("https://api.deepseek.com/v1/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer deepseek-key-123");
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      model: "deepseek-embedding",
+      input: ["test query"],
+    });
+  });
+
+  it("respects remote overrides for baseUrl and apiKey", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await createDeepseekEmbeddingProvider({
+      config: {} as never,
+      provider: "deepseek",
+      model: "deepseek-embedding",
+      fallback: "none",
+      remote: {
+        baseUrl: "https://proxy.example.com",
+        apiKey: "remote-override-key",
+        headers: { "X-Custom": "123" },
+      },
+    });
+
+    await result.provider.embedQuery("test");
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    expect(url).toBe("https://proxy.example.com/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer remote-override-key");
+    expect(headers["X-Custom"]).toBe("123");
+  });
+
+  it("normalizes model names", () => {
+    expect(normalizeDeepseekModel("deepseek/deepseek-embedding")).toBe("deepseek-embedding");
+    expect(normalizeDeepseekModel("deepseek-embedding")).toBe("deepseek-embedding");
+    expect(normalizeDeepseekModel("  deepseek-embed  ")).toBe("deepseek-embed");
+    expect(normalizeDeepseekModel("")).toBe("deepseek-embedding");
+  });
+});

--- a/src/memory/embeddings-deepseek.ts
+++ b/src/memory/embeddings-deepseek.ts
@@ -1,0 +1,67 @@
+import { resolveRemoteEmbeddingBearerClient } from "./embeddings-remote-client.js";
+import { fetchRemoteEmbeddingVectors } from "./embeddings-remote-fetch.js";
+import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
+
+export type DeepseekEmbeddingClient = {
+  baseUrl: string;
+  headers: Record<string, string>;
+  model: string;
+};
+
+export const DEFAULT_DEEPSEEK_EMBEDDING_MODEL = "deepseek-embedding";
+const DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1";
+
+export function normalizeDeepseekModel(model: string): string {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return DEFAULT_DEEPSEEK_EMBEDDING_MODEL;
+  }
+  if (trimmed.startsWith("deepseek/")) {
+    return trimmed.slice("deepseek/".length);
+  }
+  return trimmed;
+}
+
+export async function createDeepseekEmbeddingProvider(
+  options: EmbeddingProviderOptions,
+): Promise<{ provider: EmbeddingProvider; client: DeepseekEmbeddingClient }> {
+  const client = await resolveDeepseekEmbeddingClient(options);
+  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+
+  const embed = async (input: string[]): Promise<number[][]> => {
+    if (input.length === 0) {
+      return [];
+    }
+    return await fetchRemoteEmbeddingVectors({
+      url,
+      headers: client.headers,
+      body: { model: client.model, input },
+      errorPrefix: "deepseek embeddings failed",
+    });
+  };
+
+  return {
+    provider: {
+      id: "deepseek",
+      model: client.model,
+      embedQuery: async (text) => {
+        const [vec] = await embed([text]);
+        return vec ?? [];
+      },
+      embedBatch: embed,
+    },
+    client,
+  };
+}
+
+export async function resolveDeepseekEmbeddingClient(
+  options: EmbeddingProviderOptions,
+): Promise<DeepseekEmbeddingClient> {
+  const { baseUrl, headers } = await resolveRemoteEmbeddingBearerClient({
+    provider: "deepseek",
+    options,
+    defaultBaseUrl: DEFAULT_DEEPSEEK_BASE_URL,
+  });
+  const model = normalizeDeepseekModel(options.model);
+  return { baseUrl, headers, model };
+}

--- a/src/memory/embeddings-remote-client.ts
+++ b/src/memory/embeddings-remote-client.ts
@@ -1,7 +1,7 @@
 import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import type { EmbeddingProviderOptions } from "./embeddings.js";
 
-type RemoteEmbeddingProviderId = "openai" | "voyage";
+type RemoteEmbeddingProviderId = "openai" | "voyage" | "deepseek";
 
 export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -34,12 +34,7 @@ export type EmbeddingProvider = {
   embedBatch: (texts: string[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId =
-  | "openai"
-  | "local"
-  | "gemini"
-  | "voyage"
-  | "deepseek";
+export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "deepseek";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -3,7 +3,10 @@ import type { Llama, LlamaEmbeddingContext, LlamaModel } from "node-llama-cpp";
 import type { OpenClawConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveUserPath } from "../utils.js";
-import { createDeepseekEmbeddingProvider, type DeepseekEmbeddingClient } from "./embeddings-deepseek.js";
+import {
+  createDeepseekEmbeddingProvider,
+  type DeepseekEmbeddingClient,
+} from "./embeddings-deepseek.js";
 import { createGeminiEmbeddingProvider, type GeminiEmbeddingClient } from "./embeddings-gemini.js";
 import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./embeddings-openai.js";
 import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embeddings-voyage.js";
@@ -31,7 +34,12 @@ export type EmbeddingProvider = {
   embedBatch: (texts: string[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "deepseek";
+export type EmbeddingProviderId =
+  | "openai"
+  | "local"
+  | "gemini"
+  | "voyage"
+  | "deepseek";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -223,6 +223,20 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         }),
       );
     }
+    if (this.provider.id === "deepseek" && this.deepseek) {
+      const entries = Object.entries(this.deepseek.headers)
+        .filter(([key]) => key.toLowerCase() !== "authorization")
+        .toSorted(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => [key, value]);
+      return hashText(
+        JSON.stringify({
+          provider: "deepseek",
+          baseUrl: this.deepseek.baseUrl,
+          model: this.deepseek.model,
+          headers: entries,
+        }),
+      );
+    }
     if (this.provider.id === "gemini" && this.gemini) {
       const entries = Object.entries(this.gemini.headers)
         .filter(([key]) => {

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -89,12 +89,7 @@ export abstract class MemoryManagerSyncOps {
   protected abstract readonly workspaceDir: string;
   protected abstract readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null = null;
-  protected fallbackFrom?:
-    | "openai"
-    | "local"
-    | "gemini"
-    | "voyage"
-    | "deepseek";
+  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "deepseek";
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;
@@ -950,12 +945,7 @@ export abstract class MemoryManagerSyncOps {
     if (this.fallbackFrom) {
       return false;
     }
-    const fallbackFrom = this.provider.id as
-      | "openai"
-      | "gemini"
-      | "local"
-      | "voyage"
-      | "deepseek";
+    const fallbackFrom = this.provider.id as "openai" | "gemini" | "local" | "voyage" | "deepseek";
 
     const fallbackModel =
       fallback === "gemini"

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -89,7 +89,12 @@ export abstract class MemoryManagerSyncOps {
   protected abstract readonly workspaceDir: string;
   protected abstract readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null = null;
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "deepseek";
+  protected fallbackFrom?:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "deepseek";
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -53,12 +53,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     | "voyage"
     | "deepseek"
     | "auto";
-  protected fallbackFrom?:
-    | "openai"
-    | "local"
-    | "gemini"
-    | "voyage"
-    | "deepseek";
+  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "deepseek";
   protected fallbackReason?: string;
   private readonly providerUnavailableReason?: string;
   protected openAi?: OpenAiEmbeddingClient;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -11,6 +11,7 @@ import {
   createEmbeddingProvider,
   type EmbeddingProvider,
   type EmbeddingProviderResult,
+  type DeepseekEmbeddingClient,
   type GeminiEmbeddingClient,
   type OpenAiEmbeddingClient,
   type VoyageEmbeddingClient,
@@ -45,13 +46,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected readonly workspaceDir: string;
   protected readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null;
-  private readonly requestedProvider: "openai" | "local" | "gemini" | "voyage" | "auto";
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage";
+  private readonly requestedProvider: "openai" | "local" | "gemini" | "voyage" | "deepseek" | "auto";
+  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "deepseek";
   protected fallbackReason?: string;
   private readonly providerUnavailableReason?: string;
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;
+  protected deepseek?: DeepseekEmbeddingClient;
   protected batch: {
     enabled: boolean;
     wait: boolean;
@@ -158,6 +160,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.openAi = params.providerResult.openAi;
     this.gemini = params.providerResult.gemini;
     this.voyage = params.providerResult.voyage;
+    this.deepseek = params.providerResult.deepseek;
     this.sources = new Set(params.settings.sources);
     this.db = this.openDatabase();
     this.providerKey = this.computeProviderKey();

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -46,8 +46,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected readonly workspaceDir: string;
   protected readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null;
-  private readonly requestedProvider: "openai" | "local" | "gemini" | "voyage" | "deepseek" | "auto";
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "deepseek";
+  private readonly requestedProvider:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "deepseek"
+    | "auto";
+  protected fallbackFrom?:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "deepseek";
   protected fallbackReason?: string;
   private readonly providerUnavailableReason?: string;
   protected openAi?: OpenAiEmbeddingClient;


### PR DESCRIPTION
## Summary
- Add DeepSeek embeddings provider for memory search (remote embeddings).
- Wire provider into config schema, doctor check, and docs.

## Notes
- Uses OpenAI-compatible embeddings endpoint (POST /embeddings) with base URL https://api.deepseek.com/v1.
- Requires DEEPSEEK_API_KEY or models.providers.deepseek.apiKey.

## Testing
- Added unit tests for DeepSeek embedding provider (patterned after voyage tests).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds DeepSeek as a new embedding provider for memory search. The implementation follows the existing pattern for OpenAI-compatible providers (similar to Voyage), using the standard `/embeddings` endpoint at `https://api.deepseek.com/v1`. Authentication uses `DEEPSEEK_API_KEY` or `models.providers.deepseek.apiKey`.

- Wired into config schema, doctor checks, and documentation
- Unit tests added covering client configuration, remote overrides, and model normalization
- Integration follows established patterns for remote embedding providers
- Missing DeepSeek references in a few type definitions and help text (see inline comments)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor documentation and type definition updates
- Implementation follows established patterns correctly and includes good test coverage. Score reflects minor missing type definitions in `src/agents/memory-search.ts` and help text in `src/config/schema.help.ts` that need fixing to maintain consistency across the codebase.
- `src/agents/memory-search.ts` and `src/config/schema.help.ts` need type/help text updates to include `deepseek` option

<sub>Last reviewed commit: e1de643</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->