### PR TITLE
mattermost: honor account requireMention override

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.require-mention-policy.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.require-mention-policy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveMattermostRequireMentionPolicy } from "./monitor.js";
+
+describe("resolveMattermostRequireMentionPolicy", () => {
+  it("always disables mention requirement for direct chats", () => {
+    const result = resolveMattermostRequireMentionPolicy({
+      kind: "direct",
+      accountRequireMention: true,
+      resolveGroupRequireMention: () => true,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("uses explicit account-level requireMention override for channels", () => {
+    const result = resolveMattermostRequireMentionPolicy({
+      kind: "channel",
+      accountRequireMention: false,
+      resolveGroupRequireMention: () => true,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("falls back to group resolver when account override is undefined", () => {
+    const result = resolveMattermostRequireMentionPolicy({
+      kind: "group",
+      resolveGroupRequireMention: () => true,
+    });
+    expect(result).toBe(true);
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -130,6 +130,20 @@ function channelChatType(kind: ChatType): "direct" | "group" | "channel" {
   return "channel";
 }
 
+export function resolveMattermostRequireMentionPolicy(params: {
+  kind: ChatType;
+  accountRequireMention?: boolean;
+  resolveGroupRequireMention: () => boolean;
+}): boolean {
+  if (params.kind === "direct") {
+    return false;
+  }
+  if (typeof params.accountRequireMention === "boolean") {
+    return params.accountRequireMention;
+  }
+  return params.resolveGroupRequireMention();
+}
+
 function normalizeAllowEntry(entry: string): string {
   const trimmed = entry.trim();
   if (!trimmed) {
@@ -573,14 +587,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       : { triggered: false, stripped: rawText };
     const oncharTriggered = oncharResult.triggered;
 
-    const shouldRequireMention =
-      kind !== "direct" &&
-      core.channel.groups.resolveRequireMention({
-        cfg,
-        channel: "mattermost",
-        accountId: account.accountId,
-        groupId: channelId,
-      });
+    const shouldRequireMention = resolveMattermostRequireMentionPolicy({
+      kind,
+      accountRequireMention: account.requireMention,
+      resolveGroupRequireMention: () =>
+        core.channel.groups.resolveRequireMention({
+          cfg,
+          channel: "mattermost",
+          accountId: account.accountId,
+          groupId: channelId,
+        }),
+    });
     const shouldBypassMention =
       isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;
     const effectiveWasMentioned = wasMentioned || shouldBypassMention || oncharTriggered;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added account-level `requireMention` override support to Mattermost channel handler. Previously, mention requirements were only resolved through the group-level resolver; now account configuration (`account.requireMention`) takes precedence when explicitly set.

- Extracted mention policy logic into new `resolveMattermostRequireMentionPolicy` helper
- Direct messages always disable mention requirement
- Account-level `requireMention` override is honored when set (derived from `chatmode` or explicit config)
- Falls back to group-level resolver when account override is undefined
- Added comprehensive test coverage for all three policy paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-contained, properly tested, follows existing patterns in the codebase (similar to how `resolveMattermostRequireMention` works in `accounts.ts`), and has clear logical precedence. The refactoring extracts logic into a testable helper without changing behavior for existing configurations.
- No files require special attention

<sub>Last reviewed commit: a0218cc</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->