### PR TITLE
OpenClaw changes for cliapi (CLIProxyAPI 8317 / claude-cli, codex-cli…

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -438,13 +438,16 @@ export async function sanitizeSessionHistory(params: {
       modelId: params.modelId,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
+  const forceToolIdSanitizeForOpenAiCompletions =
+    params.modelApi === "openai-completions" && !policy.sanitizeToolCallIds;
   const sanitizedImages = await sanitizeSessionMessagesImages(
     withInterSessionMarkers,
     "session:history",
     {
       sanitizeMode: policy.sanitizeMode,
-      sanitizeToolCallIds: policy.sanitizeToolCallIds,
-      toolCallIdMode: policy.toolCallIdMode,
+      sanitizeToolCallIds: policy.sanitizeToolCallIds || forceToolIdSanitizeForOpenAiCompletions,
+      toolCallIdMode:
+        policy.toolCallIdMode ?? (forceToolIdSanitizeForOpenAiCompletions ? "strict" : undefined),
       preserveSignatures: policy.preserveSignatures,
       sanitizeThoughtSignatures: policy.sanitizeThoughtSignatures,
       ...resolveImageSanitizationLimits(params.config),

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -161,11 +161,20 @@ function rewriteAssistantToolCallIds(params: {
     const rec = block as { type?: unknown; id?: unknown };
     const type = rec.type;
     const id = rec.id;
-    if (
-      (type !== "functionCall" && type !== "toolUse" && type !== "toolCall") ||
-      typeof id !== "string" ||
-      !id
-    ) {
+    if (typeof id !== "string" || !id) {
+      return block;
+    }
+    const typeStr = typeof type === "string" ? type.toLowerCase() : "";
+    const isToolCallBlock =
+      type === "functionCall" ||
+      type === "function_call" ||
+      type === "toolUse" ||
+      type === "tool_use" ||
+      type === "toolCall" ||
+      typeStr === "tool_call" ||
+      typeStr.includes("tool_use") ||
+      typeStr.includes("function_call");
+    if (!isToolCallBlock) {
       return block;
     }
     const nextId = params.resolve(id);

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -95,7 +95,10 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
+  // Enable for openai-completions (e.g. CLIProxyAPI 8317 for claude-cli/codex-cli) so tool_use.id
+  // is sanitized to match ^[a-zA-Z0-9_-]+$ and avoid 400 from upstream.
+  const sanitizeToolCallIds =
+    isGoogle || isMistral || isAnthropic || isOpenAi || isOpenAiApi(params.modelApi);
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
     : sanitizeToolCallIds
@@ -109,7 +112,7 @@ export function resolveTranscriptPolicy(params: {
 
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
-    sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
+    sanitizeToolCallIds,
     toolCallIdMode,
     repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
     preserveSignatures: isAntigravityClaudeModel,


### PR DESCRIPTION
…): cliapi-supporting version

Per cliapi skill: fix OpenClaw only (do not modify CLIProxyAPI).

1) claude-cli & codex-cli: use embedded path when baseUrl is set
   - model-selection.ts (isCliProvider): For claude-cli and codex-cli, when models.providers[provider].baseUrl is set (e.g. http://127.0.0.1:8317/v1), return false so OpenClaw uses runEmbeddedPiAgent (HTTP to 8317) instead of runCliAgent (CLI subprocess). Aligns with antigravity-cli.

2) resolveModel: prefer config over registry for 8317
   - pi-embedded-runner/model.ts: For codex-cli (openai-codex / openai-codex-responses) and claude-cli (anthropic / anthropic-messages), when config defines the provider with same modelId, return config model (openai-completions, 8317) so requests go to CLIProxyAPI, not thread API or direct Anthropic.

3) 400 tool_use.id: sanitize ids to match ^[a-zA-Z0-9_-]+$
   - transcript-policy.ts: Enable sanitizeToolCallIds when modelApi is openai-completions (isOpenAiApi(params.modelApi)) so 8317 requests get tool_use id sanitization.
   - tool-call-id.ts: In rewriteAssistantToolCallIds, treat tool_use / tool_call / function_call (and camelCase variants) as tool-call blocks and rewrite id via sanitizeToolCallIdsForCloudCodeAssist; permissive type check.
   - pi-embedded-runner/google.ts: In sanitizeSessionHistory, when modelApi === "openai-completions", force sanitizeToolCallIds and toolCallIdMode "strict" so session history sent to 8317 always has valid tool_use ids.

This is a version that supports cliapi (antigravity-cli, codex-cli, claude-cli via CLIProxyAPI at 8317; Telegram /model and chat/completions work without 502/403 and without tool_use.id 400).

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds CLIProxyAPI support for `claude-cli` and `codex-cli` providers by routing them through HTTP (port 8317) instead of CLI subprocesses when a `baseUrl` is configured. It also sanitizes tool call IDs to comply with the `^[a-zA-Z0-9_-]+$` pattern required by upstream APIs.

- Routes `claude-cli`/`codex-cli` to embedded HTTP path when `baseUrl` is set (matching `antigravity-cli` behavior)
- Prefers config-defined providers over registry to ensure requests go to CLIProxyAPI instead of direct APIs
- Enables tool call ID sanitization for `openai-completions` API to prevent 400 errors
- Expands tool call block detection to handle snake_case variants (`tool_use`, `function_call`)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor risk - changes are well-scoped to CLI proxy routing and tool ID sanitization
- The changes are focused and follow existing patterns (antigravity-cli). Code is defensive with multiple fallback paths. The tool ID sanitization expands type checking which could be more permissive than intended, but is unlikely to cause runtime issues since it still validates the presence of an id field.
- `src/agents/tool-call-id.ts` (expanded type detection logic should be monitored)

<sub>Last reviewed commit: 7ce49dd</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->