### PR TITLE
Config: load valid backup when primary config is invalid

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -286,18 +286,15 @@ describe("doctor config flow", () => {
       expect(cfg.channels.discord.guilds["100"].channels.general.users).toEqual(["333"]);
       expect(cfg.channels.discord.guilds["100"].channels.general.roles).toEqual(["444"]);
       expect(cfg.channels.discord.accounts.default.allowFrom).toEqual(["123"]);
-      expect(cfg.channels.discord.accounts.work.allowFrom).toEqual(["555"]);
-      expect(cfg.channels.discord.accounts.work.dm.allowFrom).toEqual(["666"]);
-      expect(cfg.channels.discord.accounts.work.dm.groupChannels).toEqual(["777"]);
-      expect(cfg.channels.discord.accounts.work.execApprovals.approvers).toEqual(["888"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].users).toEqual(["999"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].roles).toEqual(["1010"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.users).toEqual([
-        "1111",
-      ]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.roles).toEqual([
-        "1212",
-      ]);
+      const work = cfg.channels.discord.accounts.work;
+      expect(work.allowFrom).toEqual(["555"]);
+      expect(work.dm.allowFrom).toEqual(["666"]);
+      expect(work.dm.groupChannels).toEqual(["777"]);
+      expect(work.execApprovals.approvers).toEqual(["888"]);
+      expect(work.guilds["200"].users).toEqual(["999"]);
+      expect(work.guilds["200"].roles).toEqual(["1010"]);
+      expect(work.guilds["200"].channels.help.users).toEqual(["1111"]);
+      expect(work.guilds["200"].channels.help.roles).toEqual(["1212"]);
     });
   });
 

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createConfigIO } from "./io.js";
 
 async function withTempHome(run: (home: string) => Promise<void>): Promise<void> {
@@ -135,6 +135,59 @@ describe("config io paths", () => {
         },
       });
       expect(cfg.agents?.list?.[0]?.tools?.exec?.safeBinTrustedDirs).toEqual(["/ops/bin"]);
