### PR TITLE
fix: fire agent_end hook in streaming mode (#21862)

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -77,6 +77,7 @@ export type EmbeddedPiSubscribeState = {
   successfulCronAdds: number;
   pendingMessagingMediaUrls: Map<string, string[]>;
   lastAssistant?: AgentMessage;
+  agentStartedAt?: number;
 };
 
 export type EmbeddedPiSubscribeContext = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `agent_end` hook not firing in streaming mode by calling it from `handleAgentEnd()` in the streaming path.

- In non-streaming mode, the `agent_end` hook is called in `runEmbeddedAttempt()` (src/agents/pi-embedded-runner/run/attempt.ts:1151-1170)
- In streaming mode, the execution never reaches that code path, so the hook was never fired
- This PR adds the hook call to `handleAgentEnd()` which is invoked when the `agent_end` event is processed during streaming
- Added tracking of `agentStartedAt` timestamp in `handleAgentStart()` to calculate `durationMs` for the hook event

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that adds missing hook invocation in the streaming path. The implementation correctly mirrors the non-streaming path's hook call structure, uses proper error handling with .catch(), and adds the necessary state tracking for duration measurement. The hook is only called when hooks exist, making it safe.
- No files require special attention

<sub>Last reviewed commit: 72d1d36</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->