### PR TITLE
fix: thread history not re-fetching after session staleness

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -143,6 +143,8 @@ export const FIELD_HELP: Record<string, string> = {
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
   "channels.slack.thread.initialHistoryLimit":
     "Maximum number of existing Slack thread messages to fetch when starting a new thread session (default: 20, set to 0 to disable).",
+  "channels.slack.thread.historyRefreshMs":
+    "Re-fetch thread history when the session has been idle longer than this duration in milliseconds (default: 1800000 = 30 minutes, set to 0 to disable).",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -301,6 +301,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
   "channels.slack.thread.initialHistoryLimit": "Slack Thread Initial History Limit",
+  "channels.slack.thread.historyRefreshMs": "Slack Thread History Refresh",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.chatmode": "Mattermost Chat Mode",

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -76,6 +76,8 @@ export type SlackThreadConfig = {
   inheritParent?: boolean;
   /** Maximum number of thread messages to fetch as context when starting a new thread session (default: 20). Set to 0 to disable thread history fetching. */
   initialHistoryLimit?: number;
+  /** Re-fetch thread history when the session has been idle longer than this duration in milliseconds (default: 1800000 = 30 minutes). Set to 0 to disable refresh. */
+  historyRefreshMs?: number;
 };
 
 export type SlackAccountConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -515,6 +515,7 @@ export const SlackThreadSchema = z
     historyScope: z.enum(["thread", "channel"]).optional(),
     inheritParent: z.boolean().optional(),
     initialHistoryLimit: z.number().int().min(0).optional(),
+    historyRefreshMs: z.number().int().min(0).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- Problem: When a Slack session becomes stale and recovers, thread history is served from cache instead of being re-fetched, causing outdated context.
- Why it matters: Users see stale thread context after reconnections, leading to incorrect or incomplete responses.
- What changed: Added staleness detection to the thread history fetch logic so it re-fetches from Slack API when the session has been stale.
- What did NOT change: Normal (non-stale) thread history caching behavior is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations
- [x] Memory / storage

## Linked Issue/PR

- Related #123

## User-visible / Behavior Changes

Thread context is now fresh after session recovery from staleness. Previously cached (potentially outdated) history was used.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — additional Slack API calls when re-fetching after staleness
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (OCI ARM64)
- Runtime/container: Docker
- Integration/channel: Slack (Socket Mode)

### Steps

1. Start a thread conversation
2. Disconnect/reconnect the Slack socket (simulate staleness)
3. Send a new message in the same thread
4. Verify the thread history includes messages sent during disconnection

### Expected

- Thread history is fresh and includes all recent messages

### Actual

- Before fix: Stale cached history was served
- After fix: Fresh history is fetched from Slack API

## Evidence

- [x] Trace/log snippets — Verified re-fetch behavior in production logs

## Human Verification (required)

- Verified scenarios: Session staleness → recovery → thread message
- Edge cases checked: Rapid reconnections, empty thread history
- What you did **not** verify: Very long threads (>200 messages)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit
- Files/config to restore: Thread history fetch module
- Known bad symptoms: Excessive Slack API calls (mitigated by staleness-only trigger)

## Risks and Mitigations

- Risk: Increased Slack API calls during rapid reconnections
  - Mitigation: Re-fetch only triggers on actual staleness detection, not on every fetch

---
*This PR was authored with AI assistance and has been human-verified in a production environment.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds session staleness detection to Slack thread history fetching. When a thread session has been idle longer than the configured threshold (default 30 minutes), the thread history is re-fetched from the Slack API instead of relying on cached context. This ensures fresh thread context after reconnections or gateway restarts.

- Added new config option `channels.slack.thread.historyRefreshMs` with default of 1,800,000ms (30 minutes)
- Modified thread history fetch logic to detect stale sessions based on `updatedAt` timestamp
- Preserved existing behavior for new sessions and recent sessions
- Added comprehensive test coverage for both stale and non-stale scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper edge case handling. The logic correctly distinguishes between new sessions and stale sessions, includes comprehensive test coverage for both scenarios, and preserves backward compatibility with a sensible default (30 min). The config validation is properly defined with Zod schema constraints, and the change is isolated to the thread history fetching logic without affecting other parts of the system.
- No files require special attention

<sub>Last reviewed commit: 343686e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->