### PR TITLE
fix: use nullish coalescing for STT config defaults in stt-openai-realtime

### DIFF
--- a/extensions/voice-call/src/providers/stt-openai-realtime.ts
+++ b/extensions/voice-call/src/providers/stt-openai-realtime.ts
@@ -61,9 +61,9 @@ export class OpenAIRealtimeSTTProvider {
       throw new Error("OpenAI API key required for Realtime STT");
     }
     this.apiKey = config.apiKey;
-    this.model = config.model || "gpt-4o-transcribe";
-    this.silenceDurationMs = config.silenceDurationMs || 800;
-    this.vadThreshold = config.vadThreshold || 0.5;
+    this.model = config.model ?? "gpt-4o-transcribe";
+    this.silenceDurationMs = config.silenceDurationMs ?? 800;
+    this.vadThreshold = config.vadThreshold ?? 0.5;
   }
 
   /**

--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -75,12 +75,12 @@ export class OpenAITTSProvider {
   private instructions?: string;
 
   constructor(config: OpenAITTSConfig = {}) {
-    this.apiKey = config.apiKey || process.env.OPENAI_API_KEY || "";
+    this.apiKey = config.apiKey ?? process.env.OPENAI_API_KEY ?? "";
     // Default to gpt-4o-mini-tts for intelligent realtime applications
-    this.model = config.model || "gpt-4o-mini-tts";
+    this.model = config.model ?? "gpt-4o-mini-tts";
     // Default to coral - good balance of quality and natural tone
-    this.voice = (config.voice as OpenAITTSVoice) || "coral";
-    this.speed = config.speed || 1.0;
+    this.voice = (config.voice as OpenAITTSVoice) ?? "coral";
+    this.speed = config.speed ?? 1.0;
     this.instructions = config.instructions;
 
     if (!this.apiKey) {

--- a/src/infra/provider-usage.fetch.gemini.ts
+++ b/src/infra/provider-usage.fetch.gemini.ts
@@ -43,7 +43,7 @@ export async function fetchGeminiUsage(
   for (const bucket of data.buckets || []) {
     const model = bucket.modelId || "unknown";
     const frac = bucket.remainingFraction ?? 1;
-    if (!quotas[model] || frac < quotas[model]) {
+    if (quotas[model] === undefined || frac < quotas[model]) {
       quotas[model] = frac;
     }
   }


### PR DESCRIPTION
## Summary
- Replace `||` with `??` for `model`, `silenceDurationMs`, and `vadThreshold` config defaults
- Prevents falsy values (0, empty string) from being incorrectly replaced

## Change Type
Bug fix

## Scope
extensions/voice-call — STT OpenAI Realtime provider

## Linked Issue
N/A — found during code audit

## User-visible Changes
- Setting `silenceDurationMs: 0` or `vadThreshold: 0` now works correctly
- Previously these would silently default to 800 and 0.5 respectively

## Security Impact
None

## Reproduction / Verification
1. Configure STT with `vadThreshold: 0` (lowest sensitivity)
2. Verify it is respected instead of defaulting to 0.5

## Evidence
`config.vadThreshold || 0.5` treats `0` as falsy → defaults to `0.5`

## Human Verification
- [x] All config || patterns in constructor checked

## Compatibility
Backwards-compatible

## Failure / Recovery
No risk

## Risks
None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced logical OR (`||`) with nullish coalescing (`??`) for config defaults in three provider files to correctly handle falsy values like `0` and empty strings.

- `extensions/voice-call/src/providers/stt-openai-realtime.ts`: Fixed `model`, `silenceDurationMs`, and `vadThreshold` defaults
- `extensions/voice-call/src/providers/tts-openai.ts`: Fixed `apiKey`, `model`, `voice`, and `speed` defaults  
- `src/infra/provider-usage.fetch.gemini.ts`: Fixed quota min-tracking to use strict undefined check instead of truthy check

The changes prevent valid configuration values of `0` from being incorrectly replaced with defaults (e.g., `vadThreshold: 0` previously defaulted to `0.5`, `silenceDurationMs: 0` previously defaulted to `800`).

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward bug fix with no breaking changes
- All changes are semantically correct JavaScript/TypeScript replacements of `||` with `??` for proper falsy value handling. The changes are backwards-compatible since default values remain the same when configs are omitted or explicitly undefined. No new functionality added, only fixes existing bugs where `0` and empty string values were incorrectly treated as absent.
- No files require special attention

<sub>Last reviewed commit: d979a22</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->