### PR TITLE
fix(gateway): clear pairing state on device token mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Pairing: prevent device-token rotate scope escalation by enforcing an approved-scope baseline, preserving approved scopes across metadata updates, and rejecting rotate requests that exceed approved role scope implications. (#20703) thanks @coygeek.
 - Gateway/Security: require secure context and paired-device checks for Control UI auth even when `gateway.controlUi.allowInsecureAuth` is set, and align audit messaging with the hardened behavior. (#20684) thanks @coygeek.
 - macOS/Build: default release packaging to `BUNDLE_ID=ai.openclaw.mac` in `scripts/package-mac-dist.sh`, so Sparkle feed URL is retained and auto-update no longer fails with an empty appcast feed. (#19750) thanks @loganprit.
+- Gateway/Pairing: clear persisted paired-device state when the gateway client closes with `device token mismatch` (`1008`) so reconnect flows can cleanly re-enter pairing. (#22071) Thanks @mbelinky.
 
 - Signal/Outbound: preserve case for Base64 group IDs during outbound target normalization so cross-context routing and policy checks no longer break when group IDs include uppercase characters. (#5578) Thanks @heyhudson.
 - Providers/Copilot: add `claude-sonnet-4.6` and `claude-sonnet-4.5` to the default GitHub Copilot model catalog and add coverage for model-list/definition helpers. (#20270, fixes #20091) Thanks @Clawborn.

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -189,7 +189,7 @@ export class GatewayClient {
           void clearDevicePairing(deviceId).catch((err) => {
             logDebug(`failed clearing stale device pairing for device ${deviceId}: ${String(err)}`);
           });
-          logDebug(`cleared stale device-auth token and pairing for device ${deviceId}`);
+          logDebug(`cleared stale device-auth token for device ${deviceId}`);
         } catch (err) {
           logDebug(
             `failed clearing stale device-auth token for device ${deviceId}: ${String(err)}`,

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -11,6 +11,7 @@ import {
   publicKeyRawBase64UrlFromPem,
   signDevicePayload,
 } from "../infra/device-identity.js";
+import { clearDevicePairing } from "../infra/device-pairing.js";
 import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 import { rawDataToString } from "../infra/ws.js";
 import { logDebug, logError } from "../logger.js";
@@ -175,21 +176,23 @@ export class GatewayClient {
     this.ws.on("close", (code, reason) => {
       const reasonText = rawDataToString(reason);
       this.ws = null;
-      // If closed due to device token mismatch, clear the stored token so next attempt can get a fresh one
+      // If closed due to device token mismatch, clear the stored token and pairing so next attempt can get a fresh one
       if (
         code === 1008 &&
         reasonText.toLowerCase().includes("device token mismatch") &&
         this.opts.deviceIdentity
       ) {
+        const deviceId = this.opts.deviceIdentity.deviceId;
         const role = this.opts.role ?? "operator";
         try {
-          clearDeviceAuthToken({ deviceId: this.opts.deviceIdentity.deviceId, role });
-          logDebug(
-            `cleared stale device-auth token for device ${this.opts.deviceIdentity.deviceId}`,
-          );
+          clearDeviceAuthToken({ deviceId, role });
+          void clearDevicePairing(deviceId).catch((err) => {
+            logDebug(`failed clearing stale device pairing for device ${deviceId}: ${String(err)}`);
+          });
+          logDebug(`cleared stale device-auth token and pairing for device ${deviceId}`);
         } catch (err) {
           logDebug(
-            `failed clearing stale device-auth token for device ${this.opts.deviceIdentity.deviceId}: ${String(err)}`,
+            `failed clearing stale device-auth token for device ${deviceId}: ${String(err)}`,
           );
         }
       }

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 import {
   approveDevicePairing,
+  clearDevicePairing,
   getPairedDevice,
   removePairedDevice,
   requestDevicePairing,
@@ -220,5 +221,14 @@ describe("device pairing tokens", () => {
     await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
 
     await expect(removePairedDevice("device-1", baseDir)).resolves.toBeNull();
+  });
+
+  test("clears paired device state by device id", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    await setupPairedOperatorDevice(baseDir, ["operator.read"]);
+
+    await expect(clearDevicePairing("device-1", baseDir)).resolves.toBe(true);
+    await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
+    await expect(clearDevicePairing("device-1", baseDir)).resolves.toBe(false);
   });
 });

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -620,3 +620,16 @@ export async function revokeDeviceToken(params: {
     return entry;
   });
 }
+
+export async function clearDevicePairing(deviceId: string, baseDir?: string): Promise<boolean> {
+  return await withLock(async () => {
+    const state = await loadState(baseDir);
+    const normalizedId = normalizeDeviceId(deviceId);
+    if (!state.pairedByDeviceId[normalizedId]) {
+      return false;
+    }
+    delete state.pairedByDeviceId[normalizedId];
+    await persistState(state, baseDir);
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- clear paired-device state when gateway client receives close code `1008` with a `device token mismatch` reason
- keep token-clear behavior and add explicit async error handling for pairing-state clear
- add focused tests for close-handling and `clearDevicePairing` behavior

## Why
This is the minimal safe salvage of #19562. It keeps only the pairing-recovery behavior needed for re-pairing after token mismatch and drops unrelated changes.

## Changes
- `src/gateway/client.ts`
- `src/infra/device-pairing.ts`
- `src/gateway/client.test.ts`
- `src/infra/device-pairing.test.ts`

## Validation run locally
- `pnpm exec vitest run src/gateway/client.test.ts -t "GatewayClient close handling"`
- `pnpm exec vitest run src/infra/device-pairing.test.ts -t "clears paired device state by device id"`

Supersedes #19562 for this fix scope.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added device pairing state cleanup alongside token cleanup when gateway receives close code 1008 with device token mismatch. The new `clearDevicePairing` function removes paired device state by device ID.

- Added `clearDevicePairing` to remove paired device state by device ID
- Gateway client now calls `clearDevicePairing` (fire-and-forget) when clearing stale tokens
- Tests cover both successful pairing clear and error handling when pairing clear fails
- One issue found: log message prematurely claims pairing is cleared before the async operation completes

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor logging inaccuracy that doesn't affect functionality
- The implementation correctly adds pairing state cleanup when device token mismatch occurs, with proper error handling and comprehensive tests. The only issue is a premature log message that claims pairing is cleared before the async operation completes, but this is a logging cosmetic issue that doesn't affect the actual cleanup behavior.
- No files require special attention

<sub>Last reviewed commit: 4423f6e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->