### PR TITLE
Add configurable `dimensions` for embedding models (Matryoshka support)

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -28,6 +28,7 @@ export type ResolvedMemorySearchConfig = {
   };
   fallback: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "none";
   model: string;
+  dimensions?: number;
   local: {
     modelPath?: string;
     modelCacheDir?: string;
@@ -193,6 +194,7 @@ function mergeConfig(
               ? DEFAULT_OLLAMA_MODEL
               : undefined;
   const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";
+  const dimensions = overrides?.dimensions ?? defaults?.dimensions;
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,
     modelCacheDir: overrides?.local?.modelCacheDir ?? defaults?.local?.modelCacheDir,
@@ -312,6 +314,7 @@ function mergeConfig(
     },
     fallback,
     model,
+    dimensions,
     local,
     store,
     chunking: { tokens: Math.max(1, chunking.tokens), overlap },

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -331,6 +331,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.remote.batch.pollIntervalMs": "Remote Batch Poll Interval (ms)",
   "agents.defaults.memorySearch.remote.batch.timeoutMinutes": "Remote Batch Timeout (min)",
   "agents.defaults.memorySearch.model": "Memory Search Model",
+  "agents.defaults.memorySearch.dimensions": "Embedding Dimensions (Matryoshka)",
   "agents.defaults.memorySearch.fallback": "Memory Search Fallback",
   "agents.defaults.memorySearch.local.modelPath": "Local Embedding Model Path",
   "agents.defaults.memorySearch.store.path": "Memory Search Index Path",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -347,6 +347,8 @@ export type MemorySearchConfig = {
   fallback?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "none";
   /** Embedding model id (remote) or alias (local). */
   model?: string;
+  /** Number of embedding dimensions (Matryoshka support). When set, requests truncated vectors from compatible providers (OpenAI, Voyage, Gemini). */
+  dimensions?: number;
   /** Local embedding settings (node-llama-cpp). */
   local?: {
     /** GGUF model path or hf: URI. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -599,6 +599,7 @@ export const MemorySearchSchema = z
       ])
       .optional(),
     model: z.string().optional(),
+    dimensions: z.number().int().positive().optional(),
     local: z
       .object({
         modelPath: z.string().optional(),

--- a/src/memory/embeddings-gemini.ts
+++ b/src/memory/embeddings-gemini.ts
@@ -17,6 +17,7 @@ export type GeminiEmbeddingClient = {
   model: string;
   modelPath: string;
   apiKeys: string[];
+  dimensions?: number;
 };
 
 const DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
@@ -113,6 +114,7 @@ export async function createGeminiEmbeddingProvider(
         fetchWithGeminiAuth(apiKey, embedUrl, {
           content: { parts: [{ text }] },
           taskType: "RETRIEVAL_QUERY",
+          ...(client.dimensions && { outputDimensionality: client.dimensions }),
         }),
     });
     return payload.embedding?.values ?? [];
@@ -126,6 +128,7 @@ export async function createGeminiEmbeddingProvider(
       model: client.modelPath,
       content: { parts: [{ text }] },
       taskType: "RETRIEVAL_DOCUMENT",
+      ...(client.dimensions && { outputDimensionality: client.dimensions }),
     }));
     const payload = await executeWithApiKeyRotation({
       provider: "google",
@@ -191,5 +194,13 @@ export async function resolveGeminiEmbeddingClient(
     embedEndpoint: `${baseUrl}/${modelPath}:embedContent`,
     batchEndpoint: `${baseUrl}/${modelPath}:batchEmbedContents`,
   });
-  return { baseUrl, headers, ssrfPolicy, model, modelPath, apiKeys };
+  return {
+    baseUrl,
+    headers,
+    ssrfPolicy,
+    model,
+    modelPath,
+    apiKeys,
+    dimensions: options.dimensions,
+  };
 }

--- a/src/memory/embeddings-openai.ts
+++ b/src/memory/embeddings-openai.ts
@@ -11,6 +11,7 @@ export type OpenAiEmbeddingClient = {
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
   model: string;
+  dimensions?: number;
 };
 
 export const DEFAULT_OPENAI_EMBEDDING_MODEL = "text-embedding-3-small";

--- a/src/memory/embeddings-remote-provider.ts
+++ b/src/memory/embeddings-remote-provider.ts
@@ -11,6 +11,7 @@ export type RemoteEmbeddingClient = {
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
   model: string;
+  dimensions?: number;
 };
 
 export function createRemoteEmbeddingProvider(params: {
@@ -30,7 +31,11 @@ export function createRemoteEmbeddingProvider(params: {
       url,
       headers: client.headers,
       ssrfPolicy: client.ssrfPolicy,
-      body: { model: client.model, input },
+      body: {
+        model: client.model,
+        input,
+        ...(client.dimensions && { dimensions: client.dimensions }),
+      },
       errorPrefix: params.errorPrefix,
     });
   };
@@ -59,5 +64,5 @@ export async function resolveRemoteEmbeddingClient(params: {
     defaultBaseUrl: params.defaultBaseUrl,
   });
   const model = params.normalizeModel(params.options.model);
-  return { baseUrl, headers, ssrfPolicy, model };
+  return { baseUrl, headers, ssrfPolicy, model, dimensions: params.options.dimensions };
 }

--- a/src/memory/embeddings-voyage.ts
+++ b/src/memory/embeddings-voyage.ts
@@ -9,6 +9,7 @@ export type VoyageEmbeddingClient = {
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
   model: string;
+  dimensions?: number;
 };
 
 export const DEFAULT_VOYAGE_EMBEDDING_MODEL = "voyage-4-large";
@@ -37,12 +38,20 @@ export async function createVoyageEmbeddingProvider(
     if (input.length === 0) {
       return [];
     }
-    const body: { model: string; input: string[]; input_type?: "query" | "document" } = {
+    const body: {
+      model: string;
+      input: string[];
+      input_type?: "query" | "document";
+      output_dimension?: number;
+    } = {
       model: client.model,
       input,
     };
     if (input_type) {
       body.input_type = input_type;
+    }
+    if (client.dimensions) {
+      body.output_dimension = client.dimensions;
     }
 
     return await fetchRemoteEmbeddingVectors({
@@ -78,5 +87,5 @@ export async function resolveVoyageEmbeddingClient(
     defaultBaseUrl: DEFAULT_VOYAGE_BASE_URL,
   });
   const model = normalizeVoyageModel(options.model);
-  return { baseUrl, headers, ssrfPolicy, model };
+  return { baseUrl, headers, ssrfPolicy, model, dimensions: options.dimensions };
 }

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -69,6 +69,7 @@ export type EmbeddingProviderOptions = {
     headers?: Record<string, string>;
   };
   model: string;
+  dimensions?: number;
   fallback: EmbeddingProviderFallback;
   local?: {
     modelPath?: string;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -53,6 +53,7 @@ type MemoryIndexMeta = {
   chunkTokens: number;
   chunkOverlap: number;
   vectorDims?: number;
+  configuredDims?: number | null;
 };
 
 type MemorySyncProgressState = {
@@ -865,7 +866,8 @@ export abstract class MemoryManagerSyncOps {
         label: "Loading vector extension…",
       });
     }
-    const vectorReady = await this.ensureVectorReady();
+    const configuredDims = this.settings.dimensions;
+    const vectorReady = await this.ensureVectorReady(configuredDims);
     const meta = this.readMeta();
     const configuredSources = this.resolveConfiguredSourcesForMeta();
     const needsFullReindex =
@@ -877,7 +879,12 @@ export abstract class MemoryManagerSyncOps {
       this.metaSourcesDiffer(meta, configuredSources) ||
       meta.chunkTokens !== this.settings.chunking.tokens ||
       meta.chunkOverlap !== this.settings.chunking.overlap ||
-      (vectorReady && !meta?.vectorDims);
+      (vectorReady && !meta?.vectorDims) ||
+      (vectorReady &&
+        typeof configuredDims === "number" &&
+        typeof meta?.vectorDims === "number" &&
+        meta.vectorDims !== configuredDims) ||
+      (vectorReady && (meta?.configuredDims ?? null) !== (configuredDims ?? null));
     try {
       if (needsFullReindex) {
         if (
@@ -1097,6 +1104,7 @@ export abstract class MemoryManagerSyncOps {
       if (this.vector.available && this.vector.dims) {
         nextMeta.vectorDims = this.vector.dims;
       }
+      nextMeta.configuredDims = this.settings.dimensions ?? null;
 
       this.writeMeta(nextMeta);
       this.pruneEmbeddingCacheIfNeeded?.();
@@ -1164,6 +1172,7 @@ export abstract class MemoryManagerSyncOps {
     if (this.vector.available && this.vector.dims) {
       nextMeta.vectorDims = this.vector.dims;
     }
+    nextMeta.configuredDims = this.settings.dimensions ?? null;
 
     this.writeMeta(nextMeta);
     this.pruneEmbeddingCacheIfNeeded?.();

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -157,6 +157,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         provider: settings.provider,
         remote: settings.remote,
         model: settings.model,
+        dimensions: settings.dimensions,
         fallback: settings.fallback,
         local: settings.local,
       });


### PR DESCRIPTION
# Add configurable `dimensions` for embedding models (Matryoshka support)

## Summary

- Problem: No way to control embedding vector dimensions – all providers use their native defaults (e.g. 3072 for `text-embedding-3-large`), leading to larger-than-necessary vector tables
- Why it matters: Users on constrained hardware (Pi, cheap VPS) or running many agents pay a storage/search cost for dimensions they don't need. Matryoshka-trained models retain quality at lower dims
- Why it matters: Users can also run higher-quality models more efficiently – e.g. `text-embedding-3-large` at 1024 dims still outperforms `text-embedding-3-small` at its native 1536, with smaller storage and faster search (although at ~6.5x token cost) allowing users to make their own tradeoffs of size, cost, performance
- What changed: Added optional `dimensions` config field to `memorySearch`, passed through to OpenAI/Voyage/Gemini APIs with provider-specific parameter names. Added dimension mismatch detection to trigger full reindex. Stores `configuredDims` in index meta so removing the setting also reindexes back to native
- What did NOT change: Behaviour when `dimensions` is omitted is identical to before. No changes to chunking, FTS, or query logic

First time contributor 👋 – I've been running OpenClaw daily as a power user (9 agents, 200+ memory files) and wanted to contribute back.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

- Related: Discussion with @vignesh07 on Discord (memory subsystem)

## User-visible / Behavior Changes

- New optional config field: `memorySearch.dimensions` (positive integer)
- When set, embedding API calls include the dimension parameter
- Changing or removing `dimensions` triggers a full memory reindex on next sync
- Config example:
```json
{
  "memorySearch": {
    "provider": "openai",
    "model": "text-embedding-3-large",
    "dimensions": 1024
  }
}
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same API endpoints, one additional optional parameter in request body)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 14 (arm64)
- Runtime: Node 22.22.0
- Model/provider: OpenAI `text-embedding-3-large` and `text-embedding-3-small`
- Relevant config: `memorySearch.dimensions: 1024`, then `512`

### Steps

1. Set `"dimensions": 1024` in `memorySearch` config
2. Restart gateway
3. Trigger a memory search (or wait for heartbeat sync)
4. Check vec table: `sqlite3 memory.sqlite ".schema chunks_vec"` – should show `FLOAT[1024]`

### Expected

- Vec table created at configured dimensions
- Full reindex triggered on dimension change
- Memory search returns results

### Actual

- All confirmed working across 9 agents, 200+ files

## Evidence

- Tested dimension changes: 1536 → 1024 → 512 (all clean, no errors)
- Tested model + dimension change together (`3-large@1024` → `3-small@512`)
- 216 files reindexed in ~30 seconds
- Query embeddings confirmed using configured dimensions

## Human Verification (required)

- Verified scenarios: Dimension change reindex, model change reindex, combined model+dimension change, search quality at reduced dims
- Edge cases checked: Removing `dimensions` from config (triggers reindex via `configuredDims` in meta), `dimensions` unset on fresh install (no spurious reindex), cache lookup filters by dims when set
- What I did **not** verify: Voyage and Gemini providers (tested config pass-through in code, not live API calls). Local (llama-cpp) provider (no-op by design)

## Compatibility / Migration

- Backward compatible? Yes – `dimensions` is optional, omitting it preserves existing behaviour
- Config/env changes? One new optional field (`memorySearch.dimensions`)
- Migration needed? No – existing setups work unchanged. Setting `dimensions` triggers automatic reindex

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `dimensions` from config, restart gateway. Reindex triggers automatically back to native dimensions
- Known bad symptoms: `Dimension mismatch for inserted vector` errors during sync (would indicate the `ensureVectorReady` path isn't receiving dimensions – fixed in this PR)

## Risks and Mitigations

- Risk: User sets dimensions on a provider that doesn't support it (e.g. a custom OpenAI-compatible endpoint)
  - Mitigation: Dimensions are passed as an optional API parameter – most endpoints ignore unknown fields. If they error, the error message from the provider will surface in logs
- Risk: Hot-reload updates config but doesn't re-instantiate embedding provider
  - Mitigation: This is existing behaviour for all `memorySearch` fields – gateway restart required. Not introduced by this PR

## What changed (detail)

**Config & types** (4 files)

- `zod-schema.agent-runtime.ts` – added optional `dimensions` to `MemorySearchSchema`
- `types.tools.ts` – added `dimensions` to `EmbeddingProviderOptions`
- `schema.labels.ts` – added config label
- `agents/memory-search.ts` – passes dimensions through to embedding calls

**Embedding providers** (3 files) – each maps `dimensions` to the provider-specific API parameter:

- OpenAI → `dimensions`
- Voyage → `output_dimension`
- Gemini → `outputDimensionality`

**Manager & sync** (3 files + 1 type)

- `embeddings.ts` – added `dimensions` to `EmbeddingProviderOptions` type
- `manager.ts` – passes configured dimensions to provider init
- `manager-embedding-ops.ts` – passes dimensions to `ensureVectorReady()` so vec tables are created at the right size; cache lookup filters by dims when configured
- `manager-sync-ops.ts` – passes dimensions to `ensureVectorReady()` in the sync path + adds dimension mismatch detection to `needsFullReindex`. Stores `configuredDims` in index meta (distinct from the existing `vectorDims` which tracks actual vector size – `configuredDims` tracks the user's config value, so removing `dimensions` from config can be detected and triggers a reindex back to native dimensions)

**11 files changed, ~53 lines added**

## AI Disclosure

AI-assisted (Claude via OpenClaw). Fully tested on a live multi-agent install. I understand what every line does – the implementation was collaborative, not blind generation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added optional `dimensions` config field to `memorySearch` for Matryoshka embedding support. When set, OpenAI, Voyage, and Gemini providers request truncated vectors at the specified dimensionality. Changed dimension tracking logic to properly detect mismatches and trigger reindexes – stores both `configuredDims` (user config value) and `vectorDims` (actual vector size) in index metadata, so removing `dimensions` from config triggers reindex back to native dimensions. Cache lookup filters by dimensions to prevent dimension mismatches during sync.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested by the author across 9 agents with 200+ files, and follows a defensive pattern (optional parameter that defaults to existing behavior). The dimension mismatch detection is comprehensive, correctly tracking both configured and actual dimensions to trigger reindexes when needed. All three remote providers map dimensions to their respective API parameters correctly. The cache lookup properly filters by dimensions to prevent stale embeddings from being used.
- No files require special attention

<sub>Last reviewed commit: 55013c8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->