### PR TITLE
fix(skills): allowBundled: [] now blocks all bundled skills

### DIFF
--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { isBundledSkillAllowed, resolveBundledAllowlist } from "./config.js";
+import type { SkillEntry } from "./types.js";
+
+function makeEntry(name: string, source: string): SkillEntry {
+  return {
+    skill: {
+      name,
+      description: `${name} skill`,
+      filePath: `/skills/${name}/index.md`,
+      baseDir: `/skills/${name}`,
+      source,
+      disableModelInvocation: false,
+    },
+    frontmatter: {},
+  };
+}
+
+const bundledEntry = makeEntry("weather", "openclaw-bundled");
+const otherBundledEntry = makeEntry("translate", "openclaw-bundled");
+const workspaceEntry = makeEntry("my-tool", "workspace");
+
+describe("isBundledSkillAllowed", () => {
+  it("allows all skills when allowlist is undefined (not configured)", () => {
+    expect(isBundledSkillAllowed(bundledEntry, undefined)).toBe(true);
+    expect(isBundledSkillAllowed(workspaceEntry, undefined)).toBe(true);
+  });
+
+  it("blocks all bundled skills when allowlist is [] (explicitly empty)", () => {
+    expect(isBundledSkillAllowed(bundledEntry, [])).toBe(false);
+    expect(isBundledSkillAllowed(otherBundledEntry, [])).toBe(false);
+  });
+
+  it("does not block workspace skills when allowlist is []", () => {
+    expect(isBundledSkillAllowed(workspaceEntry, [])).toBe(true);
+  });
+
+  it("allows only listed bundled skills", () => {
+    const allowlist = ["weather"];
+    expect(isBundledSkillAllowed(bundledEntry, allowlist)).toBe(true);
+    expect(isBundledSkillAllowed(otherBundledEntry, allowlist)).toBe(false);
+  });
+
+  it("never blocks workspace skills regardless of allowlist", () => {
+    expect(isBundledSkillAllowed(workspaceEntry, undefined)).toBe(true);
+    expect(isBundledSkillAllowed(workspaceEntry, [])).toBe(true);
+    expect(isBundledSkillAllowed(workspaceEntry, ["weather"])).toBe(true);
+  });
+});
+
+describe("resolveBundledAllowlist", () => {
+  it("returns undefined when allowBundled is not configured", () => {
+    expect(resolveBundledAllowlist(undefined)).toBeUndefined();
+    expect(resolveBundledAllowlist({})).toBeUndefined();
+    expect(resolveBundledAllowlist({ skills: {} })).toBeUndefined();
+  });
+
+  it("returns [] when allowBundled is explicitly empty", () => {
+    expect(resolveBundledAllowlist({ skills: { allowBundled: [] } })).toEqual([]);
+  });
+
+  it("returns normalized entries when allowBundled has values", () => {
+    expect(
+      resolveBundledAllowlist({ skills: { allowBundled: ["weather", " translate "] } }),
+    ).toEqual(["weather", "translate"]);
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -43,7 +43,7 @@ function normalizeAllowlist(input: unknown): string[] | undefined {
     return undefined;
   }
   const normalized = input.map((entry) => String(entry).trim()).filter(Boolean);
-  return normalized.length > 0 ? normalized : undefined;
+  return normalized;
 }
 
 const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
@@ -57,7 +57,7 @@ export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | und
 }
 
 export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): boolean {
-  if (!allowlist || allowlist.length === 0) {
+  if (!allowlist) {
     return true;
   }
   if (!isBundledSkill(entry)) {

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { stripEnvelopeFromMessage } from "./chat-sanitize.js";
+import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "./chat-sanitize.js";
 
 describe("stripEnvelopeFromMessage", () => {
   test("removes message_id hint lines from user messages", () => {
@@ -38,5 +38,98 @@ describe("stripEnvelopeFromMessage", () => {
     };
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("note\n[message_id: 123]");
+  });
+
+  test("strips inbound user context metadata from string content", () => {
+    const metadata = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ message_id: "abc", sender: "+1234" }, null, 2),
+      "```",
+    ].join("\n");
+    const input = {
+      role: "user",
+      content: `${metadata}\n\nHello world`,
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("Hello world");
+  });
+
+  test("strips inbound user context metadata from content array", () => {
+    const metadata = [
+      "Sender (untrusted metadata):",
+      "```json",
+      JSON.stringify({ label: "Alice", name: "Alice" }, null, 2),
+      "```",
+    ].join("\n");
+    const input = {
+      role: "user",
+      content: [{ type: "text", text: `${metadata}\n\nHi there` }],
+    };
+    const result = stripEnvelopeFromMessage(input) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    expect(result.content?.[0]?.text).toBe("Hi there");
+  });
+
+  test("strips multiple metadata blocks from user message", () => {
+    const input = {
+      role: "user",
+      content: [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        JSON.stringify({ message_id: "abc" }, null, 2),
+        "```",
+        "",
+        "Sender (untrusted metadata):",
+        "```json",
+        JSON.stringify({ label: "Alice" }, null, 2),
+        "```",
+        "",
+        "Chat history since last reply (untrusted, for context):",
+        "```json",
+        JSON.stringify([{ sender: "Bob", body: "hey" }], null, 2),
+        "```",
+        "",
+        "What is the weather?",
+      ].join("\n"),
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("What is the weather?");
+  });
+
+  test("does not strip inbound context from assistant messages", () => {
+    const metadata = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ message_id: "abc" }, null, 2),
+      "```",
+    ].join("\n");
+    const input = {
+      role: "assistant",
+      content: `${metadata}\n\nSome text`,
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe(`${metadata}\n\nSome text`);
+  });
+});
+
+describe("stripEnvelopeFromMessages", () => {
+  test("strips metadata from user messages in a conversation", () => {
+    const metadata = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ message_id: "m1" }, null, 2),
+      "```",
+    ].join("\n");
+    const messages = [
+      { role: "user", content: `${metadata}\n\nHello` },
+      { role: "assistant", content: "Hi there!" },
+      { role: "user", content: `${metadata}\n\nHow are you?` },
+    ];
+    const result = stripEnvelopeFromMessages(messages) as Array<{ content: string }>;
+    expect(result[0].content).toBe("Hello");
+    expect(result[1].content).toBe("Hi there!");
+    expect(result[2].content).toBe("How are you?");
   });
 });

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,4 +1,8 @@
-import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
+import {
+  stripEnvelope,
+  stripInboundUserContext,
+  stripMessageIdHints,
+} from "../shared/chat-envelope.js";
 
 export { stripEnvelope };
 
