### PR TITLE
fix(cron): set delivered:true on SILENT_REPLY_TOKEN and suppressed ea…

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -712,7 +712,7 @@ export async function runCronIsolatedAgentTurn(params: {
       if (activeSubagentRuns > 0) {
         // Parent orchestration is still in progress; avoid announcing a partial
         // update to the main requester.
-        return withRunSession({ status: "ok", summary, outputText, ...telemetry });
+        return withRunSession({ status: "ok", summary, outputText, delivered: true, ...telemetry });
       }
       if (
         (hadActiveDescendants || expectedSubagentFollowup) &&
@@ -722,10 +722,10 @@ export async function runCronIsolatedAgentTurn(params: {
       ) {
         // Descendants existed but no post-orchestration synthesis arrived, so
         // suppress stale parent text like "on it, pulling everything together".
-        return withRunSession({ status: "ok", summary, outputText, ...telemetry });
+        return withRunSession({ status: "ok", summary, outputText, delivered: true, ...telemetry });
       }
       if (synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
-        return withRunSession({ status: "ok", summary, outputText, ...telemetry });
+        return withRunSession({ status: "ok", summary, outputText, delivered: true, ...telemetry });
       }
       try {
         const didAnnounce = await runSubagentAnnounceFlow({


### PR DESCRIPTION
## Summary

- Fixes the `SILENT_REPLY_TOKEN` (`NO_REPLY`) early-exit path in `src/cron/isolated-agent/run.ts` to set `delivered: true`, preventing the caller from injecting spurious system events into the main agent session
- Applies the same fix to two additional suppressed-delivery early-exit paths that share the same bug: active subagent orchestration and stale interim message suppression
- Resolves context window pollution for users running high-frequency hooks (e.g., Gmail watchers, notification classifiers) that legitimately return `NO_REPLY`

## Problem

When a hook agent returns `NO_REPLY` (matching `SILENT_REPLY_TOKEN`), the early-exit path in `src/cron/isolated-agent/run.ts` (line ~727) returns via `withRunSession()` **without** setting `delivered: true`:

```typescript
if (synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
  return withRunSession({ status: "ok", summary, outputText, ...telemetry });
  // ^ delivered is undefined here
}
```

The caller in `src/cron/service/timer.ts` (line ~545) checks `!res.delivered` before posting a system event:

```typescript
if (summaryText && deliveryPlan.requested && !res.delivered) {
  state.deps.enqueueSystemEvent(label, { ... });
  if (job.wakeMode === "now") {
    state.deps.requestHeartbeatNow({ ... });
  }
}
```

Since `delivered` is `undefined` (falsy), the guard passes and a system event like `"Hook Gmail: ok"` is injected into the main agent's context window. If `wakeMode` is `"now"`, it also triggers an unnecessary heartbeat.

**Impact:** High-frequency hooks (e.g., Gmail watchers firing every few minutes) fill the main agent's context window with dozens of irrelevant `"Hook <name>: ok"` entries per day. This wastes tokens, degrades agent performance, and can push important context out of the window.

## Root Cause

The `SILENT_REPLY_TOKEN` path is an intentional "nothing to deliver" signal — the hook agent explicitly chose not to respond. However, the return value omits `delivered: true`, so the caller treats it as "delivery was attempted but didn't happen" rather than "delivery was intentionally suppressed."

Two additional early-exit paths in the same function have the identical bug:
1. **Active subagent orchestration** (line ~712): When child subagent runs are still in progress, delivery is suppressed to avoid partial announcements — but `delivered` is not set.
2. **Stale interim message suppression** (line ~717): When descendants existed but no post-orchestration synthesis arrived, the stale parent text is suppressed — but again `delivered` is not set.

## Fix

Set `delivered: true` on all three early-exit paths that intentionally suppress delivery:

```diff
      if (activeSubagentRuns > 0) {
        // Parent orchestration is still in progress; avoid announcing a partial
        // update to the main requester.
-       return withRunSession({ status: "ok", summary, outputText, ...telemetry });
+       return withRunSession({ status: "ok", summary, outputText, delivered: true, ...telemetry });
      }
      if (
        (hadActiveDescendants || expectedSubagentFollowup) &&
        synthesizedText.trim() === initialSynthesizedText &&
        isLikelyInterimCronMessage(initialSynthesizedText) &&
        initialSynthesizedText.toUpperCase() !== SILENT_REPLY_TOKEN.toUpperCase()
      ) {
        // Descendants existed but no post-orchestration synthesis arrived, so
        // suppress stale parent text like "on it, pulling everything together".
-       return withRunSession({ status: "ok", summary, outputText, ...telemetry });
+       return withRunSession({ status: "ok", summary, outputText, delivered: true, ...telemetry });
      }
      if (synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
-       return withRunSession({ status: "ok", summary, outputText, ...telemetry });
+       return withRunSession({ status: "ok", summary, outputText, delivered: true, ...telemetry });
      }
```

**Semantic reasoning:** All three paths explicitly decide "do not deliver this output." Setting `delivered: true` signals to the caller that delivery handling is complete (i.e., intentionally skipped), which is semantically consistent with how `delivered` is used after a successful `runSubagentAnnounceFlow()` call later in the function (line ~753).

## Files Changed

| File | Change |
|------|--------|
| `src/cron/isolated-agent/run.ts` | Added `delivered: true` to 3 early-exit `withRunSession()` calls |

## Test Plan

- [x] `pnpm build` — TypeScript compiles cleanly, no type errors
- [x] `pnpm check` — Formatting and linting pass (0 warnings, 0 errors)
- [x] `pnpm test` — All 792 test files pass (6592 tests), no regressions
- [x] Verified that `RunCronAgentTurnResult.delivered` is typed as `boolean | undefined` and accepts `true`
- [x] Verified the `!res.delivered` guard in `timer.ts` (line ~545) correctly gates `enqueueSystemEvent` and `requestHeartbeatNow`
- [x] Confirmed no other callers of `withRunSession` are affected (the function is locally scoped)

## Related Issues

- Fixes #21343
- Related: #20242, #20199 (partial fixes in `hooks.ts` only)
- Related: #20678 (complete fix addressing both `hooks.ts` and `run.ts`)
- Related: #20196 (duplicate delivery via announce flow)
- Related: #3340 (NO_REPLY leaks into webchat responses)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where cron agent early-exit paths that intentionally suppress delivery (e.g., `NO_REPLY` token, active subagent orchestration, stale interim messages) were not setting `delivered: true`. This caused the caller in `timer.ts` to incorrectly inject spurious system events into the main agent session, polluting the context window for high-frequency hooks.

The fix correctly sets `delivered: true` on all three suppressed-delivery early-exit paths:
- Line 715: Active subagent orchestration in progress
- Line 725: Stale interim message suppression  
- Line 728: `SILENT_REPLY_TOKEN` (`NO_REPLY`) path

This aligns with the semantic meaning of `delivered` as "delivery handling is complete" (even if intentionally skipped) and matches the pattern used after successful `runSubagentAnnounceFlow()` calls (line 753).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The changes are minimal, well-targeted, and semantically correct. The fix adds `delivered: true` to three early-exit paths that intentionally suppress delivery, preventing spurious system events from polluting the main agent context. The PR description provides thorough analysis of the root cause, impact, and fix. All tests pass (792 files, 6592 tests), and the type system correctly accepts the changes. The fix is consistent with how `delivered` is used elsewhere in the function (line 753) and properly aligns with the caller's expectations in `timer.ts` (line 541).
- No files require special attention

<sub>Last reviewed commit: d5d9263</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->