### PR TITLE
fix: improve type safety and use project runtime logging

### DIFF
--- a/src/discord/monitor/sender-identity.ts
+++ b/src/discord/monitor/sender-identity.ts
@@ -2,6 +2,10 @@ import type { User } from "@buape/carbon";
 import type { PluralKitMessageInfo } from "../pluralkit.js";
 import { formatDiscordUserTag } from "./format.js";
 
+type DiscordMemberLike = {
+  nickname?: string | null;
+};
+
 export type DiscordSenderIdentity = {
   id: string;
   name?: string;
@@ -28,8 +32,7 @@ export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): str
 
 export function resolveDiscordSenderIdentity(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): DiscordSenderIdentity {
   const pkInfo = params.pluralkitInfo ?? null;
@@ -74,8 +77,7 @@ export function resolveDiscordSenderIdentity(params: {
 
 export function resolveDiscordSenderLabel(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): string {
   return resolveDiscordSenderIdentity(params).label;

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -4,11 +4,12 @@ import type { TelegramAccountConfig, TelegramActionConfig } from "../config/type
 import { isTruthyEnvValue } from "../infra/env.js";
 import { listBoundAccountIds, resolveDefaultAgentBoundAccountId } from "../routing/bindings.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
+import { defaultRuntime } from "../runtime.js";
 import { resolveTelegramToken } from "./token.js";
 
 const debugAccounts = (...args: unknown[]) => {
   if (isTruthyEnvValue(process.env.OPENCLAW_DEBUG_TELEGRAM_ACCOUNTS)) {
-    console.warn("[telegram:accounts]", ...args);
+    defaultRuntime.log("[telegram:accounts]", ...args);
   }
 };
 

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -1,5 +1,6 @@
 import { firstDefined, isSenderIdAllowed, mergeAllowFromSources } from "../channels/allow-from.js";
 import type { AllowlistMatch } from "../channels/allowlist-match.js";
+import { defaultRuntime } from "../runtime.js";
 
 export type NormalizedAllowFrom = {
   entries: string[];
@@ -21,7 +22,7 @@ function warnInvalidAllowFromEntries(entries: string[]) {
       continue;
     }
     warnedInvalidEntries.add(entry);
-    console.warn(
+    defaultRuntime.error(
       [
         "[telegram] Invalid allowFrom entry:",
         JSON.stringify(entry),

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -24,6 +24,7 @@ import { formatUncaughtError } from "../infra/errors.js";
 import { getChildLogger } from "../logging.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { defaultRuntime } from "../runtime.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { registerTelegramHandlers } from "./bot-handlers.js";
 import { createTelegramMessageProcessor } from "./bot-message.js";
@@ -114,8 +115,8 @@ export function getTelegramSequentialKey(ctx: {
 
 export function createTelegramBot(opts: TelegramBotOptions) {
   const runtime: RuntimeEnv = opts.runtime ?? {
-    log: console.log,
-    error: console.error,
+    log: defaultRuntime.log,
+    error: defaultRuntime.error,
     exit: (code: number): never => {
       throw new Error(`exit ${code}`);
     },

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -18,6 +18,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { mediaKindFromMime } from "../media/constants.js";
 import { isGifMedia } from "../media/mime.js";
 import { normalizePollInput, type PollInput } from "../polls.js";
+import { defaultRuntime } from "../runtime.js";
 import { loadWebMedia } from "../web/media.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -272,7 +273,7 @@ async function withTelegramHtmlParseFallback<T>(params: {
       throw err;
     }
     if (params.verbose) {
-      console.warn(
+      defaultRuntime.error(
         `telegram ${params.label} failed with HTML parse error, retrying as plain text: ${formatErrorMessage(
           err,
         )}`,
@@ -378,7 +379,7 @@ async function withTelegramThreadFallback<T>(
       throw err;
     }
     if (verbose) {
-      console.warn(
+      defaultRuntime.error(
         `telegram ${label} failed with message_thread_id, retrying without thread: ${formatErrorMessage(err)}`,
       );
     }


### PR DESCRIPTION
This PR improves type safety and logging consistency:

- Add `DiscordMemberLike` type to replace 'any' in sender-identity.ts
- Replace direct console usage with defaultRuntime in telegram modules
- Improves type safety and logging consistency across the codebase

## Changes
- **Type Safety**: Replaced 'any' types with proper TypeScript interfaces
- **Logging**: Unified console logging to use the project's runtime logging system
- **Consistency**: All logging now goes through the same abstraction layer

## Files Changed
- src/discord/monitor/sender-identity.ts
- src/telegram/accounts.ts
- src/telegram/bot-access.ts
- src/telegram/bot.ts
- src/telegram/monitor.ts
- src/telegram/send.ts

All changes pass the pre-commit hooks (oxlint, oxfmt) and TypeScript type checking.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves type safety and standardizes logging across Discord and Telegram modules:

- Replaced `any` type with explicit `DiscordMemberLike` type in `src/discord/monitor/sender-identity.ts`, improving type safety for the `member` parameter
- Unified logging across all Telegram modules by replacing direct `console.log`, `console.warn`, and `console.error` calls with `defaultRuntime.log` and `defaultRuntime.error`
- All changes are consistent with the project's runtime logging abstraction defined in `src/runtime.ts`, which provides centralized control over logging behavior (including test environment suppression and progress line clearing)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are low-risk refactorings that improve code quality. The type safety improvement replaces `any` with a properly typed interface, and the logging standardization uses the existing project runtime abstraction. Changes passed pre-commit hooks (oxlint, oxfmt) and TypeScript type checking.
- No files require special attention

<sub>Last reviewed commit: 0f82a7a</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->