### PR TITLE
feat(session_status): expose fallback metadata in tool details

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -384,6 +384,11 @@ export function createSessionStatusTool(opts?: {
         includeTranscriptUsage: false,
       });
 
+      const fallbackSelectedModel = resolved.entry.fallbackNoticeSelectedModel?.trim();
+      const fallbackActiveModel = resolved.entry.fallbackNoticeActiveModel?.trim();
+      const fallbackReason = resolved.entry.fallbackNoticeReason?.trim();
+      const fallbackActive = Boolean(fallbackSelectedModel && fallbackActiveModel);
+
       return {
         content: [{ type: "text", text: statusText }],
         details: {
@@ -391,6 +396,10 @@ export function createSessionStatusTool(opts?: {
           sessionKey: resolved.key,
           changedModel,
           statusText,
+          fallbackActive,
+          fallbackSelectedModel,
+          fallbackActiveModel,
+          fallbackReason,
         },
       };
     },


### PR DESCRIPTION
## Summary\n- expose fallback metadata fields in  tool  payload\n- include , , , \n- add e2e assertions for no-fallback default and active fallback scenarios\n\n## Why\nUsers need machine-readable fallback visibility after model failover to know which model actually handled the run.\n\n## Testing\n- corepack pnpm test:e2e src/agents/openclaw-tools.session-status.e2e.test.ts\n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Exposes fallback metadata fields (`fallbackActive`, `fallbackSelectedModel`, `fallbackActiveModel`, `fallbackReason`) in the `session_status` tool's `details` payload. This provides machine-readable visibility into model failover events, allowing users to programmatically determine which model actually processed a request after fallback. The implementation correctly extracts these fields from the session entry and includes comprehensive e2e test coverage for both no-fallback and active-fallback scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows existing patterns. It only exposes existing session entry fields without modifying any business logic. The PR includes comprehensive e2e test coverage for both scenarios (no fallback and active fallback), and the changes are minimal and well-contained.
- No files require special attention

<sub>Last reviewed commit: 92f04df</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->