### PR TITLE
fix: use env var instead of file-based key for Notion SKILL.md

### DIFF
--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -17,13 +17,7 @@ Use the Notion API to create/read/update pages, data sources (databases), and bl
 
 1. Create an integration at https://notion.so/my-integrations
 2. Copy the API key (starts with `ntn_` or `secret_`)
-3. Store it:
-
-```bash
-mkdir -p ~/.config/notion
-echo "ntn_your_key_here" > ~/.config/notion/api_key
-```
-
+3. Set the environment variable `NOTION_API_KEY` with the key value
 4. Share target pages/databases with your integration (click "..." → "Connect to" → your integration name)
 
 ## API Basics
@@ -31,7 +25,7 @@ echo "ntn_your_key_here" > ~/.config/notion/api_key
 All requests need:
 
 ```bash
-NOTION_KEY=$(cat ~/.config/notion/api_key)
+NOTION_KEY="$NOTION_API_KEY"
 curl -X GET "https://api.notion.com/v1/..." \
   -H "Authorization: Bearer $NOTION_KEY" \
   -H "Notion-Version: 2025-09-03" \

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -17,7 +17,14 @@ Use the Notion API to create/read/update pages, data sources (databases), and bl
 
 1. Create an integration at https://notion.so/my-integrations
 2. Copy the API key (starts with `ntn_` or `secret_`)
-3. Set the environment variable `NOTION_API_KEY` with the key value
+3. Store it persistently using `config.patch` to add it to the `env` section of the configuration:
+
+```
+config.patch action with raw: {"env":{"NOTION_API_KEY":"ntn_your_key_here"}}
+```
+
+Alternatively, set the `NOTION_API_KEY` environment variable externally (e.g., Docker `--env`, `.env` file, or CI secrets).
+
 4. Share target pages/databases with your integration (click "..." → "Connect to" → your integration name)
 
 ## API Basics


### PR DESCRIPTION
## Summary

- Problem: Notion SKILL.md references a file-based API key path that doesn't work in containerized environments.
- Why it matters: Users running OpenClaw in Docker cannot configure Notion integration without manual workarounds.
- What changed: Updated SKILL.md to use the `NOTION_API_KEY` environment variable instead of a file path.
- What did NOT change: No runtime code changes — documentation/skill config only.

## Change Type (select all)

- [x] Bug fix
- [x] Docs

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Integrations

## Linked Issue/PR

- Related #175

## User-visible / Behavior Changes

Notion skill configuration now correctly references the environment variable approach.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No (env var was already supported, just not documented correctly)
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (OCI ARM64)
- Runtime/container: Docker
- Integration/channel: Notion API

### Steps

1. Configure `NOTION_API_KEY` as an environment variable
2. Invoke the Notion skill
3. Verify the skill reads the key from the environment

### Expected

- Skill successfully authenticates with Notion API

### Actual

- Before fix: Skill looks for a file path that doesn't exist in Docker
- After fix: Skill uses the environment variable

## Evidence

- [x] Trace/log snippets — Verified Notion skill works with env var in Docker

## Human Verification (required)

- Verified scenarios: Notion skill invocation in Docker with env var
- Edge cases checked: Missing env var (graceful error)
- What you did **not** verify: File-based key path (deprecated approach)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (env var already existed)
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the SKILL.md change
- Files/config to restore: Notion SKILL.md
- Known bad symptoms: Notion skill failing to authenticate

## Risks and Mitigations

None — documentation-only change.

---
*This PR was authored with AI assistance and has been human-verified in a production environment.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Notion `SKILL.md` to replace the file-based API key storage approach (`~/.config/notion/api_key`) with the `config.patch` gateway tool action and the `NOTION_API_KEY` environment variable, fixing Notion integration setup in containerized environments.

- Replaced file-based key storage instructions with `config.patch` for persistent env var configuration
- Updated the API Basics curl example to read from `$NOTION_API_KEY` instead of `cat`-ing a file
- Added note about alternative external env var approaches (Docker `--env`, `.env`, CI secrets)
- No runtime code changes — documentation/skill config only

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only changes documentation with no runtime impact.
- Documentation-only change to a single SKILL.md file. The new config.patch syntax is consistent with how the gateway tool processes this action (auto-resolves baseHash, accepts raw JSON). The env var approach aligns with the existing metadata declaration that already requires NOTION_API_KEY. No code paths are affected.
- No files require special attention.

<sub>Last reviewed commit: e66e81f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->