### PR TITLE
fix(plugins): require explicit allowlist for non-bundled plugins

### DIFF
--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -191,6 +191,12 @@ export function resolveEnableState(
   if (origin === "bundled") {
     return { enabled: false, reason: "bundled (disabled by default)" };
   }
+  if (config.allow.length === 0) {
+    return {
+      enabled: false,
+      reason: "not in allowlist (empty allowlist blocks non-bundled plugins)",
+    };
+  }
   return { enabled: true };
 }
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -277,6 +277,7 @@ describe("loadOpenClawPlugins", () => {
       config: {
         plugins: {
           load: { paths: [plugin.file] },
+          allow: ["configurable"],
           entries: {
             configurable: {
               config: "nope" as unknown as Record<string, unknown>,


### PR DESCRIPTION
## Summary
- When `plugins.allow` is empty (default config), non-bundled plugins discovered via npm packages with `openclaw.plugin.json` auto-load with gateway privileges, creating supply chain risk.
- Added a check in `resolveEnableState()` so that when the allowlist is empty, non-bundled plugins are disabled by default. Only bundled plugins that are explicitly enabled by default can load.
- Bundled plugin behavior is unchanged; non-bundled plugins now require explicit inclusion in `plugins.allow`.

## Test plan
- [ ] Verify that with an empty `plugins.allow`, non-bundled discovered plugins are disabled with reason "not in allowlist (empty allowlist blocks non-bundled plugins)"
- [ ] Verify that bundled plugins enabled by default (device-pair, phone-control, talk-voice) still load normally
- [ ] Verify that explicitly allowlisted non-bundled plugins still load when listed in `plugins.allow`
- [ ] Verify that denylisted plugins remain blocked regardless of allowlist state

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds security protection against supply chain attacks by blocking auto-load of non-bundled plugins when the allowlist is empty. The new check in `resolveEnableState()` is correctly positioned after explicit configuration checks (memory slot, entries) and bundled plugin handling, ensuring that only non-bundled plugins without explicit configuration are blocked by the empty allowlist.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted security fix that adds a single conditional check with correct placement in the control flow. The logic properly preserves explicit configurations while blocking potentially dangerous auto-loading behavior. No tests were broken (none exist for this function), and the change aligns with the security principle of secure-by-default.
- No files require special attention

<sub>Last reviewed commit: f7c30c3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->