### PR TITLE
fix(telegram): accept colon provider ids in mdl_list callbacks

### DIFF
--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -16,6 +16,7 @@ describe("parseModelCallbackData", () => {
       ["mdl_back", { type: "back" }],
       ["mdl_list_anthropic_2", { type: "list", provider: "anthropic", page: 2 }],
       ["mdl_list_open-ai_1", { type: "list", provider: "open-ai", page: 1 }],
+      ["mdl_list_ollama:cloud_1", { type: "list", provider: "ollama:cloud", page: 1 }],
       [
         "mdl_sel_anthropic/claude-sonnet-4-5",
         { type: "select", provider: "anthropic", model: "claude-sonnet-4-5" },

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -48,7 +48,7 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
   }
 
   // mdl_list_{provider}_{page}
-  const listMatch = trimmed.match(/^mdl_list_([a-z0-9_-]+)_(\d+)$/i);
+  const listMatch = trimmed.match(/^mdl_list_([a-z0-9_:-]+)_(\d+)$/i);
   if (listMatch) {
     const [, provider, pageStr] = listMatch;
     const page = Number.parseInt(pageStr ?? "1", 10);


### PR DESCRIPTION
## Summary

- Fix Telegram `/models` callback parsing for provider ids containing `:` (example: `ollama:cloud`).
- Root cause: `mdl_list` regex rejected `:` so callback data like `mdl_list_ollama:cloud_1` fell through to non-callback handling.
- Change: widen `mdl_list` provider regex from `[a-z0-9_-]+` to `[a-z0-9_:-]+`.
- Add regression test for colon provider ids.

## Linked Issue

- Closes #21939

## Scope

- `src/telegram/model-buttons.ts`
- `src/telegram/model-buttons.test.ts`

## Verification

- `node $(ls -d node_modules/.pnpm/vitest@*/node_modules/vitest/vitest.mjs | head -n 1) run src/telegram/model-buttons.test.ts`
  - Result: 29 tests passed.
- `node_modules/.pnpm/oxfmt@0.33.0/node_modules/oxfmt/bin/oxfmt --check src/telegram/model-buttons.ts src/telegram/model-buttons.test.ts`
  - Result: formatting check passed.
- `node_modules/.pnpm/oxlint@1.48.0_oxlint-tsgolint@0.14.1/node_modules/oxlint/bin/oxlint src/telegram/model-buttons.ts src/telegram/model-buttons.test.ts`
  - Result: lint check passed (0 warnings, 0 errors).

## Notes

- No behavior changes for `mdl_sel` parsing or button rendering.
- Callback format remains constrained to `mdl_list_<provider>_<numeric_page>`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Telegram `/models` callback parsing to accept provider IDs containing colons (e.g. `ollama:cloud`). The regex pattern for `mdl_list` callbacks was broadened from `[a-z0-9_-]+` to `[a-z0-9_:-]+`, allowing colon as a valid character in provider names. Includes regression test coverage for the colon case.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-scoped, and properly tested. The regex modification is backward-compatible and doesn't introduce parsing ambiguity since the pattern remains anchored and the page delimiter is strictly numeric. The fix addresses a real bug that caused callbacks with colon-containing provider IDs to fail parsing.
- No files require special attention

<sub>Last reviewed commit: 304d8ef</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->