### PR TITLE
fix(agents): remove non-existent WORKFLOW_AUTO.md from post-compaction audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Compaction: remove non-existent `WORKFLOW_AUTO.md` from post-compaction audit required reads so the audit no longer tells agents to read a file that does not exist. (#21957)
 - Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.
 - Gateway/Auth: allow trusted-proxy mode with loopback bind for same-host reverse-proxy deployments, while still requiring configured `gateway.trustedProxies`. (#20097) thanks @xinhuagu.
 - Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.

--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 
 // Default required files — constants, extensible to config later
 const DEFAULT_REQUIRED_READS: Array<string | RegExp> = [
-  "WORKFLOW_AUTO.md",
   /memory\/\d{4}-\d{2}-\d{2}\.md/, // daily memory files
 ];
 


### PR DESCRIPTION
## Summary

- **Bug**: Post-compaction audit requires reading `WORKFLOW_AUTO.md`, but this file does not exist in the workspace
- **Root cause**: `DEFAULT_REQUIRED_READS` in `post-compaction-audit.ts` hardcodes `WORKFLOW_AUTO.md` which was never created
- **Fix**: Remove `WORKFLOW_AUTO.md` from the default required reads list

Fixes #21957

## Problem

After auto-compaction, the post-compaction read audit checks whether the agent has read certain required startup files. `DEFAULT_REQUIRED_READS` includes `WORKFLOW_AUTO.md`, but this file:

1. Does not exist anywhere in the repository
2. Is not listed in the canonical workspace file documentation (`docs/concepts/agent-workspace.md`)
3. Was never created as part of the workspace setup

This causes the audit to always fail for `WORKFLOW_AUTO.md`, generating a warning that tells the agent to read a non-existent file — leading to a confusing loop where the agent tries and fails to read it.

**Before fix:**
Input:  Agent reads all real workspace files (`AGENTS.md`, `SOUL.md`, `memory/2026-02-21.md`, etc.)
Output: Audit fails with `missingPatterns: ["WORKFLOW_AUTO.md"]` and warns agent to read it

## Changes

- `src/auto-reply/reply/post-compaction-audit.ts` — Remove `WORKFLOW_AUTO.md` from `DEFAULT_REQUIRED_READS`
- `src/auto-reply/reply/post-compaction-audit.test.ts` — Update tests to reflect removal; add regression tests for #21957

**After fix:**
Input:  Agent reads daily memory file (`memory/2026-02-21.md`)
Output: Audit passes, no spurious warning about non-existent file

## Test plan

- [x] New test: regression #21957 — audit does not require `WORKFLOW_AUTO.md`
- [x] New test: regression #21957 — audit warning never mentions `WORKFLOW_AUTO.md`
- [x] All 16 existing + new tests pass
- [x] Related `post-compaction-context.test.ts` (10 tests) still passes
- [x] Format check passes

## Effect on User Experience

**Before:** After context compaction, the agent receives a warning to read `WORKFLOW_AUTO.md`. The agent attempts to read it, fails (file not found), and may retry or get confused.
**After:** The audit only checks for files that actually exist in the workspace (daily memory files). No spurious warnings after compaction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the non-existent `WORKFLOW_AUTO.md` from the `DEFAULT_REQUIRED_READS` array in the post-compaction audit, fixing a bug where agents were warned to read a file that was never created.

- Removed `"WORKFLOW_AUTO.md"` from `DEFAULT_REQUIRED_READS` in `post-compaction-audit.ts`, leaving only the daily memory file regex pattern
- Updated existing tests to reflect that only `memory/*.md` is required, and added two regression tests ensuring `WORKFLOW_AUTO.md` is never required or mentioned in audit warnings
- Added changelog entry documenting the fix

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it removes a reference to a file that never existed, eliminating a guaranteed audit failure.
- The change is minimal and well-targeted: one line removed from a constant array, with comprehensive test updates and regression tests. The removed string literal referenced a file that was never committed to the repository. The function signature and behavior are otherwise unchanged, and the consuming code in agent-runner.ts requires no modifications.
- No files require special attention.

<sub>Last reviewed commit: faeb0d6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->