### PR TITLE
chore: Dedupe sent-message cache storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Dev tooling: add dead-code scans to CI via Knip/ts-prune/ts-unused-exports and report unused dependencies/exports in non-blocking checks. (#22468) Thanks @vincentkoc.
 - Dev tooling: move `@larksuiteoapi/node-sdk` out of root `package.json` and keep it scoped to `extensions/feishu` where it is used. (#22471) Thanks @vincentkoc.
 - Dev tooling: remove unused root dependency `signal-utils` from core manifest after confirming it was only used by extension-only paths. (#22471) Thanks @vincentkoc.
+- Telegram: dedupe sent-message cache storage by removing redundant per-chat Set tracking and using the timestamp map as the single source of truth. (#22127) thanks @TaKO8Ki.
 - Agents/Subagents: default subagent spawn depth now uses shared `maxSpawnDepth=2`, enabling depth-1 orchestrator spawning by default while keeping depth policy checks consistent across spawn and prompt paths. (#22223) Thanks @tyler6204.
 - Channels/CLI: add per-account/channel `defaultTo` outbound routing fallback so `openclaw agent --deliver` can send without explicit `--reply-to` when a default target is configured. (#16985) Thanks @KirillShchetinin.
 - iOS/Chat: clean chat UI noise by stripping inbound untrusted metadata/timestamp prefixes, formatting tool outputs into concise summaries/errors, compacting the composer while typing, and supporting tap-to-dismiss keyboard in chat view. (#22122) thanks @mbelinky.


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
  - `src/telegram/sent-message-cache.ts` stored each message ID twice (Set + Map), duplicating in-memory state.
- Why it matters:
  - Duplicate storage increases memory usage.
- What changed:
  - Removed messageIds: `Set<number>` from `CacheEntry`.
  - Kept timestamps: `Map<number, number>` as the single source of truth.
  - Replaced membership check with `timestamps.has(messageId)`.
  - Updated periodic cleanup size check to use `timestamps.size`.
- What did NOT change (scope boundary):
  - No behavior changes

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

None

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

`pnpm test src/telegram/send.test.ts` passed (59/59).

### Environment

- OS: Linux
- Runtime/container: Node.js 24 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): default test config

### Steps

1. Checkout branch `fix/telegram-sent-message-cache-dedupe`.
2. Run `pnpm test src/telegram/send.test.ts`.
3. Observe test summary.

### Expected

- Telegram send/cache tests pass with no regressions.

### Actual

- `✓ src/telegram/send.test.ts (59 tests)`
- `Test Files 1 passed (1), Tests 59 passed (59)`

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification log:

- Command: pnpm test src/telegram/send.test.ts
- Result: ✓ src/telegram/send.test.ts (59 tests)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
    - Confirmed recordSentMessage() still records sent IDs.
    - Confirmed wasSentByBot() still returns expected true/false for existing/missing IDs.
    - Confirmed TTL cleanup path still executes and stale IDs are removed.
- Edge cases checked:
    - Numeric and string chat IDs are still normalized and work the same.
    - Empty/missing cache entries still return false.
- What you did not verify:
    - Long-running production memory profiling under real Telegram traffic.
    - Full end-to-end Telegram reaction flow in a live bot.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
    - Revert commit 53a94de5c (or the PR commit SHA) on branch/main.
- Files/config to restore:
    - src/telegram/sent-message-cache.ts
- Known bad symptoms reviewers should watch for:
    - Reactions in reactionNotifications: "own" mode not being recognized for bot-sent messages.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed duplicate in-memory storage in Telegram sent-message cache by eliminating the redundant `messageIds` Set. The `timestamps` Map already tracks message IDs as keys, making the separate Set unnecessary. All membership checks now use `timestamps.has(messageId)` and the periodic cleanup size check uses `timestamps.size`. This reduces memory footprint without changing behavior—tests confirm the cache still correctly records and identifies bot-sent messages for reaction filtering in "own" mode.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a simple, well-contained refactoring that removes duplicate data storage. The Map's keys already provide membership tracking, making the Set redundant. All test cases pass (59/59), confirming that `recordSentMessage()` and `wasSentByBot()` maintain identical behavior. The cleanup logic and size-based triggering also work correctly with just the Map. No edge cases or potential issues identified.
- No files require special attention

<sub>Last reviewed commit: 7d3f623</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->