### PR TITLE
fix(telegram): allow colon in provider name for model callback parsing (#21939)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/Prompt caching: restore prefix-cache stability by keeping inbound system metadata session-stable and moving per-message IDs (`message_id`, `message_id_full`, `reply_to_id`, `sender_id`) into untrusted conversation context. (#20597) Thanks @anisoptera.
 - CLI/Onboarding: fix Anthropic-compatible custom provider verification by normalizing base URLs to avoid duplicate `/v1` paths during setup checks. (#21336) Thanks @17jmumford.
 - Security/Dependencies: bump transitive `hono` usage to `4.11.10` to incorporate timing-safe authentication comparison hardening for `basicAuth`/`bearerAuth` (`GHSA-gq3j-xvxp-8hrf`). Thanks @vincentkoc.
+- Telegram/Models: allow colon in provider names for inline keyboard callback data so providers like `ollama:cloud` no longer trigger spurious LLM runs. (#21939)
 
 ## 2026.2.19
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -30,6 +30,11 @@ describe("parseModelCallbackData", () => {
     expect(result).toEqual({ type: "list", provider: "open-ai", page: 1 });
   });
 
+  it("parses mdl_list callback with colon in provider name", () => {
+    const result = parseModelCallbackData("mdl_list_ollama:cloud_1");
+    expect(result).toEqual({ type: "list", provider: "ollama:cloud", page: 1 });
+  });
+
   it("parses mdl_sel callback with provider/model", () => {
     const result = parseModelCallbackData("mdl_sel_anthropic/claude-sonnet-4-5");
     expect(result).toEqual({

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -48,7 +48,7 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
   }
 
   // mdl_list_{provider}_{page}
-  const listMatch = trimmed.match(/^mdl_list_([a-z0-9_-]+)_(\d+)$/i);
+  const listMatch = trimmed.match(/^mdl_list_([a-z0-9_:-]+)_(\d+)$/i);
   if (listMatch) {
     const [, provider, pageStr] = listMatch;
     const page = Number.parseInt(pageStr ?? "1", 10);


### PR DESCRIPTION
## Summary

- **Bug**: Clicking a provider with `:` in its name (e.g. `ollama:cloud`) in Telegram `/models` inline keyboard triggers a new LLM run instead of showing the model list
- **Root cause**: `parseModelCallbackData` regex `[a-z0-9_-]` excludes `:`, so callback data like `mdl_list_ollama:cloud_1` never matches
- **Fix**: Add `:` to the regex character class

Fixes #21939

## Problem

The `parseModelCallbackData` function in `src/telegram/model-buttons.ts` uses this regex to parse list callbacks:

```typescript
const listMatch = trimmed.match(/^mdl_list_([a-z0-9_-]+)_(\d+)$/i);
```

The character class `[a-z0-9_-]` does not include `:`. Providers like `ollama:cloud` generate callback data `mdl_list_ollama:cloud_1` which fails to match. The function returns `null`, causing the callback to fall through to the catch-all handler that creates a synthetic text message and triggers a new LLM agent run on every button click.

**Before fix:**
Input:  `"mdl_list_ollama:cloud_1"`
Output: `null`

## Changes

- `src/telegram/model-buttons.ts` — add `:` to regex character class: `[a-z0-9_:-]`
- `src/telegram/model-buttons.test.ts` — add regression test for colon in provider name

**After fix:**
Input:  `"mdl_list_ollama:cloud_1"`
Output: `{ type: "list", provider: "ollama:cloud", page: 1 }`

## Test plan

- [x] New test: colon in provider name parses correctly
- [x] All existing model-buttons tests pass
- [x] Lint passes

## Effect on User Experience

**Before:** Clicking a provider like `ollama:cloud` in the Telegram `/models` inline keyboard triggers an endless loop of new LLM runs instead of showing the model list.
**After:** Clicking any provider (including those with colons) correctly shows the paginated model list.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed regex parsing for Telegram inline keyboard callbacks to allow colons in provider names (e.g., `ollama:cloud`). The character class in `parseModelCallbackData` was expanded from `[a-z0-9_-]` to `[a-z0-9_:-]` on line 51 of `src/telegram/model-buttons.ts`.

- **Root cause**: Provider names containing `:` like `ollama:cloud` generated callback data `mdl_list_ollama:cloud_1` that failed to match the regex, causing the parser to return `null` and triggering spurious LLM runs
- **Fix**: Added `:` to the allowed character class in the list callback regex pattern
- **Test coverage**: New regression test added for colon-containing provider names
- **Impact**: Providers with colons now correctly display model lists instead of triggering unintended agent runs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a precise, minimal change to a regex character class with comprehensive test coverage. The change is backward-compatible (still matches all previous valid provider names), fixes a real bug with a clear reproduction path, and includes a regression test. The affected code is well-isolated to the parsing function with no side effects.
- No files require special attention

<sub>Last reviewed commit: 01d5aaf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->