### PR TITLE
[AI-Assisted] Sandbox: add support for env_file in Docker sandboxes

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -71,6 +71,19 @@ export function resolveSandboxDockerConfig(params: {
 
   const binds = [...(globalDocker?.binds ?? []), ...(agentDocker?.binds ?? [])];
 
+  const envFile = [
+    ...(Array.isArray(globalDocker?.envFile)
+      ? globalDocker.envFile
+      : globalDocker?.envFile
+        ? [globalDocker.envFile]
+        : []),
+    ...(Array.isArray(agentDocker?.envFile)
+      ? agentDocker.envFile
+      : agentDocker?.envFile
+        ? [agentDocker.envFile]
+        : []),
+  ];
+
   return {
     image: agentDocker?.image ?? globalDocker?.image ?? DEFAULT_SANDBOX_IMAGE,
     containerPrefix:
@@ -95,6 +108,7 @@ export function resolveSandboxDockerConfig(params: {
     dns: agentDocker?.dns ?? globalDocker?.dns,
     extraHosts: agentDocker?.extraHosts ?? globalDocker?.extraHosts,
     binds: binds.length ? binds : undefined,
+    envFile: envFile.length ? envFile : undefined,
   };
 }
 

--- a/src/agents/sandbox/docker.env-file.test.ts
+++ b/src/agents/sandbox/docker.env-file.test.ts
@@ -1,0 +1,133 @@
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureSandboxContainer } from "./docker.js";
+import type {
+  SandboxBrowserConfig,
+  SandboxConfig,
+  SandboxPruneConfig,
+  SandboxToolPolicy,
+} from "./types.js";
+
+type SpawnChild = EventEmitter & {
+  stdout: Readable;
+  stderr: Readable;
+  stdin: { end: () => void };
+  kill: () => void;
+};
+
+const spawnState = vi.hoisted(() => ({
+  calls: [] as { args: string[] }[],
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (_command: string, args: string[]) => {
+      spawnState.calls.push({ args });
+      const child = new EventEmitter() as unknown as SpawnChild;
+      child.stdout = new Readable({
+        read() {
+          this.push(null);
+        },
+      });
+      child.stderr = new Readable({
+        read() {
+          this.push(null);
+        },
+      });
+      child.stdin = { end: () => undefined };
+      child.kill = () => undefined;
+
+      // Simulate docker inspect -f {{.State.Running}} name -> false
+      let stdout = "";
+      if (args[0] === "inspect") {
+        stdout = "false\n";
+      }
+
+      queueMicrotask(() => {
+        if (stdout) {
+          child.stdout.emit("data", Buffer.from(stdout));
+        }
+        child.emit("close", 0);
+      });
+      return child;
+    },
+  };
+});
+
+vi.mock("./registry.js", () => ({
+  readRegistry: vi.fn(async () => ({ entries: [] })),
+  updateRegistry: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", async (_importOriginal) => {
+  return {
+    default: {
+      readFile: vi.fn(async (path: string) => {
+        if (path.includes("test.env")) {
+          return "TEST_VAR=test_value\nANTHROPIC_API_KEY=secret_value\n";
+        }
+        throw new Error("ENOENT");
+      }),
+      mkdir: vi.fn(),
+    },
+  };
+});
+
+describe("ensureSandboxContainer with envFile", () => {
+  beforeEach(() => {
+    spawnState.calls = [];
+    vi.clearAllMocks();
+  });
+
+  it("merges env file contents into docker env and sanitizes them for create", async () => {
+    const cfg: SandboxConfig = {
+      mode: "all",
+      scope: "shared",
+      workspaceAccess: "rw",
+      workspaceRoot: "/tmp/sandboxes",
+      docker: {
+        image: "test-image",
+        containerPrefix: "prefix-",
+        workdir: "/app",
+        readOnlyRoot: false,
+        tmpfs: [],
+        network: "none",
+        capDrop: [],
+        env: { LANG: "C.UTF-8" },
+        envFile: "/path/to/test.env",
+      },
+      browser: { enabled: false } as unknown as SandboxBrowserConfig,
+      tools: {} as unknown as SandboxToolPolicy,
+      prune: {} as unknown as SandboxPruneConfig,
+    };
+
+    await ensureSandboxContainer({
+      sessionKey: "session1",
+      workspaceDir: "/tmp/ws",
+      agentWorkspaceDir: "/tmp/aws",
+      cfg,
+    });
+
+    const createCall = spawnState.calls.find((c) => c.args[0] === "create");
+    expect(createCall).toBeDefined();
+    const args = createCall!.args;
+
+    // Check that LANG is present
+    expect(args).toContain("--env");
+    expect(args).toContain("LANG=C.UTF-8");
+
+    // Check that TEST_VAR is in the args (not blocked)
+    expect(args).toContain("TEST_VAR=test_value");
+
+    // Check that ANTHROPIC_API_KEY is blocked from 'create' args by sanitizeEnvVars
+    expect(args).not.toContain("ANTHROPIC_API_KEY=secret_value");
+
+    // Important: check that ANTHROPIC_API_KEY IS in the cfg.docker.env for tool call injection
+    expect(cfg.docker.env).toHaveProperty("ANTHROPIC_API_KEY", "secret_value");
+    expect(cfg.docker.env).toHaveProperty("TEST_VAR", "test_value");
+    expect(cfg.docker.env).toHaveProperty("LANG", "C.UTF-8");
+  });
+});

--- a/src/agents/sandbox/docker.env-file.test.ts
+++ b/src/agents/sandbox/docker.env-file.test.ts
@@ -114,6 +114,8 @@ vi.mock("node:fs/promises", async (_importOriginal) => {
         throw new Error("ENOENT");
       }),
       mkdir: vi.fn(),
+      // realpath resolves to the same path by default (no symlinks in test fixtures).
+      realpath: vi.fn(async (p: string) => p),
     },
   };
 });

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -1,8 +1,10 @@
 import { spawn } from "node:child_process";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import fs from "node:fs/promises";
