### PR TITLE
fix(doctor): warn on conflicting exec approval config surfaces

### DIFF
--- a/src/commands/doctor-exec-approvals.test.ts
+++ b/src/commands/doctor-exec-approvals.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ExecApprovalsFile } from "../infra/exec-approvals.js";
+
+// Mock the dependencies
+vi.mock("../infra/exec-approvals.js", () => ({
+  loadExecApprovals: vi.fn(),
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: vi.fn(),
+}));
+
+vi.mock("../cli/command-format.js", () => ({
+  formatCliCommand: (cmd: string) => cmd,
+}));
+
+import { loadExecApprovals } from "../infra/exec-approvals.js";
+import { note } from "../terminal/note.js";
+import { noteExecApprovalsWarnings } from "./doctor-exec-approvals.js";
+
+const mockLoadExecApprovals = vi.mocked(loadExecApprovals);
+const mockNote = vi.mocked(note);
+
+describe("noteExecApprovalsWarnings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("warns when approvals.exec.enabled=false but gating is active", () => {
+    const cfg: OpenClawConfig = {
+      approvals: {
+        exec: {
+          enabled: false,
+        },
+      },
+    };
+
+    const execApprovals: ExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "allowlist",
+        ask: "on-miss",
+      },
+    };
+    mockLoadExecApprovals.mockReturnValue(execApprovals);
+
+    noteExecApprovalsWarnings(cfg);
+
+    expect(mockNote).toHaveBeenCalledTimes(1);
+    const [message, title] = mockNote.mock.calls[0];
+    expect(title).toBe("Exec Approvals");
+    expect(message).toContain("approvals.exec.enabled=false");
+    expect(message).toContain("exec-approvals.json has active gating");
+    expect(message).toContain('security="allowlist"');
+    expect(message).toContain('ask="on-miss"');
+  });
+
+  it("no warning when approvals.exec.enabled=false and gating is disabled", () => {
+    const cfg: OpenClawConfig = {
+      approvals: {
+        exec: {
+          enabled: false,
+        },
+      },
+    };
+
+    const execApprovals: ExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "full",
+        ask: "off",
+      },
+    };
+    mockLoadExecApprovals.mockReturnValue(execApprovals);
+
+    noteExecApprovalsWarnings(cfg);
+
+    expect(mockNote).not.toHaveBeenCalled();
+  });
+
+  it("warns when tools.exec.security differs from exec-approvals.json", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          security: "full",
+        },
+      },
+    };
+
+    const execApprovals: ExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "allowlist",
+      },
+    };
+    mockLoadExecApprovals.mockReturnValue(execApprovals);
+
+    noteExecApprovalsWarnings(cfg);
+
+    expect(mockNote).toHaveBeenCalledTimes(1);
+    const [message] = mockNote.mock.calls[0];
+    expect(message).toContain('tools.exec.security="full"');
+    expect(message).toContain('exec-approvals.json security="allowlist"');
+    expect(message).toContain("takes precedence");
+  });
+
+  it("warns when tools.exec.ask differs from exec-approvals.json", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          ask: "always",
+        },
+      },
+    };
+
+    const execApprovals: ExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        ask: "off",
+      },
+    };
+    mockLoadExecApprovals.mockReturnValue(execApprovals);
+
+    noteExecApprovalsWarnings(cfg);
+
+    expect(mockNote).toHaveBeenCalledTimes(1);
+    const [message] = mockNote.mock.calls[0];
+    expect(message).toContain('tools.exec.ask="always"');
+    expect(message).toContain('exec-approvals.json ask="off"');
+  });
+
+  it("no warning when all configs are aligned", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          security: "allowlist",
+          ask: "on-miss",
+        },
+      },
+    };
+
+    const execApprovals: ExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "allowlist",
+        ask: "on-miss",
+      },
+    };
+    mockLoadExecApprovals.mockReturnValue(execApprovals);
+
+    noteExecApprovalsWarnings(cfg);
+
+    expect(mockNote).not.toHaveBeenCalled();
+  });
+
+  it("no warning when no exec config is set", () => {
+    const cfg: OpenClawConfig = {};
+
+    const execApprovals: ExecApprovalsFile = {
+      version: 1,
+    };
+    mockLoadExecApprovals.mockReturnValue(execApprovals);
+
+    noteExecApprovalsWarnings(cfg);
+
+    expect(mockNote).not.toHaveBeenCalled();
+  });
+
+  it("handles missing defaults in exec-approvals.json gracefully", () => {
+    const cfg: OpenClawConfig = {
+      approvals: {
+        exec: {
+          enabled: false,
+        },
+      },
+    };
+
+    const execApprovals: ExecApprovalsFile = {
+      version: 1,
+      // no defaults set - should use fallback values
+    };
+    mockLoadExecApprovals.mockReturnValue(execApprovals);
+
+    noteExecApprovalsWarnings(cfg);
+
+    // Should warn because default security is "deny" and ask is "on-miss"
+    expect(mockNote).toHaveBeenCalledTimes(1);
+    const [message] = mockNote.mock.calls[0];
+    expect(message).toContain('security="deny"');
+    expect(message).toContain('ask="on-miss"');
+  });
+});

