### PR TITLE
fix(whatsapp): propagate fromMe flag through DM message pipeline

### DIFF
--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -152,6 +152,52 @@ describe("formatInboundEnvelope", () => {
     expect(body).toBe("[Telegram Alice] follow-up message");
   });
 
+  it("appends (you) to from for DM messages with fromMe (#12482)", () => {
+    const body = formatInboundEnvelope({
+      channel: "WhatsApp",
+      from: "+15550009999",
+      body: "hello",
+      chatType: "direct",
+      fromMe: true,
+    });
+    expect(body).toContain("+15550009999 (you)");
+    expect(body).toContain("hello");
+  });
+
+  it("does not append (you) for inbound DM messages", () => {
+    const body = formatInboundEnvelope({
+      channel: "WhatsApp",
+      from: "+15550001111",
+      body: "hello",
+      chatType: "direct",
+      fromMe: false,
+    });
+    expect(body).toContain("+15550001111");
+    expect(body).not.toContain("(you)");
+  });
+
+  it("does not append (you) for group messages even when fromMe", () => {
+    const body = formatInboundEnvelope({
+      channel: "WhatsApp",
+      from: "120363400000000000@g.us",
+      body: "hello",
+      chatType: "group",
+      sender: { name: "Owner" },
+      fromMe: true,
+    });
+    expect(body).not.toContain("(you)");
+  });
+
+  it("does not append (you) when fromMe is omitted (backward compat)", () => {
+    const body = formatInboundEnvelope({
+      channel: "WhatsApp",
+      from: "+15550001111",
+      body: "hello",
+      chatType: "direct",
+    });
+    expect(body).not.toContain("(you)");
+  });
+
   it("resolves envelope options from config", () => {
     const options = resolveEnvelopeFormatOptions({
       agents: {

--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -197,15 +197,19 @@ export function formatInboundEnvelope(params: {
   sender?: SenderLabelParams;
   previousTimestamp?: number | Date;
   envelope?: EnvelopeFormatOptions;
+  fromMe?: boolean;
 }): string {
   const chatType = normalizeChatType(params.chatType);
   const isDirect = !chatType || chatType === "direct";
   const resolvedSenderRaw = params.senderLabel?.trim() || resolveSenderLabel(params.sender ?? {});
   const resolvedSender = resolvedSenderRaw ? sanitizeEnvelopeHeaderPart(resolvedSenderRaw) : "";
+  // For DM messages sent by the owner, append "(you)" to the from field so the
+  // agent can distinguish its operator's messages from the contact's messages.
+  const from = isDirect && params.fromMe ? `${params.from} (you)` : params.from;
   const body = !isDirect && resolvedSender ? `${resolvedSender}: ${params.body}` : params.body;
   return formatAgentEnvelope({
     channel: params.channel,
-    from: params.from,
+    from,
     timestamp: params.timestamp,
     previousTimestamp: params.previousTimestamp,
     envelope: params.envelope,

--- a/src/web/auto-reply/monitor/message-line.ts
+++ b/src/web/auto-reply/monitor/message-line.ts
@@ -43,5 +43,6 @@ export function buildInboundLine(params: {
     },
     previousTimestamp,
     envelope,
+    fromMe: msg.fromMe,
   });
 }

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -309,6 +309,7 @@ export async function monitorWebInbox(options: {
         pushName: senderName,
         timestamp,
         chatType: group ? "group" : "direct",
+        fromMe: Boolean(msg.key?.fromMe),
         chatId: remoteJid,
         senderJid: participantJid,
         senderE164: senderE164 ?? undefined,

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -17,6 +17,7 @@ export type WebInboundMessage = {
   pushName?: string;
   timestamp?: number;
   chatType: "direct" | "group";
+  fromMe?: boolean;
   chatId: string;
   senderJid?: string;
   senderE164?: string;


### PR DESCRIPTION
## Summary

Fixes #12482

In WhatsApp DMs, the agent cannot distinguish between messages sent by the gateway owner and messages from the contact. This makes it impossible for the agent to follow a two-way conversation correctly.

### Changes

- Add `fromMe?: boolean` field to `WebInboundMessage` type
- Propagate `Boolean(msg.key?.fromMe)` from the Baileys message into the inbound message
- Pass `fromMe` through `buildInboundLine()` to `formatInboundEnvelope()`
- In DM envelopes, append `(you)` to the `from` field when `fromMe` is true, producing `[WhatsApp +1555 (you)] message` for owner messages

### Security

- `Boolean(msg.key?.fromMe)` safely defaults to `false` for null/undefined
- The `(you)` marker passes through `sanitizeEnvelopeHeaderPart` (no injection risk)
- The marker only appears in the agent's internal transcript, never in outbound messages
- `fromMe` field is optional throughout — fully backward-compatible

### Test plan

- [x] DM with `fromMe: true` → envelope contains `(you)`
- [x] DM with `fromMe: false` → no `(you)` marker
- [x] Group with `fromMe: true` → no `(you)` marker (groups unaffected)
- [x] `fromMe` omitted → no `(you)` marker (backward compat)
- [x] All existing envelope tests pass (16/16)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `fromMe` flag to the WhatsApp inbound message pipeline so the agent can distinguish between messages sent by the gateway owner and messages from the contact in DMs. The flag flows from Baileys' `msg.key.fromMe` through `WebInboundMessage` → `buildInboundLine()` → `formatInboundEnvelope()`, where DM messages with `fromMe: true` get a `(you)` suffix appended to the `from` field in the envelope header (e.g., `[WhatsApp +1555 (you)] message`).

- New optional `fromMe?: boolean` field added to `WebInboundMessage` type, ensuring backward compatibility
- `Boolean(msg.key?.fromMe)` safely coerces null/undefined to `false`
- The `(you)` marker only applies to DM messages (not groups), and passes through `sanitizeEnvelopeHeaderPart` safely
- 4 new test cases cover DM fromMe true/false, group fromMe true, and omitted fromMe scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a well-scoped, backward-compatible addition with thorough test coverage.
- The change is minimal and focused: a single optional boolean field threaded through the existing pipeline, with a small formatting change gated behind two conditions (isDirect && fromMe). All edge cases are tested (4 new tests). The field is optional throughout, so no existing callers break. The Boolean() coercion safely handles null/undefined. No security concerns — the marker only appears in internal agent transcripts.
- No files require special attention.

<sub>Last reviewed commit: 7fc1a3b</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->