### PR TITLE
fix(session): /new and /reset no longer carry over model overrides

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -256,8 +256,6 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
     }
   }
 


### PR DESCRIPTION
## Summary

After setting a per-session model override (e.g. via `/model opus`), running `/new` or `/reset` would start a fresh session but the model override persisted. The agent continued running on the overridden model instead of the configured default.

## Root Cause

In `src/auto-reply/reply/session.ts`, a carry-over block runs when `resetTriggered` is true to preserve deliberate UX preferences across `/new` so users don't have to re-enable them every time:

```typescript
if (resetTriggered && entry) {
  persistedThinking = entry.thinkingLevel;        // ✅ intentional
  persistedVerbose = entry.verboseLevel;           // ✅ intentional
  persistedReasoning = entry.reasoningLevel;       // ✅ intentional
  persistedTtsAuto = entry.ttsAuto;               // ✅ intentional
  persistedModelOverride = entry.modelOverride;    // ❌ should not carry over
  persistedProviderOverride = entry.providerOverride; // ❌ should not carry over
}
```

Model selection is a per-session choice, not a UX preference. `/new` and `/reset` mean "start fresh" — the model should return to the configured default, consistent with how message history and compaction state behave.

## Fix

Remove `modelOverride` and `providerOverride` from the `resetTriggered` carry-over block. They continue to be persisted on session resume (non-reset path) as before.

## Changes

- `src/auto-reply/reply/session.ts` — remove 2 lines
- `src/auto-reply/reply/session.test.ts` — 2 new test cases

## Tests

| Scenario | Result |
|---|---|
| `/new` does NOT carry over `modelOverride` | ✅ |
| `/new` does NOT carry over `providerOverride` | ✅ |
| `/new` still carries over `thinkingLevel`, `verboseLevel`, etc. | ✅ |
| Resume (no reset) still preserves `modelOverride` | ✅ |
| All 40 session tests pass | ✅ |

Fixes #21725

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `modelOverride` and `providerOverride` from the reset carry-over block in `session.ts`, ensuring `/new` and `/reset` commands return to the configured default model instead of persisting per-session overrides. The fix correctly distinguishes between UX preferences (thinking/verbose/reasoning levels) that should carry over and model selection that should reset.

- **Main change**: Removed 2 lines from the `resetTriggered` carry-over block (lines 257-258)
- **Preserved behavior**: Model overrides still persist on session resume (non-reset path, lines 244-245)
- **Test coverage**: Added 2 comprehensive test cases covering both reset and resume scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, well-targeted 2-line deletion that addresses the root cause precisely. The logic is sound: model selection is correctly treated as a per-session choice rather than a UX preference. Test coverage is comprehensive with 2 new test cases validating both the fix (reset doesn't carry over) and the preserved behavior (resume still carries over). All 40+ session tests reportedly pass.
- No files require special attention

<sub>Last reviewed commit: f3eea17</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->