### PR TITLE
fix(slack): preserve `this` binding in registerArgOptions

### DIFF
--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -731,21 +731,19 @@ export async function registerSlackMonitorSlashCommands(params: {
   }
 
   const registerArgOptions = () => {
-    const optionsHandler = (
-      ctx.app as unknown as {
-        options?: (
-          actionId: string,
-          handler: (args: {
-            ack: (payload: { options: unknown[] }) => Promise<void>;
-            body: unknown;
-          }) => Promise<void>,
-        ) => void;
-      }
-    ).options;
-    if (typeof optionsHandler !== "function") {
+    const appWithOptions = ctx.app as unknown as {
+      options?: (
+        actionId: string,
+        handler: (args: {
+          ack: (payload: { options: unknown[] }) => Promise<void>;
+          body: unknown;
+        }) => Promise<void>,
+      ) => void;
+    };
+    if (typeof appWithOptions.options !== "function") {
       return;
     }
-    optionsHandler(SLACK_COMMAND_ARG_ACTION_ID, async ({ ack, body }) => {
+    appWithOptions.options.call(ctx.app, SLACK_COMMAND_ARG_ACTION_ID, async ({ ack, body }) => {
       const typedBody = body as {
         value?: string;
         user?: { id?: string };


### PR DESCRIPTION
## Summary

- Problem: `registerArgOptions` loses `this` binding when called as a standalone function reference, causing runtime errors in Slack event handlers.
- Why it matters: This can lead to silent failures in Slack argument parsing during event processing.
- What changed: Wrapped the function call to preserve the correct `this` context.
- What did NOT change: No changes to the function's logic or return values.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related: Discovered during Slack event handler debugging.

## User-visible / Behavior Changes

None — fixes an internal binding issue that could cause silent failures.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (OCI ARM64)
- Runtime/container: Docker (Node.js)
- Integration/channel: Slack (Socket Mode)

### Steps

1. Register a Slack app with arg options
2. Trigger an event that invokes `registerArgOptions`
3. Observe that `this` is correctly bound

### Expected

- Function executes without binding errors

### Actual

- Without fix: `this` is undefined, causing runtime error
- With fix: Function executes correctly

## Evidence

- [x] Trace/log snippets — Verified no binding errors in production logs after patch

## Human Verification (required)

- Verified scenarios: Slack event processing with arg options registration
- Edge cases checked: Multiple concurrent event handlers
- What you did **not** verify: Other Slack event types not using argOptions

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/slack/` binding file
- Known bad symptoms reviewers should watch for: Slack events failing to parse arguments

## Risks and Mitigations

None — minimal change to fix a JavaScript `this` binding issue.

---
*This PR was authored with AI assistance and has been human-verified in a production environment.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `this` binding issue in `registerArgOptions` by using `.call(ctx.app, ...)` instead of extracting the method to a variable and calling it directly. When a method is extracted to a variable in JavaScript/TypeScript, it loses its `this` context, which can cause runtime errors if the method expects to access instance properties via `this`.

- Changed from extracting `options` method to variable and calling directly
- Now uses `.call(ctx.app, ...)` to preserve correct `this` binding
- Renamed variable from `optionsHandler` to `appWithOptions` for clarity about what the reference points to
- This pattern is correct and similar to how other Slack Bolt SDK methods should be called when extracted from the instance

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a JavaScript `this` binding issue using standard `.call()` method. The change is minimal, well-scoped, and follows correct JavaScript/TypeScript patterns. No logic changes, just proper context preservation.
- No files require special attention

<sub>Last reviewed commit: c798ae2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->