### PR TITLE
fix(cli): add actionable hints for gateway close errors

### DIFF
--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -20,7 +20,25 @@ export async function checkGatewayHealth(params: {
     healthOk = true;
   } catch (err) {
     const message = String(err);
-    if (message.includes("gateway closed")) {
+    if (message.includes("pairing required")) {
+      note(
+        "Gateway is running but this device is not paired.\nRun: openclaw devices approve --latest",
+        "Gateway pairing",
+      );
+      note(gatewayDetails.message, "Gateway connection");
+    } else if (message.includes("device token mismatch")) {
+      note(
+        "Gateway is running but the device token is out of sync.\nRun: openclaw doctor --repair",
+        "Gateway auth",
+      );
+      note(gatewayDetails.message, "Gateway connection");
+    } else if (message.includes("unauthorized")) {
+      note(
+        "Gateway is running but authentication failed.\nCheck gateway.auth.token in your config.",
+        "Gateway auth",
+      );
+      note(gatewayDetails.message, "Gateway connection");
+    } else if (message.includes("gateway closed")) {
       note("Gateway not running.", "Gateway");
       note(gatewayDetails.message, "Gateway connection");
     } else {

--- a/src/gateway/call.close-hints.test.ts
+++ b/src/gateway/call.close-hints.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveCloseReasonHint } from "./call.js";
+
+describe("resolveCloseReasonHint", () => {
+  it("returns pairing hint for 'pairing required'", () => {
+    const hint = resolveCloseReasonHint("pairing required");
+    expect(hint).toContain("openclaw devices approve");
+  });
+
+  it("returns doctor hint for 'device token mismatch'", () => {
+    const hint = resolveCloseReasonHint(
+      "unauthorized: device token mismatch (rotate/reissue device token)",
+    );
+    expect(hint).toContain("openclaw doctor");
+  });
+
+  it("returns scope hint for scope-upgrade reasons", () => {
+    const hint = resolveCloseReasonHint("scope-upgrade required");
+    expect(hint).toContain("openclaw devices approve");
+  });
+
+  it("returns auth hint for generic unauthorized", () => {
+    const hint = resolveCloseReasonHint("unauthorized");
+    expect(hint).toContain("gateway.auth.token");
+  });
+
+  it("returns undefined for unrecognized reasons", () => {
+    expect(resolveCloseReasonHint("something else")).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(resolveCloseReasonHint("")).toBeUndefined();
+  });
+});

--- a/src/gateway/call.close-hints.test.ts
+++ b/src/gateway/call.close-hints.test.ts
@@ -14,11 +14,6 @@ describe("resolveCloseReasonHint", () => {
     expect(hint).toContain("openclaw doctor");
   });
 
-  it("returns scope hint for scope-upgrade reasons", () => {
-    const hint = resolveCloseReasonHint("scope-upgrade required");
-    expect(hint).toContain("openclaw devices approve");
-  });
-
   it("returns auth hint for generic unauthorized", () => {
     const hint = resolveCloseReasonHint("unauthorized");
     expect(hint).toContain("gateway.auth.token");

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -309,9 +309,6 @@ export function resolveCloseReasonHint(reason: string): string | undefined {
   if (lower.includes("device token mismatch")) {
     return "Device token is out of sync. Run: openclaw doctor --repair";
   }
-  if (lower.includes("scope-upgrade") || lower.includes("scope")) {
-    return "Device needs updated permissions. Run: openclaw devices approve --latest";
-  }
   if (lower.includes("unauthorized")) {
     return "Authentication failed. Check gateway.auth.token in your config, or run: openclaw doctor";
   }

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -301,16 +301,38 @@ async function resolveGatewayTlsFingerprint(params: {
   );
 }
 
+export function resolveCloseReasonHint(reason: string): string | undefined {
+  const lower = reason.toLowerCase();
+  if (lower.includes("pairing required")) {
+    return "Device is not paired with the gateway. Run: openclaw devices approve --latest";
+  }
+  if (lower.includes("device token mismatch")) {
+    return "Device token is out of sync. Run: openclaw doctor --repair";
+  }
+  if (lower.includes("scope-upgrade") || lower.includes("scope")) {
+    return "Device needs updated permissions. Run: openclaw devices approve --latest";
+  }
+  if (lower.includes("unauthorized")) {
+    return "Authentication failed. Check gateway.auth.token in your config, or run: openclaw doctor";
+  }
+  return undefined;
+}
+
 function formatGatewayCloseError(
   code: number,
   reason: string,
   connectionDetails: GatewayConnectionDetails,
 ): string {
   const reasonText = reason?.trim() || "no close reason";
-  const hint =
+  const codeHint =
     code === 1006 ? "abnormal closure (no close frame)" : code === 1000 ? "normal closure" : "";
-  const suffix = hint ? ` ${hint}` : "";
-  return `gateway closed (${code}${suffix}): ${reasonText}\n${connectionDetails.message}`;
+  const suffix = codeHint ? ` ${codeHint}` : "";
+  const actionHint = reasonText ? resolveCloseReasonHint(reasonText) : undefined;
+  const parts = [`gateway closed (${code}${suffix}): ${reasonText}`, connectionDetails.message];
+  if (actionHint) {
+    parts.push(`Hint: ${actionHint}`);
+  }
+  return parts.join("\n");
 }
 
 function formatGatewayTimeoutError(


### PR DESCRIPTION
When users hit gateway connection errors like `pairing required`, `device token mismatch`, or `unauthorized`, the CLI currently shows a raw WebSocket close reason with no guidance on what to do next. This is the #1 source of confusion in issues (#21913, #16305, #21787, #21914).

**Changes:**

- `resolveCloseReasonHint()` in `call.ts` maps common close reasons to specific recovery commands
- `doctor-gateway-health.ts` now distinguishes pairing/token/auth failures instead of lumping them all as "Gateway not running"

**Before:**
```
gateway closed (1008): pairing required
Gateway target: ws://127.0.0.1:18789
Source: local loopback
```

**After:**
```
gateway closed (1008): pairing required
Gateway target: ws://127.0.0.1:18789
Source: local loopback
Hint: Device is not paired with the gateway. Run: openclaw devices approve --latest
```

Doctor also stops saying "Gateway not running" when the gateway IS running but pairing/auth failed.

Tested with `vitest` (6 new tests for hint resolution).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds actionable hints to gateway connection errors by mapping common close reasons (`pairing required`, `device token mismatch`, `unauthorized`) to specific recovery commands. The `doctor` command now distinguishes between different auth/pairing failures instead of generically reporting "Gateway not running".

**Key changes:**
- New `resolveCloseReasonHint()` function maps close reasons to CLI commands
- Enhanced error formatting in `formatGatewayCloseError()` to append hints
- Updated `doctor-gateway-health.ts` with specific pairing/auth failure messages
- Added 6 test cases for hint resolution

**Issue found:**
- The scope-upgrade hint logic on call.ts:312-314 is unreachable - the gateway always sends `"pairing required"` for scope upgrades, never `"scope-upgrade"`. The test on line 17-20 of call.close-hints.test.ts validates functionality that won't execute in practice.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical error in unreachable code
- The PR successfully implements helpful user-facing error hints and has good test coverage. However, there's a logical error where the scope-upgrade condition will never match actual gateway behavior (the gateway sends "pairing required" not "scope-upgrade" for scope upgrades). This doesn't break functionality since the fallback "pairing required" handler works correctly, but it means the scope-specific hint and its test are unreachable. The implementation is otherwise sound and well-tested.
- src/gateway/call.ts needs the scope-upgrade logic fixed (lines 312-314)

<sub>Last reviewed commit: 51e9d74</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->