### PR TITLE
Fix/windows fstat dev mismatch

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -21,7 +21,10 @@
   border-radius: 999px;
   pointer-events: none;
   opacity: 0;
-  transition: transform 260ms ease-in-out, width 260ms ease-in-out, opacity 160ms ease-in-out;
+  transition:
+    transform 260ms ease-in-out,
+    width 260ms ease-in-out,
+    opacity 160ms ease-in-out;
   will-change: transform, width;
 }
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -77,6 +77,7 @@ export type EmbeddedPiSubscribeState = {
   successfulCronAdds: number;
   pendingMessagingMediaUrls: Map<string, string[]>;
   lastAssistant?: AgentMessage;
+  agentStartedAt?: number;
 };
 
 export type EmbeddedPiSubscribeContext = {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -468,17 +468,20 @@ async function sendSubagentAnnounceDirectly(params: {
         completionDirectOrigin?.threadId != null && completionDirectOrigin.threadId !== ""
           ? String(completionDirectOrigin.threadId)
           : undefined;
+
       await callGateway({
-        method: "send",
+        method: "agent",
         params: {
-          channel: completionChannel,
-          to: completionTo,
-          accountId: completionDirectOrigin?.accountId,
-          threadId: completionThreadId,
           sessionKey: canonicalRequesterSessionKey,
           message: params.completionMessage,
+          channel: completionChannel,
+          accountId: completionDirectOrigin?.accountId,
+          to: completionTo,
+          threadId: completionThreadId,
+          deliver: true,
           idempotencyKey: params.directIdempotencyKey,
         },
+        expectFinal: true,
         timeoutMs: 15_000,
       });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Windows-specific filesystem verification bug and two agent lifecycle issues

This PR bundles four independent bug fixes:

**Changes:**
- `src/infra/fs-safe.ts:75,81` - Skipped `stat.dev` comparison on Windows where path-based stat returns `dev: 0` while handle-based fstat returns the volume serial number, causing false TOCTOU (time-of-check-time-of-use) path mismatch errors that broke local media reads
- `src/agents/pi-embedded-subscribe.handlers.lifecycle.ts:85-108` - Added `agent_end` hook firing in streaming mode (previously only fired in non-streaming path)
- `src/agents/pi-embedded-subscribe.handlers.types.ts:80` - Added `agentStartedAt` timestamp tracking for duration calculation in the `agent_end` hook
- `src/agents/subagent-announce.ts:472-486` - Changed from `send` to `agent` gateway method for subagent completion announcements to fix Telegram channel resolution failures during plugin initialization
- `docs/style.css:24-27` - Formatting-only change (multi-line CSS transition property)

**Potential Concerns:**
- The `extensions/bluebubbles/src/media-send.ts:153` file still uses the unconditional `stat.dev` comparison and may experience the same Windows issue, though it appears to gracefully continue to the next root on mismatch

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- Score reflects three well-isolated bug fixes with clear issue references and commit messages. The Windows filesystem fix addresses a real platform-specific behavior difference (path-based vs handle-based stat returning different dev values on NTFS). The agent lifecycle fixes restore missing hook calls and use the correct gateway method. All changes are defensive (adding platform checks or restoring dropped functionality). Minor concern: similar pattern in bluebubbles extension may need the same Windows fix
- Check `extensions/bluebubbles/src/media-send.ts` for the same Windows `stat.dev` comparison issue

<sub>Last reviewed commit: 5586e21</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->