### PR TITLE
Fix: clear stale session runtime model on /new, /reset, and session_status default

### DIFF
--- a/src/agents/openclaw-tools.session-status.e2e.test.ts
+++ b/src/agents/openclaw-tools.session-status.e2e.test.ts
@@ -218,6 +218,8 @@ describe("session_status tool", () => {
       main: {
         sessionId: "s1",
         updatedAt: 10,
+        modelProvider: "anthropic",
+        model: "claude-opus-4-6",
         providerOverride: "anthropic",
         modelOverride: "claude-sonnet-4-5",
         authProfileOverride: "p1",
@@ -233,6 +235,8 @@ describe("session_status tool", () => {
       Record<string, unknown>,
     ];
     const saved = savedStore.main as Record<string, unknown>;
+    expect(saved.modelProvider).toBeUndefined();
+    expect(saved.model).toBeUndefined();
     expect(saved.providerOverride).toBeUndefined();
     expect(saved.modelOverride).toBeUndefined();
     expect(saved.authProfileOverride).toBeUndefined();

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -342,7 +342,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         verboseLevel: entry?.verboseLevel,
         reasoningLevel: entry?.reasoningLevel,
         responseUsage: entry?.responseUsage,
-        model: entry?.model,
         contextTokens: entry?.contextTokens,
         sendPolicy: entry?.sendPolicy,
         label: entry?.label,

--- a/src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts
@@ -160,6 +160,8 @@ describe("gateway server sessions", () => {
         main: {
           sessionId: "sess-main",
           updatedAt: recent,
+          modelProvider: "openai",
+          model: "gpt-test-a",
           inputTokens: 10,
           outputTokens: 20,
           thinkingLevel: "low",
@@ -414,11 +416,13 @@ describe("gateway server sessions", () => {
     const reset = await rpcReq<{
       ok: true;
       key: string;
-      entry: { sessionId: string };
+      entry: { sessionId: string; model?: string; modelProvider?: string };
     }>(ws, "sessions.reset", { key: "agent:main:main" });
     expect(reset.ok).toBe(true);
     expect(reset.payload?.key).toBe("agent:main:main");
     expect(reset.payload?.entry.sessionId).not.toBe("sess-main");
+    expect(reset.payload?.entry.model).toBeUndefined();
+    expect(reset.payload?.entry.modelProvider).toBeUndefined();
     const filesAfterReset = await fs.readdir(dir);
     expect(filesAfterReset.some((f) => f.startsWith("sess-main.jsonl.reset."))).toBe(true);
 

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import { applyModelOverrideToSessionEntry } from "./model-overrides.js";
+
+describe("applyModelOverrideToSessionEntry", () => {
+  it("clears model and override state when default is selected", () => {
+    const entry: SessionEntry = {
+      sessionId: "s",
+      updatedAt: 10,
+      modelProvider: "openai",
+      model: "gpt-4.1",
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6",
+      authProfileOverride: "p1",
+      authProfileOverrideSource: "user",
+      fallbackNoticeSelectedModel: "foo",
+    };
+
+    const { updated } = applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        isDefault: true,
+      },
+    });
+
+    expect(updated).toBe(true);
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.model).toBeUndefined();
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.authProfileOverride).toBeUndefined();
+    expect(entry.authProfileOverrideSource).toBeUndefined();
+    expect(entry.fallbackNoticeSelectedModel).toBeUndefined();
+  });
+
+  it("sets override state when default is not selected", () => {
+    const entry: SessionEntry = {
+      sessionId: "s",
+      updatedAt: 10,
+    };
+
+    const { updated } = applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "openai",
+        model: "gpt-4.1",
+        isDefault: false,
+      },
+    });
+
+    expect(updated).toBe(true);
+    expect(entry.providerOverride).toBe("openai");
+    expect(entry.modelOverride).toBe("gpt-4.1");
+  });
+});

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -17,6 +17,14 @@ export function applyModelOverrideToSessionEntry(params: {
   let updated = false;
 
   if (selection.isDefault) {
+    if (entry.modelProvider) {
+      delete entry.modelProvider;
+      updated = true;
+    }
+    if (entry.model) {
+      delete entry.model;
+      updated = true;
+    }
     if (entry.providerOverride) {
       delete entry.providerOverride;
       updated = true;


### PR DESCRIPTION
## Summary
Resolves stale runtime model leakage after reset flows by ensuring session runtime model metadata is fully cleared when users reset model state to defaults.

## What changed
- Updated shared model override helper (`src/sessions/model-overrides.ts`) to clear persisted runtime fields (`model` and `modelProvider`) when `model=default` is applied.
- Updated `sessions.reset` handler (`src/gateway/server-methods/sessions.ts`) to avoid carrying forward `model` from the old session when creating a new session entry.
- Added/extended tests to enforce behavior:
  - `src/sessions/model-overrides.test.ts`: verifies default reset clears model/runtime metadata and overrides.
  - `src/agents/openclaw-tools.session-status.e2e.test.ts`: verifies `session_status(model=default)` persists model cleanup.
  - `src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts`: verifies `sessions.reset` response clears runtime model metadata.

## Why this fixes it
`session_status(model=default)` and `/new`/`/reset` paths used shared model override behavior, but runtime `model` and `modelProvider` were not being reset, so gateway resume logic kept reusing stale override values. This update makes the reset semantics explicit and consistent:
- session scoped live model resolves from store state after reset.
- default model resets remove runtime leftovers instead of leaving stale values.

## Validation
- `pnpm check`
- `pnpm test`
- `pnpm vitest run src/sessions/model-overrides.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/openclaw-tools.session-status.e2e.test.ts src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts`

## Related issue
Closes #21725

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clears runtime model state (`model` and `modelProvider`) when resetting to default model configuration. Updated `applyModelOverrideToSessionEntry` to delete runtime fields when `isDefault=true`, removed `model` field copying in `sessions.reset`, and added tests to verify the cleanup behavior persists across `session_status(model=default)` and `/new`/`/reset` flows.

<h3>Confidence Score: 5/5</h3>

- 5/5 because behavior change is tightly scoped and deterministic: exactly the two reset pathways that rehydrate runtime model metadata were updated, with no API contract changes.
- The implementation is minimal and symmetry-driven:
  - `applyModelOverrideToSessionEntry` now removes stale persisted model values when users choose `model=default`.
  - `sessions.reset` no longer copies `model` forward when building the replacement session entry.
- Verification is direct and targeted:
  - New unit tests enforce nulling `model`/`modelProvider` in the shared helper path.
  - e2E coverage validates both command-based (`session_status`) and protocol-level (`sessions.reset`) reset semantics.
  - Full suite checks (`pnpm check`, `pnpm test`) passed after the change, reducing risk of unrelated regressions.
- Rollback cost is low (revert one focused commit if needed); there is no schema migration and no dependency change.
- No files require special attention, and there are no observed side-effects for non-default model usage.

<sub>Last reviewed commit: d4f828f</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->
