### PR TITLE
fix(exec): show requested host in disallowed host hint

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,11 +1,6 @@
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type {
-  ExecElevatedDefaults,
-  ExecToolDefaults,
-  ExecToolDetails,
-} from "./bash-tools.exec-types.js";
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { type ExecHost, maxAsk, minSecurity, resolveSafeBins } from "../infra/exec-approvals.js";
 import { getTrustedSafeBinDirs } from "../infra/exec-safe-bin-trust.js";
 import {
@@ -33,6 +28,11 @@ import {
   execSchema,
   validateHostEnv,
 } from "./bash-tools.exec-runtime.js";
+import type {
+  ExecElevatedDefaults,
+  ExecToolDefaults,
+  ExecToolDetails,
+} from "./bash-tools.exec-types.js";
 import {
   buildSandboxEnv,
   clampWithDefault,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,6 +1,11 @@
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import type {
+  ExecElevatedDefaults,
+  ExecToolDefaults,
+  ExecToolDetails,
+} from "./bash-tools.exec-types.js";
 import { type ExecHost, maxAsk, minSecurity, resolveSafeBins } from "../infra/exec-approvals.js";
 import { getTrustedSafeBinDirs } from "../infra/exec-safe-bin-trust.js";
 import {
@@ -28,11 +33,6 @@ import {
   execSchema,
   validateHostEnv,
 } from "./bash-tools.exec-runtime.js";
-import type {
-  ExecElevatedDefaults,
-  ExecToolDefaults,
-  ExecToolDetails,
-} from "./bash-tools.exec-types.js";
 import {
   buildSandboxEnv,
   clampWithDefault,
@@ -285,7 +285,7 @@ export function createExecTool(
       if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {
         throw new Error(
           `exec host not allowed (requested ${renderExecHostLabel(requestedHost)}; ` +
-            `configure tools.exec.host=${renderExecHostLabel(configuredHost)} to allow).`,
+            `configure tools.exec.host=${renderExecHostLabel(requestedHost)} to allow).`,
         );
       }
       if (elevatedRequested) {

--- a/src/agents/pi-tools-agent-config.e2e.test.ts
+++ b/src/agents/pi-tools-agent-config.e2e.test.ts
@@ -4,9 +4,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { createOpenClawCodingTools } from "./pi-tools.js";
 import type { SandboxDockerConfig } from "./sandbox.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
-import { createOpenClawCodingTools } from "./pi-tools.js";
 
 type ToolWithExecute = {
   execute: (toolCallId: string, args: unknown, signal?: AbortSignal) => Promise<unknown>;

--- a/src/agents/pi-tools-agent-config.e2e.test.ts
+++ b/src/agents/pi-tools-agent-config.e2e.test.ts
@@ -4,9 +4,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { createOpenClawCodingTools } from "./pi-tools.js";
 import type { SandboxDockerConfig } from "./sandbox.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import { createOpenClawCodingTools } from "./pi-tools.js";
 
 type ToolWithExecute = {
   execute: (toolCallId: string, args: unknown, signal?: AbortSignal) => Promise<unknown>;
@@ -659,7 +659,9 @@ describe("Agent-specific tool filtering", () => {
         command: "echo done",
         host: "sandbox",
       }),
-    ).rejects.toThrow("exec host not allowed");
+    ).rejects.toThrow(
+      /exec host not allowed \(requested sandbox; configure tools\.exec\.host=sandbox to allow\)\./,
+    );
 
     const helperTools = createOpenClawCodingTools({
       config: cfg,


### PR DESCRIPTION
Fixes #21501.

### What
When `exec` is called with a host that differs from the configured default, the error message used to suggest configuring `tools.exec.host` to the *configured* host (self-referential).

This change makes the hint show the *requested* host instead.

### Tests
- Updated `src/agents/pi-tools-agent-config.e2e.test.ts` to assert the full error message.
- Verified locally:
  `vitest run --config vitest.e2e.config.ts src/agents/pi-tools-agent-config.e2e.test.ts -t "should apply agent-specific exec host defaults over global defaults"`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the error message hint when `exec` is called with a disallowed host to show the *requested* host instead of the *configured* host in the suggestion.

- **Core fix**: Changed line 288 in `bash-tools.exec.ts` from `configuredHost` to `requestedHost` in the error message hint
- **Test improvement**: Updated test assertion to verify the complete error message including the corrected hint
- **Import reordering**: Incidental formatting changes to group type imports (likely from auto-formatter)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple one-line fix to an error message that was displaying unhelpful information. The logic is correct: when a requested host differs from the configured host, the error should suggest configuring to the requested host (what the user wants) rather than the configured host (what's already set). The test was appropriately updated to verify the full error message.
- No files require special attention

<sub>Last reviewed commit: 1c4d234</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->