### PR TITLE
chore: add CODEOWNERS for auto-assigned PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,14 +34,14 @@ src/cron/                               @tyler6204
 extensions/bluebubbles/                 @tyler6204
 apps/macos/                             @tyler6204
 
-# Security
-src/security/                           @mbelinky
-src/infra/net/fetch-guard.ts            @mbelinky
-src/infra/net/fetch-guard.ssrf.test.ts  @mbelinky
-
 # Docs, Runtime Hardening
 docs/                                   @sebslight
 src/infra/                              @sebslight
+
+# Security (after src/infra/ so specific files override the broad rule)
+src/security/                           @mbelinky
+src/infra/net/fetch-guard.ts            @mbelinky
+src/infra/net/fetch-guard.ssrf.test.ts  @mbelinky
 
 # JS Infra (build, CI, packaging)
 package.json                            @cpojer
@@ -56,14 +56,14 @@ src/cli/                                @gumadeiras
 ui/                                     @gumadeiras
 src/sessions/                           @gumadeiras
 
-# Signal
+# Signal (not explicitly listed in CONTRIBUTING.md — verify owner)
 src/signal/                             @joshp123
 extensions/signal/                      @joshp123
 
-# Slack
+# Slack (not explicitly listed in CONTRIBUTING.md — verify owner)
 src/slack/                              @joshp123
 extensions/slack/                       @joshp123
 
-# WhatsApp
+# WhatsApp (not explicitly listed in CONTRIBUTING.md — verify owner)
 src/whatsapp/                           @joshp123
 extensions/whatsapp/                    @joshp123

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,19 +29,23 @@ src/gateway/                            @joshp123
 apps/ios/                               @obviyus @mbelinky
 
 # Agents, subagents, cron, BlueBubbles, macOS app
-src/agents/                             @tyler6204
+src/agents/                             @tyler6204 @vincentkoc
 src/cron/                               @tyler6204
 extensions/bluebubbles/                 @tyler6204
 apps/macos/                             @tyler6204
+
+# Telemetry, Hooks
+src/hooks/                              @vincentkoc
+extensions/diagnostics-otel/            @vincentkoc
 
 # Docs, Runtime Hardening
 docs/                                   @sebslight
 src/infra/                              @sebslight
 
 # Security (after src/infra/ so specific files override the broad rule)
-src/security/                           @mbelinky
-src/infra/net/fetch-guard.ts            @mbelinky
-src/infra/net/fetch-guard.ssrf.test.ts  @mbelinky
+src/security/                           @mbelinky @vincentkoc
+src/infra/net/fetch-guard.ts            @mbelinky @vincentkoc
+src/infra/net/fetch-guard.ssrf.test.ts  @mbelinky @vincentkoc
 
 # JS Infra (build, CI, packaging)
 package.json                            @cpojer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,69 @@
