### PR TITLE
fix(agents): treat approval timeout as denial regardless of askFallback

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.approval-timeout.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.approval-timeout.test.ts
@@ -77,7 +77,7 @@ describe("approval timeout denial", () => {
       file: "/tmp/approvals.json",
       agent: { security: "allowlist", ask: "always", askFallback: "deny" },
       allowlist: [],
-    } as ReturnType<typeof resolveExecApprovals>);
+    } as unknown as ReturnType<typeof resolveExecApprovals>);
 
     vi.mocked(minSecurity).mockReturnValue("allowlist");
     vi.mocked(maxAsk).mockReturnValue("always");
@@ -86,7 +86,7 @@ describe("approval timeout denial", () => {
       allowlistSatisfied: false,
       allowlistMatches: [],
       segments: [],
-    } as ReturnType<typeof evaluateShellAllowlist>);
+    } as unknown as ReturnType<typeof evaluateShellAllowlist>);
     vi.mocked(requiresExecApproval).mockReturnValue(true);
     vi.mocked(requestExecApprovalDecision).mockResolvedValue(null);
 
@@ -119,7 +119,7 @@ describe("approval timeout denial", () => {
       file: "/tmp/approvals.json",
       agent: { security: "allowlist", ask: "always", askFallback: "allowlist" },
       allowlist: [],
-    } as ReturnType<typeof resolveExecApprovals>);
+    } as unknown as ReturnType<typeof resolveExecApprovals>);
 
     vi.mocked(minSecurity).mockReturnValue("allowlist");
     vi.mocked(maxAsk).mockReturnValue("always");
@@ -128,7 +128,7 @@ describe("approval timeout denial", () => {
       allowlistSatisfied: false,
       allowlistMatches: [],
       segments: [],
-    } as ReturnType<typeof evaluateShellAllowlist>);
+    } as unknown as ReturnType<typeof evaluateShellAllowlist>);
     vi.mocked(requiresExecApproval).mockReturnValue(true);
     vi.mocked(requestExecApprovalDecision).mockResolvedValue(null);
 
@@ -157,7 +157,7 @@ describe("approval timeout denial", () => {
       file: "/tmp/approvals.json",
       agent: { security: "allowlist", ask: "always", askFallback: "allowlist" },
       allowlist: [],
-    } as ReturnType<typeof resolveExecApprovals>);
+    } as unknown as ReturnType<typeof resolveExecApprovals>);
 
     vi.mocked(minSecurity).mockReturnValue("allowlist");
     vi.mocked(maxAsk).mockReturnValue("always");
@@ -166,7 +166,7 @@ describe("approval timeout denial", () => {
       allowlistSatisfied: true,
       allowlistMatches: [{ pattern: "/usr/bin/echo", type: "exact" }],
       segments: [{ resolution: { resolvedPath: "/usr/bin/echo" } }],
-    } as ReturnType<typeof evaluateShellAllowlist>);
+    } as unknown as ReturnType<typeof evaluateShellAllowlist>);
     vi.mocked(requiresExecApproval).mockReturnValue(true);
     vi.mocked(requestExecApprovalDecision).mockResolvedValue(null);
 
@@ -174,7 +174,7 @@ describe("approval timeout denial", () => {
     vi.mocked(runExecProcess).mockResolvedValue({
       session: mockSession,
       promise: Promise.resolve({ aggregated: "output", exitCode: 0, timedOut: false }),
-    } as Awaited<ReturnType<typeof runExecProcess>>);
+    } as unknown as Awaited<ReturnType<typeof runExecProcess>>);
 
     const { processGatewayAllowlist } = await import("./bash-tools.exec-host-gateway.js");
     await processGatewayAllowlist(makeDefaultParams());
@@ -202,7 +202,7 @@ describe("approval timeout denial", () => {
       file: "/tmp/approvals.json",
       agent: { security: "allowlist", ask: "always", askFallback: "deny" },
       allowlist: [],
-    } as ReturnType<typeof resolveExecApprovals>);
+    } as unknown as ReturnType<typeof resolveExecApprovals>);
 
     vi.mocked(minSecurity).mockReturnValue("allowlist");
     vi.mocked(maxAsk).mockReturnValue("always");
@@ -211,7 +211,7 @@ describe("approval timeout denial", () => {
       allowlistSatisfied: false,
       allowlistMatches: [],
       segments: [],
-    } as ReturnType<typeof evaluateShellAllowlist>);
+    } as unknown as ReturnType<typeof evaluateShellAllowlist>);
     vi.mocked(requiresExecApproval).mockReturnValue(true);
     vi.mocked(requestExecApprovalDecision).mockResolvedValue("deny");
 

