### PR TITLE
Security/Browser: block upload symlink escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - Tools/web_search: handle xAI Responses API payloads that emit top-level `output_text` blocks (without a `message` wrapper) so Grok web_search no longer returns `No response` for those results. (#20508) Thanks @echoVic.
 - Telegram/Streaming: always clean up draft previews even when dispatch throws before fallback handling, preventing orphaned preview messages during failed runs. (#19041) thanks @mudrii.
 - Telegram/Streaming: split reasoning and answer draft preview lanes to prevent cross-lane overwrites, and ignore literal `<think>` tags inside inline/fenced code snippets so sample markup is not misrouted as reasoning. (#20774) Thanks @obviyus.
+- Security/Browser: harden browser upload path checks to block symlink escapes outside the uploads root for file chooser hooks and browser upload tooling.
 
 - Discord/Gateway: handle close code 4014 (missing privileged gateway intents) without crashing the gateway. Thanks @thewilloftheshadow.
 - Security/Net: strip sensitive headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Cookie2`) on cross-origin redirects in `fetchWithSsrFGuard` to prevent credential forwarding across origin boundaries. (#20313) Thanks @afurm.

--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -21,7 +21,7 @@ import {
 } from "../../browser/client.js";
 import { resolveBrowserConfig } from "../../browser/config.js";
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "../../browser/constants.js";
-import { DEFAULT_UPLOAD_DIR, resolvePathsWithinRoot } from "../../browser/paths.js";
+import { DEFAULT_UPLOAD_DIR, resolveExistingPathsWithinRoot } from "../../browser/paths.js";
 import { applyBrowserProxyPaths, persistBrowserProxyFiles } from "../../browser/proxy-files.js";
 import { loadConfig } from "../../config/config.js";
 import { wrapExternalContent } from "../../security/external-content.js";
@@ -700,7 +700,7 @@ export function createBrowserTool(opts?: {
           if (paths.length === 0) {
             throw new Error("paths required");
           }
-          const uploadPathsResult = resolvePathsWithinRoot({
+          const uploadPathsResult = await resolveExistingPathsWithinRoot({
             rootDir: DEFAULT_UPLOAD_DIR,
             requestedPaths: paths,
             scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,

--- a/src/browser/paths.test.ts
+++ b/src/browser/paths.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveExistingPathsWithinRoot } from "./paths.js";
+
+async function createFixtureRoot(): Promise<{ baseDir: string; uploadsDir: string }> {
+  const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-browser-paths-"));
+  const uploadsDir = path.join(baseDir, "uploads");
+  await fs.mkdir(uploadsDir, { recursive: true });
+  return { baseDir, uploadsDir };
+}
+
+describe("resolveExistingPathsWithinRoot", () => {
+  const cleanupDirs = new Set<string>();
+
+  afterEach(async () => {
+    await Promise.all(
+      Array.from(cleanupDirs).map(async (dir) => {
+        await fs.rm(dir, { recursive: true, force: true });
+      }),
+    );
+    cleanupDirs.clear();
+  });
+
+  it("accepts existing files under the upload root", async () => {
+    const { baseDir, uploadsDir } = await createFixtureRoot();
+    cleanupDirs.add(baseDir);
+
+    const nestedDir = path.join(uploadsDir, "nested");
+    await fs.mkdir(nestedDir, { recursive: true });
+    const filePath = path.join(nestedDir, "ok.txt");
+    await fs.writeFile(filePath, "ok", "utf8");
+
+    const result = await resolveExistingPathsWithinRoot({
+      rootDir: uploadsDir,
+      requestedPaths: [filePath],
+      scopeLabel: "uploads directory",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.paths).toEqual([await fs.realpath(filePath)]);
+    }
+  });
+
+  it("rejects traversal outside the upload root", async () => {
+    const { baseDir, uploadsDir } = await createFixtureRoot();
+    cleanupDirs.add(baseDir);
+
+    const outsidePath = path.join(baseDir, "outside.txt");
+    await fs.writeFile(outsidePath, "nope", "utf8");
+
+    const result = await resolveExistingPathsWithinRoot({
+      rootDir: uploadsDir,
+      requestedPaths: ["../outside.txt"],
+      scopeLabel: "uploads directory",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must stay within uploads directory");
+    }
+  });
+
+  it("keeps lexical in-root paths even when files do not exist yet", async () => {
+    const { baseDir, uploadsDir } = await createFixtureRoot();
+    cleanupDirs.add(baseDir);
+
+    const result = await resolveExistingPathsWithinRoot({
+      rootDir: uploadsDir,
+      requestedPaths: ["missing.txt"],
+      scopeLabel: "uploads directory",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.paths).toEqual([path.join(uploadsDir, "missing.txt")]);
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects symlink escapes outside the upload root",
+    async () => {
+      const { baseDir, uploadsDir } = await createFixtureRoot();
+      cleanupDirs.add(baseDir);
+
+      const outsidePath = path.join(baseDir, "secret.txt");
+      await fs.writeFile(outsidePath, "secret", "utf8");
+      const symlinkPath = path.join(uploadsDir, "leak.txt");
+      await fs.symlink(outsidePath, symlinkPath);
+
+      const result = await resolveExistingPathsWithinRoot({
+        rootDir: uploadsDir,
+        requestedPaths: ["leak.txt"],
+        scopeLabel: "uploads directory",
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("regular non-symlink file");
+      }
+    },
+  );
+});

--- a/src/browser/paths.ts
+++ b/src/browser/paths.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { SafeOpenError, openFileWithinRoot } from "../infra/fs-safe.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
 export const DEFAULT_BROWSER_TMP_DIR = resolvePreferredOpenClawTmpDir();
@@ -45,5 +46,47 @@ export function resolvePathsWithinRoot(params: {
     }
     resolvedPaths.push(pathResult.path);
   }
+  return { ok: true, paths: resolvedPaths };
+}
+
+export async function resolveExistingPathsWithinRoot(params: {
+  rootDir: string;
+  requestedPaths: string[];
+  scopeLabel: string;
+}): Promise<{ ok: true; paths: string[] } | { ok: false; error: string }> {
+  const resolvedPaths: string[] = [];
+
+  for (const raw of params.requestedPaths) {
+    const pathResult = resolvePathWithinRoot({
+      rootDir: params.rootDir,
+      requestedPath: raw,
+      scopeLabel: params.scopeLabel,
+    });
+    if (!pathResult.ok) {
+      return { ok: false, error: pathResult.error };
+    }
+
+    let opened: Awaited<ReturnType<typeof openFileWithinRoot>> | undefined;
+    try {
+      const relativePath = path.relative(path.resolve(params.rootDir), pathResult.path);
+      opened = await openFileWithinRoot({
+        rootDir: params.rootDir,
+        relativePath,
+      });
+      resolvedPaths.push(opened.realPath);
+    } catch (err) {
+      if (err instanceof SafeOpenError && err.code === "not-found") {
+        resolvedPaths.push(pathResult.path);
+        continue;
+      }
+      return {
+        ok: false,
+        error: `Invalid path: must stay within ${params.scopeLabel} and be a regular non-symlink file`,
+      };
+    } finally {
+      await opened?.handle.close().catch(() => {});
+    }
+  }
+
   return { ok: true, paths: resolvedPaths };
 }

--- a/src/browser/routes/agent.act.ts
+++ b/src/browser/routes/agent.act.ts
@@ -16,7 +16,7 @@ import {
   DEFAULT_DOWNLOAD_DIR,
   DEFAULT_UPLOAD_DIR,
   resolvePathWithinRoot,
-  resolvePathsWithinRoot,
+  resolveExistingPathsWithinRoot,
 } from "./path-output.js";
 import type { BrowserResponse, BrowserRouteRegistrar } from "./types.js";
 import { jsonError, toBoolean, toNumber, toStringArray, toStringOrEmpty } from "./utils.js";
@@ -382,7 +382,7 @@ export function registerBrowserAgentActRoutes(
       targetId,
       feature: "file chooser hook",
       run: async ({ cdpUrl, tab, pw }) => {
-        const uploadPathsResult = resolvePathsWithinRoot({
+        const uploadPathsResult = await resolveExistingPathsWithinRoot({
           rootDir: DEFAULT_UPLOAD_DIR,
           requestedPaths: paths,
           scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,

--- a/src/cli/browser-cli-actions-input/register.files-downloads.ts
+++ b/src/cli/browser-cli-actions-input/register.files-downloads.ts
@@ -1,13 +1,13 @@
 import type { Command } from "commander";
-import { DEFAULT_UPLOAD_DIR, resolvePathsWithinRoot } from "../../browser/paths.js";
+import { DEFAULT_UPLOAD_DIR, resolveExistingPathsWithinRoot } from "../../browser/paths.js";
 import { danger } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
 import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
 import { resolveBrowserActionContext } from "./shared.js";
 
-function normalizeUploadPaths(paths: string[]): string[] {
-  const result = resolvePathsWithinRoot({
+async function normalizeUploadPaths(paths: string[]): Promise<string[]> {
+  const result = await resolveExistingPathsWithinRoot({
     rootDir: DEFAULT_UPLOAD_DIR,
     requestedPaths: paths,
     scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,
@@ -81,7 +81,7 @@ export function registerBrowserFilesAndDownloadsCommands(
     .action(async (paths: string[], opts, cmd) => {
       const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);
       try {
-        const normalizedPaths = normalizeUploadPaths(paths);
+        const normalizedPaths = await normalizeUploadPaths(paths);
         const { timeoutMs, targetId } = resolveTimeoutAndTarget(opts);
         const result = await callBrowserRequest<{ download: { path: string } }>(
           parent,


### PR DESCRIPTION
## Summary
- harden browser upload path resolution by verifying existing paths via safe open semantics
- reject symlink escapes and keep uploads constrained to the configured upload root
- add regression tests for traversal and symlink escape cases

## Testing
- pnpm test src/browser/paths.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the browser upload path resolution by replacing the synchronous lexical-only `resolvePathsWithinRoot` with a new async `resolveExistingPathsWithinRoot` function that validates existing files via `openFileWithinRoot` from the existing `fs-safe` infrastructure. This blocks symlink escape attacks where a symlink inside the uploads directory could point to files outside the configured upload root.

- Adds `resolveExistingPathsWithinRoot` in `src/browser/paths.ts` that first performs the existing lexical path check, then uses `openFileWithinRoot` (which opens with `O_NOFOLLOW`, validates `stat`/`lstat` consistency, and checks `realpath`) to verify existing files are regular files within root. Non-existent files fall back to the lexical path to support upload-to-new-path workflows.
- Updates all three call sites (`browser-tool.ts`, `agent.act.ts`, `register.files-downloads.ts`) from the old sync function to the new async function.
- Adds regression tests covering: valid files, `../` traversal rejection, non-existent file fallback, and symlink escape rejection.
- The old `resolvePathsWithinRoot` remains available for non-upload use cases (e.g., download path resolution).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it strictly tightens path validation for upload paths and all changes are consistent across call sites.
- The implementation correctly layers the new async symlink check on top of the existing lexical check, properly handles all error codes from `openFileWithinRoot` (including not-found fallback for new files), closes file handles in a `finally` block, and all three call sites are consistently updated. The test coverage is solid, including the key symlink escape case. No functional regressions are introduced since download paths still use the old synchronous function where appropriate.
- No files require special attention.

<sub>Last reviewed commit: cba3246</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->