### PR TITLE
Fix/subagent announce telegram channel

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -77,6 +77,7 @@ export type EmbeddedPiSubscribeState = {
   successfulCronAdds: number;
   pendingMessagingMediaUrls: Map<string, string[]>;
   lastAssistant?: AgentMessage;
+  agentStartedAt?: number;
 };
 
 export type EmbeddedPiSubscribeContext = {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -468,17 +468,20 @@ async function sendSubagentAnnounceDirectly(params: {
         completionDirectOrigin?.threadId != null && completionDirectOrigin.threadId !== ""
           ? String(completionDirectOrigin.threadId)
           : undefined;
+
       await callGateway({
-        method: "send",
+        method: "agent",
         params: {
-          channel: completionChannel,
-          to: completionTo,
-          accountId: completionDirectOrigin?.accountId,
-          threadId: completionThreadId,
           sessionKey: canonicalRequesterSessionKey,
           message: params.completionMessage,
+          channel: completionChannel,
+          accountId: completionDirectOrigin?.accountId,
+          to: completionTo,
+          threadId: completionThreadId,
+          deliver: true,
           idempotencyKey: params.directIdempotencyKey,
         },
+        expectFinal: true,
         timeoutMs: 15_000,
       });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Telegram channel error in subagent completion announcements by switching from the `send` gateway method to the `agent` method. The `send` method has strict channel validation that was incorrectly rejecting Telegram as an unsupported channel, while the `agent` method properly handles both internal and external channel routing.

Key changes:
- Switched subagent completion announcements from `method: "send"` to `method: "agent"` in `subagent-announce.ts:472-486`
- Reordered params to match `agent` method signature (sessionKey first, deliver flag added, expectFinal added)
- Minor formatting fix in `docs/style.css` (multiline transition property)
- No changes to the agent_end hook logic from the previous commit #21862

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and addresses a clear bug where Telegram channel was incorrectly rejected. Switching from `send` to `agent` method is the correct fix as `agent` handles channel routing more flexibly. The parameter reordering matches the expected signature, and the addition of `deliver: true` and `expectFinal: true` flags maintains the intended behavior. The formatting change in CSS is trivial.
- No files require special attention

<sub>Last reviewed commit: 745d260</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->