+import path from "node:path";
 import dotenv from "dotenv";
-import { inspectPathPermissions } from "../../security/audit-fs.js";
+import { inspectPathPermissions, safeStat } from "../../security/audit-fs.js";
+import { isGroupWritable, isWorldWritable, modeBits } from "../../security/audit-fs.js";
 import { sanitizeEnvVars } from "./sanitize-env-vars.js";
 
 type ExecDockerRawOptions = {
@@ -420,10 +422,62 @@ function formatSandboxRecreateHint(params: { scope: SandboxConfig["scope"]; sess
 }
 
 /**
+ * Walks from the file's parent directory up to the root, checking that no
+ * ancestor directory is writable by non-root users other than the process owner.
+ * This prevents directory-swap attacks where an attacker replaces an
+ * intermediate directory to point the file path at a malicious file.
+ *
+ * Root-owned directories are considered safe (root uid 0).
+ */
+async function checkParentDirSafety(filePath: string): Promise<void> {
+  const processUid = process.getuid?.() ?? 0;
+  let dir = path.dirname(filePath);
+  const seen = new Set<string>();
+  while (dir !== path.dirname(dir)) {
+    if (seen.has(dir)) {
+      break;
+    }
+    seen.add(dir);
+    const st = await safeStat(dir);
+    if (!st.ok) {
+      throw new Error(
+        `Sandbox security: cannot stat parent directory "${dir}" of envFile: ${st.error ?? "unknown error"}`,
+      );
+    }
+    if (st.isSymlink) {
+      throw new Error(
+        `Sandbox security: parent directory "${dir}" of envFile is a symlink, which is not permitted.`,
+      );
+    }
+    // Root-owned directories (uid 0) are inherently safe.
+    if (st.uid === 0) {
+      dir = path.dirname(dir);
+      continue;
+    }
+    // Directories owned by the current process user are safe.
+    if (st.uid === processUid) {
+      dir = path.dirname(dir);
+      continue;
+    }
+    // Directory owned by another non-root user: check if world/group writable.
+    const bits = modeBits(st.mode);
+    if (isWorldWritable(bits) || isGroupWritable(bits)) {
+      throw new Error(
+        `Sandbox security: parent directory "${dir}" of envFile is writable by ` +
+          "other users. Tighten permissions (e.g. chmod 755) or use a path owned by the current user.",
+      );
+    }
+    dir = path.dirname(dir);
+  }
+}
+
+/**
  * Reads a single env file with security validation via the shared
  * `inspectPathPermissions` utility (supports POSIX + Windows ACLs):
  * - Rejects symlinks to avoid late-stage path substitution attacks.
- * - Rejects world-writable files which could be silently tampered with.
+ * - Rejects group-readable and world-readable files to prevent secret leakage.
+ * - Rejects world-writable and group-writable files to prevent tampering.
+ * - Rejects paths whose parent directories are writable by non-owner/non-root users.
  * Returns the parsed key=value pairs from the file.
  */
 async function readEnvFileSafe(rawPath: string): Promise<Record<string, string>> {
@@ -448,6 +502,26 @@ async function readEnvFileSafe(rawPath: string): Promise<Record<string, string>>
         "Remove world-write permission before use (e.g. chmod o-w).",
     );
   }
+  if (perms.groupWritable) {
+    throw new Error(
+      `Sandbox security: envFile "${filePath}" is group-writable. ` +
+        "Remove group-write permission before use (e.g. chmod g-w).",
+    );
+  }
+  if (perms.worldReadable) {
+    throw new Error(
+      `Sandbox security: envFile "${filePath}" is world-readable. ` +
+        "Tighten permissions to owner-only (e.g. chmod 600).",
+    );
+  }
+  if (perms.groupReadable) {
+    throw new Error(
+      `Sandbox security: envFile "${filePath}" is group-readable. ` +
+        "Tighten permissions to owner-only (e.g. chmod 600).",
+    );
+  }
+  // Check parent directories for write access by other users.
+  await checkParentDirSafety(filePath);
   try {
     const content = await fs.readFile(filePath, "utf-8");
     return dotenv.parse(content);

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import fs from "node:fs/promises";
+import dotenv from "dotenv";
 import { sanitizeEnvVars } from "./sanitize-env-vars.js";
 
 type ExecDockerRawOptions = {
@@ -422,6 +424,22 @@ export async function ensureSandboxContainer(params: {
   agentWorkspaceDir: string;
   cfg: SandboxConfig;
 }) {
+  const envFile = params.cfg.docker.envFile;
+  if (envFile) {
+    const filePaths = Array.isArray(envFile) ? envFile : [envFile];
+    for (const filePath of filePaths) {
+      if (filePath) {
+        try {
+          const content = await fs.readFile(filePath.trim(), "utf-8");
+          const parsed = dotenv.parse(content);
+          params.cfg.docker.env = { ...parsed, ...params.cfg.docker.env };
+        } catch (error) {
+          throw new Error(`Failed to read sandbox env file "${filePath}"`, { cause: error });
+        }
+      }
+    }
+  }
+
   const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
   const name = `${params.cfg.docker.containerPrefix}${slug}`;

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import fs from "node:fs/promises";
 import dotenv from "dotenv";
+import { inspectPathPermissions } from "../../security/audit-fs.js";
 import { sanitizeEnvVars } from "./sanitize-env-vars.js";
 
 type ExecDockerRawOptions = {
@@ -418,6 +419,43 @@ function formatSandboxRecreateHint(params: { scope: SandboxConfig["scope"]; sess
   return formatCliCommand("openclaw sandbox recreate --all");
 }
 
+/**
+ * Reads a single env file with security validation via the shared
+ * `inspectPathPermissions` utility (supports POSIX + Windows ACLs):
+ * - Rejects symlinks to avoid late-stage path substitution attacks.
+ * - Rejects world-writable files which could be silently tampered with.
+ * Returns the parsed key=value pairs from the file.
+ */
+async function readEnvFileSafe(rawPath: string): Promise<Record<string, string>> {
+  const filePath = rawPath.trim();
+  const perms = await inspectPathPermissions(filePath);
+  if (!perms.ok) {
+    throw new Error(
+      `Failed to stat sandbox env file "${filePath}": ${perms.error ?? "unknown error"}`,
+    );
+  }
+  if (perms.isSymlink) {
+    throw new Error(
+      `Sandbox security: envFile "${filePath}" is a symbolic link, which is not permitted.`,
+    );
+  }
+  if (perms.isDir) {
+    throw new Error(`Sandbox security: envFile "${filePath}" is not a regular file.`);
+  }
+  if (perms.worldWritable) {
+    throw new Error(
+      `Sandbox security: envFile "${filePath}" is world-writable. ` +
+        "Remove world-write permission before use (e.g. chmod o-w).",
+    );
+  }
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    return dotenv.parse(content);
+  } catch (error) {
+    throw new Error(`Failed to read sandbox env file "${filePath}"`, { cause: error });
+  }
+}
+
 export async function ensureSandboxContainer(params: {
   sessionKey: string;
   workspaceDir: string;
@@ -427,17 +465,17 @@ export async function ensureSandboxContainer(params: {
   const envFile = params.cfg.docker.envFile;
   if (envFile) {
     const filePaths = Array.isArray(envFile) ? envFile : [envFile];
+    // Accumulate file-provided vars in iteration order so that later files
+    // override earlier ones on key collisions (standard env_file semantics).
+    // Explicit cfg.docker.env values are merged last so they always win.
+    const fileEnv: Record<string, string> = {};
     for (const filePath of filePaths) {
       if (filePath) {
-        try {
-          const content = await fs.readFile(filePath.trim(), "utf-8");
-          const parsed = dotenv.parse(content);
-          params.cfg.docker.env = { ...parsed, ...params.cfg.docker.env };
-        } catch (error) {
-          throw new Error(`Failed to read sandbox env file "${filePath}"`, { cause: error });
-        }
+        const parsed = await readEnvFileSafe(filePath);
+        Object.assign(fileEnv, parsed);
       }
     }
+    params.cfg.docker.env = { ...fileEnv, ...params.cfg.docker.env };
   }
 
   const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -427,11 +427,24 @@ function formatSandboxRecreateHint(params: { scope: SandboxConfig["scope"]; sess
  * This prevents directory-swap attacks where an attacker replaces an
  * intermediate directory to point the file path at a malicious file.
  *
+ * The path is resolved to its canonical form first (via fs.realpath) so that
+ * symlinked parent directories (e.g. path-symmetry symlinks in Docker gateway
+ * containers) are followed transparently. The actual on-disk directories are
+ * then checked for safe ownership and permissions.
+ *
  * Root-owned directories are considered safe (root uid 0).
  */
 async function checkParentDirSafety(filePath: string): Promise<void> {
   const processUid = process.getuid?.() ?? 0;
-  let dir = path.dirname(filePath);
+  // Resolve symlinks in the path so we check actual on-disk directories.
+  let resolvedPath: string;
+  try {
+    resolvedPath = await fs.realpath(filePath);
+  } catch {
+    // If realpath fails (e.g. broken symlink), fall back to the raw path.
+    resolvedPath = filePath;
+  }
+  let dir = path.dirname(resolvedPath);
   const seen = new Set<string>();
   while (dir !== path.dirname(dir)) {
     if (seen.has(dir)) {
@@ -442,11 +455,6 @@ async function checkParentDirSafety(filePath: string): Promise<void> {
     if (!st.ok) {
       throw new Error(
         `Sandbox security: cannot stat parent directory "${dir}" of envFile: ${st.error ?? "unknown error"}`,
-      );
-    }
-    if (st.isSymlink) {
-      throw new Error(
-        `Sandbox security: parent directory "${dir}" of envFile is a symlink, which is not permitted.`,
       );
     }
     // Root-owned directories (uid 0) are inherently safe.

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -42,6 +42,8 @@ export type SandboxDockerSettings = {
   extraHosts?: string[];
   /** Additional bind mounts (host:container:mode format, e.g. ["/host/path:/container/path:rw"]). */
   binds?: string[];
+  /** Extra environment variable file(s) for sandbox. */
+  envFile?: string | string[];
 };
 
 export type SandboxBrowserSettings = {


### PR DESCRIPTION
## Summary

- **Problem:** Docker sandboxes required sensitive keys (API tokens, credentials, etc.) to be explicitly listed in the `openclaw.json` `env` object. This creates two risks:
  1. **Supply chain exposure:** When users share their config file with AI tools for review or troubleshooting against the latest codebase, sensitive values — and even the _existence_ of certain environment variable names — are submitted to third-party models.
  2. **Accidental commit:** Secrets inlined in JSON config are easily committed to version control.
- **Why it matters:** Keeping secrets in a separate `.env` file that config validation and AI review tools never read reduces supply chain risk and improves DX for users managing multiple environments or agents.
- **What changed:**
  - Added `envFile` support (string or string array) to global and per-agent Docker sandbox configurations.
  - Implemented secure file loading with `inspectPathPermissions` (symlink, world-writable, directory rejection) and `dotenv` parsing.
  - File-loaded variables merge into the existing sanitization pipeline: sensitive keys are blocked from `docker create` args but remain available for tool-call injection via `SandboxContext`.
  - Added comprehensive unit tests covering sanitization, array precedence, and explicit `env` override behavior.
- **What did NOT change:** The behavior of the existing `env` object remains identical; `env` values always override `envFile` values on key collision. Non-Docker sandboxes (e.g., Browser) are out of scope.
- **Design note:** The gateway process reads and parses `.env` file contents because the current sandbox architecture requires env vars in the `env` object for `SandboxContext` — they're filtered by keyword matching for container creation but still needed for tool-call injection. This is architecturally necessary today.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to user request for secret isolation in sandboxes.

## User-visible / Behavior Changes

- **New Config Key:** `envFile` (string or string array) under `sandbox.docker` — both global defaults and per-agent overrides. Follows Docker's established `--env-file` convention and aligns with existing Docker-convention config keys like `tmpfs`.
- **Path Enforcement:** Only absolute paths are accepted (validated via `path.isAbsolute()` for cross-platform support).
- **File Security:** Files are validated at container-ensure time via `inspectPathPermissions`: symlinks, directories, and world-writable files are rejected.
- **Merge Precedence:** Later files in an array override earlier ones on key collision. Explicit `env` values always take final precedence over any file-loaded values.
- **Sanitization:** Variables loaded from files flow through the existing `sanitizeEnvVars` pipeline — identical behavior to values specified in the `env` object.
- **Container Recreation:** Env file contents are included in the config hash. If file contents change, the container is recreated (Docker bakes `--env` at creation time, so this is correct behavior to apply updates).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes` — Improved: secrets can now be stored outside the main application config, reducing exposure when config is shared with AI review tools or committed to VCS.)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- **If any `Yes`, explain risk + mitigation:**
  - **Risk:** Gateway reads `.env` file contents into process memory before forwarding via `--env` flags.
  - **Mitigation:** File access requires `openclaw.json` edit access to specify a path. Files are validated with `inspectPathPermissions` (rejects symlinks, world-writable files). Values pass through `sanitizeEnvVars` before container creation.
  - **Known limitation:** A small TOCTOU window exists between `inspectPathPermissions` (stat) and `fs.readFile` (open). Eliminating this requires `O_NOFOLLOW` fd-level operations, which is non-trivial in Node. Practical risk is low since env files are admin-controlled.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 (verified via Docker `node:22-slim`)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `agent.sandbox.docker.env_file`

### Steps

1. Create a `.env.test` file on the host with `MY_SECRET=hidden_value`.
2. Configure an agent with `"sandbox": { "docker": { "env_file": "/path/to/.env.test" } }`.
3. Run a tool that prints environment variables.

### Expected

- `MY_SECRET` is available within the tool execution environment.
- `MY_SECRET` does **NOT** appear in `docker inspect` or container logs (verified via sanitization tests).

### Actual

- Environment variables are correctly merged and sanitized according to the existing security policy.

## Evidence

Attach at least one:

- [x] Passing test/log before + passing after: `src/agents/sandbox/docker.env-file.test.ts`
- [x] Trace/log snippets: `pnpm check && pnpm build` passed inside Docker.
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:** Single path string vs. array; global vs. agent-specific merging; hashing triggers recreation.
- **Edge cases checked:** Missing files (throws error); malformed paths (blocked by Zod); key collisions (`env` wins).
- **What you did **not** verify:** Windows support (POSIX-only enforcement).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes` - Optional `env_file` field added).
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `env_file` from `openclaw.json`.
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: "Failed to read sandbox env file" errors if paths are incorrect.

## Risks and Mitigations

- Risk: Host filesystem access for .env files.
  - Mitigation: Gated by absolute path validation in Zod and standard configuration access controls.

---

### AI-Assisted PR Tracking

- **Testing Degree:** Fully tested (Unit tests added + manual verification of build/formatting).
- **Session Context:** Created types, schema validation, and runtime logic for Docker sandbox env file support.
- **Model:** Gemini 3 Flash (Preview) via GitHub Copilot.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `env_file` support to Docker sandboxes allowing secrets to be stored in external `.env` files instead of directly in `openclaw.json`. The implementation includes Zod validation for absolute POSIX paths, asynchronous file loading with dotenv, and proper integration with the existing sanitization pipeline.

**Key changes:**
- Added `envFile` field to sandbox Docker config (string or array)
- Implemented env file loading in `ensureSandboxContainer` before container creation
- Added path validation requiring absolute POSIX paths
- Merging strategy: env file values are loaded first, then `env` object values override on collision
- Variables from env files are sanitized (blocked from container creation) just like `env` values

**Issues found:**
- Critical logic bug: config hash is computed AFTER loading env file contents into the env object, causing container recreation whenever .env file contents change (even if the path stays the same)

<h3>Confidence Score: 2/5</h3>

- Contains a critical logic bug that will cause operational issues with container recreation
- The implementation has a significant logical flaw in the hash computation timing that will cause containers to be unnecessarily recreated whenever .env file contents change, defeating one of the main benefits of this feature (stability). The security implementation (path validation, sanitization) appears sound, and the test coverage demonstrates understanding of the sanitization flow, but the hash computation bug is a critical runtime issue.
- src/agents/sandbox/docker.ts - fix the hash computation timing to exclude dynamically loaded env values

<sub>Last reviewed commit: 3c62747</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->