### PR TITLE
feat(whatsapp): add replyToOfflineMessages config to process missed messages after reconnect

### DIFF
--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -64,7 +64,9 @@ export async function handleFeishuCardAction(params: {
     },
   };
 
-  log(`feishu[${account.accountId}]: handling card action from ${event.operator.open_id}: ${content}`);
+  log(
+    `feishu[${account.accountId}]: handling card action from ${event.operator.open_id}: ${content}`,
+  );
 
   // Dispatch as normal message
   await handleFeishuMessage({

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -78,6 +78,10 @@ type WhatsAppSharedConfig = {
   debounceMs?: number;
   /** Heartbeat visibility settings. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Process offline/catch-up messages received after reconnect (default: false). */
+  replyToOfflineMessages?: boolean;
+  /** Maximum age in seconds for offline messages to be processed (default: 300). Messages older than this are still skipped. Only applies when replyToOfflineMessages is true. */
+  offlineMessageMaxAgeSeconds?: number;
 };
 
 type WhatsAppConfigCore = {
@@ -93,6 +97,10 @@ type WhatsAppConfigCore = {
   messagePrefix?: string;
   /** Outbound response prefix override. */
   responsePrefix?: string;
+  /** Process offline/catch-up messages received after reconnect (default: false). */
+  replyToOfflineMessages?: boolean;
+  /** Maximum age in seconds for offline messages to be processed (default: 300). Messages older than this are still skipped. Only applies when replyToOfflineMessages is true. */
+  offlineMessageMaxAgeSeconds?: number;
 };
 
 export type WhatsAppConfig = WhatsAppConfigCore &

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -29,6 +29,8 @@ export type ResolvedWhatsAppAccount = {
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  replyToOfflineMessages: boolean;
+  offlineMessageMaxAgeSeconds: number;
 };
 
 const { listConfiguredAccountIds, listAccountIds, resolveDefaultAccountId } =
@@ -144,6 +146,8 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
+    replyToOfflineMessages: accountCfg?.replyToOfflineMessages ?? rootCfg?.replyToOfflineMessages ?? false,
+    offlineMessageMaxAgeSeconds: accountCfg?.offlineMessageMaxAgeSeconds ?? rootCfg?.offlineMessageMaxAgeSeconds ?? 300,
   };
 }
 

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -146,8 +146,10 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
-    replyToOfflineMessages: accountCfg?.replyToOfflineMessages ?? rootCfg?.replyToOfflineMessages ?? false,
-    offlineMessageMaxAgeSeconds: accountCfg?.offlineMessageMaxAgeSeconds ?? rootCfg?.offlineMessageMaxAgeSeconds ?? 300,
+    replyToOfflineMessages:
+      accountCfg?.replyToOfflineMessages ?? rootCfg?.replyToOfflineMessages ?? false,
+    offlineMessageMaxAgeSeconds:
+      accountCfg?.offlineMessageMaxAgeSeconds ?? rootCfg?.offlineMessageMaxAgeSeconds ?? 300,
   };
 }
 

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -202,6 +202,8 @@ export async function monitorWebChannel(
       authDir: account.authDir,
       mediaMaxMb: account.mediaMaxMb,
       sendReadReceipts: account.sendReadReceipts,
+      replyToOfflineMessages: account.replyToOfflineMessages,
+      offlineMessageMaxAgeSeconds: account.offlineMessageMaxAgeSeconds,
       debounceMs: inboundDebounceMs,
       shouldDebounce,
       onMessage: async (msg: WebInboundMsg) => {

--- a/src/web/monitor-inbox.processes-offline-messages-when-enabled.test.ts
+++ b/src/web/monitor-inbox.processes-offline-messages-when-enabled.test.ts
@@ -10,7 +10,6 @@ import {
 
 describe("web monitor inbox – offline messages", () => {
   installWebMonitorInboxUnitTestHooks();
-  type InboxOnMessage = NonNullable<Parameters<typeof monitorWebInbox>[0]["onMessage"]>;
 
   async function tick() {
     await new Promise((resolve) => setImmediate(resolve));

--- a/src/web/monitor-inbox.processes-offline-messages-when-enabled.test.ts
+++ b/src/web/monitor-inbox.processes-offline-messages-when-enabled.test.ts
@@ -1,0 +1,133 @@
+import "./monitor-inbox.test-harness.js";
+import { describe, expect, it, vi } from "vitest";
+import { monitorWebInbox } from "./inbound.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  getAuthDir,
+  getSock,
+  installWebMonitorInboxUnitTestHooks,
+} from "./monitor-inbox.test-harness.js";
+
+describe("web monitor inbox – offline messages", () => {
+  installWebMonitorInboxUnitTestHooks();
+  type InboxOnMessage = NonNullable<Parameters<typeof monitorWebInbox>[0]["onMessage"]>;
+
+  async function tick() {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  function buildMessageUpsert(params: {
+    id: string;
+    remoteJid: string;
+    text: string;
+    timestamp: number;
+    type: "notify" | "append";
+    pushName?: string;
+  }) {
+    return {
+      type: params.type,
+      messages: [
+        {
+          key: {
+            id: params.id,
+            fromMe: false,
+            remoteJid: params.remoteJid,
+          },
+          message: { conversation: params.text },
+          messageTimestamp: params.timestamp,
+          pushName: params.pushName,
+        },
+      ],
+    };
+  }
+
+  it("skips append messages by default", async () => {
+    const onMessage = vi.fn(async () => {});
+    const listener = await monitorWebInbox({
+      verbose: false,
+      onMessage,
+      accountId: DEFAULT_ACCOUNT_ID,
+      authDir: getAuthDir(),
+    });
+    const sock = getSock();
+
+    const upsert = buildMessageUpsert({
+      id: "offline-1",
+      remoteJid: "999@s.whatsapp.net",
+      text: "missed message",
+      timestamp: Math.floor(Date.now() / 1000),
+      type: "append",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await tick();
+
+    expect(onMessage).not.toHaveBeenCalled();
+    await listener.close();
+  });
+
+  it("processes append messages when replyToOfflineMessages is true", async () => {
+    const onMessage = vi.fn(async () => {});
+    const listener = await monitorWebInbox({
+      verbose: false,
+      onMessage,
+      accountId: DEFAULT_ACCOUNT_ID,
+      authDir: getAuthDir(),
+      replyToOfflineMessages: true,
+    });
+    const sock = getSock();
+
+    const upsert = buildMessageUpsert({
+      id: "offline-2",
+      remoteJid: "999@s.whatsapp.net",
+      text: "missed message",
+      timestamp: Math.floor(Date.now() / 1000),
+      type: "append",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await tick();
+
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ body: "missed message" }),
+    );
+    await listener.close();
+  });
+
+  it("skips old append messages even when replyToOfflineMessages is true", async () => {
+    vi.useFakeTimers();
+    try {
+      const now = 1_700_000_600;
+      vi.setSystemTime(now * 1000);
+
+      const onMessage = vi.fn(async () => {});
+      const listener = await monitorWebInbox({
+        verbose: false,
+        onMessage,
+        accountId: DEFAULT_ACCOUNT_ID,
+        authDir: getAuthDir(),
+        replyToOfflineMessages: true,
+        offlineMessageMaxAgeSeconds: 300,
+      });
+      const sock = getSock();
+
+      // Message is 600 seconds old (> 300s threshold)
+      const upsert = buildMessageUpsert({
+        id: "offline-old",
+        remoteJid: "999@s.whatsapp.net",
+        text: "very old message",
+        timestamp: 1_700_000_000,
+        type: "append",
+      });
+
+      sock.ev.emit("messages.upsert", upsert);
+      await vi.runAllTimersAsync();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(onMessage).not.toHaveBeenCalled();
+      await listener.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/web/monitor-inbox.processes-offline-messages-when-enabled.test.ts
+++ b/src/web/monitor-inbox.processes-offline-messages-when-enabled.test.ts
@@ -88,9 +88,7 @@ describe("web monitor inbox – offline messages", () => {
     sock.ev.emit("messages.upsert", upsert);
     await tick();
 
-    expect(onMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ body: "missed message" }),
-    );
+    expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({ body: "missed message" }));
     await listener.close();
   });
 


### PR DESCRIPTION
## Problem

Closes #19856.

Related issues (all caused by the same `upsert.type === "append"` skip in `monitor.ts`):

**DM messages lost after reconnect/disconnect:**
- #1619 — Messages missed during connection drops (append-type messages skipped)
- #19856 — WhatsApp inbound messages lost after reconnect (408 timeout)
- #18672 — WhatsApp: recent append messages dropped after prekey renegotiation

**Group messages stop working after restart:**
- #1952 — Group inbound messages stop working after gateway restart (closed as config error, but root cause is append skip)
- #2767 — Group messages stop working after gateway restart (references #1619, #1952)
- #20952 — Group messages not working after restart (correct config confirmed)
- #14069 — Group messages stop arriving after relinking device (syncFullHistory: false)

**Other append-related:**
- #904 — Clawdbot messages itself on WhatsApp (closed)
- #13113 — Duplicate of append skip issue
- #14663, #17526, #19025, #19302, #19537 — Various append skip reports (open)
- #1443 — History sync triggers pairing responses (related: append messages reaching access control)
- #20887 — Capture and expose messaging-history.set for chat history search (feature request for the same underlying gap)

This is one of the most frequently reported WhatsApp issues in the project — **15+ issues** across DMs, groups, and various reconnection scenarios, all tracing back to the same 3 lines:

```typescript
// If this is history/offline catch-up, mark read above but skip auto-reply.
if (upsert.type === "append") {
  continue;
}
```

The worst part: messages are **marked as read** (blue tick sent) before being skipped, so senders see the bot read their message but never replied.

## Solution

Add an opt-in `replyToOfflineMessages` config flag (default: `false` for full backward compatibility). When enabled, offline/catch-up messages are processed normally instead of being skipped.

A safety limit `offlineMessageMaxAgeSeconds` (default: 300s / 5 minutes) ensures that only recent offline messages are processed — very old messages from extended disconnects are still skipped to prevent message flooding.

### Changes

- **`src/config/types.whatsapp.ts`** — Add `replyToOfflineMessages` and `offlineMessageMaxAgeSeconds` to both `WhatsAppConfig` and `WhatsAppAccountConfig`
- **`src/web/accounts.ts`** — Resolve the new fields with proper fallback chain (account → root → default)
- **`src/web/inbound/monitor.ts`** — Replace the unconditional `continue` for append messages with configurable logic
- **`src/web/auto-reply/monitor.ts`** — Pass the new options through to the inbox monitor
- **New test** — Verifies: default skip behavior, opt-in processing, and age-based filtering

### Example config

```json
{
  "whatsapp": {
    "replyToOfflineMessages": true,
    "offlineMessageMaxAgeSeconds": 600
  }
}
```

Or per-account:

```json
{
  "whatsapp": {
    "accounts": {
      "main": {
        "replyToOfflineMessages": true,
        "offlineMessageMaxAgeSeconds": 300
      }
    }
  }
}
```

### Safety considerations

- **Default `false`** — No behavior change unless explicitly opted in
- **Age-based filtering** — Prevents message flood after extended disconnects
- **Existing dedupe** — `isRecentInboundMessage()` (20-min TTL, 5000 entries) prevents double-processing
- **Access control** — `connectedAtMs` check already suppresses pairing replies for historical messages

---

> 🤖 AI-assisted PR — lightly tested. Default is `false` so this is a no-op unless explicitly enabled.