### PR TITLE
feat(config): auto-rollback to last known-good backup on invalid config startup

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -14,6 +14,7 @@ export {
   resolveConfigSnapshotHash,
   setRuntimeConfigSnapshotRefreshHandler,
   setRuntimeConfigSnapshot,
+  tryLoadValidConfigBackup,
   writeConfigFile,
 } from "./io.js";
 export { migrateLegacyConfig } from "./legacy-migrate.js";

--- a/src/config/io.backup-rollback.test.ts
+++ b/src/config/io.backup-rollback.test.ts
@@ -33,7 +33,7 @@ describe("tryLoadValidConfigBackup", () => {
       expect(result).not.toBeNull();
       expect(result!.backupPath).toBe(`${configPath}.bak`);
       expect(result!.snapshot.valid).toBe(true);
-      expect(result!.snapshot.config).toEqual(goodConfig);
+      expect(result!.snapshot.config.gateway?.port).toBe(18789);
     });
   });
 
@@ -49,7 +49,7 @@ describe("tryLoadValidConfigBackup", () => {
       const result = await tryLoadValidConfigBackup(configPath);
       expect(result).not.toBeNull();
       expect(result!.backupPath).toBe(`${configPath}.bak.1`);
-      expect(result!.snapshot.config).toEqual(goodConfig);
+      expect(result!.snapshot.config.gateway?.port).toBe(18789);
     });
   });
 

