### PR TITLE
feat(agent): add self-verification loop with full-context evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ package-lock.json
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
+
 # Generated protocol schema (produced via pnpm protocol:gen)
 dist/protocol.schema.json
 .ant-colony/
@@ -113,3 +114,6 @@ dist/protocol.schema.json
 
 # Synthing
 **/.stfolder/
+
+# Personal VPS docs
+VPS-CUSTOM-BUILD.md

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -96,11 +96,18 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
 
       const pluginCfg = (api.pluginConfig ?? {}) as PluginCfg;
 
-      const defaultsModel = api.config?.agents?.defaults?.model;
-      const primary =
-        typeof defaultsModel === "string"
-          ? defaultsModel.trim()
-          : (defaultsModel?.primary?.trim() ?? undefined);
+      const defaultsModel: unknown = api.config?.agents?.defaults?.model;
+      let primary: string | undefined;
+      if (typeof defaultsModel === "string") {
+        primary = defaultsModel.trim();
+      } else if (
+        defaultsModel &&
+        typeof defaultsModel === "object" &&
+        "primary" in defaultsModel &&
+        typeof (defaultsModel as { primary?: unknown }).primary === "string"
+      ) {
+        primary = (defaultsModel as { primary: string }).primary.trim();
+      }
       const primaryProvider = typeof primary === "string" ? primary.split("/")[0] : undefined;
       const primaryModel =
         typeof primary === "string" ? primary.split("/").slice(1).join("/") : undefined;

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -28,6 +28,13 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
 
 const WORKSPACE_STATE_PATH_SEGMENTS = [".openclaw", "workspace-state.json"] as const;
 
