### PR TITLE
fix(cli): models fallbacks add now includes primary model in allowlist

### DIFF
--- a/src/commands/models/fallbacks-shared.ts
+++ b/src/commands/models/fallbacks-shared.ts
@@ -84,6 +84,18 @@ export async function addFallbackCommand(
     const resolved = resolveModelTarget({ raw: modelRaw, cfg });
     const targetKey = modelKey(resolved.provider, resolved.model);
     const nextModels = { ...cfg.agents?.defaults?.models } as Record<string, unknown>;
+
+    // Ensure the currently-configured primary model is always present in the allowlist.
+    // Without this, adding the first fallback creates an allowlist that omits the primary,
+    // silently blocking all sessions that rely on it.
+    if (params.key === "model") {
+      const primaryKey = (cfg.agents?.defaults?.model as PrimaryFallbackConfig | undefined)
+        ?.primary;
+      if (primaryKey && !nextModels[primaryKey]) {
+        nextModels[primaryKey] = {};
+      }
+    }
+
     if (!nextModels[targetKey]) {
       nextModels[targetKey] = {};
     }

--- a/src/commands/models/fallbacks.allowlist.test.ts
+++ b/src/commands/models/fallbacks.allowlist.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readConfigFileSnapshot = vi.fn();
+const writeConfigFile = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../../config/config.js", () => ({
+  CONFIG_PATH: "/tmp/openclaw.json",
+  readConfigFileSnapshot,
+  writeConfigFile,
+  loadConfig: vi.fn().mockReturnValue({}),
+}));
+
+function mockConfigSnapshot(config: Record<string, unknown> = {}) {
+  readConfigFileSnapshot.mockResolvedValue({
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: "{}",
+    parsed: {},
+    valid: true,
+    config,
+    issues: [],
+    legacyIssues: [],
+  });
+}
+
+function makeRuntime() {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+}
+
+function getWrittenModels(): Record<string, unknown> {
+  const written = writeConfigFile.mock.calls[0]?.[0] as {
+    agents?: { defaults?: { models?: Record<string, unknown> } };
+  };
+  return written?.agents?.defaults?.models ?? {};
+}
+
+describe("modelsFallbacksAddCommand — allowlist safety", () => {
+  beforeEach(() => {
+    readConfigFileSnapshot.mockReset();
+    writeConfigFile.mockClear();
+    vi.resetModules();
+  });
+
+  it("includes the existing primary model in the allowlist when adding the first fallback", async () => {
+    // Regression: adding the first fallback used to create a models allowlist that only
+    // contained the fallback model, silently blocking the primary from being used.
+    mockConfigSnapshot({
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6", fallbacks: [] },
+          // No `models` allowlist yet — this is what triggers the bug.
+        },
+      },
+    });
+
+    const { modelsFallbacksAddCommand } = await import("./fallbacks.js");
+    await modelsFallbacksAddCommand("openai/gpt-5.2", makeRuntime());
+
+    const models = getWrittenModels();
+    // Both the primary AND the new fallback must be in the allowlist.
+    expect(models).toMatchObject({
+      "anthropic/claude-opus-4-6": {},
+      "openai/gpt-5.2": {},
+    });
+  });
+
+  it("does not add a phantom primary entry when no primary is configured", async () => {
+    // Guard: if there's no primary yet, we should not inject an empty/undefined key.
+    mockConfigSnapshot({
+      agents: {
+        defaults: {
+          model: { fallbacks: [] },
+        },
+      },
+    });
+
+    const { modelsFallbacksAddCommand } = await import("./fallbacks.js");
+    await modelsFallbacksAddCommand("openai/gpt-5.2", makeRuntime());
+
+    const models = getWrittenModels();
+    // Only the fallback should appear — no phantom `undefined` key.
+    expect(models).toEqual({ "openai/gpt-5.2": {} });
+    expect(Object.keys(models)).not.toContain("undefined");
+  });
+
+  it("preserves already-correct allowlist when primary is already present", async () => {
+    mockConfigSnapshot({
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6", fallbacks: [] },
+          models: { "anthropic/claude-opus-4-6": {} },
+        },
+      },
+    });
+
+    const { modelsFallbacksAddCommand } = await import("./fallbacks.js");
+    await modelsFallbacksAddCommand("openai/gpt-5.2", makeRuntime());
+
+    const models = getWrittenModels();
+    expect(models).toMatchObject({
+      "anthropic/claude-opus-4-6": {},
+      "openai/gpt-5.2": {},
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw models fallbacks add <model>` on a fresh config (no existing `models` allowlist) creates an allowlist containing only the new fallback, silently omitting the configured primary model.
- **Why it matters:** All sessions and cron jobs relying on the primary model stop working after this command — with no error or warning.
- **What changed:** In `addFallbackCommand`, before writing the updated allowlist, we now ensure the primary model (if configured) is seeded into `nextModels` when it would otherwise be absent.
- **What did NOT change:** Behaviour when the allowlist already contains the primary is untouched (idempotent).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #BUG-469

## User-visible / Behavior Changes

`openclaw models fallbacks add <model>` on a fresh config now preserves the primary model in the generated allowlist. Previously it silently dropped it.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Config has a primary model but no `models` allowlist
2. Run `openclaw models fallbacks add openai/gpt-5.2`
3. Inspect config — `models` now contains both primary and fallback

### Expected

Both primary and fallback appear in `models` allowlist.

### Actual (before fix)

Only the fallback appeared; primary was silently dropped.

## Evidence

- [x] Failing test/log before + passing after

Three new unit tests: regression case, no-phantom-key guard, idempotent case.

## Human Verification (required)

- Verified: all three unit test scenarios pass
- Not verified: live integration run with a real gateway

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

Remove the 12-line primary-seeding block added to `fallbacks-shared.ts`.

## Risks and Mitigations

- Risk: `params.key === 'model'` guard may be too narrow for per-agent key paths.
  - Mitigation: Scoped to default-agent path only; per-agent fix is a separate concern.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes critical bug where adding the first fallback on fresh config creates allowlist containing only the fallback, silently blocking the primary model. The fix seeds the primary model into the allowlist when it would otherwise be absent.

**Issue found:** The fix only applies when the key is "model" but the same bug exists for "imageModel". The image fallbacks command will skip the primary-seeding logic and have the same allowlist bug.

**What works:** Test coverage is comprehensive for the model path with regression, no-phantom-key, and idempotent scenarios. The core fix logic is sound.

<h3>Confidence Score: 3/5</h3>

- Partially safe - fixes the reported bug for text models but leaves the same bug in imageModel path
- The PR correctly fixes the allowlist bug for the model path with good test coverage, but the fix is incomplete because the imageModel path has the identical bug that remains unfixed (line 91 guards only for "model" not "imageModel")
- Pay attention to `fallbacks-shared.ts:91-97` which needs to handle both model types

<sub>Last reviewed commit: 422cd05</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->