### PR TITLE
feat(control-ui): add runtime runs filters in cron tab

### DIFF
--- a/ui/src/ui/app-defaults.ts
+++ b/ui/src/ui/app-defaults.ts
@@ -1,5 +1,5 @@
 import type { LogLevel } from "./types.ts";
-import type { CronFormState } from "./ui-types.ts";
+import type { CronFormState, CronRuntimeRunsFilters } from "./ui-types.ts";
 
 export const DEFAULT_LOG_LEVEL_FILTERS: Record<LogLevel, boolean> = {
   trace: true,
@@ -29,4 +29,13 @@ export const DEFAULT_CRON_FORM: CronFormState = {
   deliveryChannel: "last",
   deliveryTo: "",
   timeoutSeconds: "",
+};
+
+export const DEFAULT_CRON_RUNTIME_RUNS_FILTERS: CronRuntimeRunsFilters = {
+  search: "",
+  status: "all",
+  fromLocal: "",
+  toLocal: "",
+  limit: "100",
+  includeDisabledCron: true,
 };

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { parseAgentSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
+import { DEFAULT_CRON_RUNTIME_RUNS_FILTERS } from "./app-defaults.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
@@ -20,7 +21,9 @@ import {
   removeConfigFormValue,
 } from "./controllers/config.ts";
 import {
+  applyCronRuntimeRunsPreset,
   loadCronRuns,
+  loadOpsRuntimeRuns,
   toggleCronJob,
   runCronJob,
   removeCronJob,
@@ -338,6 +341,10 @@ export function renderApp(state: AppViewState) {
                 channelMeta: state.channelsSnapshot?.channelMeta ?? [],
                 runsJobId: state.cronRunsJobId,
                 runs: state.cronRuns,
+                runtimeRunsLoading: state.cronRuntimeRunsLoading,
+                runtimeRunsError: state.cronRuntimeRunsError,
+                runtimeRunsFilters: state.cronRuntimeRunsFilters,
+                runtimeRunsResult: state.cronRuntimeRuns,
                 onFormChange: (patch) =>
                   (state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch })),
                 onRefresh: () => state.loadCron(),
@@ -346,6 +353,21 @@ export function renderApp(state: AppViewState) {
                 onRun: (job) => runCronJob(state, job),
                 onRemove: (job) => removeCronJob(state, job),
                 onLoadRuns: (jobId) => loadCronRuns(state, jobId),
+                onRuntimeFiltersChange: (patch) =>
+                  (state.cronRuntimeRunsFilters = {
+                    ...state.cronRuntimeRunsFilters,
+                    ...patch,
+                  }),
+                onRuntimeApply: () => loadOpsRuntimeRuns(state),
+                onRuntimeRefresh: () => loadOpsRuntimeRuns(state),
+                onRuntimeClear: () => {
+                  state.cronRuntimeRunsFilters = { ...DEFAULT_CRON_RUNTIME_RUNS_FILTERS };
+                  void loadOpsRuntimeRuns(state);
+                },
+                onRuntimePreset: (preset) => {
+                  applyCronRuntimeRunsPreset(state, preset);
+                  void loadOpsRuntimeRuns(state);
+                },
               })
             : nothing
         }

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -12,7 +12,7 @@ import { loadAgentSkills } from "./controllers/agent-skills.ts";
 import { loadAgents } from "./controllers/agents.ts";
 import { loadChannels } from "./controllers/channels.ts";
 import { loadConfig, loadConfigSchema } from "./controllers/config.ts";
-import { loadCronJobs, loadCronStatus } from "./controllers/cron.ts";
+import { loadCronJobs, loadCronStatus, loadOpsRuntimeRuns } from "./controllers/cron.ts";
 import { loadDebug } from "./controllers/debug.ts";
 import { loadDevices } from "./controllers/devices.ts";
 import { loadExecApprovals } from "./controllers/exec-approvals.ts";
