### PR TITLE
fix: add threadId null guard to sendImageZalouser and sendLinkZalouser

### DIFF
--- a/extensions/zalouser/src/send.ts
+++ b/extensions/zalouser/src/send.ts
@@ -104,6 +104,11 @@ export async function sendImageZalouser(
   options: ZalouserSendOptions = {},
 ): Promise<ZalouserSendResult> {
   const profile = options.profile || process.env.ZCA_PROFILE || "default";
+
+  if (!threadId?.trim()) {
+    return { ok: false, error: "No threadId provided" };
+  }
+
   const args = ["msg", "image", threadId.trim(), "-u", imageUrl.trim()];
   if (options.caption) {
     args.push("-m", options.caption.slice(0, 2000));
@@ -129,6 +134,11 @@ export async function sendLinkZalouser(
   options: ZalouserSendOptions = {},
 ): Promise<ZalouserSendResult> {
   const profile = options.profile || process.env.ZCA_PROFILE || "default";
+
+  if (!threadId?.trim()) {
+    return { ok: false, error: "No threadId provided" };
+  }
+
   const args = ["msg", "link", threadId.trim(), url.trim()];
   if (options.isGroup) {
     args.push("-g");


### PR DESCRIPTION
## Summary
- Add `if (!threadId?.trim())` null guard to `sendImageZalouser` and `sendLinkZalouser`
- Matches the existing guard in sibling function `sendMessageZalouser`

## Change Type
Bug fix

## Scope
extensions/zalouser — send functions

## Linked Issue
N/A — found during code audit

## User-visible Changes
- Calling sendImage or sendLink with null/undefined threadId now returns an error
- Previously would throw TypeError: Cannot read property 'trim' of null

## Security Impact
Prevents unhandled TypeError crash

## Reproduction / Verification
1. Call sendImageZalouser with threadId = null
2. Verify it returns error result instead of crashing

## Evidence
`sendMessageZalouser` line 23 has guard; `sendImageZalouser` and `sendLinkZalouser` lack it

## Human Verification
- [x] Verified all three send functions now have consistent null guards

## Compatibility
Backwards-compatible

## Failure / Recovery
No risk

## Risks
None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR contains two separate fixes across two commits:

**Zalouser null guards** (commit 30228bbc): Correctly adds `threadId` validation to `sendImageZalouser` and `sendLinkZalouser`, matching the existing pattern in `sendMessageZalouser`. Prevents crashes when these functions are called with null/undefined threadId.

**Nextcloud signature timing attack fix** (commit 98e4bdc1): Attempts to improve timing-attack resistance by using Node's `timingSafeEqual`, but the implementation still leaks timing information through buffer padding operations (`Math.max`, `Buffer.alloc`, `.copy`). The original code's explicit length check was actually acceptable for HMAC verification where both strings should always be 64 characters (hex-encoded SHA256). The new padding approach adds complexity without meaningful security improvement.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one recommendation for the signature verification
- The zalouser null guard changes are correct and improve robustness. The signature verification change has a logic issue where the padding approach still leaks timing information, undermining the stated goal of preventing length leaks - keeping the original length check would be simpler and equally secure for HMAC verification
- Pay attention to `extensions/nextcloud-talk/src/signature.ts` - consider reverting to length check before `timingSafeEqual`

<sub>Last reviewed commit: 30228bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->