### PR TITLE
tools: fix image inbound resolution and empty allowBundled

### DIFF
--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -42,8 +42,7 @@ function normalizeAllowlist(input: unknown): string[] | undefined {
   if (!Array.isArray(input)) {
     return undefined;
   }
-  const normalized = input.map((entry) => String(entry).trim()).filter(Boolean);
-  return normalized.length > 0 ? normalized : undefined;
+  return input.map((entry) => String(entry).trim()).filter(Boolean);
 }
 
 const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
@@ -57,7 +56,10 @@ export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | und
 }
 
 export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): boolean {
-  if (!allowlist || allowlist.length === 0) {
+  if (allowlist && allowlist.length === 0) {
+    return false;
+  }
+  if (!allowlist) {
     return true;
   }
   if (!isBundledSkill(entry)) {


### PR DESCRIPTION
## Summary

This PR fixes two unrelated but user-facing regressions with clear, low-risk changes:

1. **Image tool sandbox resolution for inbound media**
- Fixes `image` tool failures when the model passes a `media/inbound/...` path in sandboxed sessions.
- It now correctly resolves inbound media paths to either the sandbox `media/inbound/...` mirror or the host media root (`~/.openclaw/media/inbound/...`) when that file exists.
- Relative inbound paths with nested folders (for example `media/inbound/topic/photo.png`) are now handled.
- Added regression coverage for sandbox + nested inbound path fallback.

2. **Bundled skill allowlist empty-array behavior**
- Aligns `skills.allowBundled` parsing so an explicit empty array is treated as an explicit deny-all.
- Previously `skills.allowBundled: []` was normalized away and acted as no filter (allow all).
- Added e2e regression coverage for this exact scenario.

## Confidence Score: 8.5/10

This PR has a narrow surface area and includes direct regression tests for both issues.

- Behavioral risk is low: logic is localized to `src/agents/tools/image-tool.ts` (path resolution + host read path selection) and `src/agents/skills/config.ts` (allowlist normalization/decision).
- Existing behavior is preserved for normal absolute path usage and non-empty allowlists.
- Tests were run against affected flows to confirm pass/fail conditions and prevent regressions.

## Validation

- `pnpm format -- src/agents/tools/image-tool.ts src/agents/tools/image-tool.e2e.test.ts src/agents/skills/config.ts src/agents/skills.buildworkspaceskillstatus.e2e.test.ts`
- `pnpm lint`
- `pnpm tsgo`
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/skills.buildworkspaceskillstatus.e2e.test.ts src/agents/tools/image-tool.e2e.test.ts`

## Related

- Fixes #21713
- Addresses #21709 behavior (empty allowBundled deny-all)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two unrelated user-facing regressions with targeted, well-tested changes:

- **Image tool sandbox resolution** - Resolves inbound media paths through a fallback chain (sandbox mirror → host media directory) when the model passes relative `media/inbound/...` paths in sandboxed sessions. The new `extractInboundMediaParts` helper correctly handles nested folders, and the `readMode` flag ensures proper file access method.

- **Bundled skill allowlist semantics** - Treats explicit empty array `allowBundled: []` as deny-all instead of normalizing it away. The logic in `isBundledSkillAllowed` now checks empty array first (return false), then undefined (return true), making the semantics clear and intentional.

Both changes have narrow scope, preserve existing behavior for normal cases, and include direct e2e regression tests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both fixes are well-isolated with clear regression tests. The image tool changes add fallback logic without breaking existing absolute path resolution. The allowlist change is a simple conditional reorder that makes empty-array semantics explicit. All 30 tests pass, including new regression coverage for both issues.
- No files require special attention

<sub>Last reviewed commit: f1e3924</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->