### PR TITLE
fix(gateway): validate session key ownership against agent scope

### DIFF
--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -1,5 +1,5 @@
-import type { IncomingMessage } from "node:http";
 import { randomUUID } from "node:crypto";
+import type { IncomingMessage } from "node:http";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
 
 export function getHeader(req: IncomingMessage, name: string): string | undefined {

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from "node:crypto";
 import type { IncomingMessage } from "node:http";
+import { randomUUID } from "node:crypto";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
 
 export function getHeader(req: IncomingMessage, name: string): string | undefined {
@@ -70,7 +70,11 @@ export function resolveSessionKey(params: {
 }): string {
   const explicit = getHeader(params.req, "x-openclaw-session-key")?.trim();
   if (explicit) {
-    return explicit;
+    const agentPrefix = `agent:${normalizeAgentId(params.agentId)}:`;
+    if (explicit.startsWith(agentPrefix)) {
+      return explicit;
+    }
+    // Explicit key does not belong to this agent's scope; fall through to default.
   }
 
   const user = params.user?.trim();


### PR DESCRIPTION
## Summary
- `resolveSessionKey()` accepted any value from the `x-openclaw-session-key` header without validating it belongs to the authenticated agent's scope, allowing cross-agent session injection.
- Added validation that the explicit session key starts with the expected `agent:<agentId>:` prefix using `normalizeAgentId()` for consistent comparison.
- If the explicit key does not match the agent's scope, the function falls through to default key generation instead of accepting the arbitrary value.

## Test plan
- [ ] Verify that a valid session key with the correct agent prefix is accepted (e.g., `agent:myagent:openai-user:alice`)
- [ ] Verify that a session key targeting a different agent (e.g., `agent:otheragent:openai-user:alice`) is rejected and the default key is generated instead
- [ ] Verify that when no `x-openclaw-session-key` header is present, default key generation works as before
- [ ] Verify both OpenAI and OpenResponses gateway endpoints correctly validate session keys

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes session key injection vulnerability by validating that explicit `x-openclaw-session-key` headers match the authenticated agent's scope.

**Key changes:**
- Added validation in `resolveSessionKey()` to check explicit session keys start with expected agent prefix
- Uses `normalizeAgentId()` for consistent comparison
- Falls through to default key generation when explicit key doesn't match agent scope

**Test coverage gap:**
The existing test (line 174-190 in `openai-http.e2e.test.ts`) only validates the happy path where the session key matches the agent. Missing test case: verify that a session key targeting a different agent is rejected and falls through to default key generation.

<h3>Confidence Score: 4/5</h3>

- Safe to merge - fixes a real security vulnerability with clean implementation
- The fix correctly validates session key ownership against agent scope, preventing cross-agent session injection. Import reordering is cosmetic. Only minor concern is missing test coverage for the negative case (mismatched agent rejection), but the implementation logic is sound and follows existing patterns.
- No files require special attention

<sub>Last reviewed commit: 1250701</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->