### PR TITLE
fix(gateway): allow Control UI session patch/delete

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -21,6 +21,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
+import { GATEWAY_CLIENT_IDS } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -81,7 +82,15 @@ function rejectWebchatSessionMutation(params: {
   isWebchatConnect: (params: GatewayClient["connect"] | null | undefined) => boolean;
   respond: RespondFn;
 }): boolean {
-  if (!params.client?.connect || !params.isWebchatConnect(params.client.connect)) {
+  const connect = params.client?.connect;
+  if (!connect) {
+    return false;
+  }
+  // Control UI is an operator surface and must retain session mutation APIs.
+  if (connect.client?.id === GATEWAY_CLIENT_IDS.CONTROL_UI) {
+    return false;
+  }
+  if (!params.isWebchatConnect(connect)) {
     return false;
   }
   params.respond(

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1113,6 +1113,7 @@ describe("gateway server sessions", () => {
     const ws = new WebSocket(`ws://127.0.0.1:${harness.port}`, {
       headers: { origin: `http://127.0.0.1:${harness.port}` },
     });
+    trackConnectChallengeNonce(ws);
     await new Promise<void>((resolve) => ws.once("open", resolve));
     await connectOk(ws, {
       client: {

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1091,4 +1091,53 @@ describe("gateway server sessions", () => {
 
     ws.close();
   });
+
+  test("control ui can patch and delete sessions", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-control-ui-"));
+    const storePath = path.join(dir, "sessions.json");
+    testState.sessionStorePath = storePath;
+
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+        },
+        "discord:group:dev": {
+          sessionId: "sess-group",
+          updatedAt: Date.now(),
+        },
+      },
+    });
+
+    const ws = new WebSocket(`ws://127.0.0.1:${harness.port}`, {
+      headers: { origin: `http://127.0.0.1:${harness.port}` },
+    });
+    await new Promise<void>((resolve) => ws.once("open", resolve));
+    await connectOk(ws, {
+      client: {
+        id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+        version: "1.0.0",
+        platform: "test",
+        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+      },
+      scopes: ["operator.admin"],
+    });
+
+    const patched = await rpcReq(ws, "sessions.patch", {
+      key: "agent:main:discord:group:dev",
+      label: "control-ui-updated",
+    });
+    expect(patched.ok).toBe(true);
+
+    const deleted = await rpcReq(ws, "sessions.delete", {
+      key: "agent:main:discord:group:dev",
+    });
+    expect(deleted.ok).toBe(true);
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, unknown>;
+    expect(store["agent:main:discord:group:dev"]).toBeUndefined();
+
+    ws.close();
+  });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `rejectWebchatSessionMutation` blocked all `mode=webchat` clients, including Control UI (`openclaw-control-ui`).
- Why it matters: Control UI operators could not use session settings or session delete actions.
- What changed: Added a Control UI exemption in the mutation guard and added an e2e test proving Control UI can patch/delete sessions.
- What did NOT change (scope boundary): The existing restriction for regular webchat clients remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #22051
- Related #22038

## User-visible / Behavior Changes

- Control UI can now successfully run `sessions.patch` and `sessions.delete` again.
- Non-control webchat clients remain blocked from these mutation APIs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI + webchat mode clients
- Relevant config (redacted): default test harness config

### Steps

1. Start gateway and connect as Control UI (`client.id=openclaw-control-ui`, `client.mode=webchat`).
2. Call `sessions.patch` on a grouped session key.
3. Call `sessions.delete` on the same session key.

### Expected

- Both RPC calls return `ok: true` for Control UI.

### Actual

- Verified passing in e2e test after fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run locally:

```bash
node node_modules/.pnpm/oxfmt@0.33.0/node_modules/oxfmt/bin/oxfmt --check \
  src/gateway/server-methods/sessions.ts \
  src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts

PATH="/tmp/openclaw-bin:$PATH" \
  node node_modules/.pnpm/oxlint@1.48.0_oxlint-tsgolint@0.14.1/node_modules/oxlint/bin/oxlint \
  --type-aware \
  src/gateway/server-methods/sessions.ts \
  src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts

node node_modules/.pnpm/vitest@4.0.18_@opentelemetry+api@1.9.0_@types+node@25.3.0_@vitest+browser-playwright@4._c9688654361f600a6ea7cb5666ec9fae/node_modules/vitest/vitest.mjs \
  run --config vitest.e2e.config.ts \
  src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts
```

Result:

```text
✓ src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts (11 tests)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Control UI path now bypasses webchat mutation rejection and patch/delete succeed.
- Edge cases checked: Non-control webchat path still hits rejection guard.
- What you did **not** verify: Full end-to-end manual UI clicking outside automated test harness.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/gateway/server-methods/sessions.ts`
- Known bad symptoms reviewers should watch for: Control UI again receiving "webchat clients cannot patch/delete sessions".

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Misclassification of client IDs could accidentally broaden access.
  - Mitigation: Exemption is limited to exact `GATEWAY_CLIENT_IDS.CONTROL_UI`, and e2e coverage validates intended behavior.

---

AI-assisted: yes
Testing level: focused + e2e for changed behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a regression where Control UI (`openclaw-control-ui`) was incorrectly blocked from using `sessions.patch` and `sessions.delete` APIs. The guard function `rejectWebchatSessionMutation` now exempts Control UI before checking if a client is in webchat mode, allowing Control UI operators to manage sessions while keeping regular webchat clients restricted.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused bug fix with comprehensive test coverage
- The change is minimal, surgical, and well-tested. It adds a single conditional check that exempts Control UI from webchat mutation restrictions, which is the correct behavior. The implementation properly checks `connect.client?.id` against the constant `GATEWAY_CLIENT_IDS.CONTROL_UI`, and the new e2e test validates both patch and delete operations work for Control UI while the existing test confirms regular webchat clients remain blocked.
- No files require special attention

<sub>Last reviewed commit: 1fffc07</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->