### PR TITLE
session-memory: filter excerpt noise + config knobs

### DIFF
--- a/src/channels/plugins/account-helpers.test.ts
+++ b/src/channels/plugins/account-helpers.test.ts
@@ -53,6 +53,14 @@ describe("createAccountListHelpers", () => {
     it("returns sorted ids", () => {
       expect(listAccountIds(cfg({ z: {}, a: {}, m: {} }))).toEqual(["a", "m", "z"]);
     });
+
+    it("includes bound account ids from bindings", () => {
+      const config = {
+        channels: { testchannel: { accounts: { work: {} } } },
+        bindings: [{ match: { channel: "testchannel", accountId: "personal" }, agentId: "helper" }],
+      } as unknown as OpenClawConfig;
+      expect(listAccountIds(config)).toEqual(["personal", "work"]);
+    });
   });
 
   describe("resolveDefaultAccountId", () => {

--- a/src/channels/plugins/account-helpers.ts
+++ b/src/channels/plugins/account-helpers.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/config.js";
+import { listBoundAccountIds } from "../../routing/bindings.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
 
 export function createAccountListHelpers(channelKey: string) {
@@ -12,7 +13,9 @@ export function createAccountListHelpers(channelKey: string) {
   }
 
   function listAccountIds(cfg: OpenClawConfig): string[] {
-    const ids = listConfiguredAccountIds(cfg);
+    const ids = Array.from(
+      new Set([...listConfiguredAccountIds(cfg), ...listBoundAccountIds(cfg, channelKey)]),
+    );
     if (ids.length === 0) {
       return [DEFAULT_ACCOUNT_ID];
     }

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { listDiscordAccountIds } from "./accounts.js";
+
+function cfg(discord?: Record<string, unknown>): OpenClawConfig {
+  return { channels: { discord: discord ?? {} } } as unknown as OpenClawConfig;
+}
+
+describe("listDiscordAccountIds", () => {
+  it('returns ["default"] when no accounts and no token', () => {
+    expect(listDiscordAccountIds(cfg())).toEqual(["default"]);
+  });
+
+  it('returns ["default"] when no accounts but top-level token exists', () => {
+    expect(listDiscordAccountIds(cfg({ token: "bot-token" }))).toEqual(["default"]);
+  });
+
+  it("injects default when sub-accounts exist and top-level token is present", () => {
+    expect(
+      listDiscordAccountIds(
+        cfg({
+          token: "top-level-token",
+          accounts: { "bot-b": {}, "bot-c": {} },
+        }),
+      ),
+    ).toEqual(["bot-b", "bot-c", "default"]);
+  });
+
+  it("does not inject default when sub-accounts exist but no top-level token", () => {
+    expect(
+      listDiscordAccountIds(
+        cfg({
+          accounts: { "bot-b": {}, "bot-c": {} },
+        }),
+      ),
+    ).toEqual(["bot-b", "bot-c"]);
+  });
+
+  it("does not duplicate default when already explicitly listed", () => {
+    expect(
+      listDiscordAccountIds(
+        cfg({
+          token: "top-level-token",
+          accounts: { default: {}, "bot-b": {} },
+        }),
+      ),
+    ).toEqual(["bot-b", "default"]);
+  });
+
+  it("returns sorted results", () => {
+    expect(
+      listDiscordAccountIds(
+        cfg({
+          token: "top-level-token",
+          accounts: { zebra: {}, alpha: {} },
+        }),
+      ),
+    ).toEqual(["alpha", "default", "zebra"]);
+  });
+});

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -63,12 +63,15 @@ The hook uses your configured LLM provider to generate slugs, so it works with a
 
 The hook supports optional configuration:
 
-| Option            | Type    | Default | Description                                                           |
-| ----------------- | ------- | ------- | --------------------------------------------------------------------- |
-| `excerptMessages` | number  | 15      | Number of user/assistant messages to include in the excerpt           |
-| `includeExcerpt`  | boolean | true    | If false, do not include the conversation excerpt section             |
-| `messages`        | number  | 15      | Back-compat alias for `excerptMessages`                               |
-| `llmSlug`         | boolean | true    | If false, disable LLM-based slug generation (timestamp slug fallback) |
+| Option            | Type     | Default | Description                                                           |
+| ----------------- | -------- | ------- | --------------------------------------------------------------------- |
+| `excerptMessages` | number   | 15      | Number of user/assistant messages to include in the excerpt           |
+| `includeExcerpt`  | boolean  | true    | If false, do not include the conversation excerpt section             |
+| `messages`        | number   | 15      | Back-compat alias for `excerptMessages`                               |
+| `llmSlug`         | boolean  | true    | If false, disable LLM-based slug generation (timestamp slug fallback) |
+| `excludeExact`    | string[] | []      | Drop messages whose trimmed text matches one of these strings exactly |
+| `excludePrefixes` | string[] | []      | Drop messages whose trimmed text starts with one of these prefixes    |
+| `excludeRegexes`  | string[] | []      | Drop messages whose trimmed text matches any of these regex patterns  |
 
 Example configuration:
 
@@ -91,6 +94,7 @@ Example configuration:
 Notes:
 
 - The excerpt is **noise-filtered** (common automation markers, heartbeat prompts, and large untrusted metadata blocks are removed) before slicing to `excerptMessages`.
+- You can add additional per-installation filtering using `excludeExact`, `excludePrefixes`, and/or `excludeRegexes`.
 - In test environments, LLM calls are disabled for determinism.
 
 ## Disabling

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -23,10 +23,9 @@ Automatically saves session context to your workspace memory when you issue the 
 When you run `/new` to start a fresh session:
 
 1. **Finds the previous session** - Uses the pre-reset session entry to locate the correct transcript
-2. **Extracts conversation** - Reads the last N user/assistant messages from the session (default: 15, configurable)
+2. **Extracts conversation excerpt** - Reads the last N user/assistant messages from the session (default: 15, configurable)
 3. **Generates descriptive slug** - Uses LLM to create a meaningful filename slug based on conversation content
 4. **Saves to memory** - Creates a new file at `<workspace>/memory/YYYY-MM-DD-slug.md`
-5. **Sends confirmation** - Notifies you with the file path
 
 ## Output Format
 
@@ -38,6 +37,11 @@ Memory files are created with the following format:
 - **Session Key**: agent:main:main
 - **Session ID**: abc123def456
 - **Source**: telegram
+
+## Conversation Summary
+
+user: ...
+assistant: ...
 ```
 
 ## Filename Examples
@@ -59,9 +63,12 @@ The hook uses your configured LLM provider to generate slugs, so it works with a
 
 The hook supports optional configuration:
 
-| Option     | Type   | Default | Description                                                     |
-| ---------- | ------ | ------- | --------------------------------------------------------------- |
-| `messages` | number | 15      | Number of user/assistant messages to include in the memory file |
+| Option            | Type    | Default | Description                                                           |
+| ----------------- | ------- | ------- | --------------------------------------------------------------------- |
+| `excerptMessages` | number  | 15      | Number of user/assistant messages to include in the excerpt           |
+| `includeExcerpt`  | boolean | true    | If false, do not include the conversation excerpt section             |
+| `messages`        | number  | 15      | Back-compat alias for `excerptMessages`                               |
+| `llmSlug`         | boolean | true    | If false, disable LLM-based slug generation (timestamp slug fallback) |
 
 Example configuration:
 
@@ -72,7 +79,8 @@ Example configuration:
       "entries": {
         "session-memory": {
           "enabled": true,
-          "messages": 25
+          "excerptMessages": 25,
+          "includeExcerpt": true
         }
       }
     }
@@ -80,11 +88,10 @@ Example configuration:
 }
 ```
 
-The hook automatically:
+Notes:
 
-- Uses your workspace directory (`~/.openclaw/workspace` by default)
-- Uses your configured LLM for slug generation
-- Falls back to timestamp slugs if LLM is unavailable
+- The excerpt is **noise-filtered** (common automation markers, heartbeat prompts, and large untrusted metadata blocks are removed) before slicing to `excerptMessages`.
+- In test environments, LLM calls are disabled for determinism.
 
 ## Disabling
 


### PR DESCRIPTION
Implements a first-pass improvement to the bundled session-memory hook so its excerpt is less dominated by automation/tool noise.

Changes:
- Strip common untrusted-metadata JSON blocks from message text
- Filter out common noise messages (NO_REPLY, HEARTBEAT_OK, heartbeat prompts, reply-*.mp3, System:/queued markers)
- Add config knobs:
  - excerptMessages (alias of messages)
  - includeExcerpt (default true)
  - llmSlug (existing behavior; documented)
- Unit tests covering new filtering + config behavior
- Docs updated: src/hooks/bundled/session-memory/HOOK.md

This does NOT yet add full LLM-generated multi-section summaries; it just makes the existing excerpt usable as input for future summarization work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the session-memory hook to filter noise from excerpts and adds Discord account configuration fixes:

**Session-memory improvements:**
- Filters common automation noise (NO_REPLY, HEARTBEAT_OK, heartbeat prompts, voice MP3 filenames)
- Strips untrusted metadata JSON blocks from messages
- Fixes message slicing to filter before limiting (ensuring N actual messages, not N raw entries)
- Adds config knobs: `excerptMessages` (alias: `messages`), `includeExcerpt`, documents existing `llmSlug`
- Comprehensive test coverage for all filtering scenarios

**Discord account fixes:**
- Ensures default Discord account is included when top-level token is configured alongside sub-accounts
- Prevents silent dropping of the implicit default account

**Account-helpers enhancement:**
- Includes bound account IDs from bindings config in addition to explicitly configured accounts

All changes maintain backward compatibility, include thorough unit tests, and follow the codebase style guidelines.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive unit tests covering all new functionality and edge cases. The code follows repository conventions, maintains backward compatibility through config aliases, and solves real bugs (message filtering order, default account dropping). All filtering logic is conservative and safe, using well-scoped regex patterns and simple string checks. The test coverage demonstrates thorough validation of the filtering behavior.
- No files require special attention

<sub>Last reviewed commit: 5ed8721</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->