### PR TITLE
fix(ios): force tls for non-loopback manual gateway hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Failover: treat non-default override runs as direct fallback-to-configured-primary (skip configured fallback chain), normalize default-model detection for provider casing/whitespace, and add regression coverage for override/auth error paths. (#18820) Thanks @Glucksberg.
 - Auto-reply/Tool results: serialize tool-result delivery and keep the delivery chain progressing after individual failures so concurrent tool outputs preserve user-visible ordering. (#21231) thanks @ahdernasr.
 - Auto-reply/Prompt caching: restore prefix-cache stability by keeping inbound system metadata session-stable and moving per-message IDs (`message_id`, `message_id_full`, `reply_to_id`, `sender_id`) into untrusted conversation context. (#20597) Thanks @anisoptera.
+- iOS/Security: force `https://` for non-loopback manual gateway hosts during iOS onboarding to block insecure remote transport URLs. (#21969) Thanks @mbelinky.
 - CLI/Onboarding: fix Anthropic-compatible custom provider verification by normalizing base URLs to avoid duplicate `/v1` paths during setup checks. (#21336) Thanks @17jmumford.
 - Security/Dependencies: bump transitive `hono` usage to `4.11.10` to incorporate timing-safe authentication comparison hardening for `basicAuth`/`bearerAuth` (`GHSA-gq3j-xvxp-8hrf`). Thanks @vincentkoc.
 

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -102,4 +102,29 @@ import Testing
 
         #expect(controller._test_didAutoConnect() == false)
     }
+
+    @Test @MainActor func manualConnectionsForceTLSForNonLoopbackHosts() async {
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+        #expect(controller._test_resolveManualUseTLS(host: "gateway.example.com", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "openclaw.local", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "127.attacker.example", useTLS: false) == true)
+
+        #expect(controller._test_resolveManualUseTLS(host: "localhost", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "127.0.0.1", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "::1", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "[::1]", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "0.0.0.0", useTLS: false) == false)
+    }
+
+    @Test @MainActor func manualDefaultPortUses443OnlyForTailnetTLSHosts() async {
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+        #expect(controller._test_resolveManualPort(host: "gateway.example.com", port: 0, useTLS: true) == 18789)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 0, useTLS: true) == 443)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net.", port: 0, useTLS: true) == 443)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 18789, useTLS: true) == 18789)
+    }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 


### PR DESCRIPTION
## Summary\n- force TLS for manual gateway hosts that are not true loopback\n- keep .ts.net default-port behavior unchanged\n- harden loopback detection to avoid prefix-bypass hosts like 127.attacker.example\n- add gateway security tests for manual TLS behavior and default port behavior\n\n## Why\nThis supersedes the iOS part of #21441 with a tighter loopback matcher and focused scope.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens iOS manual gateway connections by forcing TLS for all non-loopback hosts. It introduces a robust `isLoopbackHost` check using `inet_pton` (preventing hostname prefix-bypass attacks like `127.attacker.example`), adds `resolveManualUseTLS` to centralize the TLS decision, and consistently applies it across all three manual-connection code paths (`connectManual`, `maybeAutoConnect` manual branch, and `maybeAutoConnect` last-known branch). The existing `.ts.net` default-port logic (`shouldForceTLS`) is preserved unchanged for port resolution only.

- All three manual gateway connection paths now force TLS for non-loopback hosts
- Loopback detection covers IPv4 (`127.0.0.0/8`), IPv6 (`::1`), IPv4-mapped IPv6 (`::ffff:127.x.x.x`), `localhost`, `0.0.0.0`, `::`, bracket-wrapped addresses, and zone IDs
- New tests verify both the TLS enforcement and default-port behavior invariants
- `shouldForceTLS` (`.ts.net` detection) is retained solely for the `resolveManualPort` default-port logic

<h3>Confidence Score: 5/5</h3>

- This PR is a well-scoped security hardening change that is safe to merge.
- The changes are focused on a clear security improvement (forcing TLS for non-loopback manual gateway hosts). The loopback detection is implemented correctly using `inet_pton` for robust IP parsing, preventing hostname prefix-bypass attacks. All three manual-connection code paths are consistently updated. The existing `.ts.net` default-port behavior is preserved. New tests cover the key security invariants including edge cases. No logic errors or regressions detected.
- No files require special attention.

<sub>Last reviewed commit: 7a8ccbe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->