### PR TITLE
fix(cron): default isolated jobs to fresh sessions with sessionReuse opt-in

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2247,6 +2247,7 @@ public struct CronJob: Codable, Sendable {
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
+    public let sessionreuse: Bool?
     public let payload: AnyCodable
     public let delivery: AnyCodable?
     public let state: [String: AnyCodable]
@@ -2264,6 +2265,7 @@ public struct CronJob: Codable, Sendable {
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
+        sessionreuse: Bool?,
         payload: AnyCodable,
         delivery: AnyCodable?,
         state: [String: AnyCodable])
@@ -2280,6 +2282,7 @@ public struct CronJob: Codable, Sendable {
         self.schedule = schedule
         self.sessiontarget = sessiontarget
         self.wakemode = wakemode
+        self.sessionreuse = sessionreuse
         self.payload = payload
         self.delivery = delivery
         self.state = state
@@ -2298,6 +2301,7 @@ public struct CronJob: Codable, Sendable {
         case schedule
         case sessiontarget = "sessionTarget"
         case wakemode = "wakeMode"
+        case sessionreuse = "sessionReuse"
         case payload
         case delivery
         case state
@@ -2327,6 +2331,7 @@ public struct CronAddParams: Codable, Sendable {
     public let description: String?
     public let enabled: Bool?
     public let deleteafterrun: Bool?
+    public let sessionreuse: Bool?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
@@ -2340,6 +2345,7 @@ public struct CronAddParams: Codable, Sendable {
         description: String?,
         enabled: Bool?,
         deleteafterrun: Bool?,
+        sessionreuse: Bool?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
@@ -2352,6 +2358,7 @@ public struct CronAddParams: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.sessionreuse = sessionreuse
         self.schedule = schedule
         self.sessiontarget = sessiontarget
         self.wakemode = wakemode
@@ -2366,6 +2373,7 @@ public struct CronAddParams: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case sessionreuse = "sessionReuse"
         case schedule
         case sessiontarget = "sessionTarget"
         case wakemode = "wakeMode"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2247,6 +2247,7 @@ public struct CronJob: Codable, Sendable {
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
+    public let sessionreuse: Bool?
     public let payload: AnyCodable
     public let delivery: AnyCodable?
     public let state: [String: AnyCodable]
@@ -2264,6 +2265,7 @@ public struct CronJob: Codable, Sendable {
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
+        sessionreuse: Bool?,
         payload: AnyCodable,
         delivery: AnyCodable?,
         state: [String: AnyCodable])
@@ -2280,6 +2282,7 @@ public struct CronJob: Codable, Sendable {
         self.schedule = schedule
         self.sessiontarget = sessiontarget
         self.wakemode = wakemode
+        self.sessionreuse = sessionreuse
         self.payload = payload
         self.delivery = delivery
         self.state = state
@@ -2298,6 +2301,7 @@ public struct CronJob: Codable, Sendable {
         case schedule
         case sessiontarget = "sessionTarget"
         case wakemode = "wakeMode"
+        case sessionreuse = "sessionReuse"
         case payload
         case delivery
         case state
@@ -2327,6 +2331,7 @@ public struct CronAddParams: Codable, Sendable {
     public let description: String?
     public let enabled: Bool?
     public let deleteafterrun: Bool?
+    public let sessionreuse: Bool?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
@@ -2340,6 +2345,7 @@ public struct CronAddParams: Codable, Sendable {
         description: String?,
         enabled: Bool?,
         deleteafterrun: Bool?,
+        sessionreuse: Bool?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
@@ -2352,6 +2358,7 @@ public struct CronAddParams: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.sessionreuse = sessionreuse
         self.schedule = schedule
         self.sessiontarget = sessiontarget
         self.wakemode = wakemode
@@ -2366,6 +2373,7 @@ public struct CronAddParams: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case sessionreuse = "sessionReuse"
         case schedule
         case sessiontarget = "sessionTarget"
         case wakemode = "wakeMode"

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -151,7 +151,9 @@ Isolated jobs run a dedicated agent turn in session `cron:<jobId>`.
 Key behaviors:
 
 - Prompt is prefixed with `[cron:<jobId> <job name>]` for traceability.
-- Each run starts a **fresh session id** (no prior conversation carry-over).
+- By default, each run starts a **fresh session id** (no prior conversation carry-over).
+- Set `sessionReuse: true` to opt into reusing the same isolated cron session across runs.
+- In Control UI (`/cron`), this is exposed as a **Session reuse** toggle for isolated `agentTurn` jobs.
 - Default behavior: if `delivery` is omitted, isolated jobs announce a summary (`delivery.mode = "announce"`).
 - `delivery.mode` chooses what happens:
   - `announce`: deliver a summary to the target channel and post a brief summary to the main session.

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -72,6 +72,11 @@ export function registerCronAddCommand(cron: Command) {
       .option("--agent <id>", "Agent id for this job")
       .option("--session <target>", "Session target (main|isolated)")
       .option("--wake <mode>", "Wake mode (now|next-heartbeat)", "now")
+      .option(
+        "--session-reuse",
+        "Reuse the same isolated cron session across runs (default: fresh session per run)",
+        false,
+      )
       .option("--at <when>", "Run once at time (ISO) or +duration (e.g. 20m)")
       .option("--every <duration>", "Run every duration (e.g. 10m, 1h)")
       .option("--cron <expr>", "Cron expression (5-field or 6-field with seconds)")
@@ -202,6 +207,7 @@ export function registerCronAddCommand(cron: Command) {
           if (sessionTarget !== "main" && sessionTarget !== "isolated") {
             throw new Error("--session must be main or isolated");
           }
+          const sessionReuse = Boolean(opts.sessionReuse);
 
           if (opts.deleteAfterRun && opts.keepAfterRun) {
             throw new Error("Choose --delete-after-run or --keep-after-run, not both");
@@ -249,6 +255,7 @@ export function registerCronAddCommand(cron: Command) {
             schedule,
             sessionTarget,
             wakeMode,
+            sessionReuse: sessionReuse ? true : undefined,
             payload,
             delivery: deliveryMode
               ? {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -38,6 +38,8 @@ export function registerCronEditCommand(cron: Command) {
       .option("--agent <id>", "Set agent id")
       .option("--clear-agent", "Unset agent and use default", false)
       .option("--wake <mode>", "Wake mode (now|next-heartbeat)")
+      .option("--session-reuse", "Reuse the same isolated cron session across runs")
+      .option("--fresh-session", "Always start a fresh isolated cron session per run")
       .option("--at <when>", "Set one-shot time (ISO) or duration like 20m")
       .option("--every <duration>", "Set interval duration like 10m")
       .option("--cron <expr>", "Set cron expression")
@@ -123,6 +125,15 @@ export function registerCronEditCommand(cron: Command) {
           }
           if (typeof opts.wake === "string") {
             patch.wakeMode = opts.wake;
+          }
+          if (opts.sessionReuse && opts.freshSession) {
+            throw new Error("Choose --session-reuse or --fresh-session, not both");
+          }
+          if (opts.sessionReuse) {
+            patch.sessionReuse = true;
+          }
+          if (opts.freshSession) {
+            patch.sessionReuse = false;
           }
           if (opts.agent && opts.clearAgent) {
             throw new Error("Use --agent or --clear-agent, not both");

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -244,6 +244,40 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     process.env.OPENCLAW_TEST_FAST = previousFastTestEnv;
   });
 
+  it("forces fresh sessions for cron keys by default", async () => {
+    const result = await runCronIsolatedAgentTurn(makeParams({ sessionKey: "cron:test-job" }));
+
+    expect(result.status).toBe("ok");
+    expect(resolveCronSessionMock).toHaveBeenCalledOnce();
+    expect(resolveCronSessionMock.mock.calls[0][0]).toMatchObject({ forceNew: true });
+  });
+
+  it("allows cron session reuse when job.sessionReuse is true", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        sessionKey: "cron:test-job",
+        job: makeJob({ sessionReuse: true }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(resolveCronSessionMock).toHaveBeenCalledOnce();
+    expect(resolveCronSessionMock.mock.calls[0][0]).toMatchObject({ forceNew: false });
+  });
+
+  it("does not force new sessions for webhook-like keys", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        sessionKey: "hook:gmail:test-hook",
+        job: makeJob({ sessionReuse: false }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(resolveCronSessionMock).toHaveBeenCalledOnce();
+    expect(resolveCronSessionMock.mock.calls[0][0]).toMatchObject({ forceNew: false });
+  });
+
   it("passes agent-level skillFilter to buildWorkspaceSkillSnapshot", async () => {
     resolveAgentSkillsFilterMock.mockReturnValue(["meme-factory", "weather"]);
 

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -361,16 +361,6 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     ]);
   });
 
-  it("forces a fresh session for isolated cron runs", async () => {
-    const result = await runCronIsolatedAgentTurn(makeParams());
-
-    expect(result.status).toBe("ok");
-    expect(resolveCronSessionMock).toHaveBeenCalledOnce();
-    expect(resolveCronSessionMock.mock.calls[0]?.[0]).toMatchObject({
-      forceNew: true,
-    });
-  });
-
   it("reuses cached snapshot when version and normalized skillFilter are unchanged", async () => {
     resolveAgentSkillsFilterMock.mockReturnValue([" weather ", "meme-factory", "weather"]);
     resolveCronSessionMock.mockReturnValue({

--- a/src/cron/isolated-agent/session.force-new-cron.test.ts
+++ b/src/cron/isolated-agent/session.force-new-cron.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveCronSession } from "./session.js";
+
+describe("resolveCronSession forceNew for cron sessions", () => {
+  it("reuses when forceNew=false and rotates when forceNew=true", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cron-session-"));
+    const storePath = path.join(dir, "session-meta.json");
+    const nowMs = Date.now();
+    const sessionKey = "agent:default:main:cron:test-job";
+
+    const existingSessionId = "existing-session-id";
+    const store = {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: nowMs,
+        systemSent: true,
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store), "utf8");
+
+    const cfg = {
+      session: {
+        store: storePath,
+      },
+    } as never;
+
+    const reused = resolveCronSession({
+      cfg,
+      sessionKey,
+      nowMs: nowMs + 1_000,
+      agentId: "default",
+      forceNew: false,
+    });
+    expect(reused.sessionEntry.sessionId).toBe(existingSessionId);
+    expect(reused.isNewSession).toBe(false);
+
+    const fresh = resolveCronSession({
+      cfg,
+      sessionKey,
+      nowMs: nowMs + 2_000,
+      agentId: "default",
+      forceNew: true,
+    });
+    expect(fresh.sessionEntry.sessionId).not.toBe(existingSessionId);
+    expect(fresh.isNewSession).toBe(true);
+  });
+
+  it("keeps webhook-like sessions reusable when forceNew is false", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webhook-session-"));
+    const storePath = path.join(dir, "session-meta.json");
+    const nowMs = Date.now();
+    const sessionKey = "agent:default:main:webhook:test-hook";
+
+    const existingSessionId = "webhook-session-id";
+    const store = {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: nowMs,
+        systemSent: true,
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store), "utf8");
+
+    const cfg = {
+      session: {
+        store: storePath,
+      },
+    } as never;
+
+    const reused = resolveCronSession({
+      cfg,
+      sessionKey,
+      nowMs: nowMs + 1_000,
+      agentId: "default",
+      forceNew: false,
+    });
+
+    expect(reused.sessionEntry.sessionId).toBe(existingSessionId);
+    expect(reused.isNewSession).toBe(false);
+  });
+});

--- a/src/cron/normalize.session-reuse.test.ts
+++ b/src/cron/normalize.session-reuse.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCronJobCreate, normalizeCronJobPatch } from "./normalize.js";
+
+describe("normalizeCronJobCreate sessionReuse", () => {
+  it("coerces sessionReuse string true/false into boolean", () => {
+    const createTrue = normalizeCronJobCreate({
+      name: "cron true",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      sessionReuse: "true",
+      payload: { kind: "agentTurn", message: "hello" },
+    });
+    expect(createTrue?.sessionReuse).toBe(true);
+
+    const createFalse = normalizeCronJobCreate({
+      name: "cron false",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      sessionReuse: "false",
+      payload: { kind: "agentTurn", message: "hello" },
+    });
+    expect(createFalse?.sessionReuse).toBe(false);
+  });
+
+  it("drops invalid sessionReuse values", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "cron invalid",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      sessionReuse: "unexpected",
+      payload: { kind: "agentTurn", message: "hello" },
+    }) as { sessionReuse?: unknown } | null;
+
+    expect(normalized).not.toBeNull();
+    expect("sessionReuse" in (normalized ?? {})).toBe(false);
+  });
+});
+
+describe("normalizeCronJobPatch sessionReuse", () => {
+  it("accepts boolean and string forms", () => {
+    const patchTrue = normalizeCronJobPatch({ sessionReuse: true });
+    expect(patchTrue?.sessionReuse).toBe(true);
+
+    const patchFalse = normalizeCronJobPatch({ sessionReuse: "false" });
+    expect(patchFalse?.sessionReuse).toBe(false);
+  });
+});

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -338,6 +338,24 @@ export function normalizeCronJobInput(
     }
   }
 
+  if ("sessionReuse" in base) {
+    const sessionReuse = base.sessionReuse;
+    if (typeof sessionReuse === "boolean") {
+      next.sessionReuse = sessionReuse;
+    } else if (typeof sessionReuse === "string") {
+      const trimmed = sessionReuse.trim().toLowerCase();
+      if (trimmed === "true") {
+        next.sessionReuse = true;
+      } else if (trimmed === "false") {
+        next.sessionReuse = false;
+      } else {
+        delete next.sessionReuse;
+      }
+    } else {
+      delete next.sessionReuse;
+    }
+  }
+
   if ("sessionTarget" in base) {
     const normalized = normalizeSessionTarget(base.sessionTarget);
     if (normalized) {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -363,6 +363,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     schedule,
     sessionTarget: input.sessionTarget,
     wakeMode: input.wakeMode,
+    sessionReuse: typeof input.sessionReuse === "boolean" ? input.sessionReuse : undefined,
     payload: input.payload,
     delivery: input.delivery,
     state: {
@@ -411,6 +412,9 @@ export function applyJobPatch(job: CronJob, patch: CronJobPatch) {
   }
   if (patch.wakeMode) {
     job.wakeMode = patch.wakeMode;
+  }
+  if (typeof patch.sessionReuse === "boolean") {
+    job.sessionReuse = patch.sessionReuse;
   }
   if (patch.payload) {
     job.payload = mergeCronPayload(job.payload, patch.payload);

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -279,6 +279,27 @@ export async function ensureLoaded(
       mutated = true;
     }
 
+    if ("sessionReuse" in raw) {
+      if (typeof raw.sessionReuse === "boolean") {
+        // keep as-is
+      } else if (typeof raw.sessionReuse === "string") {
+        const lowered = raw.sessionReuse.trim().toLowerCase();
+        if (lowered === "true") {
+          raw.sessionReuse = true;
+          mutated = true;
+        } else if (lowered === "false") {
+          raw.sessionReuse = false;
+          mutated = true;
+        } else {
+          delete raw.sessionReuse;
+          mutated = true;
+        }
+      } else {
+        delete raw.sessionReuse;
+        mutated = true;
+      }
+    }
+
     const payload = raw.payload;
     if (
       (!payload || typeof payload !== "object" || Array.isArray(payload)) &&

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -121,6 +121,8 @@ export type CronJob = {
   schedule: CronSchedule;
   sessionTarget: CronSessionTarget;
   wakeMode: CronWakeMode;
+  /** Reuse isolated session across runs when true (cron-only). */
+  sessionReuse?: boolean;
   payload: CronPayload;
   delivery?: CronDelivery;
   state: CronJobState;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -60,6 +60,7 @@ const CronCommonOptionalFields = {
   description: Type.Optional(Type.String()),
   enabled: Type.Optional(Type.Boolean()),
   deleteAfterRun: Type.Optional(Type.Boolean()),
+  sessionReuse: Type.Optional(Type.Boolean()),
 };
 
 function cronIdOrJobIdParams(extraFields: Record<string, TSchema>) {
@@ -216,6 +217,7 @@ export const CronJobSchema = Type.Object(
     schedule: CronScheduleSchema,
     sessionTarget: CronSessionTargetSchema,
     wakeMode: CronWakeModeSchema,
+    sessionReuse: Type.Optional(Type.Boolean()),
     payload: CronPayloadSchema,
     delivery: Type.Optional(CronDeliverySchema),
     state: CronJobStateSchema,

--- a/ui/src/ui/app-defaults.ts
+++ b/ui/src/ui/app-defaults.ts
@@ -28,6 +28,7 @@ export const DEFAULT_CRON_FORM: CronFormState = {
   staggerUnit: "seconds",
   sessionTarget: "isolated",
   wakeMode: "now",
+  sessionReuse: false,
   payloadKind: "agentTurn",
   payloadText: "",
   payloadModel: "",

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -74,6 +74,17 @@ describe("cron controller", () => {
     expect(normalized.deliveryMode).toBe("announce");
   });
 
+  it("clears stale sessionReuse when session/payload no longer support isolated reuse", () => {
+    const normalized = normalizeCronFormState({
+      ...DEFAULT_CRON_FORM,
+      sessionTarget: "main",
+      payloadKind: "systemEvent",
+      sessionReuse: true,
+    });
+
+    expect(normalized.sessionReuse).toBe(false);
+  });
+
   it("forwards webhook delivery in cron.add payload", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.add") {
@@ -159,6 +170,88 @@ describe("cron controller", () => {
     });
     expect((addCall?.[1] as { delivery?: unknown } | undefined)?.delivery).toBeUndefined();
     expect(state.cronForm.deliveryMode).toBe("none");
+  });
+
+  it("forwards sessionReuse=true in cron.add payload when opted in", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.add") {
+        return { id: "job-3" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 0, nextWakeAtMs: null };
+      }
+      return {};
+    });
+
+    const state = createState({
+      client: {
+        request,
+      } as unknown as CronState["client"],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "reuse job",
+        scheduleKind: "every",
+        everyAmount: "1",
+        everyUnit: "minutes",
+        sessionTarget: "isolated",
+        payloadKind: "agentTurn",
+        payloadText: "run this",
+        sessionReuse: true,
+      },
+    });
+
+    await addCronJob(state);
+
+    const addCall = request.mock.calls.find(([method]) => method === "cron.add");
+    expect(addCall).toBeDefined();
+    expect(addCall?.[1]).toMatchObject({
+      name: "reuse job",
+      sessionReuse: true,
+    });
+  });
+
+  it("omits sessionReuse in cron.add payload when false (default fresh)", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.add") {
+        return { id: "job-4" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 0, nextWakeAtMs: null };
+      }
+      return {};
+    });
+
+    const state = createState({
+      client: {
+        request,
+      } as unknown as CronState["client"],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "fresh job",
+        scheduleKind: "every",
+        everyAmount: "1",
+        everyUnit: "minutes",
+        sessionTarget: "isolated",
+        payloadKind: "agentTurn",
+        payloadText: "run this",
+        sessionReuse: false,
+      },
+    });
+
+    await addCronJob(state);
+
+    const addCall = request.mock.calls.find(([method]) => method === "cron.add");
+    expect(addCall).toBeDefined();
+    expect(addCall?.[1]).toMatchObject({
+      name: "fresh job",
+    });
+    expect(addCall?.[1]).not.toHaveProperty("sessionReuse");
   });
 
   it("submits cron.update when editing an existing job", async () => {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -80,16 +80,21 @@ export function supportsAnnounceDelivery(
 }
 
 export function normalizeCronFormState(form: CronFormState): CronFormState {
-  if (form.deliveryMode !== "announce") {
-    return form;
+  const supportsAnnounce = supportsAnnounceDelivery(form);
+  let changed = false;
+  const next: CronFormState = { ...form };
+
+  if (form.deliveryMode === "announce" && !supportsAnnounce) {
+    next.deliveryMode = "none";
+    changed = true;
   }
-  if (supportsAnnounceDelivery(form)) {
-    return form;
+
+  if (!supportsAnnounce && form.sessionReuse) {
+    next.sessionReuse = false;
+    changed = true;
   }
-  return {
-    ...form,
-    deliveryMode: "none",
-  };
+
+  return changed ? next : form;
 }
 
 export function validateCronForm(form: CronFormState): CronFieldErrors {
@@ -514,6 +519,7 @@ export async function addCronJob(state: CronState) {
     const schedule = buildCronSchedule(form);
     const payload = buildCronPayload(form);
     const selectedDeliveryMode = form.deliveryMode;
+    const sessionReuse = supportsAnnounceDelivery(form) && form.sessionReuse ? true : undefined;
     const delivery =
       selectedDeliveryMode && selectedDeliveryMode !== "none"
         ? {
@@ -536,6 +542,7 @@ export async function addCronJob(state: CronState) {
       schedule,
       sessionTarget: form.sessionTarget,
       wakeMode: form.wakeMode,
+      ...(sessionReuse === true ? { sessionReuse: true } : {}),
       payload,
       delivery,
     };

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -483,6 +483,7 @@ export type CronJob = {
   schedule: CronSchedule;
   sessionTarget: CronSessionTarget;
   wakeMode: CronWakeMode;
+  sessionReuse?: boolean;
   payload: CronPayload;
   delivery?: CronDelivery;
   state?: CronJobState;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -32,6 +32,7 @@ export type CronFormState = {
   staggerUnit: "seconds" | "minutes";
   sessionTarget: "main" | "isolated";
   wakeMode: "next-heartbeat" | "now";
+  sessionReuse: boolean;
   payloadKind: "systemEvent" | "agentTurn";
   payloadText: string;
   payloadModel: string;

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -286,6 +286,28 @@ describe("cron view", () => {
     expect(options).toContain("Webhook POST");
     expect(options).toContain("None (internal)");
     expect(container.querySelector('input[placeholder="https://example.com/cron"]')).toBeNull();
+    expect(container.textContent).not.toContain("Session reuse");
+  });
+
+  it("shows session reuse toggle for isolated agentTurn jobs", () => {
+    const container = document.createElement("div");
+    render(
+      renderCron(
+        createProps({
+          form: {
+            ...DEFAULT_CRON_FORM,
+            sessionTarget: "isolated",
+            payloadKind: "agentTurn",
+          },
+        }),
+      ),
+      container,
+    );
+
+    const checkbox = container.querySelector("#cron-session-reuse");
+    expect(checkbox).toBeInstanceOf(HTMLInputElement);
+    expect((checkbox as HTMLInputElement).checked).toBe(false);
+    expect(container.textContent).toContain("Session reuse");
   });
 
   it("shows webhook delivery details for jobs", () => {
@@ -308,6 +330,52 @@ describe("cron view", () => {
     expect(container.textContent).toContain("Delivery");
     expect(container.textContent).toContain("webhook");
     expect(container.textContent).toContain("https://example.invalid/cron");
+  });
+
+  it("shows session reuse chip for isolated jobs opting in", () => {
+    const container = document.createElement("div");
+    const job = {
+      ...createJob("job-reuse"),
+      sessionTarget: "isolated" as const,
+      payload: { kind: "agentTurn" as const, message: "do it" },
+      sessionReuse: true,
+    };
+    render(
+      renderCron(
+        createProps({
+          jobs: [job],
+        }),
+      ),
+      container,
+    );
+
+    const chips = Array.from(container.querySelectorAll(".cron-job-chips .chip")).map((chip) =>
+      (chip.textContent ?? "").trim(),
+    );
+    expect(chips).toContain("reuse");
+  });
+
+  it("shows fresh chip for isolated jobs without reuse", () => {
+    const container = document.createElement("div");
+    const job = {
+      ...createJob("job-fresh"),
+      sessionTarget: "isolated" as const,
+      payload: { kind: "agentTurn" as const, message: "do it" },
+      sessionReuse: false,
+    };
+    render(
+      renderCron(
+        createProps({
+          jobs: [job],
+        }),
+      ),
+      container,
+    );
+
+    const chips = Array.from(container.querySelectorAll(".cron-job-chips .chip")).map((chip) =>
+      (chip.textContent ?? "").trim(),
+    );
+    expect(chips).toContain("fresh");
   });
 
   it("wires the Edit action and shows save/cancel controls when editing", () => {

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -721,6 +721,25 @@ export function renderCron(props: CronProps) {
                 </select>
                 <div class="cron-help">Now triggers immediately. Next heartbeat waits for the next cycle.</div>
               </label>
+              ${
+                supportsAnnounce
+                  ? html`
+                      <label class="field checkbox cron-checkbox">
+                        <input
+                          id="cron-session-reuse"
+                          type="checkbox"
+                          .checked=${props.form.sessionReuse}
+                          @change=${(e: Event) =>
+                            props.onFormChange({
+                              sessionReuse: (e.target as HTMLInputElement).checked,
+                            })}
+                        />
+                        <span class="field-checkbox__label">Session reuse</span>
+                        <div class="cron-help">Reuse the same isolated session across runs.</div>
+                      </label>
+                    `
+                  : nothing
+              }
               <label class="field ${isAgentTurn ? "" : "cron-span-2"}">
                 ${renderFieldLabel("What should run?")}
                 <select
@@ -1238,6 +1257,11 @@ function renderJob(job: CronJob, props: CronProps) {
           </span>
           <span class="chip">${job.sessionTarget}</span>
           <span class="chip">${job.wakeMode}</span>
+          ${
+            job.sessionTarget === "isolated"
+              ? html`<span class="chip">${job.sessionReuse === true ? "reuse" : "fresh"}</span>`
+              : nothing
+          }
         </div>
         <div class="row cron-job-actions">
           <button


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Since `v2026.2.17` / PR `#18031`, isolated cron jobs could reuse a stable session and accumulate prior context across runs.
- Why it matters: Stateless periodic jobs became more expensive (token growth) and could drift behavior due to unrelated past context.
- What changed:
  - Added `sessionReuse?: boolean` to cron job model and protocol schema.
  - Regenerated protocol Swift models for `sessionReuse` so `protocol:check` stays in sync.
  - Defaulted isolated `cron:` runs to fresh sessions unless `sessionReuse === true`.
  - Added CLI controls: `cron add --session-reuse`, `cron edit --session-reuse|--fresh-session`.
  - Added `/cron` New Job UI control for `sessionReuse` (isolated + agentTurn only).
  - Added isolated job chips in `/cron` list to show `fresh` / `reuse` mode.
  - Added normalization/store-migration handling for `sessionReuse` (including string coercion and invalid-value cleanup).
  - Added focused tests for `sessionReuse` normalization, `forceNew` session behavior, and UI payload/render behavior.
  - Added regression tests for webhook-like session-key reuse and explicit `forceNew` routing decisions.
  - Updated cron docs to clarify default-fresh isolated behavior and `sessionReuse` opt-in semantics.
  - Applied `docs/style.css` formatting required by repo `pnpm check` (no behavior change).
- What did NOT change (scope boundary):
  - Webhook/custom session-key reuse behavior from `#18031` remains intact.
  - Main-session cron behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Style
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #20092
- Related #18031

## User-visible / Behavior Changes

- Isolated cron jobs with default `cron:<jobId>` session key now run with a fresh session by default.
- Users who want cross-run continuity can explicitly opt in with `sessionReuse: true`.
- New CLI options are available for this toggle in `cron add` and `cron edit`.
- `/cron` New Job screen now includes a `Session reuse` toggle (shown only for isolated agentTurn jobs).
- `/cron` job cards now show `fresh`/`reuse` chip for isolated jobs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: Node + pnpm local workspace
- Model/provider: N/A
- Integration/channel (if any): Cron isolated `agentTurn`
- Relevant config (redacted): default session store behavior

### Steps

1. Create an isolated cron job with `payload.kind="agentTurn"` and default session key behavior.
2. Run the job multiple times without setting `sessionReuse`.
3. Verify each run is treated as fresh (no unintended transcript carry-over).
4. Set `sessionReuse: true` and verify continuity can still be opted in.

### Expected

- Default isolated cron runs are fresh per run.
- Explicit `sessionReuse: true` enables reuse.
- Webhook/custom session-key reuse path remains unchanged.

### Actual

- Matches expected behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation snippets:

```bash
pnpm build && pnpm check && pnpm test
# => FINAL_STATUS=0
#    check: format/tsgo/lint passed
#    test: 121 files passed, 1153 passed | 1 skipped
#    note: log includes intermittent worker OOM stack traces, but command exits 0

pnpm exec vitest run --config vitest.unit.config.ts \
  src/cron/normalize.test.ts \
  src/cron/normalize.session-reuse.test.ts \
  src/cron/service.jobs.test.ts \
  src/cron/service.store-migration.test.ts \
  src/cron/isolated-agent/run.skill-filter.test.ts \
  src/cron/isolated-agent/session.force-new-cron.test.ts \
  src/cli/cron-cli.test.ts
# => 75 passed

pnpm exec vitest run --config vitest.gateway.config.ts \
  src/gateway/protocol/cron-validators.test.ts
# => 6 passed

pnpm --dir ui exec vitest run --config vitest.config.ts \
  src/ui/controllers/cron.test.ts \
  src/ui/views/cron.test.ts
# => 18 passed

pnpm --dir ui build
# => build succeeded

# Local OpenClaw instance smoke (isolated OPENCLAW_HOME + local gateway)
OPENCLAW_HOME=/tmp/openclaw-pr20092-home node dist/entry.js gateway run \
  --bind loopback --port 18790 --force --allow-unconfigured --auth token --token pr20092-token
OPENCLAW_HOME=/tmp/openclaw-pr20092-home node dist/entry.js cron add --url ws://127.0.0.1:18790 --token pr20092-token --session isolated --message "smoke job" --every 10m --json
OPENCLAW_HOME=/tmp/openclaw-pr20092-home node dist/entry.js cron edit <jobId> --url ws://127.0.0.1:18790 --token pr20092-token --session-reuse
OPENCLAW_HOME=/tmp/openclaw-pr20092-home node dist/entry.js cron edit <jobId> --url ws://127.0.0.1:18790 --token pr20092-token --fresh-session
OPENCLAW_HOME=/tmp/openclaw-pr20092-home node dist/entry.js cron list --url ws://127.0.0.1:18790 --token pr20092-token --json
# => sessionReuse transitions: unset/null -> true -> false
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - local OpenClaw instance smoke: isolated cron `add/edit/list/rm` with `sessionReuse` transition checks (`null -> true -> false`)
  - `sessionReuse` normalize path (`true`/`false` string and boolean forms)
  - invalid `sessionReuse` input cleanup
  - `forceNew` path in cron session resolution behavior
  - CLI flag plumbing and protocol validator compatibility
  - `/cron` UI form toggle visibility and payload forwarding/omission behavior
  - `/cron` UI job list mode chip rendering (`fresh`/`reuse`)
- Edge cases checked:
  - invalid string values
  - explicit `true` opt-in vs default behavior
  - add/edit CLI toggle conflict handling
- What you did **not** verify:
  - full live integration runs across external messaging channels
  - long-duration production cron soak behavior
  - full `ui` test suite green status end-to-end (targeted cron UI tests were run and passed)

## CI Status

- Initial CI failure on `checks (node, protocol, pnpm protocol:check)` was due to generated Swift protocol models not yet updated after `sessionReuse` schema change.
- Follow-up commit regenerated Swift protocol models:
  - `apps/macos/Sources/OpenClawProtocol/GatewayModels.swift`
  - `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`
- Remaining CI state should be evaluated on latest head commit.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Set affected jobs to `sessionReuse: true` to restore continuity behavior.
  - Revert commits `d93e75e317e7f3c1849a2a9ba62a3394f7032a80`, `abd938b1569ea8bdecaed6600420c6e456c23bb7`, `9fe78f2328a1bfc9edc37bd93626f42bd3980d51`, `2cfb8f85df4bb08618209d93dd04b4ae3575e8d9`, `137d2331b7714511c443c0e728536deb035673ea`, `5ee4eb01981442aad00a2af6b9fd46ec97330e97`, `77119da4844e98f7c12c4d59e7fce45fed8f2fa8`.
- Files/config to restore:
  - `docs/style.css`
  - `src/cron/isolated-agent/run.ts`
  - `src/cron/types.ts`
  - `src/cron/normalize.ts`
  - `src/cron/service/jobs.ts`
  - `src/cron/service/store.ts`
  - `src/gateway/protocol/schema/cron.ts`
  - `apps/macos/Sources/OpenClawProtocol/GatewayModels.swift`
  - `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`
  - `src/cli/cron-cli/register.cron-add.ts`
  - `src/cli/cron-cli/register.cron-edit.ts`
  - `ui/src/ui/ui-types.ts`
  - `ui/src/ui/app-defaults.ts`
  - `ui/src/ui/types.ts`
  - `ui/src/ui/controllers/cron.ts`
  - `ui/src/ui/views/cron.ts`
- Known bad symptoms reviewers should watch for:
  - jobs that expected implicit session continuity losing context between runs

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Some existing cron jobs may have implicitly depended on session reuse.
  - Mitigation: `sessionReuse: true` opt-in preserves reuse explicitly.
- Risk: Input coercion could accept malformed values if not covered.
  - Mitigation: Added normalization tests for valid/invalid forms.
- Risk: Cross-surface contract drift (types/schema/CLI/runtime).
  - Mitigation: Updated all relevant layers and validated with unit + gateway protocol tests.

## AI Assistance Disclosure

- AI-assisted: Yes
- Human review and verification performed: Yes
- Testing degree: full `build && check && test` was run with `FINAL_STATUS=0`; test logs include intermittent worker OOM traces while summaries remain all-green.
- External model consultation: GLM-5 was used for bug/regression validation and pre-PR quality gate review.
- Prompts/session logs: consultation prompts and outputs are summarized in review notes and can be provided on request.
