### PR TITLE
feat(config): add usageDefault to agent defaults for persistent /usage mode

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -573,7 +573,8 @@ export async function runReplyAgent(params: {
 
     const responseUsageRaw =
       activeSessionEntry?.responseUsage ??
-      (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined);
+      (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined) ??
+      followupRun.run.config.agents?.defaults?.usageDefault;
     const responseUsageMode = resolveResponseUsageMode(responseUsageRaw);
     if (responseUsageMode !== "off" && hasNonzeroUsage(usage)) {
       const authMode = resolveModelAuthMode(providerUsed, cfg);

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -172,6 +172,8 @@ export type AgentDefaultsConfig = {
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */
   blockStreamingDefault?: "off" | "on";
+  /** Default per-response usage footer level. Mirrors the /usage slash command. */
+  usageDefault?: "off" | "tokens" | "full";
   /**
    * Block streaming boundary:
    * - "text_end": end of each assistant text content block (before tool calls)

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -122,6 +122,7 @@ export const AgentDefaultsSchema = z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),
     blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
+    usageDefault: z.union([z.literal("off"), z.literal("tokens"), z.literal("full")]).optional(),
     blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
     blockStreamingChunk: BlockStreamingChunkSchema.optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),


### PR DESCRIPTION
## Summary

Fixes #22083

Adds `usageDefault` to `AgentDefaultsConfig` so users can persist their preferred `/usage` footer level in `openclaw.json` without re-running `/usage` after every `/new` or restart.

## Usage

```jsonc
{
  "agents": {
    "defaults": {
      "usageDefault": "tokens"  // off | tokens | full
    }
  }
}
```

## Change Type

- [x] Feature

## Scope

- [x] Config / DX

## Linked Issues

Fixes #22083

## Root Cause

`/usage` sets `responseUsage` on the session entry, but this resets on every `/new` or restart. There was no config-level default to fall back to.

## Fix

**`src/config/types.agent-defaults.ts`** — added `usageDefault?: "off" | "tokens" | "full"` to `AgentDefaultsConfig`, following the same pattern as `verboseDefault`, `thinkingDefault`, and `elevatedDefault`.

**`src/auto-reply/reply/agent-runner.ts`** — extended the `responseUsageRaw` fallback chain:

```ts
// Before:
const responseUsageRaw =
  activeSessionEntry?.responseUsage ??
  (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined);

// After:
const responseUsageRaw =
  activeSessionEntry?.responseUsage ??
  (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined) ??
  followupRun.run.config.agents?.defaults?.usageDefault;
```

The `/usage` per-session override continues to work exactly as before — `responseUsage` on the session entry takes precedence over the config default.

## Compatibility / Migration

- Backward compatible? Yes — new optional field, defaults to `undefined` (existing behavior unchanged)
- Config/env changes? No migration needed; add `usageDefault` to `openclaw.json` to opt in

🤖 AI-Assisted: Yes (via OpenClaw / MIST)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `usageDefault` config field to persist `/usage` footer preferences across sessions and restarts, following the same pattern as `verboseDefault`, `thinkingDefault`, and `elevatedDefault`.

- Added `usageDefault?: "off" | "tokens" | "full"` to `AgentDefaultsConfig` TypeScript type
- Extended fallback chain in `agent-runner.ts` to check config default after session-level overrides
- **Critical issue**: Missing Zod schema definition for `usageDefault` field

The implementation correctly follows the existing pattern for similar defaults, with proper fallback precedence (session override → config default). However, the Zod schema wasn't updated, which will cause config validation to reject `usageDefault` due to the `.strict()` mode in `AgentDefaultsSchema`.

<h3>Confidence Score: 2/5</h3>

- Implementation is correct but missing critical schema validation, will break when users try to use the feature
- The TypeScript implementation correctly follows existing patterns and the fallback chain is properly ordered. However, the missing Zod schema entry means the feature won't work in practice - config validation will reject `usageDefault` settings, making this a breaking issue that needs to be fixed before merge.
- src/config/zod-schema.agent-defaults.ts needs the missing schema field added

<sub>Last reviewed commit: ea26de1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->