### PR TITLE
feat: add User Token fallback for thread history resolution

### DIFF
--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -6,6 +6,7 @@ import { saveMediaBuffer } from "../../media/store.js";
 import type { SlackAttachment, SlackFile } from "../types.js";
 
 import { createSlackWebClient } from "../client.js";
+import { logVerbose } from "../../globals.js";
 
 function isSlackHostname(hostname: string): boolean {
   const normalized = normalizeHostname(hostname);
@@ -494,19 +495,19 @@ export async function resolveSlackThreadHistory(params: {
   try {
     return await doFetch(params.client);
   } catch (err) {
-    console.warn(
+    logVerbose(
       `resolveSlackThreadHistory failed for channel=${params.channelId} thread=${params.threadTs}: ${String(err)}`,
     );
     // Fallback: retry with user token if available
     if (params.userToken) {
       try {
-        console.warn(
+        logVerbose(
           `resolveSlackThreadHistory: retrying with user token for channel=${params.channelId}`,
         );
         const userClient = createSlackWebClient(params.userToken);
         return await doFetch(userClient);
       } catch (retryErr) {
-        console.warn(
+        logVerbose(
           `resolveSlackThreadHistory user token fallback also failed: ${String(retryErr)}`,
         );
       }

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -526,6 +526,7 @@ export async function prepareSlackMessage(params: {
         channelId: message.channel,
         threadTs,
         client: ctx.app.client,
+        userToken: ctx.userToken,
         currentMessageTs: message.ts,
         limit: threadInitialHistoryLimit,
       });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -526,7 +526,7 @@ export async function prepareSlackMessage(params: {
         channelId: message.channel,
         threadTs,
         client: ctx.app.client,
-        userToken: ctx.userToken,
+        userToken: account.config?.userToken,
         currentMessageTs: message.ts,
         limit: threadInitialHistoryLimit,
       });


### PR DESCRIPTION
## Summary

- Problem: `resolveSlackThreadHistory` fails silently when the bot token lacks access to certain channels (e.g., private channels where the bot isn't a member but has a user token available).
- Why it matters: Thread context is lost when the bot can't read history, leading to responses without proper context.
- What changed: Added a fallback mechanism that retries thread history fetching with a user OAuth token when the bot token fails. The function now uses a `doFetch` closure pattern for clean retry logic.
- What did NOT change: Primary bot token flow is unchanged. User token is only used as a fallback.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related: User OAuth token integration

## User-visible / Behavior Changes

Thread history is now available in channels where the bot token alone can't access the history but a user token can.

## Security Impact (required)

- New permissions/capabilities? Yes — uses user OAuth token for Slack API calls (when available)
- Secrets/tokens handling changed? Yes — user token is passed to `resolveSlackThreadHistory`
- New/changed network calls? Yes — retry with user token on failure
- Command/tool execution surface changed? No
- Data access scope changed? Yes — user token may have broader channel access than bot token
- Explanation: The user token is only used as a fallback when the bot token fails. It's passed through the existing secure token handling pipeline. The user token scope is controlled by the Slack OAuth configuration.

## Repro + Verification

### Environment

- OS: Linux (OCI ARM64)
- Runtime/container: Docker
- Integration/channel: Slack (Socket Mode)

### Steps

1. Configure both bot token and user token
2. Send a message in a private channel where the bot isn't a member
3. Observe thread history is successfully retrieved via user token fallback

### Expected

- Thread history is available via user token fallback

### Actual

- Before fix: Thread history empty, warning logged
- After fix: Thread history populated via user token, fallback logged

## Evidence

- [x] Trace/log snippets — Production logs show fallback path activation and successful history retrieval

## Human Verification (required)

- Verified scenarios: Bot token success (no fallback), bot token failure + user token success, both tokens fail
- Edge cases checked: No user token configured (graceful skip), user token also fails (empty history)
- What you did **not** verify: All Slack API error codes

## Compatibility / Migration

- Backward compatible? Yes (user token is optional)
- Config/env changes? No (user token config already exists)
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; thread history reverts to bot-token-only
- Files/config to restore: `src/slack/monitor/media.ts`, `src/slack/monitor/message-handler/prepare.ts`
- Known bad symptoms: Excessive Slack API calls (mitigated by fallback-only trigger)

## Risks and Mitigations

- Risk: User token used when not intended
  - Mitigation: Only used when bot token explicitly fails; user token availability is opt-in via config
- Risk: Rate limiting from retry calls
  - Mitigation: Single retry attempt, not exponential

---
*This PR was authored with AI assistance and has been human-verified in a production environment.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added fallback mechanism to `resolveSlackThreadHistory` that retries with user OAuth token when bot token fails to access thread history. The implementation extracts pagination logic into a reusable `doFetch` closure and wraps the primary bot token call in try/catch to enable graceful fallback. When the bot token fails, the function logs the error and attempts retry with user token if available, ultimately returning empty array if both tokens fail.

- Refactored `resolveSlackThreadHistory` to use `doFetch` closure for DRY pagination logic
- Added `userToken` optional parameter to function signature
- Implemented try/catch with user token fallback on bot token failure  
- Updated `prepareSlackMessage` to pass `account.config.userToken` through to thread history resolver
- Switched from `console.warn` to `logVerbose` for consistency with codebase logging patterns

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, follow existing patterns in the codebase, maintain backward compatibility (user token is optional), and the fallback pattern is sound. The implementation properly handles errors at each step, uses existing security-validated token handling via `createSlackWebClient`, and includes appropriate logging. The refactoring to use a `doFetch` closure improves code organization without changing core logic. Tests exist for the function and cover error scenarios.
- No files require special attention

<sub>Last reviewed commit: 21dfcf2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->