### PR TITLE
docs: add local providers troubleshooting guide

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -54,6 +54,7 @@ See [Venice AI](/providers/venice).
 - [Hugging Face (Inference)](/providers/huggingface)
 - [Ollama (local models)](/providers/ollama)
 - [vLLM (local models)](/providers/vllm)
+- [Local providers troubleshooting](/providers/local-troubleshooting)
 - [Qianfan](/providers/qianfan)
 - [NVIDIA](/providers/nvidia)
 

--- a/docs/providers/local-troubleshooting.md
+++ b/docs/providers/local-troubleshooting.md
@@ -1,0 +1,112 @@
+---
+summary: "Troubleshooting common issues with local LLM providers (Ollama, vLLM)"
+read_when:
+  - Local models are not working or detected
+  - You get 'No API key found' errors for Ollama or vLLM
+  - Models run but responses are broken, slow, or missing tools
+title: "Local Providers Troubleshooting"
+---
+
+# Local Providers Troubleshooting
+
+Common issues when running OpenClaw with local model providers like Ollama and vLLM.
+
+For provider-specific setup instructions, see [Ollama](/providers/ollama) or [vLLM](/providers/vllm).
+
+## "No API key found for provider ollama"
+
+Local providers still need an API key value to register with OpenClaw. Any string works:
+
+```bash
+# Ollama
+export OLLAMA_API_KEY="ollama-local"
+
+# vLLM
+export VLLM_API_KEY="vllm-local"
+```
+
+Or set it in your config:
+
+```bash
+openclaw config set models.providers.ollama.apiKey "ollama-local"
+```
+
+Make sure the environment variable is set in the same shell (or service) that runs the gateway. If you use systemd, add it to the service environment.
+
+## "Unknown model: ollama/..."
+
+This usually means the provider was not registered (API key missing), or auto-discovery did not find the model.
+
+Check:
+
+1. Is the API key set? `echo $OLLAMA_API_KEY`
+2. Is Ollama running? `curl http://localhost:11434/api/tags`
+3. Is the model pulled? `ollama list`
+4. Does the model support tools? OpenClaw only auto-discovers tool-capable models. If your model does not report tool support, define it explicitly in config (see [Ollama explicit setup](/providers/ollama#explicit-setup-manual-models)).
+
+## No tool calling
+
+Some local models do not support tool calling or report it inconsistently. If the model runs but tools fail:
+
+- Check if the model reports tool support: `ollama show <model>` should list `tools` in capabilities
+- Try a model known to support tools: `gpt-oss:20b`, `qwen2.5-coder:32b`, `llama3.3`
+- For vLLM, ensure your model was loaded with tool support enabled
+
+## Connection refused
+
+```bash
+# Check Ollama
+curl http://localhost:11434/api/tags
+
+# Check vLLM
+curl http://localhost:8000/v1/models
+```
+
+If these fail:
+
+- Ollama: run `ollama serve` or check if the Ollama app is running
+- vLLM: verify the server is started and listening on the expected port
+- Docker users: make sure the host port is mapped (e.g., `-p 11434:11434`)
+
+## Slow responses or timeouts
+
+Local models are limited by your hardware. Common causes:
+
+- Model too large for available RAM/VRAM (check with `ollama ps`)
+- Context window set too high (reduce `contextWindow` in explicit config)
+- Multiple models loaded simultaneously (Ollama loads models on demand; unload unused ones)
+
+## Session corruption after model errors
+
+If a local model returns malformed responses (e.g., `stopReason: "toolUse"` without an actual tool call), the session can enter a broken state. Symptoms:
+
+- Every subsequent message fails with tool pairing errors
+- Gateway restart does not fix it
+
+Fix: start a fresh session with `/new` or `/reset`. If the issue persists, check the session JSONL file for orphaned `toolResult` entries.
+
+## Mixed local and cloud setup
+
+You can use a local model as primary with cloud fallbacks:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "ollama/gpt-oss:20b",
+        fallbacks: ["anthropic/claude-sonnet-4-5"],
+      },
+    },
+  },
+}
+```
+
+This gives you local-first with cloud backup when the local model fails or does not support a feature.
+
+## See Also
+
+- [Ollama](/providers/ollama)
+- [vLLM](/providers/vllm)
+- [Model Providers](/providers)
+- [Gateway Troubleshooting](/gateway/troubleshooting)


### PR DESCRIPTION
Users running Ollama, vLLM, or other local models hit the same issues repeatedly (#22055, #4544, #1695): confusing API key errors, model discovery failures, and session corruption from malformed responses.

There's no single page covering these common pitfalls across local providers. The individual provider docs have minimal troubleshooting sections.

**Adds** `docs/providers/local-troubleshooting.md` covering:
- "No API key found" (dummy key requirement)
- "Unknown model" (discovery prerequisites)
- No tool calling (model capability check)
- Connection refused (server not running)
- Slow responses/timeouts (hardware limits)
- Session corruption after model errors
- Mixed local + cloud fallback setup

Also adds a link from the providers index page.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `docs/providers/local-troubleshooting.md` page consolidating common issues when running OpenClaw with local LLM providers (Ollama, vLLM). Covers API key requirements, model discovery, tool calling, connection issues, performance, session corruption, and mixed local/cloud setups. Also adds a link from the providers index page.

- Content is accurate and consistent with the existing Ollama and vLLM provider docs
- All internal links and anchors resolve correctly (verified against `ollama.md`, `vllm.md`, and `gateway/troubleshooting.md`)
- Frontmatter follows the established `summary`/`read_when`/`title` pattern
- The page is not added to `docs.json` sidebar navigation, which follows the existing pattern (several providers like Ollama, vLLM, Venice, NVIDIA are also only linked from the index page)
- Minor style note: the troubleshooting link is inserted mid-list in the provider index between vLLM and Qianfan, which slightly disrupts the provider catalog flow

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it only adds documentation with no code changes.
- Documentation-only PR adding a well-structured troubleshooting guide. Content is accurate and links are valid. Minor placement concern in the index page is non-blocking.
- No files require special attention. The link placement in `docs/providers/index.md` is a minor style suggestion.

<sub>Last reviewed commit: cf18a52</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->