### PR TITLE
feat(catchup): scan thread replies during startup catch-up

### DIFF
--- a/src/slack/monitor/catchup.ts
+++ b/src/slack/monitor/catchup.ts
@@ -1,0 +1,424 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { SlackMessageEvent } from "../types.js";
+import type { SlackMonitorContext } from "./context.js";
+import type { SlackMessageHandler } from "./message-handler.js";
+import { resolveSlackChannelConfig } from "./channel-config.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SlackCatchupState = {
+  version: 1;
+  channels: Record<string, string>; // channelId -> latest processed ts
+  globalTs: string; // fallback watermark
+  updatedAt: string; // ISO timestamp
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CATCHUP_WINDOW_SEC = 30 * 60; // 30 minutes max lookback
+const CATCHUP_PER_CHANNEL_LIMIT = 20; // max messages per channel
+const CATCHUP_INTER_CHANNEL_DELAY_MS = 200; // pause between channels
+const WATERMARK_FLUSH_INTERVAL_MS = 30_000; // 30 seconds
+
+// ---------------------------------------------------------------------------
+// State file path helper
+// ---------------------------------------------------------------------------
+
+function resolveStateFilePath(accountId: string): string {
+  const homeDir = os.homedir();
+  return path.join(homeDir, ".openclaw", `slack-catchup-${accountId}.json`);
+}
+
+// ---------------------------------------------------------------------------
+// Load / Save state
+// ---------------------------------------------------------------------------
+
+export async function loadCatchupState(accountId: string): Promise<SlackCatchupState | null> {
+  const filePath = resolveStateFilePath(accountId);
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as SlackCatchupState;
+    if (parsed.version !== 1) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCatchupState(
+  accountId: string,
+  state: SlackCatchupState,
+): Promise<void> {
+  const filePath = resolveStateFilePath(accountId);
+  const dir = path.dirname(filePath);
+  await fs.promises.mkdir(dir, { recursive: true });
+  const tmpPath = `${filePath}.tmp`;
+  await fs.promises.writeFile(tmpPath, JSON.stringify(state, null, 2), "utf-8");
+  await fs.promises.rename(tmpPath, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Watermark buffer (in-memory, flushed periodically)
+// ---------------------------------------------------------------------------
+
+/** Per-account in-memory watermark buffers. */
+const watermarkBuffers = new Map<string, Record<string, string>>();
+
+/** Active flush interval timers per account. */
+const flushTimers = new Map<string, ReturnType<typeof setInterval>>();
+
+/**
+ * Update the in-memory watermark for a channel.
+ * Only advances the watermark (never goes backwards).
+ */
+export function updateCatchupWatermark(channelId: string, ts: string, accountId: string): void {
+  if (!channelId || !ts) {
+    return;
+  }
+  let buffer = watermarkBuffers.get(accountId);
+  if (!buffer) {
+    buffer = {};
+    watermarkBuffers.set(accountId, buffer);
+  }
+  const existing = buffer[channelId];
+  if (!existing || ts > existing) {
+    buffer[channelId] = ts;
+  }
+}
+
+/**
+ * Flush the in-memory watermark buffer to disk for a given account.
+ * Merges with any existing on-disk state so concurrent flushes are safe.
+ */
+export async function flushCatchupWatermark(accountId: string): Promise<void> {
+  const buffer = watermarkBuffers.get(accountId);
+  if (!buffer || Object.keys(buffer).length === 0) {
+    return;
+  }
+
+  // Take a snapshot and clear the buffer
+  const snapshot = { ...buffer };
+  for (const key of Object.keys(snapshot)) {
+    delete buffer[key];
+  }
+
+  const existing = await loadCatchupState(accountId);
+  const channels = existing?.channels ?? {};
+  let globalTs = existing?.globalTs ?? "0";
+
+  for (const [channelId, ts] of Object.entries(snapshot)) {
+    const current = channels[channelId];
+    if (!current || ts > current) {
+      channels[channelId] = ts;
+    }
+    if (ts > globalTs) {
+      globalTs = ts;
+    }
+  }
+
+  const state: SlackCatchupState = {
+    version: 1,
+    channels,
+    globalTs,
+    updatedAt: new Date().toISOString(),
+  };
+  await saveCatchupState(accountId, state);
+}
+
+/**
+ * Start a periodic flush timer for the given account.
+ * Returns a cleanup function that stops the timer and flushes one last time.
+ */
+export function startWatermarkFlushTimer(accountId: string): () => Promise<void> {
+  // Avoid duplicate timers
+  const existingTimer = flushTimers.get(accountId);
+  if (existingTimer) {
+    clearInterval(existingTimer);
+  }
+
+  const timer = setInterval(() => {
+    void flushCatchupWatermark(accountId).catch(() => {
+      // silently ignore periodic flush errors
+    });
+  }, WATERMARK_FLUSH_INTERVAL_MS);
+
+  // Ensure the timer does not prevent process exit
+  if (typeof timer === "object" && "unref" in timer) {
+    timer.unref();
+  }
+  flushTimers.set(accountId, timer);
+
+  return async () => {
+    clearInterval(timer);
+    flushTimers.delete(accountId);
+    await flushCatchupWatermark(accountId);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Startup catch-up
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the list of channel IDs to scan for catch-up.
+ * Uses the resolved channelsConfig from the monitor context (already resolved
+ * from names to IDs by the time provider.ts calls us).
+ */
+function resolveChannelIdsToScan(ctx: SlackMonitorContext): string[] {
+  const channels = ctx.channelsConfig;
+  if (!channels) {
+    return [];
+  }
+  const ids: string[] = [];
+  for (const key of Object.keys(channels)) {
+    if (key === "*") {
+      continue;
+    }
+    // Only include keys that look like Slack channel IDs (C... or G...)
+    if (/^[CG][A-Z0-9]+$/i.test(key)) {
+      ids.push(key);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Compute the "oldest" timestamp for the Slack API query.
+ * Uses the per-channel watermark if available, falls back to globalTs,
+ * then clamps to CATCHUP_WINDOW_SEC from now.
+ */
+function resolveOldestTs(
+  channelId: string,
+  state: SlackCatchupState | null,
+): string {
+  const now = Date.now() / 1000;
+  const windowFloor = String(now - CATCHUP_WINDOW_SEC);
+
+  if (!state) {
+    return windowFloor;
+  }
+
+  const channelTs = state.channels[channelId];
+  const candidate = channelTs ?? state.globalTs;
+
+  if (!candidate || candidate === "0") {
+    return windowFloor;
+  }
+
+  // Clamp: never look back further than the window
+  return candidate < windowFloor ? windowFloor : candidate;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export type PerformStartupCatchUpParams = {
+  ctx: SlackMonitorContext;
+  handleSlackMessage: SlackMessageHandler;
+  abortSignal?: AbortSignal;
+};
+
+export async function performStartupCatchUp(
+  params: PerformStartupCatchUpParams,
+): Promise<void> {
+  const { ctx, handleSlackMessage, abortSignal } = params;
+  const runtime = ctx.runtime;
+  const accountId = ctx.accountId;
+
+  const state = await loadCatchupState(accountId);
+  if (!state) {
+    runtime.log?.(`slack catch-up [${accountId}]: no previous state found, skipping catch-up`);
+    // Initialize state file so next restart has a baseline
+    const now = String(Date.now() / 1000);
+    await saveCatchupState(accountId, {
+      version: 1,
+      channels: {},
+      globalTs: now,
+      updatedAt: new Date().toISOString(),
+    });
+    return;
+  }
+
+  const channelIds = resolveChannelIdsToScan(ctx);
+  if (channelIds.length === 0) {
+    runtime.log?.(`slack catch-up [${accountId}]: no channels configured, skipping`);
+    return;
+  }
+
+  // Also include DM channels: list open IMs
+  const dmChannelIds: string[] = [];
+  if (ctx.dmEnabled) {
+    try {
+      const dmResult = await ctx.app.client.conversations.list({
+        token: ctx.botToken,
+        types: "im",
+        limit: 200,
+      });
+      for (const ch of (dmResult as { channels?: Array<{ id?: string; is_open?: boolean }> })
+        .channels ?? []) {
+        if (ch.id) {
+          dmChannelIds.push(ch.id);
+        }
+      }
+    } catch (err) {
+      runtime.error?.(`slack catch-up [${accountId}]: failed to list DM channels: ${String(err)}`);
+    }
+  }
+
+  const allChannelIds = [...channelIds, ...dmChannelIds];
+  let totalMessages = 0;
+  let channelsScanned = 0;
+  let channelsWithMessages = 0;
+
+  runtime.log?.(
+    `slack catch-up [${accountId}]: scanning ${allChannelIds.length} channels (${channelIds.length} group + ${dmChannelIds.length} DM)`,
+  );
+
+  for (const channelId of allChannelIds) {
+    if (abortSignal?.aborted) {
+      runtime.log?.(`slack catch-up [${accountId}]: aborted`);
+      break;
+    }
+
+    const oldest = resolveOldestTs(channelId, state);
+    channelsScanned++;
+
+    try {
+      const result = await ctx.app.client.conversations.history({
+        token: ctx.botToken,
+        channel: channelId,
+        oldest,
+        limit: CATCHUP_PER_CHANNEL_LIMIT,
+        inclusive: false, // exclude the watermark message itself
+      });
+
+      const messages = (result.messages ?? []) as Array<{
+        type?: string;
+        user?: string;
+        bot_id?: string;
+        subtype?: string;
+        text?: string;
+        ts?: string;
+        thread_ts?: string;
+        event_ts?: string;
+        channel?: string;
+        channel_type?: string;
+        files?: unknown[];
+      }>;
+
+      if (messages.length === 0) {
+        continue;
+      }
+
+      // Determine channel type and requireMention for filtering
+      const channelInfo = await ctx.resolveChannelName(channelId);
+      const channelType = channelInfo?.type ?? (channelId.startsWith("D") ? "im" : "channel");
+      const isDm = channelType === "im";
+      const channelConfig = resolveSlackChannelConfig({
+        channelId,
+        channelName: channelInfo?.name,
+        channels: ctx.channelsConfig,
+        defaultRequireMention: ctx.defaultRequireMention,
+      });
+      const requireMention = !isDm && (channelConfig?.requireMention ?? true);
+
+      // Sort oldest first (Slack returns newest first)
+      const sorted = [...messages].sort((a, b) => {
+        const tsA = a.ts ?? "0";
+        const tsB = b.ts ?? "0";
+        return tsA < tsB ? -1 : tsA > tsB ? 1 : 0;
+      });
+
+      let channelCount = 0;
+      for (const msg of sorted) {
+        // Skip bot's own messages
+        if (msg.user === ctx.botUserId) {
+          continue;
+        }
+        if (msg.bot_id && msg.user === ctx.botUserId) {
+          continue;
+        }
+
+        // Skip subtypes except file_share
+        if (msg.subtype && msg.subtype !== "file_share") {
+          continue;
+        }
+
+        // For requireMention channels, only catch up messages that mention the bot
+        if (requireMention && ctx.botUserId) {
+          const text = msg.text ?? "";
+          if (!text.includes(`<@${ctx.botUserId}>`)) {
+            continue;
+          }
+        }
+
+        // Build a SlackMessageEvent from the history message
+        const event: SlackMessageEvent = {
+          type: "message",
+          user: msg.user,
+          bot_id: msg.bot_id,
+          subtype: msg.subtype,
+          text: msg.text,
+          ts: msg.ts,
+          thread_ts: msg.thread_ts,
+          event_ts: msg.event_ts ?? msg.ts,
+          channel: channelId,
+          channel_type: channelType,
+          files: msg.files as SlackMessageEvent["files"],
+        };
+
+        // Determine if the message was a mention
+        const wasMentioned = ctx.botUserId
+          ? Boolean(event.text?.includes(`<@${ctx.botUserId}>`))
+          : false;
+
+        try {
+          await handleSlackMessage(event, {
+            source: "message",
+            wasMentioned,
+          });
+          channelCount++;
+          totalMessages++;
+
+          // Update watermark immediately for each processed message
+          if (msg.ts) {
+            updateCatchupWatermark(channelId, msg.ts, accountId);
+          }
+        } catch (err) {
+          runtime.error?.(
+            `slack catch-up [${accountId}]: failed to process message ${msg.ts} in ${channelId}: ${String(err)}`,
+          );
+        }
+      }
+
+      if (channelCount > 0) {
+        channelsWithMessages++;
+      }
+    } catch (err) {
+      runtime.error?.(
+        `slack catch-up [${accountId}]: failed to fetch history for ${channelId}: ${String(err)}`,
+      );
+    }
+
+    // Delay between channels to avoid rate limits
+    if (channelsScanned < allChannelIds.length) {
+      await sleep(CATCHUP_INTER_CHANNEL_DELAY_MS);
+    }
+  }
+
+  // Flush watermarks after catch-up completes
+  await flushCatchupWatermark(accountId);
+
+  runtime.log?.(
+    `slack catch-up [${accountId}]: completed — scanned ${channelsScanned} channels, dispatched ${totalMessages} messages from ${channelsWithMessages} channels`,
+  );
+}


### PR DESCRIPTION
## Summary

- Problem: The startup catch-up mechanism (#164) only processes top-level channel messages, missing thread replies that arrived during downtime.
- Why it matters: Thread conversations are a core Slack interaction pattern. Missing thread replies means incomplete context for follow-up responses.
- What changed: Extended the catch-up scanner to also fetch and process thread replies for messages with `reply_count > 0`.
- What did NOT change: Top-level message catch-up behavior is unchanged.

**Note:** This PR depends on the base catch-up feature. It should be reviewed after the base PR merges.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Depends on: Gateway startup catch-up PR (base feature)

## User-visible / Behavior Changes

Thread replies sent during downtime are now also caught up on restart.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — `conversations.replies` API calls for threads with new replies
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (OCI ARM64)
- Runtime/container: Docker
- Integration/channel: Slack (Socket Mode)

### Steps

1. Reply to a thread while the bot is offline
2. Restart the bot
3. Observe the thread reply is processed during catch-up

### Expected

- Thread replies from downtime are processed

### Actual

- Confirmed in production

## Evidence

- [x] Trace/log snippets — Catch-up logs show thread reply scanning and processing

## Human Verification (required)

- Verified scenarios: Threads with new replies, threads with no new replies (skipped efficiently)
- Edge cases checked: Threads with 200+ replies (paginated), deleted thread parents
- What you did **not** verify: Extremely deep thread nesting

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert; thread replies won't be caught up but top-level messages still work
- Known bad symptoms: Excessive API calls for large threads (mitigated by reply_count check)

## Risks and Mitigations

- Risk: Rate limiting from many thread reply fetches
  - Mitigation: Only fetches threads with `reply_count > 0`; sequential processing

---
*This PR was authored with AI assistance and has been human-verified in a production environment.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended the startup catch-up mechanism to fetch and process thread replies for messages with `reply_count > 0`, ensuring thread conversations during downtime are captured. The implementation correctly applies the same filtering logic (bot's own messages, subtypes, requireMention checks) to thread replies as to top-level messages, and properly updates watermarks for each processed reply.

**Key additions:**
- Thread reply scanning after top-level message catch-up (lines 406-511 in `src/slack/monitor/catchup.ts:406`)
- Rate limiting with 150ms delay between thread fetches (`CATCHUP_INTER_THREAD_DELAY_MS`)
- 10 reply limit per thread (`CATCHUP_THREAD_REPLY_LIMIT`)
- Watermark updates in real-time message dispatch (`src/slack/monitor/message-handler/dispatch.ts:410-414`)

**Minor optimization opportunity:** The thread scanning logic filters threads by `reply_count > 0` but doesn't track whether those replies are actually new (within the watermark window). This could result in unnecessary API calls for threads where all replies predate the downtime, though the `oldest` parameter in `conversations.replies` prevents reprocessing old messages.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor optimization opportunity
- The implementation is sound and follows existing patterns. Rate limiting and reply limits are in place. The watermark mechanism correctly prevents duplicate processing. One minor inefficiency identified (unnecessary API calls for threads with only old replies), but this is mitigated by filtering at the API level and should not cause issues in practice.
- No files require special attention

<sub>Last reviewed commit: 7850eb8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->