### PR TITLE
feat: rate-limit backoff, webchat error surfacing, device auth recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,96 @@
-AGENTS.md
+# OpenClaw (clawdbot) Development Guide
+
+## EC2 Production Server
+
+The OpenClaw gateway and Mission Control run on an EC2 instance in us-west-2.
+
+### SSH Connection
+```bash
+ssh -i ~/.ssh/openclaw-key.pem ec2-user@34.216.126.0
+```
+
+- **Key file:** `~/.ssh/openclaw-key.pem`
+- **User:** `ec2-user`
+- **IP:** `34.216.126.0` (Elastic IP)
+- **Region:** us-west-2
+
+### Important Paths on EC2
+| Path | Purpose |
+|------|---------|
+| `/home/ec2-user/.openclaw/openclaw.json` | Main OpenClaw config |
+| `/home/ec2-user/.openclaw/workspace/` | Agent workspace (markdown files, skills) |
+| `/home/ec2-user/.openclaw/workspace/mission-control/` | Mission Control Next.js app |
+| `/home/ec2-user/.openclaw/memory/` | Memory storage |
+| `/home/ec2-user/.openclaw/cron/` | Cron configs |
+| `/home/ec2-user/.openclaw/logs/` | Log files |
+| `/home/ec2-user/clawdbot/` | OpenClaw source code |
+
+### Gateway API
+- **Port:** 18789 (loopback only)
+- **Protocol:** WebSocket, custom JSON frames (not JSON-RPC)
+- **Auth:** Token-based (token in `openclaw.json` → `gateway.auth.token`)
+- **Control UI auth:** `allowInsecureAuth: true` is set, so `openclaw-control-ui` can connect with token over HTTP on localhost
+
+#### WebSocket Protocol
+```
+Server sends: { type: "event", event: "connect.challenge", payload: { nonce, ts } }
+Client sends: { type: "req", id: "connect", method: "connect", params: { ...ConnectParams } }
+Server sends: { type: "res", id: "connect", ok: true, payload: { type: "hello-ok", ... } }
+Client sends: { type: "req", id: "x", method: "<method>", params: {...} }
+Server sends: { type: "res", id: "x", ok: true, payload: {...} }
+```
+
+#### ConnectParams (for Mission Control)
+```json
+{
+  "minProtocol": 3, "maxProtocol": 3,
+  "client": { "id": "openclaw-control-ui", "displayName": "Mission Control", "version": "0.2.0", "platform": "linux", "mode": "backend" },
+  "auth": { "token": "<gateway-token>" },
+  "role": "operator",
+  "scopes": ["operator.admin", "operator.read"]
+}
+```
+
+#### Available Methods
+| Method | Scope | Params | Returns |
+|--------|-------|--------|---------|
+| `health` | read | `{ probe?: boolean }` | System health snapshot |
+| `sessions.list` | read | `{ limit?, sortBy?, sortOrder? }` | `{ sessions, total }` |
+| `sessions.usage` | admin | `{ key?, startDate?, endDate?, limit? }` | Usage/cost with aggregates |
+| `cron.list` | read | `{ includeDisabled?: boolean }` | `{ jobs }` |
+| `cron.runs` | read | `{ id, limit? }` | `{ entries }` |
+| `agents.list` | read | `{}` | `{ agents, defaultId }` |
+| `channels.status` | read | `{ probe?: boolean }` | Channel connectivity |
+| `usage.cost` | read | `{ startDate?, endDate? }` | Cost summary |
+
+### Mission Control (Next.js dashboard)
+- **Location:** `/home/ec2-user/.openclaw/workspace/mission-control/`
+- **Framework:** Next.js 16, Tailwind CSS 4, no database
+- **Port:** 3001 (production: `npm run start`)
+- **Architecture:** Client-side pages → Next.js API routes → Gateway WebSocket
+- **Gateway token:** Stored in `.env.local` on EC2 (server-side only)
+
+#### Pages & Data Sources
+| Page | API Route | Gateway Method |
+|------|-----------|---------------|
+| Home `/` | `/api/health`, `/api/sessions` | `health`, `sessions.list` |
+| Tasks `/tasks` | `/api/sessions` | `sessions.list` |
+| Pipeline `/pipeline` | `/api/sessions/usage` | `sessions.usage` |
+| Calendar `/calendar` | `/api/cron`, `/api/cron/[id]/runs` | `cron.list`, `cron.runs` |
+| Memory `/memory` | `/api/memory` | filesystem (workspace .md files) |
+| Team `/team` | `/api/agents`, `/api/channels` | `agents.list`, `channels.status` |
+| Office `/office` | `/api/system` | `os` module + `df` command |
+| Activity `/activity` | `/api/sessions`, `/api/cron` | `sessions.list`, `cron.list` |
+
+#### Rebuild & Deploy
+```bash
+ssh -i ~/.ssh/openclaw-key.pem ec2-user@34.216.126.0
+cd /home/ec2-user/.openclaw/workspace/mission-control
+kill $(pgrep -f next-server) 2>/dev/null
+npm run build
+nohup npm run start > prod.log 2>&1 &
+```
+
+### Network Notes
+- EC2 security group may need IP allowlisting for SSH access
+- Gateway binds to loopback only — Mission Control accesses it locally

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -582,6 +582,11 @@ const ERROR_PATTERNS = {
     "quota exceeded",
     "resource_exhausted",
     "usage limit",
+    "api limit",
+    "request limit",
+    "limit exceeded",
+    "throttl",
+    "capacity",
   ],
   overloaded: [
     /overloaded_error|"type"\s*:\s*"overloaded_error"/i,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -160,6 +160,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional per-provider overrides for billing backoff (hours).",
   "auth.cooldowns.billingMaxHours": "Cap (hours) for billing backoff (default: 24).",
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
+  "auth.cooldowns.rateLimitBackoffMinutes":
+    "Backoff for rate_limit in minutes (e.g. 0.5 = 30 sec). When set, retries happen sooner than the default 1–5–25–60 min curve.",
   "agents.defaults.bootstrapMaxChars":
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
   "agents.defaults.bootstrapTotalMaxChars":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -204,6 +204,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "auth.cooldowns.billingBackoffHoursByProvider": "Billing Backoff Overrides",
   "auth.cooldowns.billingMaxHours": "Billing Backoff Cap (hours)",
   "auth.cooldowns.failureWindowHours": "Failover Window (hours)",
+  "auth.cooldowns.rateLimitBackoffMinutes": "Rate Limit Backoff (min)",
   "agents.defaults.models": "Models",
   "agents.defaults.model.primary": "Primary Model",
   "agents.defaults.model.fallbacks": "Model Fallbacks",

--- a/src/config/types.auth.ts
+++ b/src/config/types.auth.ts
@@ -25,5 +25,10 @@ export type AuthConfig = {
      * this window, counters reset. Default: 24.
      */
     failureWindowHours?: number;
+    /**
+     * Backoff for rate_limit (minutes). When set, overrides the default 1–5–25–60 min
+     * progression so retries happen sooner. E.g. 0.5 = 30 seconds.
+     */
+    rateLimitBackoffMinutes?: number;
   };
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -284,6 +284,7 @@ export const OpenClawSchema = z
             billingBackoffHoursByProvider: z.record(z.string(), z.number().positive()).optional(),
             billingMaxHours: z.number().positive().optional(),
             failureWindowHours: z.number().positive().optional(),
+            rateLimitBackoffMinutes: z.number().min(0).max(60).optional(),
           })
           .strict()
           .optional(),

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -23,6 +23,7 @@
   line-height: 1.5;
   word-wrap: break-word;
   overflow-wrap: break-word;
