### PR TITLE
[Bug]: Preserve chat draft when aborting

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleAbortChat, type ChatHost } from "./app-chat.ts";
+
+const requestMock = vi.fn().mockResolvedValue({});
+
+function createHost(overrides: Partial<ChatHost> = {}): ChatHost {
+  return {
+    connected: true,
+    client: { request: requestMock },
+    chatMessage: "",
+    chatAttachments: [],
+    chatQueue: [],
+    chatRunId: "run-1",
+    chatSending: false,
+    sessionKey: "main",
+    basePath: "/",
+    hello: null,
+    chatAvatarUrl: null,
+    refreshSessionsAfterChat: new Set(),
+    ...overrides,
+  };
+}
+
+describe("handleAbortChat", () => {
+  it("preserves chat draft text while aborting", async () => {
+    requestMock.mockClear();
+
+    const host = createHost({ chatMessage: "typed text" });
+    await handleAbortChat(host);
+
+    expect(requestMock).toHaveBeenCalledOnce();
+    expect(requestMock).toHaveBeenCalledWith("chat.abort", {
+      sessionKey: host.sessionKey,
+      runId: host.chatRunId,
+    });
+    expect(host.chatMessage).toBe("typed text");
+  });
+
+  it("does not abort when disconnected", async () => {
+    requestMock.mockClear();
+
+    const host = createHost({ connected: false });
+    await handleAbortChat(host);
+
+    expect(requestMock).not.toHaveBeenCalled();
+    expect(host.chatMessage).toBe("");
+  });
+});

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 import { handleAbortChat, type ChatHost } from "./app-chat.ts";
 
 const requestMock = vi.fn().mockResolvedValue({});
+type TestChatHost = ChatHost & {
+  client: {
+    request: typeof requestMock;
+  };
+};
 
-function createHost(overrides: Partial<ChatHost> = {}): ChatHost {
+function createHost(overrides: Partial<TestChatHost> = {}): TestChatHost {
   return {
     connected: true,
     client: { request: requestMock },

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -64,7 +64,6 @@ export async function handleAbortChat(host: ChatHost) {
   if (!host.connected) {
     return;
   }
-  host.chatMessage = "";
   await abortChatRun(host as unknown as OpenClawApp);
 }
 


### PR DESCRIPTION
## Summary
Fixes #22063

When aborting a running chat stream, the UI previously cleared `host.chatMessage` in `handleAbortChat()`, which made users lose draft text typed during generation.

## What changed
- Removed the unconditional draft reset from `ui/src/ui/app-chat.ts`:
  - Deleted `host.chatMessage = ""` from `handleAbortChat()`.
- Added regression coverage in `ui/src/ui/app-chat.test.ts`:
  - Verifies the typed draft is preserved when `handleAbortChat()` is invoked while connected.
  - Verifies no abort request is sent when the UI is disconnected.

## Why this is correct
- Aborting a chat run is server-side cancellation and does not require clearing user input.
- Chat draft input now mirrors expected behavior from mainstream chat UX patterns: stop/abort does not erase in-progress text.
- This is a tightly scoped behavior fix with no protocol/client payload changes and no API surface changes.

## Validation
- Ran targeted UI test:
  - `cd ui && pnpm test -- src/ui/app-chat.test.ts`
  - Result: pass (2/2)

## Risk Assessment
- Very low risk; only one assignment removal and direct behavioral guardrail.
- No branching behavior changes outside abort path.
- No security, persistence, or transport protocol changes.

## Confidence Score
- 10/10 confidence
- Patch is minimal and deterministic.
- Regression test covers the reported draft-loss path and a disconnected no-op path.
- No unrelated refactors or dependency changes.
- Expected merge impact is limited to UX behavior in `ui/src/ui/app-chat.ts`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed unconditional `chatMessage` reset from `handleAbortChat()` in `ui/src/ui/app-chat.ts:67`, preserving user's draft text when aborting a running chat stream. Added regression tests covering both the connected abort path (verifying draft preservation) and disconnected no-op path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line deletion with clear UX improvement, comprehensive test coverage for the regression, and no impact on other code paths or API contracts
- No files require special attention

<sub>Last reviewed commit: f11f34a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->