### PR TITLE
feat(gateway): filter models.list by agents.defaults.models allowlist

### DIFF
--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -1,10 +1,13 @@
+import type { GatewayRequestHandlers } from "./types.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { buildAllowedModelSet } from "../../agents/model-selection.js";
+import { loadConfig } from "../../config/io.js";
 import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
   validateModelsListParams,
 } from "../protocol/index.js";
-import type { GatewayRequestHandlers } from "./types.js";
 
 export const modelsHandlers: GatewayRequestHandlers = {
   "models.list": async ({ params, respond, context }) => {
@@ -20,7 +23,40 @@ export const modelsHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
-      const models = await context.loadGatewayModelCatalog();
+      const catalog = await context.loadGatewayModelCatalog();
+      const cfg = loadConfig();
+      const allowed = buildAllowedModelSet({
+        cfg,
+        catalog,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      });
+
+      let models;
+      if (allowed.allowAny) {
+        // No allowlist configured — return full catalog.
+        models = catalog;
+      } else {
+        // Start with catalog entries that are in the allowlist.
+        const out = [...allowed.allowedCatalog];
+        const seen = new Set(out.map((e) => `${e.provider}/${e.id}`));
+        // Add allowlist entries that aren't in the built-in catalog
+        // (e.g. custom providers from models.providers).
+        for (const key of allowed.allowedKeys) {
+          if (seen.has(key)) {
+            continue;
+          }
+          const slash = key.indexOf("/");
+          if (slash <= 0) {
+            continue;
+          }
+          const provider = key.slice(0, slash);
+          const id = key.slice(slash + 1);
+          out.push({ provider, id, name: id });
+          seen.add(key);
+        }
+        models = out;
+      }
       respond(true, { models }, undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -1,4 +1,3 @@
-import type { GatewayRequestHandlers } from "./types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { buildAllowedModelSet } from "../../agents/model-selection.js";
 import { loadConfig } from "../../config/io.js";
@@ -8,6 +7,7 @@ import {
   formatValidationErrors,
   validateModelsListParams,
 } from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
 
 export const modelsHandlers: GatewayRequestHandlers = {
   "models.list": async ({ params, respond, context }) => {


### PR DESCRIPTION
## Summary

When `agents.defaults.models` is configured, the gateway `models.list` RPC now returns only the allowed subset plus any custom provider models, instead of the full 700+ model catalog.

This makes the TUI `/models` picker show only actionable models that the user has explicitly allowlisted.

When no allowlist is set (`allowAny`), the full catalog is returned unchanged — no behavioral change for users without an allowlist.

## Changes

- **`src/gateway/server-methods/models.ts`**: Apply `buildAllowedModelSet` to filter the catalog before returning. Also includes models from `allowedKeys` that aren't in the built-in catalog (custom providers from `models.providers`).

## Testing

- TUI model picker shows only allowlisted models (14 vs 713)
- Custom provider models (volcengine, zai, minimax-portal, xianyu) appear correctly
- `pnpm build` passes
- No change for users without an allowlist

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Filters the `models.list` RPC response to return only allowlisted models from `agents.defaults.models` configuration, reducing the model picker from 700+ models to only actionable models.

- Applied `buildAllowedModelSet` filter to catalog before returning
- Preserves full catalog when no allowlist is configured (`allowAny`)
- Includes custom provider models from `models.providers` that aren't in built-in catalog
- Backward compatible: no behavior change for users without an allowlist

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, reuses existing battle-tested logic from `buildAllowedModelSet`, maintains backward compatibility, and the PR description confirms it passes build and manual testing. The code correctly handles edge cases (empty allowlist, custom providers, duplicate detection).
- No files require special attention

<sub>Last reviewed commit: 644c1a4</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->