### PR TITLE
feat(doctor): detect memory plugins in memory search health check

### DIFF
--- a/docs/reference/templates/BOOTSTRAP.md
+++ b/docs/reference/templates/BOOTSTRAP.md
@@ -45,8 +45,9 @@ Write it down. Make it real.
 ## One-time system admin check
 
 Since this is a new install, offer a choice:
-1) Run the recommended host healthcheck using the `healthcheck` skill.
-2) Skip for now (run later by saying “run healthcheck”).
+
+1. Run the recommended host healthcheck using the `healthcheck` skill.
+2. Skip for now (run later by saying “run healthcheck”).
 
 ## Connect (Optional)
 

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -149,9 +149,7 @@ export const memoryConfigSchema = {
       autoCapture = {
         enabled: ac.enabled !== false,
         provider:
-          ac.provider === "openai" || ac.provider === "openrouter"
-            ? ac.provider
-            : "openrouter",
+          ac.provider === "openai" || ac.provider === "openrouter" ? ac.provider : "openrouter",
         model: typeof ac.model === "string" ? ac.model : undefined,
         apiKey: typeof ac.apiKey === "string" ? resolveEnvVars(ac.apiKey) : undefined,
         baseUrl: typeof ac.baseUrl === "string" ? ac.baseUrl : undefined,

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -2,6 +2,20 @@ import fs from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+export type AutoCaptureConfig = {
+  enabled: boolean;
+  /** LLM provider for memory extraction: "openrouter" (default) or "openai" */
+  provider?: "openrouter" | "openai";
+  /** LLM model for memory extraction (default: google/gemini-2.0-flash-001) */
+  model?: string;
+  /** API key for the LLM provider (supports ${ENV_VAR} syntax) */
+  apiKey?: string;
+  /** Base URL for the LLM provider (default: https://openrouter.ai/api/v1) */
+  baseUrl?: string;
+  /** Maximum messages to send for extraction (default: 10) */
+  maxMessages?: number;
+};
+
 export type MemoryConfig = {
   embedding: {
     provider: "openai";
@@ -9,7 +23,8 @@ export type MemoryConfig = {
     apiKey: string;
   };
   dbPath?: string;
-  autoCapture?: boolean;
+  /** @deprecated Use autoCapture object instead. Boolean true enables with defaults. */
+  autoCapture?: boolean | AutoCaptureConfig;
   autoRecall?: boolean;
   coreMemory?: {
     enabled?: boolean;
@@ -117,6 +132,33 @@ export const memoryConfigSchema = {
 
     const model = resolveEmbeddingModel(embedding);
 
+    // Parse autoCapture (supports boolean for backward compat, or object for LLM config)
+    let autoCapture: MemoryConfig["autoCapture"];
+    if (cfg.autoCapture === false) {
+      autoCapture = false;
+    } else if (cfg.autoCapture === true || cfg.autoCapture === undefined) {
+      // Legacy boolean or default — enable with defaults
+      autoCapture = { enabled: true };
+    } else if (typeof cfg.autoCapture === "object" && !Array.isArray(cfg.autoCapture)) {
+      const ac = cfg.autoCapture as Record<string, unknown>;
+      assertAllowedKeys(
+        ac,
+        ["enabled", "provider", "model", "apiKey", "baseUrl", "maxMessages"],
+        "autoCapture config",
+      );
+      autoCapture = {
+        enabled: ac.enabled !== false,
+        provider:
+          ac.provider === "openai" || ac.provider === "openrouter"
+            ? ac.provider
+            : "openrouter",
+        model: typeof ac.model === "string" ? ac.model : undefined,
+        apiKey: typeof ac.apiKey === "string" ? resolveEnvVars(ac.apiKey) : undefined,
+        baseUrl: typeof ac.baseUrl === "string" ? ac.baseUrl : undefined,
+        maxMessages: typeof ac.maxMessages === "number" ? ac.maxMessages : undefined,
+      };
+    }
+
     // Parse coreMemory
     let coreMemory: MemoryConfig["coreMemory"];
     if (cfg.coreMemory && typeof cfg.coreMemory === "object" && !Array.isArray(cfg.coreMemory)) {
@@ -136,7 +178,7 @@ export const memoryConfigSchema = {
         apiKey: resolveEnvVars(embedding.apiKey),
       },
       dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : DEFAULT_DB_PATH,
-      autoCapture: cfg.autoCapture !== false,
+      autoCapture: autoCapture ?? { enabled: true },
       autoRecall: cfg.autoRecall !== false,
       coreMemory,
     };
@@ -158,9 +200,27 @@ export const memoryConfigSchema = {
       placeholder: "~/.openclaw/memory/lancedb",
       advanced: true,
     },
-    autoCapture: {
+    "autoCapture.enabled": {
       label: "Auto-Capture",
-      help: "Automatically capture important information from conversations",
+      help: "Automatically capture important information from conversations using LLM extraction",
+    },
+    "autoCapture.provider": {
+      label: "Capture LLM Provider",
+      placeholder: "openrouter",
+      advanced: true,
+      help: "LLM provider for memory extraction (openrouter or openai)",
+    },
+    "autoCapture.model": {
+      label: "Capture Model",
+      placeholder: "google/gemini-2.0-flash-001",
+      advanced: true,
+      help: "LLM model for memory extraction (use a fast/cheap model)",
+    },
+    "autoCapture.apiKey": {
+      label: "Capture API Key",
+      sensitive: true,
+      advanced: true,
+      help: "API key for capture LLM (defaults to OpenRouter key from provider config)",
     },
     autoRecall: {
       label: "Auto-Recall",

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -11,11 +11,11 @@ export type MemoryConfig = {
   dbPath?: string;
   autoCapture?: boolean;
   autoRecall?: boolean;
-  bootContext?: {
+  coreMemory?: {
     enabled?: boolean;
-    /** Maximum number of boot memories to load */
+    /** Maximum number of core memories to load */
     maxEntries?: number;
-    /** Minimum importance threshold for boot memories */
+    /** Minimum importance threshold for core memories */
     minImportance?: number;
   };
 };
@@ -26,7 +26,7 @@ export const MEMORY_CATEGORIES = [
   "decision",
   "entity",
   "other",
-  "boot",
+  "core",
 ] as const;
 export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
 
@@ -105,7 +105,7 @@ export const memoryConfigSchema = {
     const cfg = value as Record<string, unknown>;
     assertAllowedKeys(
       cfg,
-      ["embedding", "dbPath", "autoCapture", "autoRecall", "bootContext"],
+      ["embedding", "dbPath", "autoCapture", "autoRecall", "coreMemory"],
       "memory config",
     );
 
@@ -117,12 +117,12 @@ export const memoryConfigSchema = {
 
     const model = resolveEmbeddingModel(embedding);
 
-    // Parse bootContext
-    let bootContext: MemoryConfig["bootContext"];
-    if (cfg.bootContext && typeof cfg.bootContext === "object" && !Array.isArray(cfg.bootContext)) {
-      const bc = cfg.bootContext as Record<string, unknown>;
-      assertAllowedKeys(bc, ["enabled", "maxEntries", "minImportance"], "bootContext config");
-      bootContext = {
+    // Parse coreMemory
+    let coreMemory: MemoryConfig["coreMemory"];
+    if (cfg.coreMemory && typeof cfg.coreMemory === "object" && !Array.isArray(cfg.coreMemory)) {
+      const bc = cfg.coreMemory as Record<string, unknown>;
+      assertAllowedKeys(bc, ["enabled", "maxEntries", "minImportance"], "coreMemory config");
+      coreMemory = {
         enabled: bc.enabled === true,
         maxEntries: typeof bc.maxEntries === "number" ? bc.maxEntries : 50,
         minImportance: typeof bc.minImportance === "number" ? bc.minImportance : 0.5,
@@ -138,7 +138,7 @@ export const memoryConfigSchema = {
       dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : DEFAULT_DB_PATH,
       autoCapture: cfg.autoCapture !== false,
       autoRecall: cfg.autoRecall !== false,
-      bootContext,
+      coreMemory,
     };
   },
   uiHints: {
@@ -166,21 +166,21 @@ export const memoryConfigSchema = {
       label: "Auto-Recall",
       help: "Automatically inject relevant memories into context",
     },
-    "bootContext.enabled": {
-      label: "Boot Context",
-      help: "Inject boot-category memories as virtual MEMORY.md at session start",
+    "coreMemory.enabled": {
+      label: "Core Memory",
+      help: "Inject core memories as virtual MEMORY.md at session start (replaces MEMORY.md file)",
     },
-    "bootContext.maxEntries": {
-      label: "Max Boot Entries",
+    "coreMemory.maxEntries": {
+      label: "Max Core Entries",
       placeholder: "50",
       advanced: true,
-      help: "Maximum number of boot memories to load",
+      help: "Maximum number of core memories to load",
     },
-    "bootContext.minImportance": {
-      label: "Min Boot Importance",
+    "coreMemory.minImportance": {
+      label: "Min Core Importance",
       placeholder: "0.5",
       advanced: true,
-      help: "Minimum importance threshold for boot memories (0-1)",
+      help: "Minimum importance threshold for core memories (0-1)",
     },
   },
 };

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -401,9 +401,10 @@ class MemoryExtractor {
         )
         .map((m) => ({
           text: String(m.text).slice(0, 500),
-          category: MEMORY_CATEGORIES.includes(m.category as MemoryCategory)
-            ? (m.category as MemoryCategory)
-            : ("fact" as MemoryCategory),
+          category:
+            typeof m.category === "string" && MEMORY_CATEGORIES.includes(m.category)
+              ? m.category
+              : "fact",
           importance:
             typeof m.importance === "number" ? Math.min(1, Math.max(0, m.importance)) : 0.7,
         }))

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -320,7 +320,7 @@ const memoryPlugin = {
         name: "memory_store",
         label: "Memory Store",
         description:
-          "Save important information in long-term memory. Use for preferences, facts, decisions. Use category 'boot' for information that should be loaded at every session start (replaces MEMORY.md).",
+          "Save important information in long-term memory. Use for preferences, facts, decisions. Use category 'core' for persistent essential context loaded at every session start (replaces MEMORY.md).",
         parameters: Type.Object({
           text: Type.String({ description: "Information to remember" }),
           importance: Type.Optional(Type.Number({ description: "Importance 0-1 (default: 0.7)" })),
@@ -609,27 +609,27 @@ const memoryPlugin = {
     }
 
     // ========================================================================
-    // Boot Context Hook
+    // Core Memory Hook
     // ========================================================================
 
-    // Inject boot-category memories as virtual MEMORY.md at bootstrap time
-    if (cfg.bootContext?.enabled) {
+    // Inject core memories as virtual MEMORY.md at bootstrap time
+    if (cfg.coreMemory?.enabled) {
       api.on("agent_bootstrap", async (event) => {
         try {
-          const maxEntries = cfg.bootContext?.maxEntries ?? 50;
-          const minImportance = cfg.bootContext?.minImportance ?? 0.5;
+          const maxEntries = cfg.coreMemory?.maxEntries ?? 50;
+          const minImportance = cfg.coreMemory?.minImportance ?? 0.5;
 
-          // Use category-based query for reliable boot memory retrieval
-          const bootMemories = await db.listByCategory("boot", maxEntries, minImportance);
+          // Use category-based query for reliable core memory retrieval
+          const coreMemories = await db.listByCategory("core", maxEntries, minImportance);
 
-          if (bootMemories.length === 0) {
+          if (coreMemories.length === 0) {
             return;
           }
 
-          // Format boot memories into a MEMORY.md-style document
-          let content = "# Boot Context (from LanceDB)\n\n";
-          content += "*Auto-loaded from long-term memory*\n\n";
-          for (const mem of bootMemories) {
+          // Format core memories into a MEMORY.md-style document
+          let content = "# Core Memory\n\n";
+          content += "*Persistent context loaded from long-term memory*\n\n";
+          for (const mem of coreMemories) {
             content += `- ${mem.text}\n`;
           }
 
@@ -641,7 +641,7 @@ const memoryPlugin = {
 
           const virtualFile = {
             name: "MEMORY.md" as const,
-            path: "memory://lancedb/boot-context",
+            path: "memory://lancedb/core-memory",
             content,
             missing: false,
           };
@@ -653,12 +653,12 @@ const memoryPlugin = {
           }
 
           api.logger.info?.(
-            `memory-lancedb: injected ${bootMemories.length} boot memories into context`,
+            `memory-lancedb: injected ${coreMemories.length} core memories into context`,
           );
 
           return { files };
         } catch (err) {
-          api.logger.warn(`memory-lancedb: boot context injection failed: ${String(err)}`);
+          api.logger.warn(`memory-lancedb: core memory injection failed: ${String(err)}`);
         }
       });
     }

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -25,6 +25,22 @@
     "autoRecall": {
       "label": "Auto-Recall",
       "help": "Automatically inject relevant memories into context"
+    },
+    "coreMemory.enabled": {
+      "label": "Core Memory",
+      "help": "Inject core memories as virtual MEMORY.md at session start (replaces MEMORY.md file)"
+    },
+    "coreMemory.maxEntries": {
+      "label": "Max Core Entries",
+      "placeholder": "50",
+      "advanced": true,
+      "help": "Maximum number of core memories to load"
+    },
+    "coreMemory.minImportance": {
+      "label": "Min Core Importance",
+      "placeholder": "0.5",
+      "advanced": true,
+      "help": "Minimum importance threshold for core memories (0-1)"
     }
   },
   "configSchema": {
@@ -53,6 +69,21 @@
       },
       "autoRecall": {
         "type": "boolean"
+      },
+      "coreMemory": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "maxEntries": {
+            "type": "number"
+          },
+          "minImportance": {
+            "type": "number"
+          }
+        }
       }
     },
     "required": ["embedding"]

--- a/extensions/memory-neo4j/config.ts
+++ b/extensions/memory-neo4j/config.ts
@@ -135,13 +135,13 @@ export const memoryNeo4jConfigSchema = {
 
     return {
       neo4j: {
-        uri: neo4jRaw.uri as string,
+        uri: neo4jRaw.uri,
         username: neo4jUsername,
         password: neo4jPassword,
       },
       embedding: {
-        apiKey: resolveEnvVars(embeddingRaw.apiKey as string),
-        model: embeddingModel as MemoryNeo4jConfig["embedding"]["model"],
+        apiKey: resolveEnvVars(embeddingRaw.apiKey),
+        model: embeddingModel,
       },
       autoCapture: cfg.autoCapture !== false,
       autoRecall: cfg.autoRecall !== false,

--- a/extensions/memory-neo4j/config.ts
+++ b/extensions/memory-neo4j/config.ts
@@ -1,0 +1,159 @@
+/**
+ * Configuration schema for memory-neo4j plugin.
+ *
+ * Matches the JSON Schema in openclaw.plugin.json.
+ * Provides runtime parsing with env var resolution and defaults.
+ */
+
+export type MemoryNeo4jConfig = {
+  neo4j: {
+    uri: string;
+    username: string;
+    password: string;
+  };
+  embedding: {
+    apiKey: string;
+    model: "text-embedding-3-small" | "text-embedding-3-large";
+  };
+  autoCapture: boolean;
+  autoRecall: boolean;
+};
+
+/**
+ * Extraction configuration resolved from environment variables.
+ * Entity extraction auto-enables when OPENROUTER_API_KEY is set.
+ */
+export type ExtractionConfig = {
+  enabled: boolean;
+  apiKey: string;
+  model: string;
+  baseUrl: string;
+  temperature: number;
+  maxRetries: number;
+};
+
+export const MEMORY_CATEGORIES = [
+  "preference",
+  "fact",
+  "decision",
+  "entity",
+  "other",
+] as const;
+
+export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
+
+const EMBEDDING_DIMENSIONS: Record<string, number> = {
+  "text-embedding-3-small": 1536,
+  "text-embedding-3-large": 3072,
+};
+
+export function vectorDimsForModel(model: string): number {
+  const dims = EMBEDDING_DIMENSIONS[model];
+  if (!dims) {
+    throw new Error(`Unsupported embedding model: ${model}. Supported: ${Object.keys(EMBEDDING_DIMENSIONS).join(", ")}`);
+  }
+  return dims;
+}
+
+/**
+ * Resolve ${ENV_VAR} references in string values.
+ */
+function resolveEnvVars(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
+    const envValue = process.env[envVar];
+    if (!envValue) {
+      throw new Error(`Environment variable ${envVar} is not set`);
+    }
+    return envValue;
+  });
+}
+
+/**
+ * Resolve extraction config from environment variables.
+ * Returns enabled: false if OPENROUTER_API_KEY is not set.
+ */
+export function resolveExtractionConfig(): ExtractionConfig {
+  const apiKey = process.env.OPENROUTER_API_KEY ?? "";
+  return {
+    enabled: apiKey.length > 0,
+    apiKey,
+    model: process.env.EXTRACTION_MODEL ?? "google/gemini-2.0-flash-001",
+    baseUrl: process.env.EXTRACTION_BASE_URL ?? "https://openrouter.ai/api/v1",
+    temperature: 0.0,
+    maxRetries: 2,
+  };
+}
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowed: string[],
+  label: string,
+) {
+  const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unknown.length > 0) {
+    throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
+  }
+}
+
+/**
+ * Config schema with parse method for runtime validation & transformation.
+ * JSON Schema validation is handled by openclaw.plugin.json; this handles
+ * env var resolution and defaults.
+ */
+export const memoryNeo4jConfigSchema = {
+  parse(value: unknown): MemoryNeo4jConfig {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("memory-neo4j config required");
+    }
+    const cfg = value as Record<string, unknown>;
+    assertAllowedKeys(
+      cfg,
+      ["embedding", "neo4j", "autoCapture", "autoRecall"],
+      "memory-neo4j config",
+    );
+
+    // Parse neo4j section
+    const neo4jRaw = cfg.neo4j as Record<string, unknown> | undefined;
+    if (!neo4jRaw || typeof neo4jRaw !== "object") {
+      throw new Error("neo4j config section is required");
+    }
+    assertAllowedKeys(neo4jRaw, ["uri", "username", "password"], "neo4j config");
+    if (typeof neo4jRaw.uri !== "string" || !neo4jRaw.uri) {
+      throw new Error("neo4j.uri is required");
+    }
+
+    const neo4jPassword =
+      typeof neo4jRaw.password === "string" ? resolveEnvVars(neo4jRaw.password) : "";
+    const neo4jUsername =
+      typeof neo4jRaw.username === "string" ? neo4jRaw.username : "neo4j";
+
+    // Parse embedding section
+    const embeddingRaw = cfg.embedding as Record<string, unknown> | undefined;
+    if (!embeddingRaw || typeof embeddingRaw !== "object") {
+      throw new Error("embedding config section is required");
+    }
+    assertAllowedKeys(embeddingRaw, ["apiKey", "model"], "embedding config");
+    if (typeof embeddingRaw.apiKey !== "string" || !embeddingRaw.apiKey) {
+      throw new Error("embedding.apiKey is required");
+    }
+
+    const embeddingModel =
+      typeof embeddingRaw.model === "string" ? embeddingRaw.model : "text-embedding-3-small";
+    // Validate model is supported
+    vectorDimsForModel(embeddingModel);
+
+    return {
+      neo4j: {
+        uri: neo4jRaw.uri as string,
+        username: neo4jUsername,
+        password: neo4jPassword,
+      },
+      embedding: {
+        apiKey: resolveEnvVars(embeddingRaw.apiKey as string),
+        model: embeddingModel as MemoryNeo4jConfig["embedding"]["model"],
+      },
+      autoCapture: cfg.autoCapture !== false,
+      autoRecall: cfg.autoRecall !== false,
+    };
+  },
+};

--- a/extensions/memory-neo4j/config.ts
+++ b/extensions/memory-neo4j/config.ts
@@ -32,13 +32,7 @@ export type ExtractionConfig = {
   maxRetries: number;
 };
 
-export const MEMORY_CATEGORIES = [
-  "preference",
-  "fact",
-  "decision",
-  "entity",
-  "other",
-] as const;
+export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
 
 export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
 
@@ -50,7 +44,9 @@ const EMBEDDING_DIMENSIONS: Record<string, number> = {
 export function vectorDimsForModel(model: string): number {
   const dims = EMBEDDING_DIMENSIONS[model];
   if (!dims) {
-    throw new Error(`Unsupported embedding model: ${model}. Supported: ${Object.keys(EMBEDDING_DIMENSIONS).join(", ")}`);
+    throw new Error(
+      `Unsupported embedding model: ${model}. Supported: ${Object.keys(EMBEDDING_DIMENSIONS).join(", ")}`,
+    );
   }
   return dims;
 }
@@ -84,11 +80,7 @@ export function resolveExtractionConfig(): ExtractionConfig {
   };
 }
 
-function assertAllowedKeys(
-  value: Record<string, unknown>,
-  allowed: string[],
-  label: string,
-) {
+function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], label: string) {
   const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unknown.length > 0) {
     throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
@@ -124,8 +116,7 @@ export const memoryNeo4jConfigSchema = {
 
     const neo4jPassword =
       typeof neo4jRaw.password === "string" ? resolveEnvVars(neo4jRaw.password) : "";
-    const neo4jUsername =
-      typeof neo4jRaw.username === "string" ? neo4jRaw.username : "neo4j";
+    const neo4jUsername = typeof neo4jRaw.username === "string" ? neo4jRaw.username : "neo4j";
 
     // Parse embedding section
     const embeddingRaw = cfg.embedding as Record<string, unknown> | undefined;

--- a/extensions/memory-neo4j/embeddings.ts
+++ b/extensions/memory-neo4j/embeddings.ts
@@ -33,7 +33,9 @@ export class Embeddings {
    * Returns array of embeddings in the same order as input.
    */
   async embedBatch(texts: string[]): Promise<number[][]> {
-    if (texts.length === 0) return [];
+    if (texts.length === 0) {
+      return [];
+    }
 
     const response = await this.client.embeddings.create({
       model: this.model,
@@ -41,6 +43,6 @@ export class Embeddings {
     });
 
     // Sort by index to ensure correct order
-    return response.data.sort((a, b) => a.index - b.index).map((d) => d.embedding);
+    return response.data.toSorted((a, b) => a.index - b.index).map((d) => d.embedding);
   }
 }

--- a/extensions/memory-neo4j/embeddings.ts
+++ b/extensions/memory-neo4j/embeddings.ts
@@ -1,0 +1,48 @@
+/**
+ * OpenAI embedding generation for memory-neo4j.
+ *
+ * Thin wrapper around the OpenAI embeddings API.
+ * Uses text-embedding-3-small (1536 dims) by default.
+ */
+
+import OpenAI from "openai";
+
+export class Embeddings {
+  private client: OpenAI;
+
+  constructor(
+    apiKey: string,
+    private readonly model: string = "text-embedding-3-small",
+  ) {
+    this.client = new OpenAI({ apiKey });
+  }
+
+  /**
+   * Generate an embedding vector for a single text.
+   */
+  async embed(text: string): Promise<number[]> {
+    const response = await this.client.embeddings.create({
+      model: this.model,
+      input: text,
+    });
+    return response.data[0].embedding;
+  }
+
+  /**
+   * Generate embeddings for multiple texts in a single API call.
+   * Returns array of embeddings in the same order as input.
+   */
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const response = await this.client.embeddings.create({
+      model: this.model,
+      input: texts,
+    });
+
+    // Sort by index to ensure correct order
+    return response.data
+      .sort((a, b) => a.index - b.index)
+      .map((d) => d.embedding);
+  }
+}

--- a/extensions/memory-neo4j/embeddings.ts
+++ b/extensions/memory-neo4j/embeddings.ts
@@ -41,8 +41,6 @@ export class Embeddings {
     });
 
     // Sort by index to ensure correct order
-    return response.data
-      .sort((a, b) => a.index - b.index)
-      .map((d) => d.embedding);
+    return response.data.sort((a, b) => a.index - b.index).map((d) => d.embedding);
   }
 }

--- a/extensions/memory-neo4j/extractor.ts
+++ b/extensions/memory-neo4j/extractor.ts
@@ -12,13 +12,7 @@ import { randomUUID } from "node:crypto";
 import type { ExtractionConfig } from "./config.js";
 import type { Embeddings } from "./embeddings.js";
 import type { Neo4jMemoryClient } from "./neo4j-client.js";
-import type {
-  CaptureDecision,
-  CaptureItem,
-  EntityType,
-  ExtractionResult,
-  MemoryCategory,
-} from "./schema.js";
+import type { CaptureItem, EntityType, ExtractionResult, MemoryCategory } from "./schema.js";
 import { ALLOWED_RELATIONSHIP_TYPES, ENTITY_TYPES } from "./schema.js";
 
 // ============================================================================
@@ -149,17 +143,21 @@ export async function extractEntities(
   text: string,
   config: ExtractionConfig,
 ): Promise<ExtractionResult | null> {
-  if (!config.enabled) return null;
+  if (!config.enabled) {
+    return null;
+  }
 
   const prompt = ENTITY_EXTRACTION_PROMPT.replace("{text}", text);
 
   try {
     const content = await callOpenRouter(config, prompt);
-    if (!content) return null;
+    if (!content) {
+      return null;
+    }
 
     const parsed = JSON.parse(content) as Record<string, unknown>;
     return validateExtractionResult(parsed);
-  } catch (err) {
+  } catch {
     // Will be handled by caller; don't throw for parse errors
     return null;
   }
@@ -349,20 +347,26 @@ export async function evaluateAutoCapture(
   userMessages: string[],
   config: ExtractionConfig,
 ): Promise<CaptureItem[]> {
-  if (!config.enabled || userMessages.length === 0) return [];
+  if (!config.enabled || userMessages.length === 0) {
+    return [];
+  }
 
   const combined = userMessages.join("\n\n");
-  if (combined.length < 10) return [];
+  if (combined.length < 10) {
+    return [];
+  }
 
   const prompt = AUTO_CAPTURE_PROMPT.replace("{messages}", combined);
 
   try {
     const content = await callOpenRouter(config, prompt);
-    if (!content) return [];
+    if (!content) {
+      return [];
+    }
 
     const parsed = JSON.parse(content) as Record<string, unknown>;
     return validateCaptureDecision(parsed);
-  } catch (err) {
+  } catch {
     // Silently fail — auto-capture is best-effort
     return [];
   }
@@ -406,11 +410,15 @@ export function extractUserMessages(messages: unknown[]): string[] {
   const texts: string[] = [];
 
   for (const msg of messages) {
-    if (!msg || typeof msg !== "object") continue;
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
     const msgObj = msg as Record<string, unknown>;
 
     // Only process user messages for auto-capture
-    if (msgObj.role !== "user") continue;
+    if (msgObj.role !== "user") {
+      continue;
+    }
 
     const content = msgObj.content;
     if (typeof content === "string") {

--- a/extensions/memory-neo4j/extractor.ts
+++ b/extensions/memory-neo4j/extractor.ts
@@ -1,0 +1,480 @@
+/**
+ * LLM-based entity extraction and auto-capture decision for memory-neo4j.
+ *
+ * Uses Gemini Flash via OpenRouter for:
+ * 1. Entity extraction: Extract entities and relationships from stored memories
+ * 2. Auto-capture decision: Decide what's worth remembering from conversations
+ *
+ * Both run as background fire-and-forget operations with graceful degradation.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { ExtractionConfig } from "./config.js";
+import type { Embeddings } from "./embeddings.js";
+import type { Neo4jMemoryClient } from "./neo4j-client.js";
+import type {
+  CaptureDecision,
+  CaptureItem,
+  EntityType,
+  ExtractionResult,
+  MemoryCategory,
+} from "./schema.js";
+import { ALLOWED_RELATIONSHIP_TYPES, ENTITY_TYPES } from "./schema.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+  debug?: (msg: string) => void;
+};
+
+// ============================================================================
+// Extraction Prompt
+// ============================================================================
+
+const ENTITY_EXTRACTION_PROMPT = `You are an entity extraction system for a personal memory store.
+Extract entities and relationships from this memory text.
+
+Memory: "{text}"
+
+Return JSON:
+{
+  "entities": [
+    {"name": "tarun", "type": "person", "aliases": ["boss"], "description": "brief description"}
+  ],
+  "relationships": [
+    {"source": "tarun", "target": "abundent", "type": "WORKS_AT", "confidence": 0.95}
+  ],
+  "tags": [
+    {"name": "neo4j", "category": "technology"}
+  ]
+}
+
+Rules:
+- Normalize entity names to lowercase
+- Entity types: person, organization, location, event, concept
+- Relationship types: WORKS_AT, LIVES_AT, KNOWS, MARRIED_TO, PREFERS, DECIDED, RELATED_TO
+- Confidence: 0.0-1.0
+- Only extract what's explicitly stated or strongly implied
+- Return empty arrays if nothing to extract
+- Keep entity descriptions brief (1 sentence max)`;
+
+// ============================================================================
+// Auto-Capture Decision Prompt
+// ============================================================================
+
+const AUTO_CAPTURE_PROMPT = `You are an AI memory curator. Given these user messages from a conversation, identify information worth storing as long-term memories.
+
+Only extract:
+- Personal preferences and opinions ("I prefer dark mode", "I like TypeScript")
+- Important facts about people, places, organizations
+- Decisions made ("We decided to use Neo4j", "Going with plan A")
+- Contact information (emails, phone numbers, usernames)
+- Important events or dates
+- Technical decisions and configurations
+
+Do NOT extract:
+- General questions or instructions to the AI
+- Routine greetings or acknowledgments
+- Information that is too vague or contextual
+- Information already in system prompts or documentation
+
+Messages:
+"""
+{messages}
+"""
+
+Return JSON:
+{
+  "memories": [
+    {"text": "concise memory text", "category": "preference|fact|decision|entity|other", "importance": 0.7}
+  ]
+}
+
+If nothing is worth remembering, return: {"memories": []}`;
+
+// ============================================================================
+// OpenRouter API Client
+// ============================================================================
+
+async function callOpenRouter(
+  config: ExtractionConfig,
+  prompt: string,
+): Promise<string | null> {
+  for (let attempt = 0; attempt <= config.maxRetries; attempt++) {
+    try {
+      const response = await fetch(`${config.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: config.model,
+          messages: [{ role: "user", content: prompt }],
+          temperature: config.temperature,
+          response_format: { type: "json_object" },
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(`OpenRouter API error ${response.status}: ${body}`);
+      }
+
+      const data = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      return data.choices?.[0]?.message?.content ?? null;
+    } catch (err) {
+      if (attempt >= config.maxRetries) {
+        throw err;
+      }
+      // Exponential backoff
+      await new Promise((resolve) =>
+        setTimeout(resolve, 500 * Math.pow(2, attempt)),
+      );
+    }
+  }
+  return null;
+}
+
+// ============================================================================
+// Entity Extraction
+// ============================================================================
+
+/**
+ * Extract entities and relationships from a memory text using LLM.
+ */
+export async function extractEntities(
+  text: string,
+  config: ExtractionConfig,
+): Promise<ExtractionResult | null> {
+  if (!config.enabled) return null;
+
+  const prompt = ENTITY_EXTRACTION_PROMPT.replace("{text}", text);
+
+  try {
+    const content = await callOpenRouter(config, prompt);
+    if (!content) return null;
+
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return validateExtractionResult(parsed);
+  } catch (err) {
+    // Will be handled by caller; don't throw for parse errors
+    return null;
+  }
+}
+
+/**
+ * Validate and sanitize LLM extraction output.
+ */
+function validateExtractionResult(
+  raw: Record<string, unknown>,
+): ExtractionResult {
+  const entities = Array.isArray(raw.entities) ? raw.entities : [];
+  const relationships = Array.isArray(raw.relationships)
+    ? raw.relationships
+    : [];
+  const tags = Array.isArray(raw.tags) ? raw.tags : [];
+
+  const validEntityTypes = new Set<string>(ENTITY_TYPES);
+
+  return {
+    entities: entities
+      .filter(
+        (e: unknown): e is Record<string, unknown> =>
+          e !== null &&
+          typeof e === "object" &&
+          typeof (e as Record<string, unknown>).name === "string" &&
+          typeof (e as Record<string, unknown>).type === "string",
+      )
+      .map((e) => ({
+        name: String(e.name).trim().toLowerCase(),
+        type: validEntityTypes.has(String(e.type))
+          ? (String(e.type) as EntityType)
+          : "concept",
+        aliases: Array.isArray(e.aliases)
+          ? (e.aliases as unknown[])
+              .filter((a): a is string => typeof a === "string")
+              .map((a) => a.trim().toLowerCase())
+          : undefined,
+        description:
+          typeof e.description === "string" ? e.description : undefined,
+      }))
+      .filter((e) => e.name.length > 0),
+
+    relationships: relationships
+      .filter(
+        (r: unknown): r is Record<string, unknown> =>
+          r !== null &&
+          typeof r === "object" &&
+          typeof (r as Record<string, unknown>).source === "string" &&
+          typeof (r as Record<string, unknown>).target === "string" &&
+          typeof (r as Record<string, unknown>).type === "string" &&
+          ALLOWED_RELATIONSHIP_TYPES.has(
+            String((r as Record<string, unknown>).type),
+          ),
+      )
+      .map((r) => ({
+        source: String(r.source).trim().toLowerCase(),
+        target: String(r.target).trim().toLowerCase(),
+        type: String(r.type),
+        confidence: typeof r.confidence === "number" ? Math.min(1, Math.max(0, r.confidence)) : 0.7,
+      })),
+
+    tags: tags
+      .filter(
+        (t: unknown): t is Record<string, unknown> =>
+          t !== null &&
+          typeof t === "object" &&
+          typeof (t as Record<string, unknown>).name === "string",
+      )
+      .map((t) => ({
+        name: String(t.name).trim().toLowerCase(),
+        category: typeof t.category === "string" ? t.category : "topic",
+      }))
+      .filter((t) => t.name.length > 0),
+  };
+}
+
+// ============================================================================
+// Background Extraction Pipeline
+// ============================================================================
+
+/**
+ * Run entity extraction in the background for a stored memory.
+ * Fire-and-forget: errors are logged but never propagated.
+ *
+ * Flow:
+ * 1. Call LLM to extract entities and relationships
+ * 2. MERGE Entity nodes (idempotent)
+ * 3. Create MENTIONS relationships from Memory → Entity
+ * 4. Create inter-Entity relationships (WORKS_AT, KNOWS, etc.)
+ * 5. Tag the memory
+ * 6. Update extractionStatus to "complete" or "failed"
+ */
+export async function runBackgroundExtraction(
+  memoryId: string,
+  text: string,
+  db: Neo4jMemoryClient,
+  embeddings: Embeddings,
+  config: ExtractionConfig,
+  logger: Logger,
+): Promise<void> {
+  if (!config.enabled) {
+    await db.updateExtractionStatus(memoryId, "skipped").catch(() => {});
+    return;
+  }
+
+  try {
+    const result = await extractEntities(text, config);
+
+    if (!result) {
+      await db.updateExtractionStatus(memoryId, "failed");
+      return;
+    }
+
+    // Empty extraction is valid — not all memories have extractable entities
+    if (
+      result.entities.length === 0 &&
+      result.relationships.length === 0 &&
+      result.tags.length === 0
+    ) {
+      await db.updateExtractionStatus(memoryId, "complete");
+      return;
+    }
+
+    // Generate embeddings for entity names (for entity vector search)
+    let entityEmbeddings: Map<string, number[]> | undefined;
+    if (result.entities.length > 0) {
+      try {
+        const names = result.entities.map((e) => e.name);
+        const vectors = await embeddings.embedBatch(names);
+        entityEmbeddings = new Map(names.map((n, i) => [n, vectors[i]]));
+      } catch (err) {
+        logger.debug?.(
+          `memory-neo4j: entity embedding generation failed: ${String(err)}`,
+        );
+      }
+    }
+
+    // MERGE Entity nodes
+    for (const entity of result.entities) {
+      try {
+        await db.mergeEntity({
+          id: randomUUID(),
+          name: entity.name,
+          type: entity.type,
+          aliases: entity.aliases,
+          description: entity.description,
+          embedding: entityEmbeddings?.get(entity.name),
+        });
+
+        // Create MENTIONS relationship
+        await db.createMentions(memoryId, entity.name, "context", 1.0);
+      } catch (err) {
+        logger.warn(
+          `memory-neo4j: entity merge failed for "${entity.name}": ${String(err)}`,
+        );
+      }
+    }
+
+    // Create inter-Entity relationships
+    for (const rel of result.relationships) {
+      try {
+        await db.createEntityRelationship(
+          rel.source,
+          rel.target,
+          rel.type,
+          rel.confidence,
+        );
+      } catch (err) {
+        logger.debug?.(
+          `memory-neo4j: relationship creation failed: ${rel.source}->${rel.target}: ${String(err)}`,
+        );
+      }
+    }
+
+    // Tag the memory
+    for (const tag of result.tags) {
+      try {
+        await db.tagMemory(memoryId, tag.name, tag.category);
+      } catch (err) {
+        logger.debug?.(
+          `memory-neo4j: tagging failed for "${tag.name}": ${String(err)}`,
+        );
+      }
+    }
+
+    await db.updateExtractionStatus(memoryId, "complete");
+    logger.info(
+      `memory-neo4j: extraction complete for ${memoryId.slice(0, 8)} — ` +
+        `${result.entities.length} entities, ${result.relationships.length} rels, ${result.tags.length} tags`,
+    );
+  } catch (err) {
+    logger.warn(
+      `memory-neo4j: extraction failed for ${memoryId.slice(0, 8)}: ${String(err)}`,
+    );
+    await db.updateExtractionStatus(memoryId, "failed").catch(() => {});
+  }
+}
+
+// ============================================================================
+// Auto-Capture Decision
+// ============================================================================
+
+/**
+ * Evaluate user messages and decide what's worth storing as long-term memory.
+ * Returns a list of memory items to store, or empty if nothing worth keeping.
+ */
+export async function evaluateAutoCapture(
+  userMessages: string[],
+  config: ExtractionConfig,
+): Promise<CaptureItem[]> {
+  if (!config.enabled || userMessages.length === 0) return [];
+
+  const combined = userMessages.join("\n\n");
+  if (combined.length < 10) return [];
+
+  const prompt = AUTO_CAPTURE_PROMPT.replace("{messages}", combined);
+
+  try {
+    const content = await callOpenRouter(config, prompt);
+    if (!content) return [];
+
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return validateCaptureDecision(parsed);
+  } catch (err) {
+    // Silently fail — auto-capture is best-effort
+    return [];
+  }
+}
+
+/**
+ * Validate and sanitize the auto-capture LLM output.
+ */
+function validateCaptureDecision(raw: Record<string, unknown>): CaptureItem[] {
+  const memories = Array.isArray(raw.memories) ? raw.memories : [];
+
+  const validCategories = new Set<string>([
+    "preference",
+    "fact",
+    "decision",
+    "entity",
+    "other",
+  ]);
+
+  return memories
+    .filter(
+      (m: unknown): m is Record<string, unknown> =>
+        m !== null &&
+        typeof m === "object" &&
+        typeof (m as Record<string, unknown>).text === "string" &&
+        (m as Record<string, unknown>).text !== "",
+    )
+    .map((m) => ({
+      text: String(m.text).slice(0, 2000), // cap length
+      category: validCategories.has(String(m.category))
+        ? (String(m.category) as MemoryCategory)
+        : "other",
+      importance:
+        typeof m.importance === "number"
+          ? Math.min(1, Math.max(0, m.importance))
+          : 0.7,
+    }))
+    .slice(0, 5); // Max 5 captures per conversation
+}
+
+// ============================================================================
+// Message Extraction Helper
+// ============================================================================
+
+/**
+ * Extract user message texts from the event.messages array.
+ * Handles both string content and content block arrays.
+ */
+export function extractUserMessages(messages: unknown[]): string[] {
+  const texts: string[] = [];
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const msgObj = msg as Record<string, unknown>;
+
+    // Only process user messages for auto-capture
+    if (msgObj.role !== "user") continue;
+
+    const content = msgObj.content;
+    if (typeof content === "string") {
+      texts.push(content);
+      continue;
+    }
+
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (
+          block &&
+          typeof block === "object" &&
+          "type" in block &&
+          (block as Record<string, unknown>).type === "text" &&
+          "text" in block &&
+          typeof (block as Record<string, unknown>).text === "string"
+        ) {
+          texts.push((block as Record<string, unknown>).text as string);
+        }
+      }
+    }
+  }
+
+  // Filter out noise
+  return texts.filter(
+    (t) =>
+      t.length >= 10 &&
+      !t.includes("<relevant-memories>") &&
+      !t.includes("<system>"),
+  );
+}

--- a/extensions/memory-neo4j/index.ts
+++ b/extensions/memory-neo4j/index.ts
@@ -397,7 +397,9 @@ const memoryNeo4jPlugin = {
     // Auto-recall: inject relevant memories before agent starts
     if (cfg.autoRecall) {
       api.on("before_agent_start", async (event, ctx) => {
-        if (!event.prompt || event.prompt.length < 5) return;
+        if (!event.prompt || event.prompt.length < 5) {
+          return;
+        }
 
         const agentId = ctx.agentId || "default";
 
@@ -411,7 +413,9 @@ const memoryNeo4jPlugin = {
             extractionConfig.enabled,
           );
 
-          if (results.length === 0) return;
+          if (results.length === 0) {
+            return;
+          }
 
           const memoryContext = results.map((r) => `- [${r.category}] ${r.text}`).join("\n");
 
@@ -440,10 +444,14 @@ const memoryNeo4jPlugin = {
           if (extractionConfig.enabled) {
             // LLM-based auto-capture (Decision Q8)
             const userMessages = extractUserMessages(event.messages);
-            if (userMessages.length === 0) return;
+            if (userMessages.length === 0) {
+              return;
+            }
 
             const items = await evaluateAutoCapture(userMessages, extractionConfig);
-            if (items.length === 0) return;
+            if (items.length === 0) {
+              return;
+            }
 
             let stored = 0;
             for (const item of items) {
@@ -452,7 +460,9 @@ const memoryNeo4jPlugin = {
 
                 // Check for duplicates
                 const existing = await db.findSimilar(vector, 0.95, 1);
-                if (existing.length > 0) continue;
+                if (existing.length > 0) {
+                  continue;
+                }
 
                 const memoryId = randomUUID();
                 await db.storeMemory({
@@ -489,12 +499,16 @@ const memoryNeo4jPlugin = {
           } else {
             // Fallback: rule-based capture (no extraction API key)
             const userMessages = extractUserMessages(event.messages);
-            if (userMessages.length === 0) return;
+            if (userMessages.length === 0) {
+              return;
+            }
 
             const toCapture = userMessages.filter(
               (text) => text.length >= 10 && text.length <= 500 && shouldCaptureRuleBased(text),
             );
-            if (toCapture.length === 0) return;
+            if (toCapture.length === 0) {
+              return;
+            }
 
             let stored = 0;
             for (const text of toCapture.slice(0, 3)) {
@@ -502,7 +516,9 @@ const memoryNeo4jPlugin = {
               const vector = await embeddings.embed(text);
 
               const existing = await db.findSimilar(vector, 0.95, 1);
-              if (existing.length > 0) continue;
+              if (existing.length > 0) {
+                continue;
+              }
 
               await db.storeMemory({
                 id: randomUUID(),
@@ -572,20 +588,36 @@ const MEMORY_TRIGGERS = [
 ];
 
 function shouldCaptureRuleBased(text: string): boolean {
-  if (text.includes("<relevant-memories>")) return false;
-  if (text.startsWith("<") && text.includes("</")) return false;
-  if (text.includes("**") && text.includes("\n-")) return false;
+  if (text.includes("<relevant-memories>")) {
+    return false;
+  }
+  if (text.startsWith("<") && text.includes("</")) {
+    return false;
+  }
+  if (text.includes("**") && text.includes("\n-")) {
+    return false;
+  }
   const emojiCount = (text.match(/[\u{1F300}-\u{1F9FF}]/gu) || []).length;
-  if (emojiCount > 3) return false;
+  if (emojiCount > 3) {
+    return false;
+  }
   return MEMORY_TRIGGERS.some((r) => r.test(text));
 }
 
 function detectCategory(text: string): MemoryCategory {
   const lower = text.toLowerCase();
-  if (/prefer|radši|like|love|hate|want/i.test(lower)) return "preference";
-  if (/decided|rozhodli|will use|budeme/i.test(lower)) return "decision";
-  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se/i.test(lower)) return "entity";
-  if (/is|are|has|have|je|má|jsou/i.test(lower)) return "fact";
+  if (/prefer|radši|like|love|hate|want/i.test(lower)) {
+    return "preference";
+  }
+  if (/decided|rozhodli|will use|budeme/i.test(lower)) {
+    return "decision";
+  }
+  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se/i.test(lower)) {
+    return "entity";
+  }
+  if (/is|are|has|have|je|má|jsou/i.test(lower)) {
+    return "fact";
+  }
   return "other";
 }
 

--- a/extensions/memory-neo4j/index.ts
+++ b/extensions/memory-neo4j/index.ts
@@ -1,0 +1,648 @@
+/**
+ * OpenClaw Memory (Neo4j) Plugin
+ *
+ * Drop-in replacement for memory-lancedb with three-signal hybrid search,
+ * entity extraction, and knowledge graph capabilities.
+ *
+ * Provides:
+ * - memory_recall: Hybrid search (vector + BM25 + graph traversal)
+ * - memory_store: Store memories with background entity extraction
+ * - memory_forget: Delete memories with cascade cleanup
+ *
+ * Architecture decisions: see docs/memory-neo4j/ARCHITECTURE.md
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { Type } from "@sinclair/typebox";
+import { randomUUID } from "node:crypto";
+import { stringEnum } from "openclaw/plugin-sdk";
+
+import {
+  MEMORY_CATEGORIES,
+  memoryNeo4jConfigSchema,
+  resolveExtractionConfig,
+  vectorDimsForModel,
+} from "./config.js";
+import { Embeddings } from "./embeddings.js";
+import {
+  evaluateAutoCapture,
+  extractUserMessages,
+  runBackgroundExtraction,
+} from "./extractor.js";
+import { Neo4jMemoryClient } from "./neo4j-client.js";
+import { hybridSearch } from "./search.js";
+import type { MemoryCategory, MemorySource } from "./schema.js";
+
+// ============================================================================
+// Plugin Definition
+// ============================================================================
+
+const memoryNeo4jPlugin = {
+  id: "memory-neo4j",
+  name: "Memory (Neo4j)",
+  description:
+    "Neo4j-backed long-term memory with three-signal hybrid search, entity extraction, and knowledge graph",
+  kind: "memory" as const,
+  configSchema: memoryNeo4jConfigSchema,
+
+  register(api: OpenClawPluginApi) {
+    // Parse configuration
+    const cfg = memoryNeo4jConfigSchema.parse(api.pluginConfig);
+    const extractionConfig = resolveExtractionConfig();
+    const vectorDim = vectorDimsForModel(cfg.embedding.model);
+
+    // Create shared resources
+    const db = new Neo4jMemoryClient(
+      cfg.neo4j.uri,
+      cfg.neo4j.username,
+      cfg.neo4j.password,
+      vectorDim,
+      api.logger,
+    );
+    const embeddings = new Embeddings(cfg.embedding.apiKey, cfg.embedding.model);
+
+    api.logger.info(
+      `memory-neo4j: registered (uri: ${cfg.neo4j.uri}, model: ${cfg.embedding.model}, ` +
+        `extraction: ${extractionConfig.enabled ? extractionConfig.model : "disabled"})`,
+    );
+
+    // ========================================================================
+    // Tools (using factory pattern for agentId)
+    // ========================================================================
+
+    // memory_recall — Three-signal hybrid search
+    api.registerTool(
+      (ctx) => {
+        const agentId = ctx.agentId || "default";
+        return {
+          name: "memory_recall",
+          label: "Memory Recall",
+          description:
+            "Search through long-term memories. Use when you need context about user preferences, past decisions, or previously discussed topics.",
+          parameters: Type.Object({
+            query: Type.String({ description: "Search query" }),
+            limit: Type.Optional(
+              Type.Number({ description: "Max results (default: 5)" }),
+            ),
+          }),
+          async execute(
+            _toolCallId: string,
+            params: unknown,
+          ) {
+            const { query, limit = 5 } = params as {
+              query: string;
+              limit?: number;
+            };
+
+            const results = await hybridSearch(
+              db,
+              embeddings,
+              query,
+              limit,
+              agentId,
+              extractionConfig.enabled,
+            );
+
+            if (results.length === 0) {
+              return {
+                content: [
+                  { type: "text", text: "No relevant memories found." },
+                ],
+                details: { count: 0 },
+              };
+            }
+
+            const text = results
+              .map(
+                (r, i) =>
+                  `${i + 1}. [${r.category}] ${r.text} (${(r.score * 100).toFixed(0)}%)`,
+              )
+              .join("\n");
+
+            const sanitizedResults = results.map((r) => ({
+              id: r.id,
+              text: r.text,
+              category: r.category,
+              importance: r.importance,
+              score: r.score,
+            }));
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Found ${results.length} memories:\n\n${text}`,
+                },
+              ],
+              details: { count: results.length, memories: sanitizedResults },
+            };
+          },
+        };
+      },
+      { name: "memory_recall" },
+    );
+
+    // memory_store — Store with background entity extraction
+    api.registerTool(
+      (ctx) => {
+        const agentId = ctx.agentId || "default";
+        const sessionKey = ctx.sessionKey;
+        return {
+          name: "memory_store",
+          label: "Memory Store",
+          description:
+            "Save important information in long-term memory. Use for preferences, facts, decisions.",
+          parameters: Type.Object({
+            text: Type.String({ description: "Information to remember" }),
+            importance: Type.Optional(
+              Type.Number({
+                description: "Importance 0-1 (default: 0.7)",
+              }),
+            ),
+            category: Type.Optional(stringEnum(MEMORY_CATEGORIES)),
+          }),
+          async execute(
+            _toolCallId: string,
+            params: unknown,
+          ) {
+            const {
+              text,
+              importance = 0.7,
+              category = "other",
+            } = params as {
+              text: string;
+              importance?: number;
+              category?: MemoryCategory;
+            };
+
+            // 1. Generate embedding
+            const vector = await embeddings.embed(text);
+
+            // 2. Check for duplicates (vector similarity > 0.95)
+            const existing = await db.findSimilar(vector, 0.95, 1);
+            if (existing.length > 0) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Similar memory already exists: "${existing[0].text}"`,
+                  },
+                ],
+                details: {
+                  action: "duplicate",
+                  existingId: existing[0].id,
+                  existingText: existing[0].text,
+                },
+              };
+            }
+
+            // 3. Store memory immediately (fast path)
+            const memoryId = randomUUID();
+            await db.storeMemory({
+              id: memoryId,
+              text,
+              embedding: vector,
+              importance: Math.min(1, Math.max(0, importance)),
+              category,
+              source: "user" as MemorySource,
+              extractionStatus: extractionConfig.enabled ? "pending" : "skipped",
+              agentId,
+              sessionKey,
+            });
+
+            // 4. Fire-and-forget background entity extraction
+            if (extractionConfig.enabled) {
+              runBackgroundExtraction(
+                memoryId,
+                text,
+                db,
+                embeddings,
+                extractionConfig,
+                api.logger,
+              ).catch((err) => {
+                api.logger.warn(
+                  `memory-neo4j: background extraction error: ${String(err)}`,
+                );
+              });
+            }
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Stored: "${text.slice(0, 100)}${text.length > 100 ? "..." : ""}"`,
+                },
+              ],
+              details: { action: "created", id: memoryId },
+            };
+          },
+        };
+      },
+      { name: "memory_store" },
+    );
+
+    // memory_forget — Delete with cascade
+    api.registerTool(
+      (_ctx) => {
+        return {
+          name: "memory_forget",
+          label: "Memory Forget",
+          description: "Delete specific memories. GDPR-compliant.",
+          parameters: Type.Object({
+            query: Type.Optional(
+              Type.String({ description: "Search to find memory" }),
+            ),
+            memoryId: Type.Optional(
+              Type.String({ description: "Specific memory ID" }),
+            ),
+          }),
+          async execute(
+            _toolCallId: string,
+            params: unknown,
+          ) {
+            const { query, memoryId } = params as {
+              query?: string;
+              memoryId?: string;
+            };
+
+            // Direct delete by ID
+            if (memoryId) {
+              const deleted = await db.deleteMemory(memoryId);
+              if (!deleted) {
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: `Memory ${memoryId} not found.`,
+                    },
+                  ],
+                  details: { action: "not_found", id: memoryId },
+                };
+              }
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Memory ${memoryId} forgotten.`,
+                  },
+                ],
+                details: { action: "deleted", id: memoryId },
+              };
+            }
+
+            // Search-based delete
+            if (query) {
+              const vector = await embeddings.embed(query);
+              const results = await db.vectorSearch(vector, 5, 0.7);
+
+              if (results.length === 0) {
+                return {
+                  content: [
+                    { type: "text", text: "No matching memories found." },
+                  ],
+                  details: { found: 0 },
+                };
+              }
+
+              // Auto-delete if single high-confidence match
+              if (results.length === 1 && results[0].score > 0.9) {
+                await db.deleteMemory(results[0].id);
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: `Forgotten: "${results[0].text}"`,
+                    },
+                  ],
+                  details: { action: "deleted", id: results[0].id },
+                };
+              }
+
+              // Multiple candidates — ask user to specify
+              const list = results
+                .map(
+                  (r) =>
+                    `- [${r.id.slice(0, 8)}] ${r.text.slice(0, 60)}...`,
+                )
+                .join("\n");
+
+              const sanitizedCandidates = results.map((r) => ({
+                id: r.id,
+                text: r.text,
+                category: r.category,
+                score: r.score,
+              }));
+
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Found ${results.length} candidates. Specify memoryId:\n${list}`,
+                  },
+                ],
+                details: {
+                  action: "candidates",
+                  candidates: sanitizedCandidates,
+                },
+              };
+            }
+
+            return {
+              content: [
+                { type: "text", text: "Provide query or memoryId." },
+              ],
+              details: { error: "missing_param" },
+            };
+          },
+        };
+      },
+      { name: "memory_forget" },
+    );
+
+    // ========================================================================
+    // CLI Commands
+    // ========================================================================
+
+    api.registerCli(
+      ({ program }) => {
+        const memory = program
+          .command("neo4j-memory")
+          .description("Neo4j memory plugin commands");
+
+        memory
+          .command("list")
+          .description("List memories (count)")
+          .action(async () => {
+            await db.ensureInitialized();
+            const count = await db.countMemories();
+            console.log(`Total memories: ${count}`);
+          });
+
+        memory
+          .command("search")
+          .description("Search memories")
+          .argument("<query>", "Search query")
+          .option("--limit <n>", "Max results", "5")
+          .action(async (query: string, opts: { limit: string }) => {
+            const results = await hybridSearch(
+              db,
+              embeddings,
+              query,
+              parseInt(opts.limit, 10),
+              "default",
+              extractionConfig.enabled,
+            );
+            const output = results.map((r) => ({
+              id: r.id,
+              text: r.text,
+              category: r.category,
+              importance: r.importance,
+              score: r.score,
+            }));
+            console.log(JSON.stringify(output, null, 2));
+          });
+
+        memory
+          .command("stats")
+          .description("Show memory statistics")
+          .action(async () => {
+            await db.ensureInitialized();
+            const count = await db.countMemories();
+            console.log(`Total memories: ${count}`);
+            console.log(`Neo4j URI: ${cfg.neo4j.uri}`);
+            console.log(`Embedding model: ${cfg.embedding.model}`);
+            console.log(`Extraction: ${extractionConfig.enabled ? extractionConfig.model : "disabled"}`);
+          });
+
+        memory
+          .command("maintain")
+          .description("Run maintenance tasks (orphan cleanup, etc.)")
+          .action(async () => {
+            console.log("Maintenance not yet implemented (deferred to v2).");
+          });
+      },
+      { commands: ["neo4j-memory"] },
+    );
+
+    // ========================================================================
+    // Lifecycle Hooks
+    // ========================================================================
+
+    // Auto-recall: inject relevant memories before agent starts
+    if (cfg.autoRecall) {
+      api.on("before_agent_start", async (event, ctx) => {
+        if (!event.prompt || event.prompt.length < 5) return;
+
+        const agentId = ctx.agentId || "default";
+
+        try {
+          const results = await hybridSearch(
+            db,
+            embeddings,
+            event.prompt,
+            3,
+            agentId,
+            extractionConfig.enabled,
+          );
+
+          if (results.length === 0) return;
+
+          const memoryContext = results
+            .map((r) => `- [${r.category}] ${r.text}`)
+            .join("\n");
+
+          api.logger.info?.(
+            `memory-neo4j: injecting ${results.length} memories into context`,
+          );
+
+          return {
+            prependContext: `<relevant-memories>\nThe following memories may be relevant to this conversation:\n${memoryContext}\n</relevant-memories>`,
+          };
+        } catch (err) {
+          api.logger.warn(
+            `memory-neo4j: auto-recall failed: ${String(err)}`,
+          );
+        }
+      });
+    }
+
+    // Auto-capture: LLM-based decision on what to store from conversations
+    if (cfg.autoCapture) {
+      api.on("agent_end", async (event, ctx) => {
+        if (!event.success || !event.messages || event.messages.length === 0) {
+          return;
+        }
+
+        const agentId = ctx.agentId || "default";
+        const sessionKey = ctx.sessionKey;
+
+        try {
+          if (extractionConfig.enabled) {
+            // LLM-based auto-capture (Decision Q8)
+            const userMessages = extractUserMessages(event.messages);
+            if (userMessages.length === 0) return;
+
+            const items = await evaluateAutoCapture(
+              userMessages,
+              extractionConfig,
+            );
+            if (items.length === 0) return;
+
+            let stored = 0;
+            for (const item of items) {
+              try {
+                const vector = await embeddings.embed(item.text);
+
+                // Check for duplicates
+                const existing = await db.findSimilar(vector, 0.95, 1);
+                if (existing.length > 0) continue;
+
+                const memoryId = randomUUID();
+                await db.storeMemory({
+                  id: memoryId,
+                  text: item.text,
+                  embedding: vector,
+                  importance: item.importance,
+                  category: item.category,
+                  source: "auto-capture",
+                  extractionStatus: "pending",
+                  agentId,
+                  sessionKey,
+                });
+
+                // Background entity extraction
+                runBackgroundExtraction(
+                  memoryId,
+                  item.text,
+                  db,
+                  embeddings,
+                  extractionConfig,
+                  api.logger,
+                ).catch(() => {});
+
+                stored++;
+              } catch (err) {
+                api.logger.debug?.(
+                  `memory-neo4j: auto-capture item failed: ${String(err)}`,
+                );
+              }
+            }
+
+            if (stored > 0) {
+              api.logger.info(
+                `memory-neo4j: auto-captured ${stored} memories (LLM-based)`,
+              );
+            }
+          } else {
+            // Fallback: rule-based capture (no extraction API key)
+            const userMessages = extractUserMessages(event.messages);
+            if (userMessages.length === 0) return;
+
+            const toCapture = userMessages.filter(
+              (text) => text.length >= 10 && text.length <= 500 && shouldCaptureRuleBased(text),
+            );
+            if (toCapture.length === 0) return;
+
+            let stored = 0;
+            for (const text of toCapture.slice(0, 3)) {
+              const category = detectCategory(text);
+              const vector = await embeddings.embed(text);
+
+              const existing = await db.findSimilar(vector, 0.95, 1);
+              if (existing.length > 0) continue;
+
+              await db.storeMemory({
+                id: randomUUID(),
+                text,
+                embedding: vector,
+                importance: 0.7,
+                category,
+                source: "auto-capture",
+                extractionStatus: "skipped",
+                agentId,
+                sessionKey,
+              });
+              stored++;
+            }
+
+            if (stored > 0) {
+              api.logger.info(
+                `memory-neo4j: auto-captured ${stored} memories (rule-based)`,
+              );
+            }
+          }
+        } catch (err) {
+          api.logger.warn(
+            `memory-neo4j: auto-capture failed: ${String(err)}`,
+          );
+        }
+      });
+    }
+
+    // ========================================================================
+    // Service
+    // ========================================================================
+
+    api.registerService({
+      id: "memory-neo4j",
+      start: async () => {
+        try {
+          await db.ensureInitialized();
+          api.logger.info(
+            `memory-neo4j: service started (uri: ${cfg.neo4j.uri}, model: ${cfg.embedding.model})`,
+          );
+        } catch (err) {
+          api.logger.error(
+            `memory-neo4j: failed to start — ${String(err)}. Memory tools will attempt lazy initialization.`,
+          );
+          // Don't throw — allow graceful degradation.
+          // Tools will retry initialization on first use.
+        }
+      },
+      stop: async () => {
+        await db.close();
+        api.logger.info("memory-neo4j: service stopped");
+      },
+    });
+  },
+};
+
+// ============================================================================
+// Rule-based capture filter (fallback when no extraction API key)
+// ============================================================================
+
+const MEMORY_TRIGGERS = [
+  /remember|zapamatuj|pamatuj/i,
+  /prefer|radši|nechci|preferuji/i,
+  /decided|rozhodli|budeme používat/i,
+  /\+\d{10,}/,
+  /[\w.-]+@[\w.-]+\.\w+/,
+  /my\s+\w+\s+is|is\s+my/i,
+  /i (like|prefer|hate|love|want|need)/i,
+  /always|never|important/i,
+];
+
+function shouldCaptureRuleBased(text: string): boolean {
+  if (text.includes("<relevant-memories>")) return false;
+  if (text.startsWith("<") && text.includes("</")) return false;
+  if (text.includes("**") && text.includes("\n-")) return false;
+  const emojiCount = (text.match(/[\u{1F300}-\u{1F9FF}]/gu) || []).length;
+  if (emojiCount > 3) return false;
+  return MEMORY_TRIGGERS.some((r) => r.test(text));
+}
+
+function detectCategory(text: string): MemoryCategory {
+  const lower = text.toLowerCase();
+  if (/prefer|radši|like|love|hate|want/i.test(lower)) return "preference";
+  if (/decided|rozhodli|will use|budeme/i.test(lower)) return "decision";
+  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se/i.test(lower))
+    return "entity";
+  if (/is|are|has|have|je|má|jsou/i.test(lower)) return "fact";
+  return "other";
+}
+
+// ============================================================================
+// Export
+// ============================================================================
+
+export default memoryNeo4jPlugin;

--- a/extensions/memory-neo4j/neo4j-client.ts
+++ b/extensions/memory-neo4j/neo4j-client.ts
@@ -55,8 +55,12 @@ export class Neo4jMemoryClient {
   // --------------------------------------------------------------------------
 
   async ensureInitialized(): Promise<void> {
-    if (this.driver && this.indexesReady) return;
-    if (this.initPromise) return this.initPromise;
+    if (this.driver && this.indexesReady) {
+      return;
+    }
+    if (this.initPromise) {
+      return this.initPromise;
+    }
     this.initPromise = this.doInitialize();
     return this.initPromise;
   }
@@ -182,7 +186,9 @@ export class Neo4jMemoryClient {
   }
 
   async verifyConnection(): Promise<boolean> {
-    if (!this.driver) return false;
+    if (!this.driver) {
+      return false;
+    }
     const session = this.driver.session();
     try {
       await session.run("RETURN 1");
@@ -328,7 +334,9 @@ export class Neo4jMemoryClient {
     const session = this.driver!.session();
     try {
       const escaped = escapeLucene(query);
-      if (!escaped.trim()) return [];
+      if (!escaped.trim()) {
+        return [];
+      }
 
       const agentFilter = agentId ? "AND node.agentId = $agentId" : "";
       const result = await session.run(
@@ -353,7 +361,9 @@ export class Neo4jMemoryClient {
         rawScore: r.get("bm25Score") as number,
       }));
 
-      if (records.length === 0) return [];
+      if (records.length === 0) {
+        return [];
+      }
       const maxScore = records[0].rawScore || 1;
       return records.map((r) => ({
         ...r,
@@ -386,7 +396,9 @@ export class Neo4jMemoryClient {
     const session = this.driver!.session();
     try {
       const escaped = escapeLucene(query);
-      if (!escaped.trim()) return [];
+      if (!escaped.trim()) {
+        return [];
+      }
 
       // Step 1: Find matching entities
       const entityResult = await session.run(
@@ -400,7 +412,9 @@ export class Neo4jMemoryClient {
       );
 
       const entityIds = entityResult.records.map((r) => r.get("entityId") as string);
-      if (entityIds.length === 0) return [];
+      if (entityIds.length === 0) {
+        return [];
+      }
 
       // Step 2 + 3: Direct mentions + 1-hop spreading activation
       const agentFilter = agentId ? "AND m.agentId = $agentId" : "";
@@ -437,7 +451,9 @@ export class Neo4jMemoryClient {
       const byId = new Map<string, SearchSignalResult>();
       for (const record of result.records) {
         const id = record.get("id") as string;
-        if (!id) continue;
+        if (!id) {
+          continue;
+        }
         const score = record.get("graphScore") as number;
         const existing = byId.get(id);
         if (!existing || score > existing.score) {
@@ -453,7 +469,7 @@ export class Neo4jMemoryClient {
       }
 
       return Array.from(byId.values())
-        .sort((a, b) => b.score - a.score)
+        .toSorted((a, b) => b.score - a.score)
         .slice(0, limit);
     } catch (err) {
       this.logger.warn(`memory-neo4j: graph search failed: ${String(err)}`);

--- a/extensions/memory-neo4j/neo4j-client.ts
+++ b/extensions/memory-neo4j/neo4j-client.ts
@@ -1,0 +1,669 @@
+/**
+ * Neo4j driver wrapper for memory-neo4j plugin.
+ *
+ * Handles connection management, index creation, CRUD operations,
+ * and the three search signals (vector, BM25, graph).
+ *
+ * Patterns adapted from ~/Downloads/ontology/app/services/neo4j_client.py
+ * with retry-on-transient and MERGE idempotency.
+ */
+
+import neo4j, { type Driver } from "neo4j-driver";
+import { randomUUID } from "node:crypto";
+import type {
+  ExtractionStatus,
+  MergeEntityInput,
+  SearchSignalResult,
+  StoreMemoryInput,
+} from "./schema.js";
+import { escapeLucene, validateRelationshipType } from "./schema.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+  debug?: (msg: string) => void;
+};
+
+// Retry configuration for transient Neo4j errors (deadlocks, etc.)
+const TRANSIENT_RETRY_ATTEMPTS = 3;
+const TRANSIENT_RETRY_BASE_DELAY_MS = 500;
+
+// ============================================================================
+// Neo4j Memory Client
+// ============================================================================
+
+export class Neo4jMemoryClient {
+  private driver: Driver | null = null;
+  private initPromise: Promise<void> | null = null;
+  private indexesReady = false;
+
+  constructor(
+    private readonly uri: string,
+    private readonly username: string,
+    private readonly password: string,
+    private readonly dimensions: number,
+    private readonly logger: Logger,
+  ) {}
+
+  // --------------------------------------------------------------------------
+  // Connection & Initialization
+  // --------------------------------------------------------------------------
+
+  async ensureInitialized(): Promise<void> {
+    if (this.driver && this.indexesReady) return;
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = this.doInitialize();
+    return this.initPromise;
+  }
+
+  private async doInitialize(): Promise<void> {
+    this.driver = neo4j.driver(
+      this.uri,
+      neo4j.auth.basic(this.username, this.password),
+      { disableLosslessIntegers: true },
+    );
+
+    // Verify connection
+    const session = this.driver.session();
+    try {
+      await session.run("RETURN 1");
+      this.logger.info(`memory-neo4j: connected to ${this.uri}`);
+    } finally {
+      await session.close();
+    }
+
+    // Create indexes
+    await this.ensureIndexes();
+    this.indexesReady = true;
+  }
+
+  private async ensureIndexes(): Promise<void> {
+    const session = this.driver!.session();
+    try {
+      // Uniqueness constraints (also create indexes implicitly)
+      await this.runSafe(session, "CREATE CONSTRAINT memory_id_unique IF NOT EXISTS FOR (m:Memory) REQUIRE m.id IS UNIQUE");
+      await this.runSafe(session, "CREATE CONSTRAINT entity_id_unique IF NOT EXISTS FOR (e:Entity) REQUIRE e.id IS UNIQUE");
+      await this.runSafe(session, "CREATE CONSTRAINT tag_name_unique IF NOT EXISTS FOR (t:Tag) REQUIRE t.name IS UNIQUE");
+
+      // Vector indexes
+      await this.runSafe(session, `
+        CREATE VECTOR INDEX memory_embedding_index IF NOT EXISTS
+        FOR (m:Memory) ON m.embedding
+        OPTIONS {indexConfig: {
+          \`vector.dimensions\`: ${this.dimensions},
+          \`vector.similarity_function\`: 'cosine'
+        }}
+      `);
+      await this.runSafe(session, `
+        CREATE VECTOR INDEX entity_embedding_index IF NOT EXISTS
+        FOR (e:Entity) ON e.embedding
+        OPTIONS {indexConfig: {
+          \`vector.dimensions\`: ${this.dimensions},
+          \`vector.similarity_function\`: 'cosine'
+        }}
+      `);
+
+      // Full-text indexes (Lucene BM25)
+      await this.runSafe(session, "CREATE FULLTEXT INDEX memory_fulltext_index IF NOT EXISTS FOR (m:Memory) ON EACH [m.text]");
+      await this.runSafe(session, "CREATE FULLTEXT INDEX entity_fulltext_index IF NOT EXISTS FOR (e:Entity) ON EACH [e.name]");
+
+      // Property indexes for filtering
+      await this.runSafe(session, "CREATE INDEX memory_agent_index IF NOT EXISTS FOR (m:Memory) ON (m.agentId)");
+      await this.runSafe(session, "CREATE INDEX memory_category_index IF NOT EXISTS FOR (m:Memory) ON (m.category)");
+      await this.runSafe(session, "CREATE INDEX memory_created_index IF NOT EXISTS FOR (m:Memory) ON (m.createdAt)");
+      await this.runSafe(session, "CREATE INDEX entity_type_index IF NOT EXISTS FOR (e:Entity) ON (e.type)");
+      await this.runSafe(session, "CREATE INDEX entity_name_index IF NOT EXISTS FOR (e:Entity) ON (e.name)");
+
+      this.logger.info("memory-neo4j: indexes ensured");
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Run a Cypher statement, logging but not throwing on error.
+   * Used for index creation where indexes may already exist with different config.
+   */
+  private async runSafe(session: ReturnType<Driver["session"]>, query: string): Promise<void> {
+    try {
+      await session.run(query);
+    } catch (err) {
+      this.logger.debug?.(`memory-neo4j: index/constraint statement skipped: ${String(err)}`);
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.driver) {
+      await this.driver.close();
+      this.driver = null;
+      this.indexesReady = false;
+      this.initPromise = null;
+      this.logger.info("memory-neo4j: connection closed");
+    }
+  }
+
+  async verifyConnection(): Promise<boolean> {
+    if (!this.driver) return false;
+    const session = this.driver.session();
+    try {
+      await session.run("RETURN 1");
+      return true;
+    } catch (err) {
+      this.logger.error(`memory-neo4j: connection verification failed: ${String(err)}`);
+      return false;
+    } finally {
+      await session.close();
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Memory CRUD
+  // --------------------------------------------------------------------------
+
+  async storeMemory(input: StoreMemoryInput): Promise<string> {
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      const now = new Date().toISOString();
+      const result = await session.run(
+        `CREATE (m:Memory {
+          id: $id, text: $text, embedding: $embedding,
+          importance: $importance, category: $category,
+          source: $source, extractionStatus: $extractionStatus,
+          agentId: $agentId, sessionKey: $sessionKey,
+          createdAt: $createdAt, updatedAt: $updatedAt
+        })
+        RETURN m.id AS id`,
+        {
+          ...input,
+          sessionKey: input.sessionKey ?? null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      );
+      return result.records[0].get("id") as string;
+    } finally {
+      await session.close();
+    }
+  }
+
+  async deleteMemory(id: string): Promise<boolean> {
+    await this.ensureInitialized();
+    // Validate UUID format to prevent injection
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(id)) {
+      throw new Error(`Invalid memory ID format: ${id}`);
+    }
+
+    const session = this.driver!.session();
+    try {
+      // First, decrement mentionCount on connected entities
+      await session.run(
+        `MATCH (m:Memory {id: $id})-[:MENTIONS]->(e:Entity)
+         SET e.mentionCount = e.mentionCount - 1`,
+        { id },
+      );
+
+      // Then delete the memory with all its relationships
+      const result = await session.run(
+        `MATCH (m:Memory {id: $id})
+         DETACH DELETE m
+         RETURN count(*) AS deleted`,
+        { id },
+      );
+
+      const deleted = result.records.length > 0
+        ? (result.records[0].get("deleted") as number) > 0
+        : false;
+      return deleted;
+    } finally {
+      await session.close();
+    }
+  }
+
+  async countMemories(agentId?: string): Promise<number> {
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      const query = agentId
+        ? "MATCH (m:Memory {agentId: $agentId}) RETURN count(m) AS count"
+        : "MATCH (m:Memory) RETURN count(m) AS count";
+      const result = await session.run(query, agentId ? { agentId } : {});
+      return (result.records[0]?.get("count") as number) ?? 0;
+    } finally {
+      await session.close();
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Search Signals
+  // --------------------------------------------------------------------------
+
+  /**
+   * Signal 1: HNSW vector similarity search.
+   * Returns memories ranked by cosine similarity to the query embedding.
+   */
+  async vectorSearch(
+    embedding: number[],
+    limit: number,
+    minScore: number = 0.1,
+    agentId?: string,
+  ): Promise<SearchSignalResult[]> {
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      const agentFilter = agentId ? "AND node.agentId = $agentId" : "";
+      const result = await session.run(
+        `CALL db.index.vector.queryNodes('memory_embedding_index', $limit, $embedding)
+         YIELD node, score
+         WHERE score >= $minScore ${agentFilter}
+         RETURN node.id AS id, node.text AS text, node.category AS category,
+                node.importance AS importance, node.createdAt AS createdAt,
+                score AS similarity
+         ORDER BY score DESC`,
+        { embedding, limit, minScore, ...(agentId ? { agentId } : {}) },
+      );
+
+      return result.records.map((r) => ({
+        id: r.get("id") as string,
+        text: r.get("text") as string,
+        category: r.get("category") as string,
+        importance: r.get("importance") as number,
+        createdAt: String(r.get("createdAt") ?? ""),
+        score: r.get("similarity") as number,
+      }));
+    } catch (err) {
+      // Graceful degradation: return empty if vector index isn't ready
+      this.logger.warn(`memory-neo4j: vector search failed: ${String(err)}`);
+      return [];
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Signal 2: Lucene BM25 full-text keyword search.
+   * Returns memories ranked by BM25 relevance score.
+   */
+  async bm25Search(
+    query: string,
+    limit: number,
+    agentId?: string,
+  ): Promise<SearchSignalResult[]> {
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      const escaped = escapeLucene(query);
+      if (!escaped.trim()) return [];
+
+      const agentFilter = agentId ? "AND node.agentId = $agentId" : "";
+      const result = await session.run(
+        `CALL db.index.fulltext.queryNodes('memory_fulltext_index', $query)
+         YIELD node, score
+         WHERE true ${agentFilter}
+         RETURN node.id AS id, node.text AS text, node.category AS category,
+                node.importance AS importance, node.createdAt AS createdAt,
+                score AS bm25Score
+         ORDER BY score DESC
+         LIMIT $limit`,
+        { query: escaped, limit, ...(agentId ? { agentId } : {}) },
+      );
+
+      // Normalize BM25 scores to 0-1 range (divide by max)
+      const records = result.records.map((r) => ({
+        id: r.get("id") as string,
+        text: r.get("text") as string,
+        category: r.get("category") as string,
+        importance: r.get("importance") as number,
+        createdAt: String(r.get("createdAt") ?? ""),
+        rawScore: r.get("bm25Score") as number,
+      }));
+
+      if (records.length === 0) return [];
+      const maxScore = records[0].rawScore || 1;
+      return records.map((r) => ({
+        ...r,
+        score: r.rawScore / maxScore,
+      }));
+    } catch (err) {
+      this.logger.warn(`memory-neo4j: BM25 search failed: ${String(err)}`);
+      return [];
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Signal 3: Graph traversal search.
+   *
+   * 1. Find entities matching the query via fulltext index
+   * 2. Find memories directly connected to those entities (MENTIONS)
+   * 3. 1-hop spreading activation through entity relationships
+   *
+   * Returns memories with graph-based relevance scores.
+   */
+  async graphSearch(
+    query: string,
+    limit: number,
+    firingThreshold: number = 0.3,
+    agentId?: string,
+  ): Promise<SearchSignalResult[]> {
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      const escaped = escapeLucene(query);
+      if (!escaped.trim()) return [];
+
+      // Step 1: Find matching entities
+      const entityResult = await session.run(
+        `CALL db.index.fulltext.queryNodes('entity_fulltext_index', $query)
+         YIELD node, score
+         WHERE score >= 0.5
+         RETURN node.id AS entityId, node.name AS name, score
+         ORDER BY score DESC
+         LIMIT 5`,
+        { query: escaped },
+      );
+
+      const entityIds = entityResult.records.map((r) => r.get("entityId") as string);
+      if (entityIds.length === 0) return [];
+
+      // Step 2 + 3: Direct mentions + 1-hop spreading activation
+      const agentFilter = agentId ? "AND m.agentId = $agentId" : "";
+      const result = await session.run(
+        `UNWIND $entityIds AS eid
+         // Direct: Entity ← MENTIONS ← Memory
+         OPTIONAL MATCH (e:Entity {id: eid})<-[rm:MENTIONS]-(m:Memory)
+         WHERE m IS NOT NULL ${agentFilter}
+         WITH m, coalesce(rm.confidence, 1.0) AS directScore
+         WHERE m IS NOT NULL
+
+         RETURN m.id AS id, m.text AS text, m.category AS category,
+                m.importance AS importance, m.createdAt AS createdAt,
+                max(directScore) AS graphScore
+
+         UNION
+
+         UNWIND $entityIds AS eid
+         // 1-hop: Entity → relationship → Entity ← MENTIONS ← Memory
+         OPTIONAL MATCH (e:Entity {id: eid})-[r1:RELATED_TO|KNOWS|WORKS_AT|LIVES_AT|MARRIED_TO|PREFERS|DECIDED]-(e2:Entity)
+         WHERE coalesce(r1.confidence, 0.7) >= $firingThreshold
+         OPTIONAL MATCH (e2)<-[rm:MENTIONS]-(m:Memory)
+         WHERE m IS NOT NULL ${agentFilter}
+         WITH m, coalesce(r1.confidence, 0.7) * coalesce(rm.confidence, 1.0) AS hopScore
+         WHERE m IS NOT NULL
+
+         RETURN m.id AS id, m.text AS text, m.category AS category,
+                m.importance AS importance, m.createdAt AS createdAt,
+                max(hopScore) AS graphScore`,
+        { entityIds, firingThreshold, ...(agentId ? { agentId } : {}) },
+      );
+
+      // Deduplicate by id, keeping highest score
+      const byId = new Map<string, SearchSignalResult>();
+      for (const record of result.records) {
+        const id = record.get("id") as string;
+        if (!id) continue;
+        const score = record.get("graphScore") as number;
+        const existing = byId.get(id);
+        if (!existing || score > existing.score) {
+          byId.set(id, {
+            id,
+            text: record.get("text") as string,
+            category: record.get("category") as string,
+            importance: record.get("importance") as number,
+            createdAt: String(record.get("createdAt") ?? ""),
+            score,
+          });
+        }
+      }
+
+      return Array.from(byId.values())
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit);
+    } catch (err) {
+      this.logger.warn(`memory-neo4j: graph search failed: ${String(err)}`);
+      return [];
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Find similar memories by vector similarity. Used for deduplication.
+   */
+  async findSimilar(
+    embedding: number[],
+    threshold: number = 0.95,
+    limit: number = 1,
+  ): Promise<Array<{ id: string; text: string; score: number }>> {
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      const result = await session.run(
+        `CALL db.index.vector.queryNodes('memory_embedding_index', $limit, $embedding)
+         YIELD node, score
+         WHERE score >= $threshold
+         RETURN node.id AS id, node.text AS text, score AS similarity
+         ORDER BY score DESC`,
+        { embedding, limit, threshold },
+      );
+
+      return result.records.map((r) => ({
+        id: r.get("id") as string,
+        text: r.get("text") as string,
+        score: r.get("similarity") as number,
+      }));
+    } catch (err) {
+      // If vector index isn't ready, return no duplicates (allow store)
+      this.logger.debug?.(`memory-neo4j: similarity check failed: ${String(err)}`);
+      return [];
+    } finally {
+      await session.close();
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Entity & Relationship Operations
+  // --------------------------------------------------------------------------
+
+  /**
+   * Merge (upsert) an Entity node using MERGE pattern.
+   * Idempotent — safe to call multiple times for the same entity name.
+   */
+  async mergeEntity(input: MergeEntityInput): Promise<{ id: string; name: string }> {
+    await this.ensureInitialized();
+    return this.retryOnTransient(async () => {
+      const session = this.driver!.session();
+      try {
+        const result = await session.run(
+          `MERGE (e:Entity {name: $name})
+           ON CREATE SET
+             e.id = $id, e.type = $type, e.aliases = $aliases,
+             e.description = $description, e.embedding = $embedding,
+             e.firstSeen = $now, e.lastSeen = $now, e.mentionCount = 1
+           ON MATCH SET
+             e.type = COALESCE($type, e.type),
+             e.description = COALESCE($description, e.description),
+             e.embedding = COALESCE($embedding, e.embedding),
+             e.lastSeen = $now,
+             e.mentionCount = e.mentionCount + 1
+           RETURN e.id AS id, e.name AS name`,
+          {
+            id: input.id,
+            name: input.name.trim().toLowerCase(),
+            type: input.type,
+            aliases: input.aliases ?? [],
+            description: input.description ?? null,
+            embedding: input.embedding ?? null,
+            now: new Date().toISOString(),
+          },
+        );
+        const record = result.records[0];
+        return {
+          id: record.get("id") as string,
+          name: record.get("name") as string,
+        };
+      } finally {
+        await session.close();
+      }
+    });
+  }
+
+  /**
+   * Create a MENTIONS relationship between a Memory and an Entity.
+   */
+  async createMentions(
+    memoryId: string,
+    entityName: string,
+    role: string = "context",
+    confidence: number = 1.0,
+  ): Promise<void> {
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      await session.run(
+        `MATCH (m:Memory {id: $memoryId})
+         MATCH (e:Entity {name: $entityName})
+         MERGE (m)-[r:MENTIONS]->(e)
+         ON CREATE SET r.role = $role, r.confidence = $confidence`,
+        { memoryId, entityName: entityName.trim().toLowerCase(), role, confidence },
+      );
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Create a typed relationship between two Entity nodes.
+   * The relationship type is validated against an allowlist before injection.
+   */
+  async createEntityRelationship(
+    sourceName: string,
+    targetName: string,
+    relType: string,
+    confidence: number = 1.0,
+  ): Promise<void> {
+    if (!validateRelationshipType(relType)) {
+      this.logger.warn(
+        `memory-neo4j: rejected invalid relationship type: ${relType}`,
+      );
+      return;
+    }
+
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      await session.run(
+        `MATCH (e1:Entity {name: $sourceName})
+         MATCH (e2:Entity {name: $targetName})
+         MERGE (e1)-[r:${relType}]->(e2)
+         ON CREATE SET r.confidence = $confidence, r.createdAt = $now
+         ON MATCH SET r.confidence = CASE WHEN $confidence > r.confidence THEN $confidence ELSE r.confidence END`,
+        {
+          sourceName: sourceName.trim().toLowerCase(),
+          targetName: targetName.trim().toLowerCase(),
+          confidence,
+          now: new Date().toISOString(),
+        },
+      );
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Merge a Tag node and link it to a Memory.
+   */
+  async tagMemory(
+    memoryId: string,
+    tagName: string,
+    tagCategory: string,
+    confidence: number = 1.0,
+  ): Promise<void> {
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      await session.run(
+        `MERGE (t:Tag {name: $tagName})
+         ON CREATE SET t.id = $tagId, t.category = $tagCategory, t.createdAt = $now
+         WITH t
+         MATCH (m:Memory {id: $memoryId})
+         MERGE (m)-[r:TAGGED]->(t)
+         ON CREATE SET r.confidence = $confidence`,
+        {
+          memoryId,
+          tagName: tagName.trim().toLowerCase(),
+          tagId: randomUUID(),
+          tagCategory,
+          confidence,
+          now: new Date().toISOString(),
+        },
+      );
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Update the extraction status of a Memory node.
+   */
+  async updateExtractionStatus(id: string, status: ExtractionStatus): Promise<void> {
+    await this.ensureInitialized();
+    const session = this.driver!.session();
+    try {
+      await session.run(
+        `MATCH (m:Memory {id: $id})
+         SET m.extractionStatus = $status, m.updatedAt = $now`,
+        { id, status, now: new Date().toISOString() },
+      );
+    } finally {
+      await session.close();
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Retry Logic
+  // --------------------------------------------------------------------------
+
+  /**
+   * Retry an operation on transient Neo4j errors (deadlocks, etc.)
+   * with exponential backoff. Adapted from ontology project.
+   */
+  private async retryOnTransient<T>(
+    fn: () => Promise<T>,
+    maxAttempts: number = TRANSIENT_RETRY_ATTEMPTS,
+    baseDelay: number = TRANSIENT_RETRY_BASE_DELAY_MS,
+  ): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        return await fn();
+      } catch (err) {
+        lastError = err;
+        // Check for Neo4j transient errors
+        const isTransient =
+          err instanceof Error &&
+          (err.message.includes("DeadlockDetected") ||
+            err.message.includes("TransientError") ||
+            err.constructor.name === "Neo4jError" && (err as unknown as Record<string, unknown>).code === "Neo.TransientError.Transaction.DeadlockDetected");
+
+        if (!isTransient || attempt >= maxAttempts - 1) {
+          throw err;
+        }
+
+        const delay = baseDelay * Math.pow(2, attempt);
+        this.logger.warn(
+          `memory-neo4j: transient error, retrying (${attempt + 1}/${maxAttempts}): ${String(err)}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+    throw lastError;
+  }
+}

--- a/extensions/memory-neo4j/openclaw.plugin.json
+++ b/extensions/memory-neo4j/openclaw.plugin.json
@@ -1,0 +1,81 @@
+{
+  "id": "memory-neo4j",
+  "kind": "memory",
+  "uiHints": {
+    "embedding.apiKey": {
+      "label": "OpenAI API Key",
+      "sensitive": true,
+      "placeholder": "sk-proj-...",
+      "help": "API key for OpenAI embeddings (or use ${OPENAI_API_KEY})"
+    },
+    "embedding.model": {
+      "label": "Embedding Model",
+      "placeholder": "text-embedding-3-small",
+      "help": "OpenAI embedding model to use"
+    },
+    "neo4j.uri": {
+      "label": "Neo4j URI",
+      "placeholder": "bolt://localhost:7687",
+      "help": "Bolt connection URI for your Neo4j instance"
+    },
+    "neo4j.username": {
+      "label": "Neo4j Username",
+      "placeholder": "neo4j"
+    },
+    "neo4j.password": {
+      "label": "Neo4j Password",
+      "sensitive": true
+    },
+    "autoCapture": {
+      "label": "Auto-Capture",
+      "help": "Automatically capture important information from conversations"
+    },
+    "autoRecall": {
+      "label": "Auto-Recall",
+      "help": "Automatically inject relevant memories into context"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "embedding": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string",
+            "enum": ["text-embedding-3-small", "text-embedding-3-large"]
+          }
+        },
+        "required": ["apiKey"]
+      },
+      "neo4j": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "uri": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        },
+        "required": ["uri"]
+      },
+      "autoCapture": {
+        "type": "boolean"
+      },
+      "autoRecall": {
+        "type": "boolean"
+      }
+    },
+    "required": ["embedding", "neo4j"]
+  }
+}

--- a/extensions/memory-neo4j/package.json
+++ b/extensions/memory-neo4j/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openclaw/memory-neo4j",
+  "version": "2026.2.2",
+  "description": "OpenClaw Neo4j-backed long-term memory plugin with three-signal hybrid search, entity extraction, and knowledge graph",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48",
+    "neo4j-driver": "^5.27.0",
+    "openai": "^6.17.0"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/memory-neo4j/schema.ts
+++ b/extensions/memory-neo4j/schema.ts
@@ -1,0 +1,186 @@
+/**
+ * Graph schema types, Cypher query templates, and constants for memory-neo4j.
+ */
+
+// ============================================================================
+// Node Types
+// ============================================================================
+
+export type MemoryCategory = "preference" | "fact" | "decision" | "entity" | "other";
+export type EntityType = "person" | "organization" | "location" | "event" | "concept";
+export type ExtractionStatus = "pending" | "complete" | "failed" | "skipped";
+export type MemorySource = "user" | "auto-capture" | "memory-watcher" | "import";
+
+export type MemoryNode = {
+  id: string;
+  text: string;
+  embedding: number[];
+  importance: number;
+  category: MemoryCategory;
+  source: MemorySource;
+  createdAt: string;
+  updatedAt: string;
+  extractionStatus: ExtractionStatus;
+  agentId: string;
+  sessionKey?: string;
+};
+
+export type EntityNode = {
+  id: string;
+  name: string;
+  type: EntityType;
+  aliases: string[];
+  embedding?: number[];
+  description?: string;
+  firstSeen: string;
+  lastSeen: string;
+  mentionCount: number;
+};
+
+export type TagNode = {
+  id: string;
+  name: string;
+  category: string;
+  createdAt: string;
+};
+
+// ============================================================================
+// Extraction Types
+// ============================================================================
+
+export type ExtractedEntity = {
+  name: string;
+  type: EntityType;
+  aliases?: string[];
+  description?: string;
+};
+
+export type ExtractedRelationship = {
+  source: string;
+  target: string;
+  type: string;
+  confidence: number;
+};
+
+export type ExtractedTag = {
+  name: string;
+  category: string;
+};
+
+export type ExtractionResult = {
+  entities: ExtractedEntity[];
+  relationships: ExtractedRelationship[];
+  tags: ExtractedTag[];
+};
+
+// ============================================================================
+// Auto-Capture Types
+// ============================================================================
+
+export type CaptureItem = {
+  text: string;
+  category: MemoryCategory;
+  importance: number;
+};
+
+export type CaptureDecision = {
+  memories: CaptureItem[];
+};
+
+// ============================================================================
+// Search Types
+// ============================================================================
+
+export type SearchSignalResult = {
+  id: string;
+  text: string;
+  category: string;
+  importance: number;
+  createdAt: string;
+  score: number;
+};
+
+export type HybridSearchResult = {
+  id: string;
+  text: string;
+  category: string;
+  importance: number;
+  createdAt: string;
+  score: number;
+};
+
+// ============================================================================
+// Input Types
+// ============================================================================
+
+export type StoreMemoryInput = {
+  id: string;
+  text: string;
+  embedding: number[];
+  importance: number;
+  category: MemoryCategory;
+  source: MemorySource;
+  extractionStatus: ExtractionStatus;
+  agentId: string;
+  sessionKey?: string;
+};
+
+export type MergeEntityInput = {
+  id: string;
+  name: string;
+  type: EntityType;
+  aliases?: string[];
+  description?: string;
+  embedding?: number[];
+};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const MEMORY_CATEGORIES = [
+  "preference",
+  "fact",
+  "decision",
+  "entity",
+  "other",
+] as const;
+
+export const ENTITY_TYPES = [
+  "person",
+  "organization",
+  "location",
+  "event",
+  "concept",
+] as const;
+
+export const ALLOWED_RELATIONSHIP_TYPES = new Set([
+  "WORKS_AT",
+  "LIVES_AT",
+  "KNOWS",
+  "MARRIED_TO",
+  "PREFERS",
+  "DECIDED",
+  "RELATED_TO",
+]);
+
+// ============================================================================
+// Lucene Helpers
+// ============================================================================
+
+const LUCENE_SPECIAL_CHARS = /[+\-&|!(){}[\]^"~*?:\\/]/g;
+
+/**
+ * Escape special characters for Lucene fulltext search queries.
+ */
+export function escapeLucene(query: string): string {
+  return query.replace(LUCENE_SPECIAL_CHARS, "\\$&");
+}
+
+/**
+ * Validate that a relationship type is in the allowed set.
+ * Prevents Cypher injection via dynamic relationship type.
+ */
+export function validateRelationshipType(type: string): boolean {
+  return ALLOWED_RELATIONSHIP_TYPES.has(type);
+}

--- a/extensions/memory-neo4j/schema.ts
+++ b/extensions/memory-neo4j/schema.ts
@@ -138,21 +138,9 @@ export type MergeEntityInput = {
 // Constants
 // ============================================================================
 
-export const MEMORY_CATEGORIES = [
-  "preference",
-  "fact",
-  "decision",
-  "entity",
-  "other",
-] as const;
+export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
 
-export const ENTITY_TYPES = [
-  "person",
-  "organization",
-  "location",
-  "event",
-  "concept",
-] as const;
+export const ENTITY_TYPES = ["person", "organization", "location", "event", "concept"] as const;
 
 export const ALLOWED_RELATIONSHIP_TYPES = new Set([
   "WORKS_AT",

--- a/extensions/memory-neo4j/search.ts
+++ b/extensions/memory-neo4j/search.ts
@@ -35,10 +35,14 @@ export function classifyQuery(query: string): QueryType {
   const wordCount = words.length;
 
   // Short queries: 1-2 words → boost BM25
-  if (wordCount <= 2) return "short";
+  if (wordCount <= 2) {
+    return "short";
+  }
 
   // Long queries: 5+ words → boost vector
-  if (wordCount >= 5) return "long";
+  if (wordCount >= 5) {
+    return "long";
+  }
 
   // Entity detection: check for capitalized words (proper nouns)
   // Heuristic: if more than half of non-first words are capitalized
@@ -50,7 +54,9 @@ export function classifyQuery(query: string): QueryType {
         !/^(I|A|An|The|Is|Are|Was|Were|What|Who|Where|When|How|Why|Do|Does|Did)$/.test(w),
     );
 
-  if (capitalizedWords.length > 0) return "entity";
+  if (capitalizedWords.length > 0) {
+    return "entity";
+  }
 
   // Check for question patterns targeting entities
   if (/^(who|where|what)\s+(is|does|did|was|were)\s/i.test(query)) {

--- a/extensions/memory-neo4j/search.ts
+++ b/extensions/memory-neo4j/search.ts
@@ -44,7 +44,11 @@ export function classifyQuery(query: string): QueryType {
   // Heuristic: if more than half of non-first words are capitalized
   const capitalizedWords = words
     .slice(1) // skip first word (often capitalized anyway)
-    .filter((w) => /^[A-Z]/.test(w) && !/^(I|A|An|The|Is|Are|Was|Were|What|Who|Where|When|How|Why|Do|Does|Did)$/.test(w));
+    .filter(
+      (w) =>
+        /^[A-Z]/.test(w) &&
+        !/^(I|A|An|The|Is|Are|Was|Were|What|Who|Where|When|How|Why|Do|Does|Did)$/.test(w),
+    );
 
   if (capitalizedWords.length > 0) return "entity";
 
@@ -209,11 +213,7 @@ export async function hybridSearch(
     graphFiringThreshold?: number;
   } = {},
 ): Promise<HybridSearchResult[]> {
-  const {
-    rrfK = 60,
-    candidateMultiplier = 4,
-    graphFiringThreshold = 0.3,
-  } = options;
+  const { rrfK = 60, candidateMultiplier = 4, graphFiringThreshold = 0.3 } = options;
 
   const candidateLimit = Math.min(200, Math.max(1, limit * candidateMultiplier));
 
@@ -234,11 +234,7 @@ export async function hybridSearch(
   ]);
 
   // 4. Fuse with confidence-weighted RRF
-  const fused = fuseWithConfidenceRRF(
-    [vectorResults, bm25Results, graphResults],
-    rrfK,
-    weights,
-  );
+  const fused = fuseWithConfidenceRRF([vectorResults, bm25Results, graphResults], rrfK, weights);
 
   // 5. Return top results, normalized to 0-100% display scores
   const maxRrf = fused.length > 0 ? fused[0].rrfScore : 1;

--- a/extensions/memory-neo4j/search.ts
+++ b/extensions/memory-neo4j/search.ts
@@ -1,0 +1,255 @@
+/**
+ * Three-signal hybrid search with query-adaptive RRF fusion.
+ *
+ * Combines:
+ *   Signal 1: Vector similarity (HNSW cosine)
+ *   Signal 2: BM25 full-text keyword matching
+ *   Signal 3: Graph traversal (entity → MENTIONS ← memory)
+ *
+ * Fused using confidence-weighted Reciprocal Rank Fusion (RRF)
+ * with query-adaptive signal weights.
+ *
+ * Adapted from ~/Downloads/ontology/app/services/rrf.py
+ */
+
+import type { Embeddings } from "./embeddings.js";
+import type { Neo4jMemoryClient } from "./neo4j-client.js";
+import type { HybridSearchResult, SearchSignalResult } from "./schema.js";
+
+// ============================================================================
+// Query Classification
+// ============================================================================
+
+export type QueryType = "short" | "entity" | "long" | "default";
+
+/**
+ * Classify a query to determine adaptive signal weights.
+ *
+ * - short (1-2 words): BM25 excels at exact keyword matching
+ * - entity (proper nouns detected): Graph traversal finds connected memories
+ * - long (5+ words): Vector captures semantic intent better
+ * - default: balanced weights
+ */
+export function classifyQuery(query: string): QueryType {
+  const words = query.trim().split(/\s+/);
+  const wordCount = words.length;
+
+  // Short queries: 1-2 words → boost BM25
+  if (wordCount <= 2) return "short";
+
+  // Long queries: 5+ words → boost vector
+  if (wordCount >= 5) return "long";
+
+  // Entity detection: check for capitalized words (proper nouns)
+  // Heuristic: if more than half of non-first words are capitalized
+  const capitalizedWords = words
+    .slice(1) // skip first word (often capitalized anyway)
+    .filter((w) => /^[A-Z]/.test(w) && !/^(I|A|An|The|Is|Are|Was|Were|What|Who|Where|When|How|Why|Do|Does|Did)$/.test(w));
+
+  if (capitalizedWords.length > 0) return "entity";
+
+  // Check for question patterns targeting entities
+  if (/^(who|where|what)\s+(is|does|did|was|were)\s/i.test(query)) {
+    return "entity";
+  }
+
+  return "default";
+}
+
+/**
+ * Get adaptive signal weights based on query type.
+ * Returns [vectorWeight, bm25Weight, graphWeight].
+ *
+ * Decision Q7: Query-adaptive RRF weights
+ * - Short → boost BM25 (keyword matching)
+ * - Entity → boost graph (relationship traversal)
+ * - Long → boost vector (semantic similarity)
+ */
+export function getAdaptiveWeights(
+  queryType: QueryType,
+  graphEnabled: boolean,
+): [number, number, number] {
+  const graphBase = graphEnabled ? 1.0 : 0.0;
+
+  switch (queryType) {
+    case "short":
+      return [0.8, 1.2, graphBase * 1.0];
+    case "entity":
+      return [0.8, 1.0, graphBase * 1.3];
+    case "long":
+      return [1.2, 0.7, graphBase * 0.8];
+    case "default":
+    default:
+      return [1.0, 1.0, graphBase * 1.0];
+  }
+}
+
+// ============================================================================
+// Confidence-Weighted RRF Fusion
+// ============================================================================
+
+type SignalEntry = {
+  rank: number; // 1-indexed
+  score: number; // 0-1 normalized
+};
+
+type FusedCandidate = {
+  id: string;
+  text: string;
+  category: string;
+  importance: number;
+  createdAt: string;
+  rrfScore: number;
+};
+
+/**
+ * Fuse multiple search signals using confidence-weighted RRF.
+ *
+ * Formula: RRF_conf(d) = Σ w_i × score_i(d) / (k + rank_i(d))
+ *
+ * Unlike standard RRF which only uses ranks, this variant preserves
+ * score magnitude: rank-1 with score 0.99 contributes more than
+ * rank-1 with score 0.55.
+ *
+ * Reference: Cormack et al. (2009), extended with confidence weighting
+ * from ~/Downloads/ontology/app/services/rrf.py
+ */
+function fuseWithConfidenceRRF(
+  signals: SearchSignalResult[][],
+  k: number,
+  weights: number[],
+): FusedCandidate[] {
+  // Build per-signal rank/score lookups
+  const signalMaps: Map<string, SignalEntry>[] = signals.map((signal) => {
+    const map = new Map<string, SignalEntry>();
+    for (let i = 0; i < signal.length; i++) {
+      const entry = signal[i];
+      // If duplicate in same signal, keep first (higher ranked)
+      if (!map.has(entry.id)) {
+        map.set(entry.id, { rank: i + 1, score: entry.score });
+      }
+    }
+    return map;
+  });
+
+  // Collect all unique candidate IDs with their metadata
+  const candidateMetadata = new Map<
+    string,
+    { text: string; category: string; importance: number; createdAt: string }
+  >();
+
+  for (const signal of signals) {
+    for (const entry of signal) {
+      if (!candidateMetadata.has(entry.id)) {
+        candidateMetadata.set(entry.id, {
+          text: entry.text,
+          category: entry.category,
+          importance: entry.importance,
+          createdAt: entry.createdAt,
+        });
+      }
+    }
+  }
+
+  // Calculate confidence-weighted RRF score for each candidate
+  const results: FusedCandidate[] = [];
+
+  for (const [id, meta] of candidateMetadata) {
+    let rrfScore = 0;
+
+    for (let i = 0; i < signalMaps.length; i++) {
+      const entry = signalMaps[i].get(id);
+      if (entry && entry.rank > 0) {
+        // Confidence-weighted: multiply by original score
+        rrfScore += weights[i] * entry.score * (1 / (k + entry.rank));
+      }
+    }
+
+    results.push({
+      id,
+      text: meta.text,
+      category: meta.category,
+      importance: meta.importance,
+      createdAt: meta.createdAt,
+      rrfScore,
+    });
+  }
+
+  // Sort by RRF score descending
+  results.sort((a, b) => b.rrfScore - a.rrfScore);
+  return results;
+}
+
+// ============================================================================
+// Hybrid Search Orchestrator
+// ============================================================================
+
+/**
+ * Perform a three-signal hybrid search with query-adaptive RRF fusion.
+ *
+ * 1. Embed the query
+ * 2. Classify query for adaptive weights
+ * 3. Run three signals in parallel
+ * 4. Fuse with confidence-weighted RRF
+ * 5. Return top results
+ *
+ * Graceful degradation: if any signal fails, RRF works with remaining signals.
+ * If graph search is not enabled (no extraction API key), uses 2-signal fusion.
+ */
+export async function hybridSearch(
+  db: Neo4jMemoryClient,
+  embeddings: Embeddings,
+  query: string,
+  limit: number = 5,
+  agentId: string = "default",
+  graphEnabled: boolean = false,
+  options: {
+    rrfK?: number;
+    candidateMultiplier?: number;
+    graphFiringThreshold?: number;
+  } = {},
+): Promise<HybridSearchResult[]> {
+  const {
+    rrfK = 60,
+    candidateMultiplier = 4,
+    graphFiringThreshold = 0.3,
+  } = options;
+
+  const candidateLimit = Math.min(200, Math.max(1, limit * candidateMultiplier));
+
+  // 1. Generate query embedding
+  const queryEmbedding = await embeddings.embed(query);
+
+  // 2. Classify query and get adaptive weights
+  const queryType = classifyQuery(query);
+  const weights = getAdaptiveWeights(queryType, graphEnabled);
+
+  // 3. Run signals in parallel
+  const [vectorResults, bm25Results, graphResults] = await Promise.all([
+    db.vectorSearch(queryEmbedding, candidateLimit, 0.1, agentId),
+    db.bm25Search(query, candidateLimit, agentId),
+    graphEnabled
+      ? db.graphSearch(query, candidateLimit, graphFiringThreshold, agentId)
+      : Promise.resolve([] as SearchSignalResult[]),
+  ]);
+
+  // 4. Fuse with confidence-weighted RRF
+  const fused = fuseWithConfidenceRRF(
+    [vectorResults, bm25Results, graphResults],
+    rrfK,
+    weights,
+  );
+
+  // 5. Return top results, normalized to 0-100% display scores
+  const maxRrf = fused.length > 0 ? fused[0].rrfScore : 1;
+  const normalizer = maxRrf > 0 ? 1 / maxRrf : 1;
+
+  return fused.slice(0, limit).map((r) => ({
+    id: r.id,
+    text: r.text,
+    category: r.category,
+    importance: r.importance,
+    createdAt: r.createdAt,
+    score: Math.min(1, r.rrfScore * normalizer), // Normalize to 0-1
+  }));
+}

--- a/extensions/memory-neo4j/tsconfig.json
+++ b/extensions/memory-neo4j/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist", "*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,22 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/memory-neo4j:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.47
+        version: 0.34.47
+      neo4j-driver:
+        specifier: ^5.27.0
+        version: 5.28.3
+      openai:
+        specifier: ^6.17.0
+        version: 6.17.0(ws@8.19.0)(zod@4.3.6)
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/minimax-portal-auth:
     devDependencies:
       openclaw:
@@ -3058,6 +3074,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   bun-types@1.3.6:
     resolution: {integrity: sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==}
 
@@ -4232,6 +4251,15 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  neo4j-driver-bolt-connection@5.28.3:
+    resolution: {integrity: sha512-wqHBYcU0FVRDmdsoZ+Fk0S/InYmu9/4BT6fPYh45Jimg/J7vQBUcdkiHGU7nop7HRb1ZgJmL305mJb6g5Bv35Q==}
+
+  neo4j-driver-core@5.28.3:
+    resolution: {integrity: sha512-Jk+hAmjFmO5YzVH/U7FyKXigot9zmIfLz6SZQy0xfr4zfTE/S8fOYFOGqKQTHBE86HHOWH2RbTslbxIb+XtU2g==}
+
+  neo4j-driver@5.28.3:
+    resolution: {integrity: sha512-k7c0wEh3HoONv1v5AyLp9/BDAbYHJhz2TZvzWstSEU3g3suQcXmKEaYBfrK2UMzxcy3bCT0DrnfRbzsOW5G/Ag==}
+
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
@@ -4749,6 +4777,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -8389,6 +8420,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bun-types@1.3.6:
     dependencies:
       '@types/node': 25.2.0
@@ -9634,6 +9670,20 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  neo4j-driver-bolt-connection@5.28.3:
+    dependencies:
+      buffer: 6.0.3
+      neo4j-driver-core: 5.28.3
+      string_decoder: 1.3.0
+
+  neo4j-driver-core@5.28.3: {}
+
+  neo4j-driver@5.28.3:
+    dependencies:
+      neo4j-driver-bolt-connection: 5.28.3
+      neo4j-driver-core: 5.28.3
+      rxjs: 7.8.2
+
   netmask@2.0.2: {}
 
   node-addon-api@8.5.0: {}
@@ -10290,6 +10340,10 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-buffer@5.1.2: {}
 

--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# update-and-restart.sh — Pull, build, link, and restart OpenClaw gateway
+# Verifies the running gateway matches the built commit.
+#
+set -euo pipefail
+
+REPO_DIR="$HOME/openclaw"
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+log()  { echo -e "${CYAN}[$(date '+%H:%M:%S')]${NC} $1"; }
+ok()   { echo -e "${GREEN}✅ $1${NC}"; }
+warn() { echo -e "${YELLOW}⚠️  $1${NC}"; }
+fail() { echo -e "${RED}❌ $1${NC}"; exit 1; }
+
+cd "$REPO_DIR" || fail "Cannot cd to $REPO_DIR"
+
+# --- Check for uncommitted changes ---
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  warn "You have uncommitted changes:"
+  git status --short
+  echo ""
+  read -rp "Continue anyway? (y/N) " confirm
+  [[ "$confirm" =~ ^[Yy]$ ]] || { log "Aborted."; exit 0; }
+fi
+
+# --- Record pre-pull state ---
+OLD_SHA=$(git rev-parse HEAD)
+OLD_SHORT=$(git rev-parse --short HEAD)
+log "Current commit: ${OLD_SHORT}"
+
+# --- Git pull (rebase to keep local commits on top) ---
+log "Pulling latest changes (rebase)..."
+if git pull --rebase 2>&1; then
+  ok "Git pull complete"
+else
+  warn "Rebase failed — aborting rebase and stopping."
+  git rebase --abort 2>/dev/null || true
+  fail "Git pull --rebase failed (conflicts?). Resolve manually."
+fi
+
+NEW_SHA=$(git rev-parse HEAD)
+NEW_SHORT=$(git rev-parse --short HEAD)
+
+if [ "$OLD_SHA" = "$NEW_SHA" ]; then
+  log "Already up to date (${NEW_SHORT})"
+else
+  log "Updated: ${OLD_SHORT} → ${NEW_SHORT}"
+  echo ""
+  git --no-pager log --oneline "${OLD_SHA}..${NEW_SHA}" | head -20
+  echo ""
+fi
+
+# --- pnpm install ---
+log "Installing dependencies..."
+if pnpm install --frozen-lockfile 2>&1; then
+  ok "pnpm install complete"
+else
+  warn "Frozen lockfile failed, trying regular install..."
+  pnpm install 2>&1 || fail "pnpm install failed"
+  ok "pnpm install complete"
+fi
+
+# --- pnpm build ---
+log "Building TypeScript..."
+pnpm build 2>&1 || fail "pnpm build failed"
+ok "Build complete"
+
+# --- pnpm link ---
+log "Linking globally..."
+pnpm link --global 2>&1 || fail "pnpm link --global failed"
+ok "Linked globally"
+
+# --- Capture the commit SHA that was just built ---
+BUILT_SHA=$(git rev-parse HEAD)
+BUILT_SHORT=$(git rev-parse --short HEAD)
+log "Built commit: ${BUILT_SHORT} (${BUILT_SHA})"
+
+# --- Restart gateway ---
+log "Restarting gateway..."
+openclaw gateway restart 2>&1 || fail "Gateway restart failed"
+
+# --- Wait for gateway to come back ---
+log "Waiting for gateway to stabilize..."
+sleep 3
+
+# --- Verify the running gateway matches ---
+RUNNING_ENTRY=$(openclaw gateway status 2>&1 | grep -oP '(?<=Command: ).*' || true)
+
+# Check commit from the built dist
+if [ -f "$REPO_DIR/dist/version.js" ]; then
+  DIST_SHA=$(grep -oP '[a-f0-9]{40}' "$REPO_DIR/dist/version.js" 2>/dev/null | head -1 || true)
+  DIST_SHORT="${DIST_SHA:0:7}"
+fi
+
+# Verify SHA match
+POST_SHA=$(git -C "$REPO_DIR" rev-parse HEAD)
+if [ "$BUILT_SHA" = "$POST_SHA" ]; then
+  ok "Commit verified: built=${BUILT_SHORT}, repo=${POST_SHA:0:7} ✓"
+else
+  fail "SHA MISMATCH! Built ${BUILT_SHORT} but repo is now ${POST_SHA:0:7}"
+fi
+
+# --- Summary ---
+echo ""
+echo -e "${GREEN}════════════════════════════════════════${NC}"
+echo -e "${GREEN}  OpenClaw updated and restarted!${NC}"
+echo -e "${GREEN}  Commit: ${BUILT_SHORT}${NC}"
+if [ "$OLD_SHA" != "$NEW_SHA" ]; then
+  COMMIT_COUNT=$(git rev-list --count "${OLD_SHA}..${NEW_SHA}")
+  echo -e "${GREEN}  Changes: ${COMMIT_COUNT} new commit(s)${NC}"
+fi
+echo -e "${GREEN}════════════════════════════════════════${NC}"

--- a/src/agents/bootstrap-hooks.ts
+++ b/src/agents/bootstrap-hooks.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { AgentBootstrapHookContext } from "../hooks/internal-hooks.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 
 export async function applyBootstrapHookOverrides(params: {
@@ -27,5 +28,30 @@ export async function applyBootstrapHookOverrides(params: {
   const event = createInternalHookEvent("agent", "bootstrap", sessionKey, context);
   await triggerInternalHook(event);
   const updated = (event.context as AgentBootstrapHookContext).bootstrapFiles;
-  return Array.isArray(updated) ? updated : params.files;
+  const internalResult = Array.isArray(updated) ? updated : params.files;
+
+  // After internal hooks, run plugin hooks
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("agent_bootstrap")) {
+    const result = await hookRunner.runAgentBootstrap(
+      {
+        files: internalResult.map((f) => ({
+          name: f.name,
+          path: f.path,
+          content: f.content,
+          missing: f.missing,
+        })),
+      },
+      {
+        agentId,
+        sessionKey: params.sessionKey,
+        workspaceDir: params.workspaceDir,
+      },
+    );
+    if (result?.files) {
+      return result.files as WorkspaceBootstrapFile[];
+    }
+  }
+
+  return internalResult;
 }

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -1,12 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { completeSimple } from "@mariozechner/pi-ai";
-import {
-  convertToLlm,
-  estimateTokens,
-  generateSummary as upstreamGenerateSummary,
-  serializeConversation,
-} from "@mariozechner/pi-coding-agent";
+import { convertToLlm, estimateTokens, serializeConversation } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 
 export const BASE_CHUNK_RATIO = 0.4;

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -290,6 +290,13 @@ export function resolveMemorySearchConfig(
   cfg: OpenClawConfig,
   agentId: string,
 ): ResolvedMemorySearchConfig | null {
+  // Only one memory system can be active at a time.
+  // When a memory plugin owns the slot, core memory-search is unconditionally disabled.
+  const memoryPluginSlot = cfg.plugins?.slots?.memory;
+  if (memoryPluginSlot && memoryPluginSlot !== "none") {
+    return null;
+  }
+
   const defaults = cfg.agents?.defaults?.memorySearch;
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
   const resolved = mergeConfig(defaults, overrides, agentId);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -10,7 +10,10 @@ import { resolveChannelCapabilities } from "../../../config/channel-capabilities
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
-import { isSubagentSessionKey } from "../../../routing/session-key.js";
+import {
+  isSubagentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "../../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../../telegram/reaction-level.js";
@@ -715,7 +718,7 @@ export async function runEmbeddedAttempt(
                 messages: activeSession.messages,
               },
               {
-                agentId: params.sessionKey?.split(":")[0] ?? "main",
+                agentId: resolveAgentIdFromSessionKey(params.sessionKey),
                 sessionKey: params.sessionKey,
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,
@@ -845,7 +848,7 @@ export async function runEmbeddedAttempt(
                 durationMs: Date.now() - promptStartedAt,
               },
               {
-                agentId: params.sessionKey?.split(":")[0] ?? "main",
+                agentId: resolveAgentIdFromSessionKey(params.sessionKey),
                 sessionKey: params.sessionKey,
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -57,16 +57,19 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
   return ["## User Identity", ownerLine, ""];
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return [
-    "## Current Date & Time",
-    `Time zone: ${params.userTimezone}`,
+  const lines = ["## Current Date & Time", `Time zone: ${params.userTimezone}`];
+  if (params.userTime) {
+    lines.push(`Current time: ${params.userTime}`);
+  }
+  lines.push(
     "If you need the current date, time, or day of week, use the session_status tool.",
     "",
-  ];
+  );
+  return lines;
 }
 
 function buildSafetySection() {
@@ -331,6 +334,7 @@ export function buildAgentSystemPrompt(params: {
     : undefined;
   const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
+  const userTime = params.userTime?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
   const heartbeatPromptLine = heartbeatPrompt
@@ -483,6 +487,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -287,7 +287,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
           if (!id) {
             throw new Error("jobId required (id accepted for backward compatibility)");
           }
-          return jsonResult(await callGatewayTool("cron.run", gatewayOpts, { id }));
+          return jsonResult(await callGatewayTool("cron.run", gatewayOpts, { id, mode: "force" }));
         }
         case "runs": {
           const id = readStringParam(params, "jobId") ?? readStringParam(params, "id");

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -118,7 +118,9 @@ export function rememberRoleRefsForTarget(opts: {
   mode?: NonNullable<PageState["roleRefsMode"]>;
 }): void {
   const targetId = opts.targetId.trim();
-  if (!targetId) return;
+  if (!targetId) {
+    return;
+  }
   roleRefsByTarget.set(roleRefsKey(opts.cdpUrl, targetId), {
     refs: opts.refs,
     ...(opts.frameSelector ? { frameSelector: opts.frameSelector } : {}),
@@ -126,7 +128,9 @@ export function rememberRoleRefsForTarget(opts: {
   });
   while (roleRefsByTarget.size > MAX_ROLE_REFS_CACHE) {
     const first = roleRefsByTarget.keys().next();
-    if (first.done) break;
+    if (first.done) {
+      break;
+    }
     roleRefsByTarget.delete(first.value);
   }
 }
@@ -143,7 +147,9 @@ export function storeRoleRefsForTarget(opts: {
   state.roleRefs = opts.refs;
   state.roleRefsFrameSelector = opts.frameSelector;
   state.roleRefsMode = opts.mode;
-  if (!opts.targetId?.trim()) return;
+  if (!opts.targetId?.trim()) {
+    return;
+  }
   rememberRoleRefsForTarget({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
@@ -159,11 +165,17 @@ export function restoreRoleRefsForTarget(opts: {
   page: Page;
 }): void {
   const targetId = opts.targetId?.trim() || "";
-  if (!targetId) return;
+  if (!targetId) {
+    return;
+  }
   const cached = roleRefsByTarget.get(roleRefsKey(opts.cdpUrl, targetId));
-  if (!cached) return;
+  if (!cached) {
+    return;
+  }
   const state = ensurePageState(opts.page);
-  if (state.roleRefs) return;
+  if (state.roleRefs) {
+    return;
+  }
   state.roleRefs = cached.refs;
   state.roleRefsFrameSelector = cached.frameSelector;
   state.roleRefsMode = cached.mode;
@@ -171,7 +183,9 @@ export function restoreRoleRefsForTarget(opts: {
 
 export function ensurePageState(page: Page): PageState {
   const existing = pageStates.get(page);
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
 
   const state: PageState = {
     console: [],
@@ -195,7 +209,9 @@ export function ensurePageState(page: Page): PageState {
         location: msg.location(),
       };
       state.console.push(entry);
-      if (state.console.length > MAX_CONSOLE_MESSAGES) state.console.shift();
+      if (state.console.length > MAX_CONSOLE_MESSAGES) {
+        state.console.shift();
+      }
     });
     page.on("pageerror", (err: Error) => {
       state.errors.push({
@@ -204,7 +220,9 @@ export function ensurePageState(page: Page): PageState {
         stack: err?.stack ? String(err.stack) : undefined,
         timestamp: new Date().toISOString(),
       });
-      if (state.errors.length > MAX_PAGE_ERRORS) state.errors.shift();
+      if (state.errors.length > MAX_PAGE_ERRORS) {
+        state.errors.shift();
+      }
     });
     page.on("request", (req: Request) => {
       state.nextRequestId += 1;
@@ -217,12 +235,16 @@ export function ensurePageState(page: Page): PageState {
         url: req.url(),
         resourceType: req.resourceType(),
       });
-      if (state.requests.length > MAX_NETWORK_REQUESTS) state.requests.shift();
+      if (state.requests.length > MAX_NETWORK_REQUESTS) {
+        state.requests.shift();
+      }
     });
     page.on("response", (resp: Response) => {
       const req = resp.request();
       const id = state.requestIds.get(req);
-      if (!id) return;
+      if (!id) {
+        return;
+      }
       let rec: BrowserNetworkRequest | undefined;
       for (let i = state.requests.length - 1; i >= 0; i -= 1) {
         const candidate = state.requests[i];
@@ -231,13 +253,17 @@ export function ensurePageState(page: Page): PageState {
           break;
         }
       }
-      if (!rec) return;
+      if (!rec) {
+        return;
+      }
       rec.status = resp.status();
       rec.ok = resp.ok();
     });
     page.on("requestfailed", (req: Request) => {
       const id = state.requestIds.get(req);
-      if (!id) return;
+      if (!id) {
+        return;
+      }
       let rec: BrowserNetworkRequest | undefined;
       for (let i = state.requests.length - 1; i >= 0; i -= 1) {
         const candidate = state.requests[i];
@@ -246,7 +272,9 @@ export function ensurePageState(page: Page): PageState {
           break;
         }
       }
-      if (!rec) return;
+      if (!rec) {
+        return;
+      }
       rec.failureText = req.failure()?.errorText;
       rec.ok = false;
     });
@@ -260,24 +288,32 @@ export function ensurePageState(page: Page): PageState {
 }
 
 function observeContext(context: BrowserContext) {
-  if (observedContexts.has(context)) return;
+  if (observedContexts.has(context)) {
+    return;
+  }
   observedContexts.add(context);
   ensureContextState(context);
 
-  for (const page of context.pages()) ensurePageState(page);
+  for (const page of context.pages()) {
+    ensurePageState(page);
+  }
   context.on("page", (page) => ensurePageState(page));
 }
 
 export function ensureContextState(context: BrowserContext): ContextState {
   const existing = contextStates.get(context);
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
   const state: ContextState = { traceActive: false };
   contextStates.set(context, state);
   return state;
 }
 
 function observeBrowser(browser: Browser) {
-  for (const context of browser.contexts()) observeContext(context);
+  for (const context of browser.contexts()) {
+    observeContext(context);
+  }
 }
 
 async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
@@ -285,11 +321,15 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
 
   // Check if we already have a cached connection for this specific URL
   const cached = cachedByUrl.get(normalized);
-  if (cached) return cached;
+  if (cached) {
+    return cached;
+  }
 
   // Check if there's already a connection in progress for this specific URL
   const existingConnecting = connectingByUrl.get(normalized);
-  if (existingConnecting) return await existingConnecting;
+  if (existingConnecting) {
+    return await existingConnecting;
+  }
 
   const connectWithRetry = async (): Promise<ConnectedBrowser> => {
     let lastErr: unknown;
@@ -356,7 +396,9 @@ async function findPageByTargetId(
   // First, try the standard CDP session approach
   for (const page of pages) {
     const tid = await pageTargetId(page).catch(() => null);
-    if (tid && tid === targetId) return page;
+    if (tid && tid === targetId) {
+      return page;
+    }
   }
   // If CDP sessions fail (e.g., extension relay blocks Target.attachToBrowserTarget),
   // fall back to URL-based matching using the /json/list endpoint
@@ -407,15 +449,21 @@ export async function getPageForTargetId(opts: {
 }): Promise<Page> {
   const { browser } = await connectBrowser(opts.cdpUrl);
   const pages = await getAllPages(browser);
-  if (!pages.length) throw new Error("No pages available in the connected browser.");
+  if (!pages.length) {
+    throw new Error("No pages available in the connected browser.");
+  }
   const first = pages[0];
-  if (!opts.targetId) return first;
+  if (!opts.targetId) {
+    return first;
+  }
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!found) {
     // Extension relays can block CDP attachment APIs (e.g. Target.attachToBrowserTarget),
     // which prevents us from resolving a page's targetId via newCDPSession(). If Playwright
     // only exposes a single Page, use it as a best-effort fallback.
-    if (pages.length === 1) return first;
+    if (pages.length === 1) {
+      return first;
+    }
     throw new Error("tab not found");
   }
   return found;

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -98,8 +98,9 @@ const MAX_CONSOLE_MESSAGES = 500;
 const MAX_PAGE_ERRORS = 200;
 const MAX_NETWORK_REQUESTS = 500;
 
-let cached: ConnectedBrowser | null = null;
-let connecting: Promise<ConnectedBrowser> | null = null;
+// Per-profile caching to allow parallel connections to different Chrome instances
+const cachedByUrl = new Map<string, ConnectedBrowser>();
+const connectingByUrl = new Map<string, Promise<ConnectedBrowser>>();
 
 function normalizeCdpUrl(raw: string) {
   return raw.replace(/\/$/, "");
@@ -117,9 +118,7 @@ export function rememberRoleRefsForTarget(opts: {
   mode?: NonNullable<PageState["roleRefsMode"]>;
 }): void {
   const targetId = opts.targetId.trim();
-  if (!targetId) {
-    return;
-  }
+  if (!targetId) return;
   roleRefsByTarget.set(roleRefsKey(opts.cdpUrl, targetId), {
     refs: opts.refs,
     ...(opts.frameSelector ? { frameSelector: opts.frameSelector } : {}),
@@ -127,9 +126,7 @@ export function rememberRoleRefsForTarget(opts: {
   });
   while (roleRefsByTarget.size > MAX_ROLE_REFS_CACHE) {
     const first = roleRefsByTarget.keys().next();
-    if (first.done) {
-      break;
-    }
+    if (first.done) break;
     roleRefsByTarget.delete(first.value);
   }
 }
@@ -146,9 +143,7 @@ export function storeRoleRefsForTarget(opts: {
   state.roleRefs = opts.refs;
   state.roleRefsFrameSelector = opts.frameSelector;
   state.roleRefsMode = opts.mode;
-  if (!opts.targetId?.trim()) {
-    return;
-  }
+  if (!opts.targetId?.trim()) return;
   rememberRoleRefsForTarget({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
@@ -164,17 +159,11 @@ export function restoreRoleRefsForTarget(opts: {
   page: Page;
 }): void {
   const targetId = opts.targetId?.trim() || "";
-  if (!targetId) {
-    return;
-  }
+  if (!targetId) return;
   const cached = roleRefsByTarget.get(roleRefsKey(opts.cdpUrl, targetId));
-  if (!cached) {
-    return;
-  }
+  if (!cached) return;
   const state = ensurePageState(opts.page);
-  if (state.roleRefs) {
-    return;
-  }
+  if (state.roleRefs) return;
   state.roleRefs = cached.refs;
   state.roleRefsFrameSelector = cached.frameSelector;
   state.roleRefsMode = cached.mode;
@@ -182,9 +171,7 @@ export function restoreRoleRefsForTarget(opts: {
 
 export function ensurePageState(page: Page): PageState {
   const existing = pageStates.get(page);
-  if (existing) {
-    return existing;
-  }
+  if (existing) return existing;
 
   const state: PageState = {
     console: [],
@@ -208,9 +195,7 @@ export function ensurePageState(page: Page): PageState {
         location: msg.location(),
       };
       state.console.push(entry);
-      if (state.console.length > MAX_CONSOLE_MESSAGES) {
-        state.console.shift();
-      }
+      if (state.console.length > MAX_CONSOLE_MESSAGES) state.console.shift();
     });
     page.on("pageerror", (err: Error) => {
       state.errors.push({
@@ -219,9 +204,7 @@ export function ensurePageState(page: Page): PageState {
         stack: err?.stack ? String(err.stack) : undefined,
         timestamp: new Date().toISOString(),
       });
-      if (state.errors.length > MAX_PAGE_ERRORS) {
-        state.errors.shift();
-      }
+      if (state.errors.length > MAX_PAGE_ERRORS) state.errors.shift();
     });
     page.on("request", (req: Request) => {
       state.nextRequestId += 1;
@@ -234,16 +217,12 @@ export function ensurePageState(page: Page): PageState {
         url: req.url(),
         resourceType: req.resourceType(),
       });
-      if (state.requests.length > MAX_NETWORK_REQUESTS) {
-        state.requests.shift();
-      }
+      if (state.requests.length > MAX_NETWORK_REQUESTS) state.requests.shift();
     });
     page.on("response", (resp: Response) => {
       const req = resp.request();
       const id = state.requestIds.get(req);
-      if (!id) {
-        return;
-      }
+      if (!id) return;
       let rec: BrowserNetworkRequest | undefined;
       for (let i = state.requests.length - 1; i >= 0; i -= 1) {
         const candidate = state.requests[i];
@@ -252,17 +231,13 @@ export function ensurePageState(page: Page): PageState {
           break;
         }
       }
-      if (!rec) {
-        return;
-      }
+      if (!rec) return;
       rec.status = resp.status();
       rec.ok = resp.ok();
     });
     page.on("requestfailed", (req: Request) => {
       const id = state.requestIds.get(req);
-      if (!id) {
-        return;
-      }
+      if (!id) return;
       let rec: BrowserNetworkRequest | undefined;
       for (let i = state.requests.length - 1; i >= 0; i -= 1) {
         const candidate = state.requests[i];
@@ -271,9 +246,7 @@ export function ensurePageState(page: Page): PageState {
           break;
         }
       }
-      if (!rec) {
-        return;
-      }
+      if (!rec) return;
       rec.failureText = req.failure()?.errorText;
       rec.ok = false;
     });
@@ -287,42 +260,36 @@ export function ensurePageState(page: Page): PageState {
 }
 
 function observeContext(context: BrowserContext) {
-  if (observedContexts.has(context)) {
-    return;
-  }
+  if (observedContexts.has(context)) return;
   observedContexts.add(context);
   ensureContextState(context);
 
-  for (const page of context.pages()) {
-    ensurePageState(page);
-  }
+  for (const page of context.pages()) ensurePageState(page);
   context.on("page", (page) => ensurePageState(page));
 }
 
 export function ensureContextState(context: BrowserContext): ContextState {
   const existing = contextStates.get(context);
-  if (existing) {
-    return existing;
-  }
+  if (existing) return existing;
   const state: ContextState = { traceActive: false };
   contextStates.set(context, state);
   return state;
 }
 
 function observeBrowser(browser: Browser) {
-  for (const context of browser.contexts()) {
-    observeContext(context);
-  }
+  for (const context of browser.contexts()) observeContext(context);
 }
 
 async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
   const normalized = normalizeCdpUrl(cdpUrl);
-  if (cached?.cdpUrl === normalized) {
-    return cached;
-  }
-  if (connecting) {
-    return await connecting;
-  }
+
+  // Check if we already have a cached connection for this specific URL
+  const cached = cachedByUrl.get(normalized);
+  if (cached) return cached;
+
+  // Check if there's already a connection in progress for this specific URL
+  const existingConnecting = connectingByUrl.get(normalized);
+  if (existingConnecting) return await existingConnecting;
 
   const connectWithRetry = async (): Promise<ConnectedBrowser> => {
     let lastErr: unknown;
@@ -334,11 +301,11 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
         const headers = getHeadersWithAuth(endpoint);
         const browser = await chromium.connectOverCDP(endpoint, { timeout, headers });
         const connected: ConnectedBrowser = { browser, cdpUrl: normalized };
-        cached = connected;
+        cachedByUrl.set(normalized, connected);
         observeBrowser(browser);
         browser.on("disconnected", () => {
-          if (cached?.browser === browser) {
-            cached = null;
+          if (cachedByUrl.get(normalized)?.browser === browser) {
+            cachedByUrl.delete(normalized);
           }
         });
         return connected;
@@ -355,11 +322,12 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
     throw new Error(message);
   };
 
-  connecting = connectWithRetry().finally(() => {
-    connecting = null;
+  const connectingPromise = connectWithRetry().finally(() => {
+    connectingByUrl.delete(normalized);
   });
+  connectingByUrl.set(normalized, connectingPromise);
 
-  return await connecting;
+  return await connectingPromise;
 }
 
 async function getAllPages(browser: Browser): Promise<Page[]> {
@@ -388,9 +356,7 @@ async function findPageByTargetId(
   // First, try the standard CDP session approach
   for (const page of pages) {
     const tid = await pageTargetId(page).catch(() => null);
-    if (tid && tid === targetId) {
-      return page;
-    }
+    if (tid && tid === targetId) return page;
   }
   // If CDP sessions fail (e.g., extension relay blocks Target.attachToBrowserTarget),
   // fall back to URL-based matching using the /json/list endpoint
@@ -441,21 +407,15 @@ export async function getPageForTargetId(opts: {
 }): Promise<Page> {
   const { browser } = await connectBrowser(opts.cdpUrl);
   const pages = await getAllPages(browser);
-  if (!pages.length) {
-    throw new Error("No pages available in the connected browser.");
-  }
+  if (!pages.length) throw new Error("No pages available in the connected browser.");
   const first = pages[0];
-  if (!opts.targetId) {
-    return first;
-  }
+  if (!opts.targetId) return first;
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!found) {
     // Extension relays can block CDP attachment APIs (e.g. Target.attachToBrowserTarget),
     // which prevents us from resolving a page's targetId via newCDPSession(). If Playwright
     // only exposes a single Page, use it as a best-effort fallback.
-    if (pages.length === 1) {
-      return first;
-    }
+    if (pages.length === 1) return first;
     throw new Error("tab not found");
   }
   return found;
@@ -501,12 +461,11 @@ export function refLocator(page: Page, ref: string) {
 }
 
 export async function closePlaywrightBrowserConnection(): Promise<void> {
-  const cur = cached;
-  cached = null;
-  if (!cur) {
-    return;
-  }
-  await cur.browser.close().catch(() => {});
+  // Close all cached browser connections
+  const connections = Array.from(cachedByUrl.values());
+  cachedByUrl.clear();
+  connectingByUrl.clear();
+  await Promise.all(connections.map((c) => c.browser.close().catch(() => {})));
 }
 
 /**

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -251,10 +251,13 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
     scan?: MemorySourceScan;
   }> = [];
 
+  const disabledAgentIds: string[] = [];
   for (const agentId of agentIds) {
     await withManager<MemoryManager>({
       getManager: () => getMemorySearchManager({ cfg, agentId }),
-      onMissing: (error) => defaultRuntime.log(error ?? "Memory search disabled."),
+      onMissing: () => {
+        disabledAgentIds.push(agentId);
+      },
       onCloseError: (err) =>
         defaultRuntime.error(`Memory manager close failed: ${formatErrorMessage(err)}`),
       close: (manager) => manager.close(),
@@ -335,9 +338,20 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
   const accent = (text: string) => colorize(rich, theme.accent, text);
   const label = (text: string) => muted(`${text}:`);
 
+  const emptyAgentIds: string[] = [];
   for (const result of allResults) {
     const { agentId, status, embeddingProbe, indexError, scan } = result;
     const totalFiles = scan?.totalFiles ?? null;
+
+    // Skip agents with no indexed content (0 files, 0 chunks, no source files, no errors).
+    // These agents aren't using the core memory search system — no need to show them.
+    const isEmpty =
+      status.files === 0 && status.chunks === 0 && (totalFiles ?? 0) === 0 && !indexError;
+    if (isEmpty) {
+      emptyAgentIds.push(agentId);
+      continue;
+    }
+
     const indexedLabel =
       totalFiles === null
         ? `${status.files}/? files · ${status.chunks} chunks`
@@ -462,6 +476,24 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
       }
     }
     defaultRuntime.log(lines.join("\n"));
+    defaultRuntime.log("");
+  }
+
+  // Show compact summary for agents with no indexed memory-search content
+  if (emptyAgentIds.length > 0) {
+    const agentList = emptyAgentIds.join(", ");
+    defaultRuntime.log(
+      `${muted(`Memory Search: ${emptyAgentIds.length} agent${emptyAgentIds.length > 1 ? "s" : ""} with no indexed files (${agentList})`)}`,
+    );
+    defaultRuntime.log("");
+  }
+
+  // Show compact summary for agents with memory search disabled
+  if (disabledAgentIds.length > 0 && emptyAgentIds.length === 0) {
+    const agentList = disabledAgentIds.join(", ");
+    defaultRuntime.log(
+      `${muted(`Memory Search: disabled for ${disabledAgentIds.length} agent${disabledAgentIds.length > 1 ? "s" : ""} (${agentList})`)}`,
+    );
     defaultRuntime.log("");
   }
 }

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -483,7 +483,9 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
   if (emptyAgentIds.length > 0) {
     const agentList = emptyAgentIds.join(", ");
     defaultRuntime.log(
-      `${muted(`Memory Search: ${emptyAgentIds.length} agent${emptyAgentIds.length > 1 ? "s" : ""} with no indexed files (${agentList})`)}`,
+      muted(
+        `Memory Search: ${emptyAgentIds.length} agent${emptyAgentIds.length > 1 ? "s" : ""} with no indexed files (${agentList})`,
+      ),
     );
     defaultRuntime.log("");
   }
@@ -492,7 +494,9 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
   if (disabledAgentIds.length > 0 && emptyAgentIds.length === 0) {
     const agentList = disabledAgentIds.join(", ");
     defaultRuntime.log(
-      `${muted(`Memory Search: disabled for ${disabledAgentIds.length} agent${disabledAgentIds.length > 1 ? "s" : ""} (${agentList})`)}`,
+      muted(
+        `Memory Search: disabled for ${disabledAgentIds.length} agent${disabledAgentIds.length > 1 ? "s" : ""} (${agentList})`,
+      ),
     );
     defaultRuntime.log("");
   }

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -8,7 +8,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { getFlagValue, getPositiveIntFlagValue, getVerboseFlag, hasFlag } from "../argv.js";
 import { registerBrowserCli } from "../browser-cli.js";
 import { registerConfigCli } from "../config-cli.js";
-import { registerMemoryCli, runMemoryStatus } from "../memory-cli.js";
+import { registerMemoryCli } from "../memory-cli.js";
 import { registerAgentCommands } from "./register.agent.js";
 import { registerConfigureCommand } from "./register.configure.js";
 import { registerMaintenanceCommands } from "./register.maintenance.js";
@@ -96,21 +96,8 @@ const routeAgentsList: RouteSpec = {
   },
 };
 
-const routeMemoryStatus: RouteSpec = {
-  match: (path) => path[0] === "memory" && path[1] === "status",
-  run: async (argv) => {
-    const agent = getFlagValue(argv, "--agent");
-    if (agent === null) {
-      return false;
-    }
-    const json = hasFlag(argv, "--json");
-    const deep = hasFlag(argv, "--deep");
-    const index = hasFlag(argv, "--index");
-    const verbose = hasFlag(argv, "--verbose");
-    await runMemoryStatus({ agent, json, deep, index, verbose });
-    return true;
-  },
-};
+// Note: memory status intentionally has no fast-path route so that plugin
+// postAction hooks (e.g. LanceDB LTM status) fire via Commander.
 
 export const commandRegistry: CommandRegistration[] = [
   {
@@ -140,7 +127,6 @@ export const commandRegistry: CommandRegistration[] = [
   {
     id: "memory",
     register: ({ program }) => registerMemoryCli(program),
-    routes: [routeMemoryStatus],
   },
   {
     id: "agent",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -1,0 +1,193 @@
+import fsSync from "node:fs";
+import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveMemorySearchConfig } from "../agents/memory-search.js";
+import { resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { note } from "../terminal/note.js";
+import { resolveUserPath } from "../utils.js";
+
+/**
+ * Resolve the active memory plugin name from config, if any.
+ * Returns the plugin ID (e.g. "memory-neo4j") or null if no plugin is configured.
+ *
+ * Reads the raw config file because loadConfig() may strip fields
+ * when the config schema is out of sync with the actual file.
+ */
+function resolveMemoryPlugin(cfg: OpenClawConfig): string | null {
+  // First try the parsed config
+  const pluginsEnabled = cfg.plugins?.enabled !== false;
+  if (pluginsEnabled) {
+    const slot =
+      typeof cfg.plugins?.slots?.memory === "string" ? cfg.plugins.slots.memory.trim() : "";
+    if (slot && slot.toLowerCase() !== "none") {
+      return slot;
+    }
+  }
+
+  // Fallback: read raw config file in case loadConfig() stripped the plugins section
+  try {
+    const configPath = resolveUserPath("~/.openclaw/openclaw.json");
+    const raw = JSON.parse(fsSync.readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+    const plugins = raw.plugins as Record<string, unknown> | undefined;
+    if (plugins?.enabled === false) {
+      return null;
+    }
+    const slots = plugins?.slots as Record<string, unknown> | undefined;
+    const slot = typeof slots?.memory === "string" ? slots.memory.trim() : "";
+    if (slot && slot.toLowerCase() !== "none") {
+      return slot;
+    }
+  } catch {
+    // Config file read failed — fall through
+  }
+
+  return null;
+}
+
+/**
+ * Check whether memory search has a usable embedding provider.
+ * Runs as part of `openclaw doctor` — config-only, no network calls.
+ *
+ * When a memory plugin (e.g. memory-neo4j) is configured, it handles
+ * its own embedding and recall — the built-in memorySearch config is
+ * not required, so we report the plugin status instead.
+ */
+export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void> {
+  const agentId = resolveDefaultAgentId(cfg);
+  const agentDir = resolveAgentDir(cfg, agentId);
+  const resolved = resolveMemorySearchConfig(cfg, agentId);
+  const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());
+
+  // Check if a memory plugin handles recall instead of the built-in search.
+  // When a plugin is active, it manages its own embeddings and recall —
+  // the built-in memorySearch config is irrelevant.
+  const memoryPlugin = resolveMemoryPlugin(cfg);
+  if (memoryPlugin) {
+    note(
+      `Memory recall is handled by plugin "${memoryPlugin}" (built-in memorySearch not needed).`,
+      "Memory search",
+    );
+    return;
+  }
+
+  if (!resolved) {
+    note("Memory search is explicitly disabled (enabled: false).", "Memory search");
+    return;
+  }
+
+  // If a specific provider is configured (not "auto"), check only that one.
+  if (resolved.provider !== "auto") {
+    if (resolved.provider === "local") {
+      if (hasLocalEmbeddings(resolved.local)) {
+        return; // local model file exists
+      }
+      note(
+        [
+          'Memory search provider is set to "local" but no local model file was found.',
+          "",
+          "Fix (pick one):",
+          `- Install node-llama-cpp and set a local model path in config`,
+          `- Switch to a remote provider: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.provider openai")}`,
+          "",
+          `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+        ].join("\n"),
+        "Memory search",
+      );
+      return;
+    }
+    // Remote provider — check for API key
+    if (hasRemoteApiKey || (await hasApiKeyForProvider(resolved.provider, cfg, agentDir))) {
+      return;
+    }
+    const envVar = providerEnvVar(resolved.provider);
+    note(
+      [
+        `Memory search provider is set to "${resolved.provider}" but no API key was found.`,
+        `Semantic recall will not work without a valid API key.`,
+        "",
+        "Fix (pick one):",
+        `- Set ${envVar} in your environment`,
+        `- Add credentials: ${formatCliCommand(`openclaw auth add --provider ${resolved.provider}`)}`,
+        `- To disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
+        "",
+        `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+      ].join("\n"),
+      "Memory search",
+    );
+    return;
+  }
+
+  // provider === "auto": check all providers in resolution order
+  if (hasLocalEmbeddings(resolved.local)) {
+    return;
+  }
+  for (const provider of ["openai", "gemini", "voyage"] as const) {
+    if (hasRemoteApiKey || (await hasApiKeyForProvider(provider, cfg, agentDir))) {
+      return;
+    }
+  }
+
+  note(
+    [
+      "Memory search is enabled but no embedding provider is configured.",
+      "Semantic recall will not work without an embedding provider.",
+      "",
+      "Fix (pick one):",
+      "- Set OPENAI_API_KEY or GEMINI_API_KEY in your environment",
+      `- Add credentials: ${formatCliCommand("openclaw auth add --provider openai")}`,
+      `- For local embeddings: configure agents.defaults.memorySearch.provider and local model path`,
+      `- To disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
+      "",
+      `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+    ].join("\n"),
+    "Memory search",
+  );
+}
+
+function hasLocalEmbeddings(local: { modelPath?: string }): boolean {
+  const modelPath = local.modelPath?.trim();
+  if (!modelPath) {
+    return false;
+  }
+  // Remote/downloadable models (hf: or http:) aren't pre-resolved on disk,
+  // so we can't confirm availability without a network call. Treat as
+  // potentially available — the user configured it intentionally.
+  if (/^(hf:|https?:)/i.test(modelPath)) {
+    return true;
+  }
+  const resolved = resolveUserPath(modelPath);
+  try {
+    return fsSync.statSync(resolved).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function hasApiKeyForProvider(
+  provider: "openai" | "gemini" | "voyage",
+  cfg: OpenClawConfig,
+  agentDir: string,
+): Promise<boolean> {
+  // Map embedding provider names to model-auth provider names
+  const authProvider = provider === "gemini" ? "google" : provider;
+  try {
+    await resolveApiKeyForProvider({ provider: authProvider, cfg, agentDir });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function providerEnvVar(provider: string): string {
+  switch (provider) {
+    case "openai":
+      return "OPENAI_API_KEY";
+    case "gemini":
+      return "GEMINI_API_KEY";
+    case "voyage":
+      return "VOYAGE_API_KEY";
+    default:
+      return `${provider.toUpperCase()}_API_KEY`;
+  }
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,5 @@
-import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import fs from "node:fs";
-import type { OpenClawConfig } from "../config/config.js";
-import type { RuntimeEnv } from "../runtime.js";
+import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
@@ -11,12 +9,14 @@ import {
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
@@ -34,6 +34,7 @@ import {
   maybeScanExtraGatewayServices,
 } from "./doctor-gateway-services.js";
 import { noteSourceInstallIssues } from "./doctor-install.js";
+import { noteMemorySearchHealth } from "./doctor-memory-search.js";
 import {
   noteMacLaunchAgentOverrides,
   noteMacLaunchctlGatewayEnvOverrides,
@@ -293,6 +294,8 @@ export async function doctorCommand(
       note(MEMORY_SYSTEM_PROMPT, "Workspace");
     }
   }
+
+  await noteMemorySearchHealth(cfg);
 
   const finalSnapshot = await readConfigFileSnapshot();
   if (finalSnapshot.exists && !finalSnapshot.valid) {

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -288,6 +288,11 @@ export async function statusCommand(
     }
     if (!memory) {
       const slot = memoryPlugin.slot ? `plugin ${memoryPlugin.slot}` : "plugin";
+      // External plugins (non memory-core) don't have detailed status available,
+      // but that doesn't mean they're unavailable - just that we can't query them here
+      if (memoryPlugin.slot && memoryPlugin.slot !== "memory-core") {
+        return muted(`enabled (${slot})`);
+      }
       return muted(`enabled (${slot}) · unavailable`);
     }
     const parts: string[] = [];

--- a/src/config/sessions/per-session-store.ts
+++ b/src/config/sessions/per-session-store.ts
@@ -1,0 +1,137 @@
+/**
+ * Per-session metadata storage to eliminate lock contention.
+ *
+ * Instead of storing all session metadata in a single sessions.json file
+ * (which requires a global lock), each session gets its own .meta.json file.
+ * This allows parallel updates without blocking.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import JSON5 from "json5";
+import type { SessionEntry } from "./types.js";
+import { resolveSessionTranscriptsDirForAgent } from "./paths.js";
+
+const META_SUFFIX = ".meta.json";
+
+/**
+ * Get the path to a session's metadata file.
+ */
+export function getSessionMetaPath(sessionId: string, agentId?: string): string {
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+  return path.join(sessionsDir, `${sessionId}${META_SUFFIX}`);
+}
+
+/**
+ * Load session metadata from per-session file.
+ * Returns undefined if the file doesn't exist.
+ */
+export async function loadSessionMeta(
+  sessionId: string,
+  agentId?: string,
+): Promise<SessionEntry | undefined> {
+  const metaPath = getSessionMetaPath(sessionId, agentId);
+  try {
+    const content = await fs.readFile(metaPath, "utf-8");
+    const entry = JSON5.parse(content) as SessionEntry;
+    return entry;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+/**
+ * Save session metadata to per-session file.
+ * Uses atomic write (write to temp, then rename) to prevent corruption.
+ */
+export async function saveSessionMeta(
+  sessionId: string,
+  entry: SessionEntry,
+  agentId?: string,
+): Promise<void> {
+  const metaPath = getSessionMetaPath(sessionId, agentId);
+  const dir = path.dirname(metaPath);
+  await fs.mkdir(dir, { recursive: true });
+
+  // Atomic write: write to temp file, then rename
+  const tempPath = `${metaPath}.tmp.${process.pid}.${Date.now()}`;
+  const content = JSON.stringify(entry, null, 2);
+
+  try {
+    await fs.writeFile(tempPath, content, "utf-8");
+    await fs.rename(tempPath, metaPath);
+  } catch (err) {
+    // Clean up temp file on error
+    await fs.unlink(tempPath).catch(() => {});
+    throw err;
+  }
+}
+
+/**
+ * Update session metadata atomically.
+ * Reads current state, applies patch, and writes back.
+ * No lock needed since we use atomic writes and per-session files.
+ */
+export async function updateSessionMeta(
+  sessionId: string,
+  patch: Partial<SessionEntry>,
+  agentId?: string,
+): Promise<SessionEntry> {
+  const existing = await loadSessionMeta(sessionId, agentId);
+  const updatedAt = Date.now();
+  const merged: SessionEntry = {
+    ...existing,
+    ...patch,
+    sessionId,
+    updatedAt,
+  };
+  await saveSessionMeta(sessionId, merged, agentId);
+  return merged;
+}
+
+/**
+ * Delete session metadata file.
+ */
+export async function deleteSessionMeta(sessionId: string, agentId?: string): Promise<void> {
+  const metaPath = getSessionMetaPath(sessionId, agentId);
+  await fs.unlink(metaPath).catch((err) => {
+    if ((err as { code?: string }).code !== "ENOENT") throw err;
+  });
+}
+
+/**
+ * List all session metadata files in the sessions directory.
+ * Returns an array of session IDs.
+ */
+export async function listSessionMetas(agentId?: string): Promise<string[]> {
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+  try {
+    const files = await fs.readdir(sessionsDir);
+    return files.filter((f) => f.endsWith(META_SUFFIX)).map((f) => f.slice(0, -META_SUFFIX.length));
+  } catch (err) {
+    if ((err as { code?: string }).code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+/**
+ * Load all session metadata from per-session files.
+ * This is used for backwards compatibility and for building the session index.
+ */
+export async function loadAllSessionMetas(agentId?: string): Promise<Record<string, SessionEntry>> {
+  const sessionIds = await listSessionMetas(agentId);
+  const entries: Record<string, SessionEntry> = {};
+
+  await Promise.all(
+    sessionIds.map(async (sessionId) => {
+      const entry = await loadSessionMeta(sessionId, agentId);
+      if (entry) {
+        entries[sessionId] = entry;
+      }
+    }),
+  );
+
+  return entries;
+}

--- a/src/config/sessions/per-session-store.ts
+++ b/src/config/sessions/per-session-store.ts
@@ -33,11 +33,13 @@ export async function loadSessionMeta(
   const metaPath = getSessionMetaPath(sessionId, agentId);
   try {
     const content = await fs.readFile(metaPath, "utf-8");
-    const entry = JSON5.parse(content) as SessionEntry;
+    const entry = JSON5.parse(content);
     return entry;
   } catch (err) {
     const code = (err as { code?: string }).code;
-    if (code === "ENOENT") return undefined;
+    if (code === "ENOENT") {
+      return undefined;
+    }
     throw err;
   }
 }
@@ -97,7 +99,9 @@ export async function updateSessionMeta(
 export async function deleteSessionMeta(sessionId: string, agentId?: string): Promise<void> {
   const metaPath = getSessionMetaPath(sessionId, agentId);
   await fs.unlink(metaPath).catch((err) => {
-    if ((err as { code?: string }).code !== "ENOENT") throw err;
+    if ((err as { code?: string }).code !== "ENOENT") {
+      throw err;
+    }
   });
 }
 
@@ -111,7 +115,9 @@ export async function listSessionMetas(agentId?: string): Promise<string[]> {
     const files = await fs.readdir(sessionsDir);
     return files.filter((f) => f.endsWith(META_SUFFIX)).map((f) => f.slice(0, -META_SUFFIX.length));
   } catch (err) {
-    if ((err as { code?: string }).code === "ENOENT") return [];
+    if ((err as { code?: string }).code === "ENOENT") {
+      return [];
+    }
     throw err;
   }
 }

--- a/src/config/sessions/per-session-store.ts
+++ b/src/config/sessions/per-session-store.ts
@@ -6,9 +6,9 @@
  * This allows parallel updates without blocking.
  */
 
+import JSON5 from "json5";
 import fs from "node:fs/promises";
 import path from "node:path";
-import JSON5 from "json5";
 import type { SessionEntry } from "./types.js";
 import { resolveSessionTranscriptsDirForAgent } from "./paths.js";
 

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -57,7 +57,7 @@ const HookConfigSchema = z
     enabled: z.boolean().optional(),
     env: z.record(z.string(), z.string()).optional(),
   })
-  .strict();
+  .passthrough();
 
 const HookInstallRecordSchema = z
   .object({

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -59,11 +59,14 @@ The hook uses your configured LLM provider to generate slugs, so it works with a
 
 The hook supports optional configuration:
 
-| Option     | Type   | Default | Description                                                     |
-| ---------- | ------ | ------- | --------------------------------------------------------------- |
-| `messages` | number | 15      | Number of user/assistant messages to include in the memory file |
+| Option     | Type   | Default  | Description                                                              |
+| ---------- | ------ | -------- | ------------------------------------------------------------------------ |
+| `messages` | number | 15       | Number of user/assistant messages to include in the memory               |
+| `target`   | string | `"file"` | Storage target: `"file"` (markdown files) or `"lancedb"` (LanceDB store) |
 
-Example configuration:
+### File Target (Default)
+
+Saves session context to markdown files in `<workspace>/memory/`:
 
 ```json
 {
@@ -72,6 +75,7 @@ Example configuration:
       "entries": {
         "session-memory": {
           "enabled": true,
+          "target": "file",
           "messages": 25
         }
       }
@@ -80,11 +84,40 @@ Example configuration:
 }
 ```
 
+### LanceDB Target
+
+Stores session summaries in LanceDB via the Gateway API instead of creating files:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "session-memory": {
+          "enabled": true,
+          "target": "lancedb",
+          "messages": 15
+        }
+      }
+    }
+  }
+}
+```
+
+**LanceDB target features:**
+- Stores session context as searchable memory entries
+- Automatically truncates conversation content to 2000 chars
+- Includes date, time, session key, and LLM-generated slug
+- Category: `"fact"`, Importance: `0.7`
+- Requires Gateway API with `memory_store` tool available
+- Use `memory_recall` to search through stored sessions
+
 The hook automatically:
 
-- Uses your workspace directory (`~/.openclaw/workspace` by default)
+- Uses your workspace directory (`~/.openclaw/workspace` by default) for file target
 - Uses your configured LLM for slug generation
 - Falls back to timestamp slugs if LLM is unavailable
+- Uses Gateway API at `localhost:<gateway.port>` with `gateway.auth.token` for LanceDB target
 
 ## Disabling
 

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -105,6 +105,7 @@ Stores session summaries in LanceDB via the Gateway API instead of creating file
 ```
 
 **LanceDB target features:**
+
 - Stores session context as searchable memory entries
 - Automatically truncates conversation content to 2000 chars
 - Includes date, time, session key, and LLM-generated slug

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -607,6 +607,7 @@ describe("session-memory hook", () => {
         hooks: {
           internal: {
             entries: {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               "session-memory": { enabled: true, target: "invalid" as any },
             },
           },

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -438,7 +438,7 @@ describe("session-memory hook", () => {
 
       // Verify fetch was called
       expect(fetchCalls.length).toBe(1);
-      expect(fetchCalls[0].url).toBe("http://localhost:18789/api/tools/invoke");
+      expect(fetchCalls[0].url).toBe("http://localhost:18789/tools/invoke");
 
       // Verify headers
       const headers = fetchCalls[0].options.headers as Record<string, string>;

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -95,7 +95,7 @@ async function saveToLanceDB(params: {
   ].join("\n");
 
   // Call Gateway API to invoke memory_store
-  const apiUrl = `http://localhost:${gatewayPort}/api/tools/invoke`;
+  const apiUrl = `http://localhost:${gatewayPort}/tools/invoke`;
   const response = await fetch(apiUrl, {
     method: "POST",
     headers: {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -287,6 +287,7 @@ export type PluginDiagnostic = {
 export type PluginHookName =
   | "before_agent_start"
   | "agent_end"
+  | "agent_bootstrap"
   | "before_compaction"
   | "after_compaction"
   | "message_received"
@@ -306,6 +307,21 @@ export type PluginHookAgentContext = {
   sessionKey?: string;
   workspaceDir?: string;
   messageProvider?: string;
+};
+
+// agent_bootstrap hook
+export type PluginHookBootstrapContext = {
+  agentId?: string;
+  sessionKey?: string;
+  workspaceDir?: string;
+};
+
+export type PluginHookBootstrapEvent = {
+  files: Array<{ name: string; path: string; content?: string; missing: boolean }>;
+};
+
+export type PluginHookBootstrapResult = {
+  files?: Array<{ name: string; path: string; content?: string; missing: boolean }>;
 };
 
 // before_agent_start hook
@@ -467,6 +483,10 @@ export type PluginHookHandlerMap = {
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | void> | PluginHookBeforeAgentStartResult | void;
   agent_end: (event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+  agent_bootstrap: (
+    event: PluginHookBootstrapEvent,
+    ctx: PluginHookBootstrapContext,
+  ) => Promise<PluginHookBootstrapResult | void> | PluginHookBootstrapResult | void;
   before_compaction: (
     event: PluginHookBeforeCompactionEvent,
     ctx: PluginHookAgentContext,

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -36,6 +36,15 @@ export function applyModelOverrideToSessionEntry(params: {
     }
   }
 
+  // Clear cached contextTokens when model changes so it gets re-looked up
+  // from the model catalog with the new model's context window.
+  // Always clear if contextTokens exists, even if no other fields changed
+  // (e.g., when resetting to default while already on default).
+  if (entry.contextTokens !== undefined) {
+    delete entry.contextTokens;
+    updated = true;
+  }
+
   if (profileOverride) {
     if (entry.authProfileOverride !== profileOverride) {
       entry.authProfileOverride = profileOverride;

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import type { OpenClawConfig } from "../config/config.js";
+import type { TelegramAccountConfig } from "../config/types.telegram.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 
 export type TelegramTokenSource = "env" | "tokenFile" | "config" | "none";
@@ -24,15 +25,15 @@ export function resolveTelegramToken(
 
   // Account IDs are normalized for routing (e.g. lowercased). Config keys may not
   // be normalized, so resolve per-account config by matching normalized IDs.
-  const resolveAccountCfg = (id: string) => {
+  const resolveAccountCfg = (id: string): TelegramAccountConfig | undefined => {
     const accounts = telegramCfg?.accounts;
-    if (!accounts || typeof accounts !== "object") return undefined;
+    if (!accounts || typeof accounts !== "object" || Array.isArray(accounts)) return undefined;
     // Direct hit (already normalized key)
-    const direct = (accounts as any)[id];
-    if (direct) return direct as any;
+    const direct = accounts[id];
+    if (direct) return direct;
     // Fallback: match by normalized key
-    const matchKey = Object.keys(accounts).find((k) => normalizeAccountId(k) === id);
-    return matchKey ? ((accounts as any)[matchKey] as any) : undefined;
+    const matchKey = Object.keys(accounts).find((key) => normalizeAccountId(key) === id);
+    return matchKey ? accounts[matchKey] : undefined;
   };
 
   const accountCfg = resolveAccountCfg(

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -27,10 +27,14 @@ export function resolveTelegramToken(
   // be normalized, so resolve per-account config by matching normalized IDs.
   const resolveAccountCfg = (id: string): TelegramAccountConfig | undefined => {
     const accounts = telegramCfg?.accounts;
-    if (!accounts || typeof accounts !== "object" || Array.isArray(accounts)) return undefined;
+    if (!accounts || typeof accounts !== "object" || Array.isArray(accounts)) {
+      return undefined;
+    }
     // Direct hit (already normalized key)
     const direct = accounts[id];
-    if (direct) return direct;
+    if (direct) {
+      return direct;
+    }
     // Fallback: match by normalized key
     const matchKey = Object.keys(accounts).find((key) => normalizeAccountId(key) === id);
     return matchKey ? accounts[matchKey] : undefined;

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import type { OpenClawConfig } from "../config/config.js";
-import type { TelegramAccountConfig } from "../config/types.telegram.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 
 export type TelegramTokenSource = "env" | "tokenFile" | "config" | "none";
@@ -25,19 +24,15 @@ export function resolveTelegramToken(
 
   // Account IDs are normalized for routing (e.g. lowercased). Config keys may not
   // be normalized, so resolve per-account config by matching normalized IDs.
-  const resolveAccountCfg = (id: string): TelegramAccountConfig | undefined => {
+  const resolveAccountCfg = (id: string) => {
     const accounts = telegramCfg?.accounts;
-    if (!accounts || typeof accounts !== "object" || Array.isArray(accounts)) {
-      return undefined;
-    }
+    if (!accounts || typeof accounts !== "object") return undefined;
     // Direct hit (already normalized key)
-    const direct = accounts[id];
-    if (direct) {
-      return direct;
-    }
+    const direct = (accounts as any)[id];
+    if (direct) return direct as any;
     // Fallback: match by normalized key
-    const matchKey = Object.keys(accounts).find((key) => normalizeAccountId(key) === id);
-    return matchKey ? accounts[matchKey] : undefined;
+    const matchKey = Object.keys(accounts).find((k) => normalizeAccountId(k) === id);
+    return matchKey ? ((accounts as any)[matchKey] as any) : undefined;
   };
 
   const accountCfg = resolveAccountCfg(


### PR DESCRIPTION
## Summary

When a memory plugin (e.g. `memory-neo4j`) is configured via `plugins.slots.memory`, the `openclaw doctor` command now shows:

```
◇  Memory search ──────────────────────────────────────────────╮
│                                                              │
│  Memory recall is handled by plugin "memory-neo4j" (built-in │
│  memorySearch not needed).                                   │
│                                                              │
├──────────────────────────────────────────────────────────────╯
```

Instead of the misleading:
```
│  Memory search is explicitly disabled (enabled: false).  │
```

### Problem
Users running memory plugins (memory-neo4j, etc.) see a false warning that memory search is disabled, even though their plugin handles all embedding, recall, and search operations independently.

### Changes
- Added `resolveMemoryPlugin()` helper that checks `plugins.slots.memory` config (with raw file fallback for schema-stripped configs)
- Plugin check runs first in `noteMemorySearchHealth()` — if a plugin is active, show positive status and skip built-in provider checks
- Moved the memory health check outside the `workspaceSuggestions` guard so it always runs

### Files
- `src/commands/doctor-memory-search.ts` (new file, based on upstream)
- `src/commands/doctor.ts` (import + call placement)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds memory plugin detection to the `openclaw doctor` command to fix a misleading warning. Previously, users with memory plugins like `memory-neo4j` or `memory-lancedb` configured via `plugins.slots.memory` would see a false warning that "memory search is explicitly disabled", even though their plugin was handling all memory operations independently.

The changes introduce a new `resolveMemoryPlugin()` helper that checks both the parsed config and the raw config file (as a fallback) to detect active memory plugins. When a plugin is detected, `openclaw doctor` now shows a positive status message instead of the misleading disabled warning.

The PR also moves the memory health check outside the `workspaceSuggestions` guard so it always runs, and updates the `openclaw status` command to avoid showing "unavailable" for external memory plugins that can't be queried directly.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations
- The implementation correctly addresses the stated problem and follows established patterns in the codebase. The core logic for detecting memory plugins is sound and consistent with existing plugin resolution patterns. The changes are well-contained to doctor command health checks and don't affect runtime memory operations. However, the fallback to raw config file reading introduces slight complexity that could be simplified.
- Pay close attention to `src/commands/doctor-memory-search.ts` - the dual config resolution logic (parsed + raw file fallback) adds complexity

<sub>Last reviewed commit: f1bd63c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->