### PR TITLE
fix: propagate senderIsOwner to agent loop

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -76,7 +76,7 @@ describe("agent-runner-utils", () => {
   });
 
   it("builds embedded run base params with auth profile and run metadata", () => {
-    const run = makeRun({ enforceFinalTag: true });
+    const run = makeRun({ enforceFinalTag: true, senderIsOwner: true });
     const authProfile = resolveProviderScopedAuthProfile({
       provider: "openai",
       primaryProvider: "openai",
@@ -111,6 +111,7 @@ describe("agent-runner-utils", () => {
       bashElevated: run.bashElevated,
       timeoutMs: run.timeoutMs,
       runId: "run-1",
+      senderIsOwner: true,
     });
   });
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -175,6 +175,7 @@ export function buildEmbeddedRunBaseParams(params: {
     bashElevated: params.run.bashElevated,
     timeoutMs: params.run.timeoutMs,
     runId: params.runId,
+    senderIsOwner: params.run.senderIsOwner,
   };
 }
 

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -76,6 +76,7 @@ export type FollowupRun = {
     timeoutMs: number;
     blockReplyBreak: "text_end" | "message_end";
     ownerNumbers?: string[];
+    senderIsOwner?: boolean;
     extraSystemPrompt?: string;
     enforceFinalTag?: boolean;
   };


### PR DESCRIPTION
## Summary

- Add `senderIsOwner` to `FollowupRun["run"]` type in `queue/types.ts`
- Include `senderIsOwner` in `buildEmbeddedRunBaseParams` return object in `agent-runner-utils.ts`
- Update test to verify `senderIsOwner` passes through

## Problem

`senderIsOwner` is correctly computed in `command-auth.ts` and set on `FollowupRun.run` in `get-reply-run.ts`, but `buildEmbeddedRunBaseParams` doesn't include it in its return object. This causes `applyOwnerOnlyToolPolicy` to always receive `senderIsOwner=undefined` (falsy), filtering out all ownerOnly tools (`cron`, `gateway`) for every sender — including the actual owner.

## Test plan

- [x] `vitest run src/auto-reply/reply/agent-runner-utils.test.ts` — 3 tests pass
- [x] `vitest run --config vitest.e2e.config.ts src/agents/tool-policy.e2e.test.ts` — 20 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes critical authorization bug where `senderIsOwner` wasn't propagated through the agent loop, causing owner-only tools (`cron`, `gateway`) to be incorrectly filtered for all senders including owners.

- Added `senderIsOwner` to `FollowupRun["run"]` type
- Updated `buildEmbeddedRunBaseParams` to include `senderIsOwner` in return object
- Test verifies the field propagates correctly

The fix ensures `applyOwnerOnlyToolPolicy` receives the correct authorization value, restoring access to owner-only tools for authorized users.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a critical security bug with a minimal, well-tested change
- The fix is simple and surgical: adding one missing field to a type definition and including it in the return object. The change directly addresses the described bug where owner authorization wasn't propagating. Test coverage validates the fix, and the change follows existing patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: 328ee85</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->