### PR TITLE
iOS/Security: force TLS for non-loopback manual gateway sessions

### DIFF
--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -102,4 +102,27 @@ import Testing
 
         #expect(controller._test_didAutoConnect() == false)
     }
+
+    @Test @MainActor func manualConnectionsForceTLSForNonLoopbackHosts() async {
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+        #expect(controller._test_resolveManualUseTLS(host: "gateway.example.com", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "openclaw.local", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "localhost", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "127.0.0.1", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "::1", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "[::1]", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "0.0.0.0", useTLS: false) == false)
+    }
+
+    @Test @MainActor func manualDefaultPortUses443OnlyForTailnetTLSHosts() async {
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+        #expect(controller._test_resolveManualPort(host: "gateway.example.com", port: 0, useTLS: true) == 18789)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 0, useTLS: true) == 443)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net.", port: 0, useTLS: true) == 443)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 18789, useTLS: true) == 18789)
+    }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -53,8 +53,9 @@ const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10)
 // OPENCLAW_TEST_VM_FORKS=0, and let users force-enable with =1.
 const supportsVmForks = Number.isFinite(nodeMajor) ? nodeMajor !== 24 : true;
 const useVmForks =
-  process.env.OPENCLAW_TEST_VM_FORKS === "1" ||
-  (process.env.OPENCLAW_TEST_VM_FORKS !== "0" && !isWindows && supportsVmForks);
+  !(isCI && isMacOS) &&
+  (process.env.OPENCLAW_TEST_VM_FORKS === "1" ||
+    (process.env.OPENCLAW_TEST_VM_FORKS !== "0" && !isWindows && supportsVmForks));
 const disableIsolation = process.env.OPENCLAW_TEST_NO_ISOLATE === "1";
 const runs = [
   ...(useVmForks


### PR DESCRIPTION
Supersedes #21441, which is stuck on stale head refs.

## Summary
- enforce secure transport for non-loopback manual gateway sessions on iOS
- include regression coverage for loopback vs non-loopback behavior
- include repo-wide CI guard for macOS runner stability in TS tests

## Notes
- includes docs/style.css format fix required by current main check gate

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

enforces TLS for all non-loopback manual gateway sessions on iOS to prevent plaintext credential exposure over the network

- refactored `shouldForceTLS` into `shouldRequireTLS` and `shouldUseTLSDefaultPort443` with clearer semantics: TLS requirement now applies to all non-loopback hosts, while port 443 defaults only apply to `.ts.net` hosts
- simplified loopback detection from `inet_pton`-based parsing to string matching, removing `isLoopbackIPv4` and `isLoopbackIPv6` helpers
- added comprehensive test coverage for loopback vs non-loopback TLS enforcement and port resolution behavior
- disabled vmForks on macOS CI runners to address TypeScript test stability issues
- applied oxfmt formatting to `docs/style.css` transition property

<h3>Confidence Score: 3/5</h3>

- safe to merge after addressing loopback detection gap for IPv4-mapped IPv6 addresses
- the security intent is sound (enforcing TLS for non-loopback connections), test coverage is comprehensive, and the CI fix is reasonable. however, the simplified loopback detection removed proper IPv6 parsing logic that previously handled IPv4-mapped IPv6 loopback addresses (`::ffff:127.x.x.x`), creating a gap where some loopback connections might incorrectly require TLS
- `apps/ios/Sources/Gateway/GatewayConnectionController.swift` - verify loopback detection handles all edge cases

<sub>Last reviewed commit: c84d988</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->