### PR TITLE
fix(transcript): drop empty toolCallId toolResults during persistence + repair

### DIFF
--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -254,6 +254,33 @@ describe("installSessionToolResultGuard", () => {
     expectPersistedRoles(sm, ["assistant", "toolResult"]);
   });
 
+  it("drops toolResult entries with empty toolCallId", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(toolCallMessage);
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "",
+        toolName: "read",
+        content: [{ type: "text", text: "bad" }],
+        isError: false,
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "after" }],
+      }),
+    );
+
+    const messages = getPersistedMessages(sm);
+    expect(messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "assistant"]);
+    expect((messages[1] as { isError?: boolean; toolCallId?: string }).isError).toBe(true);
+    expect((messages[1] as { isError?: boolean; toolCallId?: string }).toolCallId).toBe("call_1");
+  });
+
   it("drops malformed tool calls missing input before persistence", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -188,17 +188,23 @@ export function installSessionToolResultGuard(
 
     if (nextRole === "toolResult") {
       const id = extractToolResultId(nextMessage as Extract<AgentMessage, { role: "toolResult" }>);
-      const toolName = id ? pendingState.getToolName(id) : undefined;
-      if (id) {
-        pendingState.delete(id);
+
+      // Drop tool results with empty/missing toolCallId — they can't be paired
+      // with any assistant tool call and will corrupt the session for strict
+      // providers (Anthropic, MiniMax, Cloud Code Assist). See #21985.
+      if (!id) {
+        return undefined;
       }
+
+      const toolName = pendingState.getToolName(id);
+      pendingState.delete(id);
       const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
       const capped = capToolResultSize(persistMessage(normalizedToolResult));
       const persisted = applyBeforeWriteHook(
         persistToolResult(capped, {
-          toolCallId: id ?? undefined,
+          toolCallId: id,
           toolName,
           isSynthetic: false,
         }),

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -144,6 +144,34 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
+  it("drops tool results with empty toolCallId", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "",
+        toolName: "read",
+        content: [{ type: "text", text: "bad pairing" }],
+        isError: false,
+      },
+      { role: "user", content: "next" },
+    ] as unknown as AgentMessage[];
+
+    const result = repairToolUseResultPairing(input);
+    const toolResults = result.messages.filter((m) => m.role === "toolResult") as Array<{
+      toolCallId?: string;
+      isError?: boolean;
+    }>;
+
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0]?.toolCallId).toBe("call_1");
+    expect(toolResults[0]?.isError).toBe(true);
+    expect(result.droppedOrphanCount).toBe(1);
+  });
+
   it("skips tool call extraction for assistant messages with stopReason 'error'", () => {
     // When an assistant message has stopReason: "error", its tool_use blocks may be
     // incomplete/malformed. We should NOT create synthetic tool_results for them,

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -356,14 +356,20 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
 
   const pushToolResult = (msg: Extract<AgentMessage, { role: "toolResult" }>) => {
     const id = extractToolResultId(msg);
-    if (id && seenToolResultIds.has(id)) {
+    // Drop tool results with empty/missing toolCallId — they can't be paired
+    // with any assistant tool call and corrupt sessions for strict providers.
+    // See #21985.
+    if (!id) {
+      droppedOrphanCount += 1;
+      changed = true;
+      return;
+    }
+    if (seenToolResultIds.has(id)) {
       droppedDuplicateCount += 1;
       changed = true;
       return;
     }
-    if (id) {
-      seenToolResultIds.add(id);
-    }
+    seenToolResultIds.add(id);
     out.push(msg);
   };
 


### PR DESCRIPTION
## Summary
Prevent malformed `toolResult` entries with empty/missing `toolCallId` from being persisted or retained during transcript repair.

## Problem
Issue #21985 reports sessions becoming poisoned by phantom/orphan `toolResult` entries with blank IDs. Once these land in transcript history, strict providers can reject subsequent requests because `toolResult` pairing no longer matches any valid `tool_use` id.

## Solution
1. **Guard at write time** (`session-tool-result-guard.ts`)
   - Drop `toolResult` messages when `extractToolResultId(...)` returns empty/missing ID.
   - This prevents malformed tool results from ever entering persisted session history.

2. **Repair at sanitize time** (`session-transcript-repair.ts`)
   - Drop `toolResult` entries with empty/missing IDs during `repairToolUseResultPairing`.
   - This cleans existing corrupted transcripts defensively.

3. **Regression tests**
   - Added test: drops empty `toolCallId` in guard flow.
   - Added test: drops empty `toolCallId` in transcript repair flow.

## Testing
- `pnpm check` ✅
- `pnpm build` ✅
- `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/session-transcript-repair.e2e.test.ts src/agents/session-tool-result-guard.e2e.test.ts src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts` ✅ (30/30)

## Local Validation
- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm test` ➖ (targeted e2e suites above; full matrix deferred to CI)

## AI-Assisted
This PR was developed with AI assistance.

Fixes #21985

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents malformed `toolResult` entries with empty/missing `toolCallId` from being persisted to session transcripts or retained during repair, addressing session poisoning issues with strict providers (Anthropic, MiniMax, Cloud Code Assist).

- Added guard at write time in `session-tool-result-guard.ts` to drop toolResults when `extractToolResultId()` returns empty/null
- Added repair logic in `session-transcript-repair.ts` to drop empty-ID toolResults during `repairToolUseResultPairing()`
- Both changes include detailed comments referencing issue #21985
- Regression tests added for both guard and repair flows

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- The changes are minimal, focused, and well-tested. The implementation correctly handles the edge case of empty toolCallIds at both persistence and repair time. The code follows existing patterns, includes clear comments, and has comprehensive test coverage. No logical errors, security issues, or side effects identified.
- No files require special attention

<sub>Last reviewed commit: 764c1fa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->