### PR TITLE
fix: guard JSON.parse of Signal RPC response with try-catch

### DIFF
--- a/src/signal/client.ts
+++ b/src/signal/client.ts
@@ -77,7 +77,12 @@ export async function signalRpcRequest<T = unknown>(
   if (!text) {
     throw new Error(`Signal RPC empty response (status ${res.status})`);
   }
-  const parsed = JSON.parse(text) as SignalRpcResponse<T>;
+  let parsed: SignalRpcResponse<T>;
+  try {
+    parsed = JSON.parse(text) as SignalRpcResponse<T>;
+  } catch (err) {
+    throw new Error(`Signal RPC returned malformed JSON (status ${res.status})`, { cause: err });
+  }
   if (parsed.error) {
     const code = parsed.error.code ?? "unknown";
     const msg = parsed.error.message ?? "Signal RPC error";


### PR DESCRIPTION
## Summary
- Wrap `JSON.parse(text)` in Signal RPC client with try-catch
- Malformed responses now throw a descriptive error instead of raw SyntaxError

## Change Type
Bug fix

## Scope
src/signal — Signal RPC client

## Linked Issue
N/A — found during code audit

## User-visible Changes
- Malformed Signal RPC responses now produce a clear error message
- Previously threw a raw JSON SyntaxError with no context

## Security Impact
Prevents unhandled exception from crashing the process on malformed input

## Reproduction / Verification
1. Simulate a malformed Signal RPC response
2. Verify descriptive error is thrown instead of SyntaxError

## Evidence
Line 80: `JSON.parse(text)` with no error handling around it

## Human Verification
- [x] Verified the surrounding code flow

## Compatibility
Backwards-compatible

## Failure / Recovery
No risk

## Risks
None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps `JSON.parse(text)` in a try-catch block at line 80-85 to handle malformed Signal RPC responses. Previously, a SyntaxError would bubble up with no context; now throws a descriptive error that includes the HTTP status code and chains the original error as the cause.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - defensive error handling with no behavior change for valid responses
- Simple, well-scoped fix that adds proper error handling without changing any logic paths. The error message improvement aids debugging and the cause chain preserves the original error for inspection.
- No files require special attention

<sub>Last reviewed commit: 91cf102</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->