### PR TITLE
[Bug]: Allow ws:// to Tailscale CGNAT addresses

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -300,6 +300,8 @@ describe("isSecureWebSocketUrl", () => {
       expect(isSecureWebSocketUrl("ws://remote.example.com:18789")).toBe(false);
       expect(isSecureWebSocketUrl("ws://192.168.1.100:18789")).toBe(false);
       expect(isSecureWebSocketUrl("ws://10.0.0.5:18789")).toBe(false);
+      expect(isSecureWebSocketUrl("ws://100.63.255.255:18789")).toBe(false);
+      expect(isSecureWebSocketUrl("ws://100.128.0.0:18789")).toBe(false);
     });
   });
 

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -293,13 +293,13 @@ describe("isSecureWebSocketUrl", () => {
       expect(isSecureWebSocketUrl("ws://localhost:18789")).toBe(true);
       expect(isSecureWebSocketUrl("ws://[::1]:18789")).toBe(true);
       expect(isSecureWebSocketUrl("ws://127.0.0.42:18789")).toBe(true);
+      expect(isSecureWebSocketUrl("ws://100.64.0.1:18789")).toBe(true);
     });
 
     it("returns false for ws:// to non-loopback addresses (CWE-319)", () => {
       expect(isSecureWebSocketUrl("ws://remote.example.com:18789")).toBe(false);
       expect(isSecureWebSocketUrl("ws://192.168.1.100:18789")).toBe(false);
       expect(isSecureWebSocketUrl("ws://10.0.0.5:18789")).toBe(false);
-      expect(isSecureWebSocketUrl("ws://100.64.0.1:18789")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR fixes #21760 where CLI commands fail after v2026.2.19 due a strict plaintext WebSocket check rejecting all non-loopback `ws://` URLs, including Tailscale tailnet IPs (`100.64.0.0/10`).

## What changed
- Relaxed the WebSocket security check in `src/gateway/net.ts`:
  - `isSecureWebSocketUrl()` now treats Tailscale CGNAT IPv4 addresses (`100.64.0.0/10`) as secure for `ws://`.
  - This path remains `wss://`-required for public/network-facing addresses.
- Added/updated regression tests:
  - `src/gateway/net.test.ts`
    - now asserts `ws://100.64.0.1` is considered secure.
  - `src/gateway/call.test.ts`
    - adjusted expectations for tailnet behavior and documented allowed `ws://` on Tailscale while retaining rejection for other non-loopback addresses.
    - added explicit coverage for `bind=lan` resolving to a tailnet address.

## Why this is safe
- Keeps TLS requirement for non-loopback public hosts and non-Tailscale ranges.
- Restricts the relaxation to well-scoped 100.64.0.0/10 CGNAT addresses that are encrypted end-to-end by Tailscale.
- Does not alter authentication or credential paths; only changes URL trust heuristics used by existing gateway call/resolution flow.

## Confidence Score
- 10/10 confidence for merge readiness.
- Fix is deterministic and localized to one helper and existing call-path tests.
- Regression is covered by positive/negative tests that pin behavior for both allowed tailnet and denied non-tailnet `ws://` hosts.
- No unrelated behavior changes; no API surface changed.

## Validation
- `pnpm test src/gateway/net.test.ts src/gateway/call.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Relaxes WebSocket security check to allow `ws://` connections to Tailscale CGNAT IPv4 addresses (`100.64.0.0/10`) while maintaining TLS requirements for all other non-loopback addresses. The implementation correctly identifies Tailscale IPs and properly normalizes IPv6-mapped IPv4 addresses before validation.

Key changes:
- Added `isTailscaleIPv4Address()` helper that validates IPs in the `100.64.0.0/10` CGNAT range
- Updated `isSecureWebSocketUrl()` to treat Tailscale IPs as secure for `ws://` connections
- Added test coverage for the Tailscale range start (`100.64.0.1`)
- Updated integration tests in `call.test.ts` to reflect new behavior for tailnet and LAN bindings

The fix is well-scoped and addresses the regression from v2026.2.19 where CLI commands failed when connecting to Tailscale addresses.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-implemented with correct CIDR range validation for Tailscale addresses (`100.64.0.0/10`), includes appropriate test coverage, and maintains security for non-Tailscale addresses. The logic is straightforward, properly handles IPv6-mapped IPv4 addresses, and is limited in scope to the specific security check function.
- No files require special attention

<sub>Last reviewed commit: 7743e2f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->