### PR TITLE
docs(readme): add Windows-native dev gateway command

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ pnpm openclaw onboard --install-daemon
 
 # Dev loop (auto-reload on TS changes)
 pnpm gateway:watch
+
+# Windows (native PowerShell/cmd, no WSL2)
+node scripts/watch-node.mjs gateway run --bind loopback --port 18789 --allow-unconfigured
 ```
 
 Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` produces `dist/` for running via Node / the packaged `openclaw` binary.

--- a/README.md
+++ b/README.md
@@ -188,21 +188,65 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 
 ## How it works (short)
 
-```
-WhatsApp / Telegram / Slack / Discord / Google Chat / Signal / iMessage / BlueBubbles / Microsoft Teams / Matrix / Zalo / Zalo Personal / WebChat
-               │
-               ▼
-┌───────────────────────────────┐
-│            Gateway            │
-│       (control plane)         │
-│     ws://127.0.0.1:18789      │
-└──────────────┬────────────────┘
-               │
-               ├─ Pi agent (RPC)
-               ├─ CLI (openclaw …)
-               ├─ WebChat UI
-               ├─ macOS app
-               └─ iOS / Android nodes
+```mermaid
+flowchart LR
+  subgraph Inbound["Inbound Surfaces"]
+    WA["WhatsApp"]
+    TG["Telegram"]
+    SL["Slack"]
+    DC["Discord"]
+    GC["Google Chat"]
+    SG["Signal"]
+    IM["iMessage / BlueBubbles"]
+    EX["Extension channels<br/>(Teams / Matrix / Zalo / etc)"]
+  end
+
+  subgraph Gateway["OpenClaw Gateway (Control Plane)"]
+    GW["WS + HTTP Server<br/>127.0.0.1:18789"]
+    AUTH["Auth + Pairing + Scopes"]
+    ROUTE["Routing + Session Keys + Bindings"]
+    CH["Channel Runtime Manager"]
+    AG["Agent Runtime (Pi RPC)"]
+    TOOLS["Tools (browser / canvas / cron / webhooks / skills)"]
+    PLUG["Plugin Registry + Extension Runtime"]
+  end
+
+  subgraph Clients["Operator Clients"]
+    CLI["CLI (openclaw ...)"]
+    WEB["Control UI / WebChat"]
+    MAC["macOS app"]
+  end
+
+  subgraph Nodes["Remote/Local Nodes"]
+    IOS["iOS node"]
+    AND["Android node"]
+    DESK["Desktop node"]
+  end
+
+  subgraph State["State + Persistence"]
+    CFG["Config + Profiles"]
+    SES["Sessions + Queue + Presence"]
+    CRED["Credentials + Pairing Store"]
+  end
+
+  Inbound --> GW
+  CLI <--> GW
+  WEB <--> GW
+  MAC <--> GW
+  IOS <--> GW
+  AND <--> GW
+  DESK <--> GW
+
+  GW --> AUTH
+  GW --> ROUTE
+  GW --> CH
+  GW --> AG
+  GW --> TOOLS
+  GW --> PLUG
+
+  GW --> CFG
+  GW --> SES
+  GW --> CRED
 ```
 
 ## Key subsystems

--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ pnpm openclaw onboard --install-daemon
 # Dev loop (auto-reload on TS changes)
 pnpm gateway:watch
 
-# Windows (native PowerShell/cmd, no WSL2)
-openclaw gateway stop
-node scripts/watch-node.mjs gateway run --bind loopback --port 18789 --allow-unconfigured
+# Windows (native PowerShell/cmd, no WSL2) uses a compatible fallback automatically.
 ```
 
 Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` produces `dist/` for running via Node / the packaged `openclaw` binary.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ pnpm openclaw onboard --install-daemon
 pnpm gateway:watch
 
 # Windows (native PowerShell/cmd, no WSL2)
+openclaw gateway stop
 node scripts/watch-node.mjs gateway run --bind loopback --port 18789 --allow-unconfigured
 ```
 

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -40,11 +40,14 @@ pnpm gateway:watch
 This maps to:
 
 ```bash
-node --watch-path src --watch-path tsconfig.json --watch-path package.json --watch-preserve-output scripts/run-node.mjs gateway --force
+node scripts/gateway-watch.mjs
 ```
 
 Add any gateway CLI flags after `gateway:watch` and they will be passed through
 on each restart.
