### PR TITLE
fix: remove misleading || 1 fallback in channel status account counts

### DIFF
--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -262,7 +262,7 @@ function summarizeTokenConfig(params: {
     const hint = botHint || appHint ? ` (bot ${botHint || "?"}, app ${appHint || "?"})` : "";
     return {
       state: "ok",
-      detail: `tokens ok (bot ${botSources.label}, app ${appSources.label})${hint} · accounts ${ready.length}/${enabled.length || 1}`,
+      detail: `tokens ok (bot ${botSources.label}, app ${appSources.label})${hint} · accounts ${ready.length}/${enabled.length}`,
     };
   }
 
@@ -286,7 +286,7 @@ function summarizeTokenConfig(params: {
 
     return {
       state: "ok",
-      detail: `bot token config${hint} · accounts ${ready.length}/${enabled.length || 1}`,
+      detail: `bot token config${hint} · accounts ${ready.length}/${enabled.length}`,
     };
   }
 
@@ -306,7 +306,7 @@ function summarizeTokenConfig(params: {
     : "";
   return {
     state: "ok",
-    detail: `token ${sources.label}${hint} · accounts ${ready.length}/${enabled.length || 1}`,
+    detail: `token ${sources.label}${hint} · accounts ${ready.length}/${enabled.length}`,
   };
 }
 
@@ -435,7 +435,7 @@ export async function buildChannelsTable(
           extra.push(`auth ${formatTimeAgo(link.authAgeMs)}`);
         }
         if (accounts.length > 1 || plugin.meta.forceAccountBinding) {
-          extra.push(`accounts ${accounts.length || 1}`);
+          extra.push(`accounts ${accounts.length}`);
         }
         return extra.length > 0 ? `${base} · ${extra.join(" · ")}` : base;
       }
@@ -449,7 +449,7 @@ export async function buildChannelsTable(
         if (accounts.length <= 1 && !plugin.meta.forceAccountBinding) {
           return head;
         }
-        return `${head} · accounts ${configuredAccounts.length}/${enabledAccounts.length || 1}`;
+        return `${head} · accounts ${configuredAccounts.length}/${enabledAccounts.length}`;
       }
 
       const reason =


### PR DESCRIPTION
## Summary
- Remove `|| 1` fallback from account count displays in channel status
- When 0 accounts are enabled, the status now correctly shows `/0` instead of `/1`

## Change Type
Bug fix

## Scope
src/commands/status-all — channel status display

## Linked Issue
N/A — found during code audit

## User-visible Changes
- `/status` command now shows accurate account counts
- Previously, 0 enabled accounts displayed as `/1`, misleading users

## Security Impact
None

## Reproduction / Verification
1. Configure a channel with 0 enabled accounts
2. Run status command
3. Verify display shows `0/0` not `0/1`

## Evidence
`enabledAccounts.length || 1` when length is 0: `0 || 1 = 1`

## Human Verification
- [x] Checked all || 1 patterns in the file

## Compatibility
Backwards-compatible — display-only change

## Failure / Recovery
No risk

## Risks
None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes misleading `|| 1` fallbacks from account count displays in channel status output. All five locations where the fallback was removed have existing logic that prevents division by zero or displaying zero values, making the fallback unnecessary and misleading. When 0 accounts are enabled, the status now correctly shows `/0` instead of `/1`, or doesn't display the account count at all due to early returns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Display-only change that removes misleading fallback values. All modified lines have existing logic (early returns or subset filtering) that prevents the denominator from being 0, confirming the || 1 fallback was never needed and only caused incorrect display.
- No files require special attention

<sub>Last reviewed commit: 15da74a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->