+# OpenClaw CODEOWNERS
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Maintainer areas based on CONTRIBUTING.md
+# Default owner applies to all files not matched by a more specific rule.
+
+# Default — Benevolent Dictator
+*                                       @steipete
+
+# Discord
+src/discord/                            @thewilloftheshadow
+extensions/discord/                     @thewilloftheshadow
+
+# Memory (QMD), Lobster, TUI, IRC
+src/memory/                             @vignesh07
+src/tui/                                @vignesh07
+extensions/irc/                         @vignesh07
+extensions/lobster/                     @vignesh07
+src/config/types.irc.ts                 @vignesh07
+src/config/schema.irc.ts               @vignesh07
+
+# Telegram, API, Nix
+src/telegram/                           @joshp123 @obviyus
+extensions/telegram/                    @joshp123 @obviyus
+src/channels/telegram/                  @joshp123 @obviyus
+src/gateway/                            @joshp123
+
+# iOS app
+apps/ios/                               @obviyus @mbelinky
+
+# Agents, subagents, cron, BlueBubbles, macOS app
+src/agents/                             @tyler6204
+src/cron/                               @tyler6204
+extensions/bluebubbles/                 @tyler6204
+apps/macos/                             @tyler6204
+
+# Security
+src/security/                           @mbelinky
+src/infra/net/fetch-guard.ts            @mbelinky
+src/infra/net/fetch-guard.ssrf.test.ts  @mbelinky
+
+# Docs, Runtime Hardening
+docs/                                   @sebslight
+src/infra/                              @sebslight
+
+# JS Infra (build, CI, packaging)
+package.json                            @cpojer
+pnpm-lock.yaml                          @cpojer
+tsconfig*.json                          @cpojer
+rollup*.js                              @cpojer
+.github/workflows/                      @cpojer
+scripts/                                @cpojer
+
+# Multi-agents, CLI, Web UI
+src/cli/                                @gumadeiras
+ui/                                     @gumadeiras
+src/sessions/                           @gumadeiras
+
+# Signal
+src/signal/                             @joshp123
+extensions/signal/                      @joshp123
+
+# Slack
+src/slack/                              @joshp123
+extensions/slack/                       @joshp123
+
+# WhatsApp
+src/whatsapp/                           @joshp123
+extensions/whatsapp/                    @joshp123

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ Welcome to the lobster tank! 🦞
 - **Gustavo Madeira Santana** - Multi-agents, CLI, web UI
   - GitHub: [@gumadeiras](https://github.com/gumadeiras) · X: [@gumadeiras](https://x.com/gumadeiras)
 
+> **Note:** Maintainer areas are enforced via [`.github/CODEOWNERS`](.github/CODEOWNERS). When maintainer responsibilities change, update both this list and the CODEOWNERS file.
+
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Welcome to the lobster tank! 🦞
 - **Vision:** [`VISION.md`](VISION.md)
 - **Discord:** https://discord.gg/qkhbAGHRBT
 - **X/Twitter:** [@steipete](https://x.com/steipete) / [@openclaw](https://x.com/openclaw)
+- **Code Owners:** [`.github/CODEOWNERS`](.github/CODEOWNERS) — auto-assigns reviewers by area
 
 ## Maintainers
 


### PR DESCRIPTION
## Summary

- **Problem:** PRs are not auto-assigned to area owners, so maintainers must manually triage 4000+ open PRs to find what needs their review.
- **Why it matters:** Maintainers waste time scanning unrelated PRs. Area-specific changes sit unreviewed because the right person never gets notified.
- **What changed:** Added `.github/CODEOWNERS` mapping maintainer areas from CONTRIBUTING.md to code paths. Added a link to CODEOWNERS in CONTRIBUTING.md Quick Links.
- **What did NOT change (scope boundary):** No code changes. No CI changes. Only review routing.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #21885
- Related: maintainer scaling / PR triage overhead

## User-visible / Behavior Changes

None. This only affects GitHub review assignment.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Open a PR that touches `src/telegram/`
2. Observe that `@joshp123` and `@obviyus` are auto-requested as reviewers
3. Open a PR that touches `src/memory/`
4. Observe that `@vignesh07` is auto-requested

### Expected

- Reviewers are auto-assigned based on area ownership

### Actual

- Currently no reviewers are auto-assigned; manual triage needed

## Evidence

- [x] CODEOWNERS mappings derived directly from the existing Maintainers section in CONTRIBUTING.md
- [x] GitHub CODEOWNERS syntax verified against [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

## Human Verification (required)

- Verified scenarios: cross-referenced every maintainer area in CONTRIBUTING.md with actual directory structure in the repo
- Edge cases checked: overlapping paths (e.g. Telegram owned by both joshp123 and obviyus), default fallback to steipete
- What I did **not** verify: whether all GitHub usernames have repo access (required for CODEOWNERS to work)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: delete `.github/CODEOWNERS`
- Known bad symptoms: if a listed user lacks repo access, GitHub shows a warning but still processes other owners

## Risks and Mitigations

- Risk: Some maintainers may not have write access, causing CODEOWNERS warnings
  - Mitigation: Maintainers listed are already in CONTRIBUTING.md; access should exist

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `.github/CODEOWNERS` to auto-assign PR reviewers based on file paths, mapping maintainer areas from CONTRIBUTING.md. Also adds a Quick Links reference and a maintenance note in CONTRIBUTING.md.

- Maps all core maintainer areas (Discord, Memory, Telegram, iOS, Agents, Telemetry, Security, Docs, JS Infra, CLI/UI) to their respective code paths
- Includes co-ownership where applicable (e.g., `@joshp123` and `@obviyus` for Telegram)
- Security files correctly override the broader `src/infra/` rule via last-match-wins precedence
- Signal, Slack, WhatsApp areas include inline notes flagging they're not explicitly listed in CONTRIBUTING.md (verification needed)
- All referenced paths verified to exist in the repository
- Non-breaking change: only affects GitHub review assignment, no code or CI changes

<h3>Confidence Score: 5/5</h3>

- Safe to merge - this is a non-code infrastructure change that only affects GitHub review assignment
- The PR adds CODEOWNERS for review routing without touching any application code, CI pipelines, or runtime behavior. All file paths were verified to exist, maintainer mappings align with CONTRIBUTING.md, and precedence issues flagged in earlier reviews have been addressed. The change is easily reversible (delete the file) and includes inline verification notes for areas not explicitly documented.
- No files require special attention

<sub>Last reviewed commit: 77731f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->