### PR TITLE
fix(config): block dangerous environment variable keys from config injection

### DIFF
--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import type { OpenClawConfig } from "./types.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveConfigEnvVars } from "./env-substitution.js";
 import { applyConfigEnvVars } from "./env-vars.js";
 import { withEnvOverride, withTempHome } from "./test-helpers.js";
+import type { OpenClawConfig } from "./types.js";
 
 describe("config env vars", () => {
   it("applies env vars from env block when missing", async () => {

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -29,7 +29,7 @@ describe("config env vars", () => {
     });
   });
 
-  it("blocks dangerous environment variable keys from config injection", async () => {
+  it("blocks dangerous environment variable keys from env.vars config injection", async () => {
     const dangerousKeys = ["NODE_OPTIONS", "LD_PRELOAD", "PATH", "HOME"];
     const overrides: Record<string, string | undefined> = {};
     for (const key of dangerousKeys) {
@@ -41,6 +41,24 @@ describe("config env vars", () => {
         vars[key] = "injected-value";
       }
       applyConfigEnvVars({ env: { vars } } as OpenClawConfig);
+      for (const key of dangerousKeys) {
+        expect(process.env[key]).toBeUndefined();
+      }
+    });
+  });
+
+  it("blocks dangerous environment variable keys from top-level env config injection", async () => {
+    const dangerousKeys = ["NODE_OPTIONS", "LD_PRELOAD", "PATH", "HOME"];
+    const overrides: Record<string, string | undefined> = {};
+    for (const key of dangerousKeys) {
+      overrides[key] = undefined;
+    }
+    await withEnvOverride(overrides, async () => {
+      const env: Record<string, string> = {};
+      for (const key of dangerousKeys) {
+        env[key] = "injected-value";
+      }
+      applyConfigEnvVars({ env } as OpenClawConfig);
       for (const key of dangerousKeys) {
         expect(process.env[key]).toBeUndefined();
       }

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -1,5 +1,5 @@
-import type { OpenClawConfig } from "./types.js";
 import { logWarn } from "../logger.js";
+import type { OpenClawConfig } from "./types.js";
 
 const BLOCKED_ENV_KEYS = new Set([
   "NODE_OPTIONS",

--- a/src/config/env-vars.ts
+++ b/src/config/env-vars.ts
@@ -1,4 +1,18 @@
 import type { OpenClawConfig } from "./types.js";
+import { logWarn } from "../logger.js";
+
+const BLOCKED_ENV_KEYS = new Set([
+  "NODE_OPTIONS",
+  "NODE_DEBUG",
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "DYLD_INSERT_LIBRARIES",
+  "DYLD_LIBRARY_PATH",
+  "PATH",
+  "HOME",
+  "USER",
+  "SHELL",
+]);
 
 export function collectConfigEnvVars(cfg?: OpenClawConfig): Record<string, string> {
   const envConfig = cfg?.env;
@@ -13,6 +27,10 @@ export function collectConfigEnvVars(cfg?: OpenClawConfig): Record<string, strin
       if (!value) {
         continue;
       }
+      if (BLOCKED_ENV_KEYS.has(key.toUpperCase())) {
+        logWarn(`config: blocked dangerous environment variable "${key}" from config injection`);
+        continue;
+      }
       entries[key] = value;
     }
   }
@@ -22,6 +40,10 @@ export function collectConfigEnvVars(cfg?: OpenClawConfig): Record<string, strin
       continue;
     }
     if (typeof value !== "string" || !value.trim()) {
+      continue;
+    }
+    if (BLOCKED_ENV_KEYS.has(key.toUpperCase())) {
+      logWarn(`config: blocked dangerous environment variable "${key}" from config injection`);
       continue;
     }
     entries[key] = value;


### PR DESCRIPTION
## Summary
- Add a denylist of dangerous environment variable keys (`NODE_OPTIONS`, `LD_PRELOAD`, `PATH`, `HOME`, etc.) that are blocked from being set via config env injection
- `collectConfigEnvVars` now skips blocked keys in both `env.vars` and top-level `env` blocks, logging a warning for each blocked key
- Add test verifying blocked keys are not written to `process.env`

## Test plan
- [x] Existing tests pass (5/5)
- [x] New test confirms `NODE_OPTIONS`, `LD_PRELOAD`, `PATH`, `HOME` are blocked from config injection
- [ ] Manual: verify warning log is emitted when a blocked key is encountered in config

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a denylist of dangerous environment variables (`NODE_OPTIONS`, `LD_PRELOAD`, `PATH`, `HOME`, etc.) to prevent security vulnerabilities from config injection. The `collectConfigEnvVars` function now blocks these keys in both `env.vars` and top-level `env` blocks with warning logs.

- Blocks 10 dangerous environment variable keys that could enable code injection or system compromise
- Case-insensitive matching using `toUpperCase()` ensures variants are caught
- Consistent with existing security patterns in `src/node-host/invoke.ts` and `src/agents/sandbox/sanitize-env-vars.ts`
- Test verifies blocked keys are not written to `process.env`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it adds security hardening without breaking changes
- Score reflects solid security implementation with proper testing. The denylist approach is effective and consistent with existing patterns in the codebase. Minor test coverage gap (top-level env block not tested) prevents a score of 5, but the implementation correctly handles both cases.
- No files require special attention - the implementation is straightforward and well-tested

<sub>Last reviewed commit: 9ecf366</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->