### PR TITLE
Security: reject insecure non-loopback gateway deep links

### DIFF
--- a/apps/ios/Tests/DeepLinkParserTests.swift
+++ b/apps/ios/Tests/DeepLinkParserTests.swift
@@ -85,6 +85,12 @@ import Testing
                 .init(host: "openclaw.local", port: 18789, tls: true, token: "abc", password: "def")))
     }
 
+    @Test func parseGatewayLinkRejectsInsecureNonLoopbackWs() {
+        let url = URL(
+            string: "openclaw://gateway?host=attacker.example&port=18789&tls=0&token=abc")!
+        #expect(DeepLinkParser.parse(url) == nil)
+    }
+
     @Test func parseGatewaySetupCodeParsesBase64UrlPayload() {
         let payload = #"{"url":"wss://gateway.example.com:443","token":"tok","password":"pw"}"#
         let encoded = Data(payload.utf8)
@@ -121,6 +127,36 @@ import Testing
             host: "gateway.example.com",
             port: 443,
             tls: true,
+            token: "tok",
+            password: nil))
+    }
+
+    @Test func parseGatewaySetupCodeRejectsInsecureNonLoopbackWs() {
+        let payload = #"{"url":"ws://attacker.example:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+        #expect(link == nil)
+    }
+
+    @Test func parseGatewaySetupCodeAllowsLoopbackWs() {
+        let payload = #"{"url":"ws://127.0.0.1:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+
+        #expect(link == .init(
+            host: "127.0.0.1",
+            port: 18789,
+            tls: false,
             token: "tok",
             password: nil))
     }

--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -1,6 +1,23 @@
 import Foundation
 
 enum GatewayRemoteConfig {
+    private static func isLoopbackHost(_ rawHost: String) -> Bool {
+        let host = rawHost
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        if host.isEmpty {
+            return false
+        }
+        if host == "localhost" || host == "::1" || host == "127.0.0.1" {
+            return true
+        }
+        if host.hasPrefix("127.") || host.hasPrefix("::ffff:127.") {
+            return true
+        }
+        return false
+    }
+
     static func resolveTransport(root: [String: Any]) -> AppState.RemoteTransport {
         guard let gateway = root["gateway"] as? [String: Any],
               let remote = gateway["remote"] as? [String: Any],
@@ -39,6 +56,9 @@ enum GatewayRemoteConfig {
         guard scheme == "ws" || scheme == "wss" else { return nil }
         let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !host.isEmpty else { return nil }
+        if scheme == "ws", !self.isLoopbackHost(host) {
+            return nil
+        }
         if scheme == "ws", url.port == nil {
             guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
                 return url

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -218,9 +218,14 @@ import Testing
         #expect(url.absoluteString == "https://gateway.example:443/remote-ui/")
     }
 
-    @Test func normalizeGatewayUrlAddsDefaultPortForWs() {
-        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://gateway")
+    @Test func normalizeGatewayUrlAddsDefaultPortForLoopbackWs() {
+        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://127.0.0.1")
         #expect(url?.port == 18789)
-        #expect(url?.absoluteString == "ws://gateway:18789")
+        #expect(url?.absoluteString == "ws://127.0.0.1:18789")
+    }
+
+    @Test func normalizeGatewayUrlRejectsNonLoopbackWs() {
+        let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://gateway")
+        #expect(url == nil)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
@@ -1,0 +1,45 @@
+import OpenClawKit
+import Foundation
+import Testing
+
+@Suite struct DeepLinksSecurityTests {
+    @Test func gatewayDeepLinkRejectsInsecureNonLoopbackWs() {
+        let url = URL(
+            string: "openclaw://gateway?host=attacker.example&port=18789&tls=0&token=abc")!
+        #expect(DeepLinkParser.parse(url) == nil)
+    }
+
+    @Test func gatewayDeepLinkAllowsLoopbackWs() {
+        let url = URL(
+            string: "openclaw://gateway?host=127.0.0.1&port=18789&tls=0&token=abc")!
+        #expect(
+            DeepLinkParser.parse(url) == .gateway(
+                .init(host: "127.0.0.1", port: 18789, tls: false, token: "abc", password: nil)))
+    }
+
+    @Test func setupCodeRejectsInsecureNonLoopbackWs() {
+        let payload = #"{"url":"ws://attacker.example:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        #expect(GatewayConnectDeepLink.fromSetupCode(encoded) == nil)
+    }
+
+    @Test func setupCodeAllowsLoopbackWs() {
+        let payload = #"{"url":"ws://127.0.0.1:18789","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        #expect(
+            GatewayConnectDeepLink.fromSetupCode(encoded) == .init(
+                host: "127.0.0.1",
+                port: 18789,
+                tls: false,
+                token: "tok",
+                password: nil))
+    }
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -53,8 +53,9 @@ const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10)
 // OPENCLAW_TEST_VM_FORKS=0, and let users force-enable with =1.
 const supportsVmForks = Number.isFinite(nodeMajor) ? nodeMajor !== 24 : true;
 const useVmForks =
-  process.env.OPENCLAW_TEST_VM_FORKS === "1" ||
-  (process.env.OPENCLAW_TEST_VM_FORKS !== "0" && !isWindows && supportsVmForks);
+  !(isCI && isMacOS) &&
+  (process.env.OPENCLAW_TEST_VM_FORKS === "1" ||
+    (process.env.OPENCLAW_TEST_VM_FORKS !== "0" && !isWindows && supportsVmForks));
 const disableIsolation = process.env.OPENCLAW_TEST_NO_ISOLATE === "1";
 const runs = [
   ...(useVmForks


### PR DESCRIPTION
Supersedes #21268, which is stuck on stale head refs.

## Summary
- require secure transport or loopback-only semantics for deep-link gateway URLs
- add security-focused deep-link regression tests
- include repo-wide CI guard for macOS runner stability in TS tests

## Notes
- includes docs/style.css format fix required by current main check gate

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds critical security protection for deep link gateway URLs by requiring TLS (`wss://`) or loopback-only (`ws://127.0.0.1`, `ws://localhost`, `ws://::1`) semantics, preventing malicious deep links from redirecting users to insecure non-loopback WebSocket endpoints.

The security fix is implemented consistently across three attack vectors:
- Direct deep links via `DeepLinkParser.parse()` in `DeepLinks.swift:152-154`
- Setup code parsing via `GatewayConnectDeepLink.fromSetupCode()` in `DeepLinks.swift:57-59`
- Remote config URL normalization via `GatewayRemoteConfig.normalizeGatewayUrl()` in `GatewayRemoteConfig.swift:59-61`

Also includes formatting fix for `docs/style.css` (required by CI) and macOS CI stability guard in test runner.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with comprehensive security improvements and thorough test coverage
- Security implementation is consistently applied across all attack vectors with identical loopback validation logic, extensive regression tests cover both rejection and allowance scenarios, changes align with documented security policy in SECURITY.md, and includes necessary CI stability fix
- No files require special attention

<sub>Last reviewed commit: a073b75</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->