### PR TITLE
security(exec): platform-aware allowlist matching and restricted safe-bin trust

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -96,7 +96,8 @@ If a prompt is required but no UI is reachable, fallback decides:
 ## Allowlist (per agent)
 
 Allowlists are **per agent**. If multiple agents exist, switch which agent you’re
-editing in the macOS app. Patterns are **case-insensitive glob matches**.
+editing in the macOS app. Patterns are glob matches:
+case-insensitive on Windows and macOS, case-sensitive on Linux.
 Patterns should resolve to **binary paths** (basename-only entries are ignored).
 Legacy `agents.default` entries are migrated to `agents.main` on load.
 
@@ -133,8 +134,8 @@ behavior (for example `sort -o/--output` and grep recursive flags).
 Safe bins also force argv tokens to be treated as **literal text** at execution time (no globbing
 and no `$VARS` expansion) for stdin-only segments, so patterns like `*` or `$HOME/...` cannot be
 used to smuggle file reads.
-Safe bins must also resolve from trusted binary directories (system defaults plus the gateway
-process `PATH` at startup). This blocks request-scoped PATH hijacking attempts.
+Safe bins must also resolve from trusted binary directories (system defaults only by default).
+This blocks request-scoped PATH hijacking attempts and avoids implicit trust from `PATH`.
 Shell chaining and redirections are not auto-allowed in allowlist mode.
 
 Shell chaining (`&&`, `||`, `;`) is allowed when every top-level segment satisfies the allowlist

--- a/src/infra/exec-approvals-analysis.ts
+++ b/src/infra/exec-approvals-analysis.ts
@@ -115,7 +115,8 @@ function normalizeMatchTarget(value: string): string {
     const stripped = value.replace(/^\\\\[?.]\\/, "");
     return stripped.replace(/\\/g, "/").toLowerCase();
   }
-  return value.replace(/\\\\/g, "/").toLowerCase();
+  const normalized = value.replace(/\\\\/g, "/");
+  return process.platform === "darwin" ? normalized.toLowerCase() : normalized;
 }
 
 function tryRealpath(value: string): string | null {
@@ -126,7 +127,7 @@ function tryRealpath(value: string): string | null {
   }
 }
 
