### PR TITLE
feat: proactive auth health check on Gateway startup

### DIFF
--- a/ops/post_restart_auth_check.sh
+++ b/ops/post_restart_auth_check.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# OpenClaw Post-Restart Auth Check
+# Gateway 再起動後に認証トークンの健全性を確認する
+# - /health が返るまで待機
+# - models status --check で認証状態を検証
+# - 問題があれば auth_monitor.py を即座にトリガー
+#
+# 使い方:
+#   ExecStartPost として Gateway systemd service に組み込む
+#   または手動: bash ops/post_restart_auth_check.sh
+
+COMPOSE_DIR="/home/ubuntu/openclaw"
+HEALTH_URL="http://127.0.0.1:18789/health"
+HEALTH_TIMEOUT=5
+MAX_WAIT_SECONDS=120
+POLL_INTERVAL=3
+AUTH_MONITOR="/home/ubuntu/openclaw/ops/auth_monitor.py"
+AUTH_MONITOR_ENV="/etc/openclaw/auth-monitor.env"
+
+log() {
+  echo "$(date +%FT%T%z) post-restart-auth: $*"
+}
+
+# --- Step 1: Gateway が /health を返すまで待機 ---
+wait_for_gateway() {
+  local elapsed=0
+  log "Waiting for Gateway health endpoint..."
+  while [ "$elapsed" -lt "$MAX_WAIT_SECONDS" ]; do
+    local status
+    status=$(curl -sf -o /dev/null -w "%{http_code}" --max-time "$HEALTH_TIMEOUT" "$HEALTH_URL" 2>/dev/null) || status="000"
+    if [ "$status" = "200" ]; then
+      log "Gateway healthy after ${elapsed}s"
+      return 0
+    fi
+    sleep "$POLL_INTERVAL"
+    elapsed=$((elapsed + POLL_INTERVAL))
+  done
+  log "ERROR: Gateway did not become healthy within ${MAX_WAIT_SECONDS}s"
+  return 1
+}
+
+# --- Step 2: models status --check で認証状態を検証 ---
+check_auth() {
+  log "Running models status --check..."
+  local rc
+  cd "$COMPOSE_DIR"
+  rc=0
+  docker compose run --rm openclaw-cli models status --check 2>/dev/null || rc=$?
+
+  case $rc in
+    0)
+      log "AUTH OK: all tokens valid (rc=0)"
+      return 0
+      ;;
+    2)
+      log "AUTH WARNING: tokens expiring within 24h (rc=2)"
+      return 2
+      ;;
+    *)
+      log "AUTH ERROR: tokens expired or missing (rc=$rc)"
+      return "$rc"
+      ;;
+  esac
+}
+
+# --- Step 3: 問題時 auth_monitor をトリガー ---
+trigger_auth_monitor() {
+  if [ ! -f "$AUTH_MONITOR" ]; then
+    log "auth_monitor.py not found, skipping notification"
+    return 0
+  fi
+  log "Triggering auth monitor for immediate notification..."
+
+  local env_args=()
+  if [ -f "$AUTH_MONITOR_ENV" ]; then
+    # shellcheck disable=SC2046
+    env_args=(env $(grep -v '^#' "$AUTH_MONITOR_ENV" | grep '=' | xargs))
+  fi
+
+  "${env_args[@]}" /usr/bin/python3 "$AUTH_MONITOR" --notify-first-run 2>&1 || true
+  log "Auth monitor completed"
+}
+
+# --- main ---
+log "Post-restart auth check starting..."
+
+if ! wait_for_gateway; then
+  log "Gateway not ready, cannot check auth"
+  exit 1
+fi
+
+auth_rc=0
+check_auth || auth_rc=$?
+
+if [ "$auth_rc" -ne 0 ]; then
+  trigger_auth_monitor
+fi
+
+log "Post-restart auth check complete (auth_rc=$auth_rc)"
+exit 0

--- a/ops/post_restart_auth_check.sh
+++ b/ops/post_restart_auth_check.sh
@@ -10,14 +10,26 @@ set -euo pipefail
 # 使い方:
 #   ExecStartPost として Gateway systemd service に組み込む
 #   または手動: bash ops/post_restart_auth_check.sh
