### PR TITLE
fix(mattermost): stream tool status + preserve channel/thread history

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -3,7 +3,7 @@ import { createMattermostClient, patchMattermostPost } from "./client.js";
 
 describe("mattermost client", () => {
   it("request returns undefined on 204 responses", async () => {
-    const fetchImpl = vi.fn(async () => {
+    const fetchImpl = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(async () => {
       return new Response(null, { status: 204 });
     });
 
@@ -18,7 +18,7 @@ describe("mattermost client", () => {
   });
 
   it("patchMattermostPost updates a post via /patch endpoint", async () => {
-    const fetchImpl = vi.fn(async () => {
+    const fetchImpl = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(async () => {
       return new Response(JSON.stringify({ id: "post-123", message: "updated" }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -38,8 +38,12 @@ describe("mattermost client", () => {
 
     expect(post).toMatchObject({ id: "post-123", message: "updated" });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const [url, init] = fetchImpl.mock.calls[0]!;
     expect(url).toBe("https://chat.example.com/api/v4/posts/post-123/patch");
+    expect(init).toBeDefined();
+    if (!init) {
+      throw new Error("expected fetch init for patch request");
+    }
     expect(init.method).toBe("PUT");
     expect(String(init.body)).toBe(JSON.stringify({ message: "updated" }));
   });

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createMattermostClient } from "./client.js";
+import { createMattermostClient, patchMattermostPost } from "./client.js";
 
 describe("mattermost client", () => {
   it("request returns undefined on 204 responses", async () => {
@@ -15,5 +15,32 @@ describe("mattermost client", () => {
 
     const result = await client.request<unknown>("/anything", { method: "DELETE" });
     expect(result).toBeUndefined();
+  });
+
+  it("patchMattermostPost updates a post via /patch endpoint", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(JSON.stringify({ id: "post-123", message: "updated" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const client = createMattermostClient({
+      baseUrl: "https://chat.example.com",
+      botToken: "test-token",
+      fetchImpl: fetchImpl as any,
+    });
+
+    const post = await patchMattermostPost(client, {
+      postId: "post-123",
+      message: "updated",
+    });
+
+    expect(post).toMatchObject({ id: "post-123", message: "updated" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://chat.example.com/api/v4/posts/post-123/patch");
+    expect(init.method).toBe("PUT");
+    expect(String(init.body)).toBe(JSON.stringify({ message: "updated" }));
   });
 });

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -190,6 +190,25 @@ export async function createMattermostPost(
   });
 }
 
+export async function patchMattermostPost(
+  client: MattermostClient,
+  params: {
+    postId: string;
+    message: string;
+  },
+): Promise<MattermostPost> {
+  const postId = params.postId?.trim();
+  if (!postId) {
+    throw new Error("Mattermost post id is required");
+  }
+  return await client.request<MattermostPost>(`/posts/${postId}/patch`, {
+    method: "PUT",
+    body: JSON.stringify({
+      message: params.message,
+    }),
+  });
+}
+
 export async function uploadMattermostFile(
   client: MattermostClient,
   params: {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -964,15 +964,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           disableBlockStreaming:
             typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
           onPartialReply: async (payload) => {
-            await replyOptions.onPartialReply?.(payload);
             queueStreamPreviewUpdate(payload.text);
           },
           onReasoningStream: async (payload) => {
-            await replyOptions.onReasoningStream?.(payload);
             queueStreamPreviewUpdate(payload.text);
           },
           onToolStart: async (payload) => {
-            await replyOptions.onToolStart?.(payload);
             queueStreamPreviewUpdate(buildMattermostToolStatusText(payload));
           },
           onModelSelected,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -14,6 +14,7 @@ import {
   logInboundDrop,
   logTypingFailure,
   buildPendingHistoryContextFromMap,
+  clearHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
   isDangerousNameMatchingEnabled,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -14,7 +14,6 @@ import {
   logInboundDrop,
   logTypingFailure,
   buildPendingHistoryContextFromMap,
-  clearHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
   isDangerousNameMatchingEnabled,
@@ -30,11 +29,13 @@ import {
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
+  createMattermostPost,
   createMattermostClient,
   fetchMattermostChannel,
   fetchMattermostMe,
   fetchMattermostUser,
   normalizeMattermostBaseUrl,
+  patchMattermostPost,
   sendMattermostTyping,
   type MattermostChannel,
   type MattermostPost,
@@ -78,6 +79,8 @@ const RECENT_MATTERMOST_MESSAGE_TTL_MS = 5 * 60_000;
 const RECENT_MATTERMOST_MESSAGE_MAX = 2000;
 const CHANNEL_CACHE_TTL_MS = 5 * 60_000;
 const USER_CACHE_TTL_MS = 10 * 60_000;
+const MATTERMOST_STREAM_PREVIEW_MAX_CHARS = 4000;
+const MATTERMOST_STREAM_PREVIEW_THROTTLE_MS = 1000;
 
 const recentInboundMessages = createDedupeCache({
   ttlMs: RECENT_MATTERMOST_MESSAGE_TTL_MS,
@@ -169,6 +172,23 @@ function buildMattermostWsUrl(baseUrl: string): string {
   }
   const wsBase = normalized.replace(/^http/i, "ws");
   return `${wsBase}/api/v4/websocket`;
+}
+
+function normalizeMattermostStreamPreviewText(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+}
+
+function buildMattermostToolStatusText(params: { name?: string; phase?: string }): string {
+  const phase = params.phase === "update" ? "Running" : "Starting";
+  const tool = params.name?.trim() ? ` \`${params.name.trim()}\`` : " tool";
+  return `Status: ${phase}${tool}...`;
 }
 
 export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}): Promise<void> {
@@ -518,6 +538,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     });
     const sessionKey = threadKeys.sessionKey;
     const historyKey = kind === "direct" ? null : sessionKey;
+    const threadLabel = threadRootId ? `Mattermost thread ${roomLabel}` : undefined;
 
     const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, route.agentId);
     const wasMentioned =
@@ -587,6 +608,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     if (!bodyText) {
       return;
     }
+    const currentHistoryEntry =
+      historyKey && bodyText.trim()
+        ? {
+            sender: senderName,
+            body: bodyText.trim(),
+            timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
+            messageId: post.id ?? undefined,
+          }
+        : null;
 
     core.channel.activity.record({
       channel: "mattermost",
@@ -687,6 +717,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         allMessageIds.length > 1 ? allMessageIds[allMessageIds.length - 1] : undefined,
       ReplyToId: threadRootId,
       MessageThreadId: threadRootId,
+      ThreadLabel: threadLabel,
       Timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
       WasMentioned: kind !== "direct" ? effectiveWasMentioned : undefined,
       CommandAuthorized: commandAuthorized,
@@ -748,14 +779,146 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         });
       },
     });
+    const streamPreviewMaxChars = Math.min(textLimit, MATTERMOST_STREAM_PREVIEW_MAX_CHARS);
+    let streamPreviewPostId: string | undefined;
+    let streamPreviewLastText = "";
+    let streamPreviewPendingText: string | undefined;
+    let streamPreviewLastSentAt = 0;
+    let streamPreviewDisabled = false;
+    let streamPreviewTimer: ReturnType<typeof setTimeout> | undefined;
+    let streamPreviewQueue: Promise<void> = Promise.resolve();
+
+    const updateStreamPreviewNow = async (text: string): Promise<void> => {
+      if (streamPreviewDisabled) {
+        return;
+      }
+      const normalized = normalizeMattermostStreamPreviewText(text, streamPreviewMaxChars);
+      if (!normalized || normalized === streamPreviewLastText) {
+        return;
+      }
+      try {
+        if (streamPreviewPostId) {
+          await patchMattermostPost(client, {
+            postId: streamPreviewPostId,
+            message: normalized,
+          });
+        } else {
+          const sent = await createMattermostPost(client, {
+            channelId,
+            message: normalized,
+            rootId: threadRootId,
+          });
+          const postId = sent.id?.trim();
+          if (!postId) {
+            throw new Error("missing preview post id");
+          }
+          streamPreviewPostId = postId;
+        }
+        streamPreviewLastText = normalized;
+        streamPreviewLastSentAt = Date.now();
+      } catch (err) {
+        streamPreviewDisabled = true;
+        logVerboseMessage(`mattermost stream preview disabled: ${String(err)}`);
+      }
+    };
+
+    const flushQueuedStreamPreview = async (): Promise<void> => {
+      const nextText = streamPreviewPendingText;
+      streamPreviewPendingText = undefined;
+      if (!nextText || streamPreviewDisabled) {
+        return;
+      }
+      await updateStreamPreviewNow(nextText);
+      if (streamPreviewPendingText && !streamPreviewTimer) {
+        const elapsed = Date.now() - streamPreviewLastSentAt;
+        const delay = Math.max(0, MATTERMOST_STREAM_PREVIEW_THROTTLE_MS - elapsed);
+        streamPreviewTimer = setTimeout(() => {
+          streamPreviewTimer = undefined;
+          streamPreviewQueue = streamPreviewQueue.then(flushQueuedStreamPreview).catch(() => {});
+        }, delay);
+      }
+    };
+
+    const queueStreamPreviewUpdate = (text?: string): void => {
+      if (streamPreviewDisabled) {
+        return;
+      }
+      const normalized = normalizeMattermostStreamPreviewText(text ?? "", streamPreviewMaxChars);
+      if (!normalized) {
+        return;
+      }
+      streamPreviewPendingText = normalized;
+      const elapsed = Date.now() - streamPreviewLastSentAt;
+      if (elapsed >= MATTERMOST_STREAM_PREVIEW_THROTTLE_MS && !streamPreviewTimer) {
+        streamPreviewQueue = streamPreviewQueue.then(flushQueuedStreamPreview).catch(() => {});
+        return;
+      }
+      if (!streamPreviewTimer) {
+        const delay = Math.max(0, MATTERMOST_STREAM_PREVIEW_THROTTLE_MS - elapsed);
+        streamPreviewTimer = setTimeout(() => {
+          streamPreviewTimer = undefined;
+          streamPreviewQueue = streamPreviewQueue.then(flushQueuedStreamPreview).catch(() => {});
+        }, delay);
+      }
+    };
+
+    const flushStreamPreview = async (): Promise<void> => {
+      if (streamPreviewTimer) {
+        clearTimeout(streamPreviewTimer);
+        streamPreviewTimer = undefined;
+      }
+      streamPreviewQueue = streamPreviewQueue.then(flushQueuedStreamPreview).catch(() => {});
+      await streamPreviewQueue;
+    };
+
+    const previewTextForPayload = (payload: ReplyPayload): string => {
+      return core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode).trim();
+    };
+
+    const finalizeStreamPreviewWithPayload = async (payload: ReplyPayload): Promise<boolean> => {
+      const finalText = previewTextForPayload(payload);
+      const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+      const canFinalizeViaEdit =
+        Boolean(streamPreviewPostId) &&
+        mediaUrls.length === 0 &&
+        !payload.isError &&
+        finalText.length > 0 &&
+        finalText.length <= streamPreviewMaxChars;
+      if (!canFinalizeViaEdit || !streamPreviewPostId) {
+        return false;
+      }
+      try {
+        await patchMattermostPost(client, {
+          postId: streamPreviewPostId,
+          message: finalText,
+        });
+        streamPreviewLastText = finalText;
+        streamPreviewLastSentAt = Date.now();
+        return true;
+      } catch (err) {
+        logVerboseMessage(`mattermost stream final edit failed: ${String(err)}`);
+        return false;
+      }
+    };
+
     const { dispatcher, replyOptions, markDispatchIdle } =
       core.channel.reply.createReplyDispatcherWithTyping({
         ...prefixOptions,
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
         typingCallbacks,
         deliver: async (payload: ReplyPayload) => {
+          await flushStreamPreview();
+          if (await finalizeStreamPreviewWithPayload(payload)) {
+            runtime.log?.(`delivered streamed reply to ${to}`);
+            return;
+          }
+
           const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
           const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+          if (streamPreviewPostId && mediaUrls.length > 0) {
+            queueStreamPreviewUpdate("Status: complete. Final answer posted below.");
+            await flushStreamPreview();
+          }
           if (mediaUrls.length === 0) {
             const chunkMode = core.channel.text.resolveChunkMode(
               cfg,
@@ -791,30 +954,41 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         },
       });
 
-    await core.channel.reply.withReplyDispatcher({
-      dispatcher,
-      onSettled: () => {
-        markDispatchIdle();
-      },
-      run: () =>
-        core.channel.reply.dispatchReplyFromConfig({
-          ctx: ctxPayload,
-          cfg,
-          dispatcher,
-          replyOptions: {
-            ...replyOptions,
-            disableBlockStreaming:
-              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-            onModelSelected,
+    try {
+      await core.channel.reply.dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          ...replyOptions,
+          disableBlockStreaming:
+            typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+          onPartialReply: async (payload) => {
+            await replyOptions.onPartialReply?.(payload);
+            queueStreamPreviewUpdate(payload.text);
           },
-        }),
-    });
-    if (historyKey) {
-      clearHistoryEntriesIfEnabled({
-        historyMap: channelHistories,
-        historyKey,
-        limit: historyLimit,
+          onReasoningStream: async (payload) => {
+            await replyOptions.onReasoningStream?.(payload);
+            queueStreamPreviewUpdate(payload.text);
+          },
+          onToolStart: async (payload) => {
+            await replyOptions.onToolStart?.(payload);
+            queueStreamPreviewUpdate(buildMattermostToolStatusText(payload));
+          },
+          onModelSelected,
+        },
       });
+    } finally {
+      await flushStreamPreview();
+      markDispatchIdle();
+      if (historyKey) {
+        recordPendingHistoryEntryIfEnabled({
+          historyMap: channelHistories,
+          historyKey,
+          limit: historyLimit,
+          entry: currentHistoryEntry,
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Example: Before vs Now

### Before
- Thread context had no explicit channel-vs-thread label.
- Tool/reasoning progress was not visible in-channel during generation.
- With `historyLimit > 0`, internal context flags in affected Mattermost channel/thread turns still showed `history_count: 0`.

### Now
- Thread runs include a dedicated `ThreadLabel` (`Mattermost thread <room>`) in context.
- Streaming preview/status updates are visible in-channel during generation.
- History is preserved by recording the current inbound entry after dispatch, so subsequent turns can include prior context up to the configured limit.

## Streaming Finalization Rules

| Case | Behavior |
| --- | --- |
| Text-only final reply (<= preview cap) | Edit the preview/status post into final answer |
| Media reply or oversized final text | Keep status update and send final answer as normal post |
| Preview post update failure | Disable preview updates and fall back to normal delivery |

## What Changed
- add Mattermost post patch support (`PUT /posts/{id}/patch`) with unit coverage
- add streamed status preview queue/throttle for partial/reasoning/tool-start events
- preserve history by recording the current inbound entry after dispatch completion
- include `ThreadLabel` in context payload for thread/channel distinction

## Testing
- `pnpm -s vitest extensions/mattermost/src/mattermost/client.test.ts`
- `pnpm check`
