### PR TITLE
feat(whatsapp): sender prefix on BodyForAgent + contactNames config

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -103,6 +103,12 @@ export type WhatsAppConfig = {
   debounceMs?: number;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /**
+   * Optional mapping of E.164 phone numbers to display names.
+   * Overrides WhatsApp push-names in agent context (BodyForAgent / SenderName).
+   * Example: `{ "+15551234567": "Alice Smith" }`
+   */
+  contactNames?: Record<string, string>;
 };
 
 export type WhatsAppAccountConfig = {
@@ -153,4 +159,10 @@ export type WhatsAppAccountConfig = {
   debounceMs?: number;
   /** Heartbeat visibility settings for this account. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /**
+   * Optional mapping of E.164 phone numbers to display names.
+   * Overrides WhatsApp push-names in agent context (BodyForAgent / SenderName).
+   * Example: `{ "+15551234567": "Alice Smith" }`
+   */
+  contactNames?: Record<string, string>;
 };

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -55,6 +55,7 @@ const WhatsAppSharedSchema = z.object({
   ackReaction: WhatsAppAckReactionSchema,
   debounceMs: z.number().int().nonnegative().optional().default(0),
   heartbeat: ChannelHeartbeatVisibilitySchema,
+  contactNames: z.record(z.string(), z.string()).optional(),
 });
 
 function enforceOpenDmPolicyAllowFromStar(params: {

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -28,6 +28,7 @@ export type ResolvedWhatsAppAccount = {
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  contactNames?: Record<string, string>;
 };
 
 const { listConfiguredAccountIds, listAccountIds, resolveDefaultAccountId } =
@@ -148,6 +149,7 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
+    contactNames: accountCfg?.contactNames ?? rootCfg?.contactNames,
   };
 }
 

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -38,6 +38,7 @@ import { maybeSendAckReaction } from "./ack-reaction.js";
 import { formatGroupMembers } from "./group-members.js";
 import { trackBackgroundTask, updateLastRouteInBackground } from "./last-route.js";
 import { buildInboundLine } from "./message-line.js";
+import { resolveDmSenderName } from "./resolve-contact-name.js";
 
 export type GroupHistoryEntry = {
   sender: string;
@@ -284,9 +285,21 @@ export async function processMessage(params: {
         )
       : undefined;
 
+  // Resolve per-account contactNames config (account-level overrides channel-level).
+  const accountContactNames =
+    params.cfg.channels?.whatsapp?.accounts?.[params.route.accountId]?.contactNames;
+  const channelContactNames = params.cfg.channels?.whatsapp?.contactNames;
+  const contactNames = accountContactNames ?? channelContactNames;
+
+  // For direct chats, resolve a display name and prefix BodyForAgent so the LLM
+  // sees who is speaking (e.g. "[Alice]: hello" instead of just "hello").
+  const resolvedSenderName = resolveDmSenderName({ msg: params.msg, contactNames });
+  const bodyForAgent =
+    resolvedSenderName != null ? `[${resolvedSenderName}]: ${params.msg.body}` : params.msg.body;
+
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
-    BodyForAgent: params.msg.body,
+    BodyForAgent: bodyForAgent,
     InboundHistory: inboundHistory,
     RawBody: params.msg.body,
     CommandBody: params.msg.body,
@@ -309,7 +322,7 @@ export async function processMessage(params: {
       roster: params.groupMemberNames.get(params.groupHistoryKey),
       fallbackE164: params.msg.senderE164,
     }),
-    SenderName: params.msg.senderName,
+    SenderName: resolvedSenderName ?? params.msg.senderName,
     SenderId: params.msg.senderJid?.trim() || params.msg.senderE164,
     SenderE164: params.msg.senderE164,
     CommandAuthorized: commandAuthorized,

--- a/src/web/auto-reply/monitor/resolve-contact-name.test.ts
+++ b/src/web/auto-reply/monitor/resolve-contact-name.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { resolveDmSenderName } from "./resolve-contact-name.js";
+
+describe("resolveDmSenderName", () => {
+  it("returns undefined for group chats", () => {
+    const result = resolveDmSenderName({
+      msg: {
+        chatType: "group",
+        from: "+15551234567",
+        senderE164: "+15551234567",
+        senderName: "Alice",
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("uses contactNames when phone matches", () => {
+    const result = resolveDmSenderName({
+      msg: {
+        chatType: "direct",
+        from: "+15551234567",
+        senderE164: "+15551234567",
+        senderName: "MG",
+      },
+      contactNames: { "+15551234567": "Alice Smith" },
+    });
+    expect(result).toBe("Alice Smith");
+  });
+
+  it("falls back to pushName when contactNames has no entry", () => {
+    const result = resolveDmSenderName({
+      msg: {
+        chatType: "direct",
+        from: "+15559999999",
+        senderE164: "+15559999999",
+        senderName: "Bob",
+      },
+      contactNames: { "+15551111111": "Someone Else" },
+    });
+    expect(result).toBe("Bob");
+  });
+
+  it("falls back to phone number when pushName is empty", () => {
+    const result = resolveDmSenderName({
+      msg: {
+        chatType: "direct",
+        from: "+15551234567",
+        senderE164: "+15551234567",
+        senderName: "",
+      },
+    });
+    expect(result).toBe("+15551234567");
+  });
+
+  it("falls back to 'contact' when no phone and no pushName", () => {
+    const result = resolveDmSenderName({
+      msg: {
+        chatType: "direct",
+        from: "",
+        senderE164: undefined,
+        senderName: undefined,
+      },
+    });
+    expect(result).toBe("contact");
+  });
+
+  it("normalizes phone number for contactNames lookup", () => {
+    const result = resolveDmSenderName({
+      msg: {
+        chatType: "direct",
+        from: "15551234567",
+        senderE164: "15551234567",
+        senderName: "MG",
+      },
+      contactNames: { "+15551234567": "Alice Smith" },
+    });
+    expect(result).toBe("Alice Smith");
+  });
+
+  it("uses senderE164 over from for lookup", () => {
+    const result = resolveDmSenderName({
+      msg: {
+        chatType: "direct",
+        from: "15551234567@s.whatsapp.net",
+        senderE164: "+15559876543",
+        senderName: "MG",
+      },
+      contactNames: { "+15559876543": "Carol" },
+    });
+    expect(result).toBe("Carol");
+  });
+
+  it("prefers contactNames over pushName even when pushName is set", () => {
+    const result = resolveDmSenderName({
+      msg: {
+        chatType: "direct",
+        from: "+15551234567",
+        senderE164: "+15551234567",
+        senderName: "Weird PushName 123",
+      },
+      contactNames: { "+15551234567": "Proper Name" },
+    });
+    expect(result).toBe("Proper Name");
+  });
+
+  it("works with undefined contactNames", () => {
+    const result = resolveDmSenderName({
+      msg: {
+        chatType: "direct",
+        from: "+15551234567",
+        senderE164: "+15551234567",
+        senderName: "Alice",
+      },
+      contactNames: undefined,
+    });
+    expect(result).toBe("Alice");
+  });
+});

--- a/src/web/auto-reply/monitor/resolve-contact-name.ts
+++ b/src/web/auto-reply/monitor/resolve-contact-name.ts
@@ -1,0 +1,30 @@
+import { normalizeE164 } from "../../../utils.js";
+import type { WebInboundMsg } from "../types.js";
+
+/**
+ * Resolve a display name for the sender in direct chats.
+ * Priority: contactNames config → WhatsApp push-name → phone number → "contact".
+ * Returns undefined for group chats (groups already have sender labels in the envelope).
+ */
+export function resolveDmSenderName(params: {
+  msg: Pick<WebInboundMsg, "chatType" | "senderE164" | "from" | "senderName">;
+  contactNames?: Record<string, string>;
+}): string | undefined {
+  if (params.msg.chatType === "group") {
+    return undefined;
+  }
+  const raw = normalizeE164(params.msg.senderE164 ?? params.msg.from ?? "");
+  // normalizeE164("") returns "+", so only treat it as a valid phone if it has digits.
+  const phone = raw && raw.length > 1 ? raw : undefined;
+  if (phone && params.contactNames?.[phone]) {
+    return params.contactNames[phone];
+  }
+  const pushName = params.msg.senderName?.trim();
+  if (pushName) {
+    return pushName;
+  }
+  if (phone) {
+    return phone;
+  }
+  return "contact";
+}


### PR DESCRIPTION
## Summary

- In direct chats, prefix `BodyForAgent` with the sender name so the LLM sees who is speaking (e.g. `[Alice]: hello` instead of just `hello`)
- Add `contactNames` config option (`Record<string, string>`) for overriding WhatsApp push-names with custom display names
- Also populate `SenderName` context with the resolved name for consistency

### Name resolution priority

1. `contactNames` config mapping (E.164 → display name)
2. WhatsApp push-name (`senderName` / `pushName`)
3. Normalized phone number
4. `"contact"` fallback

### Why

- In DMs, the LLM currently receives raw message text with no sender identity in `BodyForAgent`. The sender info is only in the envelope header (`[WhatsApp +1555...]`) and in `SenderName` context — but `SenderName` is not included in DM system prompt metadata (see `inbound-meta.ts` line 102: `isDirect ? undefined : {...}`)
- WhatsApp push-names are user-controlled and can be ambiguous (e.g. two contacts both using "MG"). `contactNames` lets gateway operators map phone numbers to stable display names

### Config example

```json
{
  "channels": {
    "whatsapp": {
      "contactNames": {
        "+15551234567": "Alice Smith",
        "+15559876543": "Bob Jones"
      }
    }
  }
}
```

Per-account override:
```json
{
  "channels": {
    "whatsapp": {
      "accounts": {
        "work": {
          "contactNames": {
            "+15551234567": "Alice (Work)"
          }
        }
      }
    }
  }
}
```

### What's NOT changed

- Group messages (already have sender labels in the envelope body)
- `CommandBody` / `RawBody` (unchanged — command parsing unaffected)
- Backward compatible: without `contactNames` config, behavior is the same as before except DMs now show pushName prefix

## Test plan

- [x] Unit tests for `resolveDmSenderName` (9 cases: group skip, contactNames match, pushName fallback, phone fallback, empty fallback, normalization, senderE164 priority, contactNames precedence, undefined contactNames)
- [x] TypeScript type-check passes
- [x] All existing web/auto-reply tests pass (222 tests, 31 files)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `contactNames` configuration to WhatsApp channels for mapping E.164 phone numbers to custom display names. In direct chats, `BodyForAgent` is now prefixed with the sender name (e.g., `[Alice]: hello`), resolving the issue where LLMs couldn't identify who was speaking in DM conversations.

- Introduced `contactNames` config at both channel and account levels with account-level taking precedence
- Created `resolveDmSenderName` utility with fallback chain: `contactNames` → push-name → phone number → "contact"
- Updated `BodyForAgent` to include sender prefix for direct messages only (groups unchanged as they already include sender labels)
- Populated `SenderName` context with resolved name for consistency
- Comprehensive test coverage (9 test cases) validates name resolution priority and edge cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-designed feature with clear separation of concerns, comprehensive test coverage (9 test cases), backward compatible implementation, and consistent config resolution pattern. The change is isolated to WhatsApp direct messages and preserves existing group chat behavior.
- No files require special attention

<sub>Last reviewed commit: 8632ba0</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->