### PR TITLE
iOS Chat: clean UI noise and format tool outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Channels/CLI: add per-account/channel `defaultTo` outbound routing fallback so `openclaw agent --deliver` can send without explicit `--reply-to` when a default target is configured. (#16985) Thanks @KirillShchetinin.
+- iOS/Chat: clean chat UI noise by stripping inbound untrusted metadata/timestamp prefixes, formatting tool outputs into concise summaries/errors, compacting the composer while typing, and supporting tap-to-dismiss keyboard in chat view. (#22122) thanks @mbelinky.
 - iOS/Tests: cover IPv4-mapped IPv6 loopback in manual TLS policy tests for connect validation paths. (#22045) Thanks @mbelinky.
 - iOS/Gateway: stabilize background wake and reconnect behavior with background reconnect suppression/lease windows, BGAppRefresh wake fallback, location wake hook throttling, and APNs wake retry+nudge instrumentation. (#21226) thanks @mbelinky.
 - Auto-reply/UI: add model fallback lifecycle visibility in verbose logs, /status active-model context with fallback reason, and cohesive WebUI fallback indicators. (#20704) Thanks @joshavant.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -180,10 +180,12 @@ struct OpenClawChatComposer: View {
         VStack(alignment: .leading, spacing: 8) {
             self.editorOverlay
 
-            Rectangle()
-                .fill(OpenClawChatTheme.divider)
-                .frame(height: 1)
-                .padding(.horizontal, 2)
+            if !self.isComposerCompacted {
+                Rectangle()
+                    .fill(OpenClawChatTheme.divider)
+                    .frame(height: 1)
+                    .padding(.horizontal, 2)
+            }
 
             HStack(alignment: .center, spacing: 8) {
                 if self.showsConnectionPill {
@@ -308,7 +310,7 @@ struct OpenClawChatComposer: View {
     }
 
     private var showsToolbar: Bool {
-        self.style == .standard
+        self.style == .standard && !self.isComposerCompacted
     }
 
     private var showsAttachments: Bool {
@@ -316,15 +318,15 @@ struct OpenClawChatComposer: View {
     }
 
     private var showsConnectionPill: Bool {
-        self.style == .standard
+        self.style == .standard && !self.isComposerCompacted
     }
 
     private var composerPadding: CGFloat {
-        self.style == .onboarding ? 5 : 6
+        self.style == .onboarding ? 5 : (self.isComposerCompacted ? 4 : 6)
     }
 
     private var editorPadding: CGFloat {
-        self.style == .onboarding ? 5 : 6
+        self.style == .onboarding ? 5 : (self.isComposerCompacted ? 4 : 6)
     }
 
     private var textMinHeight: CGFloat {
@@ -333,6 +335,14 @@ struct OpenClawChatComposer: View {
 
     private var textMaxHeight: CGFloat {
         self.style == .onboarding ? 52 : 64
+    }
+
+    private var isComposerCompacted: Bool {
+        #if os(macOS)
+        false
+        #else
+        self.style == .standard && self.isFocused
+        #endif
     }
 
     #if os(macOS)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 @MainActor
 public struct OpenClawChatView: View {
@@ -105,6 +108,9 @@ public struct OpenClawChatView: View {
                 .padding(.top, Layout.messageListPaddingTop)
                 .padding(.horizontal, Layout.messageListPaddingHorizontal)
             }
+            #if !os(macOS)
+            .scrollDismissesKeyboard(.interactively)
+            #endif
             // Keep the scroll pinned to the bottom for new messages.
             .scrollPosition(id: self.$scrollPosition, anchor: .bottom)
             .onChange(of: self.scrollPosition) { _, position in
@@ -123,6 +129,10 @@ public struct OpenClawChatView: View {
         // Ensure the message list claims vertical space on the first layout pass.
         .frame(maxHeight: .infinity, alignment: .top)
         .layoutPriority(1)
+        .simultaneousGesture(
+            TapGesture().onEnded {
+                self.dismissKeyboardIfNeeded()
+            })
         .onChange(of: self.viewModel.isLoading) { _, isLoading in
             guard !isLoading, !self.hasPerformedInitialScroll else { return }
             self.scrollPosition = self.scrollerBottomID
@@ -405,6 +415,16 @@ public struct OpenClawChatView: View {
             return content.text
         }
         return parts.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func dismissKeyboardIfNeeded() {
+        #if canImport(UIKit)
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil)
+        #endif
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+enum ToolResultTextFormatter {
+    static func format(text: String, toolName: String?) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+
+        guard self.looksLikeJSON(trimmed),
+              let data = trimmed.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data)
+        else {
+            return trimmed
+        }
+
+        let normalizedTool = toolName?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return self.renderJSON(json, toolName: normalizedTool)
+    }
+
+    private static func looksLikeJSON(_ value: String) -> Bool {
+        guard let first = value.first else { return false }
+        return first == "{" || first == "["
+    }
+
+    private static func renderJSON(_ json: Any, toolName: String?) -> String {
+        if let dict = json as? [String: Any] {
+            return self.renderDictionary(dict, toolName: toolName)
+        }
+        if let array = json as? [Any] {
+            if array.isEmpty { return "No items." }
+            return "\(array.count) item\(array.count == 1 ? "" : "s")."
+        }
+        return ""
+    }
+
+    private static func renderDictionary(_ dict: [String: Any], toolName: String?) -> String {
+        let status = (dict["status"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let errorText = self.firstString(in: dict, keys: ["error", "reason"])
+        let messageText = self.firstString(in: dict, keys: ["message", "result", "detail"])
+
+        if status?.lowercased() == "error" || errorText != nil {
+            if let errorText {
+                return "Error: \(self.sanitizeError(errorText))"
+            }
+            if let messageText {
+                return "Error: \(self.sanitizeError(messageText))"
+            }
+            return "Error"
+        }
+
+        if toolName == "nodes", let summary = self.renderNodesSummary(dict) {
+            return summary
+        }
+
+        if let message = messageText {
+            return message
+        }
+
+        if let status, !status.isEmpty {
+            return "Status: \(status)"
+        }
+
+        return ""
+    }
+
+    private static func renderNodesSummary(_ dict: [String: Any]) -> String? {
+        if let nodes = dict["nodes"] as? [[String: Any]] {
+            if nodes.isEmpty { return "No nodes found." }
+            var lines: [String] = []
+            lines.append("\(nodes.count) node\(nodes.count == 1 ? "" : "s") found.")
+
+            for node in nodes.prefix(3) {
+                let label = self.firstString(in: node, keys: ["displayName", "name", "nodeId"]) ?? "Node"
+                var details: [String] = []
+
+                if let connected = node["connected"] as? Bool {
+                    details.append(connected ? "connected" : "offline")
+                }
+                if let platform = self.firstString(in: node, keys: ["platform"]) {
+                    details.append(platform)
+                }
+                if let version = self.firstString(in: node, keys: ["osVersion", "appVersion", "version"]) {
+                    details.append(version)
+                }
+                if let pairing = self.pairingDetail(node) {
+                    details.append(pairing)
+                }
+
+                if details.isEmpty {
+                    lines.append("• \(label)")
+                } else {
+                    lines.append("• \(label) - \(details.joined(separator: ", "))")
+                }
+            }
+
+            let extra = nodes.count - 3
+            if extra > 0 {
+                lines.append("... +\(extra) more")
+            }
+            return lines.joined(separator: "\n")
+        }
+
+        if let pending = dict["pending"] as? [Any], let paired = dict["paired"] as? [Any] {
+            return "Pairing requests: \(pending.count) pending, \(paired.count) paired."
+        }
+
+        if let pending = dict["pending"] as? [Any] {
+            if pending.isEmpty { return "No pending pairing requests." }
+            return "\(pending.count) pending pairing request\(pending.count == 1 ? "" : "s")."
+        }
+
+        return nil
+    }
+
+    private static func pairingDetail(_ node: [String: Any]) -> String? {
+        if let paired = node["paired"] as? Bool, !paired {
+            return "pairing required"
+        }
+
+        for key in ["status", "state", "deviceStatus"] {
+            if let raw = node[key] as? String, raw.lowercased().contains("pairing required") {
+                return "pairing required"
+            }
+        }
+        return nil
+    }
+
+    private static func firstString(in dict: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            if let value = dict[key] as? String {
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    return trimmed
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func sanitizeError(_ raw: String) -> String {
+        var cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.contains("agent="),
+           cleaned.contains("action="),
+           let marker = cleaned.range(of: ": ")
+        {
+            cleaned = String(cleaned[marker.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        if let firstLine = cleaned.split(separator: "\n").first {
+            cleaned = String(firstLine).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        if cleaned.count > 220 {
+            cleaned = String(cleaned.prefix(217)) + "..."
+        }
+        return cleaned
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
@@ -17,4 +17,39 @@ struct ChatMarkdownPreprocessorTests {
         #expect(result.images.count == 1)
         #expect(result.images.first?.image != nil)
     }
+
+    @Test func stripsInboundUntrustedContextBlocks() {
+        let markdown = """
+        Conversation info (untrusted metadata):
+        ```json
+        {
+          "message_id": "123",
+          "sender": "openclaw-ios"
+        }
+        ```
+
+        Sender (untrusted metadata):
+        ```json
+        {
+          "label": "Razor"
+        }
+        ```
+
+        Razor?
+        """
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Razor?")
+    }
+
+    @Test func stripsLeadingTimestampPrefix() {
+        let markdown = """
+        [Fri 2026-02-20 18:45 GMT+1] How's it going?
+        """
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "How's it going?")
+    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
@@ -1,0 +1,54 @@
+import Testing
+@testable import OpenClawChatUI
+
+@Suite("ToolResultTextFormatter")
+struct ToolResultTextFormatterTests {
+    @Test func leavesPlainTextUntouched() {
+        let result = ToolResultTextFormatter.format(text: "All good", toolName: "nodes")
+        #expect(result == "All good")
+    }
+
+    @Test func summarizesNodesListJSON() {
+        let json = """
+        {
+          "ts": 1771610031380,
+          "nodes": [
+            {
+              "displayName": "iPhone 16 Pro Max",
+              "connected": true,
+              "platform": "ios"
+            }
+          ]
+        }
+        """
+
+        let result = ToolResultTextFormatter.format(text: json, toolName: "nodes")
+        #expect(result.contains("1 node found."))
+        #expect(result.contains("iPhone 16 Pro Max"))
+        #expect(result.contains("connected"))
+    }
+
+    @Test func summarizesErrorJSONAndDropsAgentPrefix() {
+        let json = """
+        {
+          "status": "error",
+          "tool": "nodes",
+          "error": "agent=main node=iPhone gateway=default action=invoke: pairing required"
+        }
+        """
+
+        let result = ToolResultTextFormatter.format(text: json, toolName: "nodes")
+        #expect(result == "Error: pairing required")
+    }
+
+    @Test func suppressesUnknownStructuredPayload() {
+        let json = """
+        {
+          "foo": "bar"
+        }
+        """
+
+        let result = ToolResultTextFormatter.format(text: json, toolName: "nodes")
+        #expect(result.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- hide inbound untrusted metadata blocks and timestamp prefixes from rendered chat text
- add structured tool-result formatter to suppress raw JSON noise and show concise summaries/errors
- compact composer while typing and dismiss keyboard by tapping chat area
- remove redundant "thinking..." text while keeping typing indicator dots

## Files
- `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift`
- `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift`
- `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift`
- `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift`
- `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift`
- `apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift`
- `apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift`

## Validation
- `cd apps/shared/OpenClawKit && swift test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Cleaned up iOS chat UI by hiding inbound metadata blocks and timestamp prefixes, added structured tool-result formatter to suppress raw JSON noise, compacted composer while typing with keyboard dismiss on chat tap, and removed redundant "thinking..." text while keeping typing indicator.

- Added `ChatMarkdownPreprocessor` filters to strip untrusted metadata context blocks and timestamp prefixes from rendered chat text
- Introduced `ToolResultTextFormatter` to format raw JSON tool results into concise summaries (e.g., nodes list, error messages)
- Modified `ChatComposer` to compact UI on iOS when focused (hides toolbar, connection pill, and divider)
- Added tap-to-dismiss keyboard gesture on `ChatView` for iOS
- Removed "OpenClaw is thinking..." text from typing indicator bubble
- All changes include corresponding test coverage

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean UI improvements with comprehensive test coverage. All changes are isolated to iOS chat UI components with proper platform conditionals. New formatter logic is well-tested and defensive (returns original text on parse failures). No breaking changes or security concerns.
- No files require special attention

<sub>Last reviewed commit: 3e4e1f7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->