### PR TITLE
feat: execution plan governance plugin

### DIFF
--- a/extensions/external-plan-governance/README.md
+++ b/extensions/external-plan-governance/README.md
@@ -1,0 +1,68 @@
+# Execution Plan Governance
+
+A governance plugin for OpenClaw that implements execution plan as a distinct artifact that execution is bound to: before any tools execute, an LLM generates a structured execution plan. Tool calls are then validated against this plan, not in form of free-form tool calls from LLM.
+
+The plan is the **single source of truth**. Nothing executes unless it's in the plan.
+
+## How It Works
+
+1. `before_request` hook intercepts user message
+2. Call LLM with message + schema → get structured plan
+3. Store plan (keyed by `runId`)
+4. If `execution_mode: "preview"` → show plan, block execution
+
+## The Schema
+
+Plans follow a simple schema (`execution-plan.schema.json`). Required fields are:
+
+```json
+{
+  "description_for_user": "Delete old log files",
+  "five_w_one_h": {
+    "who": "system",
+    "what": "remove files matching *.log older than 7 days",
+    "where": "/var/log",
+    "when": "immediate",
+    "why": "free disk space",
+    "how": "find + rm"
+  },
+  "procedure": [
+    { "step": 1, "action": "find files matching *.log older than 7 days" },
+    { "step": 2, "action": "delete matched files" }
+  ],
+  "surface_effects": {
+    "touches": ["/var/log"],
+    "modifies": false,
+    "creates": false,
+    "deletes": true
+  },
+  "constraints": ["do not delete files newer than 7 days"],
+  "execution_mode": "preview"
+}
+```
+
+## Configuration
+
+```json
+{
+  "extensions": {
+    "execution-plan-governance": {
+      "enabled": true,
+      "defaultMode": "preview",
+      "failOpen": false
+    }
+  }
+}
+```
+
+## Integration with #6095
+
+Uses hooks from [PR #6095](https://github.com/openclaw/openclaw/pull/6095):
+
+- `before_request`: Generate plan
+
+Complements security guardrails: they block _dangerous_ calls, this blocks _unplanned_ calls.
+
+## License
+
+MIT

--- a/extensions/external-plan-governance/execution-plan.schema.json
+++ b/extensions/external-plan-governance/execution-plan.schema.json
@@ -1,0 +1,451 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ExecutionPlan",
+  "description": "A machine-enforceable execution plan for agent tool calls",
+  "type": "object",
+  "required": [
+    "description_for_user",
+    "five_w_one_h",
+    "procedure",
+    "surface_effects",
+    "constraints",
+    "execution_mode"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0.0",
+      "description": "Schema version for forward compatibility"
+    },
+    "description_for_user": {
+      "type": "string",
+      "description": "Short, human-readable description of what will be executed. Written for user confirmation, not implementation."
+    },
+    "five_w_one_h": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["who", "what", "where", "when", "why", "how"],
+      "properties": {
+        "who": {
+          "type": "string",
+          "description": "Who or what executes the plan (e.g. user, tool, system)."
+        },
+        "what": {
+          "type": "string",
+          "description": "Concrete operation being performed (not a goal)."
+        },
+        "where": {
+          "type": "string",
+          "description": "Execution surface: filesystem path, service, account, environment."
+        },
+        "when": {
+          "type": "string",
+          "description": "When execution happens (e.g. immediate, scheduled, conditional)."
+        },
+        "why": {
+          "type": "string",
+          "description": "User-facing reason for this execution."
+        },
+        "how": {
+          "type": "string",
+          "description": "High-level method description without commands or flags."
+        }
+      }
+    },
+    "procedure": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["step", "action"],
+        "properties": {
+          "step": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Sequential step number. Order matters."
+          },
+          "action": {
+            "type": "string",
+            "description": "Atomic, declarative action with no branching or conditionals."
+          }
+        }
+      },
+      "description": "Ordered list of execution steps. No branching, retries, or conditionals."
+    },
+    "surface_effects": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["touches", "modifies", "creates", "deletes"],
+      "properties": {
+        "touches": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Resources or surfaces that will be accessed."
+        },
+        "modifies": {
+          "type": "boolean",
+          "description": "Whether existing resources are modified."
+        },
+        "creates": {
+          "type": "boolean",
+          "description": "Whether new resources are created."
+        },
+        "deletes": {
+          "type": "boolean",
+          "description": "Whether resources are deleted."
+        }
+      }
+    },
+    "constraints": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Hard negative constraint that must not be violated."
+      },
+      "description": "Hard execution limits. No soft preferences or guidance."
+    },
+    "execution_mode": {
+      "type": "string",
+      "enum": ["preview", "execute"],
+      "description": "Whether this plan is only previewed or actually executed."
+    },
+    "planId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for plan binding and audit"
+    },
+    "sessionId": {
+      "type": "string",
+      "description": "Bound session (from Yi's enforcement layer)"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Plan TTL — rejected after expiry"
+    },
+    "intent": {
+      "$ref": "#/$defs/Intent"
+    },
+    "operations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Operation"
+      },
+      "minItems": 1
+    },
+    "metadata": {
+      "$ref": "#/$defs/Metadata"
+    }
+  },
+  "$defs": {
+    "Intent": {
+      "type": "object",
+      "required": ["summary", "category", "riskLevel"],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "description": "One-line description of what this plan accomplishes"
+        },
+        "category": {
+          "type": "string",
+          "enum": ["read", "write", "execute", "search", "mixed"],
+          "description": "Primary operation type"
+        },
+        "riskLevel": {
+          "type": "string",
+          "enum": ["low", "medium", "high", "critical"],
+          "description": "Assessed risk for approval routing"
+        },
+        "userMessage": {
+          "type": "string",
+          "description": "Original user request (for audit)"
+        },
+        "enriched": {
+          "$ref": "#/$defs/EnrichedIntent"
+        }
+      }
+    },
+    "EnrichedIntent": {
+      "type": "object",
+      "description": "5W1H structured intent (from sdd-mcp pattern)",
+      "properties": {
+        "what": {
+          "type": "string"
+        },
+        "why": {
+          "type": "string"
+        },
+        "who": {
+          "type": "string"
+        },
+        "where": {
+          "type": "string"
+        },
+        "when": {
+          "type": "string"
+        },
+        "how": {
+          "type": "string"
+        }
+      }
+    },
+    "Operation": {
+      "type": "object",
+      "required": ["id", "tool", "description", "allow"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^op-[0-9]{3}$",
+          "description": "Unique operation ID (op-001, op-002)"
+        },
+        "tool": {
+          "type": "string",
+          "description": "Tool name (exec, read, write, browser, etc.)"
+        },
+        "description": "Human-readable description of this operation",
+        "allow": {
+          "$ref": "#/$defs/AllowRules",
+          "description": "What this operation permits"
+        },
+        "deny": {
+          "$ref": "#/$defs/DenyRules",
+          "description": "Explicit denials (overrides allow)"
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Operation IDs that must complete first"
+        },
+        "parallel": {
+          "type": "boolean",
+          "default": false,
+          "description": "Can run concurrently with other parallel ops"
+        },
+        "maxInvocations": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1,
+          "description": "How many times this operation can be called"
+        },
+        "requiresConfirmation": {
+          "type": "boolean",
+          "default": false,
+          "description": "Pause for user confirmation before execution"
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "Operation-specific timeout (ms)"
+        }
+      }
+    },
+    "AllowRules": {
+      "type": "object",
+      "description": "Whitelist rules — at least one must match",
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CommandPattern"
+          },
+          "description": "Allowed command patterns (for exec)"
+        },
+        "paths": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/PathPattern"
+          },
+          "description": "Allowed file paths (for read/write)"
+        },
+        "urls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/UrlPattern"
+          },
+          "description": "Allowed URLs (for browser/fetch)"
+        },
+        "args": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "$ref": "#/$defs/ArgPattern"
+              }
+            ]
+          },
+          "description": "Allowed argument values by name"
+        }
+      }
+    },
+    "DenyRules": {
+      "type": "object",
+      "description": "Blacklist rules — any match blocks (overrides allow)",
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CommandPattern"
+          }
+        },
+        "paths": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/PathPattern"
+          }
+        },
+        "urls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/UrlPattern"
+          }
+        }
+      }
+    },
+    "CommandPattern": {
+      "type": "object",
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Glob or regex pattern for command"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["exact", "glob", "regex"],
+          "default": "glob"
+        }
+      }
+    },
+    "PathPattern": {
+      "type": "object",
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Glob pattern for file path"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["exact", "glob", "regex"],
+          "default": "glob"
+        }
+      }
+    },
+    "UrlPattern": {
+      "type": "object",
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "URL pattern (supports * wildcard)"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["exact", "glob", "regex"],
+          "default": "glob"
+        }
+      }
+    },
+    "ArgPattern": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["exact", "glob", "regex", "range"],
+          "default": "exact"
+        },
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        }
+      }
+    },
+    "GlobalConstraints": {
+      "type": "object",
+      "properties": {
+        "maxTotalOperations": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 50,
+          "description": "Max tool calls across all operations"
+        },
+        "maxDurationMs": {
+          "type": "integer",
+          "default": 300000,
+          "description": "Plan execution timeout (5 min default)"
+        },
+        "forbiddenPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Global path blacklist"
+        },
+        "forbiddenCommands": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Global command blacklist"
+        },
+        "requireSequential": {
+          "type": "boolean",
+          "default": false,
+          "description": "Force all operations to run in order"
+        },
+        "allowUnplanned": {
+          "type": "boolean",
+          "default": false,
+          "description": "Permit tool calls not in operations list"
+        }
+      }
+    },
+    "Metadata": {
+      "type": "object",
+      "properties": {
+        "generatedBy": {
+          "type": "string",
+          "description": "Model that generated this plan"
+        },
+        "qualityScore": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Plan quality assessment (from sdd-mcp pattern)"
+        },
+        "projectContext": {
+          "type": "string",
+          "description": "Reference to constitution/context file"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/external-plan-governance/index.ts
+++ b/extensions/external-plan-governance/index.ts
@@ -1,0 +1,168 @@
+/**
+ * Execution Plan Governance Plugin for OpenClaw
+ *
+ * Simple approach:
+ * 1. before_request: Call LLM with user message + schema → get execution plan
+ * 2. before_tool_call: Validate tool call against plan's procedure
+ *
+ * The plan is the single source of truth.
+ */
+
+import type { PluginApi, PluginHookContext, PluginHookToolContext } from "@anthropic/plugin-sdk";
+
+// ============================================================================
+// Execution Plan Schema (from execution-plan.json)
+// ============================================================================
+
+interface ExecutionPlan {
+  description_for_user: string;
+  five_w_one_h: {
+    who: string;
+    what: string;
+    where: string;
+    when: string;
+    why: string;
+    how: string;
+  };
+  procedure: Array<{
+    step: number;
+    action: string;
+  }>;
+  surface_effects: {
+    touches: string[];
+    modifies: boolean;
+    creates: boolean;
+    deletes: boolean;
+  };
+  constraints: string[];
+  execution_mode: "preview" | "execute";
+}
+
+// ============================================================================
+// Plan Store
+// ============================================================================
+
+const planStore: Map<string, ExecutionPlan> = new Map();
+
+// ============================================================================
+// Config
+// ============================================================================
+
+interface ExecutionPlanConfig {
+  enabled?: boolean;
+  defaultMode?: "preview" | "execute";
+  failOpen?: boolean;
+}
+
+// ============================================================================
+// Planning Prompt
+// ============================================================================
+
+function buildPlanningPrompt(userMessage: string, defaultMode: "preview" | "execute"): string {
+  return `...`;
+}
+
+// ============================================================================
+// Plugin
+// ============================================================================
+
+export default function executionPlanGovernance(api: PluginApi): void {
+  const config = (api.config ?? {}) as ExecutionPlanConfig;
+
+  if (config.enabled === false) {
+    return;
+  }
+
+  api.log?.info?.("[execution-plan] Plugin initialized");
+
+  // -------------------------------------------------------------------------
+  // before_request: Generate execution plan via LLM
+  // -------------------------------------------------------------------------
+  api.on("before_request", async (event, ctx: PluginHookContext) => {
+    const runId = ctx.runId;
+    if (!runId) return {};
+
+    // Get user message
+    const messages =
+      (event as { messages?: Array<{ role: string; content: string }> }).messages ?? [];
+    const lastUserMessage = messages.filter((m) => m.role === "user").pop();
+    if (!lastUserMessage) return {};
+
+    const userContent = lastUserMessage.content;
+
+    // Build planning prompt
+    const planningPrompt = buildPlanningPrompt(userContent, config.defaultMode ?? "preview");
+
+    try {
+      // Call LLM to generate plan
+      // Note: This uses OpenClaw's internal completion API
+      const planResponse = await api.completion?.({
+        messages: [{ role: "user", content: planningPrompt }],
+        max_tokens: 1024,
+        temperature: 0,
+      });
+
+      if (!planResponse?.content) {
+        throw new Error("No response from planning model");
+      }
+
+      // Parse plan
+      const planText =
+        typeof planResponse.content === "string"
+          ? planResponse.content
+          : (planResponse.content[0]?.text ?? "");
+
+      const plan: ExecutionPlan = JSON.parse(planText.trim());
+
+      // Store plan
+      planStore.set(runId, plan);
+
+      api.log?.info?.(`[execution-plan] Generated plan: ${plan.description_for_user}`);
+      api.log?.debug?.(`[execution-plan] Procedure: ${plan.procedure.length} steps`);
+
+      // If preview mode, inject plan into context and don't execute
+      if (plan.execution_mode === "preview") {
+        const previewMessage = `[Execution Plan - Preview Only]
+
+${plan.description_for_user}
+
+Steps:
+${plan.procedure.map((p) => `${p.step}. ${p.action}`).join("\n")}
+
+Effects: ${
+          [
+            plan.surface_effects.modifies && "modifies",
+            plan.surface_effects.creates && "creates",
+            plan.surface_effects.deletes && "deletes",
+          ]
+            .filter(Boolean)
+            .join(", ") || "read-only"
+        }
+
+Touches: ${plan.surface_effects.touches.join(", ")}
+
+Constraints: ${plan.constraints.join("; ") || "none"}
+
+This is a preview. No actions will be executed. Reply to confirm or modify.`;
+
+        return {
+          block: true,
+          blockReason: previewMessage,
+        };
+      }
+
+      return {};
+    } catch (error) {
+      api.log?.error?.(`[execution-plan] Plan generation failed: ${error}`);
+
+      if (config.failOpen) {
+        return {};
+      }
+
+      return {
+        block: true,
+        blockReason: "Could not generate execution plan. Please rephrase your request.",
+      };
+    }
+  });
+}


### PR DESCRIPTION
## **Summary**

Introduces a plan-first governance layer making execution explicit and inspectable.  Before tools run, an LLM generates a structured execution plan. The plan becomes the single source of truth — nothing happens unless it's in the plan.

## **Why**

Current flow: LLM decides tool → tool executes → you find out after.

Governed flow: LLM generates plan → plan validated → execution bound to plan.

This complements security guardrails \#6095: they block *dangerous* calls, this blocks *unplanned* calls.

## **How It Works**

1. `before_request` hook intercepts user message  
2. LLM generates structured plan (schema-defined JSON)  
3. Plan stored by `runId`  
4. Plan later validated/constrained/executed (probably without free-form tool calls from LLM) — not present in this PR

## **Schema**

Current simplistic schema:

* `description_for_user` — human-readable summary  
* `five_w_one_h` — who, what, where, when, why, how  
* `procedure` — ordered steps, no branching  
* `surface_effects` — what gets touched/modified/created/deleted  
* `constraints` — hard limits  
* `execution_mode` — preview or execute

## **Related**

* Depends on \#6095(hook system)  
* Sketch/discussion:[ https://github.com/nayname/openclaw-secure-stack/pull/1](https://github.com/nayname/openclaw-secure-stack/pull/1)

## **Status**

Proof of concept. This PR defines the model and artifact shape — it does not implement enforcement or execution binding. Looking for feedback on whether this direction aligns with governance extensibility post-\#6095.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a governance layer that generates execution plans before tool execution. However, the implementation has several critical issues that prevent it from working:

- Uses non-existent hook `before_request` instead of valid hooks like `before_agent_start` or `before_prompt_build`
- Imports incorrect types from `@anthropic/plugin-sdk` that don't exist in the actual exports
- Calls `api.completion()` method which is not available on the plugin API
- Accesses `runId` on hook context where it doesn't exist
- Empty planning prompt template that would cause plan generation to fail
- Event structure assumptions that don't match actual hook event types

The concept is solid and aligns with the security extensibility goals, but the code needs significant rework to use the correct OpenClaw plugin APIs and hooks defined in PR \#6095.

<h3>Confidence Score: 0/5</h3>

- This PR cannot be merged - it contains multiple critical implementation errors that would cause runtime failures
- The code uses non-existent hooks, imports types that don't exist, calls undefined API methods, and has an empty planning prompt. These are not minor issues but fundamental implementation problems that prevent the code from executing at all. The plugin would fail immediately on load or first invocation.
- extensions/external-plan-governance/index.ts requires complete rework to use correct OpenClaw plugin APIs and hook system

<sub>Last reviewed commit: 404ad20</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->