### PR TITLE
fix: resolve cross-context messaging policy from agent defaults

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -37,6 +37,24 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts agents.defaults.tools.message cross-context configuration", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          tools: {
+            message: {
+              crossContext: {
+                allowAcrossProviders: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts safe iMessage remoteHost", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -104,6 +104,20 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
+  "agents.defaults.tools.message.allowCrossContextSend":
+    "Default for cross-context messaging across providers and channels (legacy override).",
+  "agents.defaults.tools.message.crossContext.allowWithinProvider":
+    "Default: allow sends to other channels within the same provider.",
+  "agents.defaults.tools.message.crossContext.allowAcrossProviders":
+    "Default: allow sends across providers.",
+  "agents.defaults.tools.message.crossContext.marker.enabled":
+    "Default: add visible origin marker for cross-context messages.",
+  "agents.defaults.tools.message.crossContext.marker.prefix":
+    'Default prefix for cross-context marker (supports "{channel}").',
+  "agents.defaults.tools.message.crossContext.marker.suffix":
+    'Default suffix for cross-context marker (supports "{channel}").',
+  "agents.defaults.tools.message.broadcast.enabled":
+    "Default: allow broadcast action for message tool.",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -134,6 +134,15 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.envelopeTimezone": "Envelope Timezone",
   "agents.defaults.envelopeTimestamp": "Envelope Timestamp",
   "agents.defaults.envelopeElapsed": "Envelope Elapsed",
+  "agents.defaults.tools.message.allowCrossContextSend": "Default Cross-Context Messaging",
+  "agents.defaults.tools.message.crossContext.allowWithinProvider":
+    "Default Cross-Context (Same Provider)",
+  "agents.defaults.tools.message.crossContext.allowAcrossProviders":
+    "Default Cross-Context (Across Providers)",
+  "agents.defaults.tools.message.crossContext.marker.enabled": "Default Cross-Context Marker",
+  "agents.defaults.tools.message.crossContext.marker.prefix": "Default Cross-Context Marker Prefix",
+  "agents.defaults.tools.message.crossContext.marker.suffix": "Default Cross-Context Marker Suffix",
+  "agents.defaults.tools.message.broadcast.enabled": "Default Message Broadcast",
   "agents.defaults.memorySearch": "Memory Search",
   "agents.defaults.memorySearch.enabled": "Enable Memory Search",
   "agents.defaults.memorySearch.sources": "Memory Search Sources",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -10,7 +10,7 @@ import type {
   SandboxDockerSettings,
   SandboxPruneSettings,
 } from "./types.sandbox.js";
-import type { MemorySearchConfig } from "./types.tools.js";
+import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
 export type AgentModelEntryConfig = {
   alias?: string;
@@ -164,6 +164,8 @@ export type AgentDefaultsConfig = {
   compaction?: AgentCompactionConfig;
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;
+  /** Tool policy defaults for all agents (overridden by `agents.list[].tools`). */
+  tools?: AgentToolsConfig;
   /** Default thinking level when no /think directive is present. */
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Default verbose level when no /verbose directive is present. */

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -252,6 +252,33 @@ export type AgentToolsConfig = {
   fs?: FsToolsConfig;
   /** Runtime loop detection for repetitive/ stuck tool-call patterns. */
   loopDetection?: ToolLoopDetectionConfig;
+  /** Message tool configuration. */
+  message?: {
+    /**
+     * @deprecated Use tools.message.crossContext settings.
+     * Allows cross-context sends across providers.
+     */
+    allowCrossContextSend?: boolean;
+    crossContext?: {
+      /** Allow sends to other channels within the same provider (default: true). */
+      allowWithinProvider?: boolean;
+      /** Allow sends across different providers (default: false). */
+      allowAcrossProviders?: boolean;
+      /** Cross-context marker configuration. */
+      marker?: {
+        /** Enable origin markers for cross-context sends (default: true). */
+        enabled?: boolean;
+        /** Text prefix template, supports {channel}. */
+        prefix?: string;
+        /** Text suffix template, supports {channel}. */
+        suffix?: string;
+      };
+    };
+    broadcast?: {
+      /** Enable broadcast action (default: true). */
+      enabled?: boolean;
+    };
+  };
   sandbox?: {
     tools?: {
       allow?: string[];

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -55,6 +55,38 @@ export const AgentDefaultsSchema = z
     contextTokens: z.number().int().positive().optional(),
     cliBackends: z.record(z.string(), CliBackendSchema).optional(),
     memorySearch: MemorySearchSchema,
+    tools: z
+      .object({
+        message: z
+          .object({
+            allowCrossContextSend: z.boolean().optional(),
+            crossContext: z
+              .object({
+                allowWithinProvider: z.boolean().optional(),
+                allowAcrossProviders: z.boolean().optional(),
+                marker: z
+                  .object({
+                    enabled: z.boolean().optional(),
+                    prefix: z.string().optional(),
+                    suffix: z.string().optional(),
+                  })
+                  .strict()
+                  .optional(),
+              })
+              .strict()
+              .optional(),
+            broadcast: z
+              .object({
+                enabled: z.boolean().optional(),
+              })
+              .strict()
+              .optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
     contextPruning: z
       .object({
         mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -192,6 +192,7 @@ async function maybeApplyCrossContextMarker(params: {
   args: Record<string, unknown>;
   message: string;
   preferComponents: boolean;
+  agentId?: string;
 }): Promise<string> {
   if (!shouldApplyCrossContextMarker(params.action) || !params.toolContext) {
     return params.message;
@@ -202,6 +203,7 @@ async function maybeApplyCrossContextMarker(params: {
     target: params.target,
     toolContext: params.toolContext,
     accountId: params.accountId ?? undefined,
+    agentId: params.agentId,
   });
   if (!decoration) {
     return params.message;
@@ -458,6 +460,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     args: params,
     message,
     preferComponents: true,
+    agentId,
   });
 
   const mediaUrl = readStringParam(params, "media", { trim: false });
@@ -560,7 +563,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
 }
 
 async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
-  const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal } = ctx;
+  const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal, agentId } = ctx;
   throwIfAborted(abortSignal);
   const action: ChannelMessageActionName = "poll";
   const to = readStringParam(params, "to", { required: true });
@@ -612,6 +615,7 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
     args: params,
     message: base,
     preferComponents: false,
+    agentId,
   });
 
   const poll = await executePollAction({
@@ -795,6 +799,7 @@ export async function runMessageAction(
     args: params,
     toolContext: input.toolContext,
     cfg,
+    agentId: resolvedAgentId,
   });
 
   const gateway = resolveGateway(input);
@@ -823,6 +828,7 @@ export async function runMessageAction(
       dryRun,
       gateway,
       input,
+      agentId: resolvedAgentId,
       abortSignal: input.abortSignal,
     });
   }

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -605,6 +605,80 @@ describe("outbound policy", () => {
     ).not.toThrow();
   });
 
+  it("uses agents.defaults.tools.message for cross-context policy", () => {
+    const cfg = {
+      ...slackConfig,
+      tools: {
+        message: { crossContext: { allowAcrossProviders: false } },
+      },
+      agents: {
+        defaults: {
+          tools: {
+            message: {
+              crossContext: {
+                allowAcrossProviders: true,
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(() =>
+      enforceCrossContextPolicy({
+        cfg,
+        channel: "telegram",
+        action: "send",
+        args: { to: "telegram:@ops" },
+        toolContext: { currentChannelId: "C12345678", currentChannelProvider: "slack" },
+        agentId: "main",
+      }),
+    ).not.toThrow();
+  });
+
+  it("prioritizes agent message policy over defaults when resolving cross-context", () => {
+    const cfg = {
+      ...slackConfig,
+      tools: {
+        message: { crossContext: { allowAcrossProviders: false } },
+      },
+      agents: {
+        defaults: {
+          tools: {
+            message: {
+              crossContext: {
+                allowAcrossProviders: false,
+              },
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            tools: {
+              message: {
+                crossContext: {
+                  allowAcrossProviders: true,
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(() =>
+      enforceCrossContextPolicy({
+        cfg,
+        channel: "telegram",
+        action: "send",
+        args: { to: "telegram:@ops" },
+        toolContext: { currentChannelId: "C12345678", currentChannelProvider: "slack" },
+        agentId: "main",
+      }),
+    ).not.toThrow();
+  });
+
   it("uses components when available and preferred", async () => {
     const decoration = await buildCrossContextDecoration({
       cfg: discordConfig,


### PR DESCRIPTION
## Summary
- Implement cross-context policy resolution precedence across global config, `agents.defaults.tools.message`, and per-agent `tools.message`.
- Apply `agents.defaults.tools.message` and agent tool overrides when evaluating:
  - cross-context send denial in `enforceCrossContextPolicy`
  - cross-context marker decoration in `buildCrossContextDecoration`
- Thread `agentId` through outbound message execution paths so policy context is resolved consistently for send/poll actions.
- Extend config schema + types so `agents.defaults.tools.message.*` is valid and typed.
- Add UI labels/help entries for new `agents.defaults.tools.message` paths.
- Add regression tests for precedence and schema acceptance in:
  - `src/config/config.schema-regressions.test.ts`
  - `src/infra/outbound/outbound.test.ts`

## Testing
- `pnpm vitest run src/config/config.schema-regressions.test.ts src/infra/outbound/outbound.test.ts`

## Notes
Closes #22052.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a three-tier policy resolution for cross-context messaging: per-agent `tools.message` > `agents.defaults.tools.message` > global `tools.message`. The core `resolveMessagePolicy` function in `outbound-policy.ts` correctly merges these layers using nullish coalescing, and `agentId` is properly threaded through send/poll execution paths in `message-action-runner.ts`.

- Config schema (`zod-schema.agent-defaults.ts`), types, UI labels, and help entries are all extended to support the new `agents.defaults.tools.message.*` paths.
- Two regression tests verify defaults override global config and per-agent overrides take priority over defaults.
- Schema regression test confirms the new config paths validate correctly.
- `handleBroadcastAction` still reads `broadcast.enabled` directly from global config (`cfg.tools?.message?.broadcast?.enabled`), so the newly-exposed `agents.defaults.tools.message.broadcast.enabled` config path has no runtime effect — this is a gap that should be addressed.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, but the broadcast policy gap means one advertised config path is silently ignored at runtime.
- The core cross-context policy resolution is well-implemented with correct precedence logic and consistent agentId threading. However, the broadcast.enabled check in handleBroadcastAction is not wired through the new resolveMessagePolicy, creating a discrepancy between the config surface (schema/types/labels/help all accept agents.defaults.tools.message.broadcast.enabled) and actual runtime behavior (only global config is consulted). Tests cover positive precedence cases but not the negative restriction case or broadcast policy resolution.
- Pay close attention to `src/infra/outbound/message-action-runner.ts` — the `handleBroadcastAction` function at line 304 does not use the new policy resolution chain for `broadcast.enabled`.

<sub>Last reviewed commit: d695d01</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->