### PR TITLE
fix #21914 - Add the most obvious option to the error message

### DIFF
--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -316,7 +316,8 @@ clawdock-devices() {
     echo ""
     echo -e "${_CLR_CYAN}💡 If you see token errors above:${_CLR_RESET}"
     echo -e "   1. Verify token is set: $(_cmd clawdock-token)"
-    echo "   2. Try manual config inside container:"
+    echo "   2. Try fixing the token automatically: $(_cmd clawdock-fix-token)"
+    echo "   3. If you still see errors, try manual config inside container:"
     echo -e "      $(_cmd clawdock-shell)"
     echo -e "      $(_cmd 'openclaw config get gateway.remote.token')"
     return 1

--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -316,7 +316,7 @@ clawdock-devices() {
     echo ""
     echo -e "${_CLR_CYAN}💡 If you see token errors above:${_CLR_RESET}"
     echo -e "   1. Verify token is set: $(_cmd clawdock-token)"
-    echo "   2. Try fixing the token automatically: $(_cmd clawdock-fix-token)"
+    echo -e "   2. Try fixing the token automatically: $(_cmd clawdock-fix-token)"
     echo "   3. If you still see errors, try manual config inside container:"
     echo -e "      $(_cmd clawdock-shell)"
     echo -e "      $(_cmd 'openclaw config get gateway.remote.token')"


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: See #21914 
- Why it matters:  This can lead to user uninstalling openclaw as they cannot connect to dashboard on browser
- What changed: `clawdock` helper -> `clawdock-devices` command's log output
- What did NOT change (scope boundary): Anything except `clawdock` script

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21914

## User-visible / Behavior Changes

Now, the trouble-shooting options at the end of `clawdock-devices`  command shows the following:

```
💡 If you see token errors above:
   1. Verify token is set: clawdock-token
   2. Try fixing the token automatically: clawdock-fix-token
   3. If you still see errors, try manual config inside container:
      clawdock-shell
      openclaw config get gateway.remote.token
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Docker
- Model/provider: NA
- Integration/channel (if any): NA
- Relevant config (redacted): NA

### Steps

Same as in bug #21914 

### Expected

Same as in bug #21914 

### Actual

Same as in bug #21914 

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

<img width="2013" height="937" alt="image" src="https://github.com/user-attachments/assets/285e80fd-5bec-460e-9253-0589a3d193d3" />

Logs (AFTER FIX):

```
$ clawdock-devices
🔍 Checking device pairings...
gateway connect failed: Error: unauthorized: device token mismatch (rotate/reissue device token)
[openclaw] CLI failed: Error: gateway closed (1008): unauthorized: device token mismatch (rotate/reissue device token)
Gateway target: ws://127.0.0.1:18789
Source: local loopback
Config: /home/node/.openclaw/openclaw.json
Bind: loopback
    at Object.onClose (file:///app/dist/call-UGOrZHFc.js:266:10)
    at WebSocket.<anonymous> (file:///app/dist/client-z7qQOWgJ.js:1512:23)
    at WebSocket.emit (node:events:519:28)
    at WebSocket.emitClose (/app/node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/websocket.js:273:10)
    at Socket.socketOnClose (/app/node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/websocket.js:1346:15)
    at Socket.emit (node:events:519:28)
    at TCP.<anonymous> (node:net:346:12)

💡 If you see token errors above:
   1. Verify token is set: clawdock-token
   2. Try fixing the token automatically: clawdock-fix-token
   3. If you still see errors, try manual config inside container:
      clawdock-shell
      openclaw config get gateway.remote.token


```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: CLI output verified personally for `clawdock-devices`
- Edge cases checked: NA
- What you did **not** verify: NA

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: Revert the file  `scripts/shell-helpers/clawdock-helpers.sh`
- Known bad symptoms reviewers should watch for: None

## Risks and Mitigations

None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a troubleshooting step to the `clawdock-devices` error output that suggests using `clawdock-fix-token` before resorting to manual configuration. This improves the user experience by providing an automated fix option between basic verification and manual intervention.

**Key changes:**
- Added step 2: "Try fixing the token automatically: `clawdock-fix-token`"
- Renumbered manual config step from 2 to 3
- Maintains consistent formatting with `-e` flag for color-coded output

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple, localized text output modification that adds a helpful troubleshooting step. It references an existing, working function (`clawdock-fix-token`), follows established formatting patterns, and improves user experience without changing any logic or behavior
- No files require special attention

<sub>Last reviewed commit: 5613c99</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->