### PR TITLE
fix(web): enforce sendPolicy on WhatsApp auto-reply delivery path

### DIFF
--- a/src/web/auto-reply/monitor/process-message.test.ts
+++ b/src/web/auto-reply/monitor/process-message.test.ts
@@ -1,0 +1,192 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let sessionDir: string | undefined;
+let sessionStorePath: string;
+let backgroundTasks: Set<Promise<unknown>>;
+
+const defaultReplyLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+function makeProcessMessageArgs(params: {
+  msg: Record<string, unknown>;
+  routeSessionKey: string;
+  groupHistoryKey: string;
+  cfg?: unknown;
+}) {
+  return {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    cfg: (params.cfg ?? { messages: {}, session: { store: sessionStorePath } }) as any,
+    // oxlint-disable-next-line typescript/no-explicit-any
+    msg: params.msg as any,
+    route: {
+      agentId: "main",
+      accountId: "default",
+      sessionKey: params.routeSessionKey,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any,
+    groupHistoryKey: params.groupHistoryKey,
+    groupHistories: new Map(),
+    groupMemberNames: new Map(),
+    connectionId: "conn",
+    verbose: false,
+    maxMediaBytes: 1,
+    // oxlint-disable-next-line typescript/no-explicit-any
+    replyResolver: (async () => undefined) as any,
+    // oxlint-disable-next-line typescript/no-explicit-any
+    replyLogger: defaultReplyLogger as any,
+    backgroundTasks,
+    rememberSentText: (_text: string | undefined, _opts: unknown) => {},
+    echoHas: () => false,
+    echoForget: () => {},
+    buildCombinedEchoKey: () => "echo",
+    groupHistory: [],
+    // oxlint-disable-next-line typescript/no-explicit-any
+  } as any;
+}
+
+let dispatchCalled = false;
+
+vi.mock("../../../auto-reply/reply/provider-dispatcher.js", () => ({
+  // oxlint-disable-next-line typescript/no-explicit-any
+  dispatchReplyWithBufferedBlockDispatcher: vi.fn(async (_params: any) => {
+    dispatchCalled = true;
+    return { queuedFinal: false };
+  }),
+}));
+
+vi.mock("./last-route.js", () => ({
+  trackBackgroundTask: (tasks: Set<Promise<unknown>>, task: Promise<unknown>) => {
+    tasks.add(task);
+    void task.finally(() => {
+      tasks.delete(task);
+    });
+  },
+  updateLastRouteInBackground: vi.fn(),
+}));
+
+import { processMessage } from "./process-message.js";
+
+describe("processMessage send-policy gating", () => {
+  beforeEach(async () => {
+    dispatchCalled = false;
+    backgroundTasks = new Set();
+    sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pm-sendpol-"));
+    sessionStorePath = path.join(sessionDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    await Promise.allSettled(Array.from(backgroundTasks));
+    if (sessionDir) {
+      await fs.rm(sessionDir, { recursive: true, force: true });
+      sessionDir = undefined;
+    }
+  });
+
+  const baseMsg = {
+    id: "msg1",
+    from: "+15550001111",
+    to: "+15550002222",
+    chatType: "direct",
+    body: "hello",
+    senderE164: "+15550001111",
+  };
+
+  it("returns false and skips dispatch when sendPolicy denies the session", async () => {
+    const result = await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+15550001111",
+        groupHistoryKey: "+15550001111",
+        cfg: {
+          messages: {},
+          session: {
+            store: sessionStorePath,
+            sendPolicy: {
+              default: "allow",
+              rules: [{ action: "deny", match: { channel: "whatsapp" } }],
+            },
+          },
+        },
+        msg: baseMsg,
+      }),
+    );
+
+    expect(result).toBe(false);
+    expect(dispatchCalled).toBe(false);
+  });
+
+  it("proceeds to dispatch when sendPolicy allows the session", async () => {
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+15550001111",
+        groupHistoryKey: "+15550001111",
+        cfg: {
+          messages: {},
+          session: {
+            store: sessionStorePath,
+            sendPolicy: {
+              default: "allow",
+              rules: [{ action: "deny", match: { channel: "discord" } }],
+            },
+          },
+        },
+        msg: baseMsg,
+      }),
+    );
+
+    // The dispatcher was called (reply was attempted)
+    expect(dispatchCalled).toBe(true);
+  });
+
+  it("proceeds to dispatch when no sendPolicy is configured", async () => {
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+15550001111",
+        groupHistoryKey: "+15550001111",
+        cfg: {
+          messages: {},
+          session: { store: sessionStorePath },
+        },
+        msg: baseMsg,
+      }),
+    );
+
+    expect(dispatchCalled).toBe(true);
+  });
+
+  it("denies group chat when rule targets whatsapp groups", async () => {
+    const result = await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:group:123@g.us",
+        groupHistoryKey: "whatsapp:default:group:123@g.us",
+        cfg: {
+          messages: {},
+          session: {
+            store: sessionStorePath,
+            sendPolicy: {
+              default: "allow",
+              rules: [{ action: "deny", match: { channel: "whatsapp", chatType: "group" } }],
+            },
+          },
+        },
+        msg: {
+          ...baseMsg,
+          from: "123@g.us",
+          chatType: "group",
+          senderName: "Alice",
+          groupSubject: "Test Group",
+          groupParticipants: [],
+        },
+      }),
+    );
+
+    expect(result).toBe(false);
+    expect(dispatchCalled).toBe(false);
+  });
+});

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -30,6 +30,7 @@ import {
   readStoreAllowFromForDmPolicy,
   resolveDmGroupAccessWithCommandGate,
 } from "../../../security/dm-policy-shared.js";
