### PR TITLE
fix(canvas): add CSP and security headers to HTML responses

### DIFF
--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -1,15 +1,15 @@
-import type { Socket } from "node:net";
-import type { Duplex } from "node:stream";
-import chokidar from "chokidar";
 import * as fsSync from "node:fs";
 import fs from "node:fs/promises";
 import http, { type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { Socket } from "node:net";
 import path from "node:path";
+import type { Duplex } from "node:stream";
+import chokidar from "chokidar";
 import { type WebSocket, WebSocketServer } from "ws";
-import type { RuntimeEnv } from "../runtime.js";
 import { resolveStateDir } from "../config/paths.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { detectMime } from "../media/mime.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { ensureDir, resolveUserPath } from "../utils.js";
 import {
   CANVAS_HOST_PATH,

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -1,15 +1,15 @@
+import type { Socket } from "node:net";
+import type { Duplex } from "node:stream";
+import chokidar from "chokidar";
 import * as fsSync from "node:fs";
 import fs from "node:fs/promises";
 import http, { type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import type { Socket } from "node:net";
 import path from "node:path";
-import type { Duplex } from "node:stream";
-import chokidar from "chokidar";
 import { type WebSocket, WebSocketServer } from "ws";
+import type { RuntimeEnv } from "../runtime.js";
 import { resolveStateDir } from "../config/paths.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { detectMime } from "../media/mime.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { ensureDir, resolveUserPath } from "../utils.js";
 import {
   CANVAS_HOST_PATH,
@@ -333,6 +333,12 @@ export async function createCanvasHostHandler(
         if (urlPath === "/" || urlPath.endsWith("/")) {
           res.statusCode = 404;
           res.setHeader("Content-Type", "text/html; charset=utf-8");
+          res.setHeader(
+            "Content-Security-Policy",
+            "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'",
+          );
+          res.setHeader("X-Frame-Options", "SAMEORIGIN");
+          res.setHeader("X-Content-Type-Options", "nosniff");
           res.end(
             `<!doctype html><meta charset="utf-8" /><title>OpenClaw Canvas</title><pre>Missing file.\nCreate ${rootDir}/index.html</pre>`,
           );
@@ -362,6 +368,12 @@ export async function createCanvasHostHandler(
       if (mime === "text/html") {
         const html = data.toString("utf8");
         res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.setHeader(
+          "Content-Security-Policy",
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'",
+        );
+        res.setHeader("X-Frame-Options", "SAMEORIGIN");
+        res.setHeader("X-Content-Type-Options", "nosniff");
         res.end(liveReload ? injectCanvasLiveReload(html) : html);
         return true;
       }


### PR DESCRIPTION
## Summary

- Add `Content-Security-Policy`, `X-Frame-Options`, and `X-Content-Type-Options` headers to all HTML responses served by the canvas host in `src/canvas-host/server.ts`.
- CSP allows `'unsafe-inline'` for scripts and styles because the injected action bridge (`injectCanvasLiveReload`) and the default index page use inline `<script>` and `<style>` blocks.
- Headers are applied to both the normal HTML file serving path and the 404 "missing file" HTML fallback.

## Test plan

- [x] Verified the injected live-reload/action-bridge script uses inline `<script>` tags, confirming `'unsafe-inline'` is needed in `script-src`
- [x] Verified the default index HTML uses inline `<style>` tags, confirming `'unsafe-inline'` is needed in `style-src`
- [x] Formatter and linter pass with no warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `Content-Security-Policy`, `X-Frame-Options`, and `X-Content-Type-Options` headers to all HTML responses served by the canvas host. The CSP policy correctly allows `'unsafe-inline'` for scripts and styles, which is necessary because the live-reload injection (`injectCanvasLiveReload`) adds inline `<script>` tags and the default index page includes inline `<style>` blocks. Headers are properly applied to both the normal HTML file serving path and the 404 fallback response.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The security headers are correctly implemented with appropriate CSP directives that match the actual usage patterns (inline scripts/styles). The changes are minimal, focused, and properly cover all HTML response paths. Import reordering is cosmetic and follows standard conventions.
- No files require special attention

<sub>Last reviewed commit: 4f837f1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->