### PR TITLE
fix: qmd search/vsearch silently return empty with multiple -c collection flags (#21865)

### DIFF
--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -407,32 +407,31 @@ export class QmdMemoryManager implements MemorySearchManager {
     const qmdSearchCommand = this.qmd.searchMode;
     let parsed: QmdQueryResult[];
     try {
-      if (qmdSearchCommand === "query" && collectionNames.length > 1) {
-        parsed = await this.runQueryAcrossCollections(trimmed, limit, collectionNames);
+      if (collectionNames.length > 1) {
+        // When multiple collections are configured, iterate each collection separately and merge
+        // results. Passing all collections as multiple -c flags to qmd search/vsearch causes a
+        // silent failure (exit 0, empty results) in QMD 1.0.x — see:
+        // https://github.com/openclaw/openclaw/issues/21865
+        parsed = await this.runQueryAcrossCollections(trimmed, limit, collectionNames, qmdSearchCommand);
       } else {
         const args = this.buildSearchArgs(qmdSearchCommand, trimmed, limit);
         args.push(...this.buildCollectionFilterArgs(collectionNames));
-        // Always scope to managed collections (default + custom). Even for `search`/`vsearch`,
-        // pass collection filters; if a given QMD build rejects these flags, we fall back to `query`.
         const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
         parsed = parseQmdQueryJson(result.stdout, result.stderr);
       }
     } catch (err) {
+      // Single-collection path: if the specific search mode rejects a flag, fall back to query.
       if (qmdSearchCommand !== "query" && this.isUnsupportedQmdOptionError(err)) {
         log.warn(
           `qmd ${qmdSearchCommand} does not support configured flags; retrying search with qmd query`,
         );
         try {
-          if (collectionNames.length > 1) {
-            parsed = await this.runQueryAcrossCollections(trimmed, limit, collectionNames);
-          } else {
-            const fallbackArgs = this.buildSearchArgs("query", trimmed, limit);
-            fallbackArgs.push(...this.buildCollectionFilterArgs(collectionNames));
-            const fallback = await this.runQmd(fallbackArgs, {
-              timeoutMs: this.qmd.limits.timeoutMs,
-            });
-            parsed = parseQmdQueryJson(fallback.stdout, fallback.stderr);
-          }
+          const fallbackArgs = this.buildSearchArgs("query", trimmed, limit);
+          fallbackArgs.push(...this.buildCollectionFilterArgs(collectionNames));
+          const fallback = await this.runQmd(fallbackArgs, {
+            timeoutMs: this.qmd.limits.timeoutMs,
+          });
+          parsed = parseQmdQueryJson(fallback.stdout, fallback.stderr);
         } catch (fallbackErr) {
           log.warn(`qmd query fallback failed: ${String(fallbackErr)}`);
           throw fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
@@ -1199,13 +1198,14 @@ export class QmdMemoryManager implements MemorySearchManager {
     query: string,
     limit: number,
     collectionNames: string[],
+    searchMode: "query" | "search" | "vsearch" = "query",
   ): Promise<QmdQueryResult[]> {
     log.debug(
-      `qmd query multi-collection workaround active (${collectionNames.length} collections)`,
+      `qmd ${searchMode} multi-collection workaround active (${collectionNames.length} collections)`,
     );
     const bestByDocId = new Map<string, QmdQueryResult>();
     for (const collectionName of collectionNames) {
-      const args = this.buildSearchArgs("query", query, limit);
+      const args = this.buildSearchArgs(searchMode, query, limit);
       args.push("-c", collectionName);
       const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
       const parsed = parseQmdQueryJson(result.stdout, result.stderr);


### PR DESCRIPTION
## Problem

Fixes #21865

`memory_search` always returns `{ results: [], provider: "qmd" }` for agents with 2+ collections configured. No error is surfaced; agents silently behave as if memory is blank.

### Root cause

When `searchMode` is `"search"` or `"vsearch"` (the default), `search()` passes all managed collection names as simultaneous `-c` flags:

```
qmd search "query" --json -n 5 -c col1 -c col2 -c col3 -c col4 -c col5 -c col6
```

QMD 1.0.x returns empty results (exit 0, no error) when multiple `-c` flags are passed to `search`/`vsearch`. Because there's no exception thrown, the existing `isUnsupportedQmdOptionError` fallback never fires.

The existing `runQueryAcrossCollections()` workaround correctly handles this by iterating each collection separately, but it was only used for `searchMode: "query"`.

### Reproduction

```bash
# Silently returns empty:
qmd search "test" --json -n 5 -c col1 -c col2 -c col3 -c col4 -c col5 -c col6
# → No results found

# Works (single -c per call):
qmd search "test" --json -n 5 -c col1
# → results ✅
```

## Fix

Extend the multi-collection workaround to **all** search modes, not just `"query"`. When multiple collections are configured, `runQueryAcrossCollections()` is always used — one call per collection, results merged by best score per doc.

`runQueryAcrossCollections()` gains an optional `searchMode` parameter (default `"query"`) so the configured mode is preserved.

A single-collection search still uses the direct `-c` path since that works correctly.

## Changes

- `src/memory/qmd-manager.ts`
  - `search()`: condition `qmdSearchCommand === "query" && collectionNames.length > 1` → `collectionNames.length > 1`
  - `runQueryAcrossCollections()`: add optional `searchMode` param (default `"query"`), use it in `buildSearchArgs`
  - Catch block simplified: multi-collection branch removed (now unreachable); single-collection fallback retained

## Testing

Verified locally on OpenClaw 2026.2.17 / QMD 1.0.6 / qmd-cli 1.1.0:
- With `searchMode: "search"` (default) + 6 collections: `memory_search` now returns results ✅
- With `searchMode: "query"` + 6 collections: unchanged, still works ✅  
- With `searchMode: "vsearch"` + 6 collections: now works (same fix applies) ✅
- Single collection: unchanged, direct `-c` path still used ✅

Workaround (while awaiting merge): set `memory.qmd.searchMode: "query"` in config.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

extends multi-collection workaround from `query` mode to all search modes (`search`, `vsearch`) to fix silent empty results when agents have 2+ collections configured

**Key improvement:**
- main search path now correctly routes all multi-collection searches through `runQueryAcrossCollections` regardless of search mode, preventing the silent failure from passing multiple `-c` flags to qmd 1.0.x

**Issue found:**
- error fallback path (lines 429-434) doesn't properly handle multiple collections - when `runQueryAcrossCollections` throws an error, the fallback builds query args with multiple `-c` flags, recreating the exact bug this PR fixes. the old multi-collection branch in the catch block should be restored.

<h3>Confidence Score: 2/5</h3>

- contains logic error in error handling that could recreate the bug being fixed
- while the main fix correctly routes multi-collection searches through the workaround, the error fallback path has a logic bug that can still trigger the silent failure with multiple `-c` flags when the first collection attempt fails. this significantly undermines the fix's effectiveness in edge cases.
- `src/memory/qmd-manager.ts` lines 429-434 need correction to properly handle multi-collection fallback

<sub>Last reviewed commit: 7c89cfc</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->