@@ -425,5 +425,6 @@ export async function loadCron(host: SettingsHost) {
     loadChannels(host as unknown as OpenClawApp, false),
     loadCronStatus(host as unknown as OpenClawApp),
     loadCronJobs(host as unknown as OpenClawApp),
+    loadOpsRuntimeRuns(host as unknown as OpenClawApp),
   ]);
 }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -17,6 +17,7 @@ import type {
   ConfigSnapshot,
   ConfigUiHints,
   CronJob,
+  OpsRuntimeRunsResult,
   CronRunLogEntry,
   CronStatus,
   HealthSnapshot,
@@ -31,7 +32,12 @@ import type {
   SkillStatusReport,
   StatusSummary,
 } from "./types.ts";
-import type { ChatAttachment, ChatQueueItem, CronFormState } from "./ui-types.ts";
+import type {
+  ChatAttachment,
+  ChatQueueItem,
+  CronFormState,
+  CronRuntimeRunsFilters,
+} from "./ui-types.ts";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
 import type { SessionLogEntry } from "./views/usage.ts";
 
@@ -192,6 +198,10 @@ export type AppViewState = {
   cronForm: CronFormState;
   cronRunsJobId: string | null;
   cronRuns: CronRunLogEntry[];
+  cronRuntimeRunsLoading: boolean;
+  cronRuntimeRunsError: string | null;
+  cronRuntimeRunsFilters: CronRuntimeRunsFilters;
+  cronRuntimeRuns: OpsRuntimeRunsResult | null;
   cronBusy: boolean;
   skillsLoading: boolean;
   skillsReport: SkillStatusReport | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -19,7 +19,11 @@ import {
   handleSendChat as handleSendChatInternal,
   removeQueuedMessage as removeQueuedMessageInternal,
 } from "./app-chat.ts";
-import { DEFAULT_CRON_FORM, DEFAULT_LOG_LEVEL_FILTERS } from "./app-defaults.ts";
+import {
+  DEFAULT_CRON_FORM,
+  DEFAULT_CRON_RUNTIME_RUNS_FILTERS,
+  DEFAULT_LOG_LEVEL_FILTERS,
+} from "./app-defaults.ts";
 import type { EventLogEntry } from "./app-events.ts";
 import { connectGateway as connectGatewayInternal } from "./app-gateway.ts";
 import {
@@ -68,6 +72,7 @@ import type {
   ConfigSnapshot,
   ConfigUiHints,
   CronJob,
+  OpsRuntimeRunsResult,
   CronRunLogEntry,
   CronStatus,
   HealthSnapshot,
@@ -80,7 +85,12 @@ import type {
   StatusSummary,
   NostrProfile,
 } from "./types.ts";
-import { type ChatAttachment, type ChatQueueItem, type CronFormState } from "./ui-types.ts";
+import {
+  type ChatAttachment,
+  type ChatQueueItem,
+  type CronFormState,
+  type CronRuntimeRunsFilters,
+} from "./ui-types.ts";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
 
 declare global {
@@ -300,6 +310,12 @@ export class OpenClawApp extends LitElement {
   @state() cronForm: CronFormState = { ...DEFAULT_CRON_FORM };
   @state() cronRunsJobId: string | null = null;
   @state() cronRuns: CronRunLogEntry[] = [];
+  @state() cronRuntimeRunsLoading = false;
+  @state() cronRuntimeRunsError: string | null = null;
+  @state() cronRuntimeRunsFilters: CronRuntimeRunsFilters = {
+    ...DEFAULT_CRON_RUNTIME_RUNS_FILTERS,
+  };
+  @state() cronRuntimeRuns: OpsRuntimeRunsResult | null = null;
   @state() cronBusy = false;
 
   @state() updateAvailable: import("./types.js").UpdateAvailable | null = null;

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -503,6 +503,60 @@ export type CronRunLogEntry = {
   sessionKey?: string;
 };
 
+export type OpsRuntimeRunsSummary = {
+  jobsScanned: number;
+  jobsTotal: number;
+  jobsTruncated: boolean;
+  totalRuns: number;
+  okRuns: number;
+  errorRuns: number;
+  skippedRuns: number;
+  timeoutRuns: number;
+  jobsWithFailures: number;
+  needsAction: number;
+};
+
+export type OpsRuntimeRunItem = {
+  ts: number;
+  ageMs: number;
+  jobId: string;
+  jobName: string;
+  enabled: boolean;
+  status: "ok" | "error" | "skipped";
+  error?: string;
+  summary?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  runAtMs?: number;
+  durationMs?: number;
+  nextRunAtMs?: number;
+  model?: string;
+  provider?: string;
+  logPath: string;
+};
+
+export type OpsRuntimeFailureItem = {
+  jobId: string;
+  jobName: string;
+  enabled: boolean;
+  totalRuns: number;
+  errors: number;
+  timeoutErrors: number;
+  consecutiveErrors: number;
+  lastStatus?: string;
+  lastError?: string;
+  lastErrorAtMs?: number;
+  needsAction: boolean;
+  logPath: string;
+};
+
+export type OpsRuntimeRunsResult = {
+  ts: number;
+  summary: OpsRuntimeRunsSummary;
+  runs: OpsRuntimeRunItem[];
+  failures: OpsRuntimeFailureItem[];
+};
+
 export type SkillsStatusConfigCheck = {
   path: string;
   satisfied: boolean;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -34,3 +34,12 @@ export type CronFormState = {
   deliveryTo: string;
   timeoutSeconds: string;
 };
+
+export type CronRuntimeRunsFilters = {
+  search: string;
+  status: "all" | "ok" | "error" | "skipped";
+  fromLocal: string;
+  toLocal: string;
+  limit: string;
+  includeDisabledCron: boolean;
+};


### PR DESCRIPTION
## Summary
- extend Control UI Cron tab with runtime runs observability panel
- add filter/search/time-range controls for runtime history (`search`, `status`, `from/to`, `limit`, include disabled)
- add quick time presets (`1h`, `6h`, `24h`, `7d`) and reset/apply actions
- show cross-job failure rollups and recent runs lists from `ops.runtime.runs`
- wire new Cron state fields through app state/render/settings load path
- add controller/view tests for new filtering interactions and runtime calls

## Why
Mission Control v1 needs the operator to answer quickly:
- what recently ran?
- what is unhealthy?
- what needs manual action?

This PR provides the UI layer for filtering/search/time-range controls and readable runtime rollups.

## Notes
- This UI calls `ops.runtime.runs` (PR2: #21639).
- If the method is unavailable on an older gateway, UI shows a clear compatibility message.

## Validation
- `pnpm exec oxfmt --check ui/src/ui/app-defaults.ts ui/src/ui/app-render.ts ui/src/ui/app-settings.ts ui/src/ui/app-view-state.ts ui/src/ui/app.ts ui/src/ui/controllers/cron.ts ui/src/ui/controllers/cron.test.ts ui/src/ui/types.ts ui/src/ui/ui-types.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts`
- `pnpm exec oxlint --type-aware ui/src/ui/app-defaults.ts ui/src/ui/app-render.ts ui/src/ui/app-settings.ts ui/src/ui/app-view-state.ts ui/src/ui/app.ts ui/src/ui/controllers/cron.ts ui/src/ui/controllers/cron.test.ts ui/src/ui/types.ts ui/src/ui/ui-types.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts`
- `pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/controllers/cron.test.ts src/ui/views/cron.test.ts`
- `pnpm --dir ui build`

Related: #21600

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended Control UI Cron tab with runtime runs observability panel, adding comprehensive filter/search/time-range controls for runtime history. The implementation includes search, status filtering, time range selection with quick presets (1h, 6h, 24h, 7d), and displays cross-job failure rollups and recent runs from `ops.runtime.runs` gateway method.

**Key changes:**
- Added `CronRuntimeRunsFilters` type with search, status, time range, limit, and includeDisabledCron fields
- New controller functions: `loadOpsRuntimeRuns`, `applyCronRuntimeRunsPreset`, `buildOpsRuntimeRunsParams`
- Runtime runs state management integrated through app state/render/settings
- Comprehensive test coverage for new filtering interactions and runtime API calls
- Graceful degradation with compatibility message when `ops.runtime.runs` unavailable on older gateways

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with proper type safety, comprehensive test coverage, error handling for backwards compatibility, and follows existing patterns in the codebase. No logical errors or security issues detected.
- No files require special attention

<sub>Last reviewed commit: 4a57d36</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->