### PR TITLE
feat: persist default /usage mode via agents.defaults.usage

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -171,6 +171,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.envelopeTimestamp":
     'Include absolute timestamps in message envelopes ("on" or "off").',
   "agents.defaults.envelopeElapsed": 'Include elapsed time in message envelopes ("on" or "off").',
+  "agents.defaults.usage": 'Default /usage mode for usage footers ("off", "tokens", or "full").',
   "agents.defaults.models": "Configured model catalog (keys are full provider/model IDs).",
   "agents.defaults.memorySearch":
     "Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -134,6 +134,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.envelopeTimezone": "Envelope Timezone",
   "agents.defaults.envelopeTimestamp": "Envelope Timestamp",
   "agents.defaults.envelopeElapsed": "Envelope Elapsed",
+  "agents.defaults.usage": "Usage Footer",
   "agents.defaults.memorySearch": "Memory Search",
   "agents.defaults.memorySearch.enabled": "Enable Memory Search",
   "agents.defaults.memorySearch.sources": "Memory Search Sources",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -168,6 +168,8 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
+  /** Default /usage mode when no per-session override is present ("off", "tokens", "full"). */
+  usage?: "off" | "tokens" | "full";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -118,6 +118,7 @@ export const AgentDefaultsSchema = z
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    usage: z.union([z.literal("off"), z.literal("tokens"), z.literal("full")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),


### PR DESCRIPTION
## Summary
- Add `agents.defaults.usage` to agent defaults config schema and types.
- Wire session initialization so new sessions (including `/new` resets) use the configured usage default when no per-session `/usage` override exists.
- Preserve existing `/new` per-session `/usage` override behavior by carrying prior `responseUsage` when present.
- Add regression coverage in `initSessionState` for config-backed defaults and override precedence.

## Validation
- `pnpm test src/auto-reply/reply/session.test.ts`
- `pnpm test src/config/sessions.test.ts`
- `pnpm check` (format + tsgo + lint)

## Notes
This is intentionally scoped to one issue and keeps `/usage` slash-command behavior intact while making default usage mode persistent from `openclaw.json`.

Closes #22083.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds persistent `agents.defaults.usage` configuration to control the default `/usage` mode across sessions. The implementation correctly wires the config schema, types, and help text, and includes comprehensive test coverage for the happy paths.

**Critical issue found:**
- When `/new` is triggered on an existing session without a prior `/usage` override, the config default is ignored and `"off"` is used instead. This breaks the main feature of this PR - making the usage default persistent from config.

<h3>Confidence Score: 2/5</h3>

- This PR has a critical logical error that prevents the main feature from working correctly
- The implementation contains a bug in the reset logic that breaks the config default behavior - when users trigger `/new` on existing sessions without prior overrides, the config default is bypassed. The rest of the implementation (schema, types, tests for other scenarios) is solid, but this bug undermines the core functionality
- Pay close attention to `src/auto-reply/reply/session.ts:261` - the logic error will cause incorrect behavior for the main use case

<sub>Last reviewed commit: fdac13f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->