### PR TITLE
feat: detect tombstone events and clean up thread replies

### DIFF
--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -1,5 +1,5 @@
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
-import { danger } from "../../../globals.js";
+import { danger, logVerbose } from "../../../globals.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
 import type { SlackAppMentionEvent, SlackMessageEvent } from "../../types.js";
 import { resolveSlackChannelLabel } from "../channel-config.js";
@@ -27,6 +27,9 @@ export function registerSlackMessageEvents(params: {
         channelType,
       })
     ) {
+      logVerbose(
+        `[slack/system-event] channel not allowed: channelId=${channelId ?? "unknown"} name=${channelInfo?.name ?? "unknown"} type=${channelType ?? "unknown"}`,
+      );
       return null;
     }
 
@@ -49,6 +52,16 @@ export function registerSlackMessageEvents(params: {
       }
 
       const message = event as SlackMessageEvent;
+      // Log subtypes that are handled as system events (not regular messages)
+      if (
+        message.subtype === "message_deleted" ||
+        message.subtype === "message_changed" ||
+        message.subtype === "thread_broadcast"
+      ) {
+        ctx.runtime.log?.(
+          `[slack/event] subtype=${message.subtype} channel=${(event as { channel?: string }).channel ?? "unknown"}`,
+        );
+      }
       if (message.subtype === "message_changed") {
         const changed = event as SlackMessageChangedEvent;
         const channelId = changed.channel;
@@ -57,6 +70,45 @@ export function registerSlackMessageEvents(params: {
           return;
         }
         const messageId = changed.message?.ts ?? changed.previous_message?.ts;
+
+        // Detect tombstone: Slack sends message_changed (not message_deleted)
+        // when a thread parent is deleted. The new message has subtype "tombstone".
+        const isTombstone = changed.message?.subtype === "tombstone";
+        const hadThread = (changed.previous_message?.reply_count ?? 0) > 0;
+        if (isTombstone && hadThread && channelId && messageId) {
+          ctx.runtime.log?.(
+            `[message_changed/tombstone] thread parent deleted: channel=${channelId} thread=${messageId}`,
+          );
+          void (async () => {
+            try {
+              const { deleteSlackThreadRepliesFromBot } = await import("../../actions.js");
+              const deletedTsValues = await deleteSlackThreadRepliesFromBot(
+                channelId,
+                messageId,
+                ctx.botUserId,
+              );
+              if (deletedTsValues.length > 0) {
+                ctx.logger.info(
+                  `Deleted ${deletedTsValues.length} bot reply(ies) in thread ${messageId} (tombstone detected)`,
+                );
+              } else {
+                ctx.runtime.log?.(
+                  `[message_changed/tombstone] no bot replies found in thread ${messageId}`,
+                );
+              }
+            } catch (err) {
+              ctx.logger.warn(
+                `Failed to clean up bot replies after tombstone detection: ${String(err)}`,
+              );
+            }
+          })();
+          enqueueSystemEvent(`Slack message deleted in ${target.label} (thread parent removed).`, {
+            sessionKey: target.sessionKey,
+            contextKey: `slack:message:deleted:${channelId}:${messageId}`,
+          });
+          return;
+        }
+
         enqueueSystemEvent(`Slack message edited in ${target.label}.`, {
           sessionKey: target.sessionKey,
           contextKey: `slack:message:changed:${channelId ?? "unknown"}:${messageId ?? changed.event_ts ?? "unknown"}`,
@@ -66,14 +118,52 @@ export function registerSlackMessageEvents(params: {
       if (message.subtype === "message_deleted") {
         const deleted = event as SlackMessageDeletedEvent;
         const channelId = deleted.channel;
+        ctx.runtime.log?.(
+          `[message_deleted] received: channel=${channelId ?? "unknown"} deleted_ts=${deleted.deleted_ts ?? "unknown"} event_ts=${deleted.event_ts ?? "unknown"}`,
+        );
         const target = await resolveSlackChannelSystemEventTarget(channelId);
         if (!target) {
+          ctx.runtime.log?.(
+            `[message_deleted] dropped: channel=${channelId ?? "unknown"} not in allowlist`,
+          );
           return;
         }
+        ctx.runtime.log?.(
+          `[message_deleted] allowed: channel=${channelId ?? "unknown"} label=${target.label} sessionKey=${target.sessionKey}`,
+        );
         enqueueSystemEvent(`Slack message deleted in ${target.label}.`, {
           sessionKey: target.sessionKey,
           contextKey: `slack:message:deleted:${channelId ?? "unknown"}:${deleted.deleted_ts ?? deleted.event_ts ?? "unknown"}`,
         });
+        // Clean up bot replies when parent message is deleted
+        if (deleted.deleted_ts && channelId) {
+          void (async () => {
+            try {
+              const { deleteSlackThreadRepliesFromBot } = await import("../../actions.js");
+              ctx.runtime.log?.(
+                `[message_deleted] cleaning up bot replies: channel=${channelId} thread=${deleted.deleted_ts}`,
+              );
+              const deletedTsValues = await deleteSlackThreadRepliesFromBot(
+                channelId,
+                deleted.deleted_ts!,
+                ctx.botUserId,
+              );
+              if (deletedTsValues.length > 0) {
+                ctx.logger.info(
+                  `Deleted ${deletedTsValues.length} bot reply(ies) in thread ${deleted.deleted_ts} (parent message deleted)`,
+                );
+              } else {
+                ctx.runtime.log?.(
+                  `[message_deleted] no bot replies found in thread ${deleted.deleted_ts}`,
+                );
+              }
+            } catch (err) {
+              ctx.logger.warn(
+                `Failed to clean up bot replies after parent message deletion: ${String(err)}`,
+              );
+            }
+          })();
+        }
         return;
       }
       if (message.subtype === "thread_broadcast") {

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -145,7 +145,7 @@ export function registerSlackMessageEvents(params: {
               );
               const deletedTsValues = await deleteSlackThreadRepliesFromBot(
                 channelId,
-                deleted.deleted_ts!,
+                deleted.deleted_ts,
                 ctx.botUserId,
               );
               if (deletedTsValues.length > 0) {

--- a/src/slack/monitor/types.ts
+++ b/src/slack/monitor/types.ts
@@ -66,8 +66,8 @@ export type SlackMessageChangedEvent = {
   type: "message";
   subtype: "message_changed";
   channel?: string;
-  message?: { ts?: string };
-  previous_message?: { ts?: string };
+  message?: { ts?: string; subtype?: string; text?: string; user?: string };
+  previous_message?: { ts?: string; reply_count?: number; thread_ts?: string };
   event_ts?: string;
 };
 


### PR DESCRIPTION
## Summary

- Problem: When a Slack thread parent message is deleted, Slack sends a `message_changed` event with `subtype: "tombstone"` instead of `message_deleted`. OpenClaw doesn't detect this, leaving orphaned bot replies in the thread.
- Why it matters: Orphaned bot replies in deleted threads create confusion and clutter in Slack channels.
- What changed: Added tombstone detection in the `message_changed` handler that identifies deleted thread parents and cleans up bot replies. Also added reply cleanup to the `message_deleted` handler for non-tombstone deletions.
- What did NOT change: Normal message editing behavior is unchanged. Only tombstone subtypes trigger cleanup.

## Change Type (select all)

- [x] Feature
- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #166

## User-visible / Behavior Changes

When a Slack thread parent is deleted (tombstone), the bot's replies in that thread are automatically cleaned up.

## Security Impact (required)

- New permissions/capabilities? No (uses existing bot token's `chat:write` scope)
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — `conversations.replies` to list thread messages, `chat.delete` to remove bot replies
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (OCI ARM64)
- Runtime/container: Docker
- Integration/channel: Slack (Socket Mode)

### Steps

1. Send a message that triggers a bot reply thread
2. Delete the parent message
3. Observe the bot's replies are automatically cleaned up

### Expected

- Bot replies are deleted after parent message deletion

### Actual

- Before fix: Bot replies remain orphaned
- After fix: Bot replies are cleaned up within seconds

## Evidence

- [x] Trace/log snippets — Production logs show tombstone detection and reply cleanup

## Human Verification (required)

- Verified scenarios: Thread parent deletion (tombstone), direct message deletion, thread with multiple bot replies
- Edge cases checked: Thread with no bot replies (no-op), already-deleted replies (graceful skip)
- What you did **not** verify: Threads with 200+ replies (pagination not needed for cleanup)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; orphaned replies will remain but cause no harm
- Files/config to restore: `src/slack/monitor/events/messages.ts`, `src/slack/actions.ts`
- Known bad symptoms: Unexpected message deletions (mitigated by only deleting bot's own replies)

## Risks and Mitigations

- Risk: Accidental deletion of non-bot messages
  - Mitigation: Only deletes messages where `msg.user === botUserId`; user messages are never touched
- Risk: Rate limiting from bulk deletions
  - Mitigation: Sequential deletion with error handling; typical threads have few bot replies

---
*This PR was authored with AI assistance and has been human-verified in a production environment.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds tombstone detection to handle Slack's non-standard deletion behavior where thread parent deletions trigger `message_changed` events with `subtype: "tombstone"` instead of `message_deleted`. Implements automatic cleanup of orphaned bot replies in both tombstone and direct deletion scenarios. The implementation includes comprehensive error handling, pagination support for large threads, and extensive logging for debugging. Key changes:

- New `deleteSlackThreadRepliesFromBot` function in `src/slack/actions.ts` with cursor-based pagination and per-message error handling
- Tombstone detection in `message_changed` handler that checks for `subtype: "tombstone"` and `reply_count > 0`
- Parallel cleanup logic in `message_deleted` handler for standard deletions
- Type extensions to support `reply_count`, `subtype`, and other tombstone-related fields
- Fire-and-forget async cleanup to avoid blocking event processing

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The implementation correctly handles Slack's tombstone event pattern and includes proper error handling. However, `conversations.replies` in `deleteSlackThreadRepliesFromBot` could fail when called on already-deleted threads, which would cause the cleanup to abort. While this is caught by the caller's try-catch, wrapping the API call itself would make the function more robust and allow partial cleanup on API failures. The fire-and-forget async pattern, security mitigation (bot user ID filtering), and comprehensive logging are well-implemented.
- Pay attention to `src/slack/actions.ts` - the `conversations.replies` call may need error handling if Slack returns errors for deleted threads

<sub>Last reviewed commit: 5f23f04</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->