### PR TITLE
fix(session): clear model/provider overrides on /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1,12 +1,10 @@
-import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import type { OpenClawConfig } from "../../config/config.js";
-import type { TtsAutoMode } from "../../config/types.tts.js";
-import type { MsgContext, TemplateContext } from "../templating.js";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import {
   DEFAULT_RESET_TRIGGERS,
   deriveSessionMetaPatch,
@@ -26,12 +24,14 @@ import {
   type SessionScope,
   updateSessionStore,
 } from "../../config/sessions.js";
+import type { TtsAutoMode } from "../../config/types.tts.js";
 import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
+import type { MsgContext, TemplateContext } from "../templating.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 
@@ -245,11 +245,17 @@ export async function initSessionState(params: {
     // When a reset trigger (/new, /reset) starts a new session, carry over
     // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
     // so the user doesn't have to re-enable them every time.
+    // Model/provider overrides are intentionally NOT carried over — /new should
+    // start fresh on the configured default model. Users can combine
+    // `/new <model>` to both reset and switch.
     if (resetTriggered && entry) {
       persistedThinking = entry.thinkingLevel;
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+      // Clear model/provider so /new starts on default model
+      persistedModelOverride = undefined;
+      persistedProviderOverride = undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #21725

`/new` and `/reset` now start the session on the configured default model instead of carrying over the previous per-session model override.

## Problem

When a user sets a per-session model override via `/model opus`, then later runs `/new`, the model override persists in the session state. The new session starts on the overridden model instead of the configured default, and the runtime metadata in the system prompt reflects the stale override.

## Root Cause

In `session.ts`, the reset handler carried over `modelOverride` and `providerOverride` alongside behavioral overrides (verbose, thinking, reasoning, ttsAuto). The behavioral carry-over is intentional — users don't want to re-enable thinking/verbose every time they start a new session. But model selection is a heavier, more intentional choice that should reset to the configured default.

## Fix

Remove `modelOverride` and `providerOverride` from the carry-over block in the reset path. The `/new <model>` syntax still works (handled by `applyResetModelOverride` downstream).

### What changes:
- `/new` → starts on default model ✅
- `/new opus` → starts on opus ✅ (unchanged)
- `/model opus` then `/new` → resets to default ✅ (was broken, now fixed)
- `/new` → preserves verbose/thinking/reasoning/ttsAuto ✅ (unchanged)

## Test

Added regression test verifying model overrides are cleared while behavioral overrides are preserved across `/new`.

All 39 tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed `modelOverride` and `providerOverride` from the reset carry-over block in `session.ts:257-261`, ensuring `/new` and `/reset` start fresh on the configured default model instead of persisting the previous session's model selection. Behavioral overrides (verbose, thinking, reasoning, ttsAuto) still carry over as intended. The PR also includes a cache-skipping fix for session store loading and a threadId inheritance fix for non-thread sessions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-tested. The two-line change removes model/provider override persistence during reset, with comprehensive test coverage verifying the fix works as intended. The PR also includes two related improvements (cache bypass and threadId handling) that strengthen session management. All tests pass.
- No files require special attention

<sub>Last reviewed commit: 9307767</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->