### PR TITLE
feat(gateway): crash-loop protection with escalating backoff

### DIFF
--- a/src/cli/gateway-cli/crash-loop-guard.test.ts
+++ b/src/cli/gateway-cli/crash-loop-guard.test.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyCrashLoopGuard,
+  clearGatewayCrashHistory,
+  CrashLoopError,
+  recordGatewayCrash,
+  _TEST_ONLY,
+} from "./crash-loop-guard.js";
+
+const { CRASH_WINDOW_MS, BACKOFF_THRESHOLD, MAX_CRASHES } = _TEST_ONLY;
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "crash-guard-"));
+}
+
+function rmDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("crash-loop-guard", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs) {
+      rmDir(d);
+    }
+    dirs.length = 0;
+  });
+
+  function tempDir(): string {
+    const d = makeTempDir();
+    dirs.push(d);
+    return d;
+  }
+
+  describe("recordGatewayCrash / clearGatewayCrashHistory", () => {
+    it("records crash timestamps and clears them", () => {
+      const dir = tempDir();
+      recordGatewayCrash(dir, 1000);
+      recordGatewayCrash(dir, 2000);
+
+      const raw = JSON.parse(
+        fs.readFileSync(path.join(dir, "gateway-crash-history.json"), "utf-8"),
+      );
+      expect(raw.crashes).toEqual([1000, 2000]);
+
+      clearGatewayCrashHistory(dir);
+      const cleared = JSON.parse(
+        fs.readFileSync(path.join(dir, "gateway-crash-history.json"), "utf-8"),
+      );
+      expect(cleared.crashes).toEqual([]);
+    });
+
+    it("prunes timestamps outside the window", () => {
+      const dir = tempDir();
+      const now = Date.now();
+      const old = now - CRASH_WINDOW_MS - 1000;
+      recordGatewayCrash(dir, old);
+      recordGatewayCrash(dir, now);
+
+      const raw = JSON.parse(
+        fs.readFileSync(path.join(dir, "gateway-crash-history.json"), "utf-8"),
+      );
+      expect(raw.crashes).toEqual([now]);
+    });
+  });
+
+  describe("applyCrashLoopGuard", () => {
+    it("does nothing when crash history is empty", async () => {
+      const dir = tempDir();
+      const sleep = vi.fn(async () => {});
+      await applyCrashLoopGuard({
+        stateDir: dir,
+        sleep,
+        logger: { warn: vi.fn(), error: vi.fn() },
+      });
+      expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it("does nothing for fewer than BACKOFF_THRESHOLD crashes", async () => {
+      const dir = tempDir();
+      const now = Date.now();
+      for (let i = 0; i < BACKOFF_THRESHOLD - 1; i++) {
+        recordGatewayCrash(dir, now - i * 1000);
+      }
+
+      const sleep = vi.fn(async () => {});
+      await applyCrashLoopGuard({
+        stateDir: dir,
+        now: () => now,
+        sleep,
+        logger: { warn: vi.fn(), error: vi.fn() },
+      });
+      expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it("applies 30s backoff for 4-6 crashes", async () => {
+      const dir = tempDir();
+      const now = Date.now();
+      for (let i = 0; i < 5; i++) {
+        recordGatewayCrash(dir, now - i * 1000);
+      }
+
+      const sleep = vi.fn(async () => {});
+      const warn = vi.fn();
+      await applyCrashLoopGuard({
+        stateDir: dir,
+        now: () => now,
+        sleep,
+        logger: { warn, error: vi.fn() },
+      });
+      expect(sleep).toHaveBeenCalledWith(30_000);
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it("applies 5-min backoff for 7+ crashes", async () => {
+      const dir = tempDir();
+      const now = Date.now();
+      for (let i = 0; i < 8; i++) {
+        recordGatewayCrash(dir, now - i * 1000);
+      }
+
+      const sleep = vi.fn(async () => {});
+      await applyCrashLoopGuard({
+        stateDir: dir,
+        now: () => now,
+        sleep,
+        logger: { warn: vi.fn(), error: vi.fn() },
+      });
+      expect(sleep).toHaveBeenCalledWith(5 * 60 * 1000);
+    });
+
+    it("throws CrashLoopError after MAX_CRASHES", async () => {
+      const dir = tempDir();
+      const now = Date.now();
+      for (let i = 0; i < MAX_CRASHES; i++) {
+        recordGatewayCrash(dir, now - i * 1000);
+      }
+
+      await expect(
+        applyCrashLoopGuard({
+          stateDir: dir,
+          now: () => now,
+          sleep: vi.fn(async () => {}),
+          logger: { warn: vi.fn(), error: vi.fn() },
+        }),
+      ).rejects.toThrow(CrashLoopError);
+    });
+
+    it("ignores corrupt history file gracefully", async () => {
+      const dir = tempDir();
+      fs.writeFileSync(path.join(dir, "gateway-crash-history.json"), "NOT JSON", "utf-8");
+
+      const sleep = vi.fn(async () => {});
+      await applyCrashLoopGuard({
+        stateDir: dir,
+        sleep,
+        logger: { warn: vi.fn(), error: vi.fn() },
+      });
+      expect(sleep).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cli/gateway-cli/crash-loop-guard.ts
+++ b/src/cli/gateway-cli/crash-loop-guard.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Crash-loop protection for the gateway process.
+ *
+ * Tracks recent crash timestamps in a lightweight JSON file inside the state
+ * directory and applies an escalating backoff schedule when the gateway keeps
+ * crashing within a sliding window:
+ *
+ *   1-3  crashes  →  immediate restart  (current behaviour)
+ *   4-6  crashes  →  30 s delay
+ *   7-9  crashes  →  5 min delay
+ *   10+  crashes  →  refuse to start, write crash report
+ *
+ * See issue #16810.
+ */
+
+const CRASH_HISTORY_FILENAME = "gateway-crash-history.json";
+const CRASH_WINDOW_MS = 15 * 60 * 1000; // 15-minute sliding window
+const BACKOFF_THRESHOLD = 3;
+const MAX_CRASHES = 10;
+
+const BACKOFF_TIERS: ReadonlyArray<{ minCrashes: number; delayMs: number }> = [
+  { minCrashes: 7, delayMs: 5 * 60 * 1000 },
+  { minCrashes: 4, delayMs: 30 * 1000 },
+];
+
+export interface CrashHistory {
+  crashes: number[];
+}
+
+export interface CrashLoopGuardDeps {
+  stateDir: string;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  logger: { warn: (msg: string) => void; error: (msg: string) => void };
+}
+
+function crashHistoryPath(stateDir: string): string {
+  return path.join(stateDir, CRASH_HISTORY_FILENAME);
+}
+
+function readCrashHistory(filePath: string): CrashHistory {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as CrashHistory;
+    if (Array.isArray(parsed?.crashes)) {
+      return { crashes: parsed.crashes.filter((t) => typeof t === "number") };
+    }
+  } catch {
+    // missing or corrupt — start fresh
+  }
+  return { crashes: [] };
+}
+
+function writeCrashHistory(filePath: string, history: CrashHistory): void {
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(history, null, 2), "utf-8");
+  } catch {
+    // best-effort — don't let crash tracking itself break startup
+  }
+}
+
+function resolveBackoffMs(recentCount: number): number {
+  for (const tier of BACKOFF_TIERS) {
+    if (recentCount >= tier.minCrashes) {
+      return tier.delayMs;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Record a crash timestamp.  Safe to call from a synchronous
+ * `process.on('exit')` handler because it uses only sync I/O.
+ */
+export function recordGatewayCrash(stateDir: string, now: number = Date.now()): void {
+  const filePath = crashHistoryPath(stateDir);
+  const history = readCrashHistory(filePath);
+  history.crashes.push(now);
+  const cutoff = now - CRASH_WINDOW_MS;
+  history.crashes = history.crashes.filter((t) => t > cutoff);
+  writeCrashHistory(filePath, history);
+}
+
+/**
+ * Clear the crash history (called after a healthy startup period).
+ */
+export function clearGatewayCrashHistory(stateDir: string): void {
+  const filePath = crashHistoryPath(stateDir);
+  writeCrashHistory(filePath, { crashes: [] });
+}
+
+export class CrashLoopError extends Error {
+  public readonly recentCrashCount: number;
+  constructor(count: number, windowMinutes: number) {
+    super(
+      `CRASH LOOP DETECTED: ${count} crashes in the last ${windowMinutes} minutes. ` +
+        `The gateway will not restart automatically. ` +
+        `Fix the root cause, then run the gateway manually.`,
+    );
+    this.name = "CrashLoopError";
+    this.recentCrashCount = count;
+  }
+}
+
+/**
+ * Inspect crash history and apply backoff if needed.  Throws
+ * `CrashLoopError` when the crash count exceeds the hard limit.
+ */
+export async function applyCrashLoopGuard(deps: CrashLoopGuardDeps): Promise<void> {
+  const now = (deps.now ?? Date.now)();
+  const filePath = crashHistoryPath(deps.stateDir);
+  const history = readCrashHistory(filePath);
+  const cutoff = now - CRASH_WINDOW_MS;
+  const recentCrashes = history.crashes.filter((t) => t > cutoff);
+
+  if (recentCrashes.length >= MAX_CRASHES) {
+    throw new CrashLoopError(recentCrashes.length, CRASH_WINDOW_MS / 60_000);
+  }
+
+  if (recentCrashes.length >= BACKOFF_THRESHOLD) {
+    const delayMs = resolveBackoffMs(recentCrashes.length);
+    if (delayMs > 0) {
+      deps.logger.warn(
+        `Crash-loop backoff: ${recentCrashes.length} crashes in the last ${CRASH_WINDOW_MS / 60_000} min — ` +
+          `waiting ${delayMs / 1000}s before starting gateway.`,
+      );
+      const sleep = deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+      await sleep(delayMs);
+    }
+  }
+}
+
+// Re-export constants for testing
+export const _TEST_ONLY = {
+  CRASH_WINDOW_MS,
+  BACKOFF_THRESHOLD,
+  MAX_CRASHES,
+  BACKOFF_TIERS,
+} as const;

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -220,12 +220,6 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     throw err;
   }
 
-  process.on("exit", (code) => {
-    if (code !== 0) {
-      recordGatewayCrash(stateDir);
-    }
-  });
-
   if (devMode) {
     await ensureDevGatewayConfig({ reset: Boolean(opts.reset) });
   }
@@ -451,7 +445,17 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
         }
       : undefined;
 
+<<<<<<< HEAD
   const startLoop = async () =>
+=======
+  process.on("exit", (code) => {
+    if (code !== 0) {
+      recordGatewayCrash(stateDir);
+    }
+  });
+
+  try {
+>>>>>>> 430b320cd0 (fix: register crash-recording exit handler after all validation passes)
     await runGatewayLoop({
       runtime: defaultRuntime,
       lockPort: port,

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -1,8 +1,9 @@
-import fs from "node:fs";
-import path from "node:path";
 import type { Command } from "commander";
 import { readSecretFromFile } from "../../acp/secret-file.js";
+import fs from "node:fs";
+import path from "node:path";
 import type { GatewayAuthMode, GatewayTailscaleMode } from "../../config/config.js";
+import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import {
   CONFIG_PATH,
   loadConfig,
@@ -13,7 +14,6 @@ import {
 import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
 import { startGatewayServer } from "../../gateway/server.js";
-import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
@@ -26,6 +26,12 @@ import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { forceFreePortAndWait, waitForPortBindable } from "../ports.js";
+import {
+  applyCrashLoopGuard,
+  CrashLoopError,
+  clearGatewayCrashHistory,
+  recordGatewayCrash,
+} from "./crash-loop-guard.js";
 import { ensureDevGatewayConfig } from "./dev.js";
 import { runGatewayLoop } from "./run-loop.js";
 import {
@@ -198,6 +204,27 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   if (rawStreamPath) {
     process.env.OPENCLAW_RAW_STREAM_PATH = rawStreamPath;
   }
+
+  const stateDir = resolveStateDir(process.env);
+  try {
+    await applyCrashLoopGuard({
+      stateDir,
+      logger: gatewayLog,
+    });
+  } catch (err) {
+    if (err instanceof CrashLoopError) {
+      defaultRuntime.error(err.message);
+      defaultRuntime.exit(1);
+      return;
+    }
+    throw err;
+  }
+
+  process.on("exit", (code) => {
+    if (code !== 0) {
+      recordGatewayCrash(stateDir);
+    }
+  });
 
   if (devMode) {
     await ensureDevGatewayConfig({ reset: Boolean(opts.reset) });
@@ -428,12 +455,15 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     await runGatewayLoop({
       runtime: defaultRuntime,
       lockPort: port,
-      start: async () =>
-        await startGatewayServer(port, {
+      start: async () => {
+        const server = await startGatewayServer(port, {
           bind,
           auth: authOverride,
           tailscale: tailscaleOverride,
-        }),
+        });
+        clearGatewayCrashHistory(stateDir);
+        return server;
+      },
     });
 
   try {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -1,7 +1,7 @@
-import type { Command } from "commander";
-import { readSecretFromFile } from "../../acp/secret-file.js";
 import fs from "node:fs";
 import path from "node:path";
+import type { Command } from "commander";
+import { readSecretFromFile } from "../../acp/secret-file.js";
 import type { GatewayAuthMode, GatewayTailscaleMode } from "../../config/config.js";
 import {
   CONFIG_PATH,

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -3,7 +3,6 @@ import { readSecretFromFile } from "../../acp/secret-file.js";
 import fs from "node:fs";
 import path from "node:path";
 import type { GatewayAuthMode, GatewayTailscaleMode } from "../../config/config.js";
-import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import {
   CONFIG_PATH,
   loadConfig,
@@ -14,6 +13,7 @@ import {
 import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
 import { startGatewayServer } from "../../gateway/server.js";
+import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";


### PR DESCRIPTION
## TL;DR for maintainers

Adds built-in restart rate-limiting so the gateway stops burning CPU/disk
when it hits a fatal error that can't self-heal. Escalating backoff
(0 → 30 s → 5 min → hard stop) based on crash frequency in a 15-minute
sliding window. Zero behavioural change for healthy startups.

Closes #16810

---

## Problem

When the gateway process crashes, there is no rate limiting on restart
attempts. A single bad flag in `NODE_OPTIONS` or an invalid config entry
causes an unbounded crash loop — 18 restarts in 5 minutes was observed
in production, saturating CPU and disk I/O and taking down all channels
(Telegram, Discord, WhatsApp) for 30+ minutes.

System-level supervisors (`launchd`, `systemd`) handle process restarts
but cannot diagnose or fix the root cause — they just restart into the
same crash.

## Solution

A new self-contained module `src/cli/gateway-cli/crash-loop-guard.ts`
that:

1. **Records** crash timestamps to `<stateDir>/gateway-crash-history.json`
   via a synchronous `process.on('exit')` handler (safe for exit hooks).

2. **Checks** crash history at the very start of `runGatewayCommand` and
   applies an escalating backoff schedule:

   | Recent crashes (15 min window) | Action |
   |---|----|
   | 1–3 | Immediate restart (current behaviour) |
   | 4–6 | 30-second delay before starting |
   | 7–9 | 5-minute delay before starting |
   | 10+ | Refuse to start (`CrashLoopError`) |

3. **Clears** the crash history once `startGatewayServer` completes
   successfully, so normal restarts (SIGUSR1, config reload) are never
   penalised.

### Files changed

| File | Change |
|---|---|
| `src/cli/gateway-cli/crash-loop-guard.ts` | New module: `recordGatewayCrash`, `clearGatewayCrashHistory`, `applyCrashLoopGuard`, `CrashLoopError` |
| `src/cli/gateway-cli/crash-loop-guard.test.ts` | 8 unit tests covering all tiers + edge cases |
| `src/cli/gateway-cli/run.ts` | Integrate guard at startup + exit hook + clear on success |

## What's NOT in this PR

- Notification via messaging channel on crash loop (could be a follow-up)
- Systemd unit file template (docs-only, separate PR)

## Testing

- 8 new unit tests: empty history, below threshold, 30 s tier, 5 min tier,
  hard stop (CrashLoopError), corrupt file recovery
- Existing run-loop tests pass (4/4)

## AI disclosure

This change was AI-assisted (research + implementation). All code was
manually reviewed and tested by the author.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds escalating crash-loop protection for the gateway process to prevent unbounded restart attempts when hitting fatal errors. Tracks crash history in a 15-minute sliding window and applies graduated backoff (30s → 5min → hard stop) to protect against CPU/disk saturation.

**Key changes:**
- New `crash-loop-guard.ts` module with `recordGatewayCrash`, `clearGatewayCrashHistory`, and `applyCrashLoopGuard`
- Integration in `run.ts`: guard check at startup, exit handler to record crashes, clear history on successful server start
- 8 unit tests covering all backoff tiers, corrupt file recovery, and edge cases

**Issues found:**
- Exit handler registered before validation checks, causing config errors to be recorded as crashes (see inline comment)

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe but has a logic issue that needs fixing before merge
- The implementation is well-structured with good test coverage, but the exit handler placement causes validation errors to be incorrectly counted as crashes. This could lead to false crash-loop detection after config mistakes. The core crash-loop protection logic is sound, file I/O is safely handled, and the backoff tiers are reasonable. Fix the exit handler timing and this becomes a solid PR.
- Pay close attention to `src/cli/gateway-cli/run.ts` - the exit handler needs to be moved after validation checks

<sub>Last reviewed commit: 123ebcd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->