### PR TITLE
fix: extend cacheRetention auto-injection to amazon-bedrock Anthropic models

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -54,8 +54,7 @@ function resolveCacheRetention(
 ): CacheRetention | undefined {
   const isAnthropicDirect = provider === "anthropic";
   const isAnthropicBedrock =
-    provider === "amazon-bedrock" &&
-    extraParams?.cacheRetention !== undefined;
+    provider === "amazon-bedrock" && extraParams?.cacheRetention !== undefined;
   if (!isAnthropicDirect && !isAnthropicBedrock) {
     return undefined;
   }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -42,16 +42,21 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
  *
  * Mapping: "5m" → "short", "1h" → "long"
  *
- * Only applies to Anthropic provider (OpenRouter uses openai-completions API
- * with hardcoded cache_control, not the cacheRetention stream option).
+ * Only applies to Anthropic provider and Anthropic Claude models on Bedrock.
+ * (OpenRouter uses openai-completions API with hardcoded cache_control,
+ * not the cacheRetention stream option).
  *
- * Defaults to "short" for Anthropic provider when not explicitly configured.
+ * Defaults to "short" for Anthropic when not explicitly configured.
  */
 function resolveCacheRetention(
   extraParams: Record<string, unknown> | undefined,
   provider: string,
 ): CacheRetention | undefined {
-  if (provider !== "anthropic") {
+  const isAnthropicDirect = provider === "anthropic";
+  const isAnthropicBedrock =
+    provider === "amazon-bedrock" &&
+    extraParams?.cacheRetention !== undefined;
+  if (!isAnthropicDirect && !isAnthropicBedrock) {
     return undefined;
   }
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -388,7 +388,15 @@ export function applyContextPruningDefaults(cfg: OpenClawConfig): OpenClawConfig
 
     for (const [key, entry] of Object.entries(nextModels)) {
       const parsed = parseModelRef(key, "anthropic");
-      if (!parsed || parsed.provider !== "anthropic") {
+      if (!parsed) {
+        continue;
+      }
+      // Accept both direct Anthropic and Anthropic Claude models on Bedrock.
+      const isAnthropicDirect = parsed.provider === "anthropic";
+      const isAnthropicBedrock =
+        parsed.provider === "amazon-bedrock" &&
+        parsed.model.toLowerCase().includes("anthropic.claude");
+      if (!isAnthropicDirect && !isAnthropicBedrock) {
         continue;
       }
       const current = entry ?? {};
@@ -406,7 +414,11 @@ export function applyContextPruningDefaults(cfg: OpenClawConfig): OpenClawConfig
     const primary = resolvePrimaryModelRef(defaults.model?.primary ?? undefined);
     if (primary) {
       const parsedPrimary = parseModelRef(primary, "anthropic");
-      if (parsedPrimary?.provider === "anthropic") {
+      const isPrimaryAnthropicDirect = parsedPrimary?.provider === "anthropic";
+      const isPrimaryAnthropicBedrock =
+        parsedPrimary?.provider === "amazon-bedrock" &&
+        parsedPrimary.model.toLowerCase().includes("anthropic.claude");
+      if (isPrimaryAnthropicDirect || isPrimaryAnthropicBedrock) {
         const key = `${parsedPrimary.provider}/${parsedPrimary.model}`;
         const entry = nextModels[key];
         const current = entry ?? {};


### PR DESCRIPTION
## Summary

Two changes to make `cacheRetention` work end-to-end for Anthropic Claude models on the `amazon-bedrock` provider.

## Changes

### 1. `src/config/defaults.ts` — config auto-injection

The config auto-injection in `applyContextPruningDefaults` only sets `cacheRetention: "short"` for `provider === "anthropic"`, skipping Bedrock Claude models. Extended the provider gate to also match `amazon-bedrock` models whose ID contains `anthropic.claude`.

### 2. `src/agents/pi-embedded-runner/extra-params.ts` — runtime pass-through

`resolveCacheRetention` hard-gates on `provider !== "anthropic"` and returns `undefined` for all other providers. This means `cacheRetention` written to config is never consumed at runtime for Bedrock models. Extended the gate to also accept `amazon-bedrock` when `cacheRetention` is explicitly set in `extraParams`. No default is applied for Bedrock since pi-ai's own provider already defaults to `"short"` internally.

## Related

- Fixes the config + runtime parts of #21986
- Complements PR #20866 (disables caching for non-Anthropic Bedrock models)
- The TTL validation gap (`cacheRetention: "long"` → `ttl: "1h"` on unsupported models) is a separate upstream pi-ai concern, tracked in #21986 and [pi-mono discussion #1571](https://github.com/badlogic/pi-mono/discussions/1571)

## Testing

- [x] AI-assisted (Kiro CLI)
- [x] Lightly tested against local openclaw instance with `amazon-bedrock/us.anthropic.claude-opus-4-6-v1`
- [x] Confirmed `cacheRetention` is auto-injected and consumed at runtime for Bedrock Claude models
- [x] Confirmed non-Anthropic Bedrock models are correctly skipped