### PR TITLE
iOS/Gateway: harden pairing resolution and settings-driven capability refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Watch: refresh iOS and watch app icon assets with the lobster icon set to keep phone/watch branding aligned. (#21997) Thanks @mbelinky.
 - CLI/Onboarding: fix Anthropic-compatible custom provider verification by normalizing base URLs to avoid duplicate `/v1` paths during setup checks. (#21336) Thanks @17jmumford.
 - Security/Dependencies: bump transitive `hono` usage to `4.11.10` to incorporate timing-safe authentication comparison hardening for `basicAuth`/`bearerAuth` (`GHSA-gq3j-xvxp-8hrf`). Thanks @vincentkoc.
+- iOS/Gateway/Tools: prefer uniquely connected node matches when duplicate display names exist, surface actionable `nodes invoke` pairing-required guidance with request IDs, and refresh active iOS gateway registration after location-capability setting changes so capability updates apply immediately. (#22120) thanks @mbelinky.
 
 ## 2026.2.19
 

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -216,6 +216,23 @@ final class GatewayConnectionController {
         }
     }
 
+    /// Rebuild connect options from current local settings (caps/commands/permissions)
+    /// and re-apply the active gateway config so capability changes take effect immediately.
+    func refreshActiveGatewayRegistrationFromSettings() {
+        guard let appModel else { return }
+        guard let cfg = appModel.activeGatewayConnectConfig else { return }
+        guard appModel.gatewayAutoReconnectEnabled else { return }
+
+        let refreshedConfig = GatewayConnectConfig(
+            url: cfg.url,
+            stableID: cfg.stableID,
+            tls: cfg.tls,
+            token: cfg.token,
+            password: cfg.password,
+            nodeOptions: self.makeConnectOptions(stableID: cfg.stableID))
+        appModel.applyGatewayConnectConfig(refreshedConfig)
+    }
+
     func clearPendingTrustPrompt() {
         self.pendingTrustPrompt = nil
         self.pendingTrustConnect = nil

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -461,6 +461,10 @@ struct SettingsTab: View {
                             self.locationEnabledModeRaw = previous
                             self.lastLocationModeRaw = previous
                         }
+                        return
+                    }
+                    await MainActor.run {
+                        self.gatewayController.refreshActiveGatewayRegistrationFromSettings()
                     }
                 }
             }

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -48,6 +48,20 @@ const NOTIFY_DELIVERIES = ["system", "overlay", "auto"] as const;
 const CAMERA_FACING = ["front", "back", "both"] as const;
 const LOCATION_ACCURACY = ["coarse", "balanced", "precise"] as const;
 
+function isPairingRequiredMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return lower.includes("pairing required") || lower.includes("not_paired");
+}
+
+function extractPairingRequestId(message: string): string | null {
+  const match = message.match(/\(requestId:\s*([^)]+)\)/i);
+  if (!match) {
+    return null;
+  }
+  const value = (match[1] ?? "").trim();
+  return value.length > 0 ? value : null;
+}
+
 // Flattened schema: runtime validates per-action requirements.
 const NodesToolSchema = Type.Object({
   action: stringEnum(NODES_TOOL_ACTIONS),
@@ -544,7 +558,14 @@ export function createNodesTool(options?: {
             ? gatewayOpts.gatewayUrl.trim()
             : "default";
         const agentLabel = agentId ?? "unknown";
-        const message = err instanceof Error ? err.message : String(err);
+        let message = err instanceof Error ? err.message : String(err);
+        if (action === "invoke" && isPairingRequiredMessage(message)) {
+          const requestId = extractPairingRequestId(message);
+          const approveHint = requestId
+            ? `Approve pairing request ${requestId} and retry.`
+            : "Approve the pending pairing request and retry.";
+          message = `pairing required before node invoke. ${approveHint}`;
+        }
         throw new Error(
           `agent=${agentLabel} node=${nodeLabel} gateway=${gatewayLabel} action=${action}: ${message}`,
           { cause: err },

--- a/src/shared/shared-misc.test.ts
+++ b/src/shared/shared-misc.test.ts
@@ -124,4 +124,28 @@ describe("resolveNodeIdFromCandidates", () => {
       resolveNodeIdFromCandidates([{ nodeId: "mac-abcdef" }, { nodeId: "mac-abc999" }], "mac-abc"),
     ).toThrow(/ambiguous node: mac-abc.*matches:/);
   });
+
+  it("prefers a unique connected node when names are duplicated", () => {
+    expect(
+      resolveNodeIdFromCandidates(
+        [
+          { nodeId: "ios-old", displayName: "iPhone", connected: false },
+          { nodeId: "ios-live", displayName: "iPhone", connected: true },
+        ],
+        "iphone",
+      ),
+    ).toBe("ios-live");
+  });
+
+  it("stays ambiguous when multiple connected nodes match", () => {
+    expect(() =>
+      resolveNodeIdFromCandidates(
+        [
+          { nodeId: "ios-a", displayName: "iPhone", connected: true },
+          { nodeId: "ios-b", displayName: "iPhone", connected: true },
+        ],
+        "iphone",
+      ),
+    ).toThrow(/ambiguous node: iphone.*matches:/);
+  });
 });


### PR DESCRIPTION
## Summary
- prefer connected node matches when duplicate display names exist
- improve `nodes invoke` pairing-required error text with actionable hint
- refresh active iOS gateway registration when settings permissions/capabilities change

## Files
- `src/shared/node-match.ts`
- `src/shared/shared-misc.test.ts`
- `src/agents/tools/nodes-tool.ts`
- `apps/ios/Sources/Gateway/GatewayConnectionController.swift`
- `apps/ios/Sources/Settings/SettingsTab.swift`

## Validation
- `pnpm test -- src/shared/shared-misc.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens pairing resolution and settings-driven capability refresh in iOS gateway connections. The changes address three main areas:

- **Node matching with duplicate names**: Modified `resolveNodeIdFromCandidates` in `src/shared/node-match.ts` to prefer connected nodes when multiple nodes share the same display name (common during re-pairing/reinstall flows)
- **Improved pairing error messages**: Enhanced `nodes-tool.ts` to extract pairing request IDs from error messages and provide actionable hints for users to approve pending pairing requests
- **iOS capability refresh**: Added `refreshActiveGatewayRegistrationFromSettings()` method to rebuild gateway registration when location permissions change, ensuring capability updates take effect immediately

The implementation is well-tested with new unit tests covering both the connected node preference logic and ambiguous match scenarios. The Swift code follows proper guard patterns and MainActor execution for UI updates.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with noted capability refresh gaps for camera and voice wake settings
- The core changes are well-implemented with proper tests and guard clauses. However, the PR introduces capability refresh for location settings but misses the same pattern for camera and voice wake settings, creating an inconsistent user experience where some capability changes take effect immediately while others require reconnection
- apps/ios/Sources/Settings/SettingsTab.swift needs refresh calls added for camera and voice wake toggles to match the location setting pattern

<sub>Last reviewed commit: 41bbd41</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->