### PR TITLE
fix(slack): dedupe mentions by ts fallback for app_mention

### DIFF
--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -1,7 +1,7 @@
 import type { App } from "@slack/bolt";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../../../config/config.js";
-import type { RuntimeEnv } from "../../../runtime.js";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import type { RuntimeEnv } from "../../../src/runtime.js";
 import type { SlackMessageEvent } from "../types.js";
 import { createSlackMonitorContext } from "./context.js";
 import { createSlackMessageHandler } from "./message-handler.js";
@@ -120,7 +120,7 @@ describe("slack createSlackMessageHandler", () => {
       type: "app_mention",
       ts: undefined,
       event_ts: sharedTs,
-    } as SlackMessageEvent;
+    } as unknown as SlackMessageEvent;
 
     await handler(slackMessage, { source: "message" });
     await handler(slackMention, { source: "app_mention", wasMentioned: true });

--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -1,0 +1,131 @@
+import type { App } from "@slack/bolt";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { RuntimeEnv } from "../../../runtime.js";
+import type { SlackMessageEvent } from "../types.js";
+import { createSlackMonitorContext } from "./context.js";
+import { createSlackMessageHandler } from "./message-handler.js";
+import { dispatchPreparedSlackMessage } from "./message-handler/dispatch.js";
+import { prepareSlackMessage } from "./message-handler/prepare.js";
+import type { PreparedSlackMessage } from "./message-handler/types.js";
+
+vi.mock("./message-handler/prepare.js", () => ({
+  prepareSlackMessage: vi.fn(),
+}));
+
+vi.mock("./message-handler/dispatch.js", () => ({
+  dispatchPreparedSlackMessage: vi.fn(),
+}));
+
+const prepareSlackMessageMock = vi.mocked(prepareSlackMessage);
+const dispatchPreparedSlackMessageMock = vi.mocked(dispatchPreparedSlackMessage);
+
+describe("slack createSlackMessageHandler", () => {
+  function createInboundSlackCtx(params: {
+    cfg: OpenClawConfig;
+    appClient?: App["client"];
+    defaultRequireMention?: boolean;
+  }) {
+    return createSlackMonitorContext({
+      cfg: params.cfg,
+      accountId: "default",
+      botToken: "token",
+      app: { client: params.appClient ?? ({} as App["client"]) } as App,
+      runtime: {} as RuntimeEnv,
+      botUserId: "B1",
+      teamId: "T1",
+      apiAppId: "A1",
+      historyLimit: 0,
+      sessionScope: "per-sender",
+      mainKey: "main",
+      dmEnabled: true,
+      dmPolicy: "open",
+      allowFrom: [],
+      groupDmEnabled: true,
+      groupDmChannels: [],
+      defaultRequireMention: params.defaultRequireMention ?? true,
+      channelsConfig: {},
+      groupPolicy: "open",
+      useAccessGroups: false,
+      reactionMode: "off",
+      reactionAllowlist: [],
+      replyToMode: "off",
+      threadHistoryScope: "thread",
+      threadInheritParent: false,
+      slashCommand: {
+        enabled: false,
+        name: "openclaw",
+        sessionPrefix: "slack:slash",
+        ephemeral: true,
+      },
+      textLimit: 4000,
+      ackReactionScope: "group-mentions",
+      mediaMaxBytes: 1024,
+      removeAckAfterReply: false,
+    });
+  }
+
+  const defaultAccount = {
+    accountId: "default",
+    enabled: true,
+    botTokenSource: "config",
+    appTokenSource: "config",
+    config: {},
+  } as const;
+
+  const basePreparedMessage = {
+    route: {
+      sessionKey: "session",
+      mainSessionKey: "main",
+      agentId: "main",
+      accountId: "default",
+    },
+    channelConfig: null,
+    isDirectMessage: false,
+    isRoomish: true,
+    historyKey: "main",
+    preview: "",
+    ackReactionValue: "ack",
+    ackReactionPromise: Promise.resolve(false),
+    replyTarget: "C123",
+    ctxPayload: {},
+  } as unknown as PreparedSlackMessage;
+
+  beforeEach(() => {
+    prepareSlackMessageMock.mockReset().mockResolvedValue(basePreparedMessage);
+    dispatchPreparedSlackMessageMock.mockReset();
+  });
+
+  it("deduplicates message + app_mention using event_ts when ts is missing", async () => {
+    const ctx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+    });
+    const handler = createSlackMessageHandler({ ctx, account: defaultAccount });
+    const sharedTs = "1700000000.000";
+    const baseMessage = {
+      channel: "C123",
+      channel_type: "channel",
+      user: "U123",
+      text: "<@B1> hello",
+      ts: sharedTs,
+      event_ts: sharedTs,
+      type: "message",
+    } as SlackMessageEvent;
+
+    const slackMessage = { ...baseMessage };
+    const slackMention = {
+      ...baseMessage,
+      type: "app_mention",
+      ts: undefined,
+      event_ts: sharedTs,
+    } as SlackMessageEvent;
+
+    await handler(slackMessage, { source: "message" });
+    await handler(slackMention, { source: "app_mention", wasMentioned: true });
+
+    expect(prepareSlackMessageMock).toHaveBeenCalledTimes(1);
+    expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/slack/monitor/thread-resolution.test.ts
+++ b/src/slack/monitor/thread-resolution.test.ts
@@ -1,0 +1,39 @@
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+import type { SlackMessageEvent } from "../types.js";
+import { createSlackThreadTsResolver } from "./thread-resolution.js";
+
+describe("slack createSlackThreadTsResolver", () => {
+  it("uses event_ts when ts is missing for cache key and history lookup", async () => {
+    const conversations = {
+      history: vi.fn().mockResolvedValue({
+        messages: [{ ts: "100.555", thread_ts: "100.500" }],
+      }),
+    };
+    const resolver = createSlackThreadTsResolver({
+      client: { conversations } as unknown as WebClient,
+    });
+
+    const message = {
+      channel: "C123",
+      channel_type: "channel",
+      user: "U1",
+      text: "hi",
+      event_ts: "100.555",
+      parent_user_id: "U2",
+      thread_ts: undefined,
+      type: "message",
+    } as SlackMessageEvent;
+
+    const resolved = await resolver.resolve({ message, source: "app_mention" });
+
+    expect(resolved.thread_ts).toBe("100.500");
+    expect(conversations.history).toHaveBeenCalledWith({
+      channel: "C123",
+      latest: "100.555",
+      oldest: "100.555",
+      inclusive: true,
+      limit: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes duplicated Slack channel replies when a channel message is delivered both via `message` and `app_mention` events.
- Normalize inbound Slack message keys to `ts || event_ts` before dedupe and thread-resolution, so Slack app mention payloads that omit `ts` still map to the same message identity.
- Preserve context IDs when possible by collecting message IDs from `ts || event_ts` for grouped dispatch payloads.
- Add regression tests for both handler dedupe behavior and thread-resolution lookup fallback.

## Root Cause
`createSlackMessageHandler` only passed `message.ts` into dedupe and thread-resolution logic. When `app_mention` events arrive without `ts` but with `event_ts`, the same inbound post can be treated as distinct after the `message` event path, creating two lane enqueues and two embedded-agent runs.

## Fix Details
- `src/slack/monitor/message-handler.ts`
  - Deduplicate with `const messageTs = message.ts ?? message.event_ts` before `markMessageSeen`.
  - Pass normalized `ts` through thread resolver so `thread_ts` lookup works consistently.
  - Track Message IDs from `ts || event_ts` when batching events.
- `src/slack/monitor/thread-resolution.ts`
  - Use `ts || event_ts` for thread resolution cache key and API lookup.
  - Keep verbose logs aligned to the normalized identifier.

## Testing
- `pnpm vitest run src/slack/monitor/message-handler.test.ts src/slack/monitor/thread-resolution.test.ts`
- `pnpm exec oxlint src/slack/monitor/message-handler.ts src/slack/monitor/thread-resolution.ts src/slack/monitor/message-handler.test.ts src/slack/monitor/thread-resolution.test.ts`
- `pnpm exec oxfmt --check src/slack/monitor/message-handler.ts src/slack/monitor/thread-resolution.ts src/slack/monitor/message-handler.test.ts src/slack/monitor/thread-resolution.test.ts`

## Confidence Score: 5/5
- This change is a narrowly scoped data-id normalization bugfix with deterministic behavior and zero user-facing semantic drift.
- It prevents dual processing by making both Slack event shapes map to the same dedupe identity and ensures thread lookup remains deterministic when `ts` is absent.
- The logic is covered by direct regression tests at both the inbound-message-handler and thread-resolution layers.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalizes Slack message identifiers to use `ts ?? event_ts` instead of just `ts`, preventing duplicate processing when `app_mention` events arrive without `ts` but with `event_ts`. The fix ensures both event types map to the same dedupe identity and thread resolution cache key.

- Applied normalization at dedupe check (message-handler.ts:115-120)
- Applied normalization in message ID collection for batched events (message-handler.ts:87-89)  
- Applied normalization in thread resolution cache key and API lookup (thread-resolution.ts:81-104)
- Added regression tests for both handler dedupe and thread-resolution fallback scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Narrowly scoped data normalization fix with deterministic behavior, covered by regression tests, and zero semantic drift in message processing logic
- No files require special attention

<sub>Last reviewed commit: 1bfd4fc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->