### PR TITLE
fix: isolate agent sessions by explicit --session-id

### DIFF
--- a/src/commands/agent/session.test.ts
+++ b/src/commands/agent/session.test.ts
@@ -119,7 +119,21 @@ describe("resolveSessionKeyForRequest", () => {
       cfg: baseCfg,
       sessionId: "nonexistent-id",
     });
-    expect(result.sessionKey).toBeUndefined();
+    expect(result.sessionKey).toBe("agent:main:session:nonexistent-id");
+  });
+
+  it("uses derived session key for --agent + unknown session-id", async () => {
+    mocks.listAgentIds.mockReturnValue(["main", "mybot"]);
+    mocks.resolveStorePath.mockReturnValue(MAIN_STORE_PATH);
+    mocks.loadSessionStore.mockReturnValue({});
+
+    const result = resolveSessionKeyForRequest({
+      cfg: baseCfg,
+      sessionId: "session-id-1234",
+      agentId: "testagent",
+    });
+    expect(result.sessionKey).toBe("agent:testagent:session:session-id-1234");
+    expect(result.storePath).toBe(MAIN_STORE_PATH);
   });
 
   it("does not search other stores when explicitSessionKey is set", async () => {


### PR DESCRIPTION
## Summary
- In `resolveSessionKeyForRequest`, when `--session-id` does not match an existing entry, we now create a dedicated session key instead of falling back to the default agent key.
- Existing behavior is preserved for explicit `--session-key` and reverse lookup cases (`--session-id` matches a saved session in any configured agent store).
- Added a deterministic dedicated key shape: `agent:<agent-id>:session:<normalized-session-id>`.
- Added unit coverage for fallback creation and `--agent`-scoped session-id isolation.

## Testing
- `pnpm vitest run src/commands/agent/session.test.ts`

Closes #22085

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes session isolation for explicit `--session-id` flags by synthesizing a deterministic session key (`agent:<agentId>:session:<sessionId>`) when a provided session ID doesn't match any existing entry across all agent stores. Previously, this scenario returned `undefined` for the session key, which could cause unintended session reuse or failures.

- Adds `normalizeSessionIdSessionSuffix` and `buildSessionIdSessionKey` helpers to sanitize and construct isolated session keys
- Splits the former `explicitSessionKey` variable into `explicitSessionKey` (user-provided `--session-key`) and `explicitAgentSessionKey` (resolved from agent config), enabling the new fallback to distinguish between the two
- New fallback block fires only after primary store lookup and cross-store search both fail to find the session ID
- Tests updated to reflect the new behavior and cover the `--agent` + unknown session ID case

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the new fallback is well-gated behind existing resolution paths and only fires as a last resort for unknown session IDs.
- The change is narrowly scoped to a single function with clear before/after behavior. The new session key namespace (`session:`) doesn't collide with existing patterns. Tests cover both the default agent and explicit agent scenarios. The only concern is a minor naming style issue.
- No files require special attention.

<sub>Last reviewed commit: 4d12ebd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->