-function globToRegExp(pattern: string): RegExp {
+function globToRegExp(pattern: string, caseInsensitive: boolean): RegExp {
   let regex = "^";
   let i = 0;
   while (i < pattern.length) {
@@ -151,7 +152,7 @@ function globToRegExp(pattern: string): RegExp {
     i += 1;
   }
   regex += "$";
-  return new RegExp(regex, "i");
+  return new RegExp(regex, caseInsensitive ? "i" : undefined);
 }
 
 function matchesPattern(pattern: string, target: string): boolean {
@@ -169,7 +170,8 @@ function matchesPattern(pattern: string, target: string): boolean {
   }
   normalizedPattern = normalizeMatchTarget(normalizedPattern);
   normalizedTarget = normalizeMatchTarget(normalizedTarget);
-  const regex = globToRegExp(normalizedPattern);
+  const caseInsensitive = process.platform === "win32" || process.platform === "darwin";
+  const regex = globToRegExp(normalizedPattern, caseInsensitive);
   return regex.test(normalizedTarget);
 }
 

--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -73,6 +73,21 @@ describe("exec approvals allowlist matching", () => {
     expect(match).toBeNull();
   });
 
+  it("treats allowlist matching as case-insensitive on Windows/macOS, case-sensitive otherwise", () => {
+    const resolution = {
+      rawExecutable: "rg",
+      resolvedPath: "/opt/homebrew/bin/rg",
+      executableName: "rg",
+    };
+    const entries: ExecAllowlistEntry[] = [{ pattern: "/OPT/**/RG" }];
+    const match = matchAllowlist(entries, resolution);
+    if (process.platform === "win32" || process.platform === "darwin") {
+      expect(match?.pattern).toBe("/OPT/**/RG");
+      return;
+    }
+    expect(match).toBeNull();
+  });
+
   it("requires a resolved path", () => {
     const resolution = {
       rawExecutable: "bin/rg",

--- a/src/infra/exec-safe-bin-trust.test.ts
+++ b/src/infra/exec-safe-bin-trust.test.ts
@@ -7,11 +7,25 @@ import {
 } from "./exec-safe-bin-trust.js";
 
 describe("exec safe bin trust", () => {
-  it("builds trusted dirs from defaults and injected PATH", () => {
+  it("builds trusted dirs from defaults only by default", () => {
     const dirs = buildTrustedSafeBinDirs({
       pathEnv: "/custom/bin:/alt/bin:/custom/bin",
       delimiter: ":",
       baseDirs: ["/usr/bin"],
+    });
+
+    expect(dirs.has(path.resolve("/usr/bin"))).toBe(true);
+    expect(dirs.has(path.resolve("/custom/bin"))).toBe(false);
+    expect(dirs.has(path.resolve("/alt/bin"))).toBe(false);
+    expect(dirs.size).toBe(1);
+  });
+
+  it("includes PATH entries only when explicitly enabled", () => {
+    const dirs = buildTrustedSafeBinDirs({
+      pathEnv: "/custom/bin:/alt/bin:/custom/bin",
+      delimiter: ":",
+      baseDirs: ["/usr/bin"],
+      includePathEnv: true,
     });
 
     expect(dirs.has(path.resolve("/usr/bin"))).toBe(true);
@@ -20,19 +34,22 @@ describe("exec safe bin trust", () => {
     expect(dirs.size).toBe(3);
   });
 
-  it("memoizes trusted dirs per PATH snapshot", () => {
+  it("memoizes trusted dirs per PATH snapshot when PATH trust is enabled", () => {
     const a = getTrustedSafeBinDirs({
       pathEnv: "/first/bin",
       delimiter: ":",
       refresh: true,
+      includePathEnv: true,
     });
     const b = getTrustedSafeBinDirs({
       pathEnv: "/first/bin",
       delimiter: ":",
+      includePathEnv: true,
     });
     const c = getTrustedSafeBinDirs({
       pathEnv: "/second/bin",
       delimiter: ":",
+      includePathEnv: true,
     });
 
     expect(a).toBe(b);


### PR DESCRIPTION
## Summary

- Allowlist glob matching follows host filesystem case semantics: case-insensitive
  on Windows and macOS (where the default filesystem is case-insensitive),
  case-sensitive on Linux (ext4/btrfs/etc. are case-sensitive). Previously it was
  always case-insensitive on all platforms, which meant a differently-cased path
  could bypass an allowlist entry on Linux.
- Safe-bin trusted directories now default to hardcoded system paths only
  (/bin, /usr/bin, /usr/local/bin, /opt/homebrew/bin, /opt/local/bin, /snap/bin,
  /run/current-system/sw/bin). PATH entries are no longer implicitly trusted.
  Callers can opt in with `includePathEnv: true` if needed. This prevents a
  manipulated PATH from getting arbitrary binaries auto-approved as safe bins.

## Test plan

- [x] Existing allowlist matching tests pass (72 tests)
- [x] New test: mismatched-case pattern rejected on Linux, accepted on Windows/macOS
- [x] Existing safe-bin trust tests updated for new default (5 tests)
- [x] New test: PATH entries excluded by default, included only with opt-in
- [ ] Verify on Linux that a differently-cased allowlist pattern correctly fails to match

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements two critical security improvements to exec approval logic:

**Platform-aware allowlist matching**: Allowlist glob patterns now follow filesystem case semantics - case-insensitive on Windows/macOS (matching their default case-insensitive filesystems) and case-sensitive on Linux (matching ext4/btrfs behavior). This prevents attackers from bypassing allowlist entries on Linux by using differently-cased paths.

**Restricted safe-bin trust**: Safe-bin trusted directories now default to hardcoded system paths only (`/bin`, `/usr/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, `/opt/local/bin`, `/snap/bin`, `/run/current-system/sw/bin`). PATH entries are excluded by default to prevent PATH manipulation attacks. Callers can opt in with `includePathEnv: true` when needed.

Both changes close real security vulnerabilities:
- The case-sensitivity issue allowed bypass on Linux systems
- The PATH trust issue allowed attackers to manipulate PATH to get arbitrary binaries approved as safe bins

Test coverage includes platform-conditional tests for case sensitivity and explicit tests for the new PATH exclusion behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence - it strengthens security without breaking functionality
- This PR fixes legitimate security vulnerabilities with careful implementation. The changes are well-tested (73+ tests pass), backward-compatible (existing functionality preserved via opt-in flag), and focused on hardening security. The case-sensitivity fix prevents allowlist bypass on Linux, and the PATH restriction prevents manipulation attacks. All test updates properly reflect the new secure-by-default behavior.
- No files require special attention

<sub>Last reviewed commit: 5799945</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->