### PR TITLE
fix(shared): reject insecure non-loopback gateway deep links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/Tool results: serialize tool-result delivery and keep the delivery chain progressing after individual failures so concurrent tool outputs preserve user-visible ordering. (#21231) thanks @ahdernasr.
 - Auto-reply/Prompt caching: restore prefix-cache stability by keeping inbound system metadata session-stable and moving per-message IDs (`message_id`, `message_id_full`, `reply_to_id`, `sender_id`) into untrusted conversation context. (#20597) Thanks @anisoptera.
 - iOS/Security: force `https://` for non-loopback manual gateway hosts during iOS onboarding to block insecure remote transport URLs. (#21969) Thanks @mbelinky.
+- Shared/Security: reject insecure deep links that use `ws://` non-loopback gateway URLs to prevent plaintext remote websocket configuration. (#21970) Thanks @mbelinky.
 - CLI/Onboarding: fix Anthropic-compatible custom provider verification by normalizing base URLs to avoid duplicate `/v1` paths during setup checks. (#21336) Thanks @17jmumford.
 - Security/Dependencies: bump transitive `hono` usage to `4.11.10` to incorporate timing-safe authentication comparison hardening for `basicAuth`/`bearerAuth` (`GHSA-gq3j-xvxp-8hrf`). Thanks @vincentkoc.
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 
 public enum DeepLinkRoute: Sendable, Equatable {
     case agent(AgentDeepLink)
@@ -20,6 +21,40 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         self.password = password
     }
 
+    fileprivate static func isLoopbackHost(_ raw: String) -> Bool {
+        var host = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        if host.hasSuffix(".") {
+            host.removeLast()
+        }
+        if let zoneIndex = host.firstIndex(of: "%") {
+            host = String(host[..<zoneIndex])
+        }
+        if host.isEmpty {
+            return false
+        }
+        if host == "localhost" || host == "0.0.0.0" || host == "::" {
+            return true
+        }
+
+        if let ipv4 = IPv4Address(host) {
+            return ipv4.rawValue.first == 127
+        }
+        if let ipv6 = IPv6Address(host) {
+            let bytes = Array(ipv6.rawValue)
+            let isV6Loopback = bytes[0..<15].allSatisfy { $0 == 0 } && bytes[15] == 1
+            if isV6Loopback {
+                return true
+            }
+            let isMappedV4 = bytes[0..<10].allSatisfy { $0 == 0 } && bytes[10] == 0xFF && bytes[11] == 0xFF
+            return isMappedV4 && bytes[12] == 127
+        }
+
+        return false
+    }
+
     public var websocketURL: URL? {
         let scheme = self.tls ? "wss" : "ws"
         return URL(string: "\(scheme)://\(self.host):\(self.port)")
@@ -35,7 +70,11 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         else { return nil }
 
         let scheme = (parsed.scheme ?? "ws").lowercased()
+        guard scheme == "ws" || scheme == "wss" else { return nil }
         let tls = scheme == "wss"
+        if !tls, !Self.isLoopbackHost(hostname) {
+            return nil
+        }
         let port = parsed.port ?? (tls ? 443 : 18789)
         let token = json["token"] as? String
         let password = json["password"] as? String
@@ -128,6 +167,9 @@ public enum DeepLinkParser {
             }
             let port = query["port"].flatMap { Int($0) } ?? 18789
             let tls = (query["tls"] as NSString?)?.boolValue ?? false
+            if !tls, !GatewayConnectDeepLink.isLoopbackHost(hostParam) {
+                return nil
+            }
             return .gateway(
                 .init(
                     host: hostParam,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import OpenClawKit
+import Testing
+
+@Suite struct DeepLinksSecurityTests {
+    @Test func gatewayDeepLinkRejectsInsecureNonLoopbackWs() {
+        let url = URL(
+            string: "openclaw://gateway?host=attacker.example&port=18789&tls=0&token=abc")!
+        #expect(DeepLinkParser.parse(url) == nil)
+    }
+
+    @Test func gatewayDeepLinkRejectsInsecurePrefixBypassHost() {
+        let url = URL(
+            string: "openclaw://gateway?host=127.attacker.example&port=18789&tls=0&token=abc")!
+        #expect(DeepLinkParser.parse(url) == nil)
+    }
+
+    @Test func gatewayDeepLinkAllowsLoopbackWs() {
+        let url = URL(
+            string: "openclaw://gateway?host=127.0.0.1&port=18789&tls=0&token=abc")!
+        #expect(
+            DeepLinkParser.parse(url) == .gateway(
+                .init(host: "127.0.0.1", port: 18789, tls: false, token: "abc", password: nil)))
+    }
+
+    @Test func setupCodeRejectsInsecureNonLoopbackWs() {
+        let payload = #"{"url":"ws://attacker.example:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        #expect(GatewayConnectDeepLink.fromSetupCode(encoded) == nil)
+    }
+
+    @Test func setupCodeRejectsInsecurePrefixBypassHost() {
+        let payload = #"{"url":"ws://127.attacker.example:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        #expect(GatewayConnectDeepLink.fromSetupCode(encoded) == nil)
+    }
+
+    @Test func setupCodeAllowsLoopbackWs() {
+        let payload = #"{"url":"ws://127.0.0.1:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        #expect(
+            GatewayConnectDeepLink.fromSetupCode(encoded) == .init(
+                host: "127.0.0.1",
+                port: 18789,
+                tls: false,
+                token: "tok",
+                password: nil))
+    }
+}


### PR DESCRIPTION
## Summary\n- reject insecure non-loopback ws:// gateway deep links in shared parser\n- reject insecure non-loopback ws:// setup-code payload URLs\n- use strict loopback parsing (blocks 127.attacker.example bypass)\n- add shared DeepLinksSecurityTests and iOS parser coverage\n\n## Why\nThis lands the deep-link security intent from #21268 with a strict matcher and focused scope.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds security validation to reject insecure `ws://` gateway deep links when connecting to non-loopback hosts. The `isLoopbackHost` helper uses Swift's `Network` framework to parse and validate IPv4/IPv6 addresses, blocking prefix-bypass attacks like `127.attacker.example`. Validation is enforced in both the direct gateway deep link parser (DeepLinks.swift:170-172) and setup code payload parser (DeepLinks.swift:75-77).

- Comprehensive test coverage includes bypass attempts and positive loopback cases
- Aligns with existing Node.js loopback validation patterns in the codebase (src/gateway/net.ts)
- Properly handles edge cases: IPv6 zone indices, trailing dots, bracket notation, IPv4-mapped IPv6

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues identified.
- The security fix is well-implemented with robust validation logic, comprehensive test coverage for both attack vectors and valid loopback scenarios, and consistent with existing patterns in the codebase. The `isLoopbackHost` function correctly handles edge cases and bypass attempts.
- No files require special attention

<sub>Last reviewed commit: f57fb0b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->