### PR TITLE
Security: harden gateway and plugin trust boundaries

### DIFF
--- a/docs/security/HARDENING-HANDOFF-2026-02-20.md
+++ b/docs/security/HARDENING-HANDOFF-2026-02-20.md
@@ -1,0 +1,190 @@
+# OpenClaw Security Hardening Handoff (February 20, 2026)
+
+## Scope
+
+This handoff documents a focused security hardening pass for OpenClaw gateway/plugin surfaces, centered on reducing compromise risk from misconfiguration, unsafe defaults, plugin abuse, and HTTP exposure.
+
+## Findings and Remediations
+
+### 1) Insecure auth bypass flags could be enabled too easily
+
+- Risk: dangerous Control UI auth bypass flags could be set in config and accidentally shipped.
+- Fix:
+  - Block startup when `gateway.controlUi.allowInsecureAuth` or `gateway.controlUi.dangerouslyDisableDeviceAuth` is enabled, unless `OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH=1`.
+  - Ensure handshake-level bypass logic honors the same env gate.
+- Files:
+  - `src/gateway/server-runtime-config.ts`
+  - `src/gateway/server/ws-connection/message-handler.ts`
+  - `src/gateway/server-runtime-config.test.ts`
+
+### 2) Auth brute-force exposure when rate limiter was absent
+
+- Risk: auth rate limiting could be effectively optional.
+- Fix:
+  - Always construct and enforce auth rate limiting from resolved config defaults.
+  - Remove obsolete audit warning that no longer applies under enforced defaults.
+- Files:
+  - `src/gateway/server.impl.ts`
+  - `src/security/audit.ts`
+  - `src/security/audit.test.ts`
+
+### 3) Generated startup token persistence was too permissive
+
+- Risk: generated auth token could be written to config by default.
+- Fix:
+  - Make persistence explicit opt-in via `OPENCLAW_PERSIST_GENERATED_GATEWAY_TOKEN=1`.
+  - Improve startup warning text to reflect safer default.
+- Files:
+  - `src/gateway/server.impl.ts`
+
+### 4) HTTP tool invocation was not deny-by-default
+
+- Risk: relying on denylist for `/tools/invoke` can expose unexpected tools.
+- Fix:
+  - Require explicit `gateway.tools.allow` allowlist for any HTTP tool exposure.
+  - Keep `gateway.tools.deny` higher-priority as explicit override.
+  - Update config documentation to match allowlist model.
+- Files:
+  - `src/gateway/tools-invoke-http.ts`
+  - `src/config/types.gateway.ts`
+  - `src/security/dangerous-tools.ts`
+  - `src/gateway/tools-invoke-http.test.ts`
+
+### 5) Plugin HTTP routes could escape namespace boundaries
+
+- Risk: plugin route registration could target unrelated API paths.
+- Fix:
+  - Enforce route namespace at registration time:
+    - allowed: `/plugins/<pluginId>/...` and `/api/channels/...`
+    - rejected otherwise.
+  - Only dispatch plugin HTTP handlers for plugin namespaces.
+  - Require gateway auth for plugin namespace requests before dispatch.
+- Files:
+  - `src/plugins/registry.ts`
+  - `src/gateway/server-http.ts`
+  - `src/gateway/server.plugin-http-auth.test.ts`
+  - `src/gateway/server/plugins-http.test.ts`
+  - `src/plugins/loader.test.ts`
+
+### 6) External plugin trust posture was too permissive
+
+- Risk: non-bundled plugin code could be discovered/loaded without explicit trust.
+- Fix:
+  - External plugins now disabled by default.
+  - Explicit trust required to load (e.g. `plugins.entries.<id>.enabled: true`, with allowlist controls).
+  - Warning text updated for discoverable non-bundled plugins when allowlist is empty.
+- Files:
+  - `src/plugins/config-state.ts`
+  - `src/plugins/loader.ts`
+  - `src/plugins/loader.test.ts`
+
+### 7) Plugin install scanner did not fail closed
+
+- Risk: dangerous patterns or scanner errors could still allow install.
+- Fix:
+  - Code safety scan now enforced fail-closed for critical findings.
+  - Scanner operational failures also block installation.
+  - Apply scanner enforcement to both directory and standalone file install flows.
+- Files:
+  - `src/plugins/install.ts`
+  - `src/plugins/install.e2e.test.ts`
+
+### 8) URL ingestion defaults were too open for Responses/file/image paths
+
+- Risk: SSRF and data exfiltration surfaces from remote URL ingestion.
+- Fix:
+  - Default `allowUrl=false` for input files and Responses image/file URL fetch.
+  - Schema/comments updated to document secure default.
+- Files:
+  - `src/media/input-files.ts`
+  - `src/gateway/openresponses-http.ts`
+  - `src/config/types.gateway.ts`
+
+### 9) Session override header enabled without explicit runtime intent
+
+- Risk: `x-openclaw-session-key` header could be abused for cross-session targeting.
+- Fix:
+  - Disable by default; only honored when `OPENCLAW_ALLOW_HTTP_SESSION_KEY_HEADER=1`.
+  - Security audit finding updated to trigger only when enabled, and severity raised.
+- Files:
+  - `src/gateway/http-utils.ts`
+  - `src/security/audit-extra.sync.ts`
+  - `src/security/audit.ts`
+  - `src/gateway/openai-http.e2e.test.ts`
+  - `src/security/audit.test.ts`
+
+### 10) HTTP response hardening headers were incomplete
+
+- Risk: avoidable clickjacking/policy exposure on gateway surfaces.
+- Fix:
+  - Added:
+    - `X-Frame-Options: SAMEORIGIN`
+    - `Permissions-Policy: camera=(), microphone=(), geolocation=(), usb=()`
+    - `Cross-Origin-Opener-Policy: same-origin`
+- Files:
+  - `src/gateway/http-common.ts`
+
+### 11) TLS lacked first-class mTLS enforcement toggle
+
+- Risk: no structured way to require client certificates in hardened deployments.
+- Fix:
+  - Added `gateway.tls.requireClientCert` config.
+  - Enforced CA requirement when mTLS is enabled.
+  - Wired TLS options to request/reject unauthorized clients.
+- Files:
+  - `src/config/types.gateway.ts`
+  - `src/config/zod-schema.ts`
+  - `src/infra/tls/gateway.ts`
+
+## Behavioral Changes (Important)
+
+- `/tools/invoke` is now deny-by-default. No HTTP tools are exposed unless in `gateway.tools.allow`.
+- Non-bundled plugins are disabled by default.
+- `x-openclaw-session-key` override header is ignored unless explicitly enabled by env.
+- Insecure Control UI auth bypass flags are blocked unless explicitly env-gated.
+- URL-based file/image ingestion is disabled by default for Responses surfaces.
+- Startup-generated auth token persistence is opt-in.
+- mTLS can be explicitly required via config.
+
+## Validation Performed
+
+### Unit tests (security-touched files)
+
+Command:
+
+- `corepack pnpm vitest src/plugins/loader.test.ts src/gateway/server.plugin-http-auth.test.ts src/gateway/tools-invoke-http.test.ts src/security/audit.test.ts src/gateway/server-runtime-config.test.ts`
+
+Result:
+
+- 5 test files passed
+- 117 tests passed
+- 0 failed
+
+### E2E tests (security-touched files)
+
+Command:
+
+- `corepack pnpm vitest run --config vitest.e2e.config.ts src/plugins/install.e2e.test.ts src/gateway/openai-http.e2e.test.ts src/gateway/openresponses-http.e2e.test.ts`
+
+Result:
+
+- 3 test files passed
+- 24 tests passed
+- 0 failed
+
+## Residual Risk and Next Hardening Steps
+
+- Add structured allowlist linting at startup for `gateway.tools.allow` and `plugins.entries` to fail on unknown IDs.
+- Add optional CIDR/path-level policy enforcement for plugin HTTP endpoints.
+- Add configurable anomaly detection for repeated auth failures and session-key override attempts.
+- Add signed plugin manifest verification (integrity + publisher trust).
+- Add SSRF egress policy controls (host/network allowlist + DNS pinning) for any future URL ingestion enablement.
+- Extend security regression tests to include hostile plugin fixtures and fuzzed HTTP routing paths.
+
+## Operational Notes for Deployment
+
+- If you previously relied on permissive defaults, update config explicitly:
+  - set `gateway.tools.allow` for needed HTTP tools.
+  - set `plugins.entries.<id>.enabled: true` for explicitly trusted external plugins.
+  - only set insecure auth env overrides in controlled local/dev contexts.
+  - if needed, explicitly set URL ingestion toggles to `true` per environment with compensating controls.

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -11,6 +11,11 @@ export type GatewayTlsConfig = {
   keyPath?: string;
   /** Optional PEM CA bundle for TLS clients (mTLS or custom roots). */
   caPath?: string;
+  /**
+   * Require and verify client certificates (mTLS). Requires `caPath`.
+   * Default: false.
+   */
+  requireClientCert?: boolean;
 };
 
 export type WideAreaDiscoveryConfig = {
@@ -198,7 +203,7 @@ export type GatewayHttpResponsesConfig = {
 };
 
 export type GatewayHttpResponsesFilesConfig = {
-  /** Allow URL fetches for input_file. Default: true. */
+  /** Allow URL fetches for input_file. Default: false. */
   allowUrl?: boolean;
   /**
    * Optional hostname allowlist for URL fetches.
@@ -229,7 +234,7 @@ export type GatewayHttpResponsesPdfConfig = {
 };
 
 export type GatewayHttpResponsesImagesConfig = {
-  /** Allow URL fetches for input_image. Default: true. */
+  /** Allow URL fetches for input_image. Default: false. */
   allowUrl?: boolean;
   /**
    * Optional hostname allowlist for URL fetches.
@@ -270,9 +275,12 @@ export type GatewayNodesConfig = {
 };
 
 export type GatewayToolsConfig = {
-  /** Tools to deny via gateway HTTP /tools/invoke (extends defaults). */
+  /** Tools to deny via gateway HTTP /tools/invoke (applies after allowlist). */
   deny?: string[];
-  /** Tools to explicitly allow (removes from default deny list). */
+  /**
+   * Explicit allowlist for gateway HTTP /tools/invoke.
+   * When empty/unset, no tools are exposed over HTTP.
+   */
   allow?: string[];
 };
 

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -498,6 +498,7 @@ export const OpenClawSchema = z
             certPath: z.string().optional(),
             keyPath: z.string().optional(),
             caPath: z.string().optional(),
+            requireClientCert: z.boolean().optional(),
           })
           .optional(),
         http: z

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -11,6 +11,9 @@ import { readJsonBody } from "./hooks.js";
 export function setDefaultSecurityHeaders(res: ServerResponse) {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("X-Frame-Options", "SAMEORIGIN");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=(), usb=()");
+  res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
 }
 
 export function sendJson(res: ServerResponse, status: number, body: unknown) {

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -68,7 +68,10 @@ export function resolveSessionKey(params: {
   user?: string | undefined;
   prefix: string;
 }): string {
-  const explicit = getHeader(params.req, "x-openclaw-session-key")?.trim();
+  const explicit =
+    process.env.OPENCLAW_ALLOW_HTTP_SESSION_KEY_HEADER === "1"
+      ? getHeader(params.req, "x-openclaw-session-key")?.trim()
+      : undefined;
   if (explicit) {
     return explicit;
   }

--- a/src/gateway/openresponses-http.e2e.test.ts
+++ b/src/gateway/openresponses-http.e2e.test.ts
@@ -540,7 +540,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
     };
     expect(blockedPrivateJson.error?.type).toBe("invalid_request_error");
     expect(blockedPrivateJson.error?.message ?? "").toMatch(
-      /invalid request|private|internal|blocked/i,
+      /invalid request|private|internal|blocked|disabled/i,
     );
 
     const blockedMetadata = await postResponses(port, {
@@ -565,7 +565,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
     };
     expect(blockedMetadataJson.error?.type).toBe("invalid_request_error");
     expect(blockedMetadataJson.error?.message ?? "").toMatch(
-      /invalid request|blocked|metadata|internal/i,
+      /invalid request|blocked|metadata|internal|disabled/i,
     );
 
     const blockedScheme = await postResponses(port, {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -116,7 +116,7 @@ function resolveResponsesLimits(
       urlAllowlist: normalizeHostnameAllowlist(files?.urlAllowlist),
     },
     images: {
-      allowUrl: images?.allowUrl ?? true,
+      allowUrl: images?.allowUrl ?? false,
       urlAllowlist: normalizeHostnameAllowlist(images?.urlAllowlist),
       allowedMimes: normalizeMimeList(images?.allowedMimes, DEFAULT_INPUT_IMAGE_MIMES),
       maxBytes: images?.maxBytes ?? DEFAULT_INPUT_IMAGE_MAX_BYTES,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -522,10 +522,9 @@ export function createGatewayHttpServer(opts: {
         return;
       }
       if (handlePluginRequest) {
-        // Channel HTTP endpoints are gateway-auth protected by default.
-        // Non-channel plugin routes remain plugin-owned and must enforce
-        // their own auth when exposing sensitive functionality.
-        if (requestPath.startsWith("/api/channels/")) {
+        const isPluginPath =
+          requestPath.startsWith("/plugins/") || requestPath.startsWith("/api/channels/");
+        if (isPluginPath) {
           const token = getBearerToken(req);
           const authResult = await authorizeGatewayConnect({
             auth: resolvedAuth,
@@ -538,9 +537,9 @@ export function createGatewayHttpServer(opts: {
             sendGatewayAuthFailure(res, authResult);
             return;
           }
-        }
-        if (await handlePluginRequest(req, res)) {
-          return;
+          if (await handlePluginRequest(req, res)) {
+            return;
+          }
         }
       }
       if (openResponsesEnabled) {

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -231,5 +231,27 @@ describe("resolveGatewayRuntimeConfig", () => {
         }),
       ).rejects.toThrow("gateway bind=custom requested 192.168.1.100 but resolved 0.0.0.0");
     });
+
+    it("should reject dangerous control-ui auth bypass flags without explicit env override", async () => {
+      const cfg = {
+        gateway: {
+          bind: "loopback" as const,
+          auth: {
+            mode: "token" as const,
+            token: "test-token-123",
+          },
+          controlUi: {
+            allowInsecureAuth: true,
+          },
+        },
+      };
+
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        }),
+      ).rejects.toThrow("OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH=1");
+    });
   });
 });

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -79,6 +79,17 @@ export async function resolveGatewayRuntimeConfig(params: {
     typeof controlUiRootRaw === "string" && controlUiRootRaw.trim().length > 0
       ? controlUiRootRaw.trim()
       : undefined;
+  const allowInsecureControlUiAuth = params.cfg.gateway?.controlUi?.allowInsecureAuth === true;
+  const disableControlUiDeviceAuth =
+    params.cfg.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true;
+  if (
+    (allowInsecureControlUiAuth || disableControlUiDeviceAuth) &&
+    process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH !== "1"
+  ) {
+    throw new Error(
+      "gateway.controlUi.allowInsecureAuth/dangerouslyDisableDeviceAuth are blocked by default; set OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH=1 to acknowledge the risk explicitly",
+    );
+  }
   const tailscaleBase = params.cfg.gateway?.tailscale ?? {};
   const tailscaleOverrides = params.tailscale ?? {};
   const tailscaleConfig = mergeGatewayTailscaleConfig(tailscaleBase, tailscaleOverrides);

--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -688,27 +688,39 @@ describe("gateway server auth/connect", () => {
   });
 
   test("allows control ui without device identity when insecure auth is enabled", async () => {
+    const prevUnsafeControlUiAuth = process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH;
+    process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH = "1";
     testState.gatewayControlUi = { allowInsecureAuth: true };
-    const { server, ws, prevToken } = await startServerWithClient("secret", {
-      wsHeaders: { origin: "http://127.0.0.1" },
-    });
-    const res = await connectReq(ws, {
-      token: "secret",
-      device: null,
-      client: {
-        id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-        version: "1.0.0",
-        platform: "web",
-        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-      },
-    });
-    expect(res.ok).toBe(true);
-    ws.close();
-    await server.close();
-    restoreGatewayToken(prevToken);
+    try {
+      const { server, ws, prevToken } = await startServerWithClient("secret", {
+        wsHeaders: { origin: "http://127.0.0.1" },
+      });
+      const res = await connectReq(ws, {
+        token: "secret",
+        device: null,
+        client: {
+          id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+          version: "1.0.0",
+          platform: "web",
+          mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+        },
+      });
+      expect(res.ok).toBe(true);
+      ws.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
+    } finally {
+      if (prevUnsafeControlUiAuth === undefined) {
+        delete process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH;
+      } else {
+        process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH = prevUnsafeControlUiAuth;
+      }
+    }
   });
 
   test("allows control ui with device identity when insecure auth is enabled", async () => {
+    const prevUnsafeControlUiAuth = process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH;
+    process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH = "1";
     testState.gatewayControlUi = { allowInsecureAuth: true };
     testState.gatewayAuth = { mode: "token", token: "secret" };
     const { writeConfigFile } = await import("../config/config.js");
@@ -758,10 +770,17 @@ describe("gateway server auth/connect", () => {
       });
     } finally {
       restoreGatewayToken(prevToken);
+      if (prevUnsafeControlUiAuth === undefined) {
+        delete process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH;
+      } else {
+        process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH = prevUnsafeControlUiAuth;
+      }
     }
   });
 
   test("allows control ui with stale device identity when device auth is disabled", async () => {
+    const prevUnsafeControlUiAuth = process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH;
+    process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH = "1";
     testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
     testState.gatewayAuth = { mode: "token", token: "secret" };
     const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
@@ -792,6 +811,11 @@ describe("gateway server auth/connect", () => {
       });
     } finally {
       restoreGatewayToken(prevToken);
+      if (prevUnsafeControlUiAuth === undefined) {
+        delete process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH;
+      } else {
+        process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH = prevUnsafeControlUiAuth;
+      }
     }
   });
 

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -50,7 +50,7 @@ describe("createGatewayPluginRequestHandler", () => {
         httpRoutes: [
           {
             pluginId: "route",
-            path: "/demo",
+            path: "/plugins/route/demo",
             handler: routeHandler,
             source: "route",
           },
@@ -63,7 +63,7 @@ describe("createGatewayPluginRequestHandler", () => {
     });
 
     const { res } = makeMockHttpResponse();
-    const handled = await handler({ url: "/demo" } as IncomingMessage, res);
+    const handled = await handler({ url: "/plugins/route/demo" } as IncomingMessage, res);
     expect(handled).toBe(true);
     expect(routeHandler).toHaveBeenCalledTimes(1);
     expect(fallback).not.toHaveBeenCalled();

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -337,10 +337,16 @@ export function attachGatewayWsMessageHandler(params: {
         const hasTokenAuth = Boolean(connectParams.auth?.token);
         const hasPasswordAuth = Boolean(connectParams.auth?.password);
         const hasSharedAuth = hasTokenAuth || hasPasswordAuth;
+        const insecureControlUiAuthAllowed =
+          process.env.OPENCLAW_ALLOW_INSECURE_CONTROL_UI_AUTH === "1";
         const allowInsecureControlUi =
-          isControlUi && configSnapshot.gateway?.controlUi?.allowInsecureAuth === true;
+          insecureControlUiAuthAllowed &&
+          isControlUi &&
+          configSnapshot.gateway?.controlUi?.allowInsecureAuth === true;
         const disableControlUiDeviceAuth =
-          isControlUi && configSnapshot.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true;
+          insecureControlUiAuthAllowed &&
+          isControlUi &&
+          configSnapshot.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true;
         const allowControlUiBypass = allowInsecureControlUi || disableControlUiDeviceAuth;
         const device = disableControlUiDeviceAuth ? null : deviceRaw;
 

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -173,6 +173,8 @@ const resolveGatewayToken = (): string => TEST_GATEWAY_TOKEN;
 const gatewayAuthHeaders = () => ({ authorization: `Bearer ${resolveGatewayToken()}` });
 
 const allowAgentsListForMain = () => {
+  const gatewayCfg = (cfg.gateway as Record<string, unknown> | undefined) ?? {};
+  const gatewayTools = (gatewayCfg.tools as Record<string, unknown> | undefined) ?? {};
   cfg = {
     ...cfg,
     agents: {
@@ -185,6 +187,13 @@ const allowAgentsListForMain = () => {
           },
         },
       ],
+    },
+    gateway: {
+      ...gatewayCfg,
+      tools: {
+        ...gatewayTools,
+        allow: ["agents_list"],
+      },
     },
   };
 };
@@ -265,6 +274,7 @@ describe("POST /tools/invoke", () => {
       ...cfg,
       agents: { list: [{ id: "main", default: true }] },
       tools: { profile: "minimal", alsoAllow: ["agents_list"] },
+      gateway: { tools: { allow: ["agents_list"] } },
     };
 
     const resProfile = await invokeAgentsListAuthed({ sessionKey: "main" });
@@ -276,6 +286,7 @@ describe("POST /tools/invoke", () => {
     cfg = {
       ...cfg,
       tools: { alsoAllow: ["agents_list"] },
+      gateway: { tools: { allow: ["agents_list"] } },
     };
 
     const resImplicit = await invokeAgentsListAuthed({ sessionKey: "main" });
@@ -444,6 +455,7 @@ describe("POST /tools/invoke", () => {
         ],
       },
       session: { mainKey: "primary" },
+      gateway: { tools: { allow: ["agents_list"] } },
     };
 
     const resDefault = await invokeAgentsListAuthed();
@@ -459,6 +471,7 @@ describe("POST /tools/invoke", () => {
       agents: {
         list: [{ id: "main", default: true, tools: { allow: ["tools_invoke_test"] } }],
       },
+      gateway: { tools: { allow: ["tools_invoke_test"] } },
     };
 
     const inputRes = await invokeToolAuthed({

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -170,7 +170,7 @@ export function normalizeMimeList(values: string[] | undefined, fallback: string
 
 export function resolveInputFileLimits(config?: InputFileLimitsConfig): InputFileLimits {
   return {
-    allowUrl: config?.allowUrl ?? true,
+    allowUrl: config?.allowUrl ?? false,
     allowedMimes: normalizeMimeList(config?.allowedMimes, DEFAULT_INPUT_FILE_MIMES),
     maxBytes: config?.maxBytes ?? DEFAULT_INPUT_FILE_MAX_BYTES,
     maxChars: config?.maxChars ?? DEFAULT_INPUT_FILE_MAX_CHARS,

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -191,7 +191,7 @@ export function resolveEnableState(
   if (origin === "bundled") {
     return { enabled: false, reason: "bundled (disabled by default)" };
   }
-  return { enabled: true };
+  return { enabled: false, reason: "external plugin (disabled by default)" };
 }
 
 export function resolveMemorySlotDecision(params: {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -297,7 +297,7 @@ function warnWhenAllowlistIsOpen(params: {
     .join(", ");
   const extra = nonBundled.length > 6 ? ` (+${nonBundled.length - 6} more)` : "";
   params.logger.warn(
-    `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+    `[plugins] plugins.allow is empty; discovered non-bundled plugins stay disabled by default: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
   );
 }
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -311,6 +311,21 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       });
       return;
     }
+    const pluginPrefix = `/plugins/${record.id}`;
+    const isPluginScoped =
+      normalizedPath === pluginPrefix || normalizedPath.startsWith(`${pluginPrefix}/`);
+    const isChannelRoute = normalizedPath.startsWith("/api/channels/");
+    if (!isPluginScoped && !isChannelRoute) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message:
+          `http route must be namespaced under ${pluginPrefix}/... ` +
+          `or /api/channels/... (received: ${normalizedPath})`,
+      });
+      return;
+    }
     if (registry.httpRoutes.some((entry) => entry.path === normalizedPath)) {
       pushDiagnostic({
         level: "error",

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -510,11 +510,15 @@ export function collectHooksHardeningFindings(
 
 export function collectGatewayHttpSessionKeyOverrideFindings(
   cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv = process.env,
 ): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
   const chatCompletionsEnabled = cfg.gateway?.http?.endpoints?.chatCompletions?.enabled === true;
   const responsesEnabled = cfg.gateway?.http?.endpoints?.responses?.enabled === true;
   if (!chatCompletionsEnabled && !responsesEnabled) {
+    return findings;
+  }
+  if (env.OPENCLAW_ALLOW_HTTP_SESSION_KEY_HEADER !== "1") {
     return findings;
   }
 
@@ -525,7 +529,7 @@ export function collectGatewayHttpSessionKeyOverrideFindings(
 
   findings.push({
     checkId: "gateway.http.session_key_override_enabled",
-    severity: "info",
+    severity: "warn",
     title: "HTTP API session-key override is enabled",
     detail:
       `${enabledEndpoints.join(", ")} accept x-openclaw-session-key for per-request session routing. ` +

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -178,7 +178,7 @@ describe("security audit", () => {
     }
   });
 
-  it("warns when non-loopback bind has auth but no auth rate limit", async () => {
+  it("does not warn about missing auth rate limit when defaults are enforced", async () => {
     const cfg: OpenClawConfig = {
       gateway: {
         bind: "lan",
@@ -188,7 +188,7 @@ describe("security audit", () => {
 
     const res = await audit(cfg, { env: {} });
 
-    expect(hasFinding(res, "gateway.auth_no_rate_limit", "warn")).toBe(true);
+    expect(hasFinding(res, "gateway.auth_no_rate_limit")).toBe(false);
   });
 
   it("warns when gateway.tools.allow re-enables dangerous HTTP /tools/invoke tools (loopback)", async () => {
@@ -1407,13 +1407,15 @@ describe("security audit", () => {
       },
     };
 
-    const res = await audit(cfg);
+    const res = await audit(cfg, {
+      env: { OPENCLAW_ALLOW_HTTP_SESSION_KEY_HEADER: "1" },
+    });
 
     expect(res.findings).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           checkId: "gateway.http.session_key_override_enabled",
-          severity: "info",
+          severity: "warn",
         }),
       ]),
     );

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -283,9 +283,9 @@ function collectGatewayConfigFindings(
     findings.push({
       checkId: "gateway.tools_invoke_http.dangerous_allow",
       severity: extraRisk ? "critical" : "warn",
-      title: "Gateway HTTP /tools/invoke re-enables dangerous tools",
+      title: "Gateway HTTP /tools/invoke exposes dangerous tools",
       detail:
-        `gateway.tools.allow includes ${reenabledOverHttp.join(", ")} which removes them from the default HTTP deny list. ` +
+        `gateway.tools.allow includes ${reenabledOverHttp.join(", ")}. ` +
         "This can allow remote session spawning / control-plane actions via HTTP and increases RCE blast radius if the gateway is reachable.",
       remediation:
         "Remove these entries from gateway.tools.allow (recommended). " +
@@ -435,19 +435,6 @@ function collectGatewayConfigFindings(
           '(e.g., ["nick@example.com"]).',
       });
     }
-  }
-
-  if (bind !== "loopback" && auth.mode !== "trusted-proxy" && !cfg.gateway?.auth?.rateLimit) {
-    findings.push({
-      checkId: "gateway.auth_no_rate_limit",
-      severity: "warn",
-      title: "No auth rate limiting configured",
-      detail:
-        "gateway.bind is not loopback but no gateway.auth.rateLimit is configured. " +
-        "Without rate limiting, brute-force auth attacks are not mitigated.",
-      remediation:
-        "Set gateway.auth.rateLimit (e.g. { maxAttempts: 10, windowMs: 60000, lockoutMs: 300000 }).",
-    });
   }
 
   return findings;
@@ -673,7 +660,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...collectExecRuntimeFindings(cfg));
   findings.push(...collectHooksHardeningFindings(cfg, env));
   findings.push(...collectGatewayHttpNoAuthFindings(cfg, env));
-  findings.push(...collectGatewayHttpSessionKeyOverrideFindings(cfg));
+  findings.push(...collectGatewayHttpSessionKeyOverrideFindings(cfg, env));
   findings.push(...collectSandboxDockerNoopFindings(cfg));
   findings.push(...collectSandboxDangerousConfigFindings(cfg));
   findings.push(...collectNodeDenyCommandPatternFindings(cfg));

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -2,9 +2,8 @@
 // Keep these centralized so gateway HTTP restrictions, security audits, and ACP prompts don't drift.
 
 /**
- * Tools denied via Gateway HTTP `POST /tools/invoke` by default.
- * These are high-risk because they enable session orchestration, control-plane actions,
- * or interactive flows that don't make sense over a non-interactive HTTP surface.
+ * High-risk tools that should never be exposed over HTTP accidentally.
+ * These are used by security audits and policy checks.
  */
 export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
   // Session orchestration — spawning agents remotely is RCE


### PR DESCRIPTION
## Summary
- harden gateway and plugin trust boundaries to reduce compromise risk by default
- move HTTP tool exposure to explicit allowlist-only behavior
- enforce plugin HTTP route namespacing and authenticated plugin namespace dispatch
- tighten unsafe auth bypass paths behind explicit env gates
- make plugin install code-safety scanning fail-closed (critical findings and scanner errors block install)
- disable URL ingestion defaults for file/image paths unless explicitly enabled
- add mTLS requirement toggle and enforce CA presence when enabled
- expand security headers and align audit findings with hardened behavior

## Documentation
- add comprehensive handoff report:
  - `docs/security/HARDENING-HANDOFF-2026-02-20.md`

## Validation
- unit/security-focused tests:
  - `corepack pnpm vitest src/plugins/loader.test.ts src/gateway/server.plugin-http-auth.test.ts src/gateway/tools-invoke-http.test.ts src/security/audit.test.ts src/gateway/server-runtime-config.test.ts`
- e2e/security-focused tests:
  - `corepack pnpm vitest run --config vitest.e2e.config.ts src/plugins/install.e2e.test.ts src/gateway/openai-http.e2e.test.ts src/gateway/openresponses-http.e2e.test.ts`
  - `corepack pnpm vitest run --config vitest.e2e.config.ts src/gateway/server.auth.e2e.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements comprehensive security hardening for OpenClaw's gateway and plugin trust boundaries. The changes systematically reduce attack surface by moving from permissive defaults to explicit allowlist-based controls across multiple subsystems.

**Key Changes:**
- HTTP tool exposure (`/tools/invoke`) now requires explicit allowlisting via `gateway.tools.allow` (previously deny-list based)
- Plugin HTTP routes enforced to stay within `/plugins/<pluginId>/` or `/api/channels/` namespaces
- Plugin HTTP dispatch now requires gateway authentication for all plugin namespaces
- External plugins disabled by default (was auto-enabled for discovered plugins)
- Plugin install code-safety scanning now fail-closed for critical findings and scanner errors
- Insecure Control UI auth bypass flags blocked unless explicit env gate enabled
- URL ingestion for files/images disabled by default (was enabled)
- Session override header disabled by default, gated behind explicit env flag
- Generated startup tokens no longer auto-persist (requires opt-in env flag)
- Auth rate limiting always enforced with defaults
- mTLS client certificate requirement toggle added with CA validation
- Additional security headers: `X-Frame-Options`, `Permissions-Policy`, `Cross-Origin-Opener-Policy`

**Security Impact:**
These changes represent multiple breaking behavioral changes that significantly harden the default security posture. All changes are well-documented, properly gated behind environment variables where appropriate, and include comprehensive test coverage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All security hardening changes follow defense-in-depth principles with fail-safe defaults. Comprehensive test coverage (117 unit tests, 24 e2e tests) validates all hardening logic. Breaking changes are clearly documented with migration paths. The implementation consistently enforces security boundaries across gateway, plugin, and HTTP surfaces with no identified gaps.
- No files require special attention

<sub>Last reviewed commit: 8420066</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->