### PR TITLE
fix(gateway,ios): allow node-role clients to call chat methods

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -162,7 +162,7 @@ final class NodeAppModel {
 
         let enabled = UserDefaults.standard.bool(forKey: "voiceWake.enabled")
         self.voiceWake.setEnabled(enabled)
-        self.talkMode.attachGateway(self.operatorGateway)
+        self.talkMode.attachGateway(self.nodeGateway)
         self.refreshLastShareEventFromRelay()
         let talkEnabled = UserDefaults.standard.bool(forKey: "talk.enabled")
         // Route through the coordinator so VoiceWake and Talk don't fight over the microphone.

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -97,8 +97,8 @@ struct RootCanvas: View {
                     .environment(self.gatewayController)
             case .chat:
                 ChatSheet(
-                    // Chat RPCs run on the operator session (read/write scopes).
-                    gateway: self.appModel.operatorSession,
+                    // Chat RPCs run on the node session which has device identity.
+                    gateway: self.appModel.gatewaySession,
                     sessionKey: self.appModel.mainSessionKey,
                     agentName: self.appModel.activeAgentName,
                     userAccent: self.appModel.seamColor)

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -39,6 +39,13 @@ const APPROVAL_METHODS = new Set([
   "exec.approval.resolve",
 ]);
 const NODE_ROLE_METHODS = new Set(["node.invoke.result", "node.event", "skills.bins"]);
+const NODE_CHAT_METHODS = new Set([
+  "health",
+  "chat.history",
+  "chat.send",
+  "chat.abort",
+  "sessions.list",
+]);
 const PAIRING_METHODS = new Set([
   "node.pair.request",
   "node.pair.list",
@@ -110,6 +117,11 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
       return null;
     }
     return errorShape(ErrorCodes.INVALID_REQUEST, `unauthorized role: ${role}`);
+  }
+  if (NODE_CHAT_METHODS.has(method)) {
+    if (role === "node") {
+      return null;
+    }
   }
   if (role === "node") {
     return errorShape(ErrorCodes.INVALID_REQUEST, `unauthorized role: ${role}`);


### PR DESCRIPTION
## Summary

- Add `NODE_CHAT_METHODS` allowlist so node-role clients can call `health`, `chat.history`, `chat.send`, `chat.abort`, and `sessions.list`
- Route iOS Chat and TalkMode through the node session (which has device identity) instead of the operator session (which gets scopes silently stripped)

## Problem

The iOS operator session connects with `includeDeviceIdentity: false` to avoid duplicate pairing flows. The gateway's connect handler at `message-handler.ts:416-420` silently strips all scopes when no device identity is present. This causes `chat.history` and other read/write methods to fail with `"missing scope: operator.read"`.

## Approach

Rather than changing the operator session's auth model, we allow the node session (which already has device identity and proper scopes) to call chat-related methods. The iOS app is updated to route chat and talk mode through the node session instead.

## Related issues

- #6767 — iOS chat broken (node role unauthorized + session key mismatch)
- #17570 — Connect response should warn when scopes are silently stripped
- #17750 — Control UI unusable over HTTP due to scope clearing
- #19858 — Third-party clients fail with missing scope: operator.read

## Test plan

- [ ] Verify iOS chat works after connecting to gateway
- [ ] Verify `chat.history`, `chat.send`, `chat.abort` work from node-role session
- [ ] Verify talk mode voice commands still dispatch through gateway
- [ ] Verify operator-only methods still require operator role

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `NODE_CHAT_METHODS` allowlist to enable node-role clients to call health checks and chat methods (`chat.history`, `chat.send`, `chat.abort`, `sessions.list`). Updated iOS app to route chat and talk mode through the node session (which has device identity and proper scopes) instead of the operator session (which has scopes stripped when connecting without device identity per `message-handler.ts:416-420`).

- Gateway authorization now allows node-role clients to call chat-related methods while still permitting properly-scoped operator clients
- iOS ChatSheet now uses `gatewaySession` (node) instead of `operatorSession`
- iOS TalkMode attached to `nodeGateway` instead of `operatorGateway`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The authorization logic correctly implements a dual-access pattern (node-role OR operator-with-scopes), and the iOS changes properly route chat/talk through the authenticated session. One minor outdated comment should be updated for accuracy.
- No files require special attention beyond the comment update in NodeAppModel.swift:78

<sub>Last reviewed commit: 9d099c0</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->