### PR TITLE
feat(gateway): expose session entry id on chat history messages

### DIFF
--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -380,6 +380,53 @@ describe("readSessionMessages", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  test("preserves session entry id on messages when present", () => {
+    const sessionId = "test-session-entry-id";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: sessionId }),
+      JSON.stringify({ id: "entry-1", message: { role: "user", content: "Hello" } }),
+      JSON.stringify({ id: "entry-2", message: { role: "assistant", content: "World" } }),
+      JSON.stringify({ message: { role: "user", content: "No id entry" } }),
+    ];
+    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
+
+    const out = readSessionMessages(sessionId, storePath);
+    expect(out).toHaveLength(3);
+
+    const first = out[0] as Record<string, unknown>;
+    expect(first.id).toBe("entry-1");
+    expect(first.role).toBe("user");
+    expect(first.content).toBe("Hello");
+
+    const second = out[1] as Record<string, unknown>;
+    expect(second.id).toBe("entry-2");
+    expect(second.role).toBe("assistant");
+    expect(second.content).toBe("World");
+
+    const third = out[2] as Record<string, unknown>;
+    expect(third.id).toBeUndefined();
+    expect(third.role).toBe("user");
+  });
+
+  test("does not overwrite existing id field on message", () => {
+    const sessionId = "test-session-existing-id";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({
+        id: "entry-1",
+        message: { role: "assistant", content: "Hi", id: "msg-own-id" },
+      }),
+    ];
+    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
+
+    const out = readSessionMessages(sessionId, storePath);
+    expect(out).toHaveLength(1);
+
+    const msg = out[0] as Record<string, unknown>;
+    expect(msg.id).toBe("msg-own-id");
+  });
+
   test("includes synthetic compaction markers for compaction entries", () => {
     const sessionId = "test-session-compaction";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -33,7 +33,12 @@ export function readSessionMessages(
     try {
       const parsed = JSON.parse(line);
       if (parsed?.message) {
-        messages.push(parsed.message);
+        const msg = parsed.message as Record<string, unknown>;
+        if (typeof parsed.id === "string" && !("id" in msg)) {
+          messages.push({ ...msg, id: parsed.id });
+        } else {
+          messages.push(msg);
+        }
         continue;
       }
 


### PR DESCRIPTION
## Summary

- `readSessionMessages()` now copies the Pi session entry `id` onto each message object returned to clients
- Enables the WebChat UI to use a stable, server-assigned identifier for exact message dedup during history reconciliation — replacing the current fuzzy heuristic (role + content + timestamp ±30s)
- Entry id is only added when the message does not already carry its own `id` field, so existing messages are never clobbered

## Test plan

- [x] Added test: entry IDs are preserved on messages when present in transcript
- [x] Added test: messages without entry IDs are returned unchanged
- [x] Added test: a message's own `id` field is never overwritten by the entry ID
- [x] All 38 existing tests in `session-utils.fs.test.ts` continue to pass
- [x] Lint and format hooks pass with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds session entry IDs to chat history messages returned by `readSessionMessages()`, enabling the WebChat UI to use stable server-assigned identifiers for exact message deduplication instead of the current fuzzy heuristic based on role + content + timestamp.

**Changes:**
- Modified `readSessionMessages()` in `session-utils.fs.ts` to copy the Pi session entry `id` field onto message objects when the entry has an ID and the message doesn't already have its own `id` field
- Added two comprehensive tests validating that entry IDs are preserved when present and that existing message `id` fields are never overwritten
- All 38 existing tests continue to pass

**Implementation quality:**
- The logic correctly checks both that `parsed.id` is a string and that the message doesn't already have an `id` field using the `in` operator
- Safe spread operator usage creates a shallow copy with the new field
- Proper handling of edge cases (non-string IDs, missing IDs, existing message IDs)
- Follows existing code patterns in the file

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, defensive, and well-tested. It adds a non-breaking feature (copying entry IDs to messages) with proper guards to prevent overwriting existing IDs. The change is backward-compatible, has comprehensive test coverage including edge cases, and all existing tests pass. The code follows repository conventions and handles all identified edge cases correctly.
- No files require special attention

<sub>Last reviewed commit: 3f68622</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->