@@ -12,7 +16,7 @@ function stripEnvelopeFromContent(content: unknown[]): { content: unknown[]; cha
     if (entry.type !== "text" || typeof entry.text !== "string") {
       return item;
     }
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripInboundUserContext(stripMessageIdHints(stripEnvelope(entry.text)));
     if (stripped === entry.text) {
       return item;
     }
@@ -39,7 +43,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   const next: Record<string, unknown> = { ...entry };
 
   if (typeof entry.content === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.content));
+    const stripped = stripInboundUserContext(stripMessageIdHints(stripEnvelope(entry.content)));
     if (stripped !== entry.content) {
       next.content = stripped;
       changed = true;
@@ -51,7 +55,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripInboundUserContext(stripMessageIdHints(stripEnvelope(entry.text)));
     if (stripped !== entry.text) {
       next.text = stripped;
       changed = true;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -8,6 +8,7 @@ import {
 } from "../config/sessions.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
+import { stripInboundUserContext } from "../shared/chat-envelope.js";
 import { extractToolCallNames, hasToolCall } from "../utils/transcript-tools.js";
 import { stripEnvelope } from "./chat-sanitize.js";
 import type { SessionPreviewItem } from "./session-utils.types.js";
@@ -644,7 +645,7 @@ function buildPreviewItems(
       continue;
     }
     if (role === "user") {
-      trimmed = stripEnvelope(trimmed);
+      trimmed = stripInboundUserContext(stripEnvelope(trimmed));
     }
     trimmed = truncatePreviewText(trimmed, maxChars);
     items.push({ role, text: trimmed });

--- a/src/shared/chat-envelope.test.ts
+++ b/src/shared/chat-envelope.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "vitest";
+import { stripInboundUserContext } from "./chat-envelope.js";
+
+describe("stripInboundUserContext", () => {
+  test("returns text unchanged when no metadata present", () => {
+    expect(stripInboundUserContext("Hello world")).toBe("Hello world");
+  });
+
+  test("strips a single conversation info block", () => {
+    const input = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ message_id: "abc", sender: "+1234" }, null, 2),
+      "```",
+      "",
+      "Hello world",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe("Hello world");
+  });
+
+  test("strips multiple metadata blocks", () => {
+    const input = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ message_id: "abc" }, null, 2),
+      "```",
+      "",
+      "Sender (untrusted metadata):",
+      "```json",
+      JSON.stringify({ label: "Alice", name: "Alice" }, null, 2),
+      "```",
+      "",
+      "How are you?",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe("How are you?");
+  });
+
+  test("strips 'untrusted, for context' blocks", () => {
+    const input = [
+      "Replied message (untrusted, for context):",
+      "```json",
+      JSON.stringify({ sender_label: "Bob", body: "hi" }, null, 2),
+      "```",
+      "",
+      "Reply text here",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe("Reply text here");
+  });
+
+  test("strips forwarded message context block", () => {
+    const input = [
+      "Forwarded message context (untrusted metadata):",
+      "```json",
+      JSON.stringify({ from: "Charlie", type: "user" }, null, 2),
+      "```",
+      "",
+      "Forwarded content",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe("Forwarded content");
+  });
+
+  test("strips chat history block", () => {
+    const input = [
+      "Chat history since last reply (untrusted, for context):",
+      "```json",
+      JSON.stringify([{ sender: "Alice", timestamp_ms: 123, body: "hi" }], null, 2),
+      "```",
+      "",
+      "Latest message",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe("Latest message");
+  });
+
+  test("strips thread starter block", () => {
+    const input = [
+      "Thread starter (untrusted, for context):",
+      "```json",
+      JSON.stringify({ body: "thread start" }, null, 2),
+      "```",
+      "",
+      "My reply",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe("My reply");
+  });
+
+  test("strips all block types combined", () => {
+    const input = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ message_id: "abc" }, null, 2),
+      "```",
+      "",
+      "Sender (untrusted metadata):",
+      "```json",
+      JSON.stringify({ label: "Alice" }, null, 2),
+      "```",
+      "",
+      "Thread starter (untrusted, for context):",
+      "```json",
+      JSON.stringify({ body: "start" }, null, 2),
+      "```",
+      "",
+      "Replied message (untrusted, for context):",
+      "```json",
+      JSON.stringify({ body: "quoted" }, null, 2),
+      "```",
+      "",
+      "Chat history since last reply (untrusted, for context):",
+      "```json",
+      JSON.stringify([{ sender: "Bob", body: "msg" }], null, 2),
+      "```",
+      "",
+      "The actual user message",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe("The actual user message");
+  });
+
+  test("returns empty string when text is only metadata", () => {
+    const input = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ message_id: "abc" }, null, 2),
+      "```",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe("");
+  });
+
+  test("does not strip blocks in the middle of user text", () => {
+    const input = [
+      "User message first",
+      "",
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ message_id: "abc" }, null, 2),
+      "```",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe(input);
+  });
+
+  test("preserves multiline user text after metadata", () => {
+    const input = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ message_id: "abc" }, null, 2),
+      "```",
+      "",
+      "Line one",
+      "Line two",
+      "",
+      "Line three",
+    ].join("\n");
+    expect(stripInboundUserContext(input)).toBe("Line one\nLine two\n\nLine three");
+  });
+
+  test("handles text containing '(untrusted' string but no metadata blocks", () => {
+    const input = "The user said (untrusted data) is fine";
+    expect(stripInboundUserContext(input)).toBe(input);
+  });
+});

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -47,3 +47,44 @@ export function stripMessageIdHints(text: string): string {
   const filtered = lines.filter((line) => !MESSAGE_ID_LINE.test(line));
   return filtered.length === lines.length ? text : filtered.join("\n");
 }
