### PR TITLE
feat(feishu): resolve merge_forward, enrich quoted message parsing, add media type support

### DIFF
--- a/extensions/feishu/skills/feishu-reaction/SKILL.md
+++ b/extensions/feishu/skills/feishu-reaction/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: feishu-reaction
+description: |
+  Feishu reaction auto-reply. Automatically replies with emoji when user adds reaction.
+  Activate when user mentions "reaction" or "emoji" in Feishu context.
+---
+
+# Feishu Reaction Auto-Reply
+
+Built-in feature of the Feishu plugin. Automatically replies with relevant emoji when user adds a reaction.
+
+## Implementation
+
+**File**: `extensions/feishu/src/monitor.ts`
+
+**Events Handled**:
+- `im.message.reaction.created_v1` - User adds reaction
+- `im.message.reaction.deleted_v1` - User removes reaction (logged only)
+
+## Smart Reply Mapping
+
+| Received Emoji | Bot Replies |
+|----------------|-------------|
+| THUMBSUP | FINGERHEART, HEART, SMILE, CLAP |
+| HEART | FINGERHEART, SMILE, THUMBSUP |
+| FINGERHEART | HEART, SMILE, THUMBSUP |
+| SMILE | HEART, FINGERHEART, THUMBSUP |
+| CLAP | HEART, FIRE, THUMBSUP |
+| FIRE | PARTY, CLAP, THUMBSUP |
+| CRY | HEART, FINGERHEART |
+| Others | HEART, FINGERHEART, SMILE |
+
+## Setup Requirements
+
+### 1. Feishu Open Platform Event Subscription
+
+Subscribe and publish these events:
+- `im.message.reaction.created` - Message reaction added
+- `im.message.reaction.deleted` - Message reaction removed
+
+**Important**: Events must be published (not just saved) to take effect.
+
+### 2. Robot Capability
+
+Enable robot ability in Feishu app settings.
+
+## Maintenance
+
+### After OpenClaw Update
+
+If this feature stops working after OpenClaw update:
+
+1. Check if `extensions/feishu/src/monitor.ts` still has the reaction handler
+2. If missing, re-apply the changes from the git stash or backup
+
+### Recovery Steps
+
+```bash
+cd ~/openclaw
+# Check if reaction handler exists
+grep -n "im.message.reaction.created_v1" extensions/feishu/src/monitor.ts
+
+# If not found, restore from stash
+git stash list
+git stash pop stash@{0} -- extensions/feishu/src/monitor.ts
+```
+
+### Backup Command
+
+```bash
+cd ~/openclaw
+cp extensions/feishu/src/monitor.ts ~/backups/feishu-reaction-monitor-$(date +%Y%m%d).ts
+```
+
+## Configuration
+
+No additional configuration needed. The feature is built into the Feishu plugin.
+
+## Troubleshooting
+
+### Bot doesn't respond to reactions
+
+1. **Check event subscription**: Verify `im.message.reaction.created` is published
+2. **Check gateway logs**: `tail -f ~/.openclaw/logs/gateway.log | grep reaction`
+3. **Restart gateway**: `openclaw gateway restart`
+
+### Infinite reaction loop
+
+The code filters `operator_type=app` to prevent self-reaction loops. If broken, check that this filter is present.
+
+## Common Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| No reaction events received | Events not published | Publish in Feishu Open Platform |
+| 401 API error | Bot token expired | Update app credentials |
+| Gateway crash on restart | Dirty workspace | Stash changes before update |

