### PR TITLE
fix: clear seqByRun entries in clearAgentRunContext to prevent memory leak

### DIFF
--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -48,6 +48,7 @@ export function getAgentRunContext(runId: string) {
 
 export function clearAgentRunContext(runId: string) {
   runContextById.delete(runId);
+  seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {


### PR DESCRIPTION
## Summary

- `seqByRun` Map in `src/infra/agent-events.ts` grows unbounded because `clearAgentRunContext()` only deletes from `runContextById` but never from `seqByRun`
- Every agent run adds an entry via `emitAgentEvent()` that is never cleaned up, causing the gateway process to leak memory indefinitely
- Observed 65GB RSS over ~12 hours of active Discord/Slack messaging, with `DiscordMessageListener` taking 120-946 seconds per `MESSAGE_CREATE` due to GC pressure
- Fix: add `seqByRun.delete(runId)` to `clearAgentRunContext()`

## Test plan

- [x] Verified all 3 call sites (`server-chat.ts` x2, `commands/agent.ts`) only invoke `clearAgentRunContext` at run end/error — no risk of deleting a counter mid-run
- [x] Confirmed existing tests pass (`agent-events.test.ts`)
- [x] Deployed patched build to production gateway; memory stable at ~600MB after 15+ minutes vs 1.1GB+ and climbing on unpatched version
- [x] Reviewed by OpenAI Codex — no correctness or maintainability issues found

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical memory leak where `seqByRun` Map grew unbounded because `clearAgentRunContext()` only deleted from `runContextById`

**Key changes:**
- Added `seqByRun.delete(runId)` to `clearAgentRunContext()` to properly clean up sequence counters when agent runs complete
- Production deployment confirmed memory stabilized at ~600MB vs 1.1GB+ and climbing on unpatched version

**Issue found:**
- `resetAgentRunContextForTest()` should also clear `seqByRun` to prevent test pollution between test runs

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge - it fixes a critical memory leak with a simple, targeted change
- The fix correctly addresses the memory leak by ensuring `seqByRun` entries are deleted alongside `runContextById` entries. All three call sites only invoke `clearAgentRunContext()` at run end/error, so there's no risk of mid-run deletion. Production deployment confirms the fix works. Score is 4 instead of 5 because `resetAgentRunContextForTest()` should also clear `seqByRun` for complete test isolation.
- src/infra/agent-events.ts needs a minor update to `resetAgentRunContextForTest()`

<sub>Last reviewed commit: bb9f387</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->