### PR TITLE
chore: ignore .agents directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ USER.md
 /memory/
 .agent/*.json
 !.agent/workflows/
+.agents/
 /local/
 package-lock.json
 .claude/settings.local.json


### PR DESCRIPTION
Add .agents/ to .gitignore so generated or local agent files
are excluded from version control.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `.agents/` to `.gitignore` to exclude generated/local agent files from version control.

- Critical issue: the blanket `.agents/` ignore will hide the already-tracked `.agents/maintainers.md` file
- Recommend using `.agents/*.json` with an exception for `maintainers.md` to preserve the tracked file while excluding agent artifacts

<h3>Confidence Score: 2/5</h3>

- This PR has a critical logical error that will hide an existing tracked file
- Score of 2 reflects a significant logic error: the blanket `.agents/` pattern will cause git to ignore `.agents/maintainers.md`, which is currently tracked in the repository. This will break git's ability to track changes to that file and could cause it to appear deleted in future commits.
- `.gitignore` requires attention - the ignore pattern needs to be more specific to avoid hiding tracked files

<sub>Last reviewed commit: dfefade</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->