--- a/extensions/feishu/skills/feishu-reaction/monitor.ts
+++ b/extensions/feishu/skills/feishu-reaction/monitor.ts
@@ -1,0 +1,376 @@
+import * as http from "http";
+import * as Lark from "@larksuiteoapi/node-sdk";
+import {
+  type ClawdbotConfig,
+  type RuntimeEnv,
+  type HistoryEntry,
+  installRequestBodyLimitGuard,
+} from "openclaw/plugin-sdk";
+import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
+import { handleFeishuMessage, type FeishuMessageEvent, type FeishuBotAddedEvent } from "./bot.js";
+import { createFeishuWSClient, createEventDispatcher } from "./client.js";
+import { probeFeishu } from "./probe.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+import { addReactionFeishu } from "./reactions.js";
+
+export type MonitorFeishuOpts = {
+  config?: ClawdbotConfig;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  accountId?: string;
+};
+
+// Per-account WebSocket clients, HTTP servers, and bot info
+const wsClients = new Map<string, Lark.WSClient>();
+const httpServers = new Map<string, http.Server>();
+const botOpenIds = new Map<string, string>();
+const FEISHU_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
+const FEISHU_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+
+async function fetchBotOpenId(account: ResolvedFeishuAccount): Promise<string | undefined> {
+  try {
+    const result = await probeFeishu(account);
+    return result.ok ? result.botOpenId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Register common event handlers on an EventDispatcher.
+ * When fireAndForget is true (webhook mode), message handling is not awaited
+ * to avoid blocking the HTTP response (Lark requires <3s response).
+ */
+function registerEventHandlers(
+  eventDispatcher: Lark.EventDispatcher,
+  context: {
+    cfg: ClawdbotConfig;
+    accountId: string;
+    runtime?: RuntimeEnv;
+    chatHistories: Map<string, HistoryEntry[]>;
+    fireAndForget?: boolean;
+  },
+) {
+  const { cfg, accountId, runtime, chatHistories, fireAndForget } = context;
+  const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
+
+  eventDispatcher.register({
+    "im.message.receive_v1": async (data) => {
+      try {
+        const event = data as unknown as FeishuMessageEvent;
+        const promise = handleFeishuMessage({
+          cfg,
+          event,
+          botOpenId: botOpenIds.get(accountId),
+          runtime,
+          chatHistories,
+          accountId,
+        });
+        if (fireAndForget) {
+          promise.catch((err) => {
+            error(`feishu[${accountId}]: error handling message: ${String(err)}`);
+          });
+        } else {
+          await promise;
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling message: ${String(err)}`);
+      }
+    },
+    "im.message.message_read_v1": async () => {
+      // Ignore read receipts
+    },
+    "im.chat.member.bot.added_v1": async (data) => {
+      try {
+        const event = data as unknown as FeishuBotAddedEvent;
+        log(`feishu[${accountId}]: bot added to chat ${event.chat_id}`);
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling bot added event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.bot.deleted_v1": async (data) => {
+      try {
+        const event = data as unknown as { chat_id: string };
+        log(`feishu[${accountId}]: bot removed from chat ${event.chat_id}`);
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
+      }
+    },
+    // Reaction 事件：收到用户 emoji 时随机回一个
+    "im.message.reaction.created_v1": async (data) => {
+      try {
+        const event = data as {
+          message_id: string;
+          reaction_type?: { emoji_type: string };
+          operator_type?: string;
+          user_id?: { open_id?: string; user_id?: string; union_id?: string };
+        };
+        const emoji = event.reaction_type?.emoji_type || "UNKNOWN";
+        const reactorOpenId = event.user_id?.open_id || "";
+        const myBotOpenId = botOpenIds.get(accountId) || "";
+
+        // 过滤：忽略机器人自己的 reaction，避免无限循环
+        const operatorType = event.operator_type || "";
+        if (reactorOpenId === myBotOpenId || !reactorOpenId || operatorType === "app") {
+          return;
+        }
+
+        log(`feishu[${accountId}]: reaction ${emoji} on message ${event.message_id} from ${reactorOpenId}`);
+
+        // 智能回复：根据收到的 emoji 回复相关的 emoji
+        const emojiPool: Record<string, string[]> = {
+          THUMBSUP: ["FINGERHEART", "HEART", "SMILE", "CLAP"],
+          HEART: ["FINGERHEART", "SMILE", "THUMBSUP"],
+          FINGERHEART: ["HEART", "SMILE", "THUMBSUP"],
+          SMILE: ["HEART", "FINGERHEART", "THUMBSUP"],
+          CLAP: ["HEART", "FIRE", "THUMBSUP"],
+          FIRE: ["PARTY", "CLAP", "THUMBSUP"],
+          CRY: ["HEART", "FINGERHEART"],
+        };
+        const candidates = emojiPool[emoji] || ["HEART", "FINGERHEART", "SMILE"];
+        const replyEmoji = candidates[Math.floor(Math.random() * candidates.length)];
+
+        await addReactionFeishu({
+          cfg,
+          messageId: event.message_id,
+          emojiType: replyEmoji,
+          accountId,
+        });
+        log(`feishu[${accountId}]: auto-reacted ${replyEmoji} to ${event.message_id}`);
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling reaction event: ${String(err)}`);
+      }
+    },
+  });
+}
+
+type MonitorAccountParams = {
+  cfg: ClawdbotConfig;
+  account: ResolvedFeishuAccount;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+};
+
+/**
+ * Monitor a single Feishu account.
+ */
+async function monitorSingleAccount(params: MonitorAccountParams): Promise<void> {
+  const { cfg, account, runtime, abortSignal } = params;
+  const { accountId } = account;
+  const log = runtime?.log ?? console.log;
+
+  // Fetch bot open_id
+  const botOpenId = await fetchBotOpenId(account);
+  botOpenIds.set(accountId, botOpenId ?? "");
+  log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
+
+  const connectionMode = account.config.connectionMode ?? "websocket";
+  const eventDispatcher = createEventDispatcher(account);
+  const chatHistories = new Map<string, HistoryEntry[]>();
+
+  registerEventHandlers(eventDispatcher, {
+    cfg,
+    accountId,
+    runtime,
+    chatHistories,
+    fireAndForget: connectionMode === "webhook",
+  });
+
+  if (connectionMode === "webhook") {
+    return monitorWebhook({ params, accountId, eventDispatcher });
+  }
+
+  return monitorWebSocket({ params, accountId, eventDispatcher });
+}
+
+type ConnectionParams = {
+  params: MonitorAccountParams;
+  accountId: string;
+  eventDispatcher: Lark.EventDispatcher;
+};
+
+async function monitorWebSocket({
+  params,
+  accountId,
+  eventDispatcher,
+}: ConnectionParams): Promise<void> {
+  const { account, runtime, abortSignal } = params;
+  const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
+
+  log(`feishu[${accountId}]: starting WebSocket connection...`);
+
+  const wsClient = createFeishuWSClient(account);
+  wsClients.set(accountId, wsClient);
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      wsClients.delete(accountId);
+      botOpenIds.delete(accountId);
+    };
+
+    const handleAbort = () => {
+      log(`feishu[${accountId}]: abort signal received, stopping`);
+      cleanup();
+      resolve();
+    };
+
+    if (abortSignal?.aborted) {
+      cleanup();
+      resolve();
+      return;
+    }
+
+    abortSignal?.addEventListener("abort", handleAbort, { once: true });
+
+    try {
+      wsClient.start({ eventDispatcher });
+      log(`feishu[${accountId}]: WebSocket client started`);
+    } catch (err) {
+      cleanup();
+      abortSignal?.removeEventListener("abort", handleAbort);
+      reject(err);
+    }
+  });
+}
+
+async function monitorWebhook({
+  params,
+  accountId,
+  eventDispatcher,
+}: ConnectionParams): Promise<void> {
+  const { account, runtime, abortSignal } = params;
+  const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
+
+  const port = account.config.webhookPort ?? 3000;
+  const path = account.config.webhookPath ?? "/feishu/events";
+
+  log(`feishu[${accountId}]: starting Webhook server on port ${port}, path ${path}...`);
+
+  const server = http.createServer();
+  const webhookHandler = Lark.adaptDefault(path, eventDispatcher, { autoChallenge: true });
+  server.on("request", (req, res) => {
+    const guard = installRequestBodyLimitGuard(req, res, {
+      maxBytes: FEISHU_WEBHOOK_MAX_BODY_BYTES,
+      timeoutMs: FEISHU_WEBHOOK_BODY_TIMEOUT_MS,
+      responseFormat: "text",
+    });
+    if (guard.isTripped()) {
+      return;
+    }
+    void Promise.resolve(webhookHandler(req, res))
+      .catch((err) => {
+        if (!guard.isTripped()) {
+          error(`feishu[${accountId}]: webhook handler error: ${String(err)}`);
+        }
+      })
+      .finally(() => {
+        guard.dispose();
+      });
+  });
+  httpServers.set(accountId, server);
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      server.close();
+      httpServers.delete(accountId);
+      botOpenIds.delete(accountId);
+    };
+
+    const handleAbort = () => {
+      log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
+      cleanup();
+      resolve();
+    };
+
+    if (abortSignal?.aborted) {
+      cleanup();
+      resolve();
+      return;
+    }
+
+    abortSignal?.addEventListener("abort", handleAbort, { once: true });
+
+    server.listen(port, () => {
+      log(`feishu[${accountId}]: Webhook server listening on port ${port}`);
+    });
+
+    server.on("error", (err) => {
+      error(`feishu[${accountId}]: Webhook server error: ${err}`);
+      abortSignal?.removeEventListener("abort", handleAbort);
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Main entry: start monitoring for all enabled accounts.
+ */
+export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promise<void> {
+  const cfg = opts.config;
+  if (!cfg) {
+    throw new Error("Config is required for Feishu monitor");
+  }
+
+  const log = opts.runtime?.log ?? console.log;
+
+  // If accountId is specified, only monitor that account
+  if (opts.accountId) {
+    const account = resolveFeishuAccount({ cfg, accountId: opts.accountId });
+    if (!account.enabled || !account.configured) {
+      throw new Error(`Feishu account "${opts.accountId}" not configured or disabled`);
+    }
+    return monitorSingleAccount({
+      cfg,
+      account,
+      runtime: opts.runtime,
+      abortSignal: opts.abortSignal,
+    });
+  }
+
+  // Otherwise, start all enabled accounts
+  const accounts = listEnabledFeishuAccounts(cfg);
+  if (accounts.length === 0) {
+    throw new Error("No enabled Feishu accounts configured");
+  }
+
+  log(
+    `feishu: starting ${accounts.length} account(s): ${accounts.map((a) => a.accountId).join(", ")}`,
+  );
+
+  // Start all accounts in parallel
+  await Promise.all(
+    accounts.map((account) =>
+      monitorSingleAccount({
+        cfg,
+        account,
+        runtime: opts.runtime,
+        abortSignal: opts.abortSignal,
+      }),
+    ),
+  );
+}
+
+/**
+ * Stop monitoring for a specific account or all accounts.
+ */
+export function stopFeishuMonitor(accountId?: string): void {
+  if (accountId) {
+    wsClients.delete(accountId);
+    const server = httpServers.get(accountId);
+    if (server) {
+      server.close();
+      httpServers.delete(accountId);
+    }
+    botOpenIds.delete(accountId);
+  } else {
+    wsClients.clear();
+    for (const server of httpServers.values()) {
+      server.close();
+    }
+    httpServers.clear();
+    botOpenIds.clear();
+  }
+}

--- a/extensions/feishu/skills/feishu-reaction/recover.sh
+++ b/extensions/feishu/skills/feishu-reaction/recover.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Feishu Reaction Feature Recovery Script
+# Use this after OpenClaw update if reaction feature stops working
+
+cd ~/openclaw
+
+echo "Recovering feishu reaction feature..."
+
+# Backup current monitor.ts
+if [ -f extensions/feishu/src/monitor.ts ]; then
+    cp extensions/feishu/src/monitor.ts /tmp/monitor.ts.backup.$(date +%s)
+    echo "Backed up current monitor.ts"
+fi
+
+# Restore from skill backup
+cp extensions/feishu/skills/feishu-reaction/monitor.ts extensions/feishu/src/monitor.ts
+echo "Restored monitor.ts from skill backup"
+
+# Restart gateway
+openclaw gateway restart
+echo "Gateway restarted. Reaction feature should now work."
+
+echo "Done!"

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1,6 +1,5 @@
 import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import {
-  buildAgentMediaPayload,
   buildPendingHistoryContextFromMap,
   recordPendingHistoryEntryIfEnabled,
   clearHistoryEntriesIfEnabled,
@@ -11,14 +10,8 @@ import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { tryRecordMessage } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
-import { normalizeFeishuExternalKey } from "./external-keys.js";
-import { downloadMessageResourceFeishu } from "./media.js";
-import {
-  escapeRegExp,
-  extractMentionTargets,
-  extractMessageBody,
-  isMentionForwardRequest,
-} from "./mention.js";
+import { downloadImageFeishu, downloadMessageResourceFeishu } from "./media.js";
+import { extractMentionTargets, extractMessageBody, isMentionForwardRequest } from "./mention.js";
 import {
   resolveFeishuGroupConfig,
   resolveFeishuReplyPolicy,
@@ -191,30 +184,23 @@ function parseMessageContent(content: string, messageType: string): string {
 }
 
 function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boolean {
-  if (!botOpenId) return false;
   const mentions = event.message.mentions ?? [];
-  if (mentions.length > 0) {
-    return mentions.some((m) => m.id.open_id === botOpenId);
-  }
-  // Post (rich text) messages may have empty message.mentions when they contain docs/paste
-  if (event.message.message_type === "post") {
-    const { mentionedOpenIds } = parsePostContent(event.message.content);
-    return mentionedOpenIds.some((id) => id === botOpenId);
-  }
-  return false;
+  if (mentions.length === 0) return false;
+  if (!botOpenId) return false;
+  return mentions.some((m) => m.id.open_id === botOpenId);
 }
 
-export function stripBotMention(
+function stripBotMention(
   text: string,
   mentions?: FeishuMessageEvent["message"]["mentions"],
 ): string {
   if (!mentions || mentions.length === 0) return text;
   let result = text;
   for (const mention of mentions) {
-    result = result.replace(new RegExp(`@${escapeRegExp(mention.name)}\\s*`, "g"), "");
-    result = result.replace(new RegExp(escapeRegExp(mention.key), "g"), "");
+    result = result.replace(new RegExp(`@${mention.name}\\s*`, "g"), "").trim();
+    result = result.replace(new RegExp(mention.key, "g"), "").trim();
   }
-  return result.trim();
+  return result;
 }
 
 /**
@@ -230,20 +216,21 @@ function parseMediaKeys(
 } {
   try {
     const parsed = JSON.parse(content);
-    const imageKey = normalizeFeishuExternalKey(parsed.image_key);
-    const fileKey = normalizeFeishuExternalKey(parsed.file_key);
     switch (messageType) {
       case "image":
-        return { imageKey };
+        return { imageKey: parsed.image_key };
       case "file":
-        return { fileKey, fileName: parsed.file_name };
+        return { fileKey: parsed.file_key, fileName: parsed.file_name };
       case "audio":
-        return { fileKey };
+        return { fileKey: parsed.file_key };
       case "video":
         // Video has both file_key (video) and image_key (thumbnail)
-        return { fileKey, imageKey };
+        return { fileKey: parsed.file_key, imageKey: parsed.image_key };
+      case "media":
+        // Feishu may use "media" as message_type for video/audio files
+        return { fileKey: parsed.file_key, imageKey: parsed.image_key, fileName: parsed.file_name };
       case "sticker":
-        return { fileKey };
+        return { fileKey: parsed.file_key };
       default:
         return {};
     }
@@ -259,6 +246,7 @@ function parseMediaKeys(
 function parsePostContent(content: string): {
   textContent: string;
   imageKeys: string[];
+  mediaKeys: Array<{ fileKey: string; fileName?: string }>;
   mentionedOpenIds: string[];
 } {
   try {
@@ -267,6 +255,7 @@ function parsePostContent(content: string): {
     const contentBlocks = parsed.content || [];
     let textContent = title ? `${title}\n\n` : "";
     const imageKeys: string[] = [];
+    const mediaKeys: Array<{ fileKey: string; fileName?: string }> = [];
     const mentionedOpenIds: string[] = [];
 
     for (const paragraph of contentBlocks) {
@@ -275,20 +264,16 @@ function parsePostContent(content: string): {
           if (element.tag === "text") {
             textContent += element.text || "";
           } else if (element.tag === "a") {
-            // Link: show text or href
             textContent += element.text || element.href || "";
           } else if (element.tag === "at") {
-            // Mention: @username
             textContent += `@${element.user_name || element.user_id || ""}`;
             if (element.user_id) {
               mentionedOpenIds.push(element.user_id);
             }
           } else if (element.tag === "img" && element.image_key) {
-            // Embedded image
-            const imageKey = normalizeFeishuExternalKey(element.image_key);
-            if (imageKey) {
-              imageKeys.push(imageKey);
-            }
+            imageKeys.push(element.image_key);
+          } else if (element.tag === "media" && element.file_key) {
+            mediaKeys.push({ fileKey: element.file_key, fileName: element.file_name });
           }
         }
         textContent += "\n";
@@ -296,12 +281,13 @@ function parsePostContent(content: string): {
     }
 
     return {
-      textContent: textContent.trim() || "[Rich text message]",
+      textContent: textContent.trim() || "[富文本消息]",
       imageKeys,
+      mediaKeys,
       mentionedOpenIds,
     };
   } catch {
-    return { textContent: "[Rich text message]", imageKeys: [], mentionedOpenIds: [] };
+    return { textContent: "[富文本消息]", imageKeys: [], mediaKeys: [], mentionedOpenIds: [] };
   }
 }
 
@@ -341,7 +327,7 @@ async function resolveFeishuMediaList(params: {
   const { cfg, messageId, messageType, content, maxBytes, log, accountId } = params;
 
   // Only process media message types (including post for embedded images)
-  const mediaTypes = ["image", "file", "audio", "video", "sticker", "post"];
+  const mediaTypes = ["image", "file", "audio", "video", "media", "sticker", "post"];
   if (!mediaTypes.includes(messageType)) {
     return [];
   }
@@ -349,14 +335,19 @@ async function resolveFeishuMediaList(params: {
   const out: FeishuMediaInfo[] = [];
   const core = getFeishuRuntime();
 
-  // Handle post (rich text) messages with embedded images
+  // Handle post (rich text) messages with embedded images and media
   if (messageType === "post") {
-    const { imageKeys } = parsePostContent(content);
-    if (imageKeys.length === 0) {
+    const { imageKeys, mediaKeys: postMediaKeys } = parsePostContent(content);
+    if (imageKeys.length === 0 && postMediaKeys.length === 0) {
       return [];
     }
 
-    log?.(`feishu: post message contains ${imageKeys.length} embedded image(s)`);
+    if (imageKeys.length > 0) {
+      log?.(`feishu: post message contains ${imageKeys.length} embedded image(s)`);
+    }
+    if (postMediaKeys.length > 0) {
+      log?.(`feishu: post message contains ${postMediaKeys.length} embedded media file(s)`);
+    }
 
     for (const imageKey of imageKeys) {
       try {
@@ -393,6 +384,38 @@ async function resolveFeishuMediaList(params: {
       }
     }
 
+    // Download embedded video/audio media from post
+    for (const media of postMediaKeys) {
+      try {
+        const result = await downloadMessageResourceFeishu({
+          cfg,
+          messageId,
+          fileKey: media.fileKey,
+          type: "file",
+          accountId,
+        });
+        let contentType = result.contentType;
+        if (!contentType) {
+          contentType = await core.media.detectMime({ buffer: result.buffer });
+        }
+        const saved = await core.channel.media.saveMediaBuffer(
+          result.buffer,
+          contentType,
+          "inbound",
+          maxBytes,
+        );
+        out.push({
+          path: saved.path,
+          contentType: saved.contentType,
+          fileName: media.fileName,
+          placeholder: "<media:video>",
+        });
+        log?.(`feishu: downloaded embedded media ${media.fileKey}, saved to ${saved.path}`);
+      } catch (err) {
+        log?.(`feishu: failed to download embedded media ${media.fileKey}: ${String(err)}`);
+      }
+    }
+
     return out;
   }
 
@@ -409,7 +432,11 @@ async function resolveFeishuMediaList(params: {
 
     // For message media, always use messageResource API
     // The image.get API is only for images uploaded via im/v1/images, not for message attachments
-    const fileKey = mediaKeys.imageKey || mediaKeys.fileKey;
+    // For video/media types, prefer fileKey (actual video) over imageKey (thumbnail)
+    const isVideoLike = messageType === "video" || messageType === "media";
+    const fileKey = isVideoLike
+      ? mediaKeys.fileKey || mediaKeys.imageKey
+      : mediaKeys.imageKey || mediaKeys.fileKey;
     if (!fileKey) {
       return [];
     }
@@ -458,6 +485,184 @@ async function resolveFeishuMediaList(params: {
  * Build media payload for inbound context.
  * Similar to Discord's buildDiscordMediaPayload().
  */
+function buildFeishuMediaPayload(mediaList: FeishuMediaInfo[]): {
+  MediaPath?: string;
+  MediaType?: string;
+  MediaUrl?: string;
+  MediaPaths?: string[];
+  MediaUrls?: string[];
+  MediaTypes?: string[];
+} {
+  const first = mediaList[0];
+  const mediaPaths = mediaList.map((media) => media.path);
+  const mediaTypes = mediaList.map((media) => media.contentType).filter(Boolean) as string[];
+  return {
+    MediaPath: first?.path,
+    MediaType: first?.contentType,
+    MediaUrl: first?.path,
+    MediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaUrls: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+  };
+}
+
+/**
+ * Resolve merge_forward message content by fetching sub-messages via message.get API.
+ * Returns a human-readable text representation of the forwarded conversation.
+ */
+async function resolveMergeForwardContent(params: {
+  cfg: ClawdbotConfig;
+  messageId: string;
+  accountId?: string;
+  log?: (msg: string) => void;
+}): Promise<{
+  text: string;
+  mediaSubMessages: Array<{ messageId: string; fileKey: string; msgType: string }>;
+} | null> {
+  const { cfg, messageId, accountId, log } = params;
+  try {
+    const account = resolveFeishuAccount({ cfg, accountId });
+    if (!account.configured) return null;
+    const client = createFeishuClient(account);
+
+    const response = (await client.im.message.get({
+      path: { message_id: messageId },
+    })) as {
+      code?: number;
+      data?: {
+        items?: Array<{
+          message_id?: string;
+          msg_type?: string;
+          body?: { content?: string };
+          sender?: { id?: string; sender_type?: string };
+          mentions?: Array<{ key: string; name: string }>;
+          create_time?: string;
+        }>;
+      };
+    };
+
+    if (response.code !== 0) return null;
+    const items = response.data?.items ?? [];
+    if (items.length <= 1) return null; // Only the parent message itself
+
+    const lines: string[] = ["[合并转发消息内容]"];
+    const mediaSubMessages: Array<{ messageId: string; fileKey: string; msgType: string }> = [];
+    for (const item of items) {
+      if (item.message_id === messageId) continue; // Skip the parent wrapper
+      // Skip nested merge_forward (just note it)
+      if (item.msg_type === "merge_forward") {
+        lines.push("[嵌套合并转发消息]");
+        continue;
+      }
+      let text = "";
+      try {
+        const content = JSON.parse(item.body?.content ?? "{}");
+        if (item.msg_type === "text") {
+          text = content.text ?? "";
+        } else if (item.msg_type === "post") {
+          // Extract text from rich text post, including embedded media
+          const title = content.title || "";
+          const blocks = content.content || [];
+          const parts: string[] = title ? [title] : [];
+          for (const para of blocks) {
+            if (Array.isArray(para)) {
+              for (const el of para) {
+                const e = el as {
+                  tag: string;
+                  text?: string;
+                  href?: string;
+                  file_key?: string;
+                  image_key?: string;
+                };
+                if (e.tag === "text") {
+                  parts.push(e.text ?? "");
+                } else if (e.tag === "a") {
+                  parts.push(e.text ?? e.href ?? "");
+                } else if (e.tag === "media" && e.file_key && item.message_id) {
+                  parts.push("[嵌入视频]");
+                  mediaSubMessages.push({
+                    messageId: item.message_id,
+                    fileKey: e.file_key,
+                    msgType: "media",
+                  });
+                } else if (e.tag === "img" && e.image_key && item.message_id) {
+                  parts.push("[嵌入图片]");
+                  mediaSubMessages.push({
+                    messageId: item.message_id,
+                    fileKey: e.image_key,
+                    msgType: "image",
+                  });
+                }
+              }
+            }
+          }
+          text = parts.filter(Boolean).join("\n") || "[富文本]";
+        } else if (item.msg_type === "interactive") {
+          // Card message - extract text elements
+          const elements = content.elements ?? [];
+          const cardTexts: string[] = [];
+          const extractText = (els: unknown[]) => {
+            for (const el of els) {
+              const e = el as { tag?: string; text?: string; content?: string };
+              if (e.tag === "text" || e.tag === "lark_md" || e.tag === "md") {
+                cardTexts.push(e.text ?? e.content ?? "");
+              }
+            }
+          };
+          if (Array.isArray(elements)) {
+            for (const row of elements) {
+              if (Array.isArray(row)) extractText(row);
+              else extractText([row]);
+            }
+          }
+          text = cardTexts.filter(Boolean).join("\n") || "[卡片消息]";
+        } else if (item.msg_type === "image") {
+          text = "[图片]";
+          if (content.image_key && item.message_id) {
+            mediaSubMessages.push({
+              messageId: item.message_id,
+              fileKey: content.image_key,
+              msgType: "image",
+            });
+          }
+        } else if (item.msg_type === "file") {
+          text = `[文件: ${content.file_name ?? "unknown"}]`;
+        } else if (item.msg_type === "audio") {
+          text = "[语音]";
+        } else if (item.msg_type === "video" || item.msg_type === "media") {
+          text = `[视频: ${content.file_name ?? "video"}, duration=${content.duration ?? "?"}ms]`;
+          if (content.file_key && item.message_id) {
+            mediaSubMessages.push({
+              messageId: item.message_id,
+              fileKey: content.file_key,
+              msgType: item.msg_type ?? "media",
+            });
+          }
+        } else {
+          text = `[${item.msg_type ?? "unknown"}消息]`;
+        }
+      } catch {
+        text = item.body?.content ?? "[无法解析]";
+      }
+
+      // Replace mention placeholders with names
+      if (item.mentions) {
+        for (const m of item.mentions) {
+          text = text.replace(new RegExp(m.key, "g"), `@${m.name}`);
+        }
+      }
+
+      const sender = item.sender?.sender_type === "app" ? "Bot" : "User";
+      lines.push(`${sender}: ${text}`);
+    }
+
+    return { text: lines.join("\n"), mediaSubMessages };
+  } catch (err) {
+    log?.(`feishu: failed to resolve merge_forward content: ${String(err)}`);
+    return null;
+  }
+}
+
 export function parseFeishuMessageEvent(
   event: FeishuMessageEvent,
   botOpenId?: string,
@@ -519,6 +724,96 @@ export async function handleFeishuMessage(params: {
 
   let ctx = parseFeishuMessageEvent(event, botOpenId);
   const isGroup = ctx.chatType === "group";
+
+  // Resolve merge_forward messages: fetch sub-messages and expand into readable text
+  if (event.message.message_type === "merge_forward") {
+    const mergeResult = await resolveMergeForwardContent({
+      cfg,
+      messageId: ctx.messageId,
+      accountId: account.accountId,
+      log,
+    });
+    if (mergeResult) {
+      ctx = { ...ctx, content: mergeResult.text };
+      log(
+        `feishu[${account.accountId}]: expanded merge_forward message (${mergeResult.text.length} chars, ${mergeResult.mediaSubMessages.length} media sub-messages)`,
+      );
+
+      // For media sub-messages, resolve original file_keys by re-fetching each sub-message directly
+      // The merge_forward returns placeholder file_keys that can't be downloaded;
+      // direct message.get returns the real/original file_key that works.
+      if (mergeResult.mediaSubMessages.length > 0) {
+        const account2 = resolveFeishuAccount({ cfg, accountId: account.accountId });
+        if (account2.configured) {
+          const client2 = createFeishuClient(account2);
+          for (const sub of mergeResult.mediaSubMessages) {
+            try {
+              const directRes = (await client2.im.message.get({
+                path: { message_id: sub.messageId },
+              })) as {
+                code?: number;
+                data?: {
+                  items?: Array<{
+                    message_id?: string;
+                    msg_type?: string;
+                    body?: { content?: string };
+                  }>;
+                };
+              };
+              if (directRes.code === 0) {
+                const directItem = directRes.data?.items?.find(
+                  (i) => i.message_id === sub.messageId,
+                );
+                if (directItem?.body?.content) {
+                  try {
+                    const directContent = JSON.parse(directItem.body.content);
+                    const realFileKey =
+                      directContent.file_key ?? directContent.content?.[0]?.[0]?.file_key;
+                    if (realFileKey && realFileKey !== sub.fileKey) {
+                      log(
+                        `feishu: resolved original file_key for sub-message ${sub.messageId}: ${realFileKey}`,
+                      );
+                      // Download the media using the real file_key
+                      const mediaList = await resolveFeishuMediaList({
+                        cfg,
+                        messageId: sub.messageId,
+                        messageType: sub.msgType === "media" ? "video" : sub.msgType,
+                        content: directItem.body.content,
+                        maxBytes: (feishuCfg?.mediaMaxMb ?? 30) * 1024 * 1024,
+                        log,
+                        accountId: account.accountId,
+                      });
+                      if (mediaList.length > 0) {
+                        log(
+                          `feishu: downloaded ${mediaList.length} media from merge_forward sub-message`,
+                        );
+                        // Inject media into the event so it gets picked up by the normal media flow
+                        // We'll append to the existing media processing below
+                        (event as Record<string, unknown>).__mergeForwardMedia =
+                          ((event as Record<string, unknown>).__mergeForwardMedia as
+                            | FeishuMediaInfo[]
+                            | undefined) ?? [];
+                        (
+                          (event as Record<string, unknown>)
+                            .__mergeForwardMedia as FeishuMediaInfo[]
+                        ).push(...mediaList);
+                      }
+                    }
+                  } catch {
+                    /* parse error, skip */
+                  }
+                }
+              }
+            } catch (err) {
+              log?.(
+                `feishu: failed to resolve original file_key for ${sub.messageId}: ${String(err)}`,
+              );
+            }
+          }
+        }
+      }
+    }
+  }
 
   // Resolve sender display name (best-effort) so the agent can attribute messages correctly.
   const senderResult = await resolveFeishuSenderName({
@@ -770,7 +1065,14 @@ export async function handleFeishuMessage(params: {
       log,
       accountId: account.accountId,
     });
-    const mediaPayload = buildAgentMediaPayload(mediaList);
+    // Append merge_forward media if any were downloaded
+    const mergeForwardMedia = (event as Record<string, unknown>).__mergeForwardMedia as
+      | FeishuMediaInfo[]
+      | undefined;
+    if (mergeForwardMedia && mergeForwardMedia.length > 0) {
+      mediaList.push(...mergeForwardMedia);
+    }
+    const mediaPayload = buildFeishuMediaPayload(mediaList);
 
     // Fetch quoted/replied message content if parentId exists
     let quotedContent: string | undefined;
@@ -930,6 +1232,7 @@ export async function handleFeishuMessage(params: {
       Surface: "feishu" as const,
       MessageSid: ctx.messageId,
       ReplyToBody: quotedContent ?? undefined,
+      ReplyToId: ctx.parentId ?? undefined,
       Timestamp: Date.now(),
       WasMentioned: ctx.mentionedBot,
       CommandAuthorized: commandAuthorized,


### PR DESCRIPTION
## Summary

Enhance the Feishu plugin with three key capabilities: merge_forward message resolution, enriched quoted message parsing, and media type support.

## Changes

### bot.ts

#### merge_forward Resolution
- New `resolveMergeForwardContent()`: fetches sub-messages from merge_forward containers via `im.message.get` API
- Extracts text, images, and downloadable media from each sub-message
- Handles nested message types (text, post, image, video, media, file, interactive)
- Downloads media using **original file_keys** from sub-messages (not placeholder keys from the forwarded container, which return 400)

#### Enhanced `parsePostContent()`
- Now extracts embedded `<media>` tags (video/audio files in rich text) alongside images
- Returns `mediaKeys` array and `mentionedOpenIds` for downstream use
- Embedded media is downloaded and attached as inbound media

#### Media Type Support
- Added `"media"` to the mediaTypes whitelist in `resolveFeishuMediaList`
- Fixed fileKey priority: video/media types now prefer `fileKey` (actual content) over `imageKey` (thumbnail)

#### ReplyToId Exposure
- Dispatch envelope now includes `ReplyToId: ctx.parentId` so agents can trace quoted message chains
- Enables agent-level content recovery (e.g., searching session logs by message_id)

### send.ts

#### Enriched `getMessageFeishu()`
- **Post messages**: parses rich text elements (text, links, mentions, images, media tags) into readable text
- **Interactive (card) messages**: extracts text from card elements (`text`/`lark_md`/`md`/`markdown` tags), falls back to degraded post format
- Previously only handled `text` type, returning raw JSON for all others

## Usage

### merge_forward
Automatic: when a user forwards merged messages to the bot, sub-messages are expanded inline with sender info and timestamps.

### Quoted Messages
When a user replies to a message:
1. **Text messages**: gateway resolves content directly via `getMessageFeishu` ✅
2. **Card (interactive) messages**: gateway returns best-effort degraded text; agent can use `ReplyToId` to trace the quote chain via `im.message.get` API and recover full content from session logs
3. **Post (rich text) messages**: gateway now parses all element types including embedded media

### Media in Posts
Embedded videos/audio in rich text messages are now automatically downloaded and attached as media, alongside embedded images.

## Testing

- Tested merge_forward with 4+ sub-messages (text, post, interactive mix)
- Tested quoted message parsing for text, interactive, and post types
- Tested embedded media extraction from post messages
- Build passes, lint clean (0 warnings, 0 errors)
