### PR TITLE
fix(boot): deduplicate startup notification within restart cycle

### DIFF
--- a/src/gateway/boot.test.ts
+++ b/src/gateway/boot.test.ts
@@ -11,7 +11,7 @@ vi.mock("../commands/agent.js", () => ({
   agentCommandFromIngress: agentCommand,
 }));
 
-const { runBootOnce } = await import("./boot.js");
+const { runBootOnce, _resetBootDedup } = await import("./boot.js");
 const { resolveAgentIdFromSessionKey, resolveAgentMainSessionKey, resolveMainSessionKey } =
   await import("../config/sessions/main-session.js");
 const { resolveStorePath } = await import("../config/sessions/paths.js");
@@ -37,6 +37,7 @@ describe("runBootOnce", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    _resetBootDedup();
     const { storePath } = resolveMainStore();
     await fs.rm(storePath, { force: true });
   });
@@ -258,6 +259,67 @@ describe("runBootOnce", () => {
       });
 
       expectMainSessionRestored({ storePath, sessionKey });
+    });
+  });
+
+  describe("startup notification deduplication", () => {
+    it("sends notification on the first boot run", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-boot-"));
+      await fs.writeFile(path.join(workspaceDir, "BOOT.md"), "Say hello.", "utf-8");
+
+      agentCommand.mockResolvedValue(undefined);
+      await expect(runBootOnce({ cfg: {}, deps: makeDeps(), workspaceDir })).resolves.toEqual({
+        status: "ran",
+      });
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    });
+
+    it("skips notification on subsequent boot runs within the same process lifecycle", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-boot-"));
+      await fs.writeFile(path.join(workspaceDir, "BOOT.md"), "Say hello.", "utf-8");
+
+      agentCommand.mockResolvedValue(undefined);
+
+      // First run should proceed normally.
+      await expect(runBootOnce({ cfg: {}, deps: makeDeps(), workspaceDir })).resolves.toEqual({
+        status: "ran",
+      });
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+
+      // Second run (simulating a second gateway restart within the same OS process)
+      // must be skipped — the user should not receive a duplicate notification.
+      await expect(runBootOnce({ cfg: {}, deps: makeDeps(), workspaceDir })).resolves.toEqual({
+        status: "skipped",
+        reason: "already-ran",
+      });
+      // agentCommand must NOT have been called a second time.
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    });
+
+    it("dedup flag is reset by _resetBootDedup (simulates fresh process)", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-boot-"));
+      await fs.writeFile(path.join(workspaceDir, "BOOT.md"), "Say hello.", "utf-8");
+
+      agentCommand.mockResolvedValue(undefined);
+
+      // First run.
+      await runBootOnce({ cfg: {}, deps: makeDeps(), workspaceDir });
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+
+      // Simulate a full process restart (gateway daemon stopped and re-launched).
+      _resetBootDedup();
+
+      // After reset, the next run should be allowed.
+      await expect(runBootOnce({ cfg: {}, deps: makeDeps(), workspaceDir })).resolves.toEqual({
+        status: "ran",
+      });
+      expect(agentCommand).toHaveBeenCalledTimes(2);
+
+      await fs.rm(workspaceDir, { recursive: true, force: true });
     });
   });
 });


### PR DESCRIPTION
## Problem

When the gateway recovers from a repeated config-invalid restart loop, multiple boot sessions may have been queued (one per restart cycle). All of them can complete in a short window, and each independently sends the startup notification defined in `BOOT.md`. The user ends up receiving duplicate online messages.

**Log evidence** (2026-02-20 08:10–08:15 config-invalid loop, recovered at 08:16):

- `boot-2026-02-20_08-16-21-094-3b733d68` → sent notification ✓
- `boot-2026-02-20_08-16-58-928-b27bd200` → sent duplicate notification ✗

## Root Cause

`startGatewaySidecars` is called on every gateway restart. Each call fires a `gateway:startup` hook event that is handled by `runBootChecklist` → `runBootOnce`. There was no guard to prevent `runBootOnce` from executing more than once per OS-process lifetime.

## Fix Approach

Added a module-level boolean flag `_bootNotificationSent` in `src/gateway/boot.ts`.

- The flag is checked **synchronously** at the top of `runBootOnce`. If it is already set, the function returns immediately with `{ status: "skipped", reason: "already-ran" }`.
- The flag is set **synchronously** (before any `await`) once we decide to proceed, making the read-then-write atomic at the JavaScript level (Node.js is single-threaded). This prevents race conditions from concurrent event-loop ticks.
- Because the flag lives in module scope it is **automatically reset** when the gateway daemon process exits and restarts — the right granularity for this dedup.
- A test-only `_resetBootDedup()` export allows unit tests to reset the flag between cases.

**Files changed:**

| File | Change |
|------|--------|
| `src/gateway/boot.ts` | Add dedup flag + guard in `runBootOnce`; update `BootRunResult` type |
| `src/gateway/boot.test.ts` | Add `_resetBootDedup` to `beforeEach`; add 3 dedup-specific test cases |

## Testing

Unit tests added in `src/gateway/boot.test.ts` under a new `startup notification deduplication` describe block:

1. **First run sends notification** — `agentCommand` is called once.
2. **Second run within same process is skipped** — `agentCommand` is **not** called a second time; result is `{ status: "skipped", reason: "already-ran" }`.
3. **`_resetBootDedup` restores normal behaviour** — simulates a fresh OS-process restart; the next run is allowed through.

All 10 tests pass (`pnpm vitest run src/gateway/boot.test.ts`). `pnpm check` (format + type-check + lint) exits clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents duplicate startup notifications when the gateway recovers from repeated restart cycles by adding a module-level deduplication flag. The flag is checked synchronously at the top of `runBootOnce` and set before any async operations, ensuring atomicity in Node.js's single-threaded event loop. The flag naturally resets on full process restart, which is the correct granularity for this dedup. Implementation includes comprehensive test coverage for first run, subsequent runs within the same process, and reset behavior.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - implements targeted fix with comprehensive test coverage
- The fix correctly addresses the duplicate notification issue with a simple, atomic deduplication mechanism. The flag is set synchronously before any async operations, preventing race conditions. Test coverage is thorough, including reset behavior for unit tests. The module-level scope ensures automatic cleanup on process restart, which is the correct granularity for this use case.
- No files require special attention

<sub>Last reviewed commit: d0a3502</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->