### PR TITLE
feat(TUI): show main agent model in status footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,7 @@ Docs: https://docs.openclaw.ai
 - Security/Sandbox: remove default `--no-sandbox` for the browser container entrypoint, add explicit opt-in via `OPENCLAW_BROWSER_NO_SANDBOX` / `CLAWDBOT_BROWSER_NO_SANDBOX`, and add security-audit checks for stale/missing sandbox browser Docker hash labels. Thanks @TerminalsandCoffee and @vincentkoc.
 - Security/Sandbox Browser: require VNC password auth for noVNC observer sessions in the sandbox browser entrypoint, plumb per-container noVNC passwords from runtime, and emit short-lived noVNC observer token URLs while keeping loopback-only host port publishing. Thanks @TerminalsandCoffee for reporting.
 - Security/Sandbox Browser: default browser sandbox containers to a dedicated Docker network (`openclaw-sandbox-browser`), add optional CDP ingress source-range restrictions, auto-create missing dedicated networks, and warn in `openclaw security --audit` when browser sandboxing runs on bridge without source-range limits. Thanks @TerminalsandCoffee for reporting.
+- TUI/Status: fall back to `sessions.list` defaults when the current session row is missing, so the status footer still shows the main agent model. (#21524)
 
 ## 2026.2.19
 

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -111,4 +111,66 @@ describe("tui session actions", () => {
     expect(updateFooter).toHaveBeenCalledTimes(2);
     expect(requestRender).toHaveBeenCalledTimes(2);
   });
+
+  it("falls back to session defaults when the current session row is missing", async () => {
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const updateFooter = vi.fn();
+    const updateAutocompleteProvider = vi.fn();
+    const requestRender = vi.fn();
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 0,
+      defaults: {
+        modelProvider: "anthropic",
+        model: "claude-opus-4-5",
+      },
+      sessions: [],
+    });
+
+    const { refreshSessionInfo } = createSessionActions({
+      client: { listSessions } as unknown as GatewayChatClient,
+      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter,
+      updateAutocompleteProvider,
+      setActivityStatus: vi.fn(),
+    });
+
+    await refreshSessionInfo();
+
+    expect(state.sessionInfo.modelProvider).toBe("anthropic");
+    expect(state.sessionInfo.model).toBe("claude-opus-4-5");
+    expect(updateAutocompleteProvider).toHaveBeenCalledTimes(1);
+    expect(updateFooter).toHaveBeenCalledTimes(1);
+    expect(requestRender).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -173,4 +173,69 @@ describe("tui session actions", () => {
     expect(updateFooter).toHaveBeenCalledTimes(1);
     expect(requestRender).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps current model for global session when sessions list omits the row", async () => {
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "global",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {
+        modelProvider: "minimax",
+        model: "Minimax-M2.1",
+      },
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const updateFooter = vi.fn();
+    const updateAutocompleteProvider = vi.fn();
+    const requestRender = vi.fn();
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 0,
+      defaults: {
+        modelProvider: "anthropic",
+        model: "claude-opus-4-5",
+      },
+      sessions: [],
+    });
+
+    const { refreshSessionInfo } = createSessionActions({
+      client: { listSessions } as unknown as GatewayChatClient,
+      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter,
+      updateAutocompleteProvider,
+      setActivityStatus: vi.fn(),
+    });
+
+    await refreshSessionInfo();
+
+    expect(state.sessionInfo.modelProvider).toBe("minimax");
+    expect(state.sessionInfo.model).toBe("Minimax-M2.1");
+    expect(updateAutocompleteProvider).toHaveBeenCalledTimes(1);
+    expect(updateFooter).toHaveBeenCalledTimes(1);
+    expect(requestRender).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In TUI, the status footer could show `unknown` model for the main agent when the current session row was missing from `sessions.list`.
- Why it matters: Operators cannot reliably confirm which model/provider the main agent is using, which hurts debugging and trust in runtime state.
- What changed: TUI session-info model resolution now falls back to `sessions.list` defaults (`model`/`modelProvider`) when the per-session row is absent; added regression test coverage for this path.
- What did NOT change (scope boundary): No gateway protocol/schema changes, no model-selection policy changes, no auth/token behavior changes, and no channel/integration routing changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21524
- Related 

## User-visible / Behavior Changes

TUI footer model display no longer falls back to `unknown` in the main-agent session when session defaults are available from `sessions.list`; it now shows the default provider/model.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (local dev shell)
- Runtime/container: Node 22.20.0 + pnpm
- Model/provider: anthropic/claude-opus-4-5 (example default used in regression case)
- Integration/channel (if any): TUI (Gateway client)
- Relevant config (redacted): `agents.defaults.model` configured; per-session row absent for `agent:main:main`

### Steps

1. Configure a default model for the main agent and start TUI.
2. Use a main session key where `sessions.list` returns defaults but no matching session row.
3. Check the footer model label.

### Expected

- Footer shows the resolved default provider/model instead of `unknown`.

### Actual

- Before fix: footer could show `unknown`.
- After fix: footer shows default provider/model (for example `anthropic/claude-opus-4-5`).

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace snippet:

```text
✓ src/tui/tui-session-actions.test.ts (2 tests)
Test Files  1 passed (1)
Tests       2 passed (2)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran targeted unit test `src/tui/tui-session-actions.test.ts`, including the new case for missing current session row + defaults fallback.
- Edge cases checked: Existing behavior where explicit session model/provider data still wins; missing-row fallback path now populates footer/autocomplete model info.
- What you did **not** verify: Manual live TUI interaction against a real gateway instance and non-main-agent visual checks.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `889a12c6f` (`git revert 889a12c6f`).
- Files/config to restore: `src/tui/tui-session-actions.ts`, `src/tui/tui-session-actions.test.ts` (and changelog line if needed).
- Known bad symptoms reviewers should watch for: Footer model/provider showing wrong fallback when session rows are delayed or missing.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Defaults-based fallback could temporarily show default model while a newer runtime model has not yet been persisted to the session row.
  - Mitigation: Runtime session row values still take precedence when present; fallback only applies when the row is missing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed TUI footer model resolution to fall back to session defaults when current row is missing from `sessions.list`, preventing "unknown" display for main agent model.

- Added `normalizeModelField` helper to consistently handle null/empty model strings
- Enhanced `resolveModelSelection` to accept defaults and optionally preserve current values
- Added `keepCurrentModelWhenEntryMissing` flag to preserve existing model for `global`/`unknown` sessions
- Added comprehensive test coverage for missing-row fallback scenarios
- Incidental: Stabilized media-understanding tests for Windows with platform-specific executable generation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows defensive coding practices. The fallback logic is properly scoped to only apply when session rows are missing, preserving existing runtime values when available. Test coverage validates both the main fix (missing row fallback) and the edge case (global sessions preserve current model). The media test changes are a simple cross-platform compatibility improvement with no behavioral changes.
- No files require special attention

<sub>Last reviewed commit: ca52487</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->