### PR TITLE
fix(doctor): warn when gateway is network-exposed without TLS

### DIFF
--- a/src/commands/doctor-security.e2e.test.ts
+++ b/src/commands/doctor-security.e2e.test.ts
@@ -68,6 +68,30 @@ describe("noteSecurityWarnings gateway exposure", () => {
     expect(message).toContain("CRITICAL");
   });
 
+  it("warns about missing TLS on non-loopback bind", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "token-123";
+    const cfg = { gateway: { bind: "lan" } } as OpenClawConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).toContain("without TLS");
+    expect(message).toContain("gateway.tls.enabled");
+  });
+
+  it("skips TLS warning when TLS is enabled", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "token-123";
+    const cfg = { gateway: { bind: "lan", tls: { enabled: true } } } as OpenClawConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).not.toContain("without TLS");
+  });
+
+  it("skips TLS warning for loopback bind", async () => {
+    const cfg = { gateway: { bind: "loopback" } } as OpenClawConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).not.toContain("without TLS");
+  });
+
   it("skips warning for loopback bind", async () => {
     const cfg = { gateway: { bind: "loopback" } } as OpenClawConfig;
     await noteSecurityWarnings(cfg);

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -70,6 +70,16 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
         `  Ensure your auth credentials are strong and not exposed.`,
       );
     }
+
+    const tlsEnabled = cfg.gateway?.tls?.enabled === true;
+    if (!tlsEnabled) {
+      warnings.push(
+        `- WARNING: Gateway bound to ${bindDescriptor} without TLS.`,
+        `  Credentials and chat data are sent in plaintext on the network.`,
+        `  Fix: Enable TLS (${formatCliCommand("openclaw config set gateway.tls.enabled true")})`,
+        `  or use loopback binding (${formatCliCommand("openclaw config set gateway.bind loopback")}).`,
+      );
+    }
   }
 
   const warnDmPolicy = async (params: {


### PR DESCRIPTION
Doctor already warns when the gateway is bound to a non-loopback address without authentication. But it doesn't warn about missing TLS, which means credentials and chat data travel in plaintext on the network even when auth is configured.

This is especially relevant for Docker users with `bind: "lan"` who often skip TLS setup, and it's the underlying cause of the internal tool RPC security check blocking legitimate calls (#22104).

**Changes:**
- `doctor-security.ts`: add a TLS check inside the existing `isExposed` block. Warns with specific fix commands (enable TLS or switch to loopback)
- 3 new tests covering: warning shown, suppressed with TLS, suppressed for loopback

The warning only appears for non-loopback binds - loopback users are unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added TLS security check for network-exposed gateways. When the gateway is bound to a non-loopback address without TLS enabled, doctor now warns users that credentials and chat data travel in plaintext. The warning provides two remediation options: enable TLS or switch to loopback binding.

Key changes:
- Added TLS check in `doctor-security.ts` (lines 74-82) that only triggers for non-loopback binds
- Warning appears alongside existing auth warnings in the `isExposed` block
- Three new test cases cover: warning shown for LAN bind without TLS, suppressed when TLS enabled, and suppressed for loopback binds
- Uses consistent formatting with `formatCliCommand` helper for fix suggestions

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The implementation is well-structured, follows existing code patterns, and has comprehensive test coverage. The TLS check is correctly placed inside the `isExposed` block, ensuring it only triggers for network-exposed gateways. The logic properly handles edge cases (undefined config, TLS enabled, loopback binds), and the warning messages provide clear remediation steps using the established `formatCliCommand` helper.
- No files require special attention

<sub>Last reviewed commit: 48f1db1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->