### PR TITLE
fix: use strict undefined check for Gemini quota min-tracking

### DIFF
--- a/src/infra/provider-usage.fetch.gemini.ts
+++ b/src/infra/provider-usage.fetch.gemini.ts
@@ -43,7 +43,7 @@ export async function fetchGeminiUsage(
   for (const bucket of data.buckets || []) {
     const model = bucket.modelId || "unknown";
     const frac = bucket.remainingFraction ?? 1;
-    if (!quotas[model] || frac < quotas[model]) {
+    if (quotas[model] === undefined || frac < quotas[model]) {
       quotas[model] = frac;
     }
   }


### PR DESCRIPTION
## Summary
- Replace `!quotas[model]` with `quotas[model] === undefined` in the min-fraction tracker
- When a model's remaining quota fraction is exactly 0 (fully used), the falsy check incorrectly allows overwriting with a higher value

## Change Type
Bug fix

## Scope
src/infra — Gemini provider usage tracking

## Linked Issue
N/A — found during code audit

## User-visible Changes
- Gemini usage display now correctly shows 0% remaining when a model is fully used
- Previously, a fully-used model could show a higher percentage from a later API bucket

## Security Impact
None

## Reproduction / Verification
1. Have a Gemini model with 100% usage (frac = 0)
2. Verify the status display shows 0% remaining, not a later bucket's percentage

## Evidence
\`!quotas[model]\` when \`quotas[model] = 0\`: \`!0\` is \`true\` → condition passes → overwrites minimum

## Human Verification
- [x] Confirmed quotas accumulates minimum fraction per model

## Compatibility
Backwards-compatible

## Failure / Recovery
No risk

## Risks
None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes quota tracking logic for Gemini models when fully exhausted. Previously, when `remainingFraction` was exactly 0 (100% used), the falsy check `!quotas[model]` would incorrectly evaluate to `true`, allowing a later bucket with a higher fraction to overwrite the minimum. The strict `=== undefined` check ensures only uninitialized models are set, preserving the correct minimum fraction across all buckets.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal change with clear correctness improvement
- Single-line fix corrects a clear logical error in falsy value handling. The change is well-documented, follows TypeScript best practices for explicit undefined checks, and the existing test suite validates the min-tracking behavior. No side effects or breaking changes.
- No files require special attention

<sub>Last reviewed commit: c6e32c6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->