### PR TITLE
chore: Reduce app-specific docker image size by ~50% / ~900 MB (AI assisted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Auth/Onboarding: align OAuth profile-id config mapping with stored credential IDs for OpenAI Codex and Chutes flows, preventing `provider:default` mismatches when OAuth returns email-scoped credentials. (#12692) thanks @mudrii.
 - Docker: pin base images to SHA256 digests in Docker builds to prevent mutable tag drift. (#7734) Thanks @coygeek.
 - Docker/Security: run E2E and install-sh test images as non-root by adding appuser directives. Thanks @thewilloftheshadow.
+- Docker: run build steps as the `node` user and use `COPY --chown` to avoid recursive ownership changes, trimming image size and layer churn. Thanks @huntharo.
 - Provider/HTTP: treat HTTP 503 as failover-eligible for LLM provider errors. (#21086) Thanks @Protocol-zero-0.
 - Anthropic/Agents: preserve required pi-ai default OAuth beta headers when `context1m` injects `anthropic-beta`, preventing 401 auth failures for `sk-ant-oat-*` tokens. (#19789, fixes #19769) Thanks @minupla.
 - Slack: pass `recipient_team_id` / `recipient_user_id` through Slack native streaming calls so `chat.startStream`/`appendStream`/`stopStream` work reliably across DMs and Slack Connect setups, and disable block streaming when native streaming is active. (#20988) Thanks @Dithilli. Earlier recipient-ID groundwork was contributed in #20377 by @AsserAl1012.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 RUN corepack enable
 
 WORKDIR /app
+RUN chown node:node /app
 
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
 RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
@@ -16,17 +17,19 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY ui/package.json ./ui/package.json
-COPY patches ./patches
-COPY scripts ./scripts
+COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY --chown=node:node ui/package.json ./ui/package.json
+COPY --chown=node:node patches ./patches
+COPY --chown=node:node scripts ./scripts
 
+USER node
 RUN pnpm install --frozen-lockfile
 
 # Optionally install Chromium and Xvfb for browser automation.
 # Build with: docker build --build-arg OPENCLAW_INSTALL_BROWSER=1 ...
 # Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
 # Must run after pnpm install so playwright-core is available in node_modules.
+USER root
 ARG OPENCLAW_INSTALL_BROWSER=""
 RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
@@ -36,16 +39,14 @@ RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
-COPY . .
+USER node
+COPY --chown=node:node . .
 RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build
 
 ENV NODE_ENV=production
-
-# Allow non-root user to write temp files during runtime/tests.
-RUN chown -R node:node /app
 
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `RUN chown -R node:node /app` ran in a late standalone layer and touched nearly every file under `/app` (including `node_modules`), creating a very large layer delta in Docker image history.
- Why it matters: this inflates image size and slows pulls/pushes/build cache reuse.
- What changed: switched to ownership-at-copy time (`COPY --chown=node:node ...`), moved install/build to run as `node`, and removed the late recursive `chown` layer. Kept temporary `USER root` only where apt/browser install needs root.
- What did NOT change (scope boundary): no application/runtime logic changes; no dependency/version changes; no channel/integration behavior changes.
- AI Assisted: I knew the nature of the problem and have fixed this before.  I used `dive` to validate the problem existed then provided Codex guidance on how I wanted to fix it.  Prompt below.

### Pete Interacted on This Issue - Just Trying to Save Pete Time!

<img width="602" height="463" alt="image" src="https://github.com/user-attachments/assets/5624039f-a3a8-4260-96ae-a6bbae95ba78" />


https://x.com/techonsapevole/status/2024829067065770355?s=20

https://x.com/steipete/status/2024830664256725267?s=20

### Prompt for Codex

> There is a layer in this docker image that is doing a chown which is, I believe, copying all the files in the pnpm install layer.
> 
> Image is built with: docker build -t openclaw:local -f Dockerfile .
> 
> I can share the layer size info with dive
> 
> Approaches I have in mind to fix this:
> 1. In the pnpm install layer - do a an && and run the chown in that layer then see if that prevents the size explosion in the later layer... if this doesn't fix it by itself, then also exclude the node_modules folder from the chown command layer so it can't duplicate them
> 2. Move the USER layer up before the pnpm install so that the files are owned by node and we don't need the chown.  I'm not postitive if moving this layer would have an effect?  I think it would?  If we moved it up high enough we might be able to completely get rid of the chown.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #18995
- Related #19096

## User-visible / Behavior Changes

- Smaller Docker layer footprint by removing the late recursive `chown` copy-up behavior.
- Build behavior remains functionally the same (install/build still happen in Docker image build).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Docker Desktop)
- Runtime/container: Docker (`docker build -t openclaw:local -f Dockerfile .`)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local Docker build

### Steps

1. Build image from `main` with `docker build -t openclaw:local -f Dockerfile .`.
2. Inspect image with `dive` and note large layer from `RUN chown -R node:node /app`.
3. Build this branch and inspect with `dive` to confirm recursive `chown` layer is removed.

### Expected

- No large late layer from recursive `chown`.
- Ownership is set during `COPY` and by running build steps as `node`.

### Actual

- Dockerfile now removes the recursive `chown` layer and uses `COPY --chown` + `USER node`.
- Local build attempt in my run was blocked by transient upstream npm/corepack fetch failure (HTTP 500 for pnpm tarball), not by Dockerfile syntax/ordering.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

### Verified Docker Image Size Reduction with `dive

#### Before - 3.2 GB Total, ~2 GB Non-Base Layers

<img width="1460" height="832" alt="image" src="https://github.com/user-attachments/assets/5c07ee6f-5282-4488-bc26-c6cc8e6d43e0" />

#### After - 2.3 GB Total, ~1.1 GB Non-Base Layers

<img width="1460" height="832" alt="image" src="https://github.com/user-attachments/assets/3d7e48ff-05fe-490d-b741-b5510926c8a9" />

### `pnpm test:docker:all`

The tests complete with similar output.

There are 15 `ENOENT` errors in the PR branch run and 17 `ENOENT` errors in the `main` run.  I think these vary due to miscomputed file names.  For example, `main` has this error, which is missing in the PR... clearly this is not a valid filename to begin with (`???`):

```
-stderr | src/gateway/gateway-models.profiles.live.test.ts > gateway live (dev agent, profile keys) > runs meaningful prompts across models with available keys
-[tools] read failed: ENOENT: no such file or directory, access '/tmp/openclaw-live-state-b2FodF/workspace-dev/???'
```

Run with:

```
pnpm test:docker:all > test-docker-all.out 2>&1

perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g; s/\e\][^\a]*(?:\a|\e\\)//g' test-docker-all.out \
  | col -b \
  > test-docker-all.clean.out
```

#### Baseline Logs - main

https://gist.github.com/huntharo/9c9f9f1defc97521b93c331d5564ca49

#### PR Logs

https://gist.github.com/huntharo/2770781d613213e1d010e8a10ff5d6fc

#### Diff of Baseline to PR Test Logs

https://gist.github.com/huntharo/2df0ed9c8c44b2f649121aa39bd7855a

#### `pnpm test:docker:live-models`

<img width="820" height="436" alt="image" src="https://github.com/user-attachments/assets/260262cd-65e7-4e62-a64d-ed0490f7a4f8" />

#### `pnpm test:docker:live-gateway`

<img width="858" height="408" alt="image" src="https://github.com/user-attachments/assets/b22e6de9-2cf5-4d20-967e-ec75f30c7bb5" />

#### `pnpm test:docker:onboard`

<img width="845" height="436" alt="image" src="https://github.com/user-attachments/assets/4cedea1e-b701-449d-86eb-6aa157dc0ba4" />

#### `pnpm test:docker:gateway-network`

<img width="779" height="424" alt="image" src="https://github.com/user-attachments/assets/5f5a75c9-4be9-4c05-ac30-45c62f36c0f0" />

#### `pnpm test:docker:qr`

<img width="803" height="433" alt="image" src="https://github.com/user-attachments/assets/27652e7e-ba4b-443e-b8e0-d26017411a8c" />

#### `pnpm test:docker:doctor-switch`

<img width="765" height="437" alt="image" src="https://github.com/user-attachments/assets/9eab1209-2ecf-4397-a9d2-f114c4a0654f" />

#### `pnpm test:docker:plugins`

<img width="854" height="438" alt="image" src="https://github.com/user-attachments/assets/0b95a414-fcfb-4a44-9a68-6e2315d08f3d" />


#### `pnpm test:docker:cleanup`



## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `./docker-setup.sh` script on new image, validated onboard, gateway start, and telegram pairing all work.  Ran `./docker-diff.sh` to validate no change in file owners or permissions in `/app`.
- Edge cases checked: ensured apt/browser install block still runs as root; final runtime user remains `node`.
- What you did **not** verify: I did not validate that all functionality works (not sure the test cases that break if owner is not correct), I did not validate that Chrome works correctly (had to switch back to `root` for that install in the Dockerfile - this needs to be tested)

### No File Ownership Changes in `/app`

Full 1050 line diff (not that many changes, mostly context): https://gist.github.com/huntharo/82b80991680e02838860e4d2a068c27c

#### Preview of Diff Output

The diff shows changes in chunk file names (expected).  There are no reported changes on owners or permissions.

<details>
<summary>Diff Preview - 1050 lines unified diff total length</summary>

```
--- /tmp/openclaw-app-metadata-diff/base.txt	2026-02-20 12:03:46
+++ /tmp/openclaw-app-metadata-diff/new.txt	2026-02-20 12:03:48
@@ -190,33 +190,32 @@
 dist/accounts-DlYIKCHB.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/accounts-DlYIKCHB.js'
 dist/accounts-smfqJdRz.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/accounts-smfqJdRz.js'
 dist/acp-cli-CruAkmzN.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/acp-cli-CruAkmzN.js'
-dist/acp-cli-DKLN6tCE.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/acp-cli-DKLN6tCE.js'
+dist/acp-cli-Dj-cDMaV.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/acp-cli-Dj-cDMaV.js'
 dist/active-listener-BrbKmL0r.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/active-listener-BrbKmL0r.js'
 dist/active-listener-CQhhPw2G.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/active-listener-CQhhPw2G.js'
 dist/active-listener-DFxLGYXL.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/active-listener-DFxLGYXL.js'
 dist/active-listener-DgvMdw4N.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/active-listener-DgvMdw4N.js'
-dist/agent-CahBthFh.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agent-CahBthFh.js'
+dist/agent-BHDgvhd0.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agent-BHDgvhd0.js'
 dist/agent-CyrNS6_5.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agent-CyrNS6_5.js'
 dist/agent-scope-B5p3z0Xd.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agent-scope-B5p3z0Xd.js'
 dist/agent-scope-BLYwrEEA.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agent-scope-BLYwrEEA.js'
 dist/agent-scope-BnZW9Gh2.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agent-scope-BnZW9Gh2.js'
 dist/agent-scope-RzK9Zcks.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agent-scope-RzK9Zcks.js'
-dist/agents-HXMkwTTh.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agents-HXMkwTTh.js'
+dist/agents-Bm-mx5jK.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agents-Bm-mx5jK.js'
 dist/agents.config-Cp-yoXCW.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agents.config-Cp-yoXCW.js'
 dist/agents.config-D_rsccKK.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/agents.config-D_rsccKK.js'
 dist/allow-from-BWMFfmlZ.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/allow-from-BWMFfmlZ.js'
 dist/allow-from-C4p9SsVb.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/allow-from-C4p9SsVb.js'
 dist/api-key-rotation-BZWU2a9q.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/api-key-rotation-BZWU2a9q.js'
 dist/argv-1cuXh2ix.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/argv-1cuXh2ix.js'
+dist/audio-preflight-B0OCgCQz.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audio-preflight-B0OCgCQz.js'
+dist/audio-preflight-B6qKOu3D.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audio-preflight-B6qKOu3D.js'
 dist/audio-preflight-BaRhxJgP.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audio-preflight-BaRhxJgP.js'
-dist/audio-preflight-ClUXMR-H.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audio-preflight-ClUXMR-H.js'
-dist/audio-preflight-DF0r7nVl.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audio-preflight-DF0r7nVl.js'
-dist/audio-preflight-SdolBzUA.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audio-preflight-SdolBzUA.js'
+dist/audio-preflight-yF2eVX_N.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audio-preflight-yF2eVX_N.js'
 dist/audit-DxYsLRSc.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audit-DxYsLRSc.js'
-dist/audit-GAWhf59L.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audit-GAWhf59L.js'
+dist/audit-RTirkZj-.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/audit-RTirkZj-.js'
 dist/auth-Usar6LvN.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/auth-Usar6LvN.js'
 dist/auth-bFvxXH9n.js|regular file|644|-rw-r--r--|node|node|1000|1000|'dist/auth-bFvxXH9n.js'
```
</details>

#### Prep for Docker Diff

```sh
docker build -t openclaw:baseline -f Dockerfile . # Base of branch
docker build -t openclaw:local -f Dockerfile . # Branch
./docker-diff.sh
```

#### `docker-diff.sh`

<details>
<summary>docker-diff.sh script: compare /app ownership/permissions between baseline and new image</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

# Adjust tags as needed
BASE_IMAGE="openclaw:baseline"
NEW_IMAGE="openclaw:local"

OUT_DIR="/tmp/openclaw-app-metadata-diff"
mkdir -p "$OUT_DIR"

dump_app_meta() {
  local image="$1"
  local out="$2"

  docker run --rm --entrypoint /bin/sh "$image" -lc '
    set -eu
    cd /app
    LC_ALL=C find . -xdev -mindepth 1 -printf "%P\0" \
      | sort -z \
      | xargs -0 stat -c "%n|%F|%a|%A|%U|%G|%u|%g|%N"
  ' > "$out"
}

dump_app_meta "$BASE_IMAGE" "$OUT_DIR/base.txt"
dump_app_meta "$NEW_IMAGE" "$OUT_DIR/new.txt"

# Full metadata diff
diff -u "$OUT_DIR/base.txt" "$OUT_DIR/new.txt" > "$OUT_DIR/meta.diff" || true

# Path-only diff (added/removed files)
cut -d'|' -f1 "$OUT_DIR/base.txt" | sort > "$OUT_DIR/base.paths"
cut -d'|' -f1 "$OUT_DIR/new.txt"  | sort > "$OUT_DIR/new.paths"
comm -3 "$OUT_DIR/base.paths" "$OUT_DIR/new.paths" > "$OUT_DIR/path.diff" || true

echo "Wrote:"
echo "  $OUT_DIR/meta.diff"
echo "  $OUT_DIR/path.diff"
echo
echo "First 200 lines of metadata diff:"
sed -n '1,200p' "$OUT_DIR/meta.diff"
```
</details> 

### Docker Onboard - Telegram Pairing Accepted - Bot Responds

<img width="846" height="849" alt="image" src="https://github.com/user-attachments/assets/40bde5a8-656f-40a0-b405-dc5a1f374575" />

### Docker Gateway Container Logs

```
2026-02-20 11:38:13 openclaw-gateway-1  | 2026-02-20T16:38:13.367Z [canvas] host mounted at http://0.0.0.0:18789/__openclaw__/canvas/ (root /home/node/.openclaw/canvas)
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.002Z [heartbeat] started
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.004Z [health-monitor] started (interval: 300s, grace: 60s)
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.008Z [gateway] agent model: openai-codex/gpt-5.3-codex
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.009Z [gateway] listening on ws://0.0.0.0:18789 (PID 7)
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.013Z [gateway] log file: /tmp/openclaw/openclaw-2026-02-20.log
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.060Z [browser/service] Browser control service ready (profiles=2)
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.373Z [hooks:loader] Registered hook: boot-md -> gateway:startup
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.378Z [hooks:loader] Registered hook: bootstrap-extra-files -> agent:bootstrap
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.379Z [hooks:loader] Registered hook: command-logger -> command
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.386Z [hooks:loader] Registered hook: session-memory -> command:new
2026-02-20 11:38:14 openclaw-gateway-1  | 2026-02-20T16:38:14.387Z [hooks] loaded 4 internal hook handlers
2026-02-20 11:38:16 openclaw-gateway-1  | 2026-02-20T16:38:16.659Z [telegram] [default] starting provider (@XXXXXXX_bot)
2026-02-20 11:38:16 openclaw-gateway-1  | 2026-02-20T16:38:16.689Z [telegram] autoSelectFamily=true (default-node22)
```

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR (or restore previous Dockerfile ownership pattern).
- Files/config to restore: `Dockerfile`.
- Known bad symptoms reviewers should watch for: permission denied during Docker `pnpm install`/`pnpm build` if ownership/user ordering regresses.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Running build steps as `node` may expose permission issues if files are copied without correct ownership.
- Mitigation: all relevant `COPY` steps use `--chown=node:node`; `/app` directory ownership is set before switching user - validated with dump of file owners that all owners are the same and there were no permission changes.  Details included in this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced recursive `chown -R node:node /app` layer (which touched all files in `/app` including `node_modules`) with `COPY --chown=node:node` and running build steps as the `node` user. This eliminates a ~900MB layer delta and reduces total image size from 3.2GB to 2.3GB (~50% reduction in non-base layers).

**Key Changes:**
- Added early `/app` ownership setup (`chown node:node /app` on line 10)
- All `COPY` commands now use `--chown=node:node` flag
- Switched to `USER node` before `pnpm install` and `pnpm build`
- Temporarily escalates to `USER root` only for browser/apt installations (lines 32-40)
- Removed the late-stage `RUN chown -R node:node /app` that created the large layer

**Verification:**
- Author verified with `dive` tool showing layer size reduction
- Tested Docker onboard, gateway start, and Telegram pairing successfully
- Build/install steps correctly preserve `node:node` ownership throughout

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a well-tested Docker layer optimization with no logic changes
- Score reflects a straightforward infrastructure optimization that has been thoroughly tested by the author (verified 50% image size reduction with dive, tested onboarding/gateway/Telegram pairing). The approach is sound: using --chown during COPY and running builds as the node user eliminates the expensive recursive chown layer. The USER root/node transitions are properly scoped for apt/browser installs. Author explicitly noted Chrome install needs verification, which is the only minor uncertainty.
- No files require special attention - the single Dockerfile change is well-structured and tested

<sub>Last reviewed commit: 05511dc</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->