--- a/src/agents/bash-tools.exec-host-gateway.approval-timeout.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.approval-timeout.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../infra/exec-approvals.js", () => ({
+  resolveExecApprovals: vi.fn(),
+  evaluateShellAllowlist: vi.fn(),
+  requiresExecApproval: vi.fn(),
+  minSecurity: vi.fn(),
+  maxAsk: vi.fn(),
+  addAllowlistEntry: vi.fn(),
+  recordAllowlistUse: vi.fn(),
+  buildSafeBinsShellCommand: vi.fn(),
+  buildSafeShellCommand: vi.fn(),
+}));
+
+vi.mock("./bash-tools.exec-approval-request.js", () => ({
+  requestExecApprovalDecision: vi.fn(),
+}));
+
+vi.mock("./bash-tools.exec-runtime.js", () => ({
+  emitExecSystemEvent: vi.fn(),
+  runExecProcess: vi.fn(),
+  DEFAULT_APPROVAL_TIMEOUT_MS: 120_000,
+  DEFAULT_NOTIFY_TAIL_CHARS: 2000,
+  createApprovalSlug: (id: string) => id.slice(0, 8),
+  normalizeNotifyOutput: (s: string) => s,
+}));
+
+vi.mock("./bash-process-registry.js", () => ({
+  markBackgrounded: vi.fn(),
+  tail: (s: string) => s,
+}));
+
+const flushAsync = () => new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+function makeDefaultParams() {
+  return {
+    command: "echo test",
+    workdir: "/tmp",
+    env: {},
+    pty: false,
+    defaultTimeoutSec: 60,
+    security: "allowlist" as const,
+    ask: "always" as const,
+    safeBins: new Set<string>(),
+    agentId: "main",
+    sessionKey: "session-1",
+    scopeKey: "scope",
+    warnings: [] as string[],
+    notifySessionKey: "session-1",
+    approvalRunningNoticeMs: 0,
+    maxOutput: 10000,
+    pendingMaxOutput: 10000,
+  };
+}
+
+describe("approval timeout denial", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("denies on approval timeout when askFallback is not allowlist", async () => {
+    const {
+      resolveExecApprovals,
+      evaluateShellAllowlist,
+      requiresExecApproval,
+      minSecurity,
+      maxAsk,
+    } = await import("../infra/exec-approvals.js");
+    const { requestExecApprovalDecision } = await import("./bash-tools.exec-approval-request.js");
+    const { emitExecSystemEvent } = await import("./bash-tools.exec-runtime.js");
+
+    vi.mocked(resolveExecApprovals).mockReturnValue({
+      file: "/tmp/approvals.json",
+      agent: { security: "allowlist", ask: "always", askFallback: "deny" },
+      allowlist: [],
+    } as ReturnType<typeof resolveExecApprovals>);
+
+    vi.mocked(minSecurity).mockReturnValue("allowlist");
+    vi.mocked(maxAsk).mockReturnValue("always");
+    vi.mocked(evaluateShellAllowlist).mockReturnValue({
+      analysisOk: true,
+      allowlistSatisfied: false,
+      allowlistMatches: [],
+      segments: [],
+    } as ReturnType<typeof evaluateShellAllowlist>);
+    vi.mocked(requiresExecApproval).mockReturnValue(true);
+    vi.mocked(requestExecApprovalDecision).mockResolvedValue(null);
+
+    const { processGatewayAllowlist } = await import("./bash-tools.exec-host-gateway.js");
+    const result = await processGatewayAllowlist(makeDefaultParams());
+
+    expect(result.pendingResult).toBeDefined();
+    expect(result.pendingResult?.details?.status).toBe("approval-pending");
+
+    await flushAsync();
+
+    expect(emitExecSystemEvent).toHaveBeenCalledWith(
+      expect.stringContaining("approval-timeout"),
+      expect.objectContaining({ sessionKey: "session-1" }),
+    );
+  });
+
+  it("denies on approval timeout with allowlist fallback when allowlist not satisfied", async () => {
+    const {
+      resolveExecApprovals,
+      evaluateShellAllowlist,
+      requiresExecApproval,
+      minSecurity,
+      maxAsk,
+    } = await import("../infra/exec-approvals.js");
+    const { requestExecApprovalDecision } = await import("./bash-tools.exec-approval-request.js");
+    const { emitExecSystemEvent } = await import("./bash-tools.exec-runtime.js");
+
+    vi.mocked(resolveExecApprovals).mockReturnValue({
+      file: "/tmp/approvals.json",
+      agent: { security: "allowlist", ask: "always", askFallback: "allowlist" },
+      allowlist: [],
+    } as ReturnType<typeof resolveExecApprovals>);
+
+    vi.mocked(minSecurity).mockReturnValue("allowlist");
+    vi.mocked(maxAsk).mockReturnValue("always");
+    vi.mocked(evaluateShellAllowlist).mockReturnValue({
+      analysisOk: true,
+      allowlistSatisfied: false,
+      allowlistMatches: [],
+      segments: [],
+    } as ReturnType<typeof evaluateShellAllowlist>);
+    vi.mocked(requiresExecApproval).mockReturnValue(true);
+    vi.mocked(requestExecApprovalDecision).mockResolvedValue(null);
+
+    const { processGatewayAllowlist } = await import("./bash-tools.exec-host-gateway.js");
+    await processGatewayAllowlist(makeDefaultParams());
+    await flushAsync();
+
+    expect(emitExecSystemEvent).toHaveBeenCalledWith(
+      expect.stringContaining("approval-timeout (allowlist-miss)"),
+      expect.objectContaining({ sessionKey: "session-1" }),
+    );
+  });
+
+  it("approves on timeout with allowlist fallback when allowlist is satisfied", async () => {
+    const {
+      resolveExecApprovals,
+      evaluateShellAllowlist,
+      requiresExecApproval,
+      minSecurity,
+      maxAsk,
+    } = await import("../infra/exec-approvals.js");
+    const { requestExecApprovalDecision } = await import("./bash-tools.exec-approval-request.js");
+    const { emitExecSystemEvent, runExecProcess } = await import("./bash-tools.exec-runtime.js");
+
+    vi.mocked(resolveExecApprovals).mockReturnValue({
+      file: "/tmp/approvals.json",
+      agent: { security: "allowlist", ask: "always", askFallback: "allowlist" },
+      allowlist: [],
+    } as ReturnType<typeof resolveExecApprovals>);
+
+    vi.mocked(minSecurity).mockReturnValue("allowlist");
+    vi.mocked(maxAsk).mockReturnValue("always");
+    vi.mocked(evaluateShellAllowlist).mockReturnValue({
+      analysisOk: true,
+      allowlistSatisfied: true,
+      allowlistMatches: [{ pattern: "/usr/bin/echo", type: "exact" }],
+      segments: [{ resolution: { resolvedPath: "/usr/bin/echo" } }],
+    } as ReturnType<typeof evaluateShellAllowlist>);
+    vi.mocked(requiresExecApproval).mockReturnValue(true);
+    vi.mocked(requestExecApprovalDecision).mockResolvedValue(null);
+
+    const mockSession = { id: "test-session" };
+    vi.mocked(runExecProcess).mockResolvedValue({
+      session: mockSession,
+      promise: Promise.resolve({ aggregated: "output", exitCode: 0, timedOut: false }),
+    } as Awaited<ReturnType<typeof runExecProcess>>);
+
+    const { processGatewayAllowlist } = await import("./bash-tools.exec-host-gateway.js");
+    await processGatewayAllowlist(makeDefaultParams());
+    await flushAsync();
+
+    expect(runExecProcess).toHaveBeenCalled();
+    const denialCalls = vi
+      .mocked(emitExecSystemEvent)
+      .mock.calls.filter(([msg]) => typeof msg === "string" && msg.includes("denied"));
+    expect(denialCalls).toHaveLength(0);
+  });
+
+  it("denies when user explicitly denies", async () => {
+    const {
+      resolveExecApprovals,
+      evaluateShellAllowlist,
+      requiresExecApproval,
+      minSecurity,
+      maxAsk,
+    } = await import("../infra/exec-approvals.js");
+    const { requestExecApprovalDecision } = await import("./bash-tools.exec-approval-request.js");
+    const { emitExecSystemEvent } = await import("./bash-tools.exec-runtime.js");
+
+    vi.mocked(resolveExecApprovals).mockReturnValue({
+      file: "/tmp/approvals.json",
+      agent: { security: "allowlist", ask: "always", askFallback: "deny" },
+      allowlist: [],
+    } as ReturnType<typeof resolveExecApprovals>);
+
+    vi.mocked(minSecurity).mockReturnValue("allowlist");
+    vi.mocked(maxAsk).mockReturnValue("always");
+    vi.mocked(evaluateShellAllowlist).mockReturnValue({
+      analysisOk: true,
+      allowlistSatisfied: false,
+      allowlistMatches: [],
+      segments: [],
+    } as ReturnType<typeof evaluateShellAllowlist>);
+    vi.mocked(requiresExecApproval).mockReturnValue(true);
+    vi.mocked(requestExecApprovalDecision).mockResolvedValue("deny");
+
+    const { processGatewayAllowlist } = await import("./bash-tools.exec-host-gateway.js");
+    await processGatewayAllowlist(makeDefaultParams());
+    await flushAsync();
+
+    expect(emitExecSystemEvent).toHaveBeenCalledWith(
+      expect.stringContaining("user-denied"),
+      expect.objectContaining({ sessionKey: "session-1" }),
+    );
+  });
+});

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1,6 +1,5 @@
-import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import crypto from "node:crypto";
-import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import {
   addAllowlistEntry,
   type ExecAsk,
@@ -24,6 +23,7 @@ import {
   normalizeNotifyOutput,
   runExecProcess,
 } from "./bash-tools.exec-runtime.js";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 
 export type ProcessGatewayAllowlistParams = {
   command: string;

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1,5 +1,6 @@
-import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import crypto from "node:crypto";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import {
   addAllowlistEntry,
   type ExecAsk,
@@ -23,7 +24,6 @@ import {
   normalizeNotifyOutput,
   runExecProcess,
 } from "./bash-tools.exec-runtime.js";
-import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 
 export type ProcessGatewayAllowlistParams = {
   command: string;
@@ -126,9 +126,7 @@ export async function processGatewayAllowlist(
       if (decision === "deny") {
         deniedReason = "user-denied";
       } else if (!decision) {
-        if (askFallback === "full") {
-          approvedByAsk = true;
-        } else if (askFallback === "allowlist") {
+        if (askFallback === "allowlist") {
           if (!analysisOk || !allowlistSatisfied) {
             deniedReason = "approval-timeout (allowlist-miss)";
           } else {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -1,6 +1,5 @@
-import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import crypto from "node:crypto";
-import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import {
   type ExecApprovalsFile,
   type ExecAsk,
@@ -19,6 +18,7 @@ import {
   createApprovalSlug,
   emitExecSystemEvent,
 } from "./bash-tools.exec-runtime.js";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { callGatewayTool } from "./tools/gateway.js";
 import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
 

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -1,5 +1,6 @@
-import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import crypto from "node:crypto";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import {
   type ExecApprovalsFile,
   type ExecAsk,
@@ -18,7 +19,6 @@ import {
   createApprovalSlug,
   emitExecSystemEvent,
 } from "./bash-tools.exec-runtime.js";
-import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { callGatewayTool } from "./tools/gateway.js";
 import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
 
@@ -203,10 +203,7 @@ export async function executeNodeHostCommand(
       if (decision === "deny") {
         deniedReason = "user-denied";
       } else if (!decision) {
-        if (askFallback === "full") {
-          approvedByAsk = true;
-          approvalDecision = "allow-once";
-        } else if (askFallback === "allowlist") {
+        if (askFallback === "allowlist") {
           // Defer allowlist enforcement to the node host.
         } else {
           deniedReason = "approval-timeout";


### PR DESCRIPTION
## Summary
- When an exec approval request times out (`!decision`), the handler previously auto-approved the command if `askFallback === 'full'`, granting elevated permissions on timeout.
- This removes the `askFallback === 'full'` auto-approve path in the timeout branch so that timeouts always result in denial with `deniedReason = "approval-timeout"`.
- The `allowlist` fallback path is preserved: on timeout, allowlist-satisfied commands may still proceed, but unrestricted `full` fallback no longer auto-approves.

## Test plan
- [ ] Verify that exec commands with `askFallback = 'full'` are denied when the approval request times out
- [ ] Verify that `askFallback = 'allowlist'` still works correctly on timeout (allowlist-satisfied commands approved, others denied)
- [ ] Verify that explicit user decisions (`allow-once`, `allow-always`, `deny`) are unaffected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Closes a security vulnerability where exec approval request timeouts would auto-approve commands when `askFallback = 'full'` is configured. The fix removes the auto-approval path on timeout, ensuring that timeouts always result in denial with `deniedReason = "approval-timeout"`. The `allowlist` fallback path is preserved correctly.

- Removed unsafe auto-approval on timeout for `askFallback = 'full'`
- Timeouts now consistently deny execution instead of granting elevated permissions
- `allowlist` fallback continues to work as intended (allowlist-satisfied commands approved, others denied)

Note: The parallel code in `bash-tools.exec-host-node.ts` still contains the same vulnerability (lines 206-208) and should be fixed in a follow-up.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge - it fixes a critical security vulnerability
- The fix correctly closes a security hole where timeouts granted elevated permissions. However, the identical vulnerability exists in `bash-tools.exec-host-node.ts` and should be fixed as well.
- Check `bash-tools.exec-host-node.ts` for the same vulnerability

<sub>Last reviewed commit: f6abfea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->