+    });
+  });
+
+  it("falls back to valid .bak config when primary config is invalid", async () => {
+    await withTempHome(async (home) => {
+      const warn = vi.fn();
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const backupPath = `${configPath}.bak`;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        backupPath,
+        JSON.stringify(
+          {
+            gateway: {
+              port: 19999,
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            agents: {
+              defaults: {
+                compaction: {
+                  mode: "auto",
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: {
+          warn,
+          error: vi.fn(),
+        },
+      });
+      const cfg = io.loadConfig();
+      expect(cfg.gateway?.port).toBe(19999);
+      expect(warn).toHaveBeenCalledWith(
+        `Primary config invalid at ${configPath}; loaded backup config from ${backupPath}.`,
+      );
     });
   });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -679,6 +679,136 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
   const configPath =
     candidatePaths.find((candidate) => deps.fs.existsSync(candidate)) ?? requestedConfigPath;
 
+  const applyRuntimeConfigPipeline = (config: OpenClawConfig): OpenClawConfig => {
+    warnIfConfigFromFuture(config, deps.logger);
+    const cfg = applyModelDefaults(
+      applyCompactionDefaults(
+        applyContextPruningDefaults(
+          applyAgentDefaults(
+            applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(config))),
+          ),
+        ),
+      ),
+    );
+    normalizeConfigPaths(cfg);
+
+    const duplicates = findDuplicateAgentDirs(cfg, {
+      env: deps.env,
+      homedir: deps.homedir,
+    });
+    if (duplicates.length > 0) {
+      throw new DuplicateAgentDirError(duplicates);
+    }
+
+    applyConfigEnvVars(cfg, deps.env);
+    const enabled = shouldEnableShellEnvFallback(deps.env) || cfg.env?.shellEnv?.enabled === true;
+    if (enabled && !shouldDeferShellEnvFallback(deps.env)) {
+      loadShellEnvFallback({
+        enabled: true,
+        env: deps.env,
+        expectedKeys: SHELL_ENV_EXPECTED_KEYS,
+        logger: deps.logger,
+        timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(deps.env),
+      });
+    }
+
+    return applyConfigOverrides(cfg);
+  };
+
+  const readAndValidateConfig = (targetPath: string): OpenClawConfig => {
+    const raw = deps.fs.readFileSync(targetPath, "utf-8");
+    const parsed = deps.json5.parse(raw);
+    const { resolvedConfigRaw: resolvedConfig } = resolveConfigForRead(
+      resolveConfigIncludesForRead(parsed, targetPath, deps),
+      deps.env,
+    );
+    warnOnConfigMiskeys(resolvedConfig, deps.logger);
+    if (typeof resolvedConfig !== "object" || resolvedConfig === null) {
+      return {};
+    }
+    const preValidationDuplicates = findDuplicateAgentDirs(resolvedConfig as OpenClawConfig, {
+      env: deps.env,
+      homedir: deps.homedir,
+    });
+    if (preValidationDuplicates.length > 0) {
+      throw new DuplicateAgentDirError(preValidationDuplicates);
+    }
+    const validated = validateConfigObjectWithPlugins(resolvedConfig);
+    if (!validated.ok) {
+      const details = validated.issues
+        .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
+        .join("\n");
+      const error = new Error("Invalid config");
+      (error as { code?: string; details?: string }).code = "INVALID_CONFIG";
+      (error as { code?: string; details?: string }).details = details;
+      throw error;
+    }
+    if (validated.warnings.length > 0) {
+      const details = validated.warnings
+        .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
+        .join("\n");
+      deps.logger.warn(`Config warnings:\\n${details}`);
+    }
+    return applyRuntimeConfigPipeline(validated.config);
+  };
+
+  const listBackupCandidates = (): string[] => {
+    const dir = path.dirname(configPath);
+    const base = path.basename(configPath);
+    let names: string[] = [];
+    try {
+      names = deps.fs.readdirSync(dir);
+    } catch {
+      return [];
+    }
+    const prefix = `${base}.bak`;
+    const candidates = names
+      .filter((name) => name === prefix || name.startsWith(`${prefix}.`))
+      .map((name) => path.join(dir, name));
+    const safeMtimeMs = (candidate: string): number => {
+      try {
+        return deps.fs.statSync(candidate).mtimeMs;
+      } catch {
+        // Backup files can disappear between directory scan and stat.
+        return Number.NEGATIVE_INFINITY;
+      }
+    };
+    candidates.sort((a, b) => {
+      const aTime = safeMtimeMs(a);
+      const bTime = safeMtimeMs(b);
+      return bTime - aTime;
+    });
+    return candidates;
+  };
+
+  const loadFromBackupOnInvalidPrimary = (primaryErrorDetails?: string): OpenClawConfig | null => {
+    for (const candidate of listBackupCandidates()) {
+      try {
+        const loaded = readAndValidateConfig(candidate);
+        deps.logger.warn(
+          `Primary config invalid at ${configPath}; loaded backup config from ${candidate}.`,
+        );
+        return loaded;
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        if (code === "INVALID_CONFIG") {
+          continue;
+        }
+        if (err instanceof DuplicateAgentDirError) {
+          throw err;
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        deps.logger.warn(`Failed to load backup config candidate ${candidate}: ${message}`);
+      }
+    }
+    if (primaryErrorDetails) {
+      deps.logger.error(
+        `No valid config backup found for ${configPath}. Last validation error:\n${primaryErrorDetails}`,
+      );
+    }
+    return null;
+  };
+
   function loadConfig(): OpenClawConfig {
     try {
       maybeLoadDotEnvForConfig(deps.env);
@@ -808,8 +938,16 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         deps.logger.error(err.message);
         throw err;
       }
-      const error = err as { code?: string };
+      const error = err as { code?: string; details?: string };
       if (error?.code === "INVALID_CONFIG") {
+        if (!loggedInvalidConfigs.has(configPath)) {
+          loggedInvalidConfigs.add(configPath);
+          deps.logger.error(`Invalid config at ${configPath}:\n${error.details ?? "(no details)"}`);
+        }
+        const fromBackup = loadFromBackupOnInvalidPrimary(error.details);
+        if (fromBackup) {
+          return fromBackup;
+        }
         return {};
       }
       deps.logger.error(`Failed to read config at ${configPath}`, err);

--- a/src/media-understanding/runner.test-utils.ts
+++ b/src/media-understanding/runner.test-utils.ts
@@ -19,15 +19,16 @@ export async function withMediaFixture(
   },
   run: (params: MediaFixtureParams) => Promise<void>,
 ) {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-fixture-"));
   const tmpPath = path.join(
-    os.tmpdir(),
+    tmpDir,
     `${params.filePrefix}-${Date.now().toString()}.${params.extension}`,
   );
   await fs.writeFile(tmpPath, params.fileContents);
   const ctx = { MediaPath: tmpPath, MediaType: params.mediaType };
   const media = normalizeMediaAttachments(ctx);
   const cache = createMediaAttachmentCache(media, {
-    localPathRoots: [path.dirname(tmpPath)],
+    localPathRoots: [tmpDir],
   });
 
   try {
@@ -37,6 +38,7 @@ export async function withMediaFixture(
   } finally {
     await cache.cleanup();
     await fs.unlink(tmpPath).catch(() => {});
+    await fs.rmdir(tmpDir).catch(() => {});
   }
 }
 


### PR DESCRIPTION
## Summary

  - Problem: openclaw.json can become invalid (example seen in prod logs: agents.defaults.compaction.mode: Invalid input), causing startup
    failure.
  - Why it matters: gateway startup failure can disrupt channel availability (observed Telegram outage window while config stayed invalid).
  - What changed: config loader now attempts rollback to a valid backup (openclaw.json.bak*, newest first) when primary config is invalid.
  - What did NOT change (scope boundary): schema remains strict; no coercion/normalization of invalid values (e.g. "auto" is still invalid for
    compaction.mode).

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [x] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #

  ## User-visible / Behavior Changes

  - On startup, when primary config is invalid, OpenClaw now tries valid openclaw.json.bak* backups automatically instead of immediately
    falling back to empty config.
  - Invalid config values are still rejected (strict schema unchanged).

  ## Security Impact (required)

  - New permissions/capabilities? (No)
  - Secrets/tokens handling changed? (No)
  - New/changed network calls? (No)
  - Command/tool execution surface changed? (No)
  - Data access scope changed? (No)
  - If any Yes, explain risk + mitigation:

  ## Repro + Verification

  ### Environment

  - OS: Linux
  - Runtime/container: Node 22.22.0, OpenClaw 2026.2.17 runtime logs
  - Model/provider: N/A (failure occurs during config load)
  - Integration/channel (if any): Telegram
  - Relevant config (redacted): agents.defaults.compaction.mode: "auto" (invalid)

  ### Steps

  1. Set invalid config value: agents.defaults.compaction.mode = "auto".
  2. Ensure a valid openclaw.json.bak exists.
  3. Start gateway.

  ### Expected

  - Gateway recovers by loading a valid backup config and continues startup.

  ### Actual

  - Before fix: repeated Config invalid startup failures.
  - After fix: loader can recover via valid backup; startup continues.

  ## Evidence

  - [x] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  Before (failing evidence):

  - `Config invalid`
  - `agents.defaults.compaction.mode: Invalid input`
  - `Run: openclaw doctor --fix`

  After (passing evidence):

  - Added regression test:
    - `falls back to valid .bak config when primary config is invalid` (`src/config/io.compat.test.ts`)
  - Verification command passed:
    - `pnpm test src/config/io.compat.test.ts src/config/io.write-config.test.ts`
    - Result: `13 passed`



  ## Human Verification (required)

  - Verified scenarios:
      - Confirmed invalid config failure pattern from real logs.
      - Confirmed new loader fallback path to valid backups in code and tests.
  - Edge cases checked:
      - Primary invalid + valid backup present -> backup loaded.
      - Existing config I/O tests still pass.
  - What you did not verify:
      - Full end-to-end restart behavior on a separate production host in this PR run.

  ## Compatibility / Migration

  - Backward compatible? (Yes)
  - Config/env changes? (No)
  - Migration needed? (No)
  - If yes, exact upgrade steps:

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly:
      - Revert commit 0801a6f34.
  - Files/config to restore:
      - src/config/io.ts
      - src/config/io.compat.test.ts
  - Known bad symptoms reviewers should watch for:
      - Unexpected backup selection if multiple backups exist and newest valid backup is not the one operator expected.

  ## Risks and Mitigations

  - Risk:
      - Backup chosen may not match operator expectation when multiple backups are present.
      - Mitigation:
      - Backups are ordered by newest mtime and must pass full validation before use.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements automatic recovery from invalid primary config by falling back to valid backup files (`openclaw.json.bak*`), ordered by newest modification time. This prevents gateway startup failures when the primary config becomes corrupted.

**Key changes:**
- Extracted config reading/validation logic into `readAndValidateConfig` helper
- Extracted runtime pipeline into `applyRuntimeConfigPipeline` helper  
- Added `listBackupCandidates` to find and sort backup files by mtime
- Added `loadFromBackupOnInvalidPrimary` to attempt loading valid backups
- Modified `loadConfig` error handling to try backup recovery before returning empty config

**Issues found:**
- Race condition: `statSync` in backup sorting could fail if file is deleted between directory read and stat
- Error handling gap: non-validation errors (file system, parse, `DuplicateAgentDirError`) are silently swallowed when loading backups, which could hide legitimate problems

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor fixes recommended
- The core functionality is solid and addresses a real production issue, with good test coverage for the happy path. However, two error handling edge cases need attention: a potential race condition in file stat operations and incomplete error handling when loading backup configs. These issues are unlikely to occur in practice but could cause confusing failures in edge cases.
- Pay attention to `src/config/io.ts` - the error handling improvements are recommended but not critical for merge

<sub>Last reviewed commit: 0801a6f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->