+
+/**
+ * Matches a single inbound-user-context metadata block produced by
+ * `buildInboundUserContextPrefix` in `src/auto-reply/reply/inbound-meta.ts`.
+ *
+ * Each block looks like:
+ *   <Label> (untrusted metadata|untrusted, for context):\n```json\n<JSON>\n```
+ *
+ * The regex is anchored so it only matches from the current position
+ * (used with lastIndex / sticky flag via the loop below).
+ */
+const INBOUND_CONTEXT_BLOCK =
+  /[^\n]*\(untrusted(?:,? (?:metadata|for context))\):\n```json\n[\s\S]*?\n```/;
+
+/**
+ * Strip inbound-user-context metadata blocks that `buildInboundUserContextPrefix`
+ * prepends to user messages for agent context.  These blocks should never be
+ * shown in the webchat/macOS UI.
+ *
+ * Returns the original user text with leading metadata blocks removed.
+ * If the entire text consists of metadata, returns an empty string.
+ */
+export function stripInboundUserContext(text: string): string {
+  if (!text.includes("(untrusted")) {
+    return text;
+  }
+  let remaining = text;
+  while (true) {
+    const match = remaining.match(INBOUND_CONTEXT_BLOCK);
+    if (!match || match.index === undefined) {
+      break;
+    }
+    // Only strip blocks anchored at the very start (possibly after whitespace).
+    const before = remaining.slice(0, match.index);
+    if (before.trim().length > 0) {
+      break;
+    }
+    remaining = remaining.slice(match.index + match[0].length);
+  }
+  return remaining.replace(/^\n+/, "");
+}


