### PR TITLE
fix(hooks): pass configured model to slug generator (#21650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Hooks/Slug: pass configured model/provider from `resolveDefaultModelForAgent` to `runEmbeddedPiAgent` in `generateSlugViaLLM` so session-memory slug generation respects the user's configured model instead of always falling back to hardcoded `anthropic/claude-opus-4-6` defaults. (#21650)
 - macOS/Build: default release packaging to `BUNDLE_ID=ai.openclaw.mac` in `scripts/package-mac-dist.sh`, so Sparkle feed URL is retained and auto-update no longer fails with an empty appcast feed. (#19750) thanks @loganprit.
 
 - Signal/Outbound: preserve case for Base64 group IDs during outbound target normalization so cross-context routing and policy checks no longer break when group IDs include uppercase characters. (#5578) Thanks @heyhudson.

--- a/src/hooks/llm-slug-generator.model-selection.test.ts
+++ b/src/hooks/llm-slug-generator.model-selection.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression test for #21650:
+ * generateSlugViaLLM must pass the configured model from config to
+ * runEmbeddedPiAgent, not rely on hardcoded anthropic/claude-opus-4-6 defaults.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: vi.fn().mockResolvedValue({
+    payloads: [{ text: "test-slug" }],
+  }),
+}));
+
+const { runEmbeddedPiAgent } = await import("../agents/pi-embedded.js");
+const { generateSlugViaLLM } = await import("./llm-slug-generator.js");
+
+describe("generateSlugViaLLM – model selection (#21650)", () => {
+  afterEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockClear();
+  });
+
+  it("passes configured model/provider to runEmbeddedPiAgent", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.3-codex",
+          },
+        },
+      },
+    };
+
+    await generateSlugViaLLM({ sessionContent: "API design discussion", cfg });
+
+    expect(runEmbeddedPiAgent).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls[0][0];
+    expect(callArgs.provider).toBe("openai-codex");
+    expect(callArgs.model).toBe("gpt-5.3-codex");
+  });
+
+  it("passes anthropic model when that is what is configured", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4.6",
+          },
+        },
+      },
+    };
+
+    await generateSlugViaLLM({ sessionContent: "Bug triage", cfg });
+
+    const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls[0][0];
+    expect(callArgs.provider).toBe("anthropic");
+    expect(callArgs.model).toBe("claude-sonnet-4.6");
+  });
+
+  it("falls back to anthropic defaults when no model is configured", async () => {
+    const cfg: OpenClawConfig = {};
+
+    await generateSlugViaLLM({ sessionContent: "General chat", cfg });
+
+    const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls[0][0];
+    // When nothing is configured, resolveDefaultModelForAgent returns the
+    // hardcoded defaults — this is expected and correct.
+    expect(callArgs.provider).toBe("anthropic");
+    expect(callArgs.model).toBe("claude-opus-4-6");
+  });
+});

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -10,6 +10,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 
@@ -38,6 +39,8 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
+    const resolvedModel = resolveDefaultModelForAgent({ cfg: params.cfg, agentId });
+
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,
       sessionKey: "temp:slug-generator",
@@ -47,6 +50,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
+      provider: resolvedModel.provider,
+      model: resolvedModel.model,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
     });


### PR DESCRIPTION
## Summary

- **Bug**: `generateSlugViaLLM` ignores user-configured model, always falls back to hardcoded `anthropic/claude-opus-4-6`
- **Root cause**: `runEmbeddedPiAgent()` called without `provider`/`model` params in `src/hooks/llm-slug-generator.ts`
- **Fix**: resolve configured model via `resolveDefaultModelForAgent()` and pass it through

Fixes #21650

## Problem

`generateSlugViaLLM()` calls `runEmbeddedPiAgent()` without passing `provider` or `model`. The embedded runner defaults to `DEFAULT_PROVIDER="anthropic"` / `DEFAULT_MODEL="claude-opus-4-6"` (from `src/agents/defaults.ts`), ignoring whatever the user configured in `agents.defaults.model.primary`.

**Before fix:**
```
Config:  agents.defaults.model.primary = "openai-codex/gpt-5.3-codex"
Actual:  runEmbeddedPiAgent called with provider=undefined, model=undefined
Result:  Falls back to anthropic/claude-opus-4-6
```

## Changes

- `src/hooks/llm-slug-generator.ts` — import `resolveDefaultModelForAgent`, call it to resolve the configured model, and pass `provider`/`model` to `runEmbeddedPiAgent()`
- `src/hooks/llm-slug-generator.model-selection.test.ts` — 3 regression tests covering configured non-anthropic model, configured anthropic model, and empty-config fallback
- `CHANGELOG.md` — add fix entry under 2026.2.20

**After fix:**
```
Config:  agents.defaults.model.primary = "openai-codex/gpt-5.3-codex"
Actual:  runEmbeddedPiAgent called with provider="openai-codex", model="gpt-5.3-codex"
```

## Test plan

- [x] New test: configured openai-codex model passes through to runEmbeddedPiAgent
- [x] New test: configured anthropic model passes through correctly
- [x] New test: empty config falls back to anthropic/claude-opus-4-6 defaults (expected behavior)
- [x] All 3 tests pass
- [x] Lint passes (0 errors)
- [x] Format check passes

## E2E verification (DashScope/Qwen)

Verified the full resolution chain with a real DashScope API call using `qwen3.5-plus`:

```
── Step 1: Model resolution ──
  provider: dashscope
  model:    qwen3.5-plus
  ✅ PASS — resolves to dashscope/qwen3.5-plus (not anthropic defaults)

── Step 2: Direct DashScope API call ──
  model used: qwen3.5-plus
  raw slug:   rate-limit
  cleaned:    rate-limit
  ✅ PASS — Qwen returned a valid slug
```

Config used:
```json
{
  "models": {
    "providers": {
      "dashscope": {
        "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode/v1",
        "api": "openai-completions",
        "models": [{ "id": "qwen3.5-plus", "contextWindow": 131072 }]
      }
    }
  },
  "agents": {
    "defaults": {
      "model": { "primary": "dashscope/qwen3.5-plus" }
    }
  }
}
```

This confirms:
1. `resolveDefaultModelForAgent` correctly resolves `dashscope/qwen3.5-plus` from config
2. DashScope API responds to the slug prompt with a valid slug (`rate-limit`)
3. Unit tests verify these resolved params reach `runEmbeddedPiAgent`

## Bug reproduction on main

```
── main branch ──
  provider passed: undefined
  model passed:    undefined
  ❌ BUG CONFIRMED — provider/model are undefined, will default to anthropic/claude-opus-4-6
```

## Effect on User Experience

**Before:** Slug generation always uses anthropic/claude-opus-4-6 regardless of user config, causing failures or unexpected billing for users on non-Anthropic providers.
**After:** Slug generation respects the user's configured model/provider, consistent with all other agent operations.