### PR TITLE
fix(session): clear model override on /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -6,6 +6,7 @@ import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import {
   __testing as sessionBindingTesting,
@@ -1426,6 +1427,83 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
       expect(result.sessionEntry, testCase.name).toMatchObject(overrides);
     }
+  });
+
+  it("/new clears per-session model/provider overrides while preserving behavior overrides", async () => {
+    const storePath = await createStorePath("openclaw-reset-clear-model-override-");
+    const sessionKey = "agent:main:telegram:dm:user-model-override";
+    const existingSessionId = "existing-session-model-override";
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      overrides: {
+        verboseLevel: "on",
+        thinkingLevel: "high",
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-6",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "user-model-override",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionEntry.verboseLevel).toBe("on");
+    expect(result.sessionEntry.thinkingLevel).toBe("high");
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+
+    const persisted = loadSessionStore(storePath)[sessionKey];
+    expect(persisted?.providerOverride).toBeUndefined();
+    expect(persisted?.modelOverride).toBeUndefined();
+  });
+
+  it("/new in a new session does not preserve overrides", async () => {
+    const storePath = await createStorePath("openclaw-new-no-preserve-");
+    const sessionKey = "agent:main:telegram:dm:user3";
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "user3",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
   });
 
   it("archives the old session store entry on /new", async () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -6,7 +6,7 @@ import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
+import { loadSessionStore } from "../../config/sessions.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import {
   __testing as sessionBindingTesting,
@@ -1455,6 +1455,54 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         RawBody: "/new",
         CommandBody: "/new",
         From: "user-model-override",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionEntry.verboseLevel).toBe("on");
+    expect(result.sessionEntry.thinkingLevel).toBe("high");
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+
+    const persisted = loadSessionStore(storePath)[sessionKey];
+    expect(persisted?.providerOverride).toBeUndefined();
+    expect(persisted?.modelOverride).toBeUndefined();
+  });
+
+  it("/reset clears per-session model/provider overrides while preserving behavior overrides", async () => {
+    const storePath = await createStorePath("openclaw-reset-clear-model-override-reset-");
+    const sessionKey = "agent:main:telegram:dm:user-model-override-reset";
+    const existingSessionId = "existing-session-model-override-reset";
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      overrides: {
+        verboseLevel: "on",
+        thinkingLevel: "high",
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-6",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/reset",
+        RawBody: "/reset",
+        CommandBody: "/reset",
+        From: "user-model-override-reset",
         To: "bot",
         ChatType: "direct",
         SessionKey: sessionKey,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -388,8 +388,8 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
+      // Intentionally do NOT carry forward model/provider session overrides on
+      // /new or /reset. A reset should return model selection to configured defaults.
       persistedLabel = entry.label;
     }
   }

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -521,6 +521,87 @@ describe("fs-safe", () => {
     await expect(fs.stat(outsideTarget)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it.runIf(process.platform !== "win32")(
+    "does not truncate out-of-root file when symlink retarget races write open",
+    async () => {
+      const root = await tempDirs.make("openclaw-fs-safe-root-");
+      const inside = path.join(root, "inside");
+      const outside = await tempDirs.make("openclaw-fs-safe-outside-");
+      await fs.mkdir(inside, { recursive: true });
+      const insideTarget = path.join(inside, "target.txt");
+      const outsideTarget = path.join(outside, "target.txt");
+      await fs.writeFile(insideTarget, "inside");
+      await fs.writeFile(outsideTarget, "X".repeat(4096));
+      const slot = path.join(root, "slot");
+      await fs.symlink(inside, slot);
+
+      const realRealpath = fs.realpath.bind(fs);
+      let flipped = false;
+      const realpathSpy = vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+        const [filePath] = args;
+        if (!flipped && String(filePath).endsWith(path.join("slot", "target.txt"))) {
+          flipped = true;
+          await fs.rm(slot, { recursive: true, force: true });
+          await fs.symlink(outside, slot);
+        }
+        return await realRealpath(...args);
+      });
+      try {
+        await expect(
+          writeFileWithinRoot({
+            rootDir: root,
+            relativePath: path.join("slot", "target.txt"),
+            data: "new-content",
+            mkdir: false,
+          }),
+        ).rejects.toMatchObject({ code: "outside-workspace" });
+      } finally {
+        realpathSpy.mockRestore();
+      }
+
+      await expect(fs.readFile(outsideTarget, "utf8")).resolves.toBe("X".repeat(4096));
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "cleans up created out-of-root file when symlink retarget races create path",
+    async () => {
+      const root = await tempDirs.make("openclaw-fs-safe-root-");
+      const inside = path.join(root, "inside");
+      const outside = await tempDirs.make("openclaw-fs-safe-outside-");
+      await fs.mkdir(inside, { recursive: true });
+      const outsideTarget = path.join(outside, "target.txt");
+      const slot = path.join(root, "slot");
+      await fs.symlink(inside, slot);
+
+      const realOpen = fs.open.bind(fs);
+      let flipped = false;
+      const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const [filePath] = args;
+        if (!flipped && String(filePath).endsWith(path.join("slot", "target.txt"))) {
+          flipped = true;
+          await fs.rm(slot, { recursive: true, force: true });
+          await fs.symlink(outside, slot);
+        }
+        return await realOpen(...args);
+      });
+      try {
+        await expect(
+          writeFileWithinRoot({
+            rootDir: root,
+            relativePath: path.join("slot", "target.txt"),
+            data: "new-content",
+            mkdir: false,
+          }),
+        ).rejects.toMatchObject({ code: "outside-workspace" });
+      } finally {
+        openSpy.mockRestore();
+      }
+
+      await expect(fs.stat(outsideTarget)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
   it("returns not-found for missing files", async () => {
     const dir = await tempDirs.make("openclaw-fs-safe-");
     const missing = path.join(dir, "missing.txt");


### PR DESCRIPTION
## Problem

`/model` sets per-session overrides (`providerOverride`, `modelOverride`). After `/new` or `/reset`, these overrides were still carried forward, so users could not reliably return to configured defaults.

This is surprising behavior for a reset and is reported in #21725.

## Root cause

`initSessionState` preserved model/provider overrides during reset-triggered session initialization.

## What changed

- Keep preserving behavior toggles (`thinking`, `verbose`, `reasoning`, `ttsAuto`) across `/new` and `/reset`.
- **Stop** preserving `providerOverride` / `modelOverride` across `/new` and `/reset`.
- Added regression test that verifies:
  - behavior overrides are preserved
  - model/provider overrides are cleared
  - cleared state persists to session store

## Testing

- `pnpm vitest run src/auto-reply/reply/session.test.ts`
- `pnpm check`
- `pnpm build`

## Local Validation

```bash
pnpm build && pnpm check && pnpm vitest run src/auto-reply/reply/session.test.ts
```

## AI-Assisted

AI-assisted. Changes and tests were reviewed and run locally.

Fixes #21725

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clears `providerOverride` and `modelOverride` session state on `/new` and `/reset` commands while preserving behavior toggles (`thinking`, `verbose`, `reasoning`, `ttsAuto`). This fixes unexpected behavior where model selection persisted after reset instead of returning to configured defaults.

- Removed preservation of `persistedModelOverride` and `persistedProviderOverride` in the reset-triggered session initialization path (session.ts:254-261)
- Added regression test verifying model/provider overrides are cleared on `/new` while behavior overrides are preserved
- Test confirms cleared state persists to session store

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor test coverage gap
- Implementation is correct and surgical - only removes the two lines preserving model/provider overrides in the reset path. Test coverage verifies the fix for `/new` and persistence to store. Score reflects incomplete test coverage (missing `/reset` test) rather than implementation issues.
- No files require special attention - implementation is straightforward

<sub>Last reviewed commit: 871d72d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->