### PR TITLE
fix(heartbeat): propagate sessionKey in exec/hooks to fix async context loss

### DIFF
--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -129,14 +129,18 @@ describe("node exec events", () => {
         exitCode: 0,
         timedOut: false,
         output: "done",
+        sessionKey: "agent:test:main",
       }),
     });
 
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
-      { sessionKey: "node-node-2", contextKey: "exec:run-2" },
+      { sessionKey: "agent:test:main", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:test:main",
+    });
   });
 
   it("suppresses noisy exec.finished success events with empty output", async () => {
@@ -164,6 +168,7 @@ describe("node exec events", () => {
         exitCode: 0,
         timedOut: false,
         output: "x".repeat(600),
+        sessionKey: "agent:test:main",
       }),
     });
 
@@ -172,7 +177,10 @@ describe("node exec events", () => {
     expect(text.startsWith("Exec finished (node=node-2 id=run-long, code 0)\n")).toBe(true);
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(280);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:test:main",
+    });
   });
 
   it("enqueues exec.denied events with reason", async () => {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -29,7 +29,7 @@ export function createGatewayHooksRequestHandler(params: {
     const sessionKey = resolveMainSessionKeyFromConfig();
     enqueueSystemEvent(value.text, { sessionKey });
     if (value.mode === "now") {
-      requestHeartbeatNow({ reason: "hook:wake" });
+      requestHeartbeatNow({ reason: "hook:wake", sessionKey });
     }
   };
 

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -85,7 +85,7 @@ export function createGatewayHooksRequestHandler(params: {
             sessionKey: mainSessionKey,
           });
           if (value.wakeMode === "now") {
-            requestHeartbeatNow({ reason: `hook:${jobId}` });
+            requestHeartbeatNow({ reason: `hook:${jobId}`, sessionKey: mainSessionKey });
           }
         }
       } catch (err) {
@@ -94,7 +94,7 @@ export function createGatewayHooksRequestHandler(params: {
           sessionKey: mainSessionKey,
         });
         if (value.wakeMode === "now") {
-          requestHeartbeatNow({ reason: `hook:${jobId}:error` });
+          requestHeartbeatNow({ reason: `hook:${jobId}:error`, sessionKey: mainSessionKey });
         }
       }
     })();

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildCronEventPrompt, buildExecEventPrompt } from "./heartbeat-events-filter.js";
+import {
+  buildCronEventPrompt,
+  buildExecEventPrompt,
+  isExecCompletionEvent,
+} from "./heartbeat-events-filter.js";
 
 describe("heartbeat event prompts", () => {
   it("builds user-relay cron prompt by default", () => {
@@ -17,5 +21,32 @@ describe("heartbeat event prompts", () => {
     const prompt = buildExecEventPrompt({ deliverToUser: false });
     expect(prompt).toContain("Handle the result internally");
     expect(prompt).not.toContain("Please relay the command output to the user");
+  });
+});
+
+describe("isExecCompletionEvent", () => {
+  it("matches emitExecSystemEvent (gateway/node approval path) events", () => {
+    expect(isExecCompletionEvent("Exec finished (gateway id=g1, session=s1, code 0)")).toBe(true);
+    expect(isExecCompletionEvent("exec finished (node=n1, code 1)\nsome output")).toBe(true);
+  });
+
+  it("matches maybeNotifyOnExit (backgrounded allowlisted commands) events", () => {
+    expect(isExecCompletionEvent("Exec completed (abc12345, code 0) :: some output")).toBe(true);
+    expect(isExecCompletionEvent("Exec completed (abc12345, code 0)")).toBe(true);
+    expect(isExecCompletionEvent("Exec failed (abc12345, code 1) :: error text")).toBe(true);
+    expect(isExecCompletionEvent("Exec failed (abc12345, signal SIGTERM)")).toBe(true);
+    expect(isExecCompletionEvent("Exec killed (abc12345, signal SIGKILL)")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isExecCompletionEvent("EXEC COMPLETED (abc12345, code 0)")).toBe(true);
+    expect(isExecCompletionEvent("exec failed (abc12345, code 2)")).toBe(true);
+  });
+
+  it("does not match non-exec events", () => {
+    expect(isExecCompletionEvent("Exec running (gateway id=g1, session=s1, >5s): ls")).toBe(false);
+    expect(isExecCompletionEvent("Exec denied (gateway id=g1, reason): rm -rf /")).toBe(false);
+    expect(isExecCompletionEvent("Heartbeat wake")).toBe(false);
+    expect(isExecCompletionEvent("")).toBe(false);
   });
 });

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -84,7 +84,15 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
 }
 
 export function isExecCompletionEvent(evt: string): boolean {
-  return evt.toLowerCase().includes("exec finished");
+  const lower = evt.toLowerCase();
+  // "exec finished" — emitExecSystemEvent (gateway/node approval path)
+  // "exec completed/failed/killed" — maybeNotifyOnExit (backgrounded allowlisted commands)
+  return (
+    lower.includes("exec finished") ||
+    lower.includes("exec completed") ||
+    lower.includes("exec failed") ||
+    lower.includes("exec killed")
+  );
 }
 
 // Returns true when a system event should be treated as real cron reminder content.

--- a/src/infra/heartbeat-reason.test.ts
+++ b/src/infra/heartbeat-reason.test.ts
@@ -18,6 +18,8 @@ describe("heartbeat-reason", () => {
     expect(resolveHeartbeatReasonKind("interval")).toBe("interval");
     expect(resolveHeartbeatReasonKind("manual")).toBe("manual");
     expect(resolveHeartbeatReasonKind("exec-event")).toBe("exec-event");
+    // maybeNotifyOnExit backgrounded exec path: exec:<sessionId>:exit
+    expect(resolveHeartbeatReasonKind("exec:abc12345abc12345:exit")).toBe("exec-event");
     expect(resolveHeartbeatReasonKind("wake")).toBe("wake");
     expect(resolveHeartbeatReasonKind("cron:job-1")).toBe("cron");
     expect(resolveHeartbeatReasonKind("hook:wake")).toBe("hook");
@@ -33,6 +35,7 @@ describe("heartbeat-reason", () => {
 
   it("matches event-driven behavior used by heartbeat preflight", () => {
     expect(isHeartbeatEventDrivenReason("exec-event")).toBe(true);
+    expect(isHeartbeatEventDrivenReason("exec:abc123:exit")).toBe(true);
     expect(isHeartbeatEventDrivenReason("cron:job-1")).toBe(true);
     expect(isHeartbeatEventDrivenReason("wake")).toBe(true);
     expect(isHeartbeatEventDrivenReason("hook:gmail:sync")).toBe(true);
@@ -44,6 +47,7 @@ describe("heartbeat-reason", () => {
   it("matches action-priority wake behavior", () => {
     expect(isHeartbeatActionWakeReason("manual")).toBe(true);
     expect(isHeartbeatActionWakeReason("exec-event")).toBe(true);
+    expect(isHeartbeatActionWakeReason("exec:abc123:exit")).toBe(true);
     expect(isHeartbeatActionWakeReason("hook:wake")).toBe(true);
     expect(isHeartbeatActionWakeReason("interval")).toBe(false);
     expect(isHeartbeatActionWakeReason("cron:job-1")).toBe(false);

--- a/src/infra/heartbeat-reason.ts
+++ b/src/infra/heartbeat-reason.ts
@@ -31,6 +31,10 @@ export function resolveHeartbeatReasonKind(reason?: string): HeartbeatReasonKind
   if (trimmed === "exec-event") {
     return "exec-event";
   }
+  // exec:<sessionId>:exit — emitted by maybeNotifyOnExit for backgrounded commands
+  if (trimmed.startsWith("exec:")) {
+    return "exec-event";
+  }
   if (trimmed === "wake") {
     return "wake";
   }

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -216,10 +216,10 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(sendTelegram).not.toHaveBeenCalled();
   });
 
-  it("uses an internal-only exec prompt when delivery target is none", async () => {
+  it("relays exec prompt to last channel when delivery target is none", async () => {
     const { result, sendTelegram, calledCtx } = await runHeartbeatCase({
       tmpPrefix: "openclaw-exec-internal-",
-      replyText: "Handled internally",
+      replyText: "Exec completed successfully",
       reason: "exec-event",
       target: "none",
       enqueue: (sessionKey) => {
@@ -229,7 +229,8 @@ describe("Ghost reminder bug (issue #13317)", () => {
 
     expect(result.status).toBe("ran");
     expect(calledCtx?.Provider).toBe("exec-event");
-    expect(calledCtx?.Body).toContain("Handle the result internally");
-    expect(sendTelegram).not.toHaveBeenCalled();
+    expect(calledCtx?.Body).toContain("Please relay the command output to the user");
+    expect(calledCtx?.Body).not.toContain("Handle the result internally");
+    expect(sendTelegram).toHaveBeenCalled();
   });
 });

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1259,7 +1259,7 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
-  it("uses an internal-only exec prompt when heartbeat delivery target is none", async () => {
+  it("relays exec completion to last channel when heartbeat delivery target is none", async () => {
     const tmpDir = await createCaseDir("hb-exec-target-none");
     const storePath = path.join(tmpDir, "sessions.json");
     const cfg: OpenClawConfig = {
@@ -1290,7 +1290,7 @@ describe("runHeartbeatOnce", () => {
     });
 
     const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
-    replySpy.mockResolvedValue({ text: "Handled internally" });
+    replySpy.mockResolvedValue({ text: "Exec completed successfully" });
     const sendWhatsApp = vi
       .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
       .mockResolvedValue({ messageId: "m1", toJid: "jid" });
@@ -1302,11 +1302,16 @@ describe("runHeartbeatOnce", () => {
         deps: createHeartbeatDeps(sendWhatsApp),
       });
       expect(res.status).toBe("ran");
-      expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      expect(sendWhatsApp).toHaveBeenCalledWith(
+        "120363401234567890@g.us",
+        "Exec completed successfully",
+        expect.objectContaining({ accountId: undefined }),
+      );
       const calledCtx = replySpy.mock.calls[0]?.[0] as { Provider?: string; Body?: string };
       expect(calledCtx.Provider).toBe("exec-event");
-      expect(calledCtx.Body).toContain("Handle the result internally");
-      expect(calledCtx.Body).not.toContain("Please relay the command output to the user");
+      expect(calledCtx.Body).toContain("Please relay the command output to the user");
+      expect(calledCtx.Body).not.toContain("Handle the result internally");
     } finally {
       replySpy.mockRestore();
     }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -651,7 +651,12 @@ export async function runHeartbeatOnce(opts: {
   }
   const { entry, sessionKey, storePath } = preflight.session;
   const previousUpdatedAt = entry?.updatedAt;
-  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
+  const delivery = resolveHeartbeatDeliveryTarget({
+    cfg,
+    entry,
+    heartbeat,
+    forceLastTargetWhenNone: preflight.isExecEventReason,
+  });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {
     log.warn("heartbeat: unknown accountId", {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -241,9 +241,11 @@ export function resolveHeartbeatDeliveryTarget(params: {
   cfg: OpenClawConfig;
   entry?: SessionEntry;
   heartbeat?: AgentDefaultsConfig["heartbeat"];
+  forceLastTargetWhenNone?: boolean;
 }): OutboundTarget {
   const { cfg, entry } = params;
   const heartbeat = params.heartbeat ?? cfg.agents?.defaults?.heartbeat;
+  const forceLastTargetWhenNone = params.forceLastTargetWhenNone === true;
   const rawTarget = heartbeat?.target;
   let target: HeartbeatTarget = "none";
   if (rawTarget === "none" || rawTarget === "last") {
@@ -255,13 +257,19 @@ export function resolveHeartbeatDeliveryTarget(params: {
     }
   }
 
-  if (target === "none") {
+  if (target === "none" && !forceLastTargetWhenNone) {
     const base = resolveSessionDeliveryTarget({ entry });
     return buildNoHeartbeatDeliveryTarget({
       reason: "target-none",
       lastChannel: base.lastChannel,
       lastAccountId: base.lastAccountId,
     });
+  }
+
+  // For async exec completion events, always fall back to the session's last
+  // delivery target even when heartbeat target is explicitly set to "none".
+  if (target === "none" && forceLastTargetWhenNone) {
+    target = "last";
   }
 
   const resolvedTarget = resolveSessionDeliveryTarget({


### PR DESCRIPTION
📝 Summary
This PR reintroduces and extends the async-session routing fix on top of current `main`.

It resolves two related issues for async exec flows:
1. wake signals losing session context in non-main sessions, and
2. exec completion replies being handled internally (not delivered back to the originating channel) when `heartbeat.target = none`.

As a result, async exec responses now reliably route back to the original session/channel (e.g. Discord channel/thread) without requiring user config changes.

Note: This supersedes #11888 after upstream refactors.

🔍 Problems Addressed

1. Missing `sessionKey` in wake requests:
- Some paths called `requestHeartbeatNow` without `sessionKey`, which could wake/coalesce on the wrong context (main/default) instead of the originating session.

2. Exec-event delivery suppressed by heartbeat target policy:
- With `heartbeat.target = none`, exec completion runs were treated as internal-only, so model output was generated but not sent back to the user channel.

🛠 Changes

Gateway
- `src/gateway/server/hooks.ts`
  - Pass `sessionKey` when triggering heartbeat for hook wake, success, and error paths.

Heartbeat delivery
- `src/infra/outbound/targets.ts`
  - Add `forceLastTargetWhenNone` to heartbeat delivery resolution.
  - When enabled, `target=none` falls back to session `last` target instead of hard no-delivery.

- `src/infra/heartbeat-runner.ts`
  - For exec-event runs, call delivery resolution with `forceLastTargetWhenNone: true`.
  - This ensures async exec completion responses are relayed to the originating channel/session.

Tests
- `src/infra/heartbeat-runner.returns-default-unset.test.ts`
  - Update exec target-none case to assert delivery to last channel and user-facing exec prompt.
  - Keep cron target-none behavior internal-only.

- `src/gateway/server-node-events.test.ts`
  - Update assertions to verify session-scoped heartbeat behavior with canonical agent session keys.

Before:
<img width="1572" height="565" alt="image" src="https://github.com/user-attachments/assets/03687e01-e287-48d7-a024-fecd64cab113" />
After:
<img width="1551" height="554" alt="image" src="https://github.com/user-attachments/assets/9167fc7e-0b94-488f-a805-37c663def060" />
✅ Behavioral Result

- Async exec completion responses now return to the original channel/session by default.
- Non-main sessions (Discord/Slack/etc.) no longer lose wake context in hook-related paths.
- Cron/reminder internal-only behavior under `target=none` remains unchanged.

 Why this matters
This ensures the feedback loop for async actions is session-aware. Users in specialized sessions (Discord/Slack) will no longer be "ghosted" by the bot after long-running tasks or manual approvals.

Fixes #14191 #39978   #29215 

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes async context loss in exec operations and webhook wakes by propagating `sessionKey` to the heartbeat system. The changes ensure that execution results and webhook notifications reach the correct session (Discord threads/DMs, Slack channels) instead of defaulting to the main session.

The implementation adds `sessionKey` to four `requestHeartbeatNow` call sites:
- `bash-tools.exec-runtime.ts`: propagates sessionKey on exec completion and exit notifications
- `server-node-events.ts`: includes sessionKey from remote node exec events (started/finished/denied)
- `server/hooks.ts`: passes sessionKey from wake hook dispatcher

Test coverage is comprehensive, with all test assertions updated to verify sessionKey propagation.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it's a targeted fix that adds proper context propagation without changing core logic
- The changes are focused, well-tested, and address a specific bug. The implementation correctly propagates sessionKey through the call chain, and tests verify the behavior. Score reduced from 5 due to one observation: `dispatchAgentHook` in `hooks.ts` has two `requestHeartbeatNow` calls (lines 93, 101) that weren't updated with sessionKey. While events go to mainSessionKey, those heartbeats might also benefit from explicit sessionKey for consistency - though this may be intentional behavior for agent hooks vs wake hooks.
- `src/gateway/server/hooks.ts` - verify whether `dispatchAgentHook` heartbeats on lines 93 and 101 should also include mainSessionKey

<sub>Last reviewed commit: f96b4f3</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->