### PR TITLE
fix: use nullish coalescing for TTS config defaults in tts-openai

### DIFF
--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -75,12 +75,12 @@ export class OpenAITTSProvider {
   private instructions?: string;
 
   constructor(config: OpenAITTSConfig = {}) {
-    this.apiKey = config.apiKey || process.env.OPENAI_API_KEY || "";
+    this.apiKey = config.apiKey ?? process.env.OPENAI_API_KEY ?? "";
     // Default to gpt-4o-mini-tts for intelligent realtime applications
-    this.model = config.model || "gpt-4o-mini-tts";
+    this.model = config.model ?? "gpt-4o-mini-tts";
     // Default to coral - good balance of quality and natural tone
-    this.voice = (config.voice as OpenAITTSVoice) || "coral";
-    this.speed = config.speed || 1.0;
+    this.voice = (config.voice as OpenAITTSVoice) ?? "coral";
+    this.speed = config.speed ?? 1.0;
     this.instructions = config.instructions;
 
     if (!this.apiKey) {


### PR DESCRIPTION
## Summary
- Replace `||` with `??` for `speed`, `model`, `voice`, and `apiKey` config defaults
- Prevents falsy values (0, empty string) from being incorrectly replaced by defaults

## Change Type
Bug fix

## Scope
extensions/voice-call — TTS OpenAI provider config initialization

## Linked Issue
N/A — found during code audit

## User-visible Changes
- Setting `speed: 0` now works correctly instead of silently defaulting to 1.0
- Setting explicit empty values for model/voice/apiKey respects the provided value

## Security Impact
None

## Reproduction / Verification
1. Configure TTS with `speed: 0` 
2. Verify speed is respected instead of defaulting to 1.0

## Evidence
`config.speed || 1.0` treats `0` as falsy → defaults to `1.0`
`config.speed ?? 1.0` only defaults when `null`/`undefined`

## Human Verification
- [x] Checked all || usage in the constructor

## Compatibility
Fully backwards-compatible — only changes behavior for intentional falsy values

## Failure / Recovery
No risk — straightforward operator change

## Risks
None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces logical OR (`||`) with nullish coalescing (`??`) in the `OpenAITTSProvider` constructor for `apiKey`, `model`, `voice`, and `speed` config defaults. This fixes a bug where falsy values like `speed: 0` (valid per OpenAI's 0.25-4.0 range) would be incorrectly replaced by the default 1.0. The change is backwards-compatible and only affects intentional falsy values.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple operator change from `||` to `??` that correctly fixes a bug with no side effects. The change is backwards-compatible (undefined/null still get defaults), only affects edge cases where users intentionally pass falsy values like `speed: 0`, and follows TypeScript best practices for optional config defaults.
- No files require special attention

<sub>Last reviewed commit: e566f01</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->