### PR TITLE
fix(cron): drop session-inherited threadId from announce delivery

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -640,7 +640,9 @@ export async function runCronIsolatedAgentTurn(params: {
             channel: resolvedDelivery.channel,
             to: resolvedDelivery.to,
             accountId: resolvedDelivery.accountId,
-            threadId: resolvedDelivery.threadId,
+            // Cron delivery has no explicit threadId; drop session-inherited
+            // values so messages post at the channel top level.
+            threadId: undefined,
             payloads: payloadsForDelivery,
             agentId,
             identity,
@@ -673,7 +675,9 @@ export async function runCronIsolatedAgentTurn(params: {
           channel: resolvedDelivery.channel,
           to: resolvedDelivery.to,
           accountId: resolvedDelivery.accountId,
-          threadId: resolvedDelivery.threadId,
+          // Do not pass session-inherited threadId; cron announce should
+          // target the top-level channel, not a stale thread.
+          threadId: undefined,
         },
       });
       const taskLabel =
@@ -736,7 +740,11 @@ export async function runCronIsolatedAgentTurn(params: {
             channel: resolvedDelivery.channel,
             to: resolvedDelivery.to,
             accountId: resolvedDelivery.accountId,
-            threadId: resolvedDelivery.threadId,
+            // Cron delivery config has no threadId field, so any threadId here
+            // was inherited from the channel session's last conversation.
+            // Passing it through would cause announce messages to land in a
+            // stale thread instead of the channel's top level.
+            threadId: undefined,
           },
           requesterDisplayKey: announceSessionKey,
           task: taskLabel,


### PR DESCRIPTION
## Summary

Cron jobs with `delivery.mode: "announce"` post as thread replies to the most recent threaded conversation instead of as top-level channel messages.

## Root Cause

`resolveDeliveryTarget()` returns a `threadId` inherited from the channel session's `deliveryContext` (the last threaded conversation). Since cron delivery config has no `threadId` field, this is always a stale session-derived value. It gets passed through to:

1. `deliverOutboundPayloads()` — structured content delivery
2. `resolveCronAnnounceSessionKey()` — session key resolution (may resolve to thread session)
3. `runSubagentAnnounceFlow()` — announce flow `requesterOrigin`

All three paths inherit the stale threadId, causing messages to land in threads.

## Fix

Set `threadId: undefined` in all three delivery paths. Cron output always posts at the channel top level since there's no way to explicitly configure a threadId in cron delivery config.

## Testing

Existing cron delivery tests pass (13/13).

Fixes #22057

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed cron jobs with `delivery.mode: "announce"` incorrectly posting as thread replies instead of top-level channel messages by explicitly setting `threadId: undefined` in all delivery paths. Since cron delivery config has no `threadId` field, any threadId present was inherited from the channel session's `deliveryContext` (the last threaded conversation). The fix ensures cron output always posts at the channel top level by dropping the session-inherited threadId in three key locations: structured content delivery (`deliverOutboundPayloads`), session key resolution (`resolveCronAnnounceSessionKey`), and announce flow requester origin (`runSubagentAnnounceFlow`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a targeted, well-understood change that addresses a clear bug where stale threadId values were being inherited from session context. The solution correctly sets `threadId: undefined` in all three delivery code paths, ensuring cron messages post at the channel top level as intended. The PR description thoroughly explains the root cause, the fix is minimal and focused, existing tests pass (13/13), and the change aligns with the documented behavior that cron delivery config has no threadId field.
- No files require special attention

<sub>Last reviewed commit: d41324d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->