### PR TITLE
fix(whatsapp): pass user-provided fileName through document send pipe…

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -305,13 +305,14 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       });
       return { channel: "whatsapp", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback, fileName }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
       const result = await send(to, text, {
         verbose: false,
         mediaUrl,
         accountId: accountId ?? undefined,
         gifPlayback,
+        fileName: fileName ?? undefined,
       });
       return { channel: "whatsapp", ...result };
     },

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -22,7 +22,16 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "whatsapp", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback }) => {
+  sendMedia: async ({
+    to,
+    text,
+    mediaUrl,
+    mediaLocalRoots,
+    accountId,
+    deps,
+    gifPlayback,
+    fileName,
+  }) => {
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
     const result = await send(to, text, {
@@ -31,6 +40,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
       mediaLocalRoots,
       accountId: accountId ?? undefined,
       gifPlayback,
+      fileName: fileName ?? undefined,
     });
     return { channel: "whatsapp", ...result };
   },

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -88,6 +88,7 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
+  fileName?: string;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -26,6 +26,8 @@ export const SendParamsSchema = Type.Object(
     threadId: Type.Optional(Type.String()),
     /** Optional session key for mirroring delivered output back into the transcript. */
     sessionKey: Type.Optional(Type.String()),
+    /** Optional file name override for document attachments. */
+    fileName: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
   },
   { additionalProperties: false },

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -66,6 +66,7 @@ export const sendHandlers: GatewayRequestHandlers = {
       accountId?: string;
       threadId?: string;
       sessionKey?: string;
+      fileName?: string;
       idempotencyKey: string;
     };
     const idem = request.idempotencyKey;
@@ -134,6 +135,10 @@ export const sendHandlers: GatewayRequestHandlers = {
     const threadId =
       typeof request.threadId === "string" && request.threadId.trim().length
         ? request.threadId.trim()
+        : undefined;
+    const fileName =
+      typeof request.fileName === "string" && request.fileName.trim().length
+        ? request.fileName.trim()
         : undefined;
     const outboundChannel = channel;
     const plugin = getChannelPlugin(channel);
@@ -209,6 +214,7 @@ export const sendHandlers: GatewayRequestHandlers = {
             ? resolveSessionAgentId({ sessionKey: providedSessionKey, config: cfg })
             : derivedAgentId,
           gifPlayback: request.gifPlayback,
+          fileName,
           threadId: threadId ?? null,
           deps: outboundDeps,
           mirror: providedSessionKey

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -114,6 +114,7 @@ type ChannelHandlerParams = {
   gifPlayback?: boolean;
   silent?: boolean;
   mediaLocalRoots?: readonly string[];
+  fileName?: string;
 };
 
 // Channel docking: outbound delivery delegates to plugin.outbound adapters.
@@ -187,6 +188,7 @@ function createChannelOutboundContextBase(
     deps: params.deps,
     silent: params.silent,
     mediaLocalRoots: params.mediaLocalRoots,
+    fileName: params.fileName,
   };
 }
 
@@ -209,6 +211,7 @@ type DeliverOutboundPayloadsCoreParams = {
   onPayload?: (payload: NormalizedOutboundPayload) => void;
   /** Active agent id for media local-root scoping. */
   agentId?: string;
+  fileName?: string;
   mirror?: {
     sessionKey: string;
     agentId?: string;
@@ -309,6 +312,7 @@ async function deliverOutboundPayloadsCore(
     gifPlayback: params.gifPlayback,
     silent: params.silent,
     mediaLocalRoots,
+    fileName: params.fileName,
   });
   const textLimit = handler.chunker
     ? resolveTextChunkLimit(cfg, channel, accountId, {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -471,6 +471,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     throw new Error("send requires text or media");
   }
   params.message = message;
+  const fileName = readStringParam(params, "filename");
   const gifPlayback = readBooleanParam(params, "gifPlayback") ?? false;
   const bestEffort = readBooleanParam(params, "bestEffort");
   const silent = readBooleanParam(params, "silent");
@@ -544,6 +545,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     bestEffort: bestEffort ?? undefined,
     replyToId: replyToId ?? undefined,
     threadId: resolvedThreadId ?? undefined,
+    fileName: fileName ?? undefined,
   });
 
   return {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -42,6 +42,7 @@ type MessageSendParams = {
   threadId?: string | number;
   dryRun?: boolean;
   bestEffort?: boolean;
+  fileName?: string;
   deps?: OutboundSendDeps;
   cfg?: OpenClawConfig;
   gateway?: MessageGatewayOptions;
@@ -220,6 +221,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       gifPlayback: params.gifPlayback,
       deps: params.deps,
       bestEffort: params.bestEffort,
+      fileName: params.fileName,
       abortSignal: params.abortSignal,
       silent: params.silent,
       mirror: params.mirror
@@ -253,6 +255,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       accountId: params.accountId,
       channel,
       sessionKey: params.mirror?.sessionKey,
+      fileName: params.fileName,
       idempotencyKey: params.idempotencyKey ?? randomIdempotencyKey(),
     },
   });

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -85,6 +85,7 @@ export async function executeSendAction(params: {
   bestEffort?: boolean;
   replyToId?: string;
   threadId?: string | number;
+  fileName?: string;
 }): Promise<{
   handledBy: "plugin" | "core";
   payload: unknown;
@@ -131,6 +132,7 @@ export async function executeSendAction(params: {
     gifPlayback: params.gifPlayback,
     dryRun: params.ctx.dryRun,
     bestEffort: params.bestEffort ?? undefined,
+    fileName: params.fileName,
     deps: params.ctx.deps,
     gateway: params.ctx.gateway,
     mirror: params.ctx.mirror,

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -21,6 +21,7 @@ export async function sendMessageWhatsApp(
     mediaLocalRoots?: readonly string[];
     gifPlayback?: boolean;
     accountId?: string;
+    fileName?: string;
   },
 ): Promise<{ messageId: string; toJid: string }> {
   let text = body;
@@ -66,7 +67,7 @@ export async function sendMessageWhatsApp(
         text = caption ?? "";
       } else {
         text = caption ?? "";
-        documentFileName = media.fileName;
+        documentFileName = options.fileName || media.fileName;
       }
     }
     outboundLog.info(`Sending message -> ${jid}${options.mediaUrl ? " (media)" : ""}`);


### PR DESCRIPTION
## Summary

- Threads the `filename` tool parameter through the entire outbound delivery pipeline so that WhatsApp documents arrive with the user-specified file name instead of the hardcoded default "File"
- Adds `fileName` as an optional field to the gateway protocol schema, channel outbound context, and all intermediate delivery types
- Uses the caller-supplied name as an override, preserving the existing auto-detection from media URL as fallback

## Problem

When sending documents (PDFs, spreadsheets, etc.) via the `message` tool on WhatsApp, the `filename` parameter is accepted by the tool schema but never forwarded through the send pipeline. The Baileys library defaults the document name to "File" when none is provided, so every document arrives with a generic name regardless of what the user specified.

**Root cause:** The `filename` parameter was defined in the message tool schema (`message-tool.ts`) but the outbound delivery pipeline had no mechanism to carry it from the tool invocation through to `sendMessageWhatsApp`. The pipeline consists of multiple layers (action runner, send service, message dispatcher, delivery queue, channel handler, and finally the WhatsApp-specific sender), and none of them included a `fileName` field.

**Reproduction steps:**
1. Configure a WhatsApp channel and link an account
2. Use the message tool to send a document with an explicit filename:
   ```
   message --to <recipient> --media /path/to/report.pdf --filename "Q4 Financial Report.pdf"
   ```
3. Observe that the recipient receives the document named "File" instead of "Q4 Financial Report.pdf"

## Solution

Added `fileName` as an optional string field at each layer of the outbound pipeline:

1. **`ChannelOutboundContext`** (`types.adapters.ts`) -- the type received by all channel plugin outbound adapters
2. **`ChannelHandlerParams` and `DeliverOutboundPayloadsCoreParams`** (`deliver.ts`) -- internal delivery pipeline types
3. **`createChannelOutboundContextBase`** (`deliver.ts`) -- propagates `fileName` from handler params to outbound context
4. **`MessageSendParams`** (`message.ts`) -- the params accepted by the core `sendMessage` function
5. **`executeSendAction`** (`outbound-send-service.ts`) -- bridges the action runner to `sendMessage`
6. **`handleSendAction`** (`message-action-runner.ts`) -- extracts `filename` from tool params via `readStringParam`
7. **`SendParamsSchema`** (`agent.ts`) -- gateway protocol validation schema (has `additionalProperties: false`)
8. **Gateway `send` handler** (`send.ts`) -- extracts `fileName` from the validated request and passes it to `deliverOutboundPayloads`
9. **WhatsApp outbound adapters** (both `extensions/whatsapp/src/channel.ts` and `src/channels/plugins/outbound/whatsapp.ts`) -- destructure `fileName` from context and forward to `sendMessageWhatsApp`
10. **`sendMessageWhatsApp`** (`outbound.ts`) -- accepts `fileName` in options and uses it as override: `options.fileName || media.fileName`

The override logic in `sendMessageWhatsApp` is:
```typescript
documentFileName = options.fileName || media.fileName;
```
This means the user-provided name takes priority. If not provided, the existing auto-detection from the media URL path continues to work as before. If neither is available, Baileys' internal default ("file") applies.

## Files Changed

| File | Change |
|------|--------|
| `src/channels/plugins/types.adapters.ts` | Added `fileName?: string` to `ChannelOutboundContext` |
| `src/infra/outbound/deliver.ts` | Added `fileName` to `ChannelHandlerParams`, `DeliverOutboundPayloadsCoreParams`, `createChannelOutboundContextBase`, and `createChannelHandler` call |
| `src/infra/outbound/message.ts` | Added `fileName` to `MessageSendParams`, threaded through both direct and gateway delivery paths |
| `src/infra/outbound/outbound-send-service.ts` | Added `fileName` to `executeSendAction` params, passed to `sendMessage` |
| `src/infra/outbound/message-action-runner.ts` | Extracts `filename` from tool params, passes to `executeSendAction` |
| `src/gateway/protocol/schema/agent.ts` | Added optional `fileName` to `SendParamsSchema` |
| `src/gateway/server-methods/send.ts` | Extracts `fileName` from gateway request, passes to `deliverOutboundPayloads` |
| `src/web/outbound.ts` | Added `fileName` to `sendMessageWhatsApp` options, uses as override for `documentFileName` |
| `extensions/whatsapp/src/channel.ts` | Passes `fileName` from context to `sendMessageWhatsApp` |
| `src/channels/plugins/outbound/whatsapp.ts` | Passes `fileName` from context to `sendMessageWhatsApp` |

## Test Plan

- [x] `pnpm tsgo` -- type checking passes with zero errors
- [x] `pnpm lint` -- linter passes with zero warnings
- [x] `pnpm format:check` -- formatting passes
- [x] `pnpm vitest run src/web/outbound.test.ts` -- 9 tests pass
- [x] `pnpm vitest run src/infra/outbound/outbound-send-service.test.ts` -- 3 tests pass
- [x] `pnpm vitest run src/gateway/server-methods/send.test.ts` -- 10 tests pass
- [x] `pnpm vitest run src/infra/outbound/message-action-runner.threading.test.ts` -- 7 tests pass
- [x] `pnpm vitest run src/channels/channels-misc.test.ts` -- 5 tests pass
- [ ] Manual verification: send a document via WhatsApp with `--filename "My Report.pdf"` and confirm the recipient sees the correct name

## Backward Compatibility

This change is fully backward compatible:

- `fileName` is optional at every layer; omitting it preserves existing behavior
- When not provided, `media.fileName` (auto-detected from URL/path) is still used as before
- The gateway schema change adds an optional field; existing clients that don't send `fileName` are unaffected
- No changes to the public tool schema (the `filename` parameter was already defined)

Fixes openclaw/openclaw#21838

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully threads the `fileName` parameter through the entire WhatsApp document send pipeline, fixing the issue where documents were always sent with the default "File" name. The implementation adds `fileName` as an optional field at each layer (gateway schema, outbound context, delivery pipeline, and WhatsApp sender), with proper fallback to auto-detected filenames from media URLs when not provided.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward parameter threading exercise with proper optional field handling, existing test coverage, and no breaking changes. The implementation follows established patterns in the codebase and maintains backward compatibility.
- No files require special attention

<sub>Last reviewed commit: 07f5209</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->