### PR TITLE
fix(line): remove redundant group:/room: prefix from buildPeerId (#21907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- LINE: remove redundant `group:`/`room:` prefix from `buildPeerId` so peer-based binding routes match the raw group/room ID as documented. (#21907)
+
 - macOS/Build: default release packaging to `BUNDLE_ID=ai.openclaw.mac` in `scripts/package-mac-dist.sh`, so Sparkle feed URL is retained and auto-update no longer fails with an empty appcast feed. (#19750) thanks @loganprit.
 
 - Signal/Outbound: preserve case for Base64 group IDs during outbound target normalization so cross-context routing and policy checks no longer break when group IDs include uppercase characters. (#5578) Thanks @heyhudson.

--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/src/line/bot-message-context.ts
+++ b/src/line/bot-message-context.ts
@@ -51,10 +51,10 @@ export function getLineSourceInfo(source: EventSource): LineSourceInfo {
 
 function buildPeerId(source: EventSource): string {
   if (source.type === "group" && source.groupId) {
-    return `group:${source.groupId}`;
+    return source.groupId;
   }
   if (source.type === "room" && source.roomId) {
-    return `room:${source.roomId}`;
+    return source.roomId;
   }
   if (source.type === "user" && source.userId) {
     return source.userId;


### PR DESCRIPTION
## Summary

- **Bug**: LINE `buildPeerId` adds redundant `group:`/`room:` prefix to peer IDs, breaking binding route matching.
- **Root cause**: `buildPeerId()` in `src/line/bot-message-context.ts` prepends `group:` to `source.groupId` and `room:` to `source.roomId`, but `matchesBindingScope()` compares peer IDs as raw strings — the binding's `peer.id` never matches the prefixed runtime value.
- **Fix**: Return raw `source.groupId`/`source.roomId` from `buildPeerId()` without prefix.

Fixes #21907

## Problem

`buildPeerId()` returns `group:${source.groupId}` for group messages. This value is passed as `peer.id` to `resolveAgentRoute()`. The binding system does strict string comparison in `matchesBindingScope()`:

```
scope.peer.id !== match.peer.id
```

- Runtime peer.id: `group:cc7e3bece...` (with prefix)
- Binding peer.id: `cc7e3bece...` (raw, as configured by user)
- Result: no match → falls through to default agent

**Before fix:**
```
Input:  source.groupId = "Cc7e3bece1234567890abcdef"
Output: peer.id = "group:Cc7e3bece1234567890abcdef"
Route:  agentId = "main" (default, binding not matched)
Session key: agent:main:line:group:group:cc7e3bece... (double prefix)
```

## Changes

- `src/line/bot-message-context.ts` — Remove `group:`/`room:` prefix from `buildPeerId()`, return raw IDs

**After fix:**
```
Input:  source.groupId = "Cc7e3bece1234567890abcdef"
Output: peer.id = "Cc7e3bece1234567890abcdef"
Route:  agentId = "line-group-agent" (binding matched)
Session key: agent:line-group-agent:line:group:cc7e3bece... (correct)
```

## Test plan

- [x] New test: group peer binding matches raw groupId without prefix
- [x] New test: room peer binding matches raw roomId without prefix
- [x] All 4 existing `bot-message-context` tests pass
- [x] Format and lint pass

## Effect on User Experience

**Before:** LINE group/room messages always route to the default agent, ignoring peer-based bindings.
**After:** LINE group/room messages correctly route to the agent specified in peer-based bindings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where LINE group and room messages always routed to the default agent because `buildPeerId()` was prepending `group:` and `room:` prefixes that didn't match user-configured binding peer IDs.

**Key changes:**
- Removed `group:` and `room:` prefixes from `buildPeerId()` return values in `src/line/bot-message-context.ts:52-57`
- Added comprehensive test coverage for both group and room peer binding scenarios
- Updated CHANGELOG.md with clear description of the fix

**How it works:**
The binding system in `matchesBindingScope()` (`src/routing/resolve-route.ts:274`) performs strict string comparison between `scope.peer.id` and `match.peer.id`. Previously, `buildPeerId()` returned prefixed values like `group:Cc7e3bece...` while user bindings contained raw IDs like `Cc7e3bece...`, causing mismatches. The fix returns raw IDs directly.

**Impact verification:**
- The `line:group:` and `line:room:` prefixes are still correctly added in `resolveLineAddresses()` (`src/line/bot-message-context.ts:201-203`) for message addresses
- The `send.ts` normalizer already strips these prefixes when processing targets (`src/line/send.ts:43-44`)
- Existing tests for group routing still pass, verifying addresses remain correct

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a focused bug fix with comprehensive test coverage
- The fix is surgical and well-tested: removes only the problematic prefixes from `buildPeerId()` (2 lines changed), adds 2 new tests covering both group and room scenarios, and all existing tests pass. The addresses/session keys in other parts of the codebase correctly retain their `line:group:` and `line:room:` prefixes, so no side effects are expected
- No files require special attention

<sub>Last reviewed commit: b14538c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->