### PR TITLE
fix: apply schema cleaning for google-antigravity in normalizeToolParameters

### DIFF
--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -78,7 +78,8 @@ export function normalizeToolParameters(
   // - Gemini rejects several JSON Schema keywords, so we scrub those.
   // - OpenAI rejects function tool schemas unless the *top-level* is `type: "object"`.
   //   (TypeBox root unions compile to `{ anyOf: [...] }` without `type`).
-  // - Anthropic (google-antigravity) expects full JSON Schema draft 2020-12 compliance.
+  // - google-antigravity routes through Cloud Code Assist's OpenAPI 3.03
+  //   `parameters` field, which has the same restrictions as Gemini.
   //
   // Normalize once here so callers can always pass `tools` through unchanged.
 
@@ -86,11 +87,10 @@ export function normalizeToolParameters(
     options?.modelProvider?.toLowerCase().includes("google") ||
     options?.modelProvider?.toLowerCase().includes("gemini");
   const isAnthropicProvider =
-    options?.modelProvider?.toLowerCase().includes("anthropic") ||
-    options?.modelProvider?.toLowerCase().includes("google-antigravity");
+    options?.modelProvider?.toLowerCase().includes("anthropic");
 
   // If schema already has type + properties (no top-level anyOf to merge),
-  // clean it for Gemini compatibility (but only if using Gemini, not Anthropic)
+  // clean it for Gemini compatibility (also for google-antigravity via Cloud Code Assist)
   if ("type" in schema && "properties" in schema && !Array.isArray(schema.anyOf)) {
     return {
       ...tool,


### PR DESCRIPTION
## Problem

PR #20124 fixed `sanitizeToolsForGoogle` to include `google-antigravity`, but the error persisted because there is a **second cleaning path** in `normalizeToolParameters` (`pi-tools.schema.ts`) that was still skipping schema cleaning for `google-antigravity`.

Users still report `patternProperties` 400 errors even on the latest beta.

## Root Cause

In `normalizeToolParameters`, `google-antigravity` was explicitly listed in `isAnthropicProvider`:

```typescript
const isAnthropicProvider =
  options?.modelProvider?.toLowerCase().includes("anthropic") ||
  options?.modelProvider?.toLowerCase().includes("google-antigravity");
```

Since `google-antigravity` also matches `isGeminiProvider` (contains `"google"`), the guard `isGeminiProvider && !isAnthropicProvider` evaluated to `false`, skipping `cleanSchemaForGemini` on all three code paths.

But `google-antigravity` routes through Cloud Code Assist's OpenAPI 3.03 `parameters` field, which has the **same restrictions as Gemini** — not Anthropic's native API. It needs schema cleaning.

## Fix

Remove `google-antigravity` from the `isAnthropicProvider` check:

```diff
  const isAnthropicProvider =
-    options?.modelProvider?.toLowerCase().includes("anthropic") ||
-    options?.modelProvider?.toLowerCase().includes("google-antigravity");
+    options?.modelProvider?.toLowerCase().includes("anthropic");
```

This allows all 3 occurrences of `isGeminiProvider && !isAnthropicProvider` to correctly apply `cleanSchemaForGemini` for `google-antigravity`.

## Testing

- Verified locally by patching the compiled dist files and restarting the daemon
- The change is minimal and only affects provider classification logic, no tool behavior changes

Fixes #20163
Related to #19860, #20124

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `google-antigravity` from the `isAnthropicProvider` check in `normalizeToolParameters`. This fix allows `google-antigravity` to correctly receive schema cleaning via `cleanSchemaForGemini` in all three code paths where the condition `isGeminiProvider && !isAnthropicProvider` is evaluated.

- Before: `google-antigravity` was excluded from schema cleaning because it matched both `isGeminiProvider` (contains "google") and `isAnthropicProvider` (explicitly listed), causing the guard `isGeminiProvider && !isAnthropicProvider` to be false
- After: `google-antigravity` now only matches `isGeminiProvider`, allowing it to properly receive schema cleaning for Cloud Code Assist's OpenAPI 3.03 `parameters` field
- Completes the fix started in PR #20124 by addressing the second cleaning path
- Resolves `patternProperties` 400 errors for users on the latest beta

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is surgical and correct: it removes `google-antigravity` from `isAnthropicProvider` check, allowing it to receive proper schema cleaning. The logic is well-documented, the fix addresses a confirmed bug with user reports, and it completes the work started in PR #20124. The change affects only provider classification logic and has clear test coverage via the related e2e tests in `google.e2e.test.ts`.
- No files require special attention

<sub>Last reviewed commit: fd76813</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->