### PR TITLE
fix(gitignore): include top-level .agents directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ USER.md
 .agent/*.json
 !.agent/workflows/
 .agents/
+.agents
 /local/
 package-lock.json
 .claude/settings.local.json


### PR DESCRIPTION
Add a .agents entry to .gitignore to ensure the repository
ignores a top-level directory named ".agents" in addition to the
existing .agents/ pattern and other agent-related files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `.agents` pattern to gitignore alongside existing `.agents/` pattern. The new pattern provides additional coverage for ignoring a file named `.agents` (the existing pattern only ignores directories). Both patterns work at any level of the repository, not just top-level.

- The change is redundant for the primary use case (ignoring the `.agents` directory) but provides harmless extra coverage
- No functional issues introduced

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change adds a redundant but harmless gitignore pattern. It doesn't break anything, doesn't affect tracked files, and provides belt-and-suspenders coverage for ignoring `.agents` entries.
- No files require special attention

<sub>Last reviewed commit: b4fce95</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->