### PR TITLE
[Bug]: return 200 for hook invocations

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -369,7 +369,7 @@ export function createHooksRequestHandler(
         sessionKey: sessionKey.value,
         agentId: resolveHookTargetAgentId(hooksConfig, normalized.value.agentId),
       });
-      sendJson(res, 202, { ok: true, runId });
+      sendJson(res, 200, { ok: true, runId });
       return true;
     }
 
@@ -431,7 +431,7 @@ export function createHooksRequestHandler(
             timeoutSeconds: mapped.action.timeoutSeconds,
             allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
           });
-          sendJson(res, 202, { ok: true, runId });
+          sendJson(res, 200, { ok: true, runId });
           return true;
         }
       } catch (err) {

--- a/src/gateway/server.hooks.e2e.test.ts
+++ b/src/gateway/server.hooks.e2e.test.ts
@@ -53,7 +53,7 @@ describe("gateway server hooks", () => {
         },
         body: JSON.stringify({ message: "Do it", name: "Email" }),
       });
-      expect(resAgent.status).toBe(202);
+      expect(resAgent.status).toBe(200);
       const agentEvents = await waitForSystemEvent();
       expect(agentEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
       drainSystemEvents(resolveMainKey());
@@ -75,7 +75,7 @@ describe("gateway server hooks", () => {
           model: "openai/gpt-4.1-mini",
         }),
       });
-      expect(resAgentModel.status).toBe(202);
+      expect(resAgentModel.status).toBe(200);
       await waitForSystemEvent();
       const call = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { payload?: { model?: string } };
@@ -96,7 +96,7 @@ describe("gateway server hooks", () => {
         },
         body: JSON.stringify({ message: "Do it", name: "Email", agentId: "hooks" }),
       });
-      expect(resAgentWithId.status).toBe(202);
+      expect(resAgentWithId.status).toBe(200);
       await waitForSystemEvent();
       const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
@@ -117,7 +117,7 @@ describe("gateway server hooks", () => {
         },
         body: JSON.stringify({ message: "Do it", name: "Email", agentId: "missing-agent" }),
       });
-      expect(resAgentUnknown.status).toBe(202);
+      expect(resAgentUnknown.status).toBe(200);
       await waitForSystemEvent();
       const fallbackCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
@@ -248,7 +248,7 @@ describe("gateway server hooks", () => {
         },
         body: JSON.stringify({ message: "No key" }),
       });
-      expect(defaultRoute.status).toBe(202);
+      expect(defaultRoute.status).toBe(200);
       await waitForSystemEvent();
       const defaultCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string }
@@ -266,7 +266,7 @@ describe("gateway server hooks", () => {
         },
         body: JSON.stringify({ subject: "hello", id: "42" }),
       });
-      expect(mappedOk.status).toBe(202);
+      expect(mappedOk.status).toBe(200);
       await waitForSystemEvent();
       const mappedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string }
@@ -330,7 +330,7 @@ describe("gateway server hooks", () => {
         },
         body: JSON.stringify({ message: "No explicit agent" }),
       });
-      expect(resNoAgent.status).toBe(202);
+      expect(resNoAgent.status).toBe(200);
       await waitForSystemEvent();
       const noAgentCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
@@ -351,7 +351,7 @@ describe("gateway server hooks", () => {
         },
         body: JSON.stringify({ message: "Allowed", agentId: "hooks" }),
       });
-      expect(resAllowed.status).toBe(202);
+      expect(resAllowed.status).toBe(200);
       await waitForSystemEvent();
       const allowedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };


### PR DESCRIPTION
## Summary
Fixes #22036 by returning HTTP 200 for webhook invocations while keeping async job dispatch unchanged.

## Changes
- Updated `src/gateway/server-http.ts` hook handling to respond with status 200 for:
  - `/hooks/agent`
  - mapped hook action dispatches that call `dispatchAgentHook`
- Kept run payload behavior (`{ ok: true, runId }`) the same so existing consumers still receive run context.

## Validation
- `pnpm test:e2e src/gateway/server.hooks.e2e.test.ts`

## Confidence Score
- 10/10 confidence.
- Change is narrowly scoped to HTTP response codes and directly matches the issue report that integrations expect 200.
- Behavior remains async; only response status and semantics changed.
- Regression coverage updated in existing hook e2e suite to pin new expected status.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed webhook invocation responses from HTTP 202 (Accepted) to 200 (OK) to align with webhook consumer expectations. The async dispatch behavior remains unchanged - hooks still execute asynchronously and return a `runId` immediately. All test assertions updated to reflect the new status code.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is narrowly scoped to HTTP status codes only. The async behavior and response payload remain identical, so existing consumers are unaffected. Comprehensive test coverage validates the change across all webhook endpoints.
- No files require special attention

<sub>Last reviewed commit: 3429e81</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->