### PR TITLE
fix(antigravity): map deprecated Gemini 3 Pro to Gemini 3.1 Pro

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentConfig, resolveAgentModelPrimary } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
-import { normalizeGoogleModelId } from "./models-config.providers.js";
+import { normalizeAntigravityModelId, normalizeGoogleModelId } from "./models-config.providers.js";
 
 export type ModelRef = {
   provider: string;
@@ -103,6 +103,9 @@ function normalizeProviderModelId(provider: string, model: string): string {
   }
   if (provider === "google") {
     return normalizeGoogleModelId(model);
+  }
+  if (provider === "google-antigravity") {
+    return normalizeAntigravityModelId(model);
   }
   return model;
 }

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -329,6 +329,17 @@ export function normalizeGoogleModelId(id: string): string {
   return id;
 }
 
+/**
+ * Normalize model IDs for the google-antigravity (Google Antigravity) provider.
+ * Gemini 3 Pro was deprecated; map it to Gemini 3.1 Pro.
+ */
+export function normalizeAntigravityModelId(id: string): string {
+  if (id === "gemini-3-pro" || id === "gemini-3-pro-preview") {
+    return "gemini-3.1-pro";
+  }
+  return id;
+}
+
 function normalizeGoogleProvider(provider: ProviderConfig): ProviderConfig {
   let mutated = false;
   const models = provider.models.map((model) => {


### PR DESCRIPTION
## Summary

Fixes #21875

- Google deprecated Gemini 3 Pro in Google Antigravity. Users selecting a Gemini model via the `google-antigravity` provider get: *"Gemini 3 Pro is no longer available. Please switch to Gemini 3.1 Pro"*
- The existing `normalizeGoogleModelId` function was never called for the `google-antigravity` provider path — only for the direct `google` (API key) provider
- Adds `normalizeAntigravityModelId` that remaps `gemini-3-pro` and `gemini-3-pro-preview` to `gemini-3.1-pro`
- Wires it into `normalizeProviderModelId` for the `google-antigravity` provider

## Test plan

- [ ] CI passes
- [ ] Configure `google-antigravity/gemini-3-pro` and verify it resolves to `gemini-3.1-pro`
- [ ] Verify direct `google` provider (`gemini-3-pro-preview`) is unaffected