### PR TITLE
fix(whatsapp): include outbound DMs in agent context for allowed contacts

### DIFF
--- a/src/web/inbound/access-control.test.ts
+++ b/src/web/inbound/access-control.test.ts
@@ -66,6 +66,131 @@ describe("checkInboundAccessControl pairing grace", () => {
   });
 });
 
+describe("outbound DM (fromMe) context inclusion (#12480)", () => {
+  it("allows outbound DMs for contacts in the allowlist", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          allowFrom: ["+15550001111"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.shouldMarkRead).toBe(false);
+  });
+
+  it("blocks outbound DMs for contacts NOT in the allowlist", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          allowFrom: ["+15559999999"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(false);
+  });
+
+  it("allows outbound DMs when dmPolicy is open", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "open",
+          allowFrom: [],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.shouldMarkRead).toBe(false);
+  });
+
+  it("allows outbound DMs when allowFrom has wildcard", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          allowFrom: ["*"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks outbound DMs when dmPolicy is disabled even for allowed contacts", async () => {
+    // dmPolicy: "disabled" blocks all DMs unconditionally, including outbound.
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "disabled",
+          allowFrom: ["+15550001111"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(false);
+  });
+});
+
 describe("WhatsApp dmPolicy precedence", () => {
   it("uses account-level dmPolicy instead of channel-level (#8736)", async () => {
     // Channel-level says "pairing" but the account-level says "allowlist".

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -122,7 +122,25 @@ export async function checkInboundAccessControl(params: {
   // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled".
   if (!params.group) {
     if (params.isFromMe && !isSamePhone) {
-      logVerbose("Skipping outbound DM (fromMe); no pairing reply needed.");
+      // Allow outbound DMs through for contacts in the allowlist so the agent
+      // can see both sides of the conversation.  Without this the agent loses
+      // the owner's messages and only sees inbound replies, breaking context.
+      const candidate = params.from;
+      const contactAllowed =
+        dmPolicy !== "disabled" &&
+        (dmPolicy === "open" ||
+          dmHasWildcard ||
+          (normalizedAllowFrom.length > 0 && normalizedAllowFrom.includes(candidate)));
+      if (contactAllowed) {
+        logVerbose("Including outbound DM (fromMe) for allowed contact.");
+        return {
+          allowed: true,
+          shouldMarkRead: false,
+          isSelfChat,
+          resolvedAccountId: account.accountId,
+        };
+      }
+      logVerbose("Skipping outbound DM (fromMe); contact not in allowlist.");
       return {
         allowed: false,
         shouldMarkRead: false,


### PR DESCRIPTION
## Summary

Fixes #12480

When the gateway owner sends a WhatsApp DM to an allowed contact, `checkInboundAccessControl()` blocks the message. This means the agent only sees the contact's replies and loses the owner's side of the conversation, breaking context.

This PR allows outbound DMs through (with `shouldMarkRead: false`) when the contact passes the allowlist check. Outbound DMs to contacts NOT in the allowlist remain blocked.

### Changes

- In `checkInboundAccessControl()`, when `isFromMe && !isSamePhone`, check if the contact is in the allowlist before blocking
- Respect `dmPolicy: "disabled"` — outbound DMs are blocked when DMs are disabled entirely
- `shouldMarkRead: false` is preserved for all outbound DMs (owner messages need no read receipt)

### Security

- `msg.key.fromMe` comes from the WhatsApp protocol (Signal layer) and cannot be spoofed by remote contacts
- Allowlist check mirrors the existing inbound DM check pattern exactly
- `dmPolicy: "disabled"` is respected as a hard block for both directions

### Test plan

- [x] Outbound DM to allowed contact → `allowed: true, shouldMarkRead: false`
- [x] Outbound DM to non-allowed contact → `allowed: false`
- [x] Outbound DM with `dmPolicy: "open"` → `allowed: true`
- [x] Outbound DM with `allowFrom: ["*"]` → `allowed: true`
- [x] Outbound DM with `dmPolicy: "disabled"` → `allowed: false`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added logic to include outbound DMs from the gateway owner in agent context when the contact is in the allowlist. Previously, when the owner sent a WhatsApp DM to an allowed contact, the message was blocked by `checkInboundAccessControl()`, causing the agent to only see the contact's replies without the owner's messages, breaking conversation context.

The change adds a check before blocking outbound DMs (`isFromMe && !isSamePhone`) to allow them through if:
- The contact is in the allowlist (matches existing inbound DM pattern)
- `dmPolicy` is not "disabled" (respects hard blocks)
- Returns `shouldMarkRead: false` to avoid marking owner's own messages as read

Security is maintained since `msg.key.fromMe` comes from the WhatsApp protocol layer and cannot be spoofed by remote contacts. The allowlist check mirrors the existing inbound DM pattern exactly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns in the codebase exactly, mirrors the inbound DM allowlist check logic, includes comprehensive test coverage for all scenarios (allowlist match, no match, open policy, wildcard, disabled policy), respects the `dmPolicy: "disabled"` hard block, and maintains security guarantees since `msg.key.fromMe` is protocol-level and cannot be spoofed
- No files require special attention

<sub>Last reviewed commit: 74c0eb8</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->