### PR TITLE
feat(tools): add EXA as web search provider

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -234,6 +234,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "exa") {
+    return {
+      error: "missing_exa_api_key",
+      message:
+        "web_search (exa) needs an EXA API key. Set EXA_API_KEY in the Gateway environment, or configure tools.web.search.exa.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_brave_api_key",
     message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -18,7 +18,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "grok"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "exa"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -31,6 +31,8 @@ const OPENROUTER_KEY_PREFIXES = ["sk-or-"];
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
+
+const EXA_API_ENDPOINT = "https://api.exa.ai/search";
 
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
@@ -100,6 +102,11 @@ type GrokConfig = {
   apiKey?: string;
   model?: string;
   inlineCitations?: boolean;
+};
+
+type ExaConfig = {
+  apiKey?: string;
+  baseUrl?: string;
 };
 
 type GrokSearchResponse = {
@@ -248,6 +255,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   if (raw === "brave") {
     return "brave";
   }
+  if (raw === "exa") {
+    return "exa";
+  }
   return "brave";
 }
 
@@ -368,6 +378,17 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
     return {};
   }
   return grok as GrokConfig;
+}
+
+function resolveExaConfig(search?: WebSearchConfig): ExaConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const exa = "exa" in search ? search.exa : undefined;
+  if (!exa || typeof exa !== "object") {
+    return {};
+  }
+  return exa as ExaConfig;
 }
 
 function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
@@ -573,6 +594,43 @@ async function runGrokSearch(params: {
   return { content, citations, inlineCitations };
 }
 
+type ExaSearchResult = {
+  title: string;
+  url: string;
+  text?: string;
+  score?: number;
+};
+
+async function runExaSearch(params: {
+  query: string;
+  apiKey: string;
+  count: number;
+  timeoutSeconds: number;
+}): Promise<ExaSearchResult[]> {
+  const res = await fetch(EXA_API_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${params.apiKey}`,
+    },
+    body: JSON.stringify({
+      query: params.query,
+      numResults: params.count,
+      type: "neural",
+    }),
+    signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+  });
+
+  if (!res.ok) {
+    const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+    const detail = detailResult.text;
+    throw new Error(`EXA API error (${res.status}): ${detail || res.statusText}`);
+  }
+
+  const data = (await res.json()) as { results?: ExaSearchResult[] };
+  return data.results ?? [];
+}
+
 async function runWebSearch(params: {
   query: string;
   count: number;
@@ -659,6 +717,34 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "exa") {
+    const results = await runExaSearch({
+      query: params.query,
+      apiKey: params.apiKey,
+      count: params.count,
+      timeoutSeconds: params.timeoutSeconds,
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      results: results.map((r) => ({
+        title: r.title,
+        url: r.url,
+        snippet: r.text?.substring(0, 500),
+      })),
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -739,13 +825,16 @@ export function createWebSearchTool(options?: {
   const provider = resolveSearchProvider(search);
   const perplexityConfig = resolvePerplexityConfig(search);
   const grokConfig = resolveGrokConfig(search);
+  const exaConfig = resolveExaConfig(search);
 
   const description =
     provider === "perplexity"
       ? "Search the web using Perplexity Sonar (direct or via OpenRouter). Returns AI-synthesized answers with citations from real-time web search."
       : provider === "grok"
         ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
-        : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+        : provider === "exa"
+          ? "Search the web using EXA AI. Provides neural search optimized for LLMs with high-quality, context-aware results."
+          : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -755,12 +844,15 @@ export function createWebSearchTool(options?: {
     execute: async (_toolCallId, args) => {
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
+      const exaAuth = provider === "exa" ? exaConfig.apiKey : undefined;
       const apiKey =
         provider === "perplexity"
           ? perplexityAuth?.apiKey
           : provider === "grok"
             ? resolveGrokApiKey(grokConfig)
-            : resolveSearchApiKey(search);
+            : provider === "exa"
+              ? exaAuth || process.env.EXA_API_KEY
+              : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -660,7 +660,9 @@ async function runWebSearch(params: {
       ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
       : params.provider === "perplexity"
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}:${params.freshness || "default"}`
-        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
+        : params.provider === "exa"
+          ? `${params.provider}:${params.query}`
+          : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -105,7 +105,7 @@ export const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", "grok", or "exa").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -389,8 +389,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", or "grok"). */
-      provider?: "brave" | "perplexity" | "grok";
+      /** Search provider ("brave", "perplexity", "grok", or "exa"). */
+      provider?: "brave" | "perplexity" | "grok" | "exa";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -416,6 +416,13 @@ export type ToolsConfig = {
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */
         inlineCitations?: boolean;
+      };
+      /** EXA-specific configuration (used when provider="exa"). */
+      exa?: {
+        /** API key for EXA (defaults to EXA_API_KEY env var). */
+        apiKey?: string;
+        /** Base URL for EXA API (defaults to https://api.exa.ai). */
+        baseUrl?: string;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -227,7 +227,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("grok")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("grok"), z.literal("exa")])
+      .optional(),
     apiKey: z.string().optional().register(sensitive),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -245,6 +247,13 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional().register(sensitive),
         model: z.string().optional(),
         inlineCitations: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    exa: z
+      .object({
+        apiKey: z.string().optional().register(sensitive),
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Add EXA AI as a new search provider for the web_search tool. EXA provides neural search optimized for LLMs with high-quality, context-aware results.

## Changes

- Add EXA to SEARCH_PROVIDERS array
- Add ExaConfig type and resolveExaConfig function
- Add runExaSearch function for API calls
- Update provider type unions in types.tools.ts
- Add EXA config section to zod schema
- Update schema help text

## Why EXA?

EXA is an AI-powered search engine designed specifically for LLMs. It provides:
- Neural search (AI understanding of query intent)
- Better results for complex/abstract queries
- Competitive pricing vs Brave/Perplexity

## Testing

Tested the build locally with `pnpm build` - passes successfully.

## AI-assisted

This PR was AI-assisted (built by Eli Rook, an autonomous AI).

---
Closes: [feature request]

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds EXA AI as a fourth web search provider alongside Brave, Perplexity, and Grok. The implementation follows the existing pattern for other providers by adding EXA to the provider array, defining config types, implementing the API call function, and integrating it into the main search flow.

**Critical issues found:**
- Missing EXA case in `missingSearchKeyPayload` function - users will see incorrect Brave error message when EXA API key is missing
- Cache key generation doesn't handle EXA provider - will use wrong grok parameters for cache keys

**Style concerns:**
- EXA API key resolution differs from other providers (inline vs dedicated resolver function)

**Missing updates:**
- Documentation (`docs/tools/web.md`) doesn't mention EXA as a provider option
- No test coverage added for EXA provider

<h3>Confidence Score: 2/5</h3>

- This PR has critical logical errors that will cause incorrect behavior in production
- Two critical bugs found: missing EXA error handling will show wrong error messages to users, and missing cache key logic will cause cache collisions with grok provider. These are functional regressions that must be fixed before merge.
- Focus on `src/agents/tools/web-search.ts` lines 220-242 (error messages) and 650-656 (cache keys)

<sub>Last reviewed commit: 24607d7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->