### PR DESCRIPTION
## Summary

Setting `skills.allowBundled: []` had no effect — all bundled skills remained eligible. An empty array was treated identically to an unconfigured (undefined) allowlist.

## Root Cause

Two compounding issues in `src/agents/skills/config.ts`:

1. **`normalizeAllowlist()`** collapsed `[]` to `undefined` via `normalized.length > 0 ? normalized : undefined`, erasing the explicit empty-array signal before it could be checked downstream.

2. **`isBundledSkillAllowed()`** treated `!allowlist` and `allowlist.length === 0` identically — both returned `true` (allow all).

## Fix

- `normalizeAllowlist()` now returns the normalized array directly, preserving `[]` as a meaningful value.
- `isBundledSkillAllowed()` only short-circuits on `!allowlist` (undefined = not configured). An empty array falls through to `allowlist.includes(key)`, which naturally returns `false` for all bundled skills. The existing `!isBundledSkill(entry)` guard still allows workspace skills through regardless.

## Changes

- `src/agents/skills/config.ts` — 2-line fix
- `src/agents/skills/config.test.ts` — 8 new unit tests

## Tests

| Scenario | Result |
|---|---|
| `allowBundled: undefined` → all skills allowed | ✅ |
| `allowBundled: []` → all bundled blocked | ✅ |
| `allowBundled: []` → workspace skills unaffected | ✅ |
| `allowBundled: ["weather"]` → only weather allowed | ✅ |
| Workspace skills never blocked by allowlist | ✅ |
| `resolveBundledAllowlist` preserves undefined vs [] | ✅ |

All 13 skill tests pass (8 new + 5 existing).

Fixes #21709

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where setting `skills.allowBundled: []` had no effect - all bundled skills remained eligible. The root cause was twofold: `normalizeAllowlist()` collapsed empty arrays to `undefined`, and `isBundledSkillAllowed()` treated both `undefined` and empty arrays as "allow all". The fix preserves the empty array signal and only treats `undefined` as unconfigured. Comprehensive unit tests validate the fix across undefined, empty, and populated allowlist scenarios for both bundled and workspace skills.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical (2 lines changed), logically sound, and backed by comprehensive unit tests covering all edge cases. The change correctly distinguishes between unconfigured (undefined) and explicitly empty ([]) allowlists. The PR only modifies the skills allowlist logic and adds corresponding tests - no behavioral regressions expected.
- No files require special attention

<sub>Last reviewed commit: 1cd52df</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->