### PR TITLE
fix(models): prioritize exact model-id match over fuzzy scoring (#21942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - macOS/Build: default release packaging to `BUNDLE_ID=ai.openclaw.mac` in `scripts/package-mac-dist.sh`, so Sparkle feed URL is retained and auto-update no longer fails with an empty appcast feed. (#19750) thanks @loganprit.
+- Auto-reply/Models: prioritize exact model-id matches over fuzzy scoring so similar model names like `gemini-3.1-pro-preview` no longer resolve to the wrong candidate. (#21942)
 
 - Signal/Outbound: preserve case for Base64 group IDs during outbound target normalization so cross-context routing and policy checks no longer break when group IDs include uppercase characters. (#5578) Thanks @heyhudson.
 - Providers/Copilot: add `claude-sonnet-4.6` and `claude-sonnet-4.5` to the default GitHub Copilot model catalog and add coverage for model-list/definition helpers. (#20270, fixes #20091) Thanks @Clawborn.

--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -485,6 +485,12 @@ export function resolveModelDirectiveSelection(params: {
       return {};
     }
 
+    // Exact model-id match takes priority over fuzzy scoring (#21942).
+    const exactMatch = candidates.find((c) => c.model.toLowerCase() === fragment);
+    if (exactMatch) {
+      return { selection: buildSelection(exactMatch.provider, exactMatch.model) };
+    }
+
     const scored = candidates
       .map((candidate) => {
         const details = scoreFuzzyMatch({


### PR DESCRIPTION
## Summary

- **Bug**: Model resolver fuzzy-matches `gemini-3.1-pro-preview` to wrong model (`gemini-3-flash-preview` or `gemini-3.1-pro`)
- **Root cause**: `resolveFuzzy` in `model-selection.ts` runs fuzzy scoring without first checking for exact model ID matches
- **Fix**: Add exact model-id match check before fuzzy scoring in `resolveFuzzy`

Fixes #21942

## Problem

The `resolveFuzzy` function in `src/auto-reply/reply/model-selection.ts` scores all candidate models using weighted fuzzy matching (Levenshtein distance, substring matching, variant token penalties). When model names are similar (e.g. `gemini-3.1-pro-preview` vs `gemini-3-flash-preview` vs `gemini-3.1-pro`), the scoring can pick the wrong candidate because:

1. The `FUZZY_VARIANT_TOKENS` list includes "preview", and variant token penalties can reduce the score of the correct model
2. Levenshtein distance between similar model names may favor a shorter/different model

**Before fix:**
Input:  `"gemini-3.1-pro-preview"`
Output: resolves to `gemini-3-flash-preview` or `gemini-3.1-pro` (wrong)

## Changes

- `src/auto-reply/reply/model-selection.ts` — add exact model-id match check at the top of `resolveFuzzy`, before fuzzy scoring
- `src/auto-reply/reply/model-selection.test.ts` — add regression test for exact match priority

**After fix:**
Input:  `"gemini-3.1-pro-preview"`
Output: resolves to `gemini-3.1-pro-preview` (correct exact match)

## Test plan

- [x] New test: exact model ID resolves correctly over fuzzy candidates
- [x] All existing model-selection tests pass
- [x] Lint passes

## Effect on User Experience

**Before:** Using `/model gemini-3.1-pro-preview` could switch to the wrong model (e.g. `gemini-3-flash-preview`), causing unexpected behavior and confusion.
**After:** Exact model ID matches always take priority, so `/model gemini-3.1-pro-preview` correctly selects that exact model.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a model resolution bug where similar model names like `gemini-3.1-pro-preview` would incorrectly resolve to wrong candidates (`gemini-3-flash-preview` or `gemini-3.1-pro`) due to fuzzy scoring with variant token penalties.

**Key changes:**
- Added exact model-id match check before fuzzy scoring in `resolveFuzzy` function (src/auto-reply/reply/model-selection.ts:488-492)
- Added regression test to verify exact matches take priority over fuzzy matches
- Fixed telegram model-buttons parser to allow colons in provider names (e.g. `ollama:cloud`)

**How it works:**
The fix adds a simple exact match check that runs before the complex fuzzy scoring logic. When a user specifies a model like `gemini-3.1-pro-preview`, the resolver now checks if any candidate's model ID exactly matches the input (case-insensitive) before attempting fuzzy matching with Levenshtein distance and variant token penalties.

The telegram fix updates the regex pattern for parsing `mdl_list_{provider}_{page}` callback data to allow colon characters in provider names, preventing spurious LLM runs when using providers like `ollama:cloud`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-tested, and directly address the reported bug. The exact match check is a simple, defensive addition that runs before fuzzy scoring, so it cannot break existing behavior - it only prevents incorrect fuzzy matches. The test coverage verifies the fix works as intended. The telegram regex change is also straightforward and properly tested.
- No files require special attention

<sub>Last reviewed commit: 611829d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->