### PR TITLE
security(slack): add explicit webhook signature verification

### DIFF
--- a/src/slack/http/registry.test.ts
+++ b/src/slack/http/registry.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -5,6 +6,18 @@ import {
   normalizeSlackWebhookPath,
   registerSlackHttpHandler,
 } from "./registry.js";
+
+const SIGNING_SECRET = "test-signing-secret-abc123";
+const NOW_S = Math.floor(Date.now() / 1000);
+
+function freshTimestamp(): string {
+  return String(NOW_S);
+}
+
+function makeSignature(secret: string, timestamp: string, body: string): string {
+  const base = `v0:${timestamp}:${body}`;
+  return `v0=${createHmac("sha256", secret).update(base).digest("hex")}`;
+}
 
 describe("normalizeSlackWebhookPath", () => {
   it("returns the default path when input is empty", () => {
@@ -52,6 +65,144 @@ describe("registerSlackHttpHandler", () => {
     const handled = await handleSlackHttpRequest(req, res);
 
     expect(handled).toBe(false);
+  });
+
+  it("dispatches without signingSecret (no pre-check)", async () => {
+    const handler = vi.fn();
+    unregisters.push(
+      registerSlackHttpHandler({
+        path: "/slack/open",
+        handler,
+        // no signingSecret — handler is responsible for its own auth
+      }),
+    );
+
+    const req = { url: "/slack/open", headers: {} } as IncomingMessage;
+    const res = {} as ServerResponse;
+
+    const handled = await handleSlackHttpRequest(req, res);
+
+    expect(handled).toBe(true);
+    expect(handler).toHaveBeenCalledWith(req, res);
+  });
+
+  it("pre-rejects requests with missing timestamp header when signingSecret is configured", async () => {
+    const handler = vi.fn();
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    unregisters.push(
+      registerSlackHttpHandler({
+        path: "/slack/events-signed",
+        handler,
+        signingSecret: SIGNING_SECRET,
+      }),
+    );
+
+    const req = {
+      url: "/slack/events-signed",
+      headers: {
+        // intentionally missing x-slack-request-timestamp
+        "x-slack-signature": "v0=fake",
+      },
+    } as unknown as IncomingMessage;
+    const res = { writeHead, end } as unknown as ServerResponse;
+
+    const handled = await handleSlackHttpRequest(req, res);
+
+    expect(handled).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+    expect(writeHead).toHaveBeenCalledWith(400, { "Content-Type": "text/plain" });
+    expect(end).toHaveBeenCalledWith(expect.stringMatching(/Timestamp/i));
+  });
+
+  it("pre-rejects requests with missing signature header when signingSecret is configured", async () => {
+    const handler = vi.fn();
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    unregisters.push(
+      registerSlackHttpHandler({
+        path: "/slack/events-signed2",
+        handler,
+        signingSecret: SIGNING_SECRET,
+      }),
+    );
+
+    const req = {
+      url: "/slack/events-signed2",
+      headers: {
+        "x-slack-request-timestamp": freshTimestamp(),
+        // intentionally missing x-slack-signature
+      },
+    } as unknown as IncomingMessage;
+    const res = { writeHead, end } as unknown as ServerResponse;
+
+    const handled = await handleSlackHttpRequest(req, res);
+
+    expect(handled).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+    expect(writeHead).toHaveBeenCalledWith(400, { "Content-Type": "text/plain" });
+  });
+
+  it("pre-rejects requests with a stale timestamp when signingSecret is configured", async () => {
+    const handler = vi.fn();
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    unregisters.push(
+      registerSlackHttpHandler({
+        path: "/slack/events-signed3",
+        handler,
+        signingSecret: SIGNING_SECRET,
+      }),
+    );
+
+    const staleTimestamp = String(NOW_S - 6 * 60); // 6 minutes ago
+    const body = "{}";
+    const sig = makeSignature(SIGNING_SECRET, staleTimestamp, body);
+
+    const req = {
+      url: "/slack/events-signed3",
+      headers: {
+        "x-slack-request-timestamp": staleTimestamp,
+        "x-slack-signature": sig,
+      },
+    } as unknown as IncomingMessage;
+    const res = { writeHead, end } as unknown as ServerResponse;
+
+    const handled = await handleSlackHttpRequest(req, res);
+
+    expect(handled).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+    expect(writeHead).toHaveBeenCalledWith(400, { "Content-Type": "text/plain" });
+    expect(end).toHaveBeenCalledWith(expect.stringMatching(/timestamp/i));
+  });
+
+  it("forwards to handler when timestamp is fresh (HMAC verified by handler)", async () => {
+    const handler = vi.fn();
+    unregisters.push(
+      registerSlackHttpHandler({
+        path: "/slack/events-signed4",
+        handler,
+        signingSecret: SIGNING_SECRET,
+      }),
+    );
+
+    const ts = freshTimestamp();
+    const body = '{"type":"event_callback"}';
+    const sig = makeSignature(SIGNING_SECRET, ts, body);
+
+    const req = {
+      url: "/slack/events-signed4",
+      headers: {
+        "x-slack-request-timestamp": ts,
+        "x-slack-signature": sig,
+      },
+    } as unknown as IncomingMessage;
+    const res = {} as ServerResponse;
+
+    const handled = await handleSlackHttpRequest(req, res);
+
+    expect(handled).toBe(true);
+    expect(handler).toHaveBeenCalledWith(req, res);
   });
 
   it("logs and ignores duplicate registrations", async () => {

--- a/src/slack/http/registry.ts
+++ b/src/slack/http/registry.ts
@@ -1,18 +1,41 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { verifySlackRequestSignature } from "./verify.js";
 
 export type SlackHttpRequestHandler = (
   req: IncomingMessage,
   res: ServerResponse,
 ) => Promise<void> | void;
 
+type SlackHttpRoute = {
+  handler: SlackHttpRequestHandler;
+  /**
+   * Slack app signing secret used to verify X-Slack-Signature on incoming
+   * requests. When present, the registry performs a timestamp staleness check
+   * before dispatching to the handler (fast pre-rejection without reading the
+   * body). Full HMAC verification must still be performed by the handler, or
+   * by wrapping with {@link withSlackSignatureVerification}.
+   *
+   * Security note: all HTTP-mode Slack routes SHOULD supply a signingSecret so
+   * that replayed / stale requests are rejected at the routing layer even before
+   * the handler reads the body.
+   */
+  signingSecret?: string;
+};
+
 type RegisterSlackHttpHandlerArgs = {
   path?: string | null;
   handler: SlackHttpRequestHandler;
+  /**
+   * Slack app signing secret for this route. When provided the registry will
+   * reject requests with a stale or missing X-Slack-Request-Timestamp header
+   * before forwarding to the handler.
+   */
+  signingSecret?: string;
   log?: (message: string) => void;
   accountId?: string;
 };
 
-const slackHttpRoutes = new Map<string, SlackHttpRequestHandler>();
+const slackHttpRoutes = new Map<string, SlackHttpRoute>();
 
 export function normalizeSlackWebhookPath(path?: string | null): string {
   const trimmed = path?.trim();
@@ -29,7 +52,10 @@ export function registerSlackHttpHandler(params: RegisterSlackHttpHandlerArgs): 
     params.log?.(`slack: webhook path ${normalizedPath} already registered${suffix}`);
     return () => {};
   }
-  slackHttpRoutes.set(normalizedPath, params.handler);
+  slackHttpRoutes.set(normalizedPath, {
+    handler: params.handler,
+    signingSecret: params.signingSecret,
+  });
   return () => {
     slackHttpRoutes.delete(normalizedPath);
   };
@@ -40,10 +66,38 @@ export async function handleSlackHttpRequest(
   res: ServerResponse,
 ): Promise<boolean> {
   const url = new URL(req.url ?? "/", "http://localhost");
-  const handler = slackHttpRoutes.get(url.pathname);
-  if (!handler) {
+  const route = slackHttpRoutes.get(url.pathname);
+  if (!route) {
     return false;
   }
-  await handler(req, res);
+
+  // Fast pre-rejection: if a signing secret is registered for this route,
+  // check the timestamp header before the body is read. This prevents the
+  // handler from processing obviously stale or replayed requests at zero cost.
+  // Full HMAC verification (which requires the body) is the handler's
+  // responsibility — see withSlackSignatureVerification().
+  if (route.signingSecret) {
+    const timestampResult = verifySlackRequestSignature({
+      signingSecret: route.signingSecret,
+      body: "", // body not yet read; we only need the timestamp check here
+      timestamp: req.headers["x-slack-request-timestamp"] as string | undefined,
+      signature: req.headers["x-slack-signature"] as string | undefined,
+    });
+    // Reject on missing/stale timestamp. An invalid HMAC at this stage is
+    // expected (body is empty), so only surface timestamp-related failures.
+    if (
+      !timestampResult.ok &&
+      (timestampResult.reason.includes("Timestamp") ||
+        timestampResult.reason.includes("timestamp") ||
+        timestampResult.reason.includes("Missing X-Slack-Request-Timestamp") ||
+        timestampResult.reason.includes("Missing X-Slack-Signature"))
+    ) {
+      res.writeHead(timestampResult.statusCode, { "Content-Type": "text/plain" });
+      res.end(timestampResult.reason);
+      return true;
+    }
+  }
+
+  await route.handler(req, res);
   return true;
 }

--- a/src/slack/http/verify.test.ts
+++ b/src/slack/http/verify.test.ts
@@ -1,0 +1,199 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { verifySlackRequestSignature } from "./verify.js";
+
+const SIGNING_SECRET = "8f742231b10e8888abcd99yyyzzz85a5";
+
+function makeSignature(secret: string, timestamp: string, body: string): string {
+  const baseString = `v0:${timestamp}:${body}`;
+  const hmac = createHmac("sha256", secret).update(baseString).digest("hex");
+  return `v0=${hmac}`;
+}
+
+const NOW_MS = 1_700_000_000_000;
+const FRESH_TIMESTAMP = String(Math.floor(NOW_MS / 1000));
+
+describe("verifySlackRequestSignature", () => {
+  it("returns ok=true for a valid signature", () => {
+    const body = '{"type":"event_callback"}';
+    const signature = makeSignature(SIGNING_SECRET, FRESH_TIMESTAMP, body);
+
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body,
+      timestamp: FRESH_TIMESTAMP,
+      signature,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a missing timestamp header (400)", () => {
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body: "{}",
+      timestamp: undefined,
+      signature: "v0=abc",
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(400);
+    expect(result.reason).toMatch(/Timestamp/i);
+  });
+
+  it("rejects a missing signature header (400)", () => {
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body: "{}",
+      timestamp: FRESH_TIMESTAMP,
+      signature: undefined,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(400);
+    expect(result.reason).toMatch(/Signature/i);
+  });
+
+  it("rejects a timestamp more than 5 minutes old (400)", () => {
+    const staleTimestamp = String(Math.floor(NOW_MS / 1000) - 6 * 60);
+    const body = "{}";
+    const signature = makeSignature(SIGNING_SECRET, staleTimestamp, body);
+
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body,
+      timestamp: staleTimestamp,
+      signature,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(400);
+    expect(result.reason).toMatch(/timestamp/i);
+  });
+
+  it("rejects a timestamp more than 5 minutes in the future (400)", () => {
+    const futureTimestamp = String(Math.floor(NOW_MS / 1000) + 6 * 60);
+    const body = "{}";
+    const signature = makeSignature(SIGNING_SECRET, futureTimestamp, body);
+
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body,
+      timestamp: futureTimestamp,
+      signature,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(400);
+    expect(result.reason).toMatch(/timestamp/i);
+  });
+
+  it("rejects a tampered body (401)", () => {
+    const body = '{"type":"event_callback"}';
+    const signature = makeSignature(SIGNING_SECRET, FRESH_TIMESTAMP, body);
+    const tamperedBody = '{"type":"event_callback","extra":"injected"}';
+
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body: tamperedBody,
+      timestamp: FRESH_TIMESTAMP,
+      signature,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(401);
+  });
+
+  it("rejects a wrong signing secret (401)", () => {
+    const body = "{}";
+    const signature = makeSignature("wrong-secret", FRESH_TIMESTAMP, body);
+
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body,
+      timestamp: FRESH_TIMESTAMP,
+      signature,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(401);
+  });
+
+  it("rejects a malformed signature string (401)", () => {
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body: "{}",
+      timestamp: FRESH_TIMESTAMP,
+      signature: "not-a-valid-signature",
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(401);
+  });
+
+  it("rejects a non-numeric timestamp (400)", () => {
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body: "{}",
+      timestamp: "not-a-number",
+      signature: "v0=abc",
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(400);
+  });
+
+  it("accepts a timestamp exactly at the 5-minute boundary", () => {
+    const borderTimestamp = String(Math.floor(NOW_MS / 1000) - 5 * 60);
+    const body = "{}";
+    const signature = makeSignature(SIGNING_SECRET, borderTimestamp, body);
+
+    const result = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body,
+      timestamp: borderTimestamp,
+      signature,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("is resistant to timing attacks (uses timingSafeEqual)", () => {
+    // This is a property test: ensure that a request with a completely wrong
+    // signature returns the same result shape as one with a nearly-right
+    // signature, verifying the function does not short-circuit.
+    const body = "{}";
+    const correctSignature = makeSignature(SIGNING_SECRET, FRESH_TIMESTAMP, body);
+    const almostCorrect = correctSignature.slice(0, -1) + "0"; // flip last char
+
+    const result1 = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body,
+      timestamp: FRESH_TIMESTAMP,
+      signature: almostCorrect,
+      nowMs: NOW_MS,
+    });
+    const result2 = verifySlackRequestSignature({
+      signingSecret: SIGNING_SECRET,
+      body,
+      timestamp: FRESH_TIMESTAMP,
+      signature: "v0=0000000000000000000000000000000000000000000000000000000000000000",
+      nowMs: NOW_MS,
+    });
+
+    expect(result1.ok).toBe(false);
+    expect(result2.ok).toBe(false);
+    expect(result1.statusCode).toBe(401);
+    expect(result2.statusCode).toBe(401);
+  });
+});

--- a/src/slack/http/verify.ts
+++ b/src/slack/http/verify.ts
@@ -1,0 +1,76 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const SLACK_SIGNATURE_VERSION = "v0";
+
+/**
+ * Maximum age of a Slack request before it is rejected as potentially replayed.
+ * Slack recommends 5 minutes.
+ */
+const SLACK_TIMESTAMP_MAX_AGE_MS = 5 * 60 * 1000;
+
+export type SlackSignatureVerificationResult =
+  | { ok: true }
+  | { ok: false; reason: string; statusCode: 400 | 401 };
+
+/**
+ * Verify a Slack request signature.
+ *
+ * Implements the verification algorithm described at:
+ * https://api.slack.com/authentication/verifying-requests-from-slack
+ *
+ * @param signingSecret - The Slack app signing secret (channels.slack.signingSecret)
+ * @param body          - The raw request body as a UTF-8 string (must be read before calling)
+ * @param timestamp     - Value of the X-Slack-Request-Timestamp header
+ * @param signature     - Value of the X-Slack-Signature header (format: "v0=<hex>")
+ * @param nowMs         - Current time in milliseconds (injectable for testing)
+ */
+export function verifySlackRequestSignature(params: {
+  signingSecret: string;
+  body: string;
+  timestamp: string | undefined;
+  signature: string | undefined;
+  nowMs?: number;
+}): SlackSignatureVerificationResult {
+  const { signingSecret, body, timestamp, signature, nowMs = Date.now() } = params;
+
+  if (!timestamp) {
+    return { ok: false, reason: "Missing X-Slack-Request-Timestamp header", statusCode: 400 };
+  }
+  if (!signature) {
+    return { ok: false, reason: "Missing X-Slack-Signature header", statusCode: 400 };
+  }
+
+  // Reject requests with a timestamp too far in the past or future (replay protection).
+  // CWE-294: Authentication Bypass by Capture-replay
+  const timestampMs = Number(timestamp) * 1000;
+  if (!Number.isFinite(timestampMs)) {
+    return { ok: false, reason: "Invalid X-Slack-Request-Timestamp value", statusCode: 400 };
+  }
+  if (Math.abs(nowMs - timestampMs) > SLACK_TIMESTAMP_MAX_AGE_MS) {
+    return {
+      ok: false,
+      reason: "X-Slack-Request-Timestamp is too old or too far in the future",
+      statusCode: 400,
+    };
+  }
+
+  // Compute the expected signature.
+  // Slack signature base string: "v0:{timestamp}:{body}"
+  const baseString = `${SLACK_SIGNATURE_VERSION}:${timestamp}:${body}`;
+  const hmacHex = createHmac("sha256", signingSecret).update(baseString).digest("hex");
+  const expected = `${SLACK_SIGNATURE_VERSION}=${hmacHex}`;
+
+  // Constant-time comparison to prevent timing oracle attacks.
+  // CWE-208: Observable Timing Discrepancy
+  const expectedBuf = Buffer.from(expected, "utf8");
+  const signatureBuf = Buffer.from(signature, "utf8");
+
+  if (
+    expectedBuf.length !== signatureBuf.length ||
+    !timingSafeEqual(expectedBuf, signatureBuf)
+  ) {
+    return { ok: false, reason: "Invalid X-Slack-Signature", statusCode: 401 };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary

Fixes: Slack webhook endpoints in HTTP mode dispatched incoming requests without verifying Slack's HMAC-SHA256 signature, allowing any attacker who knew a registered webhook path to forge or replay arbitrary Slack events.

- **`src/slack/http/verify.ts`** — new `verifySlackRequestSignature()` implementing Slack's signing algorithm per spec, with `timingSafeEqual` for constant-time comparison (CWE-208) and a 5-minute timestamp window for replay protection (CWE-294)
- **`src/slack/http/registry.ts`** — fast pre-rejection at the routing layer: stale/missing timestamp headers rejected before the body is read when a `signingSecret` is registered for a route
- **`src/slack/monitor/provider.ts`** — full HMAC-SHA256 verification after buffering the raw body, before forwarding to Bolt; 1 MB body size limit (DoS protection); `signingSecret` is now required when running in HTTP mode

## Test plan

- [x] `verifySlackRequestSignature` — valid signature accepted
- [x] `verifySlackRequestSignature` — missing timestamp header → 400
- [x] `verifySlackRequestSignature` — missing signature header → 400
- [x] `verifySlackRequestSignature` — stale timestamp (>5 min old) → 400
- [x] `verifySlackRequestSignature` — future timestamp (>5 min ahead) → 400
- [x] `verifySlackRequestSignature` — tampered body → 401
- [x] `verifySlackRequestSignature` — wrong signing secret → 401
- [x] `verifySlackRequestSignature` — malformed signature string → 401
- [x] `verifySlackRequestSignature` — non-numeric timestamp → 400
- [x] `verifySlackRequestSignature` — timestamp exactly at 5-min boundary accepted
- [x] `verifySlackRequestSignature` — timing attack resistance (timingSafeEqual)
- [x] Registry pre-rejects missing timestamp header when signingSecret configured
- [x] Registry pre-rejects missing signature header when signingSecret configured
- [x] Registry pre-rejects stale timestamp when signingSecret configured
- [x] Registry forwards to handler when timestamp is fresh
- [x] Registry routes requests to registered handler
- [x] Registry returns false when no handler matches
- [x] Registry dispatches without signingSecret (no pre-check)
- [x] Registry logs and ignores duplicate registrations
- [x] `normalizeSlackWebhookPath` — returns default path for empty input
- [x] `normalizeSlackWebhookPath` — ensures leading slash

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added HMAC-SHA256 signature verification to Slack HTTP webhooks to fix critical authentication bypass (F-01). The implementation follows Slack's official specification with constant-time comparison (`timingSafeEqual`) to prevent timing attacks and 5-minute timestamp validation for replay protection. Two-layer defense: registry pre-rejects stale timestamps before body reads, provider performs full HMAC verification after buffering. Signing secret now required for HTTP mode. Comprehensive test coverage validates all security scenarios including edge cases.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - implements critical security fix with proper cryptographic verification
- Implementation correctly follows Slack's authentication spec with timing-safe comparison, comprehensive replay protection, proper error handling, and extensive test coverage for all attack vectors including timing attacks, tampering, and stale timestamps. Defense-in-depth approach with early rejection at routing layer.
- No files require special attention

<sub>Last reviewed commit: 97902a9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->