### PR TITLE
fix(gateway): use loopback for self-connections regardless of bind mode

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -133,7 +133,7 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
   });
 
-  it("uses tailnet IP with TLS when local bind is tailnet", async () => {
+  it("uses loopback with TLS when local bind is tailnet (self-connection)", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "local", bind: "tailnet", tls: { enabled: true } },
     });
@@ -142,18 +142,20 @@ describe("callGateway url resolution", () => {
 
     await callGateway({ method: "health" });
 
-    expect(lastClientOptions?.url).toBe("wss://100.64.0.1:18800");
+    expect(lastClientOptions?.url).toBe("wss://127.0.0.1:18800");
   });
 
-  it("blocks ws:// to tailnet IP without TLS (CWE-319)", async () => {
+  it("uses loopback ws:// when local bind is tailnet and no TLS (self-connection)", async () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "tailnet" } });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue("100.64.0.1");
 
-    await expect(callGateway({ method: "health" })).rejects.toThrow("SECURITY ERROR");
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
   });
 
-  it("uses LAN IP with TLS when bind is lan", async () => {
+  it("uses loopback with TLS when bind is lan (self-connection)", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "local", bind: "lan", tls: { enabled: true } },
     });
@@ -163,16 +165,18 @@ describe("callGateway url resolution", () => {
 
     await callGateway({ method: "health" });
 
-    expect(lastClientOptions?.url).toBe("wss://192.168.1.42:18800");
+    expect(lastClientOptions?.url).toBe("wss://127.0.0.1:18800");
   });
 
-  it("blocks ws:// to LAN IP without TLS (CWE-319)", async () => {
+  it("uses loopback ws:// when bind is lan and no TLS (self-connection)", async () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
     pickPrimaryLanIPv4.mockReturnValue("192.168.1.42");
 
-    await expect(callGateway({ method: "health" })).rejects.toThrow("SECURITY ERROR");
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
   });
 
   it("falls back to loopback when bind is lan but no LAN IP found", async () => {
@@ -270,7 +274,7 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.message).toContain("Gateway target: ws://127.0.0.1:18789");
   });
 
-  it("uses LAN IP with TLS and reports lan source when bind is lan", () => {
+  it("uses loopback with TLS and reports lan source when bind is lan (self-connection)", () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "local", bind: "lan", tls: { enabled: true } },
     });
@@ -280,12 +284,12 @@ describe("buildGatewayConnectionDetails", () => {
 
     const details = buildGatewayConnectionDetails();
 
-    expect(details.url).toBe("wss://10.0.0.5:18800");
+    expect(details.url).toBe("wss://127.0.0.1:18800");
     expect(details.urlSource).toBe("local lan 10.0.0.5");
     expect(details.bindDetail).toBe("Bind: lan");
   });
 
-  it("throws for ws:// to LAN IP without TLS (CWE-319)", () => {
+  it("uses loopback ws:// without TLS when bind is lan (self-connection, no SECURITY ERROR)", () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "local", bind: "lan" },
     });
@@ -293,7 +297,10 @@ describe("buildGatewayConnectionDetails", () => {
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
     pickPrimaryLanIPv4.mockReturnValue("10.0.0.5");
 
-    expect(() => buildGatewayConnectionDetails()).toThrow("SECURITY ERROR");
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://127.0.0.1:18800");
+    expect(details.urlSource).toBe("local lan 10.0.0.5");
   });
 
   it("prefers remote url when configured", () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -122,12 +122,11 @@ export function buildGatewayConnectionDetails(
   const preferLan = bindMode === "lan";
   const lanIPv4 = preferLan ? pickPrimaryLanIPv4() : undefined;
   const scheme = tlsEnabled ? "wss" : "ws";
-  const localUrl =
-    preferTailnet && tailnetIPv4
-      ? `${scheme}://${tailnetIPv4}:${localPort}`
-      : preferLan && lanIPv4
-        ? `${scheme}://${lanIPv4}:${localPort}`
-        : `${scheme}://127.0.0.1:${localPort}`;
+  // Self-connection always uses loopback regardless of bind mode.
+  // bind=lan/tailnet controls which interface the *server* listens on; agents running
+  // on the same host must use 127.0.0.1 to satisfy the ws:// non-loopback security check.
+  // LAN/tailnet IPs are still available via lanIPv4/tailnetIPv4 for display purposes (QR, hints).
+  const localUrl = `${scheme}://127.0.0.1:${localPort}`;
   const urlOverride =
     typeof options.url === "string" && options.url.trim().length > 0
       ? options.url.trim()

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -93,23 +93,23 @@ describe("resolveGatewayConnection", () => {
     });
   });
 