--- a/src/commands/doctor-exec-approvals.ts
+++ b/src/commands/doctor-exec-approvals.ts
@@ -1,0 +1,88 @@
+import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { loadExecApprovals } from "../infra/exec-approvals.js";
+import { note } from "../terminal/note.js";
+
+/**
+ * Check for conflicting exec approval configurations between openclaw.json
+ * and exec-approvals.json. Runs as part of `openclaw doctor`.
+ *
+ * This addresses the "two config surfaces" issue where users expect
+ * `approvals.exec.enabled: false` to disable all approval behavior,
+ * but exec-approvals.json has its own independent gating policy.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/15047
+ */
+export function noteExecApprovalsWarnings(cfg: OpenClawConfig): void {
+  const warnings: string[] = [];
+
+  // Load exec-approvals.json (creates default if missing)
+  const approvals = loadExecApprovals();
+  const approvalsDefaults = approvals.defaults ?? {};
+
+  // Load approvals.exec forwarding config from openclaw.json
+  const approvalsExecForwarding = cfg.approvals?.exec ?? {};
+
+  // Load tools.exec config from openclaw.json
+  const toolsExec = cfg.tools?.exec ?? {};
+
+  // =========================================
+  // CHECK 1: approvals.exec.enabled=false but gating still active
+  // =========================================
+  // Users expect `approvals.exec.enabled: false` to disable all approval
+  // behavior, but it only disables forwarding to chat channels.
+  // The actual gating is controlled by exec-approvals.json.
+  if (approvalsExecForwarding.enabled === false) {
+    const effectiveSecurity = approvalsDefaults.security ?? "deny";
+    const effectiveAsk = approvalsDefaults.ask ?? "on-miss";
+    const gatingActive = effectiveSecurity !== "full" || effectiveAsk !== "off";
+
+    if (gatingActive) {
+      warnings.push(
+        `- WARNING: approvals.exec.enabled=false but exec-approvals.json has active gating.`,
+        `  Effective policy: security="${effectiveSecurity}", ask="${effectiveAsk}"`,
+        `  Exec commands may still require approval and timeout without UI.`,
+        ``,
+        `  This happens because there are two config surfaces:`,
+        `  - approvals.exec.enabled controls approval *forwarding* to chat channels`,
+        `  - exec-approvals.json controls actual execution *gating*`,
+        ``,
+        `  Fix (to disable all exec approvals):`,
+        `  - ${formatCliCommand("openclaw approvals set")} and set security="full", ask="off"`,
+        `  - Or edit ~/.openclaw/exec-approvals.json directly`,
+      );
+    }
+  }
+
+  // =========================================
+  // CHECK 2: tools.exec.security differs from exec-approvals.json
+  // =========================================
+  // When both are set but differ, exec-approvals.json takes precedence.
+  // This can be confusing for users who only look at openclaw.json.
+  const toolsSecurity = toolsExec.security;
+  const approvalsSecurity = approvalsDefaults.security;
+  if (toolsSecurity && approvalsSecurity && toolsSecurity !== approvalsSecurity) {
+    warnings.push(
+      `- INFO: tools.exec.security="${toolsSecurity}" differs from exec-approvals.json security="${approvalsSecurity}".`,
+      `  exec-approvals.json takes precedence for actual gating.`,
+      `  See: ${formatCliCommand("openclaw approvals get")} to view current policy.`,
+    );
+  }
+
+  // =========================================
+  // CHECK 3: tools.exec.ask differs from exec-approvals.json
+  // =========================================
+  const toolsAsk = toolsExec.ask;
+  const approvalsAsk = approvalsDefaults.ask;
+  if (toolsAsk && approvalsAsk && toolsAsk !== approvalsAsk) {
+    warnings.push(
+      `- INFO: tools.exec.ask="${toolsAsk}" differs from exec-approvals.json ask="${approvalsAsk}".`,
+      `  exec-approvals.json takes precedence for actual gating.`,
+      `  See: ${formatCliCommand("openclaw approvals get")} to view current policy.`,
+    );
+  }
+
+  if (warnings.length > 0) {
+    note(warnings.join("\n"), "Exec Approvals");
+  }
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -28,6 +28,7 @@ import {
 } from "./doctor-auth.js";
 import { doctorShellCompletion } from "./doctor-completion.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+import { noteExecApprovalsWarnings } from "./doctor-exec-approvals.js";
 import { maybeRepairGatewayDaemon } from "./doctor-gateway-daemon-flow.js";
 import { checkGatewayHealth } from "./doctor-gateway-health.js";
 import {
@@ -198,6 +199,7 @@ export async function doctorCommand(
   await noteMacLaunchctlGatewayEnvOverrides(cfg);
 
   await noteSecurityWarnings(cfg);
+  noteExecApprovalsWarnings(cfg);
 
   if (cfg.hooks?.gmail?.model?.trim()) {
     const hooksModelRef = resolveHooksGmailModel({


### PR DESCRIPTION
## Summary

- Adds a `openclaw doctor` check that warns when `approvals.exec.enabled=false` but `exec-approvals.json` has active gating
- Helps users understand the two-config-surface behavior and avoid unexpected approval timeouts
- Also warns when `tools.exec.security` or `tools.exec.ask` differs from `exec-approvals.json` defaults

## What it checks

The new check handles 3 scenarios:

1. **`approvals.exec.enabled=false` but gating active** — WARNING: Users expect this to disable approvals entirely, but `exec-approvals.json` still controls actual gating
2. **`tools.exec.security` differs from `exec-approvals.json`** — INFO: The latter takes precedence, which can be confusing
3. **`tools.exec.ask` differs from `exec-approvals.json`** — INFO: Same as above

## Why

Users expect `approvals.exec.enabled: false` to disable all exec approval behavior, but it only disables forwarding to chat channels. The actual execution gating is controlled by `~/.openclaw/exec-approvals.json`. This causes unexpected approval timeouts when no UI is available to respond.

This check surfaces the issue during `openclaw doctor` with specific, actionable fix guidance.

## Design decisions

- **Config-only, no side effects** — Only reads config and warns; doesn't modify anything
- **Follows existing patterns** — Structured like `doctor-memory-search.ts` and `doctor-security.ts`
- **Non-breaking** — Adds warnings without changing existing behavior

## Scope

This PR addresses option 3 (validation/warning) from #15047. Options 1 (documentation) and 2 (config unification) are left for future discussion.

Note: Option 2 (making `approvals.exec.enabled: false` actually disable `exec-approvals.json` gating) would be a more complete fix but involves breaking changes. Happy to discuss this approach if maintainers prefer it.

## Test plan

- [x] TypeScript compilation passes
- [x] Lint passes (0 warnings, 0 errors)
- [x] Unit tests pass (7 tests)
- [x] Build passes

Refs #15047

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `openclaw doctor` check that warns users when their exec approval configuration is conflicting or confusing. The implementation is well-structured and follows existing patterns in the codebase.

**What changed:**
- New module `doctor-exec-approvals.ts` with logic to detect three config conflict scenarios
- Comprehensive test coverage (7 tests) for all scenarios
- Integration into the `openclaw doctor` command

**Key checks:**
1. **WARNING**: `approvals.exec.enabled=false` with active gating - Users expect this to disable all approvals, but `exec-approvals.json` still gates execution
2. **INFO**: `tools.exec.security` differs from `exec-approvals.json` - Clarifies precedence
3. **INFO**: `tools.exec.ask` differs from `exec-approvals.json` - Clarifies precedence

The checks are config-only (no side effects), include actionable fix guidance, and handle edge cases gracefully (e.g., missing defaults).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The implementation is clean, well-tested, and follows established patterns. All logic is read-only (no side effects), test coverage is comprehensive (7 unit tests covering all scenarios including edge cases), and the changes integrate seamlessly with existing doctor checks. The defaults are correctly aligned with runtime values, and warning messages provide clear, actionable guidance.
- No files require special attention

<sub>Last reviewed commit: 1e95fd8</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->