### PR TITLE
fix(sandbox): add /home and /Users to bind-mount denylist

### DIFF
--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -28,12 +28,22 @@ describe("validateBindMounts", () => {
   it("allows legitimate project directory mounts", () => {
     expect(() =>
       validateBindMounts([
-        "/home/user/source:/source:rw",
-        "/home/user/projects:/projects:ro",
+        "/srv/myproject/source:/source:rw",
+        "/opt/myapp/projects:/projects:ro",
         "/var/data/myapp:/data",
         "/opt/myapp/config:/config:ro",
       ]),
     ).not.toThrow();
+  });
+
+  it("blocks /home mount", () => {
+    expect(() => validateBindMounts(["/home/user/data:/data"])).toThrow(/blocked path "\/home"/);
+  });
+
+  it("blocks /Users mount", () => {
+    expect(() => validateBindMounts(["/Users/dev/project:/project"])).toThrow(
+      /blocked path "\/Users"/,
+    );
   });
 
   it("allows undefined or empty binds", () => {
@@ -65,7 +75,7 @@ describe("validateBindMounts", () => {
   });
 
   it("blocks paths with .. traversal to dangerous directories", () => {
-    expect(() => validateBindMounts(["/home/user/../../etc/shadow:/mnt/shadow"])).toThrow(
+    expect(() => validateBindMounts(["/srv/user/../../etc/shadow:/mnt/shadow"])).toThrow(
       /blocked path "\/etc"/,
     );
   });
@@ -143,7 +153,7 @@ describe("validateSandboxSecurity", () => {
   it("passes with safe config", () => {
     expect(() =>
       validateSandboxSecurity({
-        binds: ["/home/user/src:/src:rw"],
+        binds: ["/srv/user/src:/src:rw"],
         network: "none",
         seccompProfile: "/tmp/seccomp.json",
         apparmorProfile: "openclaw-sandbox",

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -18,6 +18,9 @@ export const BLOCKED_HOST_PATHS = [
   "/dev",
   "/root",
   "/boot",
+  // User home directories — may contain SSH keys, cloud credentials, etc.
+  "/home",
+  "/Users",
   // Directories that commonly contain (or alias) the Docker socket.
   "/run",
   "/var/run",
@@ -114,7 +117,7 @@ function formatBindBlockedError(params: { bind: string; reason: BlockedBindReaso
   return new Error(
     `Sandbox security: bind mount "${params.bind}" ${verb} blocked path "${params.reason.blockedPath}". ` +
       "Mounting system directories (or Docker socket paths) into sandbox containers is not allowed. " +
-      "Use project-specific paths instead (e.g. /home/user/myproject).",
+      "Use project-specific paths instead (e.g. /srv/myproject or /opt/myproject).",
   );
 }
 


### PR DESCRIPTION
## Summary

- Add `/home` and `/Users` to the `BLOCKED_HOST_PATHS` array in `validate-sandbox-security.ts` so that user home directories containing SSH keys and cloud credentials cannot be bind-mounted into sandbox containers.
- Update the error message to suggest `/srv` or `/opt` paths instead of `/home` paths.
- Update existing tests that expected `/home` mounts to succeed, and add new test cases verifying that `/home` and `/Users` mounts are blocked.

## Test plan

- [x] Existing test suite passes (21 tests)
- [x] New tests verify `/home` and `/Users` bind mounts are rejected with correct error messages
- [x] Formatter and linter pass with no warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `/home` and `/Users` to the bind-mount denylist to prevent SSH keys and cloud credentials from being exposed in sandbox containers. Updated error messages to suggest `/srv` or `/opt` paths instead of `/home`. Test suite updated to verify the new blocks work correctly.

**Critical Issue**: Multiple documentation files contain examples using `/home/user/*` paths that will now be rejected by this security change:
- `docs/gateway/sandboxing.md` (lines 70, 87)
- `docs/help/faq.md` (line 1197)
- `docs/gateway/configuration-reference.md` (line 896)
- `docs/channels/groups.md` (line 108)
- `docs/install/docker.md` (lines 125, 156)

These docs need updating to use `/srv` or `/opt` examples instead, or users following the documentation will encounter validation errors.

<h3>Confidence Score: 3/5</h3>

- Safe implementation but incomplete - documentation updates are missing
- The code changes are well-implemented with proper tests and clear security benefits. However, the PR introduces a breaking change that invalidates examples in at least 8 documentation files across the repository. Users following current docs will encounter validation errors. Score would be 5 if documentation was updated to match the new path restrictions.
- Documentation files outside this PR need updating to replace `/home/*` examples with `/srv/*` or `/opt/*` paths

<sub>Last reviewed commit: 77d2e92</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->