### PR TITLE
fix(plugin-sdk): re-export missing plugin authoring types

### DIFF
--- a/src/plugin-sdk/index.test.ts
+++ b/src/plugin-sdk/index.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type {
+  OpenClawPluginDefinition,
+  OpenClawPluginModule,
+  OpenClawPluginToolContext,
+  OpenClawPluginToolFactory,
+  OpenClawPluginToolOptions,
+} from "./index.js";
 import * as sdk from "./index.js";
 
 describe("plugin-sdk exports", () => {
@@ -45,5 +52,13 @@ describe("plugin-sdk exports", () => {
     for (const key of forbidden) {
       expect(Object.prototype.hasOwnProperty.call(sdk, key)).toBe(false);
     }
+  });
+
+  it("re-exports plugin authoring types", () => {
+    expectTypeOf<OpenClawPluginDefinition>().toEqualTypeOf<OpenClawPluginDefinition>();
+    expectTypeOf<OpenClawPluginModule>().toEqualTypeOf<OpenClawPluginModule>();
+    expectTypeOf<OpenClawPluginToolContext>().toEqualTypeOf<OpenClawPluginToolContext>();
+    expectTypeOf<OpenClawPluginToolFactory>().toEqualTypeOf<OpenClawPluginToolFactory>();
+    expectTypeOf<OpenClawPluginToolOptions>().toEqualTypeOf<OpenClawPluginToolOptions>();
   });
 });

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -64,8 +64,13 @@ export type { ChannelConfigSchema, ChannelPlugin } from "../channels/plugins/typ
 export type {
   AnyAgentTool,
   OpenClawPluginApi,
+  OpenClawPluginDefinition,
+  OpenClawPluginModule,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
+  OpenClawPluginToolContext,
+  OpenClawPluginToolFactory,
+  OpenClawPluginToolOptions,
   ProviderAuthContext,
   ProviderAuthResult,
 } from "../plugins/types.js";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The `openclaw/plugin-sdk` barrel did not re-export key plugin authoring types (`OpenClawPluginDefinition`, `OpenClawPluginToolContext`, etc.), so they were not importable from the public SDK path.
- Why it matters: Plugin authors could not reference default plugin definition and tool factory/context types from the official SDK entrypoint, which hurts type-safe plugin development DX.
- What changed: Added 5 missing type re-exports to `src/plugin-sdk/index.ts` from `../plugins/types.js`, and added a type re-export smoke test in `src/plugin-sdk/index.test.ts`.
- What did NOT change (scope boundary): No runtime logic changes in plugin loading/execution, no config schema changes, and no protocol behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Plugin authors can now import the following types directly from `openclaw/plugin-sdk`:
`OpenClawPluginDefinition`, `OpenClawPluginToolContext`, `OpenClawPluginToolFactory`, `OpenClawPluginToolOptions`, `OpenClawPluginModule`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm build:plugin-sdk:dts`
2. `pnpm test src/plugin-sdk/index.test.ts`
3. `pnpm check`
4. `pnpm build`

### Expected

- `dist/plugin-sdk/plugin-sdk/index.d.ts` re-exports the previously missing plugin authoring types.
- plugin-sdk export tests pass.

### Actual

- Matches expectation.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Generated `dist/plugin-sdk/plugin-sdk/index.d.ts` snippet:

```ts
export type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginDefinition, OpenClawPluginModule, OpenClawPluginService, OpenClawPluginServiceContext, OpenClawPluginToolContext, OpenClawPluginToolFactory, OpenClawPluginToolOptions, ProviderAuthContext, ProviderAuthResult, } from "../plugins/types.js";
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed the 5 missing types are exported from the `openclaw/plugin-sdk` barrel in source and generated declaration output.
- Edge cases checked: Confirmed existing runtime export guard test (`does not expose runtime modules`) still passes.
- What you did **not** verify: Full `pnpm test` is not green due to unrelated pre-existing/environmental failures (for example loopback bind `EPERM` in this sandbox).

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR to restore the prior export surface.
- Files/config to restore: `src/plugin-sdk/index.ts`, `src/plugin-sdk/index.test.ts`
- Known bad symptoms reviewers should watch for: Type import failures for the newly exposed plugin types from `openclaw/plugin-sdk`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Slight increase in public SDK type surface to maintain.
  - Mitigation: Type-only re-exports (no runtime impact) plus smoke test coverage for regression prevention.