--- a/src/config/io.backup-rollback.test.ts
+++ b/src/config/io.backup-rollback.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "./home-env.test-harness.js";
+import { tryLoadValidConfigBackup } from "./io.js";
+
+describe("tryLoadValidConfigBackup", () => {
+  async function setupConfigDir(home: string) {
+    const configDir = path.join(home, ".openclaw");
+    await fs.mkdir(configDir, { recursive: true });
+    return path.join(configDir, "openclaw.json");
+  }
+
+  it("returns null when no backup files exist", async () => {
+    await withTempHome("backup-rollback-", async (home) => {
+      const configPath = await setupConfigDir(home);
+      await fs.writeFile(configPath, '{"invalid": }', "utf-8");
+
+      const result = await tryLoadValidConfigBackup(configPath);
+      expect(result).toBeNull();
+    });
+  });
+
+  it("returns the first valid backup (.bak)", async () => {
+    await withTempHome("backup-rollback-", async (home) => {
+      const configPath = await setupConfigDir(home);
+      const goodConfig = { gateway: { port: 18789 } };
+
+      await fs.writeFile(configPath, "BROKEN", "utf-8");
+      await fs.writeFile(`${configPath}.bak`, JSON.stringify(goodConfig), "utf-8");
+
+      const result = await tryLoadValidConfigBackup(configPath);
+      expect(result).not.toBeNull();
+      expect(result!.backupPath).toBe(`${configPath}.bak`);
+      expect(result!.snapshot.valid).toBe(true);
+      expect(result!.snapshot.config).toEqual(goodConfig);
+    });
+  });
+
+  it("skips invalid backups and finds the next valid one", async () => {
+    await withTempHome("backup-rollback-", async (home) => {
+      const configPath = await setupConfigDir(home);
+      const goodConfig = { gateway: { port: 18789 } };
+
+      await fs.writeFile(configPath, "BROKEN", "utf-8");
+      await fs.writeFile(`${configPath}.bak`, "ALSO_BROKEN", "utf-8");
+      await fs.writeFile(`${configPath}.bak.1`, JSON.stringify(goodConfig), "utf-8");
+
+      const result = await tryLoadValidConfigBackup(configPath);
+      expect(result).not.toBeNull();
+      expect(result!.backupPath).toBe(`${configPath}.bak.1`);
+      expect(result!.snapshot.config).toEqual(goodConfig);
+    });
+  });
+
+  it("returns null when all backups are invalid", async () => {
+    await withTempHome("backup-rollback-", async (home) => {
+      const configPath = await setupConfigDir(home);
+
+      await fs.writeFile(configPath, "BROKEN", "utf-8");
+      await fs.writeFile(`${configPath}.bak`, "BROKEN_TOO", "utf-8");
+      await fs.writeFile(`${configPath}.bak.1`, '{"also": }', "utf-8");
+
+      const result = await tryLoadValidConfigBackup(configPath);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -49,6 +49,7 @@ import { normalizeConfigPaths } from "./normalize-paths.js";
 import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
+import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
@@ -1560,7 +1561,9 @@ export async function writeConfigFile(
 
 /**
  * Iterate through config backup files (.bak, .bak.1, …) and return the first
- * snapshot that passes validation.  Returns `null` when no usable backup exists.
+ * snapshot that passes the full config read pipeline ($include resolution,
+ * ${ENV} substitution, and Zod validation).
+ * Returns `null` when no usable backup exists.
  */
 export async function tryLoadValidConfigBackup(
   configPath: string,
@@ -1573,34 +1576,16 @@ export async function tryLoadValidConfigBackup(
 
   for (const candidate of candidates) {
     try {
-      const raw = await fs.promises.readFile(candidate, "utf-8");
-      const parsed = JSON5.parse(raw);
-      if (typeof parsed !== "object" || parsed === null) {
+      if (!fs.existsSync(candidate)) {
         continue;
       }
-
-      const validated = validateConfigObjectRawWithPlugins(parsed);
-      if (!validated.ok) {
-        continue;
+      const io = createConfigIO({ configPath: candidate });
+      const snapshot = await io.readConfigFileSnapshot();
+      if (snapshot.exists && snapshot.valid) {
+        return { snapshot, backupPath: candidate };
       }
-
-      return {
-        snapshot: {
-          path: candidate,
-          exists: true,
-          raw,
-          parsed,
-          resolved: parsed as OpenClawConfig,
-          valid: true,
-          config: parsed as OpenClawConfig,
-          issues: [],
-          warnings: validated.warnings ?? [],
-          legacyIssues: [],
-        },
-        backupPath: candidate,
-      };
     } catch {
-      // Backup missing or unreadable — try the next one.
+      // Backup unreadable or invalid — try the next one.
     }
   }
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1,10 +1,11 @@
+import JSON5 from "json5";
+import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
+import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
-import JSON5 from "json5";
-import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {
@@ -16,7 +17,7 @@ import {
 import { sanitizeTerminalText } from "../terminal/safe-text.js";
 import { VERSION } from "../version.js";
 import { DuplicateAgentDirError, findDuplicateAgentDirs } from "./agent-dirs.js";
-import { maintainConfigBackups } from "./backup-rotation.js";
+import { CONFIG_BACKUP_COUNT, maintainConfigBackups } from "./backup-rotation.js";
 import {
   applyCompactionDefaults,
   applyContextPruningDefaults,
@@ -48,7 +49,6 @@ import { normalizeConfigPaths } from "./normalize-paths.js";
 import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
-import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
@@ -1556,4 +1556,53 @@ export async function writeConfigFile(
   }
   // When we had no runtime snapshot, keep callers reading from disk/cache so external/manual
   // edits to openclaw.json remain visible (no stale snapshot).
+}
+
+/**
+ * Iterate through config backup files (.bak, .bak.1, …) and return the first
+ * snapshot that passes validation.  Returns `null` when no usable backup exists.
+ */
+export async function tryLoadValidConfigBackup(
+  configPath: string,
+): Promise<{ snapshot: ConfigFileSnapshot; backupPath: string } | null> {
+  const backupBase = `${configPath}.bak`;
+  const candidates = [backupBase];
+  for (let i = 1; i < CONFIG_BACKUP_COUNT; i++) {
+    candidates.push(`${backupBase}.${i}`);
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const raw = await fs.promises.readFile(candidate, "utf-8");
+      const parsed = JSON5.parse(raw);
+      if (typeof parsed !== "object" || parsed === null) {
+        continue;
+      }
+
+      const validated = validateConfigObjectRawWithPlugins(parsed);
+      if (!validated.ok) {
+        continue;
+      }
+
+      return {
+        snapshot: {
+          path: candidate,
+          exists: true,
+          raw,
+          parsed,
+          resolved: parsed as OpenClawConfig,
+          valid: true,
+          config: parsed as OpenClawConfig,
+          issues: [],
+          warnings: validated.warnings ?? [],
+          legacyIssues: [],
+        },
+        backupPath: candidate,
+      };
+    } catch {
+      // Backup missing or unreadable — try the next one.
+    }
+  }
+
+  return null;
 }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1,11 +1,10 @@
-import JSON5 from "json5";
-import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
-import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
+import JSON5 from "json5";
+import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,15 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { CanvasHostServer } from "../canvas-host/server.js";
-import type { PluginServicesHandle } from "../plugins/services.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { ControlUiRootState } from "./control-ui.js";
-import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
+import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createDefaultDeps } from "../cli/deps.js";
@@ -73,12 +69,14 @@ import { runSetupWizard } from "../wizard/setup.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
+import type { ControlUiRootState } from "./control-ui.js";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { NodeRegistry } from "./node-registry.js";
+import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
 import { createGatewayCloseHandler } from "./server-close.js";
@@ -404,14 +402,13 @@ export async function startGatewayServer(
       await writeConfigFile(backup.snapshot.config);
       configSnapshot = await readConfigFileSnapshot();
       assertValidGatewayStartupConfigSnapshot(configSnapshot);
+      const brokenMsg = brokenSaved
+        ? `Broken config saved to: ${brokenDest}`
+        : `Failed to save broken config to: ${brokenDest}`;
       log.warn(
         `gateway: invalid config detected - rolled back to last known-good backup.\n` +
           `  Original errors:\n${issues}\n` +
-          `  ${
-            brokenSaved
-              ? `Broken config saved to: ${brokenDest}`
-              : "Failed to save broken config copy"
-          }\n` +
+          `  ${brokenMsg}\n` +
           `  Restored from: ${backup.backupPath}`,
       );
     } else {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,10 +1,15 @@
+import fs from "node:fs";
 import path from "node:path";
+import type { CanvasHostServer } from "../canvas-host/server.js";
+import type { PluginServicesHandle } from "../plugins/services.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { ControlUiRootState } from "./control-ui.js";
+import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
-import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createDefaultDeps } from "../cli/deps.js";
@@ -17,6 +22,7 @@ import {
   loadConfig,
   migrateLegacyConfig,
   readConfigFileSnapshot,
+  tryLoadValidConfigBackup,
   writeConfigFile,
 } from "../config/config.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
@@ -50,9 +56,7 @@ import { resolveConfiguredDeferredChannelPluginIds } from "../plugins/channel-pl
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
-import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
-import type { RuntimeEnv } from "../runtime.js";
 import type { CommandSecretAssignment } from "../secrets/command-config.js";
 import {
   GATEWAY_AUTH_SURFACE_PATHS,
@@ -69,14 +73,12 @@ import { runSetupWizard } from "../wizard/setup.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
-import type { ControlUiRootState } from "./control-ui.js";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { NodeRegistry } from "./node-registry.js";
-import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
 import { createGatewayCloseHandler } from "./server-close.js";
@@ -383,6 +385,42 @@ export async function startGatewayServer(
   }
 
   configSnapshot = await readConfigFileSnapshot();
+  if (configSnapshot.exists && !configSnapshot.valid) {
+    const issues =
+      configSnapshot.issues.length > 0
+        ? formatConfigIssueLines(configSnapshot.issues, "", { normalizeRoot: true }).join("\n")
+        : "Unknown validation issue.";
+
+    const backup = await tryLoadValidConfigBackup(configSnapshot.path);
+    if (backup) {
+      const brokenDest = `${configSnapshot.path}.broken-${Date.now()}`;
+      let brokenSaved = false;
+      try {
+        await fs.promises.copyFile(configSnapshot.path, brokenDest);
+        brokenSaved = true;
+      } catch {
+        // best-effort: preserve the broken config for debugging
+      }
+      await writeConfigFile(backup.snapshot.config);
+      configSnapshot = await readConfigFileSnapshot();
+      assertValidGatewayStartupConfigSnapshot(configSnapshot);
+      log.warn(
+        `gateway: invalid config detected - rolled back to last known-good backup.\n` +
+          `  Original errors:\n${issues}\n` +
+          `  ${
+            brokenSaved
+              ? `Broken config saved to: ${brokenDest}`
+              : "Failed to save broken config copy"
+          }\n` +
+          `  Restored from: ${backup.backupPath}`,
+      );
+    } else {
+      throw new Error(
+        `Invalid config at ${configSnapshot.path}.\n${issues}\n` +
+          `No usable backup found - run "${formatCliCommand("openclaw doctor")}" to repair, then retry.`,
+      );
+    }
+  }
   if (configSnapshot.exists) {
     assertValidGatewayStartupConfigSnapshot(configSnapshot, { includeDoctorHint: true });
   }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -52,7 +52,9 @@ import { resolveConfiguredDeferredChannelPluginIds } from "../plugins/channel-pl
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
+import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
+import type { RuntimeEnv } from "../runtime.js";
 import type { CommandSecretAssignment } from "../secrets/command-config.js";
 import {
   GATEWAY_AUTH_SURFACE_PATHS,


### PR DESCRIPTION
## TL;DR for maintainers

When `openclaw.json` fails validation at gateway startup, the gateway now
automatically restores the most recent valid `.bak` backup instead of crashing
into an unrecoverable restart loop.  The broken config is preserved as
`openclaw.json.broken-<timestamp>` for debugging.

Closes #18200

---

## Problem

If a user (or an agent via `config.patch`) writes a broken `openclaw.json`,
the gateway throws at startup and exits.  Process supervisors (`launchd`,
`systemd`) immediately restart it — into the same crash.  Because the gateway
**is** the bot connection, users cannot fix the config through the UI and are
stuck in a silent failure loop (see [tweet with 828 likes](https://x.com/xBenJamminx/status/1888741825891164190)).

## Solution

OpenClaw already creates up to 5 rotated backups (`.bak`, `.bak.1`, …,
`.bak.4`) every time `writeConfigFile` persists a change.  This PR adds the
**restore** side:

1. **`tryLoadValidConfigBackup(configPath)`** (`src/config/io.ts`)
   Iterates `.bak` → `.bak.4`, reads + validates each file, and returns the
   first snapshot that passes `validateConfigObjectRawWithPlugins`.  Returns
   `null` when no usable backup exists.

2. **Gateway startup fallback** (`src/gateway/server.impl.ts`)
   When `configSnapshot.exists && !configSnapshot.valid`:
   - Copies the broken config to `openclaw.json.broken-<timestamp>` (best-effort)
   - Calls `tryLoadValidConfigBackup` — if a valid backup is found, writes it
     back to `openclaw.json` and continues startup with a loud `log.warn`
   - If no backup is valid, throws the same error as before (with an updated
     message noting that no backup was found)

3. **Re-export** (`src/config/config.ts`) — exposes the new helper.

## What's NOT in this PR

- Notification via messaging channel on rollback (Issue #18200 item 3 — separate PR)
- Crash-loop rate limiting (tracked in #16810)

## Testing

- 4 new unit tests for `tryLoadValidConfigBackup`:
  - Returns `null` when no backups exist
  - Finds first valid `.bak`
  - Skips invalid backups and finds the next valid one
  - Returns `null` when all backups are invalid
- All existing config IO tests pass (8/8 write-config, 25/25 config-misc)

## AI disclosure

This change was AI-assisted (research + implementation). All code was manually
reviewed and tested by the author.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automatic config rollback to prevent crash loops when `openclaw.json` fails validation at gateway startup. The gateway now attempts to restore from up to 5 rotated backups (`.bak` through `.bak.4`) when the config is invalid, preserving the broken config as `openclaw.json.broken-<timestamp>` for debugging. If no valid backup exists, the gateway throws an error as before.

The implementation is well-structured with clear separation of concerns:
- `tryLoadValidConfigBackup` in `src/config/io.ts` handles the backup search and validation logic
- Gateway startup in `src/gateway/server.impl.ts` orchestrates the rollback when needed
- Comprehensive test coverage validates all rollback scenarios

The rollback logic correctly leverages the existing backup rotation system (5 backups created on each config write) and uses the same validation function (`validateConfigObjectRawWithPlugins`) to ensure consistency. The broken config is preserved for debugging before restoration, and a warning is logged with full details about the rollback.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - the implementation is well-designed, thoroughly tested, and solves a critical crash-loop issue without introducing risk.
- The code follows existing patterns, includes comprehensive unit tests covering all scenarios (no backups, first valid backup, skipping invalid backups, all invalid), and handles edge cases properly with best-effort error handling where appropriate. The rollback logic integrates cleanly with the existing config validation and backup rotation systems. No breaking changes or risky modifications to core logic.
- No files require special attention

<sub>Last reviewed commit: 73fcbf9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->