+  color: var(--chat-text);
 }
 
 .chat-text :where(p, ul, ol, pre, blockquote, table) {

--- a/ui/src/ui/device-auth.ts
+++ b/ui/src/ui/device-auth.ts
@@ -93,3 +93,12 @@ export function clearDeviceAuthToken(params: { deviceId: string; role: string })
   delete next.tokens[role];
   writeStore(next);
 }
+
+/** Clears all stored device auth so the next connect uses shared token and gets a new device token. */
+export function clearAllDeviceAuth(): void {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}


### PR DESCRIPTION
## Summary
- Add `rateLimitBackoffMinutes` config so rate-limited auth profiles retry sooner than the default 1-5-25-60 min curve
- Expand rate-limit error pattern detection (api limit, throttle, capacity)
- Surface webchat agent run failures to the UI when no reply is produced
- Clear device auth on token mismatch to allow automatic re-pairing
- Replace CLAUDE.md symlink with standalone EC2/Mission Control reference docs

## Test plan
- [ ] Verify rate-limit backoff respects new `rateLimitBackoffMinutes` config
- [ ] Confirm webchat shows error when agent run fails with no response
- [ ] Test device auth recovery after token mismatch disconnect
- [ ] Validate config schema accepts `rateLimitBackoffMinutes` (0-60 range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `rateLimitBackoffMinutes` config to allow faster retries for rate-limited auth profiles, expanded rate-limit error detection patterns, implemented webchat error surfacing when agent runs fail without producing a response, and added automatic device auth recovery on token mismatch disconnects.

- Replaced `CLAUDE.md` symlink with standalone EC2/Mission Control reference docs
- Rate-limit backoff now respects new `rateLimitBackoffMinutes` config (0-60 min range) and uses `Math.min` to take the shorter of the configured backoff or the default exponential curve
- Rate-limit detection expanded to catch "api limit", "request limit", "limit exceeded", "throttl", and "capacity" error patterns
- Webchat now surfaces agent run failures to the UI when no response is generated, using `lastDispatchError` for context
- Device auth cleared on "device token mismatch" disconnect to enable automatic re-pairing with shared token
- Added `color: var(--chat-text)` to `.chat-text` CSS class for consistent text color theming

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects well-structured implementation with clear purpose. The rate-limit backoff config uses proper validation (0-60 min cap, type checking), error pattern expansion is conservative (added common variants without removing existing patterns), and device auth recovery handles a specific disconnect scenario cleanly. The webchat error surfacing logic correctly differentiates between pre-launch and post-launch failures. One minor consideration: the fallback error message in chat.ts assumes `lastDispatchError` capture is complete, which could be verified with edge-case testing.
- No files require special attention

<sub>Last reviewed commit: 67fa27f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->