### PR TITLE
iOS Watch: bridge mirrored notification actions into quick replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Channels/CLI: add per-account/channel `defaultTo` outbound routing fallback so `openclaw agent --deliver` can send without explicit `--reply-to` when a default target is configured. (#16985) Thanks @KirillShchetinin.
 - iOS/Chat: clean chat UI noise by stripping inbound untrusted metadata/timestamp prefixes, formatting tool outputs into concise summaries/errors, compacting the composer while typing, and supporting tap-to-dismiss keyboard in chat view. (#22122) thanks @mbelinky.
+- iOS/Watch: bridge mirrored watch prompt notification actions into iOS quick-reply handling, including queued action handoff until app model initialization. (#22123) thanks @mbelinky.
 - iOS/Tests: cover IPv4-mapped IPv6 loopback in manual TLS policy tests for connect validation paths. (#22045) Thanks @mbelinky.
 - iOS/Gateway: stabilize background wake and reconnect behavior with background reconnect suppression/lease windows, BGAppRefresh wake fallback, location wake hook throttling, and APNs wake retry+nudge instrumentation. (#21226) thanks @mbelinky.
 - Auto-reply/UI: add model fallback lifecycle visibility in verbose logs, /status active-model context with fallback reason, and cohesive WebUI fallback indicators. (#20704) Thanks @joshavant.


### PR DESCRIPTION
## Summary
- add iOS notification bridge plumbing for mirrored watch prompt actions
- route approve/decline actions tapped from mirrored notifications into `NodeAppModel` quick-reply flow
- queue pending notification actions until app model is available

## Files
- `apps/ios/Sources/OpenClawApp.swift`
- `apps/ios/Sources/Model/NodeAppModel.swift`

## Validation
- targeted behavior validated via manual e2e flow during watch approval testing
- note: full `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` currently fails on existing baseline issue in `GatewayConnectionController.swift` (`ntohl` symbol), not introduced by this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented iOS notification bridge to route mirrored watch prompt actions into the quick-reply flow. When watch notifications fail immediate delivery, the system schedules equivalent iOS notifications with actionable buttons, queuing actions until `NodeAppModel` is available.

- Added `UNUserNotificationCenterDelegate` protocol conformance to handle notification actions
- Created `WatchPromptNotificationBridge` enum with notification scheduling and category management
- Implemented pending action queue pattern that mirrors existing APNs token pattern
- Extended `NodeAppModel` with `handleMirroredWatchPromptAction` to bridge actions into `WatchQuickReplyEvent` flow

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logic fix required
- Code follows established patterns and integrates cleanly with existing notification and quick-reply infrastructure. One critical force-unwrap bug needs addressing before merge. The queueing mechanism correctly mirrors the existing APNs token pattern. Extensive input validation with whitespace trimming throughout.
- Check `apps/ios/Sources/OpenClawApp.swift` line 439 for the force unwrap fix

<sub>Last reviewed commit: 06c1ca1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->