### PR TITLE
fix(tools): apply SSRF guard to Firecrawl fallback fetch path

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,12 +1,12 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { AnyAgentTool } from "./common.js";
 import { fetchWithSsrFGuard, type GuardedFetchResult } from "../../infra/net/fetch-guard.js";
 import { SsrFBlockedError } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { stringEnum } from "../schema/typebox.js";
+import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import {
   extractReadableContent,


### PR DESCRIPTION
## Summary
- Replace plain `fetch()` in `fetchFirecrawlContent` with `fetchWithSsrFGuard` to validate the Firecrawl endpoint URL against the same SSRF policy
- Properly release the guarded fetch dispatcher via `try/finally` after the Firecrawl request completes
- Remove unused `withTimeout` import that was previously used by the plain fetch call

## Test plan
- [x] Linting passes with no errors
- [ ] Manual: verify Firecrawl fallback still works with valid public endpoint URLs
- [ ] Manual: verify SSRF-blocked Firecrawl endpoint URLs (e.g., pointing to internal IPs) are rejected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds SSRF protection to the Firecrawl fallback fetch path by replacing plain `fetch()` with `fetchWithSsrFGuard()`, ensuring the Firecrawl endpoint URL is validated against the same SSRF policy used for direct web fetches.

- Replaced plain `fetch()` call with `fetchWithSsrFGuard()` wrapper that validates the endpoint URL
- Added proper resource cleanup via `try/finally` block to release the guarded dispatcher
- Removed unused `withTimeout` import (timeout now handled by `fetchWithSsrFGuard`)
- Follows the same pattern already established in the `performDirectFetch` function within this file

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward security improvement that follows existing patterns in the codebase. The implementation correctly handles SSRF protection, error handling, and resource cleanup. The removed import was genuinely unused.
- No files require special attention

<sub>Last reviewed commit: f25fbed</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->