+#
+# Dependencies:
+#   - curl: for health endpoint polling
+#   - docker compose: for running models status --check
+#   - auth_monitor.py (optional): triggers Slack notification on auth failure
+#
+# Environment:
+#   OC_HOME       — OpenClaw project root (default: script's parent directory)
+#   HEALTH_URL    — Gateway health endpoint (default: http://127.0.0.1:18789/health)
+#   AUTH_MONITOR_ENV — Path to auth monitor env file (default: /etc/openclaw/auth-monitor.env)
 
-COMPOSE_DIR="/home/ubuntu/openclaw"
-HEALTH_URL="http://127.0.0.1:18789/health"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OC_HOME="${OC_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+COMPOSE_DIR="$OC_HOME"
+HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:18789/health}"
 HEALTH_TIMEOUT=5
 MAX_WAIT_SECONDS=120
 POLL_INTERVAL=3
-AUTH_MONITOR="/home/ubuntu/openclaw/ops/auth_monitor.py"
-AUTH_MONITOR_ENV="/etc/openclaw/auth-monitor.env"
+AUTH_MONITOR="$OC_HOME/ops/auth_monitor.py"
+AUTH_MONITOR_ENV="${AUTH_MONITOR_ENV:-/etc/openclaw/auth-monitor.env}"
 
 log() {
   echo "$(date +%FT%T%z) post-restart-auth: $*"

--- a/ops/systemd/openclaw-post-restart-auth.service
+++ b/ops/systemd/openclaw-post-restart-auth.service
@@ -1,0 +1,26 @@
+# OpenClaw Post-Restart Auth Check
+# Gateway 起動後に認証トークンの健全性を即座に確認する
+# - Gateway の /health エンドポイントが応答するまで待機
+# - models status --check で認証状態を検証
+# - 問題があれば auth_monitor.py で Slack 通知
+[Unit]
+Description=OpenClaw Post-Restart Auth Check
+After=openclaw-gateway.service docker.service
+Requires=docker.service
+BindsTo=openclaw-gateway.service
+
+[Service]
+Type=oneshot
+User=ubuntu
+WorkingDirectory=/home/ubuntu/openclaw
+SupplementaryGroups=docker
+EnvironmentFile=-/etc/openclaw/auth-monitor.env
+ExecStart=/bin/bash /home/ubuntu/openclaw/ops/post_restart_auth_check.sh
+TimeoutStartSec=180
+# Security: read-only + write only to ops dir for state
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/home/ubuntu/openclaw/ops
+
+[Install]
+WantedBy=openclaw-gateway.service

--- a/ops/systemd/openclaw-post-restart-auth.service
+++ b/ops/systemd/openclaw-post-restart-auth.service
@@ -1,8 +1,11 @@
 # OpenClaw Post-Restart Auth Check
 # Gateway 起動後に認証トークンの健全性を即座に確認する
 # - Gateway の /health エンドポイントが応答するまで待機
-# - models status --check で認証状態を検証
+# - models status --check で認証状態を検証 (exit 1=expired, 2=expiring)
 # - 問題があれば auth_monitor.py で Slack 通知
+#
+# NOTE: Adjust User, WorkingDirectory, ReadWritePaths, and EnvironmentFile
+# paths to match your deployment environment before installing this unit.
 [Unit]
 Description=OpenClaw Post-Restart Auth Check
 After=openclaw-gateway.service docker.service
@@ -11,15 +14,19 @@ BindsTo=openclaw-gateway.service
 
 [Service]
 Type=oneshot
+# TODO: Change to your deployment user
 User=ubuntu
+# TODO: Change to your OpenClaw installation path
 WorkingDirectory=/home/ubuntu/openclaw
 SupplementaryGroups=docker
+# TODO: Adjust path to your auth-monitor env file (optional, dash prefix = no error if missing)
 EnvironmentFile=-/etc/openclaw/auth-monitor.env
 ExecStart=/bin/bash /home/ubuntu/openclaw/ops/post_restart_auth_check.sh
 TimeoutStartSec=180
 # Security: read-only + write only to ops dir for state
 NoNewPrivileges=yes
 ProtectSystem=strict
+# TODO: Must match WorkingDirectory + /ops
 ReadWritePaths=/home/ubuntu/openclaw/ops
 
 [Install]


### PR DESCRIPTION
## Summary

- Problem: Gateway silently starts with expired or invalid auth tokens, leading to failures only discovered when the first user request arrives.
- Why it matters: Delays in detecting auth issues cause poor user experience and make debugging harder.
- What changed: Added a proactive auth health check during Gateway startup that validates the token before accepting requests.
- What did NOT change: No changes to the auth flow itself or token refresh logic.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens

## Linked Issue/PR

- Related: Auth reliability improvements

## User-visible / Behavior Changes

Gateway now logs auth health status on startup. If auth is unhealthy, a warning is emitted before the gateway starts accepting connections.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No (reads existing token, doesn't modify)
- New/changed network calls? Yes — one additional API call at startup to validate the token
- Command/tool execution surface changed? No
- Data access scope changed? No
- Explanation: The health check makes a lightweight API call to verify the token is valid. No new permissions are required.

## Repro + Verification

### Environment

- OS: Linux (OCI ARM64)
- Runtime/container: Docker
- Model/provider: Anthropic API (Claude)

### Steps

1. Start Gateway with a valid token
2. Observe startup log showing "auth health: OK"
3. Start Gateway with an expired token
4. Observe startup log showing auth warning

### Expected

- Valid token: Gateway starts with health confirmation
- Invalid token: Gateway starts with warning log

### Actual

- Confirmed both scenarios in production

## Evidence

- [x] Trace/log snippets — Startup logs show auth health check results

## Human Verification (required)

- Verified scenarios: Valid token startup, expired token startup, network timeout during check
- Edge cases checked: Auth check timeout (proceeds with warning, doesn't block startup)
- What you did **not** verify: All possible token error states

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; startup proceeds without the check
- Files/config to restore: Gateway startup file
- Known bad symptoms: Slower startup if auth endpoint is slow (mitigated by timeout)

## Risks and Mitigations

- Risk: Auth endpoint slow/unreachable delays startup
  - Mitigation: Health check has a short timeout and is non-blocking (warning only)

---
*This PR was authored with AI assistance and has been human-verified in a production environment.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added proactive auth health check during Gateway startup to validate tokens before accepting requests. The TypeScript implementation in `server-startup.ts` checks auth profiles and attempts to refresh expired OAuth tokens. Additionally includes bash script and systemd service for Docker-based deployments.

**Key changes:**
- `checkAndRefreshAuthOnStartup()` function validates auth profiles on startup using existing `buildAuthHealthSummary()` helper
- Attempts proactive OAuth token refresh for expired profiles to avoid first-request latency
- Logs auth health status at startup (profile counts, expiring/expired warnings)
- Bash script `post_restart_auth_check.sh` waits for Gateway health endpoint, runs `models status --check`, and triggers optional `auth_monitor.py` notification
- Systemd service to run the bash script as a post-restart hook

**Critical issue found:**
The OAuth profile filtering logic has a bug. OAuth profiles with valid refresh tokens are marked as `status: "ok"` by `buildAuthHealthSummary()` (per `auth-health.ts:143-152`), so they won't appear in the `expired` array and won't be proactively refreshed, defeating the feature's purpose for the most common OAuth use case.

<h3>Confidence Score: 2/5</h3>

- This PR has a critical logic bug that prevents the main feature from working for OAuth profiles with refresh tokens
- The filtering logic in `checkAndRefreshAuthOnStartup()` won't catch OAuth profiles that need refreshing because `buildAuthHealthSummary()` marks them as "ok" when they have refresh tokens. This is a significant functional defect that breaks the stated purpose. Additionally, the bash script has portability issues with hardcoded paths and references missing dependencies.
- Pay close attention to `src/gateway/server-startup.ts` lines 53-55 where the OAuth filtering logic needs correction

<sub>Last reviewed commit: b9486ec</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->