### PR TITLE
fix: skills.allowBundled: [] should block all bundled skills

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -238,7 +238,6 @@ This is often easier than hand-editing JSON manifests.
 
 ## Onboarding (minimal)
 
-
 1. **Install the Microsoft Teams plugin**
    - From npm: `openclaw plugins install @openclaw/msteams`
    - From a local checkout: `openclaw plugins install ./extensions/msteams`

--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  isBundledSkillAllowed,
-  resolveBundledAllowlist,
-  type SkillEntry,
-} from "./config.js";
+import { isBundledSkillAllowed, resolveBundledAllowlist, type SkillEntry } from "./config.js";
 
 function mockBundledEntry(name: string): SkillEntry {
   return {

--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  isBundledSkillAllowed,
+  resolveBundledAllowlist,
+  type SkillEntry,
+} from "./config.js";
+
+function mockBundledEntry(name: string): SkillEntry {
+  return {
+    skill: { name, source: "openclaw-bundled", description: "" },
+    frontmatter: {},
+  };
+}
+
+function mockWorkspaceEntry(name: string): SkillEntry {
+  return {
+    skill: { name, source: "workspace", description: "" },
+    frontmatter: {},
+  };
+}
+
+describe("allowBundled", () => {
+  describe("resolveBundledAllowlist", () => {
+    it("returns undefined when allowBundled is not set", () => {
+      expect(resolveBundledAllowlist({})).toBeUndefined();
+      expect(resolveBundledAllowlist({ skills: {} })).toBeUndefined();
+    });
+
+    it("returns [] when allowBundled is empty array (block all bundled)", () => {
+      const cfg = { skills: { allowBundled: [] } };
+      expect(resolveBundledAllowlist(cfg)).toEqual([]);
+    });
+
+    it("returns normalized list when allowBundled has entries", () => {
+      const cfg = { skills: { allowBundled: ["github", "slack"] } };
+      expect(resolveBundledAllowlist(cfg)).toEqual(["github", "slack"]);
+    });
+  });
+
+  describe("isBundledSkillAllowed", () => {
+    it("allows all when allowlist is undefined", () => {
+      const bundled = mockBundledEntry("any-bundled");
+      expect(isBundledSkillAllowed(bundled, undefined)).toBe(true);
+    });
+
+    it("blocks all bundled when allowlist is empty array", () => {
+      const bundled = mockBundledEntry("github");
+      expect(isBundledSkillAllowed(bundled, [])).toBe(false);
+    });
+
+    it("allows non-bundled skills even when allowlist is empty", () => {
+      const workspace = mockWorkspaceEntry("my-skill");
+      expect(isBundledSkillAllowed(workspace, [])).toBe(true);
+    });
+
+    it("allows bundled skill only when listed", () => {
+      const bundled = mockBundledEntry("github");
+      expect(isBundledSkillAllowed(bundled, ["slack"])).toBe(false);
+      expect(isBundledSkillAllowed(bundled, ["github"])).toBe(true);
+    });
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -36,14 +36,14 @@ export function resolveSkillConfig(
 }
 
 function normalizeAllowlist(input: unknown): string[] | undefined {
-  if (!input) {
+  if (input === undefined || input === null) {
     return undefined;
   }
   if (!Array.isArray(input)) {
     return undefined;
   }
   const normalized = input.map((entry) => String(entry).trim()).filter(Boolean);
-  return normalized.length > 0 ? normalized : undefined;
+  return normalized;
 }
 
 const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
@@ -57,11 +57,14 @@ export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | und
 }
 
 export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): boolean {
-  if (!allowlist || allowlist.length === 0) {
+  if (allowlist === undefined) {
     return true;
   }
   if (!isBundledSkill(entry)) {
     return true;
+  }
+  if (allowlist.length === 0) {
+    return false;
   }
   const key = resolveSkillKey(entry.skill, entry);
   return allowlist.includes(key) || allowlist.includes(entry.skill.name);

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1,10 +1,10 @@
 import { createHmac, createHash } from "node:crypto";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
+import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 
 /**

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -1,5 +1,5 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { createHash } from "node:crypto";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 export type ToolCallIdMode = "strict" | "strict9";
 


### PR DESCRIPTION
- 修复空 allowlist 被错误处理的问题
- 空数组现在正确阻止所有 bundled skills
- 保持向后兼容（非空数组行为不变）

Fixes openclaw/openclaw#21709

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the handling of empty `allowBundled` arrays to correctly block all bundled skills instead of allowing them. The fix distinguishes between `undefined` (allow all - default) and `[]` (block all - intentional), maintaining backward compatibility for non-empty arrays.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal, well-tested, and correctly addresses the bug without breaking backward compatibility. The logic change is clear: empty arrays now properly return `[]` instead of `undefined`, and the check distinguishes between undefined and empty arrays.
- No files require special attention

<sub>Last reviewed commit: ef9be1b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->