### PR TITLE
Agents: support gemini-3.1-pro-preview normalization

### DIFF
--- a/src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts
+++ b/src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts
@@ -77,6 +77,16 @@ describe("models-config", () => {
                   contextWindow: 1048576,
                   maxTokens: 65536,
                 },
+                {
+                  id: "gemini-3.1-pro",
+                  name: "Gemini 3.1 Pro",
+                  api: "google-generative-ai",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1048576,
+                  maxTokens: 65536,
+                },
               ],
             },
           },
@@ -91,7 +101,11 @@ describe("models-config", () => {
         providers: Record<string, { models: Array<{ id: string }> }>;
       };
       const ids = parsed.providers.google?.models?.map((model) => model.id);
-      expect(ids).toEqual(["gemini-3-pro-preview", "gemini-3-flash-preview"]);
+      expect(ids).toEqual([
+        "gemini-3-pro-preview",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+      ]);
     });
   });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -195,6 +195,9 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3-flash") {
     return "gemini-3-flash-preview";
   }
+  if (id === "gemini-3.1-pro") {
+    return "gemini-3.1-pro-preview";
+  }
   return id;
 }
 


### PR DESCRIPTION
This adds support for the 'gemini-3.1-pro' model ID, normalizing it to 'gemini-3.1-pro-preview'. Verified with tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added support for normalizing the `gemini-3.1-pro` model ID to `gemini-3.1-pro-preview` in the Google provider configuration.

- Extends the existing `normalizeGoogleModelId` function to handle `gemini-3.1-pro` alongside the existing `gemini-3-pro` and `gemini-3-flash` normalizations
- Updated the test to verify all three model IDs are correctly normalized to their `-preview` variants
- Follows the established pattern for handling Google Gemini model ID normalization across the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple, focused change that follows the existing pattern for model ID normalization. The implementation is straightforward, adds one new conditional check to an existing function, and includes comprehensive test coverage that validates the expected behavior. No breaking changes, no security concerns, and consistent with the codebase style.
- No files require special attention

<sub>Last reviewed commit: 55fcf7f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->