-  it("uses tailnet host when local bind is tailnet", () => {
+  it("uses loopback when local bind is tailnet (self-connection)", () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "tailnet" } });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue("100.64.0.1");
 
     const result = resolveGatewayConnection({});
 
-    expect(result.url).toBe("ws://100.64.0.1:18800");
+    expect(result.url).toBe("ws://127.0.0.1:18800");
   });
 
-  it("uses lan host when local bind is lan", () => {
+  it("uses loopback when local bind is lan (self-connection)", () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryLanIPv4.mockReturnValue("192.168.1.42");
 
     const result = resolveGatewayConnection({});
 
-    expect(result.url).toBe("ws://192.168.1.42:18800");
+    expect(result.url).toBe("ws://127.0.0.1:18800");
   });
 });


### PR DESCRIPTION
## Problem

Closes #22047

`bind: "lan"` causes the browser tool (and any Gateway self-connection) to fail with a `SECURITY ERROR` after the plaintext ws:// block introduced in #20803.

Two commits are in conflict:
- **#11448** — `localUrl` now uses the LAN IP when `bind=lan`
- **#20803** — plaintext `ws://` to non-loopback addresses is rejected

Result: agents running on the **same host** as the Gateway hit `SECURITY ERROR: Gateway URL "ws://192.168.x.x" uses plaintext ws:// to a non-loopback address.`

## Fix

`localUrl` in `buildGatewayConnectionDetails()` always uses `ws(s)://127.0.0.1:<port>` regardless of bind mode.

`bind` controls which interface the **server** listens on — it should not affect the connection URL for agents on the same host. LAN/tailnet IPs are still available in `lanIPv4` / `tailnetIPv4` for display purposes (QR codes, `urlSource` labels, onboarding hints).

## Changes

- `src/gateway/call.ts`: `localUrl` simplified to `ws(s)://127.0.0.1:${localPort}`
- `src/gateway/call.test.ts`: updated test names and assertions to reflect new behavior

## Tests

```
✓ src/gateway/call.test.ts (29 tests) 167ms
```

All 29 tests passing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a regression where `bind: "lan"` caused browser tools and Gateway self-connections to fail with `SECURITY ERROR` due to a conflict between two previous commits. The fix ensures agents on the same host always connect via `127.0.0.1` regardless of bind mode, since `bind` controls which interface the server listens on, not the connection URL for local agents. LAN/tailnet IPs remain available for display purposes (QR codes, onboarding hints).

- Modified `buildGatewayConnectionDetails()` in `src/gateway/call.ts` to always use `ws(s)://127.0.0.1` for `localUrl`, removing the conditional logic that previously used LAN/tailnet IPs based on bind mode
- Updated all related tests in `src/gateway/call.test.ts` to reflect the new behavior, converting tests that expected `SECURITY ERROR` exceptions into tests that verify loopback connections succeed
- All 29 tests passing, confirming the fix resolves the security error while maintaining proper functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly resolves a clear regression caused by conflicting commits. The change is well-contained, maintains backward compatibility for all use cases, and actually improves security by ensuring local agents always use loopback addresses. All 29 tests pass, including updated tests that specifically verify the new behavior works correctly for all bind modes (loopback, lan, tailnet) with and without TLS. The implementation is simple, well-commented, and aligns with the security principle that ws:// to non-loopback addresses should be blocked.
- No files require special attention

<sub>Last reviewed commit: e97ebcf</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->