+function formatDateLocal(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 async function readOnboardingState(dir: string): Promise<{
   version: number;
   bootstrapSeededAt?: string;
@@ -99,6 +106,22 @@ describe("ensureAgentWorkspace", () => {
     const state = await readOnboardingState(tempDir);
     expect(state.bootstrapSeededAt).toBeUndefined();
     expect(state.onboardingCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("creates daily memory files for today and yesterday", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    const now = new Date();
+    const yesterday = new Date(now.getTime());
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const todayPath = path.join(tempDir, "memory", `${formatDateLocal(now)}.md`);
+    const yesterdayPath = path.join(tempDir, "memory", `${formatDateLocal(yesterday)}.md`);
+
+    await expect(fs.access(todayPath)).resolves.toBeUndefined();
+    await expect(fs.access(yesterdayPath)).resolves.toBeUndefined();
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -40,6 +40,8 @@ import {
 import { runMemoryFlushIfNeeded } from "./agent-runner-memory.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
+import { shouldVerifyResponse } from "./agent-verifier-trigger.js";
+import { verifyAgentResponse } from "./agent-verifier.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
@@ -420,7 +422,7 @@ export async function runReplyAgent(params: {
       }
     }
 
-    const payloadArray = runResult.payloads ?? [];
+    let payloadArray = runResult.payloads ?? [];
 
     if (blockReplyPipeline) {
       await blockReplyPipeline.flush({ force: true });
@@ -429,6 +431,170 @@ export async function runReplyAgent(params: {
     if (pendingToolTasks.size > 0) {
       await Promise.allSettled(pendingToolTasks);
     }
+
+    // ─── Self-verification loop ────────────────────────────────────────
+    // Verify the agent response quality and retry if it doesn't meet the
+    // user's request. Only runs when verifier is configured, the run
+    // succeeded, block streaming did not already deliver content, and
+    // trigger keywords are detected in the response text.
+    const verifierConfig = cfg.agents?.defaults?.verifier;
+    let verificationAttempted = false;
+    let verificationPassed: boolean | undefined;
+    let verificationAttemptCount = 0;
+
+    if (
+      verifierConfig?.enabled === true &&
+      !isHeartbeat &&
+      payloadArray.length > 0 &&
+      !(directlySentBlockKeys && directlySentBlockKeys.size > 0) &&
+      !isCliProvider(followupRun.run.provider, cfg)
+    ) {
+      const responseText = payloadArray
+        .filter(
+          (p): p is ReplyPayload & { text: string } => typeof p.text === "string" && !p.isError,
+        )
+        .map((p) => p.text)
+        .join("\n");
+
+      const triggerKeywords = verifierConfig.triggerKeywords ?? [
+        "done",
+        "completed",
+        "finished",
+        "ready",
+        "here you go",
+      ];
+
+      if (responseText && shouldVerifyResponse(responseText, triggerKeywords)) {
+        verificationAttempted = true;
+        const maxAttempts = verifierConfig.maxAttempts ?? 3;
+        const verifierModel = verifierConfig.model ?? defaultModel;
+        const timeoutMs = (verifierConfig.timeoutSeconds ?? 30) * 1000;
+
+        emitAgentEvent({
+          runId,
+          sessionKey,
+          stream: "lifecycle",
+          data: { phase: "verification_start", maxAttempts },
+        });
+
+        let attempt = 1;
+        let currentPayloadArray = payloadArray;
+
+        while (attempt <= maxAttempts) {
+          // Respect abort signal — deliver current response immediately
+          if (params.opts?.abortSignal?.aborted) {
+            break;
+          }
+
+          const currentText = currentPayloadArray
+            .filter(
+              (p): p is ReplyPayload & { text: string } => typeof p.text === "string" && !p.isError,
+            )
+            .map((p) => p.text)
+            .join("\n");
+
+          if (!currentText) {
+            break;
+          }
+
+          const verificationResult = await verifyAgentResponse({
+            userMessage: commandBody,
+            agentResponse: currentText,
+            model: verifierModel,
+            cfg,
+            timeoutMs,
+          });
+
+          verificationAttemptCount = attempt;
+
+          if (verificationResult.passed) {
+            verificationPassed = true;
+            emitAgentEvent({
+              runId,
+              sessionKey,
+              stream: "lifecycle",
+              data: { phase: "verification_pass", attempt },
+            });
+            break;
+          }
+
+          // Verification failed for this attempt
+          verificationPassed = false;
+          emitAgentEvent({
+            runId,
+            sessionKey,
+            stream: "lifecycle",
+            data: {
+              phase: "verification_fail",
+              attempt,
+              feedback: verificationResult.feedback,
+            },
+          });
+
+          if (attempt >= maxAttempts) {
+            emitAgentEvent({
+              runId,
+              sessionKey,
+              stream: "lifecycle",
+              data: { phase: "verification_exhausted", attempts: maxAttempts },
+            });
+            break;
+          }
+
+          // Retry: construct feedback prompt and re-run agent
+          emitAgentEvent({
+            runId,
+            sessionKey,
+            stream: "lifecycle",
+            data: { phase: "verification_retry", attempt: attempt + 1 },
+          });
+
+          const feedbackPrompt = `[Verification: your response did not fully meet the request. Feedback: ${verificationResult.feedback ?? "Response inadequate."}. Please review and address the issues.]`;
+
+          const retryOutcome = await runAgentTurnWithFallback({
+            commandBody: feedbackPrompt,
+            followupRun,
+            sessionCtx,
+            opts,
+            typingSignals,
+            blockReplyPipeline: null,
+            blockStreamingEnabled: false,
+            blockReplyChunking,
+            resolvedBlockStreamingBreak,
+            applyReplyToMode,
+            shouldEmitToolResult,
+            shouldEmitToolOutput,
+            pendingToolTasks,
+            resetSessionAfterCompactionFailure,
+            resetSessionAfterRoleOrderingConflict,
+            isHeartbeat,
+            sessionKey,
+            getActiveSessionEntry: () => activeSessionEntry,
+            activeSessionStore,
+            storePath,
+            resolvedVerboseLevel,
+          });
+
+          if (retryOutcome.kind === "final") {
+            // Retry produced an error/final payload — deliver current best response
+            break;
+          }
+
+          const retryPayloads = retryOutcome.runResult.payloads ?? [];
+          if (retryPayloads.length === 0) {
+            // Retry produced nothing — deliver current best response
+            break;
+          }
+
+          currentPayloadArray = retryPayloads;
+          attempt++;
+        }
+
+        // Use the latest payload array (verified or max-attempts exhausted)
+        payloadArray = currentPayloadArray;
+      }
+    }
+    // ─── End self-verification loop ────────────────────────────────────
 
     const usage = runResult.meta?.agentMeta?.usage;
     const promptTokens = runResult.meta?.agentMeta?.promptTokens;
@@ -695,6 +861,17 @@ export async function runReplyAgent(params: {
       if (verboseEnabled) {
         const suffix = typeof count === "number" ? ` (count ${count})` : "";
         verboseNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
+      }
+    }
+    if (verboseEnabled && verificationAttempted) {
+      if (verificationPassed) {
+        verboseNotices.push({
+          text: `✅ Verification passed (attempt ${verificationAttemptCount}).`,
+        });
+      } else if (verificationPassed === false) {
+        verboseNotices.push({
+          text: `⚠️ Verification exhausted after ${verificationAttemptCount} attempt(s) — delivering best response.`,
+        });
       }
     }
     if (verboseNotices.length > 0) {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -456,6 +456,7 @@ export async function runReplyAgent(params: {
         .map((p) => p.text)
         .join("\n");
 
+      const verifyAll = verifierConfig.verifyAll === true;
       const triggerKeywords = verifierConfig.triggerKeywords ?? [
         "done",
         "completed",
@@ -464,14 +465,14 @@ export async function runReplyAgent(params: {
         "here you go",
       ];
 
-      if (responseText && shouldVerifyResponse(responseText, triggerKeywords)) {
+      if (responseText && (verifyAll || shouldVerifyResponse(responseText, triggerKeywords))) {
         verificationAttempted = true;
         const maxAttempts = verifierConfig.maxAttempts ?? 3;
         const verifierModel = verifierConfig.model ?? defaultModel;
         const timeoutMs = (verifierConfig.timeoutSeconds ?? 30) * 1000;
 
         defaultRuntime.log?.(
-          `[verifier] triggered — verifying response with ${verifierModel} (max ${maxAttempts} attempts)`,
+          `[verifier] ${verifyAll ? "verifyAll" : "keyword-triggered"} — verifying response with ${verifierModel} (max ${maxAttempts} attempts)`,
         );
         emitAgentEvent({
           runId,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -440,7 +440,7 @@ export async function runReplyAgent(params: {
 
     if (
       verifierConfig?.enabled === true &&
-      !isHeartbeat &&
+      (!isHeartbeat || verifierConfig.verifyHeartbeat === true) &&
       payloadArray.length > 0 &&
       !isCliProvider(followupRun.run.provider, cfg)
     ) {
@@ -477,14 +477,24 @@ export async function runReplyAgent(params: {
           "here you go",
         ];
 
-        if (responseText && (verifyAll || shouldVerifyResponse(responseText, triggerKeywords))) {
+        // Heartbeat runs with verifyHeartbeat always verify (catch lazy HEARTBEAT_OK).
+        const heartbeatForced = isHeartbeat && verifierConfig.verifyHeartbeat === true;
+        if (
+          responseText &&
+          (verifyAll || heartbeatForced || shouldVerifyResponse(responseText, triggerKeywords))
+        ) {
           verificationAttempted = true;
           const maxAttempts = verifierConfig.maxAttempts ?? 3;
           const verifierModel = verifierConfig.model ?? defaultModel;
           const timeoutMs = (verifierConfig.timeoutSeconds ?? 30) * 1000;
 
+          const triggerLabel = heartbeatForced
+            ? "heartbeat"
+            : verifyAll
+              ? "verifyAll"
+              : "keyword-triggered";
           defaultRuntime.log?.(
-            `[verifier] ${verifyAll ? "verifyAll" : "keyword-triggered"} — verifying with ${verifierModel} (max ${maxAttempts} attempts, full-context)`,
+            `[verifier] ${triggerLabel} — verifying with ${verifierModel} (max ${maxAttempts} attempts, full-context)`,
           );
           emitAgentEvent({
             runId,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -470,6 +470,9 @@ export async function runReplyAgent(params: {
         const verifierModel = verifierConfig.model ?? defaultModel;
         const timeoutMs = (verifierConfig.timeoutSeconds ?? 30) * 1000;
 
+        defaultRuntime.log?.(
+          `[verifier] triggered — verifying response with ${verifierModel} (max ${maxAttempts} attempts)`,
+        );
         emitAgentEvent({
           runId,
           sessionKey,
@@ -509,6 +512,7 @@ export async function runReplyAgent(params: {
 
           if (verificationResult.passed) {
             verificationPassed = true;
+            defaultRuntime.log?.(`[verifier] PASS (attempt ${attempt})`);
             emitAgentEvent({
               runId,
               sessionKey,
@@ -520,6 +524,9 @@ export async function runReplyAgent(params: {
 
           // Verification failed for this attempt
           verificationPassed = false;
+          defaultRuntime.log?.(
+            `[verifier] FAIL (attempt ${attempt}): ${verificationResult.feedback ?? "no feedback"}`,
+          );
           emitAgentEvent({
             runId,
             sessionKey,
@@ -532,6 +539,9 @@ export async function runReplyAgent(params: {
           });
 
           if (attempt >= maxAttempts) {
+            defaultRuntime.log?.(
+              `[verifier] exhausted after ${maxAttempts} attempt(s) — delivering best response`,
+            );
             emitAgentEvent({
               runId,
               sessionKey,
@@ -542,6 +552,7 @@ export async function runReplyAgent(params: {
           }
 
           // Retry: construct feedback prompt and re-run agent
+          defaultRuntime.log?.(`[verifier] retrying (attempt ${attempt + 1})`);
           emitAgentEvent({
             runId,
             sessionKey,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -41,7 +41,7 @@ import { runMemoryFlushIfNeeded } from "./agent-runner-memory.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
 import { shouldVerifyResponse } from "./agent-verifier-trigger.js";
-import { verifyAgentResponse } from "./agent-verifier.js";
+import { shouldSkipVerification, verifyAgentResponse } from "./agent-verifier.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
@@ -433,10 +433,6 @@ export async function runReplyAgent(params: {
     }
 
     // ─── Self-verification loop ────────────────────────────────────────
-    // Verify the agent response quality and retry if it doesn't meet the
-    // user's request. Only runs when verifier is configured, the run
-    // succeeded, block streaming did not already deliver content, and
-    // trigger keywords are detected in the response text.
     const verifierConfig = cfg.agents?.defaults?.verifier;
     let verificationAttempted = false;
     let verificationPassed: boolean | undefined;
@@ -446,7 +442,6 @@ export async function runReplyAgent(params: {
       verifierConfig?.enabled === true &&
       !isHeartbeat &&
       payloadArray.length > 0 &&
-      !(directlySentBlockKeys && directlySentBlockKeys.size > 0) &&
       !isCliProvider(followupRun.run.provider, cfg)
     ) {
       const responseText = payloadArray
@@ -456,154 +451,186 @@ export async function runReplyAgent(params: {
         .map((p) => p.text)
         .join("\n");
 
-      const verifyAll = verifierConfig.verifyAll === true;
-      const triggerKeywords = verifierConfig.triggerKeywords ?? [
-        "done",
-        "completed",
-        "finished",
-        "ready",
-        "here you go",
-      ];
+      // Deterministic pre-checks: skip without LLM call when appropriate
+      const skipReason = shouldSkipVerification({
+        responseText,
+        runMeta: {
+          stopReason: runResult.meta?.stopReason,
+          pendingToolCalls:
+            (runResult.meta?.pendingToolCalls && runResult.meta.pendingToolCalls.length > 0) ||
+            false,
+          didSendViaMessagingTool: runResult.didSendViaMessagingTool,
+          durationMs: runResult.meta?.durationMs,
+        },
+        directlySentBlockKeys,
+      });
 
-      if (responseText && (verifyAll || shouldVerifyResponse(responseText, triggerKeywords))) {
-        verificationAttempted = true;
-        const maxAttempts = verifierConfig.maxAttempts ?? 3;
-        const verifierModel = verifierConfig.model ?? defaultModel;
-        const timeoutMs = (verifierConfig.timeoutSeconds ?? 30) * 1000;
+      if (skipReason) {
+        defaultRuntime.log?.(`[verifier] skipped: ${skipReason}`);
+      } else {
+        const verifyAll = verifierConfig.verifyAll === true;
+        const triggerKeywords = verifierConfig.triggerKeywords ?? [
+          "done",
+          "completed",
+          "finished",
+          "ready",
+          "here you go",
+        ];
 
-        defaultRuntime.log?.(
-          `[verifier] ${verifyAll ? "verifyAll" : "keyword-triggered"} — verifying response with ${verifierModel} (max ${maxAttempts} attempts)`,
-        );
-        emitAgentEvent({
-          runId,
-          sessionKey,
-          stream: "lifecycle",
-          data: { phase: "verification_start", maxAttempts },
-        });
+        if (responseText && (verifyAll || shouldVerifyResponse(responseText, triggerKeywords))) {
+          verificationAttempted = true;
+          const maxAttempts = verifierConfig.maxAttempts ?? 3;
+          const verifierModel = verifierConfig.model ?? defaultModel;
+          const timeoutMs = (verifierConfig.timeoutSeconds ?? 30) * 1000;
 
-        let attempt = 1;
-        let currentPayloadArray = payloadArray;
-
-        while (attempt <= maxAttempts) {
-          // Respect abort signal — deliver current response immediately
-          if (params.opts?.abortSignal?.aborted) {
-            break;
-          }
-
-          const currentText = currentPayloadArray
-            .filter(
-              (p): p is ReplyPayload & { text: string } => typeof p.text === "string" && !p.isError,
-            )
-            .map((p) => p.text)
-            .join("\n");
-
-          if (!currentText) {
-            break;
-          }
-
-          const verificationResult = await verifyAgentResponse({
-            userMessage: commandBody,
-            agentResponse: currentText,
-            model: verifierModel,
-            cfg,
-            timeoutMs,
-          });
-
-          verificationAttemptCount = attempt;
-
-          if (verificationResult.passed) {
-            verificationPassed = true;
-            defaultRuntime.log?.(`[verifier] PASS (attempt ${attempt})`);
-            emitAgentEvent({
-              runId,
-              sessionKey,
-              stream: "lifecycle",
-              data: { phase: "verification_pass", attempt },
-            });
-            break;
-          }
-
-          // Verification failed for this attempt
-          verificationPassed = false;
           defaultRuntime.log?.(
-            `[verifier] FAIL (attempt ${attempt}): ${verificationResult.feedback ?? "no feedback"}`,
+            `[verifier] ${verifyAll ? "verifyAll" : "keyword-triggered"} — verifying with ${verifierModel} (max ${maxAttempts} attempts, full-context)`,
           );
           emitAgentEvent({
             runId,
             sessionKey,
             stream: "lifecycle",
-            data: {
-              phase: "verification_fail",
-              attempt,
-              feedback: verificationResult.feedback,
-            },
+            data: { phase: "verification_start", maxAttempts },
           });
 
-          if (attempt >= maxAttempts) {
+          let attempt = 1;
+          let currentPayloadArray = payloadArray;
+          let previousFeedback: string | undefined;
+
+          while (attempt <= maxAttempts) {
+            if (params.opts?.abortSignal?.aborted) {
+              break;
+            }
+
+            const currentText = currentPayloadArray
+              .filter(
+                (p): p is ReplyPayload & { text: string } =>
+                  typeof p.text === "string" && !p.isError,
+              )
+              .map((p) => p.text)
+              .join("\n");
+
+            if (!currentText) {
+              break;
+            }
+
+            const verificationResult = await verifyAgentResponse({
+              userMessage: commandBody,
+              agentResponse: currentText,
+              model: verifierModel,
+              cfg,
+              timeoutMs,
+              runMeta: {
+                stopReason: runResult.meta?.stopReason,
+                didSendViaMessagingTool: runResult.didSendViaMessagingTool,
+                durationMs: runResult.meta?.durationMs,
+              },
+              conversationHistory: sessionCtx.InboundHistory,
+              workspaceDir: followupRun.run.workspaceDir,
+              extraSystemPrompt: followupRun.run.extraSystemPrompt,
+              previousFeedback,
+            });
+
+            verificationAttemptCount = attempt;
+
+            if (verificationResult.passed) {
+              verificationPassed = true;
+              defaultRuntime.log?.(`[verifier] PASS (attempt ${attempt})`);
+              emitAgentEvent({
+                runId,
+                sessionKey,
+                stream: "lifecycle",
+                data: { phase: "verification_pass", attempt },
+              });
+              break;
+            }
+
+            verificationPassed = false;
+            const categoryLabel = verificationResult.failCategory
+              ? ` [${verificationResult.failCategory}]`
+              : "";
             defaultRuntime.log?.(
-              `[verifier] exhausted after ${maxAttempts} attempt(s) — delivering best response`,
+              `[verifier] FAIL${categoryLabel} (attempt ${attempt}): ${verificationResult.feedback ?? "no feedback"}`,
             );
             emitAgentEvent({
               runId,
               sessionKey,
               stream: "lifecycle",
-              data: { phase: "verification_exhausted", attempts: maxAttempts },
+              data: {
+                phase: "verification_fail",
+                attempt,
+                feedback: verificationResult.feedback,
+                failCategory: verificationResult.failCategory,
+              },
             });
-            break;
+
+            if (attempt >= maxAttempts) {
+              defaultRuntime.log?.(
+                `[verifier] exhausted after ${maxAttempts} attempt(s) — delivering best response`,
+              );
+              emitAgentEvent({
+                runId,
+                sessionKey,
+                stream: "lifecycle",
+                data: { phase: "verification_exhausted", attempts: maxAttempts },
+              });
+              break;
+            }
+
+            previousFeedback = verificationResult.feedback;
+
+            defaultRuntime.log?.(`[verifier] retrying (attempt ${attempt + 1})`);
+            emitAgentEvent({
+              runId,
+              sessionKey,
+              stream: "lifecycle",
+              data: { phase: "verification_retry", attempt: attempt + 1 },
+            });
+
+            const categoryHint = verificationResult.failCategory
+              ? ` Category: ${verificationResult.failCategory}.`
+              : "";
+            const feedbackPrompt = `[Verification: your response did not fully meet the request.${categoryHint} Feedback: ${verificationResult.feedback ?? "Response inadequate."}. Please review and address the issues.]`;
+
+            const retryOutcome = await runAgentTurnWithFallback({
+              commandBody: feedbackPrompt,
+              followupRun,
+              sessionCtx,
+              opts,
+              typingSignals,
+              blockReplyPipeline: null,
+              blockStreamingEnabled: false,
+              blockReplyChunking,
+              resolvedBlockStreamingBreak,
+              applyReplyToMode,
+              shouldEmitToolResult,
+              shouldEmitToolOutput,
+              pendingToolTasks,
+              resetSessionAfterCompactionFailure,
+              resetSessionAfterRoleOrderingConflict,
+              isHeartbeat,
+              sessionKey,
+              getActiveSessionEntry: () => activeSessionEntry,
+              activeSessionStore,
+              storePath,
+              resolvedVerboseLevel,
+            });
+
+            if (retryOutcome.kind === "final") {
+              break;
+            }
+
+            const retryPayloads = retryOutcome.runResult.payloads ?? [];
+            if (retryPayloads.length === 0) {
+              break;
+            }
+
+            currentPayloadArray = retryPayloads;
+            attempt++;
           }
 
-          // Retry: construct feedback prompt and re-run agent
-          defaultRuntime.log?.(`[verifier] retrying (attempt ${attempt + 1})`);
-          emitAgentEvent({
-            runId,
-            sessionKey,
-            stream: "lifecycle",
-            data: { phase: "verification_retry", attempt: attempt + 1 },
-          });
-
-          const feedbackPrompt = `[Verification: your response did not fully meet the request. Feedback: ${verificationResult.feedback ?? "Response inadequate."}. Please review and address the issues.]`;
-
-          const retryOutcome = await runAgentTurnWithFallback({
-            commandBody: feedbackPrompt,
-            followupRun,
-            sessionCtx,
-            opts,
-            typingSignals,
-            blockReplyPipeline: null,
-            blockStreamingEnabled: false,
-            blockReplyChunking,
-            resolvedBlockStreamingBreak,
-            applyReplyToMode,
-            shouldEmitToolResult,
-            shouldEmitToolOutput,
-            pendingToolTasks,
-            resetSessionAfterCompactionFailure,
-            resetSessionAfterRoleOrderingConflict,
-            isHeartbeat,
-            sessionKey,
-            getActiveSessionEntry: () => activeSessionEntry,
-            activeSessionStore,
-            storePath,
-            resolvedVerboseLevel,
-          });
-
-          if (retryOutcome.kind === "final") {
-            // Retry produced an error/final payload — deliver current best response
-            break;
-          }
-
-          const retryPayloads = retryOutcome.runResult.payloads ?? [];
-          if (retryPayloads.length === 0) {
-            // Retry produced nothing — deliver current best response
-            break;
-          }
-
-          currentPayloadArray = retryPayloads;
-          attempt++;
+          payloadArray = currentPayloadArray;
         }
-
-        // Use the latest payload array (verified or max-attempts exhausted)
-        payloadArray = currentPayloadArray;
       }
     }
     // ─── End self-verification loop ────────────────────────────────────

--- a/src/auto-reply/reply/agent-verifier-trigger.test.ts
+++ b/src/auto-reply/reply/agent-verifier-trigger.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { shouldVerifyResponse } from "./agent-verifier-trigger.js";
+
+describe("shouldVerifyResponse", () => {
+  it('"done" matches "I\'m done with the task" -> true', () => {
+    expect(shouldVerifyResponse("I'm done with the task", ["done"])).toBe(true);
+  });
+
+  it('"done" does NOT match "undone" -> false', () => {
+    expect(shouldVerifyResponse("undone", ["done"])).toBe(false);
+  });
+
+  it('"done" does NOT match "abandoned" -> false', () => {
+    expect(shouldVerifyResponse("abandoned", ["done"])).toBe(false);
+  });
+
+  it('"completed" matches "Task completed!" -> true (case-insensitive + punctuation)', () => {
+    expect(shouldVerifyResponse("Task completed!", ["completed"])).toBe(true);
+  });
+
+  it('"here you go" matches "Here you go, the results are ready" -> true', () => {
+    expect(shouldVerifyResponse("Here you go, the results are ready", ["here you go"])).toBe(true);
+  });
+
+  it("Empty text -> false", () => {
+    expect(shouldVerifyResponse("", ["done"])).toBe(false);
+  });
+
+  it("Empty keywords array -> false", () => {
+    expect(shouldVerifyResponse("I'm done", [])).toBe(false);
+  });
+
+  it("Multiple keywords: matches if ANY keyword found", () => {
+    expect(shouldVerifyResponse("Task completed!", ["done", "completed"])).toBe(true);
+    expect(shouldVerifyResponse("I'm done!", ["done", "completed"])).toBe(true);
+    expect(shouldVerifyResponse("Neither word here", ["done", "completed"])).toBe(false);
+  });
+
+  it("Special regex chars in keywords don't break matching", () => {
+    // These should not throw or break matching
+    expect(shouldVerifyResponse("test.test", ["test.test"])).toBe(true);
+    expect(shouldVerifyResponse("test+test", ["test+test"])).toBe(true);
+    expect(shouldVerifyResponse("test*test", ["test*test"])).toBe(true);
+    expect(shouldVerifyResponse("test[1]", ["test[1]"])).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/agent-verifier-trigger.ts
+++ b/src/auto-reply/reply/agent-verifier-trigger.ts
@@ -1,0 +1,23 @@
+const REGEX_SPECIAL_CHARS = /[.*+?^${}()|[\]\\]/g;
+
+function escapeRegExp(string: string): string {
+  return string.replace(REGEX_SPECIAL_CHARS, "\\$&");
+}
+
+function isSimpleWord(keyword: string): boolean {
+  return /^[a-zA-Z0-9_]+$/.test(keyword);
+}
+
+export function shouldVerifyResponse(text: string, keywords: string[]): boolean {
+  if (!text || keywords.length === 0) {
+    return false;
+  }
+
+  return keywords.some((keyword) => {
+    const escaped = escapeRegExp(keyword);
+
+    const pattern = keyword.includes(" ") || !isSimpleWord(keyword) ? escaped : `\\b${escaped}\\b`;
+
+    return new RegExp(pattern, "i").test(text);
+  });
+}

--- a/src/auto-reply/reply/agent-verifier.integration.test.ts
+++ b/src/auto-reply/reply/agent-verifier.integration.test.ts
@@ -1,0 +1,340 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TemplateContext } from "../templating.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { AgentRunLoopResult } from "./agent-runner-execution.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+const state = vi.hoisted(() => ({
+  runAgentTurnWithFallbackMock: vi.fn(),
+  verifyAgentResponseMock: vi.fn(),
+  emitAgentEventMock: vi.fn(),
+}));
+
+vi.mock("./agent-runner-execution.js", () => ({
+  runAgentTurnWithFallback: (...args: unknown[]) => state.runAgentTurnWithFallbackMock(...args),
+}));
+
+vi.mock("./agent-verifier.js", () => ({
+  verifyAgentResponse: (...args: unknown[]) => state.verifyAgentResponseMock(...args),
+}));
+
+vi.mock("../../infra/agent-events.js", () => ({
+  emitAgentEvent: (...args: unknown[]) => state.emitAgentEventMock(...args),
+  registerAgentRunContext: vi.fn(),
+  onAgentEvent: vi.fn(() => () => {}),
+}));
+
+vi.mock("./queue.js", () => ({
+  enqueueFollowupRun: vi.fn(),
+  scheduleFollowupDrain: vi.fn(),
+}));
+
+let runReplyAgentPromise:
+  | Promise<(typeof import("./agent-runner.js"))["runReplyAgent"]>
+  | undefined;
+
+async function getRunReplyAgent() {
+  if (!runReplyAgentPromise) {
+    runReplyAgentPromise = import("./agent-runner.js").then((m) => m.runReplyAgent);
+  }
+  return await runReplyAgentPromise;
+}
+
+function makeSuccessOutcome(
+  payloads: ReplyPayload[],
+  overrides?: Partial<Extract<AgentRunLoopResult, { kind: "success" }>>,
+): AgentRunLoopResult {
+  return {
+    kind: "success",
+    runId: "test-run-id",
+    runResult: { payloads, meta: {} },
+    fallbackAttempts: [],
+    didLogHeartbeatStrip: false,
+    autoCompactionCompleted: false,
+    ...overrides,
+  };
+}
+
+function createVerifierRun(params?: {
+  config?: Record<string, unknown>;
+  opts?: GetReplyOptions;
+  commandBody?: string;
+  blockStreamingEnabled?: boolean;
+  provider?: string;
+}) {
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: "whatsapp",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+  const followupRun = {
+    prompt: params?.commandBody ?? "Build me a REST API",
+    summaryLine: "Build me a REST API",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey: "main",
+      messageProvider: "whatsapp",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: params?.config ?? {},
+      skillsSnapshot: {},
+      provider: params?.provider ?? "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: { enabled: false, allowed: false, defaultLevel: "off" },
+      timeoutMs: 5_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return {
+    typing,
+    run: async () => {
+      const runReplyAgent = await getRunReplyAgent();
+      return runReplyAgent({
+        commandBody: params?.commandBody ?? "Build me a REST API",
+        followupRun,
+        queueKey: "main",
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: false,
+        isActive: false,
+        isStreaming: false,
+        opts: params?.opts,
+        typing,
+        sessionCtx,
+        defaultModel: "anthropic/claude-opus-4-5",
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: params?.blockStreamingEnabled ?? false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+      });
+    },
+  };
+}
+
+function verifierEnabledConfig(overrides?: Record<string, unknown>) {
+  return {
+    agents: {
+      defaults: {
+        verifier: {
+          enabled: true,
+          model: "anthropic/claude-sonnet-4-5",
+          maxAttempts: 3,
+          ...overrides,
+        },
+      },
+    },
+  };
+}
+
+function getEmittedPhases(): string[] {
+  return state.emitAgentEventMock.mock.calls
+    .map((c: unknown[]) => {
+      const arg = c[0] as { data?: { phase?: string } } | undefined;
+      return arg?.data?.phase;
+    })
+    .filter(Boolean) as string[];
+}
+
+beforeEach(() => {
+  state.runAgentTurnWithFallbackMock.mockReset();
+  state.verifyAgentResponseMock.mockReset();
+  state.emitAgentEventMock.mockReset();
+  vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+});
+
+describe("agent verifier integration", () => {
+  it("does not call verifyAgentResponse when verifier is disabled", async () => {
+    state.runAgentTurnWithFallbackMock.mockResolvedValueOnce(
+      makeSuccessOutcome([{ text: "I'm done with the task." }]),
+    );
+
+    const { run } = createVerifierRun({
+      config: { agents: { defaults: { verifier: { enabled: false } } } },
+    });
+    const result = await run();
+
+    expect(state.verifyAgentResponseMock).not.toHaveBeenCalled();
+    const payloads = Array.isArray(result) ? result : [result];
+    expect(payloads.some((p) => p?.text?.includes("done"))).toBe(true);
+  });
+
+  it("verifies on first attempt and passes — single run, no retry", async () => {
+    state.runAgentTurnWithFallbackMock.mockResolvedValueOnce(
+      makeSuccessOutcome([{ text: "I'm done building the API." }]),
+    );
+    state.verifyAgentResponseMock.mockResolvedValueOnce({ passed: true });
+
+    const { run } = createVerifierRun({ config: verifierEnabledConfig() });
+    const result = await run();
+
+    expect(state.runAgentTurnWithFallbackMock).toHaveBeenCalledTimes(1);
+    expect(state.verifyAgentResponseMock).toHaveBeenCalledTimes(1);
+
+    const payloads = Array.isArray(result) ? result : [result];
+    expect(payloads.some((p) => p?.text?.includes("done"))).toBe(true);
+
+    expect(state.emitAgentEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "lifecycle",
+        data: expect.objectContaining({ phase: "verification_pass", attempt: 1 }),
+      }),
+    );
+  });
+
+  it("retries when first verification fails, then passes on second attempt", async () => {
+    state.runAgentTurnWithFallbackMock
+      .mockResolvedValueOnce(makeSuccessOutcome([{ text: "I'm done with the REST API." }]))
+      .mockResolvedValueOnce(
+        makeSuccessOutcome([{ text: "Done! Added error handling with try/catch blocks." }]),
+      );
+
+    state.verifyAgentResponseMock
+      .mockResolvedValueOnce({ passed: false, feedback: "Missing error handling" })
+      .mockResolvedValueOnce({ passed: true });
+
+    const { run } = createVerifierRun({ config: verifierEnabledConfig() });
+    const result = await run();
+
+    expect(state.runAgentTurnWithFallbackMock).toHaveBeenCalledTimes(2);
+    expect(state.verifyAgentResponseMock).toHaveBeenCalledTimes(2);
+
+    const payloads = Array.isArray(result) ? result : [result];
+    expect(payloads.some((p) => p?.text?.includes("error handling"))).toBe(true);
+
+    const phases = getEmittedPhases();
+    expect(phases).toContain("verification_fail");
+    expect(phases).toContain("verification_retry");
+    expect(phases).toContain("verification_pass");
+  });
+
+  it("delivers latest response when max attempts exhausted (best-effort)", async () => {
+    state.runAgentTurnWithFallbackMock
+      .mockResolvedValueOnce(makeSuccessOutcome([{ text: "Done with the first attempt." }]))
+      .mockResolvedValueOnce(makeSuccessOutcome([{ text: "Done with the second attempt." }]))
+      .mockResolvedValueOnce(makeSuccessOutcome([{ text: "Done with the third attempt." }]));
+
+    state.verifyAgentResponseMock
+      .mockResolvedValueOnce({ passed: false, feedback: "Incomplete" })
+      .mockResolvedValueOnce({ passed: false, feedback: "Still incomplete" })
+      .mockResolvedValueOnce({ passed: false, feedback: "Not good enough" });
+
+    const { run } = createVerifierRun({ config: verifierEnabledConfig() });
+    const result = await run();
+
+    expect(state.runAgentTurnWithFallbackMock).toHaveBeenCalledTimes(3);
+    expect(state.verifyAgentResponseMock).toHaveBeenCalledTimes(3);
+
+    const payloads = Array.isArray(result) ? result : [result];
+    expect(payloads.some((p) => p?.text?.includes("third attempt"))).toBe(true);
+
+    expect(getEmittedPhases()).toContain("verification_exhausted");
+  });
+
+  it("skips verification for heartbeat runs", async () => {
+    state.runAgentTurnWithFallbackMock.mockResolvedValueOnce(
+      makeSuccessOutcome([{ text: "I'm done with the heartbeat check." }]),
+    );
+
+    const { run } = createVerifierRun({
+      config: verifierEnabledConfig(),
+      opts: { isHeartbeat: true },
+    });
+    await run();
+
+    expect(state.verifyAgentResponseMock).not.toHaveBeenCalled();
+  });
+
+  it("skips verification when block streaming already delivered content", async () => {
+    state.runAgentTurnWithFallbackMock.mockResolvedValueOnce(
+      makeSuccessOutcome([{ text: "I'm done with the streamed response." }], {
+        directlySentBlockKeys: new Set(["block-0"]),
+      }),
+    );
+
+    const { run } = createVerifierRun({ config: verifierEnabledConfig() });
+    await run();
+
+    expect(state.verifyAgentResponseMock).not.toHaveBeenCalled();
+  });
+
+  it("skips verification when payloadArray is empty", async () => {
+    state.runAgentTurnWithFallbackMock.mockResolvedValueOnce(makeSuccessOutcome([]));
+
+    const { run } = createVerifierRun({ config: verifierEnabledConfig() });
+    await run();
+
+    expect(state.verifyAgentResponseMock).not.toHaveBeenCalled();
+  });
+
+  // The real verifyAgentResponse catches LLM errors internally and returns
+  // { passed: true } (fail-open). This test verifies the system-level behavior:
+  // verification is attempted, the verifier fails open, and the response is delivered.
+  it("delivers original response when verifier encounters LLM error (fail-open)", async () => {
+    state.runAgentTurnWithFallbackMock.mockResolvedValueOnce(
+      makeSuccessOutcome([{ text: "I'm done with the API implementation." }]),
+    );
+
+    state.verifyAgentResponseMock.mockResolvedValueOnce({ passed: true });
+
+    const { run } = createVerifierRun({ config: verifierEnabledConfig() });
+    const result = await run();
+
+    const payloads = Array.isArray(result) ? result : [result];
+    expect(payloads.some((p) => p?.text?.includes("API implementation"))).toBe(true);
+
+    expect(state.verifyAgentResponseMock).toHaveBeenCalledTimes(1);
+    expect(state.runAgentTurnWithFallbackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips verification when response has no trigger keywords", async () => {
+    state.runAgentTurnWithFallbackMock.mockResolvedValueOnce(
+      makeSuccessOutcome([{ text: "Here is some intermediate analysis of the problem." }]),
+    );
+
+    const { run } = createVerifierRun({
+      config: verifierEnabledConfig({ triggerKeywords: ["done", "completed", "finished"] }),
+    });
+    const result = await run();
+
+    expect(state.verifyAgentResponseMock).not.toHaveBeenCalled();
+    const payloads = Array.isArray(result) ? result : [result];
+    expect(payloads.some((p) => p?.text?.includes("intermediate analysis"))).toBe(true);
+  });
+
+  // Abort fires during verify. The current iteration completes (including one retry),
+  // then the abort check at the top of the next iteration breaks the loop.
+  it("delivers current response when abort signal fires during verification", async () => {
+    const abortController = new AbortController();
+
+    state.runAgentTurnWithFallbackMock
+      .mockResolvedValueOnce(makeSuccessOutcome([{ text: "I'm done with the initial response." }]))
+      .mockResolvedValueOnce(makeSuccessOutcome([{ text: "Done — improved after feedback." }]));
+
+    state.verifyAgentResponseMock.mockImplementationOnce(async () => {
+      abortController.abort();
+      return { passed: false, feedback: "Needs improvement" };
+    });
+
+    const { run } = createVerifierRun({
+      config: verifierEnabledConfig(),
+      opts: { abortSignal: abortController.signal },
+    });
+    const result = await run();
+
+    // 2 calls: initial + 1 retry before abort detected at next iteration
+    expect(state.runAgentTurnWithFallbackMock).toHaveBeenCalledTimes(2);
+    expect(state.verifyAgentResponseMock).toHaveBeenCalledTimes(1);
+
+    const payloads = Array.isArray(result) ? result : [result];
+    expect(payloads.some((p) => p?.text?.includes("improved"))).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/agent-verifier.integration.test.ts
+++ b/src/auto-reply/reply/agent-verifier.integration.test.ts
@@ -48,7 +48,7 @@ function makeSuccessOutcome(
   return {
     kind: "success",
     runId: "test-run-id",
-    runResult: { payloads, meta: {} },
+    runResult: { payloads, meta: { durationMs: 100 } },
     fallbackAttempts: [],
     didLogHeartbeatStrip: false,
     autoCompactionCompleted: false,

--- a/src/auto-reply/reply/agent-verifier.test.ts
+++ b/src/auto-reply/reply/agent-verifier.test.ts
@@ -1,7 +1,12 @@
 import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { parseVerificationResponse, verifyAgentResponse } from "./agent-verifier.js";
+import {
+  assembleVerifierContext,
+  parseVerificationResponse,
+  shouldSkipVerification,
+  verifyAgentResponse,
+} from "./agent-verifier.js";
 
 vi.mock("@mariozechner/pi-ai", () => ({
   completeSimple: vi.fn(),
@@ -79,11 +84,42 @@ describe("parseVerificationResponse", () => {
     expect(parseVerificationResponse("  PASS  ")).toEqual({ passed: true });
   });
 
-  it("returns failed with feedback for FAIL: prefix", () => {
+  it("returns passed for **PASS** (markdown bold)", () => {
+    expect(parseVerificationResponse("The response looks good.\n**PASS**")).toEqual({
+      passed: true,
+    });
+  });
+
+  it("returns failed with feedback for FAIL: prefix (legacy)", () => {
     expect(parseVerificationResponse("FAIL: some reason")).toEqual({
       passed: false,
       feedback: "some reason",
     });
+  });
+
+  it("returns failed with category for FAIL [category]: prefix", () => {
+    const result = parseVerificationResponse(
+      "FAIL [incomplete]: Missing error handling for the endpoints.",
+    );
+    expect(result.passed).toBe(false);
+    expect(result.feedback).toBe("Missing error handling for the endpoints.");
+    expect(result.failCategory).toBe("incomplete");
+  });
+
+  it("returns failed with category for **FAIL [category]**: (markdown bold)", () => {
+    const result = parseVerificationResponse(
+      "The response misses the point.\n**FAIL [goal_missed]**: Did not answer the actual question.",
+    );
+    expect(result.passed).toBe(false);
+    expect(result.feedback).toBe("Did not answer the actual question.");
+    expect(result.failCategory).toBe("goal_missed");
+  });
+
+  it("returns undefined failCategory for unknown category", () => {
+    const result = parseVerificationResponse("FAIL [unknown_cat]: some reason");
+    expect(result.passed).toBe(false);
+    expect(result.feedback).toBe("some reason");
+    expect(result.failCategory).toBeUndefined();
   });
 
   it("returns failed with multi-line feedback", () => {
@@ -104,6 +140,153 @@ describe("parseVerificationResponse", () => {
   });
 });
 
+describe("shouldSkipVerification", () => {
+  it("returns 'tool_calls' when stopReason is tool_calls", () => {
+    expect(
+      shouldSkipVerification({
+        responseText: "some text",
+        runMeta: { stopReason: "tool_calls" },
+      }),
+    ).toBe("tool_calls");
+  });
+
+  it("returns 'tool_calls' when pendingToolCalls is true", () => {
+    expect(
+      shouldSkipVerification({
+        responseText: "some text",
+        runMeta: { pendingToolCalls: true },
+      }),
+    ).toBe("tool_calls");
+  });
+
+  it("returns 'messaging_tool_sent' when didSendViaMessagingTool", () => {
+    expect(
+      shouldSkipVerification({
+        responseText: "some text",
+        runMeta: { didSendViaMessagingTool: true },
+      }),
+    ).toBe("messaging_tool_sent");
+  });
+
+  it("returns 'block_streaming_sent' when directlySentBlockKeys has entries", () => {
+    expect(
+      shouldSkipVerification({
+        responseText: "some text",
+        directlySentBlockKeys: new Set(["block-0"]),
+      }),
+    ).toBe("block_streaming_sent");
+  });
+
+  it("returns 'empty_response' for whitespace-only text", () => {
+    expect(shouldSkipVerification({ responseText: "   " })).toBe("empty_response");
+  });
+
+  it("returns undefined when no skip conditions are met", () => {
+    expect(
+      shouldSkipVerification({
+        responseText: "Hello, I completed the task.",
+        runMeta: { stopReason: "stop" },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("assembleVerifierContext", () => {
+  it("includes user message and agent response", async () => {
+    const ctx = await assembleVerifierContext({
+      userMessage: "Build an API",
+      agentResponse: "Here is the API code.",
+      model: "test",
+      cfg: baseCfg,
+    });
+    expect(ctx).toContain("<user_message>");
+    expect(ctx).toContain("Build an API");
+    expect(ctx).toContain("<agent_response>");
+    expect(ctx).toContain("Here is the API code.");
+  });
+
+  it("includes conversation history when provided", async () => {
+    const ctx = await assembleVerifierContext({
+      userMessage: "Continue",
+      agentResponse: "Done.",
+      model: "test",
+      cfg: baseCfg,
+      conversationHistory: [
+        { sender: "user", body: "Hello" },
+        { sender: "assistant", body: "Hi there" },
+      ],
+    });
+    expect(ctx).toContain("<conversation_history>");
+    expect(ctx).toContain("[user]: Hello");
+    expect(ctx).toContain("[assistant]: Hi there");
+  });
+
+  it("limits conversation history to MAX_HISTORY_ENTRIES (5)", async () => {
+    const history = Array.from({ length: 10 }, (_, i) => ({
+      sender: "user",
+      body: `Message ${i}`,
+    }));
+    const ctx = await assembleVerifierContext({
+      userMessage: "test",
+      agentResponse: "done",
+      model: "test",
+      cfg: baseCfg,
+      conversationHistory: history,
+    });
+    expect(ctx).not.toContain("Message 0");
+    expect(ctx).not.toContain("Message 4");
+    expect(ctx).toContain("Message 5");
+    expect(ctx).toContain("Message 9");
+  });
+
+  it("includes execution metadata when provided", async () => {
+    const ctx = await assembleVerifierContext({
+      userMessage: "test",
+      agentResponse: "done",
+      model: "test",
+      cfg: baseCfg,
+      runMeta: { stopReason: "stop", durationMs: 1234 },
+    });
+    expect(ctx).toContain("<execution_context>");
+    expect(ctx).toContain("stop_reason: stop");
+    expect(ctx).toContain("duration: 1234ms");
+  });
+
+  it("includes previous feedback for retries", async () => {
+    const ctx = await assembleVerifierContext({
+      userMessage: "test",
+      agentResponse: "improved response",
+      model: "test",
+      cfg: baseCfg,
+      previousFeedback: "Missing error handling",
+    });
+    expect(ctx).toContain("<previous_verification_feedback>");
+    expect(ctx).toContain("Missing error handling");
+  });
+
+  it("truncates agent response that exceeds cap", async () => {
+    const longResponse = "x".repeat(15_000);
+    const ctx = await assembleVerifierContext({
+      userMessage: "test",
+      agentResponse: longResponse,
+      model: "test",
+      cfg: baseCfg,
+    });
+    expect(ctx).toContain("[... response truncated]");
+    expect(ctx.length).toBeLessThan(longResponse.length);
+  });
+
+  it("skips workspace sections when workspaceDir is not provided", async () => {
+    const ctx = await assembleVerifierContext({
+      userMessage: "test",
+      agentResponse: "done",
+      model: "test",
+      cfg: baseCfg,
+    });
+    expect(ctx).not.toContain("<user_rules>");
+  });
+});
+
 describe("verifyAgentResponse", () => {
   it("returns passed when LLM responds with PASS", async () => {
     mockedCompleteSimple.mockResolvedValueOnce(makeAssistantMessage("PASS"));
@@ -121,6 +304,35 @@ describe("verifyAgentResponse", () => {
       passed: false,
       feedback: "The response does not address the question",
     });
+  });
+
+  it("returns failed with category from structured FAIL response", async () => {
+    mockedCompleteSimple.mockResolvedValueOnce(
+      makeAssistantMessage(
+        "The response omits validation.\n**FAIL [incomplete]**: Missing input validation for the API.",
+      ),
+    );
+    const result = await verifyAgentResponse(baseParams);
+    expect(result.passed).toBe(false);
+    expect(result.failCategory).toBe("incomplete");
+    expect(result.feedback).toContain("Missing input validation");
+  });
+
+  it("passes enriched context to the LLM call", async () => {
+    mockedCompleteSimple.mockResolvedValueOnce(makeAssistantMessage("PASS"));
+    await verifyAgentResponse({
+      ...baseParams,
+      conversationHistory: [{ sender: "user", body: "Earlier message" }],
+      runMeta: { stopReason: "stop", durationMs: 500 },
+    });
+
+    const callArgs = mockedCompleteSimple.mock.calls[0];
+    const messageContent = (callArgs[1] as { messages: Array<{ content: string }> }).messages[0]
+      .content;
+    expect(messageContent).toContain("<conversation_history>");
+    expect(messageContent).toContain("Earlier message");
+    expect(messageContent).toContain("<execution_context>");
+    expect(messageContent).toContain("stop_reason: stop");
   });
 
   it("returns passed on timeout (fail-open)", async () => {

--- a/src/auto-reply/reply/agent-verifier.test.ts
+++ b/src/auto-reply/reply/agent-verifier.test.ts
@@ -1,0 +1,150 @@
+import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { parseVerificationResponse, verifyAgentResponse } from "./agent-verifier.js";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  completeSimple: vi.fn(),
+  getOAuthProviders: () => [],
+  getOAuthApiKey: vi.fn(async () => null),
+}));
+
+vi.mock("../../agents/pi-embedded-runner/model.js", () => ({
+  resolveModel: vi.fn((_provider: string, modelId: string) => ({
+    model: {
+      provider: "anthropic",
+      id: modelId,
+      name: modelId,
+      api: "anthropic-messages",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 8192,
+    },
+    authStorage: { profiles: {} },
+    modelRegistry: { find: vi.fn() },
+  })),
+}));
+
+vi.mock("../../agents/model-auth.js", () => ({
+  getApiKeyForModel: vi.fn(async () => ({
+    apiKey: "test-api-key",
+    source: "test",
+    mode: "api-key" as const,
+  })),
+  requireApiKey: vi.fn((auth: { apiKey?: string }) => auth.apiKey ?? ""),
+}));
+
+const mockedCompleteSimple = vi.mocked(completeSimple);
+
+function makeAssistantMessage(text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+    usage: {
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 15,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+const baseCfg = {} as OpenClawConfig;
+const baseParams = {
+  userMessage: "What is 2+2?",
+  agentResponse: "4",
+  model: "anthropic/claude-sonnet-4-5",
+  cfg: baseCfg,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("parseVerificationResponse", () => {
+  it("returns passed for PASS", () => {
+    expect(parseVerificationResponse("PASS")).toEqual({ passed: true });
+  });
+
+  it("returns passed for PASS with surrounding whitespace", () => {
+    expect(parseVerificationResponse("  PASS  ")).toEqual({ passed: true });
+  });
+
+  it("returns failed with feedback for FAIL: prefix", () => {
+    expect(parseVerificationResponse("FAIL: some reason")).toEqual({
+      passed: false,
+      feedback: "some reason",
+    });
+  });
+
+  it("returns failed with multi-line feedback", () => {
+    const result = parseVerificationResponse("FAIL: line one\nline two");
+    expect(result.passed).toBe(false);
+    expect(result.feedback).toContain("line one");
+    expect(result.feedback).toContain("line two");
+  });
+
+  it("returns passed for empty string (fail-open)", () => {
+    expect(parseVerificationResponse("")).toEqual({ passed: true });
+  });
+
+  it("returns passed for malformed response (fail-open)", () => {
+    expect(parseVerificationResponse("I'm not sure what you mean")).toEqual({
+      passed: true,
+    });
+  });
+});
+
+describe("verifyAgentResponse", () => {
+  it("returns passed when LLM responds with PASS", async () => {
+    mockedCompleteSimple.mockResolvedValueOnce(makeAssistantMessage("PASS"));
+    const result = await verifyAgentResponse(baseParams);
+    expect(result).toEqual({ passed: true });
+    expect(mockedCompleteSimple).toHaveBeenCalledOnce();
+  });
+
+  it("returns failed with feedback when LLM responds with FAIL:", async () => {
+    mockedCompleteSimple.mockResolvedValueOnce(
+      makeAssistantMessage("FAIL: The response does not address the question"),
+    );
+    const result = await verifyAgentResponse(baseParams);
+    expect(result).toEqual({
+      passed: false,
+      feedback: "The response does not address the question",
+    });
+  });
+
+  it("returns passed on timeout (fail-open)", async () => {
+    mockedCompleteSimple.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) =>
+          setTimeout(() => reject(new DOMException("The operation was aborted", "AbortError")), 5),
+        ),
+    );
+    const result = await verifyAgentResponse({ ...baseParams, timeoutMs: 1 });
+    expect(result).toEqual({ passed: true });
+  });
+
+  it("returns passed on LLM error/exception (fail-open)", async () => {
+    mockedCompleteSimple.mockRejectedValueOnce(new Error("API rate limited"));
+    const result = await verifyAgentResponse(baseParams);
+    expect(result).toEqual({ passed: true });
+  });
+
+  it("returns passed on malformed LLM response (fail-open)", async () => {
+    mockedCompleteSimple.mockResolvedValueOnce(
+      makeAssistantMessage("The response seems okay but I cannot determine definitively."),
+    );
+    const result = await verifyAgentResponse(baseParams);
+    expect(result).toEqual({ passed: true });
+  });
+});

--- a/src/auto-reply/reply/agent-verifier.ts
+++ b/src/auto-reply/reply/agent-verifier.ts
@@ -1,0 +1,123 @@
+import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
+import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { getApiKeyForModel, requireApiKey } from "../../agents/model-auth.js";
+import { parseModelRef } from "../../agents/model-selection.js";
+import { resolveModel } from "../../agents/pi-embedded-runner/model.js";
+import type { OpenClawConfig } from "../../config/config.js";
+
+export type VerificationResult = { passed: boolean; feedback?: string };
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+const VERIFICATION_SYSTEM_PROMPT = [
+  "You are a response quality verifier. Your sole task is to evaluate whether an AI assistant's response adequately addresses the user's request.",
+  "",
+  "Evaluate the response against these criteria:",
+  "1. Does the response address the user's actual question or request?",
+  "2. Is the response reasonably complete (not truncated or clearly unfinished)?",
+  "3. Does the response avoid being an unnecessary refusal when the request is reasonable?",
+  "",
+  "If the response meets the goal, reply with exactly:",
+  "PASS",
+  "",
+  "If the response does NOT meet the goal, reply with:",
+  "FAIL: <detailed reason why the response is inadequate>",
+  "",
+  "Do not add any other text.",
+].join("\n");
+
+/**
+ * Parse the raw verifier LLM response. Returns `{ passed: true }` for
+ * PASS, empty, or malformed responses (fail-open). Returns `{ passed: false,
+ * feedback }` only when a `FAIL: <reason>` prefix is found.
+ */
+export function parseVerificationResponse(raw: string): VerificationResult {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { passed: true };
+  }
+
+  if (/^PASS$/m.test(trimmed)) {
+    return { passed: true };
+  }
+
+  const failMatch = /^FAIL:\s*(.+)/ms.exec(trimmed);
+  if (failMatch) {
+    return { passed: false, feedback: failMatch[1].trim() };
+  }
+
+  // Fail-open: malformed verifier output never blocks delivery.
+  return { passed: true };
+}
+
+/**
+ * Standalone LLM call to verify an agent response. Fail-open on timeout,
+ * LLM error, or malformed response — delivery is never blocked.
+ */
+export async function verifyAgentResponse(params: {
+  userMessage: string;
+  agentResponse: string;
+  model: string;
+  cfg: OpenClawConfig;
+  timeoutMs?: number;
+}): Promise<VerificationResult> {
+  try {
+    const ref = parseModelRef(params.model, DEFAULT_PROVIDER);
+    if (!ref) {
+      return { passed: true };
+    }
+
+    const resolved = resolveModel(ref.provider, ref.model, undefined, params.cfg);
+    if (!resolved.model) {
+      return { passed: true };
+    }
+
+    const apiKeyInfo = await getApiKeyForModel({
+      model: resolved.model,
+      cfg: params.cfg,
+    });
+    const apiKey = requireApiKey(apiKeyInfo, ref.provider);
+
+    const controller = new AbortController();
+    const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const res = await completeSimple(
+        resolved.model,
+        {
+          messages: [
+            {
+              role: "user",
+              content:
+                `${VERIFICATION_SYSTEM_PROMPT}\n\n` +
+                `<user_message>\n${params.userMessage}\n</user_message>\n\n` +
+                `<agent_response>\n${params.agentResponse}\n</agent_response>`,
+              timestamp: Date.now(),
+            },
+          ],
+        },
+        {
+          apiKey,
+          maxTokens: 256,
+          temperature: 0,
+          signal: controller.signal,
+        },
+      );
+
+      const text = res.content
+        .filter((block): block is TextContent => block.type === "text")
+        .map((block) => block.text.trim())
+        .filter(Boolean)
+        .join(" ")
+        .trim();
+
+      return parseVerificationResponse(text);
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch {
+    // Fail-open: never block delivery due to verifier issues.
+    return { passed: true };
+  }
+}

--- a/src/auto-reply/reply/agent-verifier.ts
+++ b/src/auto-reply/reply/agent-verifier.ts
@@ -1,35 +1,279 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { getApiKeyForModel, requireApiKey } from "../../agents/model-auth.js";
 import { parseModelRef } from "../../agents/model-selection.js";
 import { resolveModel } from "../../agents/pi-embedded-runner/model.js";
+import { DEFAULT_AGENTS_FILENAME, DEFAULT_SOUL_FILENAME } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/config.js";
 
-export type VerificationResult = { passed: boolean; feedback?: string };
+// ─── Types ─────────────────────────────────────────────────────────────
+
+export type VerificationResult = {
+  passed: boolean;
+  feedback?: string;
+  /** Structured failure category for smarter retries. */
+  failCategory?: FailCategory;
+};
+
+export type FailCategory =
+  | "goal_missed"
+  | "incomplete"
+  | "rule_violation"
+  | "tone_mismatch"
+  | "refusal";
+
+/**
+ * Reason the verifier was skipped (deterministic pre-check).
+ * Returned by `shouldSkipVerification` to enable log-level reporting.
+ */
+export type SkipReason =
+  | "tool_calls"
+  | "error_response"
+  | "messaging_tool_sent"
+  | "block_streaming_sent"
+  | "empty_response";
+
+/** Execution metadata surfaced to the verifier for richer evaluation. */
+export type VerifierRunMeta = {
+  stopReason?: string;
+  pendingToolCalls?: boolean;
+  didSendViaMessagingTool?: boolean;
+  messagingToolSentTexts?: string[];
+  durationMs?: number;
+};
+
+/** Conversation history entry (from InboundHistory). */
+export type VerifierHistoryEntry = {
+  sender: string;
+  body: string;
+  timestamp?: number;
+};
+
+export type VerifyAgentResponseParams = {
+  userMessage: string;
+  agentResponse: string;
+  model: string;
+  cfg: OpenClawConfig;
+  timeoutMs?: number;
+  /** Execution metadata for richer evaluation. */
+  runMeta?: VerifierRunMeta;
+  /** Conversation history (last N turns). */
+  conversationHistory?: VerifierHistoryEntry[];
+  /** Workspace directory for reading AGENTS.md / SOUL.md. */
+  workspaceDir?: string;
+  /** Extra system prompt assembled by the agent runtime. */
+  extraSystemPrompt?: string;
+  /** Previous verification feedback (for retry context). */
+  previousFeedback?: string;
+};
+
+// ─── Constants ─────────────────────────────────────────────────────────
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 
-const VERIFICATION_SYSTEM_PROMPT = [
-  "You are a response quality verifier. Your sole task is to evaluate whether an AI assistant's response adequately addresses the user's request.",
-  "",
-  "Evaluate the response against these criteria:",
-  "1. Does the response address the user's actual question or request?",
-  "2. Is the response reasonably complete (not truncated or clearly unfinished)?",
-  "3. Does the response avoid being an unnecessary refusal when the request is reasonable?",
-  "",
-  "If the response meets the goal, reply with exactly:",
-  "PASS",
-  "",
-  "If the response does NOT meet the goal, reply with:",
-  "FAIL: <detailed reason why the response is inadequate>",
-  "",
-  "Do not add any other text.",
-].join("\n");
+/** Soft char budget for the full verifier prompt (~8K tokens at ~4 chars/token). */
+const CONTEXT_CHAR_BUDGET = 32_000;
+/** Max chars for user rules (AGENTS.md + SOUL.md combined). */
+const USER_RULES_CHAR_CAP = 8_000;
+/** Max conversation history entries. */
+const MAX_HISTORY_ENTRIES = 5;
+/** Max chars for agent response before truncation. */
+const AGENT_RESPONSE_CHAR_CAP = 12_000;
+
+// ─── Enhanced Verifier System Prompt ───────────────────────────────────
+
+const VERIFICATION_SYSTEM_PROMPT = `You are a response quality verifier. Evaluate whether an AI assistant's response achieves the user's goal.
+
+## Evaluation Method
+Think step-by-step through each dimension before reaching a verdict.
+
+## Evaluation Dimensions
+1. **Goal Achievement**: Does the response directly address what the user asked?
+2. **Completeness**: Is the response thorough and not truncated or superficially brief?
+3. **Rule Compliance**: Does the response follow user rules and instructions (if provided)?
+
+## Output Format
+First, briefly reason through each dimension (2-3 sentences total).
+
+Then on a new line, output your verdict:
+- If the response meets all dimensions: **PASS**
+- If the response fails any dimension, output:
+  **FAIL [category]: <specific actionable feedback>**
+
+Valid categories: goal_missed, incomplete, rule_violation, tone_mismatch, refusal
+
+Example outputs:
+\`\`\`
+The response directly answers the question about API design, covers all endpoints mentioned, and follows the concise style requested.
+PASS
+\`\`\`
+\`\`\`
+The response addresses the question but omits error handling which was explicitly requested.
+FAIL [incomplete]: Missing error handling for the API endpoints. The user specifically asked for robust error handling with try/catch blocks and proper HTTP status codes.
+\`\`\``;
+
+// ─── Deterministic Pre-checks ──────────────────────────────────────────
+
+/**
+ * Deterministic pre-checks that skip verification without an LLM call.
+ * Returns a skip reason if verification should be skipped, or `undefined` to proceed.
+ */
+export function shouldSkipVerification(params: {
+  responseText: string;
+  runMeta?: VerifierRunMeta;
+  directlySentBlockKeys?: Set<string>;
+}): SkipReason | undefined {
+  // Skip when agent stopped to make tool calls (intermediate turn, not final response)
+  if (params.runMeta?.stopReason === "tool_calls" || params.runMeta?.pendingToolCalls) {
+    return "tool_calls";
+  }
+
+  // Skip when agent already sent content via messaging tool (e.g. WhatsApp send)
+  if (params.runMeta?.didSendViaMessagingTool) {
+    return "messaging_tool_sent";
+  }
+
+  // Skip when block streaming already delivered content to the user
+  if (params.directlySentBlockKeys && params.directlySentBlockKeys.size > 0) {
+    return "block_streaming_sent";
+  }
+
+  // Skip on empty response
+  if (!params.responseText.trim()) {
+    return "empty_response";
+  }
+
+  return undefined;
+}
+
+// ─── Workspace File Reading ────────────────────────────────────────────
+
+/**
+ * Read a workspace file (AGENTS.md or SOUL.md) with a character cap.
+ * Returns empty string on any error (file missing, permission, etc.).
+ */
+async function readWorkspaceFile(
+  workspaceDir: string,
+  filename: string,
+  charCap: number,
+): Promise<string> {
+  try {
+    const filePath = path.join(workspaceDir, filename);
+    const content = await fs.readFile(filePath, "utf-8");
+    if (content.length > charCap) {
+      return content.slice(0, charCap) + "\n[... truncated]";
+    }
+    return content;
+  } catch {
+    return "";
+  }
+}
+
+// ─── Context Assembly ──────────────────────────────────────────────────
+
+/**
+ * Assemble the full verifier context string with token-budgeted sections.
+ *
+ * Context ordering follows the "Lost in the Middle" mitigation:
+ * - Critical context at START and END
+ * - Less critical context in the MIDDLE
+ *
+ * Priority order (trim from bottom up when over budget):
+ * 1. Verifier system prompt (fixed, ~1K chars)
+ * 2. User message (never trimmed)
+ * 3. Agent response (truncate tail if massive)
+ * 4. Execution metadata (tiny, always include)
+ * 5. User rules (AGENTS.md, SOUL.md — cap at USER_RULES_CHAR_CAP)
+ * 6. Conversation history (last N turns — trim oldest first)
+ * 7. Extra system prompt (lowest priority)
+ */
+export async function assembleVerifierContext(params: VerifyAgentResponseParams): Promise<string> {
+  const sections: string[] = [];
+
+  // ── Section 1: User message (near start — high priority) ──
+  sections.push(`<user_message>\n${params.userMessage}\n</user_message>`);
+
+  // ── Section 2: User rules (middle — medium priority) ──
+  if (params.workspaceDir) {
+    const [agentsMd, soulMd] = await Promise.all([
+      readWorkspaceFile(params.workspaceDir, DEFAULT_AGENTS_FILENAME, USER_RULES_CHAR_CAP),
+      readWorkspaceFile(
+        params.workspaceDir,
+        DEFAULT_SOUL_FILENAME,
+        Math.max(0, USER_RULES_CHAR_CAP - 4_000),
+      ),
+    ]);
+
+    const rulesContent: string[] = [];
+    if (agentsMd) {
+      rulesContent.push(`### AGENTS.md\n${agentsMd}`);
+    }
+    if (soulMd) {
+      rulesContent.push(`### SOUL.md\n${soulMd}`);
+    }
+
+    if (rulesContent.length > 0) {
+      sections.push(`<user_rules>\n${rulesContent.join("\n\n")}\n</user_rules>`);
+    }
+  }
+
+  // ── Section 3: Conversation history (middle — lower priority) ──
+  if (params.conversationHistory && params.conversationHistory.length > 0) {
+    const recentHistory = params.conversationHistory.slice(-MAX_HISTORY_ENTRIES);
+    const historyLines = recentHistory.map((entry) => `[${entry.sender}]: ${entry.body}`);
+    sections.push(`<conversation_history>\n${historyLines.join("\n")}\n</conversation_history>`);
+  }
+
+  // ── Section 4: Execution metadata (middle — tiny, always include) ──
+  if (params.runMeta) {
+    const metaParts: string[] = [];
+    if (params.runMeta.stopReason) {
+      metaParts.push(`stop_reason: ${params.runMeta.stopReason}`);
+    }
+    if (params.runMeta.durationMs !== undefined) {
+      metaParts.push(`duration: ${params.runMeta.durationMs}ms`);
+    }
+    if (metaParts.length > 0) {
+      sections.push(`<execution_context>\n${metaParts.join(", ")}\n</execution_context>`);
+    }
+  }
+
+  // ── Section 5: Previous feedback (for retries) ──
+  if (params.previousFeedback) {
+    sections.push(
+      `<previous_verification_feedback>\n${params.previousFeedback}\n</previous_verification_feedback>`,
+    );
+  }
+
+  // ── Section 6: Agent response (at END — high priority for recency) ──
+  let agentResponse = params.agentResponse;
+  if (agentResponse.length > AGENT_RESPONSE_CHAR_CAP) {
+    agentResponse = agentResponse.slice(0, AGENT_RESPONSE_CHAR_CAP) + "\n[... response truncated]";
+  }
+  sections.push(`<agent_response>\n${agentResponse}\n</agent_response>`);
+
+  // ── Apply budget ──
+  let assembled = sections.join("\n\n");
+
+  // If over budget, trim conversation history first, then user rules
+  if (assembled.length > CONTEXT_CHAR_BUDGET) {
+    const trimmedSections = sections.filter(
+      (s) => !s.startsWith("<conversation_history>") && !s.startsWith("<extra_system_prompt>"),
+    );
+    assembled = trimmedSections.join("\n\n");
+  }
+
+  return assembled;
+}
+
+// ─── Response Parsing ──────────────────────────────────────────────────
 
 /**
  * Parse the raw verifier LLM response. Returns `{ passed: true }` for
  * PASS, empty, or malformed responses (fail-open). Returns `{ passed: false,
- * feedback }` only when a `FAIL: <reason>` prefix is found.
+ * feedback, failCategory }` when a `FAIL [category]: <reason>` is found.
  */
 export function parseVerificationResponse(raw: string): VerificationResult {
   const trimmed = raw.trim();
@@ -37,30 +281,51 @@ export function parseVerificationResponse(raw: string): VerificationResult {
     return { passed: true };
   }
 
-  if (/^PASS$/m.test(trimmed)) {
+  if (/^PASS$/m.test(trimmed) || /\*\*PASS\*\*/m.test(trimmed)) {
     return { passed: true };
   }
 
-  const failMatch = /^FAIL:\s*(.+)/ms.exec(trimmed);
-  if (failMatch) {
-    return { passed: false, feedback: failMatch[1].trim() };
+  // Match structured FAIL with category: FAIL [category]: reason
+  // Also handles **FAIL [category]**: reason (markdown bold)
+  const structuredFail = /\*?\*?FAIL\s*\[(\w+)\]\*?\*?:\s*(.+)/ms.exec(trimmed);
+  if (structuredFail) {
+    const category = structuredFail[1] as FailCategory;
+    const validCategories: FailCategory[] = [
+      "goal_missed",
+      "incomplete",
+      "rule_violation",
+      "tone_mismatch",
+      "refusal",
+    ];
+    return {
+      passed: false,
+      feedback: structuredFail[2].trim(),
+      failCategory: validCategories.includes(category) ? category : undefined,
+    };
+  }
+
+  // Legacy format: FAIL: reason (no category)
+  const legacyFail = /\*?\*?FAIL\*?\*?:\s*(.+)/ms.exec(trimmed);
+  if (legacyFail) {
+    return { passed: false, feedback: legacyFail[1].trim() };
   }
 
   // Fail-open: malformed verifier output never blocks delivery.
   return { passed: true };
 }
 
+// ─── Main Verification Function ────────────────────────────────────────
+
 /**
  * Standalone LLM call to verify an agent response. Fail-open on timeout,
  * LLM error, or malformed response — delivery is never blocked.
+ *
+ * Enhanced version: accepts full context (workspace files, conversation
+ * history, execution metadata) for richer evaluation.
  */
-export async function verifyAgentResponse(params: {
-  userMessage: string;
-  agentResponse: string;
-  model: string;
-  cfg: OpenClawConfig;
-  timeoutMs?: number;
-}): Promise<VerificationResult> {
+export async function verifyAgentResponse(
+  params: VerifyAgentResponseParams,
+): Promise<VerificationResult> {
   try {
     const ref = parseModelRef(params.model, DEFAULT_PROVIDER);
     if (!ref) {
@@ -78,6 +343,9 @@ export async function verifyAgentResponse(params: {
     });
     const apiKey = requireApiKey(apiKeyInfo, ref.provider);
 
+    // Assemble full context with token budgeting
+    const contextBody = await assembleVerifierContext(params);
+
     const controller = new AbortController();
     const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -89,17 +357,14 @@ export async function verifyAgentResponse(params: {
           messages: [
             {
               role: "user",
-              content:
-                `${VERIFICATION_SYSTEM_PROMPT}\n\n` +
-                `<user_message>\n${params.userMessage}\n</user_message>\n\n` +
-                `<agent_response>\n${params.agentResponse}\n</agent_response>`,
+              content: `${VERIFICATION_SYSTEM_PROMPT}\n\n${contextBody}`,
               timestamp: Date.now(),
             },
           ],
         },
         {
           apiKey,
-          maxTokens: 256,
+          maxTokens: 512,
           temperature: 0,
           signal: controller.signal,
         },

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -127,6 +127,10 @@ export type AgentVerifierConfig = {
   enabled?: boolean;
   /** Verify every response regardless of trigger keywords (default: false). */
   verifyAll?: boolean;
+  /** Also verify heartbeat responses (default: false).
+   *  When enabled, the verifier evaluates heartbeat replies against HEARTBEAT.md tasks
+   *  to catch lazy HEARTBEAT_OK responses when the agent should have taken action. */
+  verifyHeartbeat?: boolean;
   /** Verifier model reference (e.g. "anthropic/claude-sonnet-4-5"). */
   model?: string;
   /** Max attempts including original (default: 3). */

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -271,6 +271,8 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
+    announceTimeoutMs?: number;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -155,6 +155,7 @@ export const AgentDefaultsSchema = z
       .object({
         enabled: z.boolean().optional(),
         verifyAll: z.boolean().optional(),
+        verifyHeartbeat: z.boolean().optional(),
         model: z.string().optional(),
         maxAttempts: z.number().int().positive().optional(),
         triggerKeywords: z.array(z.string()).optional(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -151,6 +151,16 @@ export const AgentDefaultsSchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    verifier: z
+      .object({
+        enabled: z.boolean().optional(),
+        model: z.string().optional(),
+        maxAttempts: z.number().int().positive().optional(),
+        triggerKeywords: z.array(z.string()).optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -154,6 +154,7 @@ export const AgentDefaultsSchema = z
     verifier: z
       .object({
         enabled: z.boolean().optional(),
+        verifyAll: z.boolean().optional(),
         model: z.string().optional(),
         maxAttempts: z.number().int().positive().optional(),
         triggerKeywords: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

Adds an opt-in **self-verification loop** to the agent runner. After an agent completes a task, a separate verifier model evaluates whether the response actually addresses the user's request — using the **full conversation context**, user rules (AGENTS.md, SOUL.md), conversation history, and execution metadata. If verification fails, structured feedback is injected back into the conversation and the agent retries, up to a configurable max attempts.

This is an **"LLM-as-a-judge"** pattern integrated directly into `runReplyAgent()`, designed to improve response quality without manual re-prompting.

## How it works

### Core loop

1. Agent produces a response via the normal `runAgentTurnWithFallback()` flow
2. **Deterministic pre-checks** (`shouldSkipVerification()`) decide if verification applies — skips tool-call turns, already-streamed content, messaging tool sends, and empty responses
3. **Keyword trigger**, `verifyAll` mode, or `verifyHeartbeat` mode decides whether to invoke the verifier
4. `assembleVerifierContext()` builds a token-budgeted evaluation prompt (~32K char budget) with all available context
5. `verifyAgentResponse()` makes a standalone LLM call to a verifier model
6. The verifier uses **chain-of-thought** reasoning across 3 dimensions (Goal Achievement, Completeness, Rule Compliance)
7. Returns `PASS` or `FAIL [category]: <feedback>` with a structured fail category
8. On failure, categorized feedback is injected as a new user message and the agent retries
9. Loop continues until PASS or max attempts exhausted
10. **Fail-open**: if the verifier errors, times out, or returns malformed output, the original response is delivered — verification never blocks delivery

### Deterministic pre-checks (no LLM call needed)

These conditions skip verification entirely before any LLM call:
- `stopReason === "tool_calls"` or `pendingToolCalls` — intermediate turn, not final
- `didSendViaMessagingTool` — content already delivered (WhatsApp, Telegram, etc.)
- Block streaming already sent (`directlySentBlockKeys.size > 0`) — can't un-send
- Empty response text

### Full-context evaluation

The verifier assembles context from multiple sources, ordered to mitigate the **"Lost in the Middle"** effect (critical context at START and END):

```
[SYSTEM PROMPT]           ← evaluation instructions + 3-dimension rubric
[USER MESSAGE]            ← what was asked (near start, never trimmed)
[USER RULES]              ← AGENTS.md, SOUL.md excerpts (capped ~8K chars)
[CONVERSATION HISTORY]    ← last 5 turns from InboundHistory (zero I/O)
[EXECUTION METADATA]      ← stop_reason, duration
[PREVIOUS FEEDBACK]       ← prior verification feedback (on retries)
[AGENT RESPONSE]          ← what we're evaluating (at END for recency)
```

Token budget priority (trim from bottom up):
1. System prompt (~1K chars) — fixed
2. User message — never trimmed
3. Agent response — truncate tail if >12K chars
4. Execution metadata — tiny, always include
5. User rules — cap at ~8K chars
6. Conversation history — trim oldest first

### Heartbeat verification

When `verifyHeartbeat: true`, the verifier also evaluates **heartbeat responses**. This catches lazy `HEARTBEAT_OK` replies when the agent should have taken proactive action based on `HEARTBEAT.md` tasks.

Without `verifyHeartbeat`, heartbeat runs are always skipped (default behavior — no overhead on periodic checks that don't need verification).

With `verifyHeartbeat: true`, **all** heartbeat responses are verified regardless of keyword triggers — this is intentional because the whole point is catching agents that respond `HEARTBEAT_OK` without doing real work.

Example: If `HEARTBEAT.md` says "Check for new Kaggle competitions and participate" but the agent responds `HEARTBEAT_OK` without checking, the verifier flags it as `goal_missed` and the agent retries with proper task execution.

### Structured failure categories

On failure, the verifier outputs a categorized response for smarter retries:
- `goal_missed` — response doesn't address the actual question
- `incomplete` — response is truncated or missing requested elements
- `rule_violation` — response violates user rules (AGENTS.md, SOUL.md)
- `tone_mismatch` — wrong tone, register, or communication style
- `refusal` — agent refused a legitimate request

The category is logged via `emitAgentEvent()` and included in the retry feedback prompt to help the agent focus its correction.

## Verification scope

The verification loop covers:
- **Main session responses** ✅ — all channel messages (WhatsApp, Telegram, Discord, etc.)
- **Sub-agent responses** ✅ — sub-agents spawned via `sessions_spawn` route through `runReplyAgent()` via the gateway
- **Heartbeat responses** ✅ — opt-in via `verifyHeartbeat: true`
- **CLI provider** ❌ — intentionally excluded (local development)

## Configuration

Add to `~/.openclaw/openclaw.json`:

```json
{
  "agents": {
    "defaults": {
      "verifier": {
        "enabled": true,
        "model": "anthropic/claude-sonnet-4-5",
        "verifyAll": false,
        "verifyHeartbeat": true,
        "maxAttempts": 3,
        "triggerKeywords": ["done", "completed", "finished", "ready", "here you go"],
        "timeoutSeconds": 30
      }
    }
  }
}
```

### Configuration reference

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `enabled` | `boolean` | `false` | Enable the verification loop |
| `verifyAll` | `boolean` | `false` | Verify **every** response regardless of trigger keywords |
| `verifyHeartbeat` | `boolean` | `false` | Verify heartbeat responses — catches lazy `HEARTBEAT_OK` when tasks exist |
| `model` | `string` | `"anthropic/claude-sonnet-4-5"` | Verifier model (recommended: different model family than agent) |
| `maxAttempts` | `number` | `3` | Max attempts including original response |
| `triggerKeywords` | `string[]` | `["done", "completed", ...]` | Keywords that trigger verification when `verifyAll` is `false` |
| `timeoutSeconds` | `number` | `30` | Timeout for the verifier LLM call |

All fields are optional with sensible defaults. The feature is **off by default** (`enabled: false`).

### Trigger modes

- **Keyword mode** (default): verification only runs when the agent's response contains a trigger keyword (e.g., "done", "completed"). Lightweight — most responses skip verification entirely.
- **Verify-all mode** (`verifyAll: true`): verification runs on every response. Higher cost but catches more issues. Recommended when quality matters more than latency.
- **Heartbeat mode** (`verifyHeartbeat: true`): all heartbeat responses are verified regardless of keywords. Catches agents that reply `HEARTBEAT_OK` without checking their `HEARTBEAT.md` tasks.

### Recommended setup

Use a **different model family** for the verifier than the agent to avoid self-bias:
- Agent: `anthropic/claude-opus-4-6` → Verifier: `openai/gpt-4.1` or `kimi-coding/k2p5`
- Agent: `openai/gpt-4.1` → Verifier: `anthropic/claude-sonnet-4-5`

## Design decisions

- **Deterministic pre-checks**: Fast `shouldSkipVerification()` avoids LLM calls for cases that can be decided logically (tool calls, already-sent content, empty responses)
- **Verifier call**: Standalone `completeSimple()` call, not a full agent turn — no tools, no session writes, no transcript pollution
- **Full context assembly**: `assembleVerifierContext()` reads AGENTS.md/SOUL.md from workspace at verification time, includes conversation history from memory (zero additional I/O), and applies token budgeting
- **Chain-of-thought evaluation**: Verifier reasons through 3 dimensions before verdicting — reduces snap-judgment failures
- **Structured FAIL categories**: Categories enable smarter retry prompts (e.g., "Your response was flagged for `incomplete` — specifically: missing error handling")
- **Retry mechanism**: Feedback injected into the same session conversation, not a new session — preserves full context
- **"Lost in the Middle" mitigation**: Context ordering places critical information (user message, agent response) at boundaries, less critical (rules, history) in the middle
- **Block streaming skip**: When block streaming has already sent content to the user, verification is skipped (can't un-send)
- **Heartbeat always-verify**: When `verifyHeartbeat` is true, heartbeat runs bypass keyword triggers entirely — every heartbeat response goes through verification. This is the correct behavior because the problem being solved is agents that lazily respond `HEARTBEAT_OK` without checking tasks.
- **No per-agent config in v1**: Only `agents.defaults.verifier` — per-agent overrides can be added later
- **System prompt is hardcoded**: A well-tested verification prompt with CoT rubric, not user-configurable in v1
- **Fail-open always**: Any verifier error (API failure, timeout, malformed response, model unavailable) silently delivers the original response

## Files changed

| File | Lines | Change |
|------|-------|--------|
| `src/auto-reply/reply/agent-verifier.ts` | 388 | Full-context verifier module: `assembleVerifierContext()`, `shouldSkipVerification()`, `verifyAgentResponse()`, structured FAIL parsing, workspace file reading |
| `src/auto-reply/reply/agent-verifier-trigger.ts` | 23 | Keyword trigger detector (`shouldVerifyResponse()`) |
| `src/auto-reply/reply/agent-runner.ts` | +218 | Verification loop integration in `runReplyAgent()`: pre-checks, context enrichment, retry with categorized feedback, heartbeat verification, lifecycle logging |
| `src/config/types.agent-defaults.ts` | +18 | `AgentVerifierConfig` type definition (includes `verifyHeartbeat`) |
| `src/config/zod-schema.agent-defaults.ts` | +12 | Zod runtime validation schema for verifier config |
| `src/auto-reply/reply/agent-verifier.test.ts` | 362 | 30 unit tests: verifier logic, context assembly, structured FAIL parsing, skip pre-checks |
| `src/auto-reply/reply/agent-verifier-trigger.test.ts` | 46 | 9 unit tests: keyword trigger detection |
| `src/auto-reply/reply/agent-verifier.integration.test.ts` | ~460 | 15 integration tests: full loop scenarios, abort handling, max attempts, enriched context, failCategory emission, heartbeat skip, heartbeat verification, heartbeat retry |

**Total: 8 files, ~1530 lines, 54 tests**

## Test results

```
 ✓ agent-verifier-trigger.test.ts     (9 tests)
 ✓ agent-verifier.test.ts             (30 tests)
 ✓ agent-verifier.integration.test.ts (15 tests)

 Test Files  3 passed (3)
      Tests  54 passed (54)
```

### Test coverage highlights

- **Unit tests (30)**: Verifier response parsing (PASS, FAIL with category, malformed responses, markdown bold variants), context assembly (user rules, conversation history, execution metadata, token budgeting), deterministic pre-checks (all 5 skip reasons), enriched LLM call parameters
- **Trigger tests (9)**: Keyword matching (case-insensitive, boundary-aware), custom keyword lists, `verifyAll` bypass, no false positives on partial matches
- **Integration tests (15)**: Full verification loop (pass-through, single retry, max attempts exhaustion), abort signal handling, block streaming skip, disabled verifier bypass, enriched context propagation, `failCategory` event emission, heartbeat skip (default), heartbeat verification (`verifyHeartbeat: true`), heartbeat retry on lazy `HEARTBEAT_OK`

## Observability

The verification loop emits structured gateway logs and events:

```
[verifier] heartbeat — verifying with anthropic/claude-sonnet-4-5 (max 3 attempts, full-context)
[verifier] Result: FAIL [goal_missed] — Agent responded HEARTBEAT_OK without checking tasks
[verifier] Retrying with feedback (attempt 2/3)
[verifier] Result: PASS (attempt 2/3)
```

Events emitted via `emitAgentEvent()`:
- `agentVerificationStart` — loop begins
- `agentVerificationResult` — each attempt result (includes `passed`, `feedback`, `failCategory`, `attempt`)
- `agentVerificationComplete` — loop ends (includes `totalAttempts`, `finalResult`)