### PR TITLE
fix(hooks): add security warning when loading workspace hook handlers

### DIFF
--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -8,11 +8,11 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { OpenClawConfig } from "../config/config.js";
-import type { InternalHookHandler } from "./internal-hooks.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { resolveHookConfig } from "./config.js";
 import { shouldIncludeHook } from "./config.js";
+import type { InternalHookHandler } from "./internal-hooks.js";
 import { registerInternalHook } from "./internal-hooks.js";
 import { loadWorkspaceHookEntries } from "./workspace.js";
 


### PR DESCRIPTION
## Summary
- Workspace and plugin-sourced hook handlers are auto-imported and executed with full gateway privileges
- A malicious git repository containing `.openclaw/hooks/` files could have its hooks silently loaded without any indication to the operator
- Adds a visible warning log before importing workspace-sourced and plugin-sourced hook handler modules so operators can identify when untrusted hook code is being loaded

## Changes
- `src/hooks/loader.ts`: Added a `log.warn()` call before importing hook handler modules when the hook source is `"openclaw-workspace"` or `"openclaw-plugin"`, alerting operators that the hook runs with full gateway privileges

## Test plan
- [ ] Verify warning appears in logs when a workspace-sourced hook is loaded
- [ ] Verify no warning for bundled or managed hooks
- [ ] Verify existing hook loading behavior is unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added security warning when loading workspace or plugin hook handlers to alert operators that these hooks execute with full gateway privileges and could originate from untrusted sources. The warning includes the hook name and file path to help operators identify potentially malicious hooks before they're executed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused security enhancement that only adds logging, does not alter execution logic, and follows established patterns in the codebase. The import reordering is a minor formatting change with no functional impact.
- No files require special attention

<sub>Last reviewed commit: ec3378e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->