### PR TITLE
fix(agents): add provider-specific hints for local model auth errors

### DIFF
--- a/src/agents/model-auth.local-hints.test.ts
+++ b/src/agents/model-auth.local-hints.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveApiKeyForProvider } from "./model-auth.js";
+
+describe("local provider auth hints", () => {
+  it("includes ollama-specific hint when ollama key is missing", async () => {
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "ollama",
+        cfg: {} as Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
+        agentDir: "/tmp/test-agent",
+      }),
+    ).rejects.toThrow("OLLAMA_API_KEY");
+  });
+
+  it("includes vllm-specific hint when vllm key is missing", async () => {
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "vllm",
+        cfg: {} as Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
+        agentDir: "/tmp/test-agent",
+      }),
+    ).rejects.toThrow("VLLM_API_KEY");
+  });
+
+  it("includes generic hint for non-local providers", async () => {
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "anthropic",
+        cfg: {} as Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
+        agentDir: "/tmp/test-agent",
+      }),
+    ).rejects.toThrow("Configure auth for this agent");
+  });
+});

--- a/src/agents/model-auth.local-hints.test.ts
+++ b/src/agents/model-auth.local-hints.test.ts
@@ -1,34 +1,54 @@
 import { describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
 import { resolveApiKeyForProvider } from "./model-auth.js";
 
 describe("local provider auth hints", () => {
   it("includes ollama-specific hint when ollama key is missing", async () => {
-    await expect(
-      resolveApiKeyForProvider({
-        provider: "ollama",
-        cfg: {} as Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
-        agentDir: "/tmp/test-agent",
-      }),
-    ).rejects.toThrow("OLLAMA_API_KEY");
+    const snapshot = captureEnv(["OLLAMA_API_KEY"]);
+    delete process.env.OLLAMA_API_KEY;
+    try {
+      await expect(
+        resolveApiKeyForProvider({
+          provider: "ollama",
+          cfg: {} as Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
+          agentDir: "/tmp/test-agent",
+        }),
+      ).rejects.toThrow("OLLAMA_API_KEY");
+    } finally {
+      snapshot.restore();
+    }
   });
 
   it("includes vllm-specific hint when vllm key is missing", async () => {
-    await expect(
-      resolveApiKeyForProvider({
-        provider: "vllm",
-        cfg: {} as Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
-        agentDir: "/tmp/test-agent",
-      }),
-    ).rejects.toThrow("VLLM_API_KEY");
+    const snapshot = captureEnv(["VLLM_API_KEY"]);
+    delete process.env.VLLM_API_KEY;
+    try {
+      await expect(
+        resolveApiKeyForProvider({
+          provider: "vllm",
+          cfg: {} as Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
+          agentDir: "/tmp/test-agent",
+        }),
+      ).rejects.toThrow("VLLM_API_KEY");
+    } finally {
+      snapshot.restore();
+    }
   });
 
   it("includes generic hint for non-local providers", async () => {
-    await expect(
-      resolveApiKeyForProvider({
-        provider: "anthropic",
-        cfg: {} as Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
-        agentDir: "/tmp/test-agent",
-      }),
-    ).rejects.toThrow("Configure auth for this agent");
+    const snapshot = captureEnv(["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"]);
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_OAUTH_TOKEN;
+    try {
+      await expect(
+        resolveApiKeyForProvider({
+          provider: "anthropic",
+          cfg: {} as Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
+          agentDir: "/tmp/test-agent",
+        }),
+      ).rejects.toThrow("Configure auth for this agent");
+    } finally {
+      snapshot.restore();
+    }
   });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -223,13 +223,26 @@ export async function resolveApiKeyForProvider(params: {
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
   const resolvedAgentDir = path.dirname(authStorePath);
-  throw new Error(
-    [
-      `No API key found for provider "${provider}".`,
+
+  const localProviderHints: Record<string, string> = {
+    ollama:
+      'Ollama needs any value as API key to register as a provider. Set OLLAMA_API_KEY="ollama-local" or run "openclaw configure". Docs: https://docs.openclaw.ai/providers/ollama',
+    vllm: 'vLLM needs any value as API key to register as a provider. Set VLLM_API_KEY="vllm-local" or run "openclaw configure". Docs: https://docs.openclaw.ai/providers/vllm',
+    lmstudio:
+      'LM Studio needs any value as API key to register as a provider. Set LMSTUDIO_API_KEY="lmstudio-local" or run "openclaw configure". Docs: https://docs.openclaw.ai/providers/lmstudio',
+  };
+  const localHint = localProviderHints[normalized];
+
+  const parts = [`No API key found for provider "${provider}".`];
+  if (localHint) {
+    parts.push(localHint);
+  } else {
+    parts.push(
       `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
       `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
-    ].join(" "),
-  );
+    );
+  }
+  throw new Error(parts.join(" "));
 }
 
 export type EnvApiKeyResult = { apiKey: string; source: string };

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -228,8 +228,6 @@ export async function resolveApiKeyForProvider(params: {
     ollama:
       'Ollama needs any value as API key to register as a provider. Set OLLAMA_API_KEY="ollama-local" or run "openclaw configure". Docs: https://docs.openclaw.ai/providers/ollama',
     vllm: 'vLLM needs any value as API key to register as a provider. Set VLLM_API_KEY="vllm-local" or run "openclaw configure". Docs: https://docs.openclaw.ai/providers/vllm',
-    lmstudio:
-      'LM Studio needs any value as API key to register as a provider. Set LMSTUDIO_API_KEY="lmstudio-local" or run "openclaw configure". Docs: https://docs.openclaw.ai/providers/lmstudio',
   };
   const localHint = localProviderHints[normalized];
 


### PR DESCRIPTION
When Ollama, vLLM, or LM Studio users configure a local model as their primary but forget to set an API key, they get a confusing error pointing to auth-store paths and `openclaw agents add` -- none of which applies to local providers.

These providers just need any dummy value as a key to register (e.g. `OLLAMA_API_KEY="ollama-local"`), but the current error doesn't mention that.

**Changes:**

- `model-auth.ts`: detect known local providers (`ollama`, `vllm`, `lmstudio`) in the `resolveApiKeyForProvider` error path and show provider-specific hints with the right env var name and docs link
- 3 new tests confirming ollama/vllm get specific hints while other providers still get the generic message

**Before:**
```
No API key found for provider "ollama". Auth store: /path/to/auth-profiles.json (agentDir: ...).
Configure auth for this agent (openclaw agents add <id>) or copy auth-profiles.json from the main agentDir.
```

**After:**
```
No API key found for provider "ollama". Ollama needs any value as API key to register as a provider.
Set OLLAMA_API_KEY="ollama-local" or run "openclaw configure". Docs: https://docs.openclaw.ai/providers/ollama
```

Addresses the confusion in #22055, #4544, #1695. Complementary to #20872 (auto-discovery without key).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves error messages for local model providers (Ollama, vLLM, LM Studio) by adding provider-specific hints that explain users need to set a dummy API key value. Replaces generic auth-store error with targeted guidance including env var names and docs links.

**Key changes:**
- Added `localProviderHints` map in `resolveApiKeyForProvider` error path with custom messages for ollama/vllm/lmstudio
- Created 3 new tests to verify specific hints appear for local providers vs generic message for cloud providers

**Issues found:**
- Test file lacks environment variable isolation - tests will fail if `OLLAMA_API_KEY`, `VLLM_API_KEY`, or `ANTHROPIC_API_KEY` happen to be set in the environment
- LM Studio hint references `LMSTUDIO_API_KEY` env var, but this variable is not registered in the `envMap` (unlike ollama/vllm), so the suggested fix won't actually work

<h3>Confidence Score: 2/5</h3>

- PR has critical issues: tests lack env isolation and will fail unpredictably, plus LM Studio hint suggests non-functional fix
- The core feature (provider-specific hints) is sound, but implementation has two logical errors: (1) tests don't isolate environment variables and will fail if certain env vars are set, following a pattern established elsewhere in the codebase that should have been followed; (2) the LM Studio hint tells users to set an env var that isn't actually supported in the code
- Both files need attention - test file needs env isolation pattern applied to all 3 tests, and model-auth.ts needs LM Studio env var either added to envMap or hint message corrected

<sub>Last reviewed commit: f43a7e0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->