### PR TITLE
fix(line): remove redundant peer ID prefix and block monitor on abort signal (#21907, #21908)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- LINE: remove redundant `group:`/`room:` prefix from `buildPeerId` so peer-based binding routes match the raw group/room ID as documented. (#21907)
+- LINE: block `monitorLineProvider` on the abort signal so the gateway framework no longer treats the immediate return as a provider exit and enters an auto-restart crash-loop. (#21908)
+
 - macOS/Build: default release packaging to `BUNDLE_ID=ai.openclaw.mac` in `scripts/package-mac-dist.sh`, so Sparkle feed URL is retained and auto-update no longer fails with an empty appcast feed. (#19750) thanks @loganprit.
 
 - Signal/Outbound: preserve case for Base64 group IDs during outbound target normalization so cross-context routing and policy checks no longer break when group IDs include uppercase characters. (#5578) Thanks @heyhudson.

--- a/src/line/bot-message-context.ts
+++ b/src/line/bot-message-context.ts
@@ -51,10 +51,10 @@ export function getLineSourceInfo(source: EventSource): LineSourceInfo {
 
 function buildPeerId(source: EventSource): string {
   if (source.type === "group" && source.groupId) {
-    return `group:${source.groupId}`;
+    return source.groupId;
   }
   if (source.type === "room" && source.roomId) {
-    return `room:${source.roomId}`;
+    return source.roomId;
   }
   if (source.type === "user" && source.userId) {
     return source.userId;

--- a/src/line/monitor.lifecycle.test.ts
+++ b/src/line/monitor.lifecycle.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { monitorLineProvider } from "./monitor.js";
+
+describe("monitorLineProvider lifecycle", () => {
+  it("blocks until abort signal fires (#21908)", async () => {
+    const abortController = new AbortController();
+
+    const providerPromise = monitorLineProvider({
+      channelAccessToken: "test-token",
+      channelSecret: "test-secret",
+      accountId: "test",
+      config: {},
+      runtime: {},
+      abortSignal: abortController.signal,
+    });
+
+    // The provider must block (not resolve) while the abort signal is pending.
+    // If it resolves immediately the gateway framework treats it as an exit
+    // and triggers an auto-restart crash-loop.
+    const TIMEOUT_MS = 200;
+    const result = await Promise.race([
+      providerPromise.then(() => "provider-resolved" as const),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), TIMEOUT_MS)),
+    ]);
+
+    expect(result).toBe("timeout");
+
+    // After aborting, the provider should resolve.
+    abortController.abort();
+    const monitor = await providerPromise;
+    expect(monitor.account).toBeDefined();
+  });
+
+  it("resolves immediately when abort signal is already aborted (#21908)", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const monitor = await monitorLineProvider({
+      channelAccessToken: "test-token",
+      channelSecret: "test-secret",
+      accountId: "test",
+      config: {},
+      runtime: {},
+      abortSignal: abortController.signal,
+    });
+
+    expect(monitor.account).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug 1**: LINE `buildPeerId` adds redundant `group:`/`room:` prefix to peer IDs, breaking binding route matching.
- **Root cause**: `buildPeerId()` in `src/line/bot-message-context.ts` prepends `group:` to `source.groupId` and `room:` to `source.roomId`, but `matchesBindingScope()` compares peer IDs as raw strings — the binding's `peer.id` (e.g. `Cc7e3bece...`) never matches the prefixed runtime value (`group:Cc7e3bece...`).
- **Fix**: Return raw `source.groupId`/`source.roomId` from `buildPeerId()` without prefix.

- **Bug 2**: LINE `monitorLineProvider` returns immediately, causing auto-restart crash-loop.
- **Root cause**: `monitorLineProvider()` in `src/line/monitor.ts` is async but returns a `LineProviderMonitor` object immediately after registering the webhook. The gateway framework expects provider functions to block until the abort signal fires (as Telegram/Discord/Slack providers do).
- **Fix**: Add `await new Promise` that blocks until the abort signal fires, matching the Slack provider pattern.

Fixes #21907
Fixes #21908

## Problem

### #21907: Binding route mismatch

`buildPeerId()` returns `group:${source.groupId}` for group messages. This value is passed as `peer.id` to `resolveAgentRoute()`. The binding system does strict string comparison in `matchesBindingScope()`:

```
scope.peer.id !== match.peer.id
```

- Runtime peer.id: `group:cc7e3bece...` (with prefix)
- Binding peer.id: `cc7e3bece...` (raw, as configured by user)
- Result: no match → falls through to default agent

**Before fix:**
```
Input:  source.groupId = "Cc7e3bece1234567890abcdef"
Output: peer.id = "group:Cc7e3bece1234567890abcdef"
Route:  agentId = "main" (default, binding not matched)
Session key: agent:main:line:group:group:cc7e3bece... (double prefix)
```

### #21908: Provider crash-loop

`monitorLineProvider()` returns immediately after registering the webhook HTTP route. The gateway's `trackedPromise` chain in `server-channels.ts` interprets this as "provider exited" and triggers auto-restart with exponential backoff:

```
[line] [default] starting LINE provider (Bot Name)
[line] [default] auto-restart attempt 1/10 in 5s
[line] [default] auto-restart attempt 2/10 in 11s
...
```

## Changes

- `src/line/bot-message-context.ts` — Remove `group:`/`room:` prefix from `buildPeerId()`, return raw IDs
- `src/line/monitor.ts` — Add `await new Promise` before return that blocks until abort signal fires

**After fix:**
```
Input:  source.groupId = "Cc7e3bece1234567890abcdef"
Output: peer.id = "Cc7e3bece1234567890abcdef"
Route:  agentId = "line-group-agent" (binding matched)
Session key: agent:line-group-agent:line:group:cc7e3bece... (correct)
```

Monitor blocks correctly — race against 200ms timeout returns `timeout` (provider still running).

## Test plan

- [x] New test: group peer binding matches raw groupId without prefix (#21907)
- [x] New test: room peer binding matches raw roomId without prefix (#21907)
- [x] New test: monitorLineProvider blocks until abort signal fires (#21908)
- [x] New test: monitorLineProvider resolves immediately when abort signal already aborted (#21908)
- [x] All 107 existing LINE tests pass
- [x] Format check passes (`pnpm format:check`)
- [x] Lint passes (`pnpm lint`)

## Effect on User Experience

**Before:** LINE group messages always route to the default agent, ignoring peer-based bindings. LINE provider enters a crash-loop on startup, cycling through 10 restart attempts before giving up.

**After:** LINE group/room messages correctly route to the agent specified in peer-based bindings. LINE provider stays running until explicitly stopped.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two critical LINE provider bugs: peer-based routing now works correctly by removing redundant prefixes from peer IDs, and the provider no longer crashes in an auto-restart loop. The fixes are well-tested with 4 new tests validating both the binding route matching and the blocking lifecycle behavior. All changes are surgical and focused on the root causes identified in the PR description.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fixes are surgical, well-tested, and address clear bugs with documented root causes. The blocking pattern matches the established Slack provider pattern exactly. Tests validate the fixes work correctly and the addressing logic remains unaffected.
- No files require special attention

<sub>Last reviewed commit: ee50b90</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->