### PR TITLE
fix(prompt): move per-turn ids from system prompt to user context (#21785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ Docs: https://docs.openclaw.ai
 - Browser/Relay: reuse an already-running extension relay when the relay port is occupied by another OpenClaw process, while still failing on non-relay port collisions to avoid masking unrelated listeners. (#20035) Thanks @mbelinky.
 - Scripts: update clawdock helper command support to include `docker-compose.extra.yml` where available. (#17094) Thanks @zerone0x.
 - Lobster/Config: remove Lobster executable-path overrides (`lobsterPath`), require PATH-based execution, and add focused Windows wrapper-resolution tests to keep shell-free behavior stable.
+- Security/Webhooks: harden Feishu and Zalo webhook ingress with webhook-mode token preconditions, loopback-default Feishu bind host, JSON content-type enforcement, per-path rate limiting, replay dedupe for Zalo events, constant-time Zalo secret comparison, and anomaly status counters.
+- Security/Plugins: add explicit `plugins.runtime.allowLegacyExec` opt-in to re-enable deprecated `runtime.system.runCommandWithTimeout` for legacy modules while keeping runtime command execution disabled by default. (#20874) Thanks @mbelinky.
 - Gateway/WebChat: block `sessions.patch` and `sessions.delete` for WebChat clients so session-store mutations stay restricted to non-WebChat operator flows. Thanks @allsmog for reporting.
 - Gateway: clarify launchctl GUI domain bootstrap failure on macOS. (#13795) Thanks @vincentkoc.
 - Lobster/CI: fix flaky test Windows cmd shim script resolution. (#20833) Thanks @vincentkoc.

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -24,6 +24,7 @@ describe("buildInboundMetaSystemPrompt", () => {
       MessageSid: "123",
       MessageSidFull: "123",
       ReplyToId: "99",
+      SenderId: "289522496",
       OriginatingTo: "telegram:5494292670",
       OriginatingChannel: "telegram",
       Provider: "telegram",
@@ -71,8 +72,23 @@ describe("buildInboundMetaSystemPrompt", () => {
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["sender_id"]).toBeUndefined();
   });
-});
 
+  it("system prompt is stable across turns with different message ids (#21785)", () => {
+    const base = {
+      OriginatingTo: "telegram:5494292670",
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+      SenderId: "289522496",
+    } as TemplateContext;
+
+    const turn1 = buildInboundMetaSystemPrompt({ ...base, MessageSid: "6678" } as TemplateContext);
+    const turn2 = buildInboundMetaSystemPrompt({ ...base, MessageSid: "6680" } as TemplateContext);
+
+    expect(turn1).toBe(turn2);
+  });
+});
 describe("buildInboundUserContextPrefix", () => {
   it("omits conversation label block for direct chats", () => {
     const text = buildInboundUserContextPrefix({
@@ -124,7 +140,6 @@ describe("buildInboundUserContextPrefix", () => {
     expect(conversationInfo["message_id"]).toBe("short-id");
     expect(conversationInfo["message_id_full"]).toBe("full-provider-message-id");
   });
-
   it("omits message_id_full when it matches message_id", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",


### PR DESCRIPTION
## Summary

- **Bug**: `buildInboundMetaSystemPrompt()` includes per-turn identifiers (`message_id`, `sender_id`, `reply_to_id`) that change every turn, breaking prefix-based KV cache reuse on local model providers
- **Root cause**: `message_id`, `message_id_full`, `sender_id`, and `reply_to_id` are emitted in the system-role `openclaw.inbound_meta.v1` JSON block in `inbound-meta.ts`
- **Fix**: Move per-turn identifiers to the user-role conversation info block; keep only session-level routing metadata in the system prompt

Fixes #21785

## Problem

When a local model provider (LM Studio, llama-server) receives consecutive turns, it can reuse the KV cache for the system prompt prefix — but only if the system prompt is identical across turns. `buildInboundMetaSystemPrompt()` includes `message_id`, `sender_id`, and `reply_to_id` which change on every inbound message, forcing a full prompt prefill from scratch on every turn.

**Before fix:**
```
Turn 1 system prompt: { "message_id": "6678", "sender_id": "289522496", ... }
Turn 2 system prompt: { "message_id": "6680", "sender_id": "289522496", ... }
→ System prompts differ → full KV cache invalidation every turn
```

## Changes

- `src/auto-reply/reply/inbound-meta.ts` — Remove `message_id`, `message_id_full`, `sender_id`, `reply_to_id` from `buildInboundMetaSystemPrompt()` payload; add `sender_id`, `reply_to_id`, `message_id_full` to `buildInboundUserContextPrefix()` conversation info block (where `message_id` already existed)
- `src/auto-reply/reply/inbound-meta.test.ts` — Update system prompt tests to assert per-turn ids are absent; add regression test for cross-turn prompt stability; add user context tests for relocated fields

**After fix:**
```
Turn 1 system prompt: { "chat_id": "telegram:5494292670", "channel": "telegram", ... }
Turn 2 system prompt: { "chat_id": "telegram:5494292670", "channel": "telegram", ... }
→ System prompts identical → KV cache prefix reused
```

Per-turn ids are still available to the agent in the user-role conversation info block.

## Test plan

- [x] New test: system prompt stable across turns with different message_ids
- [x] New test: per-turn ids absent from system prompt
- [x] New test: sender_id and reply_to_id present in user context
- [x] New test: message_id_full in user context when it differs from message_id
- [x] All 9 inbound-meta tests pass
- [x] All 2 get-reply-run.media-only tests pass
- [x] Format check passes

## Effect on User Experience

**Before:** Every inbound message causes a full system prompt prefill on local model providers because `message_id` changes each turn. Users on LM Studio / llama-server see slow response times and high GPU utilization.

**After:** The system prompt is stable across turns. Local model providers can reuse the KV cache prefix, reducing latency and GPU load. Per-turn identifiers remain accessible in the user-role context for tool actions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves per-turn identifiers (`message_id`, `sender_id`, `reply_to_id`, `message_id_full`) from system prompt to user-role context to enable KV cache prefix reuse on local model providers.

- Removed per-turn identifiers from `buildInboundMetaSystemPrompt()` - only session-level routing metadata remains in system prompt
- Added per-turn identifiers to `buildInboundUserContextPrefix()` conversation info block where they remain accessible to the agent
- Updated tests to verify system prompt stability across turns and presence of relocated fields in user context
- All 9 inbound-meta tests pass, confirming the refactoring maintains functionality while achieving KV cache optimization

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring is well-designed with clear separation of concerns: session-level metadata stays in the system prompt for caching, while per-turn identifiers move to user context where they remain accessible. The change is purely a relocation of data with no logic changes, comprehensive test coverage validates both the absence of per-turn IDs from system prompt and their presence in user context, and all 9 tests pass confirming functionality is preserved.
- No files require special attention

<sub>Last reviewed commit: 3ef8aa6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->