### PR TITLE
feat: add User OAuth Token support for thread-wide deletion

### DIFF
--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -194,6 +194,81 @@ export async function deleteSlackMessage(
   });
 }
 
+export async function deleteSlackThreadRepliesFromBot(
+  channelId: string,
+  threadTs: string,
+  botUserId: string,
+  opts: SlackActionClientOpts = {},
+): Promise<string[]> {
+  const result = await deleteSlackThreadReplies(channelId, threadTs, {
+    ...opts,
+    botUserId,
+  });
+  return result.deletedBot;
+}
+
+/**
+ * Delete thread replies. By default only deletes bot's own replies.
+ * When `userToken` is provided, also deletes other users' messages using the User OAuth token.
+ */
+export async function deleteSlackThreadReplies(
+  channelId: string,
+  threadTs: string,
+  opts: SlackActionClientOpts & {
+    botUserId: string;
+    userToken?: string;
+  },
+): Promise<{ deletedBot: string[]; deletedUser: string[]; failed: string[] }> {
+  const botClient = await getClient(opts);
+
+  let allReplies: Array<{ ts: string; user?: string }> = [];
+  try {
+    const result = await botClient.conversations.replies({
+      channel: channelId,
+      ts: threadTs,
+      limit: 200,
+    });
+
+    allReplies = (result.messages ?? [])
+      .filter((msg: any) => msg.ts !== threadTs)
+      .map((msg: any) => ({ ts: msg.ts, user: msg.user }));
+  } catch {
+    // Thread may not exist or may not have replies
+    return { deletedBot: [], deletedUser: [], failed: [] };
+  }
+
+  const botReplies = allReplies.filter((msg) => msg.user === opts.botUserId);
+  const userReplies = allReplies.filter((msg) => msg.user !== opts.botUserId);
+
+  const deletedBot: string[] = [];
+  for (const reply of botReplies) {
+    if (!reply.ts) continue;
+    try {
+      await deleteSlackMessage(channelId, reply.ts, opts);
+      deletedBot.push(reply.ts);
+    } catch {
+      // Message may already be deleted
+    }
+  }
+
+  const deletedUser: string[] = [];
+  const failed: string[] = [];
+  if (opts.userToken && userReplies.length > 0) {
+    const userClient = createSlackWebClient(opts.userToken);
+    for (const reply of userReplies) {
+      if (!reply.ts) continue;
+      try {
+        await userClient.chat.delete({ channel: channelId, ts: reply.ts });
+        deletedUser.push(reply.ts);
+      } catch {
+        failed.push(reply.ts);
+      }
+    }
+  }
+
+  return { deletedBot, deletedUser, failed };
+}
+
 export async function readSlackMessages(
   channelId: string,
   opts: SlackActionClientOpts & {

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -59,6 +59,8 @@ export type SlackMonitorContext = {
   botUserId: string;
   teamId: string;
   apiAppId: string;
+  userToken?: string;
+  userTokenReadOnly: boolean;
 
   historyLimit: number;
   channelHistories: Map<string, HistoryEntry[]>;
@@ -121,6 +123,8 @@ export function createSlackMonitorContext(params: {
   botUserId: string;
   teamId: string;
   apiAppId: string;
+  userToken?: string;
+  userTokenReadOnly?: boolean;
 
   historyLimit: number;
   sessionScope: SessionScope;
@@ -384,6 +388,8 @@ export function createSlackMonitorContext(params: {
     botUserId: params.botUserId,
     teamId: params.teamId,
     apiAppId: params.apiAppId,
+    userToken: params.userToken,
+    userTokenReadOnly: params.userTokenReadOnly ?? true,
     historyLimit: params.historyLimit,
     channelHistories,
     sessionScope: params.sessionScope,

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -200,6 +200,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     botUserId,
     teamId,
     apiAppId,
+    userToken: slackCfg.userToken?.trim() || undefined,
+    userTokenReadOnly: slackCfg.userTokenReadOnly ?? true,
     historyLimit,
     sessionScope,
     mainKey,
@@ -341,6 +343,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     }
   };
   opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+
+  if (slackCfg.userToken && slackCfg.userTokenReadOnly === false) {
+    runtime.log?.(
+      warn(
+        "slack: userTokenReadOnly=false — user token will be used for destructive operations (thread cleanup)",
+      ),
+    );
+  }
 
   try {
     if (slackMode === "socket") {

--- a/src/slack/monitor/types.ts
+++ b/src/slack/monitor/types.ts
@@ -66,8 +66,8 @@ export type SlackMessageChangedEvent = {
   type: "message";
   subtype: "message_changed";
   channel?: string;
-  message?: { ts?: string };
-  previous_message?: { ts?: string };
+  message?: { ts?: string; subtype?: string; text?: string; user?: string };
+  previous_message?: { ts?: string; reply_count?: number; thread_ts?: string };
   event_ts?: string;
 };
 


### PR DESCRIPTION
## Summary

- Problem: When a thread parent is deleted, only the bot's own replies can be cleaned up. Other users' messages in the thread remain orphaned because the bot token can only delete its own messages.
- Why it matters: Orphaned messages from other users in deleted threads create clutter and confusion.
- What changed: Extended `deleteSlackThreadReplies` to accept an optional user OAuth token. When provided (and `userTokenReadOnly` is `false`), user messages in the thread are also deleted. Also includes tombstone detection for thread parent deletion.
- What did NOT change: Default behavior (bot-only deletion) is unchanged when no user token is configured.

**Note:** This PR includes tombstone detection for thread parent deletion (also submitted separately in #21766). If #21766 merges first, this PR will need a rebase to remove the overlapping tombstone code.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #177
- Related #21766 (tombstone detection — overlapping scope)

## User-visible / Behavior Changes

When `userTokenReadOnly: false` is configured:
- Thread cleanup now deletes both bot AND user messages
- A warning is logged at startup about destructive user token operations
- Cleanup results now report bot/user/failed counts separately

## Security Impact (required)

- New permissions/capabilities? Yes — user OAuth token can delete other users' messages
- Secrets/tokens handling changed? Yes — user token passed to deletion functions
- New/changed network calls? Yes — `chat.delete` with user token for non-bot messages
- Command/tool execution surface changed? No
- Data access scope changed? Yes — user token enables deletion of any message in the channel
- Explanation: The user token is gated behind `userTokenReadOnly: false` (default is `true`). A startup warning is logged when destructive mode is enabled. The token is only used for thread cleanup after parent deletion, not for arbitrary message deletion.

## Repro + Verification

### Environment

- OS: Linux (OCI ARM64)
- Runtime/container: Docker
- Integration/channel: Slack (Socket Mode)
- Relevant config: `userToken: "xoxp-..."`, `userTokenReadOnly: false`

### Steps

1. Configure user token with `userTokenReadOnly: false`
2. Start a thread with bot replies and user replies
3. Delete the parent message
4. Observe both bot and user replies are cleaned up

### Expected

- All thread replies (bot and user) are deleted
- Logs show `Deleted X bot + Y user reply(ies)`

### Actual

- Confirmed in production with user token configured

## Evidence

- [x] Trace/log snippets — Production logs show bot + user reply deletion counts

## Human Verification (required)

- Verified scenarios: Bot-only mode (no user token), user token with readOnly=true (no user deletion), user token with readOnly=false (full cleanup)
- Edge cases checked: User token fails for some messages (reported as "failed" count), no replies to delete (no-op)
- What you did **not** verify: Channels where user token lacks permission

## Compatibility / Migration

- Backward compatible? Yes (user token is optional, readOnly defaults to true)
- Config/env changes? Yes — new optional config: `userToken`, `userTokenReadOnly`
- Migration needed? No (opt-in feature)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `userTokenReadOnly: true` in config (no code change needed)
- Files/config to restore: `src/slack/actions.ts`, `src/slack/monitor/events/messages.ts`, `src/slack/monitor/provider.ts`, `src/slack/monitor/context.ts`, `src/slack/monitor/types.ts`
- Known bad symptoms: Unexpected message deletions (mitigated by readOnly default and startup warning)

## Risks and Mitigations

- Risk: Accidental deletion of user messages
  - Mitigation: `userTokenReadOnly: true` by default; explicit opt-in required; startup warning logged
- Risk: User token abuse
  - Mitigation: Token only used in thread cleanup context (parent deleted); not exposed to other code paths
- Risk: Rate limiting from bulk deletions
  - Mitigation: Sequential deletion with error handling; failed deletions are tracked and reported

---
*This PR was authored with AI assistance and has been human-verified in a production environment.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for deleting user messages in Slack threads when the parent message is deleted, using an optional user OAuth token. The feature is opt-in via `userTokenReadOnly: false` configuration.

**Key Changes:**
- Extended `deleteSlackThreadReplies` function to accept optional `userToken` for deleting non-bot messages
- Added tombstone detection for thread parent deletion (Slack sends `message_changed` with `subtype: "tombstone"`)
- Thread cleanup now triggered on both `message_deleted` and tombstone events
- Added `userToken` and `userTokenReadOnly` fields to Slack monitor context
- Startup warning logged when destructive user token operations are enabled

**Critical Issue:**
- Variable declaration bug in `src/slack/actions.ts` where `failed` array is used before declaration, causing runtime error

<h3>Confidence Score: 1/5</h3>

- This PR contains a critical runtime error that will crash when bot message deletion fails
- The variable declaration bug (`failed` used before declaration on line 260, then redeclared on line 266) is a blocking issue that will cause ReferenceError at runtime whenever a bot message fails to delete. This is a straightforward logic error that must be fixed before merge.
- Pay close attention to `src/slack/actions.ts` - the variable declaration order must be corrected

<sub>Last reviewed commit: d8e52b1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->