### PR TITLE
feat(tui): queue user messages while a run is active

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -83,4 +83,65 @@ describe("tui command handlers", () => {
     expect(resetSession).toHaveBeenNthCalledWith(2, "agent:main:main", "reset");
     expect(loadHistory).toHaveBeenCalledTimes(2);
   });
+
+  it("queues messages while a run is active and flushes them in order", async () => {
+    const sendChat = vi.fn().mockResolvedValue({ runId: "r1" });
+    const addUser = vi.fn();
+    const addSystem = vi.fn();
+    const requestRender = vi.fn();
+    const setActivityStatus = vi.fn();
+    const state = {
+      currentSessionKey: "agent:main:main",
+      activeChatRunId: "active-run",
+      sessionInfo: {},
+    };
+
+    const { sendMessage, flushQueuedMessage } = createCommandHandlers({
+      client: { sendChat } as never,
+      chatLog: { addUser, addSystem } as never,
+      tui: { requestRender } as never,
+      opts: {},
+      state: state as never,
+      deliverDefault: false,
+      openOverlay: vi.fn(),
+      closeOverlay: vi.fn(),
+      refreshSessionInfo: vi.fn(),
+      loadHistory: vi.fn(),
+      setSession: vi.fn(),
+      refreshAgents: vi.fn(),
+      abortActive: vi.fn(),
+      setActivityStatus,
+      formatSessionKey: vi.fn(),
+      applySessionInfoFromPatch: vi.fn(),
+      noteLocalRunId: vi.fn(),
+      forgetLocalRunId: vi.fn(),
+    });
+
+    await sendMessage("first queued");
+    await sendMessage("second queued");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).toHaveBeenNthCalledWith(1, "first queued");
+    expect(addUser).toHaveBeenNthCalledWith(2, "second queued");
+    expect(addSystem).toHaveBeenNthCalledWith(1, "queued (1)");
+    expect(addSystem).toHaveBeenNthCalledWith(2, "queued (2)");
+
+    state.activeChatRunId = null;
+    await flushQueuedMessage();
+    expect(sendChat).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ message: "first queued", sessionKey: "agent:main:main" }),
+    );
+    expect(addSystem).toHaveBeenCalledWith("sending queued message (1 left)");
+
+    state.activeChatRunId = null;
+    await flushQueuedMessage();
+    expect(sendChat).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ message: "second queued", sessionKey: "agent:main:main" }),
+    );
+
+    expect(setActivityStatus).toHaveBeenCalledWith("sending");
+    expect(setActivityStatus).toHaveBeenCalledWith("waiting");
+  });
 });

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -90,7 +90,11 @@ describe("tui command handlers", () => {
     const addSystem = vi.fn();
     const requestRender = vi.fn();
     const setActivityStatus = vi.fn();
-    const state = {
+    const state: {
+      currentSessionKey: string;
+      activeChatRunId: string | null;
+      sessionInfo: Record<string, never>;
+    } = {
       currentSessionKey: "agent:main:main",
       activeChatRunId: "active-run",
       sessionInfo: {},

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -29,6 +29,7 @@ type EventHandlerContext = {
   isLocalRunId?: (runId: string) => boolean;
   forgetLocalRunId?: (runId: string) => void;
   clearLocalRunIds?: () => void;
+  onRunSettled?: (runId: string) => void;
 };
 
 export function createEventHandlers(context: EventHandlerContext) {
@@ -42,6 +43,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     isLocalRunId,
     forgetLocalRunId,
     clearLocalRunIds,
+    onRunSettled,
   } = context;
   const finalizedRuns = new Map<string, number>();
   const sessionRuns = new Map<string, number>();
@@ -157,6 +159,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         clearActiveRunIfMatch(evt.runId);
         if (wasActiveRun) {
           setActivityStatus("idle");
+          onRunSettled?.(evt.runId);
         }
         void refreshSessionInfo?.();
         tui.requestRender();
@@ -173,6 +176,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         clearActiveRunIfMatch(evt.runId);
         if (wasActiveRun) {
           setActivityStatus("idle");
+          onRunSettled?.(evt.runId);
         }
         void refreshSessionInfo?.();
         tui.requestRender();
@@ -198,6 +202,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       clearActiveRunIfMatch(evt.runId);
       if (wasActiveRun) {
         setActivityStatus(stopReason === "error" ? "error" : "idle");
+        onRunSettled?.(evt.runId);
       }
       // Refresh session info to update token counts in footer
       void refreshSessionInfo?.();
@@ -210,6 +215,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       clearActiveRunIfMatch(evt.runId);
       if (wasActiveRun) {
         setActivityStatus("aborted");
+        onRunSettled?.(evt.runId);
       }
       void refreshSessionInfo?.();
       maybeRefreshHistoryForRun(evt.runId);
@@ -222,6 +228,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       clearActiveRunIfMatch(evt.runId);
       if (wasActiveRun) {
         setActivityStatus("error");
+        onRunSettled?.(evt.runId);
       }
       void refreshSessionInfo?.();
       maybeRefreshHistoryForRun(evt.runId);

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -664,6 +664,34 @@ export async function runTui(opts: TuiOptions) {
     abortActive,
   } = sessionActions;
 
+  const {
+    handleCommand,
+    sendMessage,
+    flushQueuedMessage,
+    openModelSelector,
+    openAgentSelector,
+    openSessionSelector,
+  } = createCommandHandlers({
+    client,
+    chatLog,
+    tui,
+    opts,
+    state,
+    deliverDefault,
+    openOverlay,
+    closeOverlay,
+    refreshSessionInfo,
+    applySessionInfoFromPatch,
+    loadHistory,
+    setSession,
+    refreshAgents,
+    abortActive,
+    setActivityStatus,
+    formatSessionKey,
+    noteLocalRunId,
+    forgetLocalRunId,
+  });
+
   const { handleChatEvent, handleAgentEvent } = createEventHandlers({
     chatLog,
     tui,
@@ -674,29 +702,10 @@ export async function runTui(opts: TuiOptions) {
     isLocalRunId,
     forgetLocalRunId,
     clearLocalRunIds,
+    onRunSettled: () => {
+      void flushQueuedMessage();
+    },
   });
-
-  const { handleCommand, sendMessage, openModelSelector, openAgentSelector, openSessionSelector } =
-    createCommandHandlers({
-      client,
-      chatLog,
-      tui,
-      opts,
-      state,
-      deliverDefault,
-      openOverlay,
-      closeOverlay,
-      refreshSessionInfo,
-      applySessionInfoFromPatch,
-      loadHistory,
-      setSession,
-      refreshAgents,
-      abortActive,
-      setActivityStatus,
-      formatSessionKey,
-      noteLocalRunId,
-      forgetLocalRunId,
-    });
 
   const { runLocalShellLine } = createLocalShellRunner({
     chatLog,


### PR DESCRIPTION
## Summary
- queue user submissions in TUI when a run is already active instead of firing overlapping sends
- flush queued messages automatically when the active run settles (final, aborted, or error)
- keep queued messages visible in chat immediately and send them in FIFO order

## Implementation notes
- added an in-memory queue in `createCommandHandlers`
- added `flushQueuedMessage()` and wired it to event handling via `onRunSettled` callback
- avoids duplicate user chat-log entries when queued messages are later sent

## Tests
- `corepack pnpm vitest run src/tui/tui-command-handlers.test.ts src/tui/tui-event-handlers.test.ts src/tui/tui.submit-handler.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements message queuing in the TUI to prevent overlapping runs. When a user submits messages while a run is active, they're queued in FIFO order and automatically flushed when the run settles. The implementation adds a `queuedMessages` array in `tui-command-handlers.ts`, refactors the send logic into `sendMessageNow` and `sendMessage`, and wires `flushQueuedMessage` to an `onRunSettled` callback in the event handlers.

**Key changes:**
- Added in-memory queue that prevents duplicate sends when a run is active
- Queue automatically flushes on run completion (final, aborted, or error states)
- Queued messages appear immediately in chat with status indicators
- Comprehensive test coverage for the queuing behavior

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with very low risk
- The implementation is clean with proper test coverage. The queue logic is straightforward FIFO with clear state management. Only minor edge case around recursive flushing prevents a perfect score, but it's unlikely to cause issues in practice.
- No files require special attention

<sub>Last reviewed commit: 1143652</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->