### PR TITLE
fix(edit): include line numbers in duplicate match errors

### DIFF
--- a/src/agents/pi-tools.read.edit-line-numbers.test.ts
+++ b/src/agents/pi-tools.read.edit-line-numbers.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSandboxedEditTool } from "./pi-tools.read.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+
+describe("edit tool - line numbers in duplicate match errors", () => {
+  it("should include line numbers when multiple occurrences are found", async () => {
+    const testContent = `line 1
+line 2
+const foo = 'bar';
+line 4
+const foo = 'bar';
+line 6`;
+
+    const mockBridge: SandboxFsBridge = {
+      readFile: vi.fn(async () => Buffer.from(testContent, "utf-8")),
+      writeFile: vi.fn(async () => {}),
+      stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+      mkdirp: vi.fn(async () => {}),
+    };
+
+    const tool = createSandboxedEditTool({
+      root: "/test",
+      bridge: mockBridge,
+    });
+
+    await expect(
+      tool.execute("test-call", {
+        path: "test.ts",
+        oldText: "const foo = 'bar';",
+        newText: "const foo = 'baz';",
+      }),
+    ).rejects.toThrow(/Found 2 occurrences.*\(lines 3, 5\)/);
+  });
+
+  it("should include line numbers for multi-line text", async () => {
+    const testContent = `function test() {
+  return 42;
+}
+some other code
+function test() {
+  return 42;
+}`;
+
+    const mockBridge: SandboxFsBridge = {
+      readFile: vi.fn(async () => Buffer.from(testContent, "utf-8")),
+      writeFile: vi.fn(async () => {}),
+      stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+      mkdirp: vi.fn(async () => {}),
+    };
+
+    const tool = createSandboxedEditTool({
+      root: "/test",
+      bridge: mockBridge,
+    });
+
+    await expect(
+      tool.execute("test-call", {
+        path: "test.ts",
+        oldText: `function test() {
+  return 42;
+}`,
+        newText: `function test() {
+  return 100;
+}`,
+      }),
+    ).rejects.toThrow(/Found 2 occurrences.*\(lines 1, 5\)/);
+  });
+
+  it("should handle many occurrences with truncation", async () => {
+    const lines: string[] = [];
+    for (let i = 1; i <= 20; i++) {
+      lines.push(`line ${i}`);
+      if (i % 2 === 0) {
+        lines.push("duplicate line");
+      }
+    }
+    const testContent = lines.join("\n");
+
+    const mockBridge: SandboxFsBridge = {
+      readFile: vi.fn(async () => Buffer.from(testContent, "utf-8")),
+      writeFile: vi.fn(async () => {}),
+      stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+      mkdirp: vi.fn(async () => {}),
+    };
+
+    const tool = createSandboxedEditTool({
+      root: "/test",
+      bridge: mockBridge,
+    });
+
+    await expect(
+      tool.execute("test-call", {
+        path: "test.ts",
+        oldText: "duplicate line",
+        newText: "unique line",
+      }),
+    ).rejects.toThrow(/\(lines 3, 6, 9, 12, 15\.\.\. \(10 total\)\)/);
+  });
+
+  it("should work normally when text is unique", async () => {
+    const testContent = `line 1
+const foo = 'bar';
+line 3`;
+
+    const mockBridge: SandboxFsBridge = {
+      readFile: vi.fn(async () => Buffer.from(testContent, "utf-8")),
+      writeFile: vi.fn(async () => {}),
+      stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+      mkdirp: vi.fn(async () => {}),
+    };
+
+    const tool = createSandboxedEditTool({
+      root: "/test",
+      bridge: mockBridge,
+    });
+
+    const result = await tool.execute("test-call", {
+      path: "test.ts",
+      oldText: "const foo = 'bar';",
+      newText: "const foo = 'baz';",
+    });
+
+    expect(result).toMatchObject({
+      content: expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("Successfully replaced"),
+        }),
+      ]),
+    });
+  });
+});