+import { resolveSendPolicy } from "../../../sessions/send-policy.js";
 import { jidToE164, normalizeE164 } from "../../../utils.js";
 import { resolveWhatsAppAccount } from "../../accounts.js";
 import { newConnectionId } from "../../reconnect.js";
@@ -141,6 +142,18 @@ export async function processMessage(params: {
   groupHistory?: GroupHistoryEntry[];
   suppressGroupHistoryClear?: boolean;
 }) {
+  // Gate first — skip all work if send policy denies.
+  const sendPolicy = resolveSendPolicy({
+    cfg: params.cfg,
+    sessionKey: params.route.sessionKey,
+    channel: "whatsapp",
+    chatType: params.msg.chatType,
+  });
+  if (sendPolicy === "deny") {
+    logVerbose(`Skipping auto-reply: send policy denied for ${params.route.sessionKey}`);
+    return false;
+  }
+
   const conversationId = params.msg.conversationId ?? params.msg.from;
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: params.route.agentId,


### PR DESCRIPTION
## Summary

Fixes #21824

`resolveSendPolicy()` was being called in all outbound paths (commands, gateway chat, gateway agent) but was **missing** from the WhatsApp WebSocket inbound handler (`process-message.ts`). This meant `sendPolicy` config rules were silently bypassed for WhatsApp auto-replies.

## Changes

**`src/web/auto-reply/monitor/process-message.ts`**
- Import `resolveSendPolicy` from `../../../sessions/send-policy.js`
- Add policy check after echo detection, before ack reaction + dispatch
- Channel hardcoded to `'whatsapp'` (this file is WhatsApp-specific)
- Returns `false` early when policy is `'deny'`, consistent with other paths

**`src/web/auto-reply/monitor/process-message.test.ts`** (new)
- 4 tests covering the send-policy gating:
  1. Returns `false` and skips dispatch when sendPolicy denies the channel
  2. Proceeds to dispatch when policy allows (rule targets different channel)
  3. Proceeds to dispatch when no sendPolicy is configured
  4. Denies group chat when rule targets `whatsapp` + `chatType: group`

## Known Limitation

Per-session `sendPolicy` entry overrides (set directly on individual session entries in the store) are **not** checked in this path — `process-message.ts` does not load session entries. Config-level rules (channel, chatType, keyPrefix matching) work correctly. Per-session overrides can be added in a follow-up if needed.

## Verification

```
npx tsc --noEmit   → 0 new errors (2 pre-existing upstream errors in gateway-server-chat-b.e2e.test.ts unchanged)
npx vitest run src/web/auto-reply/monitor/ src/sessions/send-policy → 13/13 passed
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds missing `sendPolicy` enforcement to the WhatsApp auto-reply path (`process-message.ts`). The check is positioned after echo detection but before the ack reaction and reply dispatch, matching the gating pattern used in other outbound paths (commands, gateway chat, gateway agent). Hardcodes channel to `'whatsapp'` since this handler is WhatsApp-specific. Test coverage validates all four policy scenarios: deny, allow (different channel rule), allow (no policy), and deny with `chatType` matching.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward security fix that adds missing policy enforcement. The implementation follows existing patterns from other channels, the placement in the execution flow is correct (after echo detection, before dispatch), and comprehensive tests validate all policy scenarios. No breaking changes or regressions expected.
- No files require special attention

<sub>Last reviewed commit: 4f3405c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->