### PR TITLE
fix: guard writeConfigFile against persisting redaction sentinels

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12196,7 +12196,7 @@
         "filename": "src/config/io.write-config.test.ts",
         "hashed_secret": "13951588fd3325e25ed1e3b116d7009fb221c85e",
         "is_verified": false,
-        "line_number": 289
+        "line_number": 290
       }
     ],
     "src/config/model-alias-defaults.test.ts": [

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1,10 +1,11 @@
+import JSON5 from "json5";
+import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
+import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
-import JSON5 from "json5";
-import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {
@@ -47,8 +48,8 @@ import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.
 import { normalizeConfigPaths } from "./normalize-paths.js";
 import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
+import { REDACTED_SENTINEL } from "./redact-snapshot.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
-import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
@@ -1188,6 +1189,19 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
     const stampedOutputConfig = stampConfigVersion(outputConfig);
     const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
+
+    if (json.includes(REDACTED_SENTINEL)) {
+      deps.logger.error(
+        `Config write blocked: redaction sentinel "${REDACTED_SENTINEL}" found in output — ` +
+          `writing would destroy credentials. Config file was NOT modified.`,
+      );
+      throw new Error(
+        `Refusing to write config: found redaction sentinel "${REDACTED_SENTINEL}". ` +
+          `This is a bug — credentials would be permanently lost. ` +
+          `The config file on disk was not changed.`,
+      );
+    }
+
     const nextHash = hashConfigRaw(json);
     const previousHash = resolveConfigSnapshotHash(snapshot);
     const changedPathCount = changedPaths?.size;

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1,11 +1,10 @@
-import JSON5 from "json5";
-import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
-import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
+import JSON5 from "json5";
+import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1194,7 +1194,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     if (json.includes(REDACTED_SENTINEL)) {
       const sentinel_err = new Error(
         `Refusing to write config for "${configPath}": found redaction sentinel ` +
-          `"${REDACTED_SENTINEL}". This is a bug — credentials would be permanently lost. ` +
+          `"${REDACTED_SENTINEL}". This is a bug in the calling code shown in the attached stacktrace — credentials would be permanently lost. ` +
           `The config file on disk was not changed.`,
       );
       deps.logger.error(

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -50,6 +50,7 @@ import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } fr
 import { isBlockedObjectKey } from "./prototype-keys.js";
 import { REDACTED_SENTINEL } from "./redact-snapshot.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
+import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
@@ -1191,15 +1192,16 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
 
     if (json.includes(REDACTED_SENTINEL)) {
-      deps.logger.error(
-        `Config write blocked: redaction sentinel "${REDACTED_SENTINEL}" found in output — ` +
-          `writing would destroy credentials. Config file was NOT modified.`,
-      );
-      throw new Error(
-        `Refusing to write config: found redaction sentinel "${REDACTED_SENTINEL}". ` +
-          `This is a bug — credentials would be permanently lost. ` +
+      const sentinel_err = new Error(
+        `Refusing to write config for "${configPath}": found redaction sentinel ` +
+          `"${REDACTED_SENTINEL}". This is a bug — credentials would be permanently lost. ` +
           `The config file on disk was not changed.`,
       );
+      deps.logger.error(
+        `Config write blocked for "${configPath}": redaction sentinel "${REDACTED_SENTINEL}" ` +
+          `found in output — writing would destroy credentials. Config file was NOT modified.\n${sentinel_err.stack}`,
+      );
+      throw sentinel_err;
     }
 
     const nextHash = hashConfigRaw(json);

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createConfigIO } from "./io.js";
-import type { OpenClawConfig } from "./types.js";
 import { REDACTED_SENTINEL } from "./redact-snapshot.js";
+import type { OpenClawConfig } from "./types.js";
 
 describe("config io write", () => {
   let fixtureRoot = "";

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createConfigIO } from "./io.js";
 import type { OpenClawConfig } from "./types.js";
+import { REDACTED_SENTINEL } from "./redact-snapshot.js";
 
 describe("config io write", () => {
   let fixtureRoot = "";
@@ -546,6 +547,37 @@ describe("config io write", () => {
       expect(last.watchMode).toBe(true);
       expect(last.watchSession).toBe("watch-session-1");
       expect(last.watchCommand).toBe("gateway --force");
+    });
+  });
+
+  it("refuses to write config containing redaction sentinel (issue #18102)", async () => {
+    await withSuiteHome(async (home) => {
+      const initialConfig = {
+        gateway: { port: 18789 },
+        channels: { telegram: { botToken: "real-bot-token-123" } },
+      };
+      const errorFn = vi.fn();
+      const { configPath, io, snapshot } = await writeConfigAndCreateIo({
+        home,
+        initialConfig,
+        logger: { warn: vi.fn(), error: errorFn },
+      });
+
+      const poisoned = structuredClone(snapshot.config);
+      (poisoned as Record<string, unknown>).channels = {
+        ...poisoned.channels,
+        telegram: {
+          ...poisoned.channels?.telegram,
+          botToken: REDACTED_SENTINEL,
+        },
+      };
+
+      await expect(io.writeConfigFile(poisoned)).rejects.toThrow(/redaction sentinel/i);
+
+      const ondisk = JSON.parse(await fs.readFile(configPath, "utf-8")) as Record<string, unknown>;
+      expect(JSON.stringify(ondisk)).not.toContain(REDACTED_SENTINEL);
+      expect(ondisk).toEqual(initialConfig);
+      expect(errorFn).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #18102.

`writeConfigFile` had no safety check for the `__OPENCLAW_REDACTED__` redaction sentinel. While the gateway's config write handlers (`config.set`, `config.apply`, `config.patch`) call `restoreRedactedValues` before writing, other callers such as `doctor --fix` pass config objects directly to `writeConfigFile` without sentinel detection. If a redacted placeholder ever reached the write path, it would be serialized to disk, permanently destroying the original credential.

This PR adds a **universal pre-write guard** inside `writeConfigFile` that:

- Scans the final serialized JSON for `REDACTED_SENTINEL` after all transformations (merge-patch, validation, env-var restoration)
- Throws with a descriptive error **before any file I/O**, keeping the on-disk config intact
- Logs the blocked write via `deps.logger.error` for forensic visibility

This protects **all** callers of `writeConfigFile` (doctor, onboarding, security fix, CLI config set, etc.), not just the gateway path.

## TL;DR for maintainers

One sentinel string check (`json.includes(REDACTED_SENTINEL)`) right after `JSON.stringify` and before any disk write. ~15 lines of guard code + ~30 lines of test. Zero behaviour change for configs that don't contain the sentinel.

## Test plan

- [x] New test: `writeConfigFile` rejects a config where `botToken` is set to `__OPENCLAW_REDACTED__`
- [x] New test: on-disk config file is verified unchanged after the rejected write
- [x] All existing `io.write-config.test.ts` tests pass (9/9)
- [x] `redact-snapshot.test.ts` tests pass (57/57)
- [x] `env-preserve-io.test.ts` tests pass (4/4)

<!-- AI-assisted (protocol-zero + Claude) -->

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a universal pre-write guard to prevent the redaction sentinel `__OPENCLAW_REDACTED__` from being persisted to disk. While the gateway's config handlers already call `restoreRedactedValues` before writing, other code paths like `doctor --fix` pass config objects directly to `writeConfigFile` without sentinel detection.

The fix adds a simple string check after `JSON.stringify` and before any file I/O. If the sentinel is found, the function logs an error and throws, keeping the on-disk config unchanged.

- Prevents credential destruction across all `writeConfigFile` callers
- Test verifies both rejection and disk preservation
- Zero behavior change for configs without the sentinel

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a defensive guard that only throws when a bug would otherwise destroy credentials. The implementation is simple (a string check after JSON.stringify), well-tested (verifies rejection and disk preservation), and cannot introduce regressions since it only activates when the sentinel is present (which should never happen in valid flows). The fix protects all writeConfigFile callers universally.
- No files require special attention

<sub>Last reviewed commit: 8e87d93</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->