### PR TITLE
skills: treat allowBundled [] as denylist for bundled skills

### DIFF
--- a/src/agents/skills.buildworkspaceskillstatus.e2e.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.e2e.test.ts
@@ -89,6 +89,39 @@ describe("buildWorkspaceSkillStatus", () => {
     }
   });
 
+  it("blocks all bundled skills when allowlist is empty", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-"));
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const bundledSkillDir = path.join(bundledDir, "peekaboo");
+    const originalBundled = process.env.OPENCLAW_BUNDLED_SKILLS_DIR;
+
+    await writeSkill({
+      dir: bundledSkillDir,
+      name: "peekaboo",
+      description: "Capture UI",
+      body: "# Peekaboo\n",
+    });
+
+    try {
+      process.env.OPENCLAW_BUNDLED_SKILLS_DIR = bundledDir;
+      const report = buildWorkspaceSkillStatus(workspaceDir, {
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        config: { skills: { allowBundled: [] } },
+      });
+      const skill = report.skills.find((entry) => entry.name === "peekaboo");
+
+      expect(skill).toBeDefined();
+      expect(skill?.blockedByAllowlist).toBe(true);
+      expect(skill?.eligible).toBe(false);
+    } finally {
+      if (originalBundled === undefined) {
+        delete process.env.OPENCLAW_BUNDLED_SKILLS_DIR;
+      } else {
+        process.env.OPENCLAW_BUNDLED_SKILLS_DIR = originalBundled;
+      }
+    }
+  });
+
   it("filters install options by OS", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-"));
     const skillDir = path.join(workspaceDir, "skills", "install-skill");

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -43,7 +43,7 @@ function normalizeAllowlist(input: unknown): string[] | undefined {
     return undefined;
   }
   const normalized = input.map((entry) => String(entry).trim()).filter(Boolean);
-  return normalized.length > 0 ? normalized : undefined;
+  return normalized;
 }
 
 const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
@@ -57,8 +57,11 @@ export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | und
 }
 
 export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): boolean {
-  if (!allowlist || allowlist.length === 0) {
+  if (allowlist === undefined) {
     return true;
+  }
+  if (allowlist.length === 0) {
+    return false;
   }
   if (!isBundledSkill(entry)) {
     return true;


### PR DESCRIPTION
## Summary
- Fixes an issue where `skills.allowBundled: []` was being normalized to `undefined` and interpreted as an allow-all state.
- Normalizes allowlist values to preserve empty arrays so empty config is now treated as an explicit denylist.
- Updates bundled-skill eligibility logic so:
  - `allowBundled: undefined` keeps current behavior (bundled skills allowed by default).
  - `allowBundled: []` blocks all bundled skills.
- Adds e2e regression coverage in `src/agents/skills.buildworkspaceskillstatus.e2e.test.ts`.

## Testing
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/skills.buildworkspaceskillstatus.e2e.test.ts`
- `pnpm test:fast`

Closes #21709.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a normalization bug where `allowBundled: []` was incorrectly treated as allow-all instead of deny-all. The change preserves empty arrays through normalization and adds explicit logic to distinguish between undefined (default allow-all) and empty array (explicit deny-all). E2e test coverage added for the empty array case.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - clean bug fix with targeted changes and test coverage
- The fix is minimal and focused, changing only the normalization logic to preserve empty arrays. The distinction between `undefined` (allow-all) and `[]` (deny-all) is now explicit and well-tested. No breaking changes to existing functionality.
- No files require special attention

<sub>Last reviewed commit: 344cda1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->