--- a/src/agents/pi-tools.read.edit-line-numbers.test.ts
+++ b/src/agents/pi-tools.read.edit-line-numbers.test.ts
@@ -14,9 +14,13 @@ line 6`;
     const mockBridge: SandboxFsBridge = {
       readFile: vi.fn(async () => Buffer.from(testContent, "utf-8")),
       writeFile: vi.fn(async () => {}),
-      stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+      stat: vi.fn(async () => ({
+        type: "file" as const,
+        size: testContent.length,
+        mtimeMs: Date.now(),
+      })),
       mkdirp: vi.fn(async () => {}),
-    };
+    } as unknown as SandboxFsBridge;
 
     const tool = createSandboxedEditTool({
       root: "/test",
@@ -44,9 +48,13 @@ function test() {
     const mockBridge: SandboxFsBridge = {
       readFile: vi.fn(async () => Buffer.from(testContent, "utf-8")),
       writeFile: vi.fn(async () => {}),
-      stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+      stat: vi.fn(async () => ({
+        type: "file" as const,
+        size: testContent.length,
+        mtimeMs: Date.now(),
+      })),
       mkdirp: vi.fn(async () => {}),
-    };
+    } as unknown as SandboxFsBridge;
 
     const tool = createSandboxedEditTool({
       root: "/test",
@@ -79,9 +87,13 @@ function test() {
     const mockBridge: SandboxFsBridge = {
       readFile: vi.fn(async () => Buffer.from(testContent, "utf-8")),
       writeFile: vi.fn(async () => {}),
-      stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+      stat: vi.fn(async () => ({
+        type: "file" as const,
+        size: testContent.length,
+        mtimeMs: Date.now(),
+      })),
       mkdirp: vi.fn(async () => {}),
-    };
+    } as unknown as SandboxFsBridge;
 
     const tool = createSandboxedEditTool({
       root: "/test",
@@ -105,9 +117,13 @@ line 3`;
     const mockBridge: SandboxFsBridge = {
       readFile: vi.fn(async () => Buffer.from(testContent, "utf-8")),
       writeFile: vi.fn(async () => {}),
-      stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+      stat: vi.fn(async () => ({
+        type: "file" as const,
+        size: testContent.length,
+        mtimeMs: Date.now(),
+      })),
       mkdirp: vi.fn(async () => {}),
-    };
+    } as unknown as SandboxFsBridge;
 
     const tool = createSandboxedEditTool({
       root: "/test",


### PR DESCRIPTION
## Summary

Enhances the edit tool error message to include line numbers when multiple occurrences of `oldText` are found, enabling agents to recover by reading the relevant lines and expanding `oldText` with surrounding context.

## Problem

When the `edit` tool finds more than one occurrence of `old_string`, it returns:

```
Found 2 occurrences of the text in <file>. The text must be unique. Please provide more context to make it unique.
```

This is correct behavior — ambiguous edits should be rejected. However, the error gives the agent **no actionable information** to recover with. The agent knows it needs more context, but doesn't know *where* in the file the duplicates are, so it can't easily construct a larger unique `old_string`.

In practice, agents (Codex, Claude Code) tend to **give up and stop** rather than retry with expanded context, because the retry requires reading the whole file and manually finding surrounding lines.

## Changes

The error message now includes the **line numbers** where the duplicate matches were found:

```
Found 2 occurrences of the text in <file> (lines 284, 292). The text must be unique. Please provide more context to make it unique.
```

With line numbers, an agent can:
1. Immediately read only the relevant lines
2. Expand `old_string` to include the surrounding function signature (which is unique)
3. Retry the edit successfully — without reading the entire file

## Implementation

- Added `wrapEditToolWithLineNumbers` wrapper function in `src/agents/pi-tools.read.ts`
- Intercepts "Found X occurrences" errors from the base edit tool
- Reads the file and finds all line numbers where `oldText` appears (supports multi-line text)
- Enhances the error message with line numbers (truncates to first 5 if more than 5 total)
- Falls back to original error if enhancement fails

## Tests

Added `src/agents/pi-tools.read.edit-line-numbers.test.ts` with test cases:
- Single-line duplicate text
- Multi-line duplicate text
- Many occurrences (truncation test)
- Unique text (normal operation)

All tests pass ✅

Fixes #21645

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the edit tool error messaging by adding line numbers when duplicate text matches are found. When an edit operation fails due to multiple occurrences of `oldText`, the error now includes line numbers (e.g., "Found 2 occurrences... (lines 3, 5)") instead of just the count. This enables agents to immediately identify where duplicates exist and expand `oldText` with surrounding context to make it unique.

The implementation uses a wrapper function that intercepts duplicate match errors, reads the file to find all occurrence line numbers, and reconstructs the error message with this additional context. The wrapper handles multi-line text correctly and truncates to show only the first 5 line numbers if there are more than 5 occurrences.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a non-breaking enhancement with solid test coverage
- The change is well-isolated (wrapper pattern), thoroughly tested with 4 test cases covering single-line, multi-line, truncation, and normal operation scenarios. The error handling is defensive with fallback to original error if enhancement fails. No breaking changes to existing functionality.
- No files require special attention

<sub>Last reviewed commit: 6ec8597</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->