### PR TITLE
test(ios): cover IPv4-mapped IPv6 loopback in manual TLS policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Channels/CLI: add per-account/channel `defaultTo` outbound routing fallback so `openclaw agent --deliver` can send without explicit `--reply-to` when a default target is configured. (#16985) Thanks @KirillShchetinin.
+- iOS/Tests: cover IPv4-mapped IPv6 loopback in manual TLS policy tests for connect validation paths. (#22045) Thanks @mbelinky.
 - iOS/Gateway: stabilize background wake and reconnect behavior with background reconnect suppression/lease windows, BGAppRefresh wake fallback, location wake hook throttling, and APNs wake retry+nudge instrumentation. (#21226) thanks @mbelinky.
 - Auto-reply/UI: add model fallback lifecycle visibility in verbose logs, /status active-model context with fallback reason, and cohesive WebUI fallback indicators. (#20704) Thanks @joshavant.
 

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -115,6 +115,7 @@ import Testing
         #expect(controller._test_resolveManualUseTLS(host: "127.0.0.1", useTLS: false) == false)
         #expect(controller._test_resolveManualUseTLS(host: "::1", useTLS: false) == false)
         #expect(controller._test_resolveManualUseTLS(host: "[::1]", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "::ffff:127.0.0.1", useTLS: false) == false)
         #expect(controller._test_resolveManualUseTLS(host: "0.0.0.0", useTLS: false) == false)
     }
 


### PR DESCRIPTION
## Summary
- add regression coverage for `::ffff:127.0.0.1` in manual host TLS resolution tests
- confirms IPv4-mapped IPv6 loopback is treated as loopback (no forced TLS)

## Why
Greptile correctly pointed out this specific test gap after the loopback hardening changes.

## Changes
- `apps/ios/Tests/GatewayConnectionSecurityTests.swift`
  - add:
    - `#expect(controller._test_resolveManualUseTLS(host: "::ffff:127.0.0.1", useTLS: false) == false)`

## Verification
- attempted targeted test run:
  - `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:OpenClawTests/GatewayConnectionSecurityTests/manualConnectionsForceTLSForNonLoopbackHosts`
  - blocked in this environment because the scheme requires watchOS runtime (`watchOS 26.2 must be installed`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added regression test for IPv4-mapped IPv6 loopback address (`::ffff:127.0.0.1`) to verify it's correctly treated as loopback and doesn't force TLS in manual gateway connections.

- Test coverage fills gap identified after loopback hardening changes in #21969
- Implementation in `isLoopbackIPv6` (lines 695-707) already handles IPv4-mapped addresses by checking bytes[10-11] for `0xFF` and bytes[12] for `127`
- New test assertion verifies expected behavior is working correctly

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single test assertion added to existing test suite with no production code changes. The test verifies that IPv4-mapped IPv6 loopback addresses are correctly handled by existing implementation (confirmed by code review of `isLoopbackIPv6` at lines 704-705), filling a gap in test coverage.
- No files require special attention

<sub>Last reviewed commit: 822d26e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->