### PR TITLE
fix(slack): preserve `this` binding in registerArgOptions

### DIFF
--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -731,21 +731,19 @@ export async function registerSlackMonitorSlashCommands(params: {
   }
 
   const registerArgOptions = () => {
-    const optionsHandler = (
-      ctx.app as unknown as {
-        options?: (
-          actionId: string,
-          handler: (args: {
-            ack: (payload: { options: unknown[] }) => Promise<void>;
-            body: unknown;
-          }) => Promise<void>,
-        ) => void;
-      }
-    ).options;
-    if (typeof optionsHandler !== "function") {
+    const appWithOptions = ctx.app as unknown as {
+      options?: (
+        actionId: string,
+        handler: (args: {
+          ack: (payload: { options: unknown[] }) => Promise<void>;
+          body: unknown;
+        }) => Promise<void>,
+      ) => void;
+    };
+    if (typeof appWithOptions.options !== "function") {
       return;
     }
-    optionsHandler(SLACK_COMMAND_ARG_ACTION_ID, async ({ ack, body }) => {
+    appWithOptions.options.call(ctx.app, SLACK_COMMAND_ARG_ACTION_ID, async ({ ack, body }) => {
       const typedBody = body as {
         value?: string;
         user?: { id?: string };


### PR DESCRIPTION
## Summary

- Problem: `registerArgOptions` loses `this` binding when called as a standalone function reference, causing runtime errors in Slack event handlers.
- Why it matters: This can lead to silent failures in Slack argument parsing during event processing.
- What changed: Wrapped the function call to preserve the correct `this` context.
- What did NOT change: No changes to the function's logic or return values.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related: Discovered during Slack event handler debugging.

## User-visible / Behavior Changes

None — fixes an internal binding issue that could cause silent failures.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (OCI ARM64)
- Runtime/container: Docker (Node.js)
- Integration/channel: Slack (Socket Mode)

### Steps

1. Register a Slack app with arg options
2. Trigger an event that invokes `registerArgOptions`
3. Observe that `this` is correctly bound

### Expected

- Function executes without binding errors

### Actual

- Without fix: `this` is undefined, causing runtime error
- With fix: Function executes correctly

## Evidence

- [x] Trace/log snippets — Verified no binding errors in production logs after patch

## Human Verification (required)

- Verified scenarios: Slack event processing with arg options registration
- Edge cases checked: Multiple concurrent event handlers
- What you did **not** verify: Other Slack event types not using argOptions

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/slack/` binding file
- Known bad symptoms reviewers should watch for: Slack events failing to parse arguments

## Risks and Mitigations

None — minimal change to fix a JavaScript `this` binding issue.

---
*This PR was authored with AI assistance and has been human-verified in a production environment.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a `this` binding issue in Slack argument options registration by refactoring from extracting the method to a variable (which loses context) to calling it with explicit binding via `.call()`.

- Changed from extracting `options` method to calling it directly on the object reference
- Prevents potential runtime errors when Slack SDK's `options` method expects `this` to be the app instance
- The fix is functionally correct and resolves the binding issue

<h3>Confidence Score: 4/5</h3>

- Safe to merge - fixes a real binding bug with minimal risk
- The fix correctly resolves the `this` binding issue that would cause runtime errors. The `.call()` approach is more explicit than necessary but functionally correct. Single file change with clear intent and low risk.
- No files require special attention

<sub>Last reviewed commit: c798ae2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->