### PR TITLE
fix(macos): reject insecure non-loopback ws remote gateway urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/Prompt caching: restore prefix-cache stability by keeping inbound system metadata session-stable and moving per-message IDs (`message_id`, `message_id_full`, `reply_to_id`, `sender_id`) into untrusted conversation context. (#20597) Thanks @anisoptera.
 - iOS/Security: force `https://` for non-loopback manual gateway hosts during iOS onboarding to block insecure remote transport URLs. (#21969) Thanks @mbelinky.
 - Shared/Security: reject insecure deep links that use `ws://` non-loopback gateway URLs to prevent plaintext remote websocket configuration. (#21970) Thanks @mbelinky.
+- macOS/Security: reject non-loopback `ws://` remote gateway URLs in macOS remote config to block insecure plaintext websocket endpoints. (#21971) Thanks @mbelinky.
 - CLI/Onboarding: fix Anthropic-compatible custom provider verification by normalizing base URLs to avoid duplicate `/v1` paths during setup checks. (#21336) Thanks @17jmumford.
 - Security/Dependencies: bump transitive `hono` usage to `4.11.10` to incorporate timing-safe authentication comparison hardening for `basicAuth`/`bearerAuth` (`GHSA-gq3j-xvxp-8hrf`). Thanks @vincentkoc.
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -218,9 +218,19 @@ import Testing
         #expect(url.absoluteString == "https://gateway.example:443/remote-ui/")
     }
 
-    @Test func normalizeGatewayUrlAddsDefaultPortForWs() {
-        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://gateway")
+    @Test func normalizeGatewayUrlAddsDefaultPortForLoopbackWs() {
+        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://127.0.0.1")
         #expect(url?.port == 18789)
-        #expect(url?.absoluteString == "ws://gateway:18789")
+        #expect(url?.absoluteString == "ws://127.0.0.1:18789")
+    }
+
+    @Test func normalizeGatewayUrlRejectsNonLoopbackWs() {
+        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://gateway")
+        #expect(url == nil)
+    }
+
+    @Test func normalizeGatewayUrlRejectsPrefixBypassLoopbackHost() {
+        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://127.attacker.example")
+        #expect(url == nil)
     }
 }


### PR DESCRIPTION
## Summary\n- reject insecure non-loopback ws:// URLs in GatewayRemoteConfig normalization\n- use strict loopback parsing to avoid prefix bypasses\n- add/adjust GatewayEndpointStore tests for allowed loopback and rejected non-loopback/prefix-bypass hosts\n\n## Why\nThis lands the macOS remote-config hardening intent from #21268 as a separate focused change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds security hardening to reject insecure `ws://` URLs for non-loopback gateway connections on macOS. The implementation uses robust IP address parsing via the Network framework to prevent both direct non-loopback connections and prefix-bypass attacks (e.g., `ws://127.attacker.example`). The loopback detection correctly handles localhost, IPv4 127.x.x.x addresses, IPv6 `::1`, and IPv4-mapped IPv6 addresses.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security hardening change with appropriate test coverage
- The implementation correctly addresses the security concern by using proper IP address parsing instead of string matching, includes comprehensive loopback detection for IPv4 and IPv6, and has test coverage for the new security constraints including edge cases
- No files require special attention

<sub>Last reviewed commit: 93df6ad</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->