### PR TITLE
fix(gateway): require loopback proxy IP for trusted-proxy + bind=loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (follow-up to #20097)
 - Gateway/Auth: allow trusted-proxy mode with loopback bind for same-host reverse-proxy deployments, while still requiring configured `gateway.trustedProxies`. (#20097) thanks @xinhuagu.
 - Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.
 - Gateway/Hooks: include transform export name in hook-transform cache keys so distinct exports from the same module do not reuse the wrong cached transform function. (#13855) thanks @mcaxtr.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (follow-up to #20097)
+- Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.
 - Gateway/Auth: allow trusted-proxy mode with loopback bind for same-host reverse-proxy deployments, while still requiring configured `gateway.trustedProxies`. (#20097) thanks @xinhuagu.
 - Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.
 - Gateway/Hooks: include transform export name in hook-transform cache keys so distinct exports from the same module do not reuse the wrong cached transform function. (#13855) thanks @mcaxtr.

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -39,8 +39,8 @@ Use `trusted-proxy` auth mode when:
 ```json5
 {
   gateway: {
-    // Must bind to network interface (not loopback)
-    bind: "lan",
+    // Use loopback for same-host proxy setups; use lan/custom for remote proxy hosts
+    bind: "loopback",
 
     // CRITICAL: Only add your proxy's IP(s) here
     trustedProxies: ["10.0.0.1", "172.17.0.1"],
@@ -61,6 +61,9 @@ Use `trusted-proxy` auth mode when:
   },
 }
 ```
+
+If `gateway.bind` is `loopback`, include a loopback proxy address in
+`gateway.trustedProxies` (`127.0.0.1`, `::1`, or an equivalent loopback CIDR).
 
 ### Configuration Reference
 

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -11,7 +11,12 @@ import {
 } from "./auth.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import { resolveHooksConfig } from "./hooks.js";
-import { isLoopbackHost, isValidIPv4, resolveGatewayBindHost } from "./net.js";
+import {
+  isLoopbackHost,
+  isTrustedProxyAddress,
+  isValidIPv4,
+  resolveGatewayBindHost,
+} from "./net.js";
 import { mergeGatewayTailscaleConfig } from "./startup-auth.js";
 
 export type GatewayRuntimeConfig = {
@@ -121,6 +126,16 @@ export async function resolveGatewayRuntimeConfig(params: {
       throw new Error(
         "gateway auth mode=trusted-proxy requires gateway.trustedProxies to be configured with at least one proxy IP",
       );
+    }
+    if (isLoopbackHost(bindHost)) {
+      const hasLoopbackTrustedProxy =
+        isTrustedProxyAddress("127.0.0.1", trustedProxies) ||
+        isTrustedProxyAddress("::1", trustedProxies);
+      if (!hasLoopbackTrustedProxy) {
+        throw new Error(
+          "gateway auth mode=trusted-proxy with bind=loopback requires gateway.trustedProxies to include 127.0.0.1, ::1, or a loopback CIDR",
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

After #20097, `auth.mode=trusted-proxy` + `bind=loopback` is allowed (good), but misconfigured `gateway.trustedProxies` values (for example only `10.0.0.1`) can still make auth fail in confusing ways for same-host proxy setups.

## Fix

- In runtime config validation, when `auth.mode=trusted-proxy` and resolved bind is loopback, require `gateway.trustedProxies` to include a loopback proxy address (`127.0.0.1`, `::1`, or loopback CIDR).
- Add tests for:
  - loopback trusted-proxy with `::1` (allowed)
  - loopback trusted-proxy with non-loopback trusted proxy IP (rejected)
- Update Trusted Proxy docs to reflect loopback-first same-host proxy setup guidance.

## Verification

- `pnpm vitest run src/gateway/server-runtime-config.test.ts`

Follow-up hardening for #20097.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds runtime validation to prevent misconfigured `gateway.trustedProxies` from breaking auth in same-host proxy setups. When `bind=loopback` and `auth.mode=trusted-proxy`, the gateway now requires at least one loopback address (`127.0.0.1`, `::1`, or a loopback CIDR) in the trusted proxy list.

The implementation leverages existing `isTrustedProxyAddress` CIDR-matching logic and includes comprehensive test coverage for both IPv4 and IPv6 loopback addresses, as well as rejection cases. Documentation correctly reflects the new requirement with clear guidance for same-host proxy configurations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues
- The implementation is straightforward and defensive - it adds validation to catch a misconfiguration scenario early. The code correctly reuses existing CIDR-matching logic via `isTrustedProxyAddress`, includes comprehensive test coverage for both acceptance and rejection paths (covering `127.0.0.1`, `::1`, non-loopback addresses, and empty proxy lists), and follows the existing validation pattern. Documentation is properly updated to reflect the new requirement.
- No files require special attention

<sub>Last reviewed commit: 7cdbb65</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->