### PR TITLE
fix: selective context gating for OWNER_ONLY privacy tags (#11900)

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -76,7 +76,7 @@ These are the standard files OpenClaw expects inside the workspace:
 
 - `USER.md`
   - Who the user is and how to address them.
-  - Loaded every session.
+  - Loaded every session. Use `<!-- OWNER_ONLY -->` tags to hide sensitive sections from non-owner senders.
 
 - `IDENTITY.md`
   - The agent's name, vibe, and emoji.
@@ -105,7 +105,7 @@ These are the standard files OpenClaw expects inside the workspace:
 
 - `MEMORY.md` (optional)
   - Curated long-term memory.
-  - Only load in the main, private session (not shared/group contexts).
+  - Only load in the main, private session (not shared/group contexts). Use `<!-- OWNER_ONLY -->` tags to protect content for non-owner sessions.
 
 See [Memory](/concepts/memory) for the workflow and automatic memory flush.
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -55,6 +55,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 ## Red Lines
 
 - Don't exfiltrate private data. Ever.
+- **Privacy Gating**: Wrap sensitive info (emails, phones, home addresses) in `<!-- OWNER_ONLY -->` and `<!-- /OWNER_ONLY -->` tags to hide them from non-owner senders in public channels.
 - Don't run destructive commands without asking.
 - `trash` > `rm` (recoverable beats gone forever)
 - When in doubt, ask.

--- a/docs/reference/templates/USER.md
+++ b/docs/reference/templates/USER.md
@@ -14,6 +14,9 @@ _Learn about the person you're helping. Update this as you go._
 - **Timezone:**
 - **Notes:**
 
+<!-- OWNER_ONLY -->
+<!-- /OWNER_ONLY -->
+
 ## Context
 
 _(What do they care about? What projects are they working on? What annoys them? What makes them laugh? Build this over time.)_

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -6,7 +6,7 @@ import {
   registerInternalHook,
   type AgentBootstrapHookContext,
 } from "../hooks/internal-hooks.js";
-import { makeTempWorkspace } from "../test-helpers/workspace.js";
+import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
@@ -125,5 +125,91 @@ describe("resolveBootstrapContextForRun", () => {
     });
 
     expect(files).toEqual([]);
+  });
+
+  it("redacts OWNER_ONLY sections for non-owner senders", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await writeWorkspaceFile({
+      dir: workspaceDir,
+      name: "USER.md",
+      content:
+        "visible\n<!-- OWNER_ONLY -->private-email@example.com<!-- /OWNER_ONLY -->\nvisible-2",
+    });
+
+    const result = await resolveBootstrapContextForRun({
+      workspaceDir,
+      senderIsOwner: false,
+    });
+    const userFile = result.contextFiles.find(
+      (file) => file.path === path.join(workspaceDir, "USER.md"),
+    );
+
+    expect(userFile?.content).toContain("visible");
+    expect(userFile?.content).toContain("[Content restricted to owner]");
+    expect(userFile?.content).not.toContain("private-email@example.com");
+  });
+
+  it("does not flutter when sender role flips across turns", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await writeWorkspaceFile({
+      dir: workspaceDir,
+      name: "USER.md",
+      content: "public\n<!-- OWNER_ONLY -->super-secret-token<!-- /OWNER_ONLY -->\npublic-tail",
+    });
+
+    const nonOwnerFirst = await resolveBootstrapContextForRun({
+      workspaceDir,
+      senderIsOwner: false,
+    });
+    const ownerSecond = await resolveBootstrapContextForRun({
+      workspaceDir,
+      senderIsOwner: true,
+    });
+    const ownerThird = await resolveBootstrapContextForRun({
+      workspaceDir,
+      senderIsOwner: true,
+    });
+    const nonOwnerFourth = await resolveBootstrapContextForRun({
+      workspaceDir,
+      senderIsOwner: false,
+    });
+
+    const pickUser = (files: { path: string; content: string }[]) =>
+      files.find((file) => file.path === path.join(workspaceDir, "USER.md"))?.content ?? "";
+
+    expect(pickUser(nonOwnerFirst.contextFiles)).not.toContain("super-secret-token");
+    expect(pickUser(nonOwnerFirst.contextFiles)).toContain("[Content restricted to owner]");
+
+    expect(pickUser(ownerSecond.contextFiles)).toContain("super-secret-token");
+    expect(pickUser(ownerThird.contextFiles)).toContain("super-secret-token");
+
+    expect(pickUser(nonOwnerFourth.contextFiles)).not.toContain("super-secret-token");
+    expect(pickUser(nonOwnerFourth.contextFiles)).toContain("[Content restricted to owner]");
+  });
+
+  it("does not leak across concurrent owner/non-owner context builds", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await writeWorkspaceFile({
+      dir: workspaceDir,
+      name: "USER.md",
+      content: "visible\n<!-- OWNER_ONLY -->parallel-secret<!-- /OWNER_ONLY -->\ntail",
+    });
+
+    const [ownerRun, nonOwnerRun] = await Promise.all([
+      resolveBootstrapContextForRun({ workspaceDir, senderIsOwner: true }),
+      resolveBootstrapContextForRun({ workspaceDir, senderIsOwner: false }),
+    ]);
+
+    const pickUser = (files: { path: string; content: string }[]) =>
+      files.find((file) => file.path === path.join(workspaceDir, "USER.md"))?.content ?? "";
+
+    const ownerContent = pickUser(ownerRun.contextFiles);
+    const nonOwnerContent = pickUser(nonOwnerRun.contextFiles);
+
+    expect(ownerContent).toContain("parallel-secret");
+    expect(ownerContent).not.toContain("[Content restricted to owner]");
+
+    expect(nonOwnerContent).not.toContain("parallel-secret");
+    expect(nonOwnerContent).toContain("[Content restricted to owner]");
   });
 });

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -79,7 +79,7 @@ export async function resolveBootstrapFilesForRun(params: {
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
   const bootstrapFiles = applyContextModeFilter({
-    files: filterBootstrapFilesForSession(rawFiles, sessionKey),
+    files: filterBootstrapFilesForSession(rawFiles, { sessionKey }),
     contextMode: params.contextMode,
     runKind: params.runKind,
   });
@@ -101,6 +101,7 @@ export async function resolveBootstrapContextForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  senderIsOwner?: boolean;
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
@@ -109,10 +110,12 @@ export async function resolveBootstrapContextForRun(params: {
   contextFiles: EmbeddedContextFile[];
 }> {
   const bootstrapFiles = await resolveBootstrapFilesForRun(params);
+
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
     maxChars: resolveBootstrapMaxChars(params.config),
     totalMaxChars: resolveBootstrapTotalMaxChars(params.config),
     warn: params.warn,
+    senderIsOwner: params.senderIsOwner,
   });
   return { bootstrapFiles, contextFiles };
 }

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -197,7 +197,12 @@ export async function ensureSessionHeader(params: {
 
 export function buildBootstrapContextFiles(
   files: WorkspaceBootstrapFile[],
-  opts?: { warn?: (message: string) => void; maxChars?: number; totalMaxChars?: number },
+  opts?: {
+    warn?: (message: string) => void;
+    maxChars?: number;
+    totalMaxChars?: number;
+    senderIsOwner?: boolean;
+  },
 ): EmbeddedContextFile[] {
   const maxChars = opts?.maxChars ?? DEFAULT_BOOTSTRAP_MAX_CHARS;
   const totalMaxChars = Math.max(
@@ -206,6 +211,9 @@ export function buildBootstrapContextFiles(
   );
   let remainingTotalChars = totalMaxChars;
   const result: EmbeddedContextFile[] = [];
+
+  const isNonOwner = opts?.senderIsOwner === false;
+
   for (const file of files) {
     if (remainingTotalChars <= 0) {
       break;
@@ -216,6 +224,27 @@ export function buildBootstrapContextFiles(
         `skipping bootstrap file "${file.name}" — missing or invalid "path" field (hook may have used "filePath" instead)`,
       );
       continue;
+    }
+
+    let content = file.content ?? "";
+    if (isNonOwner) {
+      // Privacy: strip content between <!-- OWNER_ONLY --> and <!-- /OWNER_ONLY -->
+      // for non-owner senders.
+      const startTag = "<!-- OWNER_ONLY -->";
+      const endTag = "<!-- /OWNER_ONLY -->";
+      let startIndex = content.indexOf(startTag);
+      while (startIndex !== -1) {
+        const endIndex = content.indexOf(endTag, startIndex + startTag.length);
+        const before = content.slice(0, startIndex);
+        if (endIndex === -1) {
+          // Unclosed tag: strip everything from the opening tag to end of content.
+          content = before + "[Content restricted to owner]";
+          break;
+        }
+        const after = content.slice(endIndex + endTag.length);
+        content = before + "[Content restricted to owner]" + after;
+        startIndex = content.indexOf(startTag);
+      }
     }
     if (file.missing) {
       const missingText = `[MISSING] Expected at: ${pathValue}`;
@@ -237,7 +266,7 @@ export function buildBootstrapContextFiles(
       break;
     }
     const fileMaxChars = Math.max(1, Math.min(maxChars, remainingTotalChars));
-    const trimmed = trimBootstrapContent(file.content ?? "", file.name, fileMaxChars);
+    const trimmed = trimBootstrapContent(content, file.name, fileMaxChars);
     const contentWithinBudget = clampToBudget(trimmed.content, remainingTotalChars);
     if (!contentWithinBudget) {
       continue;

--- a/src/agents/pi-embedded-helpers/privacy-tags.test.ts
+++ b/src/agents/pi-embedded-helpers/privacy-tags.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceBootstrapFile } from "../workspace.js";
+import { buildBootstrapContextFiles } from "./bootstrap.js";
+
+describe("buildBootstrapContextFiles privacy tags", () => {
+  it("strips content between OWNER_ONLY tags when senderIsOwner is false", () => {
+    const files: Partial<WorkspaceBootstrapFile>[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: "/path/to/USER.md",
+        content:
+          "Public header\n<!-- OWNER_ONLY -->Private info<!-- /OWNER_ONLY -->\nPublic footer",
+        missing: false,
+      },
+    ];
+
+    const result = buildBootstrapContextFiles(files as WorkspaceBootstrapFile[], {
+      senderIsOwner: false,
+    });
+    expect(result[0].content).toContain("Public header");
+    expect(result[0].content).toContain("[Content restricted to owner]");
+    expect(result[0].content).toContain("Public footer");
+    expect(result[0].content).not.toContain("Private info");
+  });
+
+  it("preserves content between OWNER_ONLY tags when senderIsOwner is true", () => {
+    const files: Partial<WorkspaceBootstrapFile>[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: "/path/to/USER.md",
+        content:
+          "Public header\n<!-- OWNER_ONLY -->Private info<!-- /OWNER_ONLY -->\nPublic footer",
+        missing: false,
+      },
+    ];
+
+    const result = buildBootstrapContextFiles(files as WorkspaceBootstrapFile[], {
+      senderIsOwner: true,
+    });
+    expect(result[0].content).toContain("Private info");
+    expect(result[0].content).toContain("<!-- OWNER_ONLY -->");
+  });
+
+  it("strips to end of content when closing tag is missing", () => {
+    const files: Partial<WorkspaceBootstrapFile>[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: "/path/to/USER.md",
+        content: "Public header\n<!-- OWNER_ONLY -->Secret without closing tag\nMore secret",
+        missing: false,
+      },
+    ];
+
+    const result = buildBootstrapContextFiles(files as WorkspaceBootstrapFile[], {
+      senderIsOwner: false,
+    });
+    expect(result[0].content).toBe("Public header\n[Content restricted to owner]");
+    expect(result[0].content).not.toContain("Secret without closing tag");
+    expect(result[0].content).not.toContain("More secret");
+  });
+
+  it("handles multiple tags in one file", () => {
+    const files: Partial<WorkspaceBootstrapFile>[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: "/path/to/USER.md",
+        content:
+          "Part 1<!-- OWNER_ONLY -->Secret 1<!-- /OWNER_ONLY -->Part 2<!-- OWNER_ONLY -->Secret 2<!-- /OWNER_ONLY -->Part 3",
+        missing: false,
+      },
+    ];
+
+    const result = buildBootstrapContextFiles(files as WorkspaceBootstrapFile[], {
+      senderIsOwner: false,
+    });
+    expect(result[0].content).toBe(
+      "Part 1[Content restricted to owner]Part 2[Content restricted to owner]Part 3",
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -796,6 +796,7 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        senderIsOwner: params.senderIsOwner,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
         contextMode: params.bootstrapContextMode,
         runKind: params.bootstrapContextRunKind,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -564,12 +564,16 @@ const MINIMAL_BOOTSTRAP_ALLOWLIST = new Set([
 
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],
-  sessionKey?: string,
+  params: {
+    sessionKey?: string;
+  },
 ): WorkspaceBootstrapFile[] {
-  if (!sessionKey || (!isSubagentSessionKey(sessionKey) && !isCronSessionKey(sessionKey))) {
-    return files;
+  const sessionKey = params.sessionKey;
+  if (sessionKey && (isSubagentSessionKey(sessionKey) || isCronSessionKey(sessionKey))) {
+    return files.filter((file) => MINIMAL_BOOTSTRAP_ALLOWLIST.has(file.name));
   }
-  return files.filter((file) => MINIMAL_BOOTSTRAP_ALLOWLIST.has(file.name));
+
+  return files;
 }
 
 export async function loadExtraBootstrapFiles(

--- a/src/hooks/bundled/bootstrap-extra-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.ts
@@ -63,7 +63,7 @@ const bootstrapExtraFilesHook: HookHandler = async (event) => {
     }
     context.bootstrapFiles = filterBootstrapFilesForSession(
       [...context.bootstrapFiles, ...extras],
-      context.sessionKey,
+      { sessionKey: context.sessionKey },
     );
   } catch (err) {
     log.warn(`failed: ${String(err)}`);


### PR DESCRIPTION
## Summary

Closes #11900 — **Context Leak: personal workspace files exposed to non-owner senders.**

- **Problem:** OpenClaw injected the full personal context (`USER.md`, `MEMORY.md`, etc.) into every session. Any stranger messaging your agent on a public channel could ask for — and receive — your private info (email, phone, home address, API keys, etc.).
- **Fix:** Introduced `<!-- OWNER_ONLY -->` / `<!-- /OWNER_ONLY -->` privacy tags. When a non-owner sends a message, `buildBootstrapContextFiles` dynamically replaces tagged regions with `[Content restricted to owner]` before the content reaches the LLM.
- **Safety:** Unclosed tags conservatively strip everything from the opening tag to end-of-file, preventing accidental leaks from malformed markup.

### What changed

| File | Change |
|------|--------|
| `src/agents/pi-embedded-helpers/bootstrap.ts` | Core stripping logic in `buildBootstrapContextFiles` — scans for OWNER_ONLY tags and redacts for non-owners |
| `src/agents/bootstrap-files.ts` | Threads `senderIsOwner` through to `buildBootstrapContextFiles`; removed redundant double-call to `filterBootstrapFilesForSession` |
| `src/agents/workspace.ts` | Cleaned up `filterBootstrapFilesForSession` signature (removed unused `senderIsOwner` param that belonged only in the build step) |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Passes `senderIsOwner` from the runner into `resolveBootstrapContextForRun` |
| `src/hooks/bundled/bootstrap-extra-files/handler.ts` | Updated call signature to match new `filterBootstrapFilesForSession` params shape |
| `src/agents/pi-embedded-helpers/privacy-tags.test.ts` | **New** — 4 test cases: non-owner stripping, owner preservation, unclosed tag safety, multiple tags |
| `docs/reference/templates/AGENTS.md` | Added Privacy Gating rule to the Safety section |
| `docs/reference/templates/USER.md` | Added empty `<!-- OWNER_ONLY -->` block as a scaffold for users |
| `docs/concepts/agent-workspace.md` | Documented the tag usage for `USER.md` and `MEMORY.md` |

### How to use it

Just tell your agent:

> "Check my USER.md and MEMORY.md. If you see any private info like my email or phone, wrap them in the new `<!-- OWNER_ONLY -->` tags so they don't leak to others."

Or manually wrap sensitive sections:

```markdown
## About Me
- **Name:** Alice
- **Timezone:** PST

<!-- OWNER_ONLY -->
- **Email:** alice@example.com
- **Phone:** +1-555-0123
- **Home Address:** 123 Main St
<!-- /OWNER_ONLY -->

## Context
Works on the Lobster project...
```

When a non-owner messages your agent, they see the personality and public context, but the tagged sections are replaced with `[Content restricted to owner]`.

## Test plan

- [x] Unit tests pass: non-owner stripping, owner preservation, unclosed tag → strip to EOF, multiple tags in one file
- [x] Full test suite: 6437 passed (5 pre-existing Windows-only failures unrelated to this PR)
- [ ] Manual test: verify agent responds normally to owner with full context
- [ ] Manual test: verify non-owner sees redacted placeholders, cannot extract private info

## AI-assisted

This PR was developed with AI assistance. The code has been reviewed, tested, and is fully understood.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements privacy gating to prevent personal context leaks when non-owner users interact with agents on public channels. The implementation adds `<!-- OWNER_ONLY -->` HTML comment tags that can wrap sensitive information in workspace files like `USER.md` and `MEMORY.md`.

**Key Changes:**
- Core stripping logic in `buildBootstrapContextFiles` (`src/agents/pi-embedded-helpers/bootstrap.ts:212-230`) scans for OWNER_ONLY tags and replaces tagged regions with `[Content restricted to owner]` when `senderIsOwner` is false
- Unclosed tags conservatively strip content from opening tag to EOF to prevent accidental leaks
- `senderIsOwner` parameter threaded through the bootstrap pipeline from runner → bootstrap context resolution → file building
- Documentation updated with usage examples and safety guidelines
- Test coverage includes: non-owner stripping, owner preservation, unclosed tag handling, and multiple tags

**Unrelated Changes:**
The PR also includes an MS Teams SSRF security fix (commit `51837482`) that enforces allowlist checks on all redirect hops and prevents auth header forwarding to unauthorized destinations. This is a separate security improvement merged before the main privacy tag commit.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations - the privacy gating logic is sound and well-tested, though careful verification of the default behavior when senderIsOwner is undefined is recommended
- The implementation is solid with good test coverage and conservative fail-safe behavior (unclosed tags strip to EOF). The logic correctly handles the three states: owner (true), non-owner (false), and undefined. When undefined, the check `opts?.senderIsOwner === false` evaluates to false, meaning content is NOT stripped - this treats undefined as "owner" by default, which is the safe backward-compatible choice. The threading of senderIsOwner through the pipeline is clean and the MS Teams SSRF fix is a welcome security improvement. Score is 4 (not 5) only because the default undefined behavior should be explicitly verified in production to ensure it aligns with actual sender ownership detection.
- Pay close attention to `src/agents/pi-embedded-helpers/bootstrap.ts:204` - verify the default behavior when `senderIsOwner` is undefined aligns with your sender detection logic in production

<sub>Last reviewed commit: 810ef27</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->