### PR TITLE
fix(#21546): OpenAI conditional tool-first prompt

### DIFF
--- a/src/agents/live-model-filter.test.ts
+++ b/src/agents/live-model-filter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isModernModelRef } from "./live-model-filter.js";
+
+describe("isModernModelRef — xAI Grok families", () => {
+  it("recognises grok-4 variants (existing)", () => {
+    expect(isModernModelRef({ provider: "xai", id: "grok-4" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-4-1-fast" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-4-fast" })).toBe(true);
+  });
+
+  it("recognises grok-3 variants (fix #15709)", () => {
+    expect(isModernModelRef({ provider: "xai", id: "grok-3" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-3-fast" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-3-mini" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-3-mini-fast" })).toBe(true);
+  });
+
+  it("recognises grok-2 variants (fix #15709)", () => {
+    expect(isModernModelRef({ provider: "xai", id: "grok-2" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-2-1212" })).toBe(true);
+    expect(isModernModelRef({ provider: "xai", id: "grok-2-vision-1212" })).toBe(true);
+  });
+
+  it("rejects non-xai providers", () => {
+    expect(isModernModelRef({ provider: "openai", id: "grok-3" })).toBe(false);
+    expect(isModernModelRef({ provider: "anthropic", id: "grok-4" })).toBe(false);
+  });
+
+  it("rejects empty/null refs", () => {
+    expect(isModernModelRef({ provider: "", id: "grok-3" })).toBe(false);
+    expect(isModernModelRef({ provider: "xai", id: "" })).toBe(false);
+    expect(isModernModelRef({})).toBe(false);
+  });
+
+  it("still recognises other modern providers", () => {
+    expect(isModernModelRef({ provider: "anthropic", id: "claude-sonnet-4-6" })).toBe(true);
+    expect(isModernModelRef({ provider: "google", id: "gemini-3-pro" })).toBe(true);
+  });
+});

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -23,7 +23,7 @@ const CODEX_MODELS = [
 const GOOGLE_PREFIXES = ["gemini-3"];
 const ZAI_PREFIXES = ["glm-5", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx"];
 const MINIMAX_PREFIXES = ["minimax-m2.1", "minimax-m2.5"];
-const XAI_PREFIXES = ["grok-4"];
+const XAI_PREFIXES = ["grok-2", "grok-3", "grok-4"];
 
 function matchesPrefix(id: string, prefixes: string[]): boolean {
   return prefixes.some((prefix) => id.startsWith(prefix));

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -434,6 +434,7 @@ export function buildAgentSystemPrompt(params: {
     "Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.",
     "Keep narration brief and value-dense; avoid repeating obvious steps.",
     "Use plain human language for narration unless in a technical context.",
+    "CRITICAL (OpenAI/Grok): User action requests = tool call FIRST, text AFTER. No acknowledgments before completion.",
     "",
     ...safetySection,
     "## OpenClaw CLI Quick Reference",

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -376,6 +376,12 @@ export function applyHuggingfaceConfig(cfg: OpenClawConfig): OpenClawConfig {
   return applyAgentDefaultModelPrimary(next, HUGGINGFACE_DEFAULT_MODEL_REF);
 }
 
+/**
+ * Apply xAI provider configuration using the chat completions API mode.
+ * xAI supports two API modes:
+ * - openai-completions (default, chat completions API)
+ * - openai-responses (Responses API with native web_search, x_search, code_execution tools)
+ */
 export function applyXaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
   models[XAI_DEFAULT_MODEL_REF] = {
@@ -398,6 +404,29 @@ export function applyXaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
 export function applyXaiConfig(cfg: OpenClawConfig): OpenClawConfig {
   const next = applyXaiProviderConfig(cfg);
   return applyAgentDefaultModelPrimary(next, XAI_DEFAULT_MODEL_REF);
+}
+
+/**
+ * Apply xAI provider configuration using the Responses API mode.
+ * This enables native xAI server-side tools (web_search, x_search, code_execution).
+ */
+export function applyXaiResponsesApiConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[XAI_DEFAULT_MODEL_REF] = {
+    ...models[XAI_DEFAULT_MODEL_REF],
+    alias: models[XAI_DEFAULT_MODEL_REF]?.alias ?? "Grok",
+  };
+
+  const defaultModel = buildXaiModelDefinition();
+
+  return applyProviderConfigWithDefaultModel(cfg, {
+    agentModels: models,
+    providerId: "xai",
+    api: "openai-responses",
+    baseUrl: XAI_BASE_URL,
+    defaultModel,
+    defaultModelId: XAI_DEFAULT_MODEL_ID,
+  });
 }
 
 export function applyAuthProfileConfig(

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -59,6 +59,7 @@ import {
   buildZaiModelDefinition,
   buildMoonshotModelDefinition,
   buildXaiModelDefinition,
+  XAI_EXTRA_MODELS,
   QIANFAN_BASE_URL,
   QIANFAN_DEFAULT_MODEL_REF,
   KIMI_CODING_MODEL_REF,
@@ -381,6 +382,9 @@ export function applyHuggingfaceConfig(cfg: OpenClawConfig): OpenClawConfig {
  * xAI supports two API modes:
  * - openai-completions (default, chat completions API)
  * - openai-responses (Responses API with native web_search, x_search, code_execution tools)
+ *
+ * Registers grok-4 (default), grok-3, grok-3-fast, grok-3-mini, grok-3-mini-fast,
+ * and grok-2-1212 so all Grok generations work in sub-agents without silent crashes.
  */
 export function applyXaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
@@ -391,12 +395,12 @@ export function applyXaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
 
   const defaultModel = buildXaiModelDefinition();
 
-  return applyProviderConfigWithDefaultModel(cfg, {
+  return applyProviderConfigWithDefaultModels(cfg, {
     agentModels: models,
     providerId: "xai",
     api: "openai-completions",
     baseUrl: XAI_BASE_URL,
-    defaultModel,
+    defaultModels: [defaultModel, ...XAI_EXTRA_MODELS],
     defaultModelId: XAI_DEFAULT_MODEL_ID,
   });
 }
@@ -409,6 +413,7 @@ export function applyXaiConfig(cfg: OpenClawConfig): OpenClawConfig {
 /**
  * Apply xAI provider configuration using the Responses API mode.
  * This enables native xAI server-side tools (web_search, x_search, code_execution).
+ * Registers the same full set of Grok models as applyXaiProviderConfig.
  */
 export function applyXaiResponsesApiConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
@@ -419,12 +424,12 @@ export function applyXaiResponsesApiConfig(cfg: OpenClawConfig): OpenClawConfig 
 
   const defaultModel = buildXaiModelDefinition();
 
-  return applyProviderConfigWithDefaultModel(cfg, {
+  return applyProviderConfigWithDefaultModels(cfg, {
     agentModels: models,
     providerId: "xai",
     api: "openai-responses",
     baseUrl: XAI_BASE_URL,
-    defaultModel,
+    defaultModels: [defaultModel, ...XAI_EXTRA_MODELS],
     defaultModelId: XAI_DEFAULT_MODEL_ID,
   });
 }

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -180,3 +180,51 @@ export function buildXaiModelDefinition(): ModelDefinitionConfig {
     maxTokens: XAI_DEFAULT_MAX_TOKENS,
   };
 }
+
+export const XAI_EXTRA_MODELS: ModelDefinitionConfig[] = [
+  {
+    id: "grok-3",
+    name: "Grok 3",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "grok-3-fast",
+    name: "Grok 3 Fast",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "grok-3-mini",
+    name: "Grok 3 Mini",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "grok-3-mini-fast",
+    name: "Grok 3 Mini Fast",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "grok-2-1212",
+    name: "Grok 2",
+    reasoning: false,
+    input: ["text"],
+    cost: XAI_DEFAULT_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  },
+];


### PR DESCRIPTION
## Summary
Add conditional for OpenAI/xAI models: User action requests = tool call FIRST, text AFTER. No acknowledgments before completion.

This ensures proper tool call ordering for OpenAI and Grok models.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive support for Grok model families (grok-2, grok-3, grok-4) and introduces a tool-first behavior instruction for OpenAI/xAI models. The changes span three commits:

- **Extended Grok model prefix support**: Updated `live-model-filter.ts` to recognize grok-2 and grok-3 model families (previously only grok-4)
- **Model definitions registration**: Added `XAI_EXTRA_MODELS` array defining grok-3, grok-3-fast, grok-3-mini, grok-3-mini-fast, and grok-2-1212 with proper configuration including cost, context window, and max tokens
- **Responses API support**: Added `applyXaiResponsesApiConfig()` to enable native xAI server-side tools (web_search, x_search, code_execution)
- **Tool-first prompt instruction**: Added system prompt guidance directing OpenAI/Grok models to call tools first, then provide text responses

The changes ensure users receive clear API-level permission errors instead of silent crashes when their xAI key lacks access to a model, and improve tool call ordering for these model families.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are well-structured additions with proper test coverage. The new model definitions follow existing patterns, the system prompt addition is non-breaking, and the test suite validates the core functionality. The changes fix real issues (silent crashes, model recognition failures) without modifying existing behavior.
- No files require special attention

<sub>Last reviewed commit: 84ad852</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->