### PR TITLE
Add tool:before/tool:after internal hook events

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -230,6 +230,11 @@ Each event includes:
     content?: string,
     channelId?: string,
     success?: boolean,         // message:sent
+    tool?: string,             // tool:before, tool:after
+    toolCallId?: string,       // tool:before, tool:after
+    arguments?: unknown,       // tool:before, tool:after
+    durationMs?: number,       // tool:after
+    error?: string,            // tool:after (failed runs)
   }
 }
 ```
@@ -317,6 +322,39 @@ const handler: HookHandler = async (event) => {
 };
 
 export default handler;
+```
+
+### Tool Events
+
+Triggered around tool execution in the agent loop:
+
+- **`tool`**: All tool events (general listener)
+- **`tool:before`**: Right before a tool executes
+- **`tool:after`**: After a tool succeeds or fails
+
+#### Tool Event Context
+
+```typescript
+// tool:before context
+{
+  tool: string,          // Tool name (e.g., "exec", "read")
+  toolCallId?: string,   // Tool call id from provider/model
+  arguments: unknown,    // Input arguments for the tool call
+  agentId?: string,      // Agent id when available
+  abort: () => void,     // Call to block execution
+}
+
+// tool:after context
+{
+  tool: string,          // Tool name
+  toolCallId?: string,   // Tool call id
+  arguments: unknown,    // Arguments that were executed
+  agentId?: string,      // Agent id when available
+  success: boolean,      // Whether execution succeeded
+  durationMs: number,    // End-to-end tool duration
+  result?: unknown,      // Tool result payload (on success)
+  error?: string,        // Error message (on failure)
+}
 ```
 
 ### Tool Result Hooks (Plugin API)


### PR DESCRIPTION
## Summary
- add new internal hook event type `tool` with typed contexts for `tool:before` and `tool:after`
- emit `tool:before` and `tool:after` from the central tool execution wrapper (`wrapToolWithBeforeToolCallHook`)
- support pre-execution abort via `event.context.abort()` in `tool:before`
- include success/failure metadata (`durationMs`, `result`, `error`) in `tool:after`
- add tests for new type guards and end-to-end tool hook emission/abort behavior
- document tool hook events in automation hooks docs

## Issue Intent Check (#7597)
- real-time interception before execution: ✅ (`tool:before`)
- real-time execution outcome hooks: ✅ (`tool:after`)
- guardrail blocking path: ✅ (`abort()` + hook message propagated as error)
- audit payload for monitoring/compliance: ✅ (tool, toolCallId, arguments, success, durationMs, result/error)

## Validation
- `corepack pnpm exec vitest run src/hooks/internal-hooks.test.ts`
- `corepack pnpm exec vitest run --config vitest.e2e.config.ts src/agents/pi-tools.before-tool-call.e2e.test.ts`
- `corepack pnpm lint`
- `corepack pnpm test:fast`

## Notes
- Per-tool aliases like `tool:exec:before` were not added. Existing hook filtering can key off `event.context.tool === "exec"`.

Closes #7597

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive `tool:before` and `tool:after` internal hook events to enable real-time tool execution monitoring and guardrails. The implementation correctly emits hooks from the central tool wrapper (`wrapToolWithBeforeToolCallHook`), supports pre-execution abort via the `abort()` callback, and includes success/failure metadata in the `tool:after` event. The changes are well-tested with both unit tests for type guards and e2e tests for the full hook emission flow.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with comprehensive test coverage (unit tests for type guards + e2e tests for hook emission and abort behavior). The changes follow existing patterns in the codebase, maintain backward compatibility, and include clear documentation. All hook events are properly typed with TypeScript type guards, and the abort mechanism correctly prevents execution while still emitting `tool:after` events for audit trails.
- No files require special attention

<sub>Last reviewed commit: 456e637</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->