### PR TITLE
feat(auth): add refreshable Anthropic OAuth login flow

### DIFF
--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -296,7 +296,7 @@ export function registerModelsCli(program: Command) {
 
   auth
     .command("add")
-    .description("Interactive auth helper (setup-token or paste token)")
+    .description("Interactive auth helper (Anthropic OAuth, setup-token, or paste token)")
     .action(async () => {
       await runModelsCommand(async () => {
         await modelsAuthAddCommand({}, defaultRuntime);

--- a/src/commands/anthropic-oauth.ts
+++ b/src/commands/anthropic-oauth.ts
@@ -1,0 +1,78 @@
+import type { OAuthCredentials } from "@mariozechner/pi-ai";
+import { loginAnthropic } from "@mariozechner/pi-ai";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+
+const validateRequiredInput = (value: string) => (value.trim().length > 0 ? undefined : "Required");
+
+export async function loginAnthropicOAuth(params: {
+  prompter: WizardPrompter;
+  runtime: RuntimeEnv;
+  isRemote: boolean;
+  openUrl: (url: string) => Promise<void>;
+}): Promise<OAuthCredentials | null> {
+  const { prompter, runtime, isRemote, openUrl } = params;
+
+  await prompter.note(
+    isRemote
+      ? [
+          "You are running in a remote/VPS environment.",
+          "A URL will be shown for you to open in your LOCAL browser.",
+          "After signing in, paste the authorization code shown by Anthropic.",
+          "Format: code#state",
+        ].join("\n")
+      : [
+          "Browser will open for Anthropic authentication.",
+          "If it doesn't open automatically, use the printed URL.",
+          "Paste the authorization code shown by Anthropic.",
+          "Format: code#state",
+        ].join("\n"),
+    "Anthropic OAuth",
+  );
+
+  const spin = prompter.progress("Starting OAuth flow…");
+  try {
+    let authUrlShown = false;
+    const creds = await loginAnthropic(
+      (url) => {
+        authUrlShown = true;
+        if (isRemote) {
+          spin.stop("OAuth URL ready");
+          runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${url}\n`);
+          return;
+        }
+
+        spin.update("Complete sign-in in browser…");
+        void openUrl(url);
+        runtime.log(`Open: ${url}`);
+      },
+      async () => {
+        if (!authUrlShown) {
+          spin.update("Waiting for authorization URL…");
+        }
+        const code = await prompter.text({
+          message: "Paste Anthropic authorization code (code#state)",
+          placeholder: "code#state",
+          validate: (value) => validateRequiredInput(String(value ?? "")),
+        });
+        return String(code);
+      },
+    );
+
+    spin.stop("Anthropic OAuth complete");
+    return creds ?? null;
+  } catch (err) {
+    spin.stop("Anthropic OAuth failed");
+    runtime.error(String(err));
+    await prompter.note(
+      [
+        "Trouble with OAuth?",
+        "1) Ensure your Claude account has API access enabled.",
+        "2) Re-run and copy the full code exactly as shown (code#state).",
+        "3) If needed, retry with a fresh browser session.",
+      ].join("\n"),
+      "OAuth help",
+    );
+    throw err;
+  }
+}

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -19,29 +19,44 @@ describe("buildAuthChoiceOptions", () => {
   it("includes core and provider-specific auth choices", () => {
     const options = getOptions();
 
-    for (const value of [
-      "github-copilot",
-      "token",
-      "zai-api-key",
-      "xiaomi-api-key",
-      "minimax-api",
-      "minimax-api-key-cn",
-      "minimax-api-lightning",
-      "moonshot-api-key",
-      "moonshot-api-key-cn",
-      "kimi-code-api-key",
-      "together-api-key",
-      "ai-gateway-api-key",
-      "cloudflare-ai-gateway-api-key",
-      "synthetic-api-key",
-      "chutes",
-      "qwen-portal",
-      "xai-api-key",
-      "mistral-api-key",
-      "volcengine-api-key",
-      "byteplus-api-key",
-      "vllm",
-    ]) {
+    expect(options.find((opt) => opt.value === "github-copilot")).toBeDefined();
+  });
+
+  it("includes setup-token option for Anthropic", () => {
+    const options = getOptions();
+
+    expect(options.some((opt) => opt.value === "token")).toBe(true);
+  });
+
+  it("includes OAuth option for Anthropic", () => {
+    const options = getOptions();
+
+    expect(options.some((opt) => opt.value === "anthropic-oauth")).toBe(true);
+  });
+
+  it.each([
+    ["Z.AI (GLM) auth choice", ["zai-api-key"]],
+    ["Xiaomi auth choice", ["xiaomi-api-key"]],
+    ["MiniMax auth choice", ["minimax-api", "minimax-api-key-cn", "minimax-api-lightning"]],
+    [
+      "Moonshot auth choice",
+      ["moonshot-api-key", "moonshot-api-key-cn", "kimi-code-api-key", "together-api-key"],
+    ],
+    ["Vercel AI Gateway auth choice", ["ai-gateway-api-key"]],
+    ["Cloudflare AI Gateway auth choice", ["cloudflare-ai-gateway-api-key"]],
+    ["Together AI auth choice", ["together-api-key"]],
+    ["Synthetic auth choice", ["synthetic-api-key"]],
+    ["Chutes OAuth auth choice", ["chutes"]],
+    ["Qwen auth choice", ["qwen-portal"]],
+    ["xAI auth choice", ["xai-api-key"]],
+    ["Mistral auth choice", ["mistral-api-key"]],
+    ["Volcano Engine auth choice", ["volcengine-api-key"]],
+    ["BytePlus auth choice", ["byteplus-api-key"]],
+    ["vLLM auth choice", ["vllm"]],
+  ])("includes %s", (_label, expectedValues) => {
+    const options = getOptions();
+
+    for (const value of expectedValues) {
       expect(options.some((opt) => opt.value === value)).toBe(true);
     }
   });

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -32,8 +32,8 @@ const AUTH_CHOICE_GROUP_DEFS: {
   {
     value: "anthropic",
     label: "Anthropic",
-    hint: "setup-token + API key",
-    choices: ["token", "apiKey"],
+    hint: "OAuth (refreshable) + setup-token + API key",
+    choices: ["anthropic-oauth", "token", "apiKey"],
   },
   {
     value: "chutes",
@@ -213,6 +213,11 @@ function buildProviderAuthChoiceOptions(): AuthChoiceOption[] {
 }
 
 const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
+  {
+    value: "anthropic-oauth",
+    label: "Anthropic OAuth (refreshable)",
+    hint: "sign in once; OpenClaw can auto-refresh the OAuth token",
+  },
   {
     value: "token",
     label: "Anthropic token (paste setup-token)",

--- a/src/commands/auth-choice.apply.anthropic.ts
+++ b/src/commands/auth-choice.apply.anthropic.ts
@@ -1,4 +1,5 @@
 import { upsertAuthProfile } from "../agents/auth-profiles.js";
+import { loginAnthropicOAuth } from "./anthropic-oauth.js";
 import { normalizeApiKeyInput, validateApiKeyInput } from "./auth-choice.api-key.js";
 import {
   normalizeSecretInputModeInput,
@@ -8,8 +9,14 @@ import {
 } from "./auth-choice.apply-helpers.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { buildTokenProfileId, validateAnthropicSetupToken } from "./auth-token.js";
+import { isRemoteEnvironment } from "./oauth-env.js";
 import { applyAgentDefaultModelPrimary } from "./onboard-auth.config-shared.js";
-import { applyAuthProfileConfig, setAnthropicApiKey } from "./onboard-auth.js";
+import {
+  applyAuthProfileConfig,
+  setAnthropicApiKey,
+  writeOAuthCredentials,
+} from "./onboard-auth.js";
+import { openUrl } from "./onboard-helpers.js";
 
 const DEFAULT_ANTHROPIC_MODEL = "anthropic/claude-sonnet-4-6";
 
@@ -17,6 +24,35 @@ export async function applyAuthChoiceAnthropic(
   params: ApplyAuthChoiceParams,
 ): Promise<ApplyAuthChoiceResult | null> {
   const requestedSecretInputMode = normalizeSecretInputModeInput(params.opts?.secretInputMode);
+
+  if (params.authChoice === "anthropic-oauth") {
+    let nextConfig = params.config;
+    const creds = await loginAnthropicOAuth({
+      prompter: params.prompter,
+      runtime: params.runtime,
+      isRemote: isRemoteEnvironment(),
+      openUrl: async (url) => {
+        await openUrl(url);
+      },
+    });
+    if (!creds) {
+      return { config: nextConfig };
+    }
+
+    const profileId = await writeOAuthCredentials("anthropic", creds, params.agentDir, {
+      syncSiblingAgents: true,
+    });
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId,
+      provider: "anthropic",
+      mode: "oauth",
+    });
+    if (params.setDefaultModel) {
+      nextConfig = applyAgentDefaultModelPrimary(nextConfig, DEFAULT_ANTHROPIC_MODEL);
+    }
+    return { config: nextConfig };
+  }
+
   if (
     params.authChoice === "setup-token" ||
     params.authChoice === "oauth" ||

--- a/src/commands/models/auth.anthropic-oauth.test.ts
+++ b/src/commands/models/auth.anthropic-oauth.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../runtime.js";
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    updatedConfig: undefined as unknown,
+  };
+  return {
+    state,
+    resolveDefaultAgentId: vi.fn(),
+    resolveAgentDir: vi.fn(),
+    resolveAgentWorkspaceDir: vi.fn(),
+    resolveDefaultAgentWorkspaceDir: vi.fn(),
+    resolvePluginProviders: vi.fn(),
+    upsertAuthProfile: vi.fn(),
+    loginAnthropicOAuth: vi.fn(),
+    isRemoteEnvironment: vi.fn(),
+    applyAuthProfileConfig: vi.fn(),
+    applyDefaultModel: vi.fn(),
+    mergeConfigPatch: vi.fn((cfg) => cfg),
+    pickAuthMethod: vi.fn(),
+    resolveProviderMatch: vi.fn(),
+    loadValidConfigOrThrow: vi.fn(),
+    updateConfig: vi.fn(),
+    createClackPrompter: vi.fn(),
+    logConfigUpdated: vi.fn(),
+  };
+});
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
+  resolveAgentDir: mocks.resolveAgentDir,
+  resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
+}));
+
+vi.mock("../../agents/workspace.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/workspace.js")>(
+    "../../agents/workspace.js",
+  );
+  return {
+    ...actual,
+    resolveDefaultAgentWorkspaceDir: mocks.resolveDefaultAgentWorkspaceDir,
+  };
+});
+
+vi.mock("../../plugins/providers.js", () => ({
+  resolvePluginProviders: mocks.resolvePluginProviders,
+}));
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  upsertAuthProfile: mocks.upsertAuthProfile,
+}));
+
+vi.mock("../../wizard/clack-prompter.js", () => ({
+  createClackPrompter: mocks.createClackPrompter,
+}));
+
+vi.mock("../anthropic-oauth.js", () => ({
+  loginAnthropicOAuth: mocks.loginAnthropicOAuth,
+}));
+
+vi.mock("../oauth-env.js", () => ({
+  isRemoteEnvironment: mocks.isRemoteEnvironment,
+}));
+
+vi.mock("../onboard-auth.js", () => ({
+  applyAuthProfileConfig: mocks.applyAuthProfileConfig,
+}));
+
+vi.mock("../provider-auth-helpers.js", () => ({
+  applyDefaultModel: mocks.applyDefaultModel,
+  mergeConfigPatch: mocks.mergeConfigPatch,
+  pickAuthMethod: mocks.pickAuthMethod,
+  resolveProviderMatch: mocks.resolveProviderMatch,
+}));
+
+vi.mock("../../config/logging.js", () => ({
+  logConfigUpdated: mocks.logConfigUpdated,
+}));
+
+vi.mock("./shared.js", () => ({
+  loadValidConfigOrThrow: mocks.loadValidConfigOrThrow,
+  updateConfig: mocks.updateConfig,
+}));
+
+import { modelsAuthLoginCommand } from "./auth.js";
+
+const ORIGINAL_IS_TTY = process.stdin.isTTY;
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+describe("modelsAuthLoginCommand anthropic oauth path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.state.updatedConfig = undefined;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+      writable: true,
+    });
+
+    mocks.loadValidConfigOrThrow.mockResolvedValue({});
+    mocks.resolveDefaultAgentId.mockReturnValue("james");
+    mocks.resolveAgentDir.mockReturnValue("/tmp/openclaw/agents/james/agent");
+    mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace-james");
+    mocks.resolveDefaultAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
+    mocks.resolvePluginProviders.mockReturnValue([]);
+    mocks.isRemoteEnvironment.mockReturnValue(false);
+    mocks.createClackPrompter.mockReturnValue({});
+    mocks.loginAnthropicOAuth.mockResolvedValue({
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+    });
+    mocks.applyAuthProfileConfig.mockImplementation((cfg, params) => ({ ...cfg, auth: params }));
+    mocks.applyDefaultModel.mockImplementation((cfg, model) => ({ ...cfg, model }));
+    mocks.updateConfig.mockImplementation(async (updater: (cfg: unknown) => unknown) => {
+      mocks.state.updatedConfig = updater({});
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: ORIGINAL_IS_TTY,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("writes anthropic oauth creds to the resolved agent dir and applies --set-default", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthLoginCommand(
+      {
+        provider: "anthropic",
+        method: "oauth",
+        setDefault: true,
+      },
+      runtime,
+    );
+
+    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "anthropic:default",
+        agentDir: "/tmp/openclaw/agents/james/agent",
+      }),
+    );
+    expect(mocks.applyDefaultModel).toHaveBeenCalledWith(
+      expect.any(Object),
+      "anthropic/claude-sonnet-4-6",
+    );
+    expect(mocks.state.updatedConfig).toEqual(
+      expect.objectContaining({
+        model: "anthropic/claude-sonnet-4-6",
+      }),
+    );
+  });
+
+  it("does not apply a default model when --set-default is false", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthLoginCommand(
+      {
+        provider: "anthropic",
+        method: "oauth",
+        setDefault: false,
+      },
+      runtime,
+    );
+
+    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: "/tmp/openclaw/agents/james/agent",
+      }),
+    );
+    expect(mocks.applyDefaultModel).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -75,6 +75,7 @@ const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
   );
 
 type TokenProvider = "anthropic";
+const DEFAULT_ANTHROPIC_MODEL = "anthropic/claude-sonnet-4-6";
 
 function resolveTokenProvider(raw?: string): TokenProvider | "custom" | null {
   const trimmed = raw?.trim();
@@ -185,7 +186,12 @@ export async function modelsAuthPasteTokenCommand(
   runtime.log(`Auth profile: ${profileId} (${provider}/token)`);
 }
 
-export async function modelsAuthAnthropicOAuthCommand(runtime: RuntimeEnv) {
+export async function modelsAuthAnthropicOAuthCommand(params: {
+  runtime: RuntimeEnv;
+  agentDir?: string;
+  setDefault?: boolean;
+}) {
+  const { runtime, agentDir, setDefault = false } = params;
   if (!process.stdin.isTTY) {
     throw new Error("models auth oauth requires an interactive TTY.");
   }
@@ -206,6 +212,7 @@ export async function modelsAuthAnthropicOAuthCommand(runtime: RuntimeEnv) {
   const profileId = "anthropic:default";
   upsertAuthProfile({
     profileId,
+    agentDir,
     credential: {
       type: "oauth",
       provider: "anthropic",
@@ -213,16 +220,23 @@ export async function modelsAuthAnthropicOAuthCommand(runtime: RuntimeEnv) {
     },
   });
 
-  await updateConfig((cfg) =>
-    applyAuthProfileConfig(cfg, {
+  await updateConfig((cfg) => {
+    let next = applyAuthProfileConfig(cfg, {
       profileId,
       provider: "anthropic",
       mode: "oauth",
-    }),
-  );
+    });
+    if (setDefault) {
+      next = applyDefaultModel(next, DEFAULT_ANTHROPIC_MODEL);
+    }
+    return next;
+  });
 
   logConfigUpdated(runtime);
   runtime.log(`Auth profile: ${profileId} (anthropic/oauth)`);
+  if (setDefault) {
+    runtime.log(`Default model set to ${DEFAULT_ANTHROPIC_MODEL}`);
+  }
 }
 
 export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime: RuntimeEnv) {
@@ -268,7 +282,10 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
   })) as "oauth" | "setup-token" | "paste";
 
   if (method === "oauth") {
-    await modelsAuthAnthropicOAuthCommand(runtime);
+    const config = await loadValidConfigOrThrow();
+    const defaultAgentId = resolveDefaultAgentId(config);
+    const agentDir = resolveAgentDir(config, defaultAgentId);
+    await modelsAuthAnthropicOAuthCommand({ runtime, agentDir });
     return;
   }
 
@@ -427,7 +444,11 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
         `Unknown auth method "${opts.method}" for Anthropic. Use \`--method oauth\` or omit --method.`,
       );
     }
-    await modelsAuthAnthropicOAuthCommand(runtime);
+    await modelsAuthAnthropicOAuthCommand({
+      runtime,
+      agentDir,
+      setDefault: opts.setDefault,
+    });
     return;
   }
   if (providers.length === 0) {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -434,9 +434,6 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
   }
 
   const providers = resolvePluginProviders({ config, workspaceDir });
-  const requestedProviderId = opts.provider?.trim()
-    ? normalizeProviderId(opts.provider)
-    : undefined;
 
   if (requestedProviderId === "anthropic") {
     if (opts.method && normalizeProviderId(opts.method) !== "oauth") {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -22,6 +22,7 @@ import type { ProviderAuthResult, ProviderPlugin } from "../../plugins/types.js"
 import type { RuntimeEnv } from "../../runtime.js";
 import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
+import { loginAnthropicOAuth } from "../anthropic-oauth.js";
 import { validateAnthropicSetupToken } from "../auth-token.js";
 import { isRemoteEnvironment } from "../oauth-env.js";
 import { createVpsAwareOAuthHandlers } from "../oauth-flow.js";
@@ -184,6 +185,46 @@ export async function modelsAuthPasteTokenCommand(
   runtime.log(`Auth profile: ${profileId} (${provider}/token)`);
 }
 
+export async function modelsAuthAnthropicOAuthCommand(runtime: RuntimeEnv) {
+  if (!process.stdin.isTTY) {
+    throw new Error("models auth oauth requires an interactive TTY.");
+  }
+
+  const prompter = createClackPrompter();
+  const creds = await loginAnthropicOAuth({
+    prompter,
+    runtime,
+    isRemote: isRemoteEnvironment(),
+    openUrl: async (url) => {
+      await openUrl(url);
+    },
+  });
+  if (!creds) {
+    return;
+  }
+
+  const profileId = "anthropic:default";
+  upsertAuthProfile({
+    profileId,
+    credential: {
+      type: "oauth",
+      provider: "anthropic",
+      ...creds,
+    },
+  });
+
+  await updateConfig((cfg) =>
+    applyAuthProfileConfig(cfg, {
+      profileId,
+      provider: "anthropic",
+      mode: "oauth",
+    }),
+  );
+
+  logConfigUpdated(runtime);
+  runtime.log(`Auth profile: ${profileId} (anthropic/oauth)`);
+}
+
 export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime: RuntimeEnv) {
   const provider = await select({
     message: "Token provider",
@@ -211,6 +252,11 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
       ...(providerId === "anthropic"
         ? [
             {
+              value: "oauth",
+              label: "oauth (refreshable)",
+              hint: "Sign in with Anthropic OAuth (auto-refresh)",
+            },
+            {
               value: "setup-token",
               label: "setup-token (claude)",
               hint: "Paste a setup-token from `claude setup-token`",
@@ -219,7 +265,12 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
         : []),
       { value: "paste", label: "paste token" },
     ],
-  })) as "setup-token" | "paste";
+  })) as "oauth" | "setup-token" | "paste";
+
+  if (method === "oauth") {
+    await modelsAuthAnthropicOAuthCommand(runtime);
+    return;
+  }
 
   if (method === "setup-token") {
     await modelsAuthSetupTokenCommand({ provider: providerId }, runtime);
@@ -366,6 +417,19 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
   }
 
   const providers = resolvePluginProviders({ config, workspaceDir });
+  const requestedProviderId = opts.provider?.trim()
+    ? normalizeProviderId(opts.provider)
+    : undefined;
+
+  if (requestedProviderId === "anthropic") {
+    if (opts.method && normalizeProviderId(opts.method) !== "oauth") {
+      throw new Error(
+        `Unknown auth method "${opts.method}" for Anthropic. Use \`--method oauth\` or omit --method.`,
+      );
+    }
+    await modelsAuthAnthropicOAuthCommand(runtime);
+    return;
+  }
   if (providers.length === 0) {
     throw new Error(
       `No provider plugins found. Install one via \`${formatCliCommand("openclaw plugins install")}\`.`,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -8,6 +8,7 @@ export type AuthChoice =
   | "setup-token"
   | "claude-cli"
   | "token"
+  | "anthropic-oauth"
   | "chutes"
   | "vllm"
   | "openai-codex"

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -521,6 +521,87 @@ describe("fs-safe", () => {
     await expect(fs.stat(outsideTarget)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it.runIf(process.platform !== "win32")(
+    "does not truncate out-of-root file when symlink retarget races write open",
+    async () => {
+      const root = await tempDirs.make("openclaw-fs-safe-root-");
+      const inside = path.join(root, "inside");
+      const outside = await tempDirs.make("openclaw-fs-safe-outside-");
+      await fs.mkdir(inside, { recursive: true });
+      const insideTarget = path.join(inside, "target.txt");
+      const outsideTarget = path.join(outside, "target.txt");
+      await fs.writeFile(insideTarget, "inside");
+      await fs.writeFile(outsideTarget, "X".repeat(4096));
+      const slot = path.join(root, "slot");
+      await fs.symlink(inside, slot);
+
+      const realRealpath = fs.realpath.bind(fs);
+      let flipped = false;
+      const realpathSpy = vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+        const [filePath] = args;
+        if (!flipped && String(filePath).endsWith(path.join("slot", "target.txt"))) {
+          flipped = true;
+          await fs.rm(slot, { recursive: true, force: true });
+          await fs.symlink(outside, slot);
+        }
+        return await realRealpath(...args);
+      });
+      try {
+        await expect(
+          writeFileWithinRoot({
+            rootDir: root,
+            relativePath: path.join("slot", "target.txt"),
+            data: "new-content",
+            mkdir: false,
+          }),
+        ).rejects.toMatchObject({ code: "outside-workspace" });
+      } finally {
+        realpathSpy.mockRestore();
+      }
+
+      await expect(fs.readFile(outsideTarget, "utf8")).resolves.toBe("X".repeat(4096));
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "cleans up created out-of-root file when symlink retarget races create path",
+    async () => {
+      const root = await tempDirs.make("openclaw-fs-safe-root-");
+      const inside = path.join(root, "inside");
+      const outside = await tempDirs.make("openclaw-fs-safe-outside-");
+      await fs.mkdir(inside, { recursive: true });
+      const outsideTarget = path.join(outside, "target.txt");
+      const slot = path.join(root, "slot");
+      await fs.symlink(inside, slot);
+
+      const realOpen = fs.open.bind(fs);
+      let flipped = false;
+      const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const [filePath] = args;
+        if (!flipped && String(filePath).endsWith(path.join("slot", "target.txt"))) {
+          flipped = true;
+          await fs.rm(slot, { recursive: true, force: true });
+          await fs.symlink(outside, slot);
+        }
+        return await realOpen(...args);
+      });
+      try {
+        await expect(
+          writeFileWithinRoot({
+            rootDir: root,
+            relativePath: path.join("slot", "target.txt"),
+            data: "new-content",
+            mkdir: false,
+          }),
+        ).rejects.toMatchObject({ code: "outside-workspace" });
+      } finally {
+        openSpy.mockRestore();
+      }
+
+      await expect(fs.stat(outsideTarget)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
   it("returns not-found for missing files", async () => {
     const dir = await tempDirs.make("openclaw-fs-safe-");
     const missing = path.join(dir, "missing.txt");


### PR DESCRIPTION
## Summary
- add a first-class Anthropic OAuth login helper (`loginAnthropicOAuth`) that stores refreshable `type: "oauth"` credentials
- expose Anthropic OAuth in `openclaw models auth add` as `oauth (refreshable)`
- allow `openclaw models auth login --provider anthropic` to work without provider plugins by routing to the built-in Anthropic OAuth flow
- add a new onboarding auth choice `anthropic-oauth` and wire it through Anthropic auth application
- surface the new option in auth-choice groups/options and add an e2e assertion

## Why
Today Anthropic auth in OpenClaw primarily routes users through `setup-token`, which stores static bearer tokens (`type: "token"`) and cannot auto-refresh.

This PR adds an explicit OAuth path so users can obtain refreshable credentials (`access + refresh + expires`) and avoid repeated manual token pastes.

## Testing
- `pnpm -s vitest run --config vitest.e2e.config.ts src/commands/auth-choice-options.e2e.test.ts src/commands/onboard-auth.e2e.test.ts src/commands/onboard-non-interactive.provider-auth.e2e.test.ts`
- `pnpm -s vitest run src/commands/models.list.auth-sync.test.ts`
- `pnpm -s oxlint --type-aware src/commands/anthropic-oauth.ts src/commands/auth-choice.apply.anthropic.ts src/commands/auth-choice-options.ts src/commands/onboard-types.ts src/commands/models/auth.ts src/cli/models-cli.ts src/commands/auth-choice-options.e2e.test.ts`
- `pnpm -s tsgo`


## Local Validation
- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm test` ➖ (targeted command/e2e runs listed above; full matrix covered by CI)

## AI-Assisted
This PR was developed with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds first-class Anthropic OAuth support with auto-refreshable credentials, replacing the previous static token flow. The implementation introduces a new `loginAnthropicOAuth` helper, exposes OAuth as a choice in onboarding and `models auth` commands, and properly stores credentials via the existing `writeOAuthCredentials` infrastructure.

**Major changes:**
- New `anthropic-oauth.ts` module handles the OAuth flow with VPS/remote environment support
- `models auth add` and `models auth login` now offer OAuth as the primary method for Anthropic
- Auth choice UI updated to prioritize "OAuth (refreshable)" over static tokens
- OAuth credentials sync across sibling agents when enabled
- Full e2e test coverage for the new auth option

**Implementation quality:**
- Follows existing OAuth patterns (similar to OpenAI Codex and Chutes flows)
- Proper error handling with user-friendly help messages
- Remote/VPS detection correctly applied
- All tests passing with new assertions confirming OAuth option availability

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase (similar to OpenAI Codex and Chutes OAuth flows), includes comprehensive test coverage with passing e2e tests, and properly integrates with existing credential storage infrastructure. The code quality is high with appropriate error handling, user-friendly messaging, and remote environment detection. No security vulnerabilities or logical errors were identified.
- No files require special attention

<sub>Last reviewed commit: 5ac3ca7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->