### PR TITLE
fix(tool-display): `cd ~/dir && npm install` shows as `run cd` — compound commands truncated to first stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.
 - Security/OpenClawKit/UI: prevent injected inbound user context metadata blocks from leaking into chat history in TUI, webchat, and macOS surfaces by stripping all untrusted metadata prefixes at display boundaries. (#22142) Thanks @Mellowambience, @vincentkoc.
 - Agents/System Prompt: label allowlisted senders as authorized senders to avoid implying ownership. Thanks @thewilloftheshadow.
+- Agents/Tool display: fix exec cwd suffix inference so `pushd ... && popd ... && <command>` does not keep stale `(in <dir>)` context in summaries. (#21925) thanks @Lukavyi.
 - Gateway/Auth: allow trusted-proxy mode with loopback bind for same-host reverse-proxy deployments, while still requiring configured `gateway.trustedProxies`. (#20097) thanks @xinhuagu.
 - Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.
 - Gateway/Security: remove shared-IP fallback for canvas endpoints and require token or session capability for canvas access. Thanks @thewilloftheshadow.

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -1017,13 +1017,21 @@ export function resolveExecDetail(args: unknown): string | undefined {
   // Explicit workdir takes priority; fall back to cd path extracted from the command.
   const cwd = cwdRaw?.trim() || result?.chdirPath || undefined;
 
+  const compact = compactRawCommand(unwrapped);
+
   // When the summary is generic (e.g. "run jj"), use the compact raw command instead.
   if (isGenericSummary(summary)) {
-    const compact = compactRawCommand(unwrapped);
     return cwd ? `${compact} (in ${cwd})` : compact;
   }
 
-  return cwd ? `${summary} (in ${cwd})` : summary;
+  const displaySummary = cwd ? `${summary} (in ${cwd})` : summary;
+
+  // Append the raw command when the summary differs meaningfully from the command itself.
+  if (compact && compact !== displaySummary && compact !== summary) {
+    return `${displaySummary}\n\`${compact}\``;
+  }
+
+  return displaySummary;
 }
 
 export function resolveActionSpec(

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -572,6 +572,10 @@ function isChdirCommand(head: string): boolean {
   return bin === "cd" || bin === "pushd" || bin === "popd";
 }
 
+function isPopdCommand(head: string): boolean {
+  return binaryName(splitShellWords(head, 2)[0]) === "popd";
+}
+
 type PreambleResult = {
   command: string;
   chdirPath?: string;
@@ -611,7 +615,13 @@ function stripShellPreamble(command: string): PreambleResult {
     }
 
     if (isChdir) {
-      chdirPath = parseChdirTarget(head) ?? chdirPath;
+      // popd returns to the previous directory, so inferred cwd from earlier
+      // preamble steps is no longer reliable.
+      if (isPopdCommand(head)) {
+        chdirPath = undefined;
+      } else {
+        chdirPath = parseChdirTarget(head) ?? chdirPath;
+      }
     }
 
     rest = first ? rest.slice(first.index + first.length).trimStart() : "";

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -1036,7 +1036,7 @@ export function resolveExecDetail(args: unknown): string | undefined {
 
   // Append the raw command when the summary differs meaningfully from the command itself.
   if (compact && compact !== displaySummary && compact !== summary) {
-    return `${displaySummary}\n\`${compact}\``;
+    return `${displaySummary}\n\n\`${compact}\``;
   }
 
   return displaySummary;

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -568,11 +568,13 @@ function stripShellPreamble(command: string): string {
 
   for (let i = 0; i < 4; i += 1) {
     const andIndex = rest.indexOf("&&");
+    const orIndex = rest.indexOf("||");
     const semicolonIndex = rest.indexOf(";");
     const newlineIndex = rest.indexOf("\n");
 
     const candidates = [
       { index: andIndex, length: 2 },
+      { index: orIndex, length: 2 },
       { index: semicolonIndex, length: 1 },
       { index: newlineIndex, length: 1 },
     ]

--- a/src/agents/tool-display.e2e.test.ts
+++ b/src/agents/tool-display.e2e.test.ts
@@ -141,6 +141,17 @@ describe("tool display details", () => {
     expect(detail).toBe("check git status (in /tmp)\n\n`pushd /tmp && git status`");
   });
 
+  it("clears inferred cwd when popd is stripped from preamble", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: "pushd /tmp && popd && npm install" },
+      }),
+    );
+
+    expect(detail).toBe("install dependencies\n\n`pushd /tmp && popd && npm install`");
+  });
+
   it("moves cd path to context suffix with || separator", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tool-display.e2e.test.ts
+++ b/src/agents/tool-display.e2e.test.ts
@@ -137,6 +137,28 @@ describe("tool display details", () => {
     expect(detail).toBe("check git status (in /tmp)");
   });
 
+  it("strips cd preamble with || separator", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: "cd /app || npm install" },
+      }),
+    );
+
+    expect(detail).toBe("install dependencies (in /app)");
+  });
+
+  it("explicit workdir takes priority over cd path", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: "cd /tmp && npm install", workdir: "/app" },
+      }),
+    );
+
+    expect(detail).toBe("install dependencies (in /app)");
+  });
+
   it("summarizes all stages joined by && or ;", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tool-display.e2e.test.ts
+++ b/src/agents/tool-display.e2e.test.ts
@@ -104,7 +104,7 @@ describe("tool display details", () => {
     expect(detail).toContain(".openclaw/workspace)");
   });
 
-  it("moves cd path to context suffix and summarizes the real command", () => {
+  it("moves cd path to context suffix and appends raw command", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({
         name: "exec",
@@ -112,10 +112,10 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("install dependencies (in ~/my-project)");
+    expect(detail).toBe("install dependencies (in ~/my-project)\n`cd ~/my-project && npm install`");
   });
 
-  it("moves cd path to context suffix with multiple stages", () => {
+  it("moves cd path to context suffix with multiple stages and raw command", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({
         name: "exec",
@@ -123,10 +123,12 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("install dependencies → run tests (in ~/my-project)");
+    expect(detail).toBe(
+      "install dependencies → run tests (in ~/my-project)\n`cd ~/my-project && npm install && npm test`",
+    );
   });
 
-  it("moves pushd path to context suffix", () => {
+  it("moves pushd path to context suffix and appends raw command", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({
         name: "exec",
@@ -134,7 +136,7 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("check git status (in /tmp)");
+    expect(detail).toBe("check git status (in /tmp)\n`pushd /tmp && git status`");
   });
 
   it("moves cd path to context suffix with || separator", () => {
@@ -145,7 +147,7 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("install dependencies (in /app)");
+    expect(detail).toBe("install dependencies (in /app)\n`cd /app || npm install`");
   });
 
   it("explicit workdir takes priority over cd path", () => {
@@ -156,10 +158,10 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("install dependencies (in /app)");
+    expect(detail).toBe("install dependencies (in /app)\n`cd /tmp && npm install`");
   });
 
-  it("summarizes all stages joined by && or ;", () => {
+  it("summarizes all stages and appends raw command", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({
         name: "exec",
@@ -167,7 +169,9 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("fetch git changes → rebase git branch");
+    expect(detail).toBe(
+      "fetch git changes → rebase git branch\n`git fetch && git rebase origin/main`",
+    );
   });
 
   it("falls back to raw command for unknown binaries", () => {

--- a/src/agents/tool-display.e2e.test.ts
+++ b/src/agents/tool-display.e2e.test.ts
@@ -104,7 +104,7 @@ describe("tool display details", () => {
     expect(detail).toContain(".openclaw/workspace)");
   });
 
-  it("strips cd preamble and summarizes the real command", () => {
+  it("moves cd path to context suffix and summarizes the real command", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({
         name: "exec",
@@ -115,7 +115,7 @@ describe("tool display details", () => {
     expect(detail).toBe("install dependencies (in ~/my-project)");
   });
 
-  it("strips cd preamble and summarizes multiple stages", () => {
+  it("moves cd path to context suffix with multiple stages", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({
         name: "exec",
@@ -126,7 +126,7 @@ describe("tool display details", () => {
     expect(detail).toBe("install dependencies → run tests (in ~/my-project)");
   });
 
-  it("strips pushd preamble", () => {
+  it("moves pushd path to context suffix", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({
         name: "exec",
@@ -137,7 +137,7 @@ describe("tool display details", () => {
     expect(detail).toBe("check git status (in /tmp)");
   });
 
-  it("strips cd preamble with || separator", () => {
+  it("moves cd path to context suffix with || separator", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({
         name: "exec",

--- a/src/agents/tool-display.e2e.test.ts
+++ b/src/agents/tool-display.e2e.test.ts
@@ -208,6 +208,18 @@ describe("tool display details", () => {
     expect(detail).toBe("cd /tmp");
   });
 
+  it("handles chained cd commands using last path", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: "cd /tmp && cd /app" },
+      }),
+    );
+
+    // both cd's are preamble; last path wins
+    expect(detail).toBe("cd /tmp && cd /app (in /app)");
+  });
+
   it("recognizes heredoc/inline script exec details", () => {
     const pyDetail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tool-display.e2e.test.ts
+++ b/src/agents/tool-display.e2e.test.ts
@@ -220,6 +220,20 @@ describe("tool display details", () => {
     expect(detail).toBe("cd /tmp && cd /app (in /app)");
   });
 
+  it("respects quotes when splitting preamble separators", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: 'export MSG="foo && bar" && echo test' },
+      }),
+    );
+
+    // The && inside quotes must not be treated as a separator —
+    // summary line should be "print text", not "run export" (which would happen
+    // if the quoted && was mistaken for a real separator).
+    expect(detail).toMatch(/^print text/);
+  });
+
   it("recognizes heredoc/inline script exec details", () => {
     const pyDetail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tool-display.e2e.test.ts
+++ b/src/agents/tool-display.e2e.test.ts
@@ -112,7 +112,9 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("install dependencies (in ~/my-project)\n`cd ~/my-project && npm install`");
+    expect(detail).toBe(
+      "install dependencies (in ~/my-project)\n\n`cd ~/my-project && npm install`",
+    );
   });
 
   it("moves cd path to context suffix with multiple stages and raw command", () => {
@@ -124,7 +126,7 @@ describe("tool display details", () => {
     );
 
     expect(detail).toBe(
-      "install dependencies → run tests (in ~/my-project)\n`cd ~/my-project && npm install && npm test`",
+      "install dependencies → run tests (in ~/my-project)\n\n`cd ~/my-project && npm install && npm test`",
     );
   });
 
@@ -136,7 +138,7 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("check git status (in /tmp)\n`pushd /tmp && git status`");
+    expect(detail).toBe("check git status (in /tmp)\n\n`pushd /tmp && git status`");
   });
 
   it("moves cd path to context suffix with || separator", () => {
@@ -160,7 +162,7 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("install dependencies (in /app)\n`cd /tmp && npm install`");
+    expect(detail).toBe("install dependencies (in /app)\n\n`cd /tmp && npm install`");
   });
 
   it("summarizes all stages and appends raw command", () => {
@@ -172,7 +174,7 @@ describe("tool display details", () => {
     );
 
     expect(detail).toBe(
-      "fetch git changes → rebase git branch\n`git fetch && git rebase origin/main`",
+      "fetch git changes → rebase git branch\n\n`git fetch && git rebase origin/main`",
     );
   });
 

--- a/src/agents/tool-display.e2e.test.ts
+++ b/src/agents/tool-display.e2e.test.ts
@@ -147,7 +147,9 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("install dependencies (in /app)\n`cd /app || npm install`");
+    // || means npm install runs when cd FAILS — cd should NOT be stripped as preamble.
+    // Both stages are summarized; cd is not treated as context prefix.
+    expect(detail).toMatch(/^run cd \/app → install dependencies/);
   });
 
   it("explicit workdir takes priority over cd path", () => {
@@ -194,6 +196,18 @@ describe("tool display details", () => {
     );
 
     expect(detail).toBe("mycli deploy --prod (in /app)");
+  });
+
+  it("keeps multi-stage summary when only some stages are generic", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: "cargo build && npm test" },
+      }),
+    );
+
+    // "run cargo build" is generic, but "run tests" is known — keep joined summary
+    expect(detail).toMatch(/^run cargo build → run tests/);
   });
 
   it("handles standalone cd as raw command", () => {

--- a/src/agents/tool-display.e2e.test.ts
+++ b/src/agents/tool-display.e2e.test.ts
@@ -112,7 +112,7 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("install dependencies");
+    expect(detail).toBe("install dependencies (in ~/my-project)");
   });
 
   it("strips cd preamble and summarizes multiple stages", () => {
@@ -123,7 +123,7 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("install dependencies → run tests");
+    expect(detail).toBe("install dependencies → run tests (in ~/my-project)");
   });
 
   it("strips pushd preamble", () => {
@@ -134,7 +134,7 @@ describe("tool display details", () => {
       }),
     );
 
-    expect(detail).toBe("check git status");
+    expect(detail).toBe("check git status (in /tmp)");
   });
 
   it("summarizes all stages joined by && or ;", () => {


### PR DESCRIPTION
#### Problem

`cd ~/dir && npm install` shows as **`🛠️ Exec: run cd`** — the summarizer only sees the first stage before `&&` and drops everything after it.

This affects all compound commands. Since agents frequently use `cd <dir> && <actual command>`, users see useless summaries for most real exec calls.

#### Root Cause

`firstTopLevelStage()` (introduced in [#18592](https://github.com/openclaw/openclaw/pull/18592)) extracts only the text before the first `&&`/`;`/`||` separator and discards the rest. For `cd ~/dir && npm install`, only `cd ~/dir` reaches the summarizer — and since `cd` isn't in the known-command list, the generic fallback produces `run cd`.

Secondary issue: unknown binaries (e.g. `jj`, `mycli`) produce generic `run <binary>` summaries that lose all arguments.

#### Fix

Five changes in `tool-display-common.ts`, all scoped to the summarizer:

| # | Change | Why |
|---|--------|-----|
| 1 | **Treat `cd`/`pushd`/`popd` as preamble** | `stripShellPreamble()` already strips `export`/`set`/`unset`. `cd` is the same idea — it sets up context, not the actual work. The target path is preserved as an `(in <path>)` suffix. Chained cd's (`cd /tmp && cd /app`) use the last path. |
| 2 | **Summarize ALL stages, not just the first** | Replace `firstTopLevelStage()` with `splitTopLevelStages()` — joins summaries with `→`. Consistent with how pipe chains already show `first -> last`. |
| 3 | **Generic fallback → raw command** | When the summarizer produces `run <unknown-binary>`, show the compact raw command instead. Unknown tools keep their arguments visible. |
| 4 | **`\|\|` separator support in preamble** | `stripShellPreamble()` now handles `\|\|` alongside `&&`, `;`, `\n`. |
| 5 | **Append raw command below summary** | When the human-readable summary differs from the actual command, the full command is appended as a backtick-wrapped second line — shows both intent and exact command. |

#### Before / After

| Command | Before | After |
|---------|--------|-------|
| `cd ~/dir && npm install` | `run cd` | `install dependencies (in ~/dir)` ﹢ `` `cd ~/dir && npm install` `` |
| `cd ~/dir && npm install && npm test` | `run cd` | `install dependencies → run tests (in ~/dir)` ﹢ `` `cd ~/dir && npm install && npm test` `` |
| `git fetch && git rebase origin/main` | `fetch git changes` | `fetch git changes → rebase git branch` ﹢ `` `git fetch && git rebase origin/main` `` |
| `jj rebase -s abc -d main` | `run jj` | `jj rebase -s abc -d main` (raw, no duplicate) |
| `cd /tmp` (standalone) | `run cd /tmp` | `cd /tmp` (raw, no duplicate) |

The raw command line is appended whenever it meaningfully differs from the summary. It's suppressed when it would be an exact duplicate.

**Before:**
<img width="732" height="324" alt="CleanShot 2026-02-20 at 17 24 30@2x" src="https://github.com/user-attachments/assets/3cefb26c-ba9b-4e0e-8ef8-ba51edaabd4b" />

**After:**
<img width="736" height="382" alt="CleanShot 2026-02-20 at 17 24 45@2x" src="https://github.com/user-attachments/assets/47e449a1-462f-411e-96ca-fa373a7fe03c" />

#### Tests

11 new test cases in `tool-display.e2e.test.ts` (18 total, all pass):
- `cd`/`pushd` path extraction with raw command appended
- Multi-stage (`&&`) summarization
- `||` separator handling
- Explicit `workdir` priority over `cd` path
- Unknown binary fallback (with and without cwd)
- Standalone `cd` as raw command
- Chained cd's (`cd /tmp && cd /app`) using last path
- Quoted separators (`export MSG="foo && bar" && echo test`)

#### Sign-Off

- Model: Claude Opus 4.6 (via OpenClaw)
- Submitter effort: AI-assisted, human-reviewed and directed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes command summarization for compound shell commands by treating `cd`/`pushd`/`popd` as preamble context rather than the main command, summarizing all stages instead of just the first, and falling back to raw commands for unknown binaries.

Key changes:
- **Preamble stripping**: `cd`/`pushd`/`popd` are now stripped as preamble alongside `export`/`set`/`unset`, with the target path preserved as an `(in <path>)` suffix. The logic correctly handles chained cd's by using the last path, and avoids stripping cd when followed by `||` (since that would be semantically incorrect).
- **Multi-stage summarization**: `splitTopLevelStages()` replaces `firstTopLevelStage()` to summarize all command stages joined with ` → `, consistent with how pipe chains already work.
- **Generic fallback**: When all stages produce generic summaries (e.g. `run unknown-binary`), the compact raw command is shown instead to preserve arguments.
- **Raw command appending**: When the summary differs meaningfully from the actual command, the full command is appended as a backtick-wrapped second line.

The implementation correctly addresses all three issues raised in previous review comments about chained cd handling, multi-stage generic detection, and `||` separator semantics. The 11 new test cases provide good coverage of edge cases including quoted separators, explicit workdir priority, and various command combinations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with comprehensive test coverage (11 new tests, all passing). All three issues from previous review comments have been addressed correctly. The code handles edge cases properly including chained cd's, quoted separators, || vs && semantics, and mixed generic/known command stages. The changes are scoped to the tool display summarizer and don't affect command execution.
- No files require special attention

<sub>Last reviewed commit: ec1ef2d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->