### PR TITLE
fix(cron): pass agentDir to runEmbeddedPiAgent for correct auth resolution

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -480,6 +480,7 @@ export async function runCronIsolatedAgentTurn(params: {
           sessionId: cronSession.sessionEntry.sessionId,
           sessionKey: agentSessionKey,
           agentId,
+          agentDir,
           messageChannel,
           agentAccountId: resolvedDelivery.accountId,
           sessionFile,


### PR DESCRIPTION
## Summary

One-line fix: pass the already-resolved `agentDir` to `runEmbeddedPiAgent()` in the cron isolated runner, so non-main agents use their own auth-profiles store instead of falling back to `main`.

## Problem

When a cron job has `agentId: "myagent"`, the isolated runner (`src/cron/isolated-agent/run.ts`) correctly resolves `agentDir` via `resolveAgentDir(cfg, agentId)` at line 204, but the call to `runEmbeddedPiAgent({...})` at line 475 **does not pass `agentDir`**.

In `runEmbeddedPiAgent` (`src/agents/pi-embedded-runner/run.ts:204`), the fallback is:
```ts
const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
```

`resolveOpenClawAgentDir()` returns `~/.openclaw/agents/main/agent` (hardcoded `DEFAULT_AGENT_ID = "main"`), so all cron jobs end up reading auth from the `main` agent regardless of their configured `agentId`.

## Fix

```diff
         return runEmbeddedPiAgent({
           sessionId: cronSession.sessionEntry.sessionId,
           sessionKey: agentSessionKey,
           agentId,
+          agentDir,
           messageChannel,
```

The `agentDir` variable is already correctly resolved earlier in the same function. The `RunEmbeddedPiAgentParams` interface already accepts `agentDir?: string`.

## Testing

- Verified the type interface accepts the parameter
- Pre-existing type errors in `@buape/carbon` dependency are unrelated
- The fix is a single property addition to an existing object literal — no behavioral change for `agentId: "main"` (same path), only corrects non-main agents

## AI Disclosure

This PR was researched and authored with AI assistance (Claude/OpenClaw). The bug analysis, root cause identification, and fix were verified by reviewing the source code chain:
- `resolveAgentDir()` → `resolveAuthStorePath()` → `ensureAuthProfileStore()` → `resolveOpenClawAgentDir()` → `DEFAULT_AGENT_ID = "main"`

Human verification: confirmed the fix addresses the exact code path described in #10928 comments.

Fixes #10928

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes agent directory resolution for non-main cron jobs by passing the already-resolved `agentDir` parameter to `runEmbeddedPiAgent()`.

- The fix ensures non-main agents (e.g., `agentId: "myagent"`) use their own auth-profiles store instead of incorrectly falling back to the `main` agent's store
- `agentDir` was already correctly resolved at line 204 via `resolveAgentDir(cfg, agentId)` but wasn't being passed through
- The `RunEmbeddedPiAgentParams` interface already accepts the optional `agentDir` parameter
- No behavioral change for `agentId: "main"` (same path as before)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple parameter pass-through that fixes agent isolation bug
- Single-line addition passing an already-resolved variable to a function that accepts it. The fix correctly addresses the root cause where non-main agents were incorrectly using the main agent's auth store. No breaking changes, no new logic, and maintains backward compatibility for main agent.
- No files require special attention

<sub>Last reviewed commit: f90f71f</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->