+
+On native Windows, `gateway:watch` uses a compatible fallback (`gateway run ... --allow-unconfigured`)
+and runs `openclaw gateway stop` best-effort first to avoid port conflicts with an installed daemon.
 
 ## Dev profile + dev gateway (--dev)
 

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -97,6 +97,7 @@ pnpm gateway:watch
 ```
 
 `gateway:watch` runs the gateway in watch mode and reloads on TypeScript changes.
+On native Windows, it automatically switches to a compatible gateway start path.
 
 ### 2) Point the macOS app at your running Gateway
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "format:swift": "swiftformat --lint --config .swiftformat apps/macos/Sources apps/ios/Sources apps/shared/OpenClawKit/Sources",
     "gateway:dev": "OPENCLAW_SKIP_CHANNELS=1 CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway",
     "gateway:dev:reset": "OPENCLAW_SKIP_CHANNELS=1 CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --reset",
-    "gateway:watch": "node scripts/watch-node.mjs gateway --force",
+    "gateway:watch": "node scripts/gateway-watch.mjs",
     "gen:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --write",
     "ghsa:patch": "node scripts/ghsa-patch.mjs",
     "ios:build": "bash -lc './scripts/ios-configure-signing.sh && cd apps/ios && xcodegen generate && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination \"${IOS_DEST:-platform=iOS Simulator,name=iPhone 17}\" -configuration Debug build'",

--- a/scripts/gateway-watch.mjs
+++ b/scripts/gateway-watch.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const WATCH_SCRIPT = "scripts/watch-node.mjs";
+const RUN_SCRIPT = "scripts/run-node.mjs";
+const WINDOWS_WATCH_ARGS = [
+  "gateway",
+  "run",
+  "--bind",
+  "loopback",
+  "--port",
+  "18789",
+  "--allow-unconfigured",
+];
+const DEFAULT_WATCH_ARGS = ["gateway", "--force"];
+
+function runNode(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: "inherit",
+    });
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        resolve(1);
+        return;
+      }
+      resolve(code ?? 1);
+    });
+    child.once("error", () => {
+      resolve(1);
+    });
+  });
+}
+
+async function main() {
+  const passthroughArgs = process.argv.slice(2);
+  const isWindows = process.platform === "win32";
+
+  if (isWindows) {
+    // Windows developer flow commonly has a scheduled daemon running.
+    // Stop it best-effort to avoid port conflicts in watch mode.
+    await runNode([RUN_SCRIPT, "gateway", "stop"]);
+  }
+
+  const baseArgs = isWindows ? WINDOWS_WATCH_ARGS : DEFAULT_WATCH_ARGS;
+  const exitCode = await runNode([WATCH_SCRIPT, ...baseArgs, ...passthroughArgs]);
+  process.exit(exitCode);
+}
+
+void main();

--- a/src/gateway/server-methods-consistency.test.ts
+++ b/src/gateway/server-methods-consistency.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
+import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { CORE_GATEWAY_METHODS, listGatewayMethods } from "./server-methods-list.js";
+import { coreGatewayHandlers } from "./server-methods.js";
+import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
+
+const INTERNAL_ONLY_METHODS = new Set([
+  "connect",
+  "chat.inject",
+  "web.login.start",
+  "web.login.wait",
+  "sessions.resolve",
+  "push.test",
+  "poll",
+  "sessions.usage",
+  "sessions.usage.timeseries",
+  "sessions.usage.logs",
+]);
+
+describe("gateway method catalog consistency", () => {
+  let previousRegistry = getActivePluginRegistry();
+
+  beforeEach(() => {
+    previousRegistry = getActivePluginRegistry();
+  });
+
+  afterEach(() => {
+    if (previousRegistry) {
+      setActivePluginRegistry(previousRegistry);
+      return;
+    }
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("matches listed public methods to implemented handlers", () => {
+    const supplementalHandlers = createExecApprovalHandlers(new ExecApprovalManager());
+    const implementedHandlers = new Set([
+      ...Object.keys(coreGatewayHandlers),
+      ...Object.keys(supplementalHandlers),
+    ]);
+
+    const missingPublicMethods = CORE_GATEWAY_METHODS.filter(
+      (method) => !implementedHandlers.has(method),
+    );
+    expect(missingPublicMethods).toEqual([]);
+
+    const unexpectedPublicMethods = Array.from(implementedHandlers).filter(
+      (method) => !CORE_GATEWAY_METHODS.includes(method) && !INTERNAL_ONLY_METHODS.has(method),
+    );
+    expect(unexpectedPublicMethods).toEqual([]);
+  });
+
+  it("returns only core catalog methods when no channel plugins register extras", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    expect(listGatewayMethods()).toEqual(CORE_GATEWAY_METHODS);
+  });
+});

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -1,7 +1,7 @@
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 
-const BASE_METHODS = [
+export const CORE_GATEWAY_METHODS = [
   "health",
   "doctor.memory.status",
   "logs.tail",
@@ -99,7 +99,7 @@ const BASE_METHODS = [
 
 export function listGatewayMethods(): string[] {
   const channelMethods = listChannelPlugins().flatMap((plugin) => plugin.gatewayMethods ?? []);
-  return Array.from(new Set([...BASE_METHODS, ...channelMethods]));
+  return Array.from(new Set([...CORE_GATEWAY_METHODS, ...channelMethods]));
 }
 
 export const GATEWAY_EVENTS = [


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Windows-native support for `pnpm gateway:watch` and extracts gateway startup configuration into a separate module.

Changes include:
- Created `scripts/gateway-watch.mjs` to handle platform-specific watch behavior (stops daemon on Windows before starting watch mode to avoid port conflicts)
- Refactored startup config logic from `server.impl.ts` into new `startup-config.ts` module
- Added test for gateway method catalog consistency
- Updated README with mermaid architecture diagram and Windows-specific notes
- Renamed `BASE_METHODS` to `CORE_GATEWAY_METHODS` for clarity

The Windows watch flow differs from Unix: it runs `gateway run --bind loopback --port 18789 --allow-unconfigured` instead of `gateway --force`, providing more explicit configuration.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - clean refactoring with platform compatibility improvements
- Clean code extraction, no logic changes in refactoring, adds helpful test coverage, and improves Windows developer experience without affecting existing Unix/Linux/macOS behavior
- No files require special attention

<sub>Last reviewed commit: 6859bff</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->