### PR TITLE
fix(telegram): disable autoSelectFamily by default on WSL2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/WSL2: disable `autoSelectFamily` by default on WSL2 and memoize WSL2 detection in Telegram network decision logic to avoid repeated sync `/proc/version` probes on fetch/send paths. (#21916) Thanks @MizukiMachine.
 - Telegram/Streaming: preserve archived draft preview mapping after flush and clean superseded reasoning preview bubbles so multi-message preview finals no longer cross-edit or orphan stale messages under send/rotation races. (#23202) Thanks @obviyus.
 - Slack/Slash commands: preserve the Bolt app receiver when registering external select options handlers so monitor startup does not crash on runtimes that require bound `app.options` calls. (#23209) Thanks @0xgaia.
 - Slack/Telegram slash sessions: await session metadata persistence before dispatch so first-turn native slash runs do not race session-origin metadata updates. (#23065) thanks @hydro13.

--- a/src/telegram/network-config.test.ts
+++ b/src/telegram/network-config.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveTelegramAutoSelectFamilyDecision } from "./network-config.js";
+
+// Mock isWSL2Sync at the top level
+vi.mock("../infra/wsl.js", () => ({
+  isWSL2Sync: vi.fn(),
+}));
+
+import { isWSL2Sync } from "../infra/wsl.js";
 
 describe("resolveTelegramAutoSelectFamilyDecision", () => {
   it("prefers env enable over env disable", () => {
@@ -68,5 +75,45 @@ describe("resolveTelegramAutoSelectFamilyDecision", () => {
   it("returns null when no decision applies", () => {
     const decision = resolveTelegramAutoSelectFamilyDecision({ env: {}, nodeMajor: 20 });
     expect(decision).toEqual({ value: null });
+  });
+
+  describe("WSL2 detection", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("disables autoSelectFamily on WSL2", () => {
+      vi.mocked(isWSL2Sync).mockReturnValue(true);
+      const decision = resolveTelegramAutoSelectFamilyDecision({ env: {}, nodeMajor: 22 });
+      expect(decision).toEqual({ value: false, source: "default-wsl2" });
+    });
+
+    it("respects config override on WSL2", () => {
+      vi.mocked(isWSL2Sync).mockReturnValue(true);
+      const decision = resolveTelegramAutoSelectFamilyDecision({
+        env: {},
+        network: { autoSelectFamily: true },
+        nodeMajor: 22,
+      });
+      expect(decision).toEqual({ value: true, source: "config" });
+    });
+
+    it("respects env override on WSL2", () => {
+      vi.mocked(isWSL2Sync).mockReturnValue(true);
+      const decision = resolveTelegramAutoSelectFamilyDecision({
+        env: { OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY: "1" },
+        nodeMajor: 22,
+      });
+      expect(decision).toEqual({
+        value: true,
+        source: "env:OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY",
+      });
+    });
+
+    it("uses Node 22 default when not on WSL2", () => {
+      vi.mocked(isWSL2Sync).mockReturnValue(false);
+      const decision = resolveTelegramAutoSelectFamilyDecision({ env: {}, nodeMajor: 22 });
+      expect(decision).toEqual({ value: true, source: "default-node22" });
+    });
   });
 });

--- a/src/telegram/network-config.test.ts
+++ b/src/telegram/network-config.test.ts
@@ -3,12 +3,16 @@ import { resolveTelegramAutoSelectFamilyDecision } from "./network-config.js";
 
 // Mock isWSL2Sync at the top level
 vi.mock("../infra/wsl.js", () => ({
-  isWSL2Sync: vi.fn(),
+  isWSL2Sync: vi.fn(() => false),
 }));
 
 import { isWSL2Sync } from "../infra/wsl.js";
 
 describe("resolveTelegramAutoSelectFamilyDecision", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("prefers env enable over env disable", () => {
     const decision = resolveTelegramAutoSelectFamilyDecision({
       env: {
@@ -78,10 +82,6 @@ describe("resolveTelegramAutoSelectFamilyDecision", () => {
   });
 
   describe("WSL2 detection", () => {
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
     it("disables autoSelectFamily on WSL2", () => {
       vi.mocked(isWSL2Sync).mockReturnValue(true);
       const decision = resolveTelegramAutoSelectFamilyDecision({ env: {}, nodeMajor: 22 });

--- a/src/telegram/network-config.ts
+++ b/src/telegram/network-config.ts
@@ -12,6 +12,16 @@ export type TelegramAutoSelectFamilyDecision = {
   source?: string;
 };
 
+let wsl2SyncCache: boolean | undefined;
+
+function isWSL2SyncCached(): boolean {
+  if (typeof wsl2SyncCache === "boolean") {
+    return wsl2SyncCache;
+  }
+  wsl2SyncCache = isWSL2Sync();
+  return wsl2SyncCache;
+}
+
 export function resolveTelegramAutoSelectFamilyDecision(params?: {
   network?: TelegramNetworkConfig;
   env?: NodeJS.ProcessEnv;
@@ -33,11 +43,15 @@ export function resolveTelegramAutoSelectFamilyDecision(params?: {
     return { value: params.network.autoSelectFamily, source: "config" };
   }
   // WSL2 has unstable IPv6 connectivity; disable autoSelectFamily to use IPv4 directly
-  if (isWSL2Sync()) {
+  if (isWSL2SyncCached()) {
     return { value: false, source: "default-wsl2" };
   }
   if (Number.isFinite(nodeMajor) && nodeMajor >= 22) {
     return { value: true, source: "default-node22" };
   }
   return { value: null };
+}
+
+export function resetTelegramNetworkConfigStateForTests(): void {
+  wsl2SyncCache = undefined;
 }

--- a/src/telegram/network-config.ts
+++ b/src/telegram/network-config.ts
@@ -1,6 +1,7 @@
 import process from "node:process";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { isWSL2Sync } from "../infra/wsl.js";
 
 export const TELEGRAM_DISABLE_AUTO_SELECT_FAMILY_ENV =
   "OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY";
@@ -30,6 +31,10 @@ export function resolveTelegramAutoSelectFamilyDecision(params?: {
   }
   if (typeof params?.network?.autoSelectFamily === "boolean") {
     return { value: params.network.autoSelectFamily, source: "config" };
+  }
+  // WSL2 has unstable IPv6 connectivity; disable autoSelectFamily to use IPv4 directly
+  if (isWSL2Sync()) {
+    return { value: false, source: "default-wsl2" };
   }
   if (Number.isFinite(nodeMajor) && nodeMajor >= 22) {
     return { value: true, source: "default-node22" };


### PR DESCRIPTION
## Problem

In WSL2 environments, Telegram API requests fail after PR #18272's change to default `autoSelectFamily=true`.

## Environment

- OS: WSL2 (Windows Subsystem for Linux 2)
- Node.js: v22.18.0
- OpenClaw: 2026.2.20

## Symptoms

```
telegram sendMessage failed: Network request for 'sendMessage' failed!
telegram final reply failed: HttpError: Network request for 'sendMessage' failed!
```

## Diagnosis

- ✅ IPv4 connection: Works (HTTP 200)
- ❌ IPv6 connection: Fails (HTTP 000, timeout)

In WSL2, IPv6 DNS resolution succeeds but actual IPv6 connection fails. When `autoSelectFamily=true`, the request times out waiting for IPv6 before falling back to IPv4.

## Solution

Auto-detect WSL2 environment using existing `isWSL2Sync()` function and set `autoSelectFamily: false` by default.

**Changes:**
- `src/telegram/network-config.ts`: Import `isWSL2Sync` and add WSL2 detection logic
- `src/telegram/network-config.test.ts`: Add test cases for WSL2 detection

**Priority order:**
1. Environment variables (`OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY`)
2. Environment variables (`OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY`)
3. Config file (`channels.telegram.network.autoSelectFamily`)
4. **WSL2 environment** → `false` ← NEW
5. Node.js >= 22 → `true`

This preserves user config overrides while fixing the default for WSL2.

Resolves #21909

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added WSL2 detection to automatically disable `autoSelectFamily` by default on WSL2 environments where IPv6 connectivity is unstable. The change preserves the existing priority order, inserting WSL2 detection between config overrides and Node.js version defaults.

- Added `isWSL2Sync()` call in `network-config.ts:36-37` to detect WSL2 environments
- Added comprehensive test coverage for WSL2 detection and override behavior
- **Critical issue**: Test mock setup has test isolation problems that could cause flakiness

<h3>Confidence Score: 3/5</h3>

- PR fixes a real issue but has test isolation bugs that need to be addressed
- The implementation logic is sound and addresses the WSL2 IPv6 connectivity issue correctly. However, the test setup has critical flaws with mock isolation that could lead to flaky tests - the mock isn't given a default return value and `afterEach` cleanup is only in the nested describe block, not at the top level
- Pay close attention to `src/telegram/network-config.test.ts` - the test isolation issues must be fixed

<sub>Last reviewed commit: 636903e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->