### PR TITLE
fix(ui): strip injected inbound metadata from user messages in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.
 - Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.
-- OpenClawKit/UI: prevent injected inbound user context metadata blocks from leaking into chat history in TUI, webchat, and macOS surfaces by stripping all untrusted metadata prefixes at display boundaries. (#22142) Thanks @vincentkoc.
+- OpenClawKit/UI: prevent injected inbound user context metadata blocks from leaking into chat history in TUI, webchat, and macOS surfaces by stripping all untrusted metadata prefixes at display boundaries. (#22142) Thanks @Mellowambience.
 - Agents/System Prompt: label allowlisted senders as authorized senders to avoid implying ownership. Thanks @thewilloftheshadow.
 - Gateway/Auth: allow trusted-proxy mode with loopback bind for same-host reverse-proxy deployments, while still requiring configured `gateway.trustedProxies`. (#20097) thanks @xinhuagu.
 - Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.
 - Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.
-- OpenClawKit/UI: prevent injected inbound user context metadata blocks from leaking into chat history in TUI, webchat, and macOS surfaces by stripping all untrusted metadata prefixes at display boundaries. (#22142) Thanks @Mellowambience.
+- Security/OpenClawKit/UI: prevent injected inbound user context metadata blocks from leaking into chat history in TUI, webchat, and macOS surfaces by stripping all untrusted metadata prefixes at display boundaries. (#22142) Thanks @Mellowambience, @vincentkoc.
 - Agents/System Prompt: label allowlisted senders as authorized senders to avoid implying ownership. Thanks @thewilloftheshadow.
 - Gateway/Auth: allow trusted-proxy mode with loopback bind for same-host reverse-proxy deployments, while still requiring configured `gateway.trustedProxies`. (#20097) thanks @xinhuagu.
 - Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.
 - Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.
+- OpenClawKit/UI: prevent injected inbound user context metadata blocks from leaking into chat history in TUI, webchat, and macOS surfaces by stripping all untrusted metadata prefixes at display boundaries. (#22142) Thanks @vincentkoc.
 - Agents/System Prompt: label allowlisted senders as authorized senders to avoid implying ownership. Thanks @thewilloftheshadow.
 - Gateway/Auth: allow trusted-proxy mode with loopback bind for same-host reverse-proxy deployments, while still requiring configured `gateway.trustedProxies`. (#20097) thanks @xinhuagu.
 - Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 enum ChatMarkdownPreprocessor {
+    // Keep in sync with `src/auto-reply/reply/strip-inbound-meta.ts`
+    // (`INBOUND_META_SENTINELS`), and extend parser expectations in
+    // `ChatMarkdownPreprocessorTests` when sentinels change.
     private static let inboundContextHeaders = [
         "Conversation info (untrusted metadata):",
         "Sender (untrusted metadata):",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
@@ -64,11 +64,12 @@ enum ChatMarkdownPreprocessor {
             return raw
         }
 
+        let normalized = raw.replacingOccurrences(of: "\r\n", with: "\n")
         var outputLines: [String] = []
         var inMetaBlock = false
         var inFencedJson = false
 
-        for line in raw.split(whereSeparator: \.isNewline, omittingEmptySubsequences: false) {
+        for line in normalized.split(separator: "\n", omittingEmptySubsequences: false) {
             let currentLine = String(line)
 
             if !inMetaBlock && self.inboundContextHeaders.contains(where: currentLine.hasPrefix) {

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { stripInboundMetadata } from "./strip-inbound-meta.js";
+
+const CONV_BLOCK = `Conversation info (untrusted metadata):
+\`\`\`json
+{
+  "message_id": "msg-abc",
+  "sender": "+1555000"
+}
+\`\`\``;
+
+const SENDER_BLOCK = `Sender (untrusted metadata):
+\`\`\`json
+{
+  "label": "Alice",
+  "name": "Alice"
+}
+\`\`\``;
+
+const REPLY_BLOCK = `Replied message (untrusted, for context):
+\`\`\`json
+{
+  "body": "What time is it?"
+}
+\`\`\``;
+
+describe("stripInboundMetadata", () => {
+  it("fast-path: returns same string when no sentinels present", () => {
+    const text = "Hello, how are you?";
+    expect(stripInboundMetadata(text)).toBe(text);
+  });
+
+  it("fast-path: returns empty string unchanged", () => {
+    expect(stripInboundMetadata("")).toBe("");
+  });
+
+  it("strips a single Conversation info block", () => {
+    const input = `${CONV_BLOCK}\n\nWhat is the weather today?`;
+    expect(stripInboundMetadata(input)).toBe("What is the weather today?");
+  });
+
+  it("strips multiple chained metadata blocks", () => {
+    const input = `${CONV_BLOCK}\n\n${SENDER_BLOCK}\n\nCan you help me?`;
+    expect(stripInboundMetadata(input)).toBe("Can you help me?");
+  });
+
+  it("strips Replied message block leaving user message intact", () => {
+    const input = `${REPLY_BLOCK}\n\nGot it, thanks!`;
+    expect(stripInboundMetadata(input)).toBe("Got it, thanks!");
+  });
+
+  it("strips all six known sentinel types", () => {
+    const sentinels = [
+      "Conversation info (untrusted metadata):",
+      "Sender (untrusted metadata):",
+      "Thread starter (untrusted, for context):",
+      "Replied message (untrusted, for context):",
+      "Forwarded message context (untrusted metadata):",
+      "Chat history since last reply (untrusted, for context):",
+    ];
+    for (const sentinel of sentinels) {
+      const input = `${sentinel}\n\`\`\`json\n{"x": 1}\n\`\`\`\n\nUser message`;
+      expect(stripInboundMetadata(input)).toBe("User message");
+    }
+  });
+
+  it("handles metadata block with no user text after it", () => {
+    expect(stripInboundMetadata(CONV_BLOCK)).toBe("");
+  });
+
+  it("preserves message containing json fences that are not metadata", () => {
+    const text = `Here is my code:\n\`\`\`json\n{"key": "value"}\n\`\`\``;
+    expect(stripInboundMetadata(text)).toBe(text);
+  });
+
+  it("preserves leading newlines in user content after stripping", () => {
+    const input = `${CONV_BLOCK}\n\nActual message`;
+    expect(stripInboundMetadata(input)).toBe("Actual message");
+  });
+});

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -77,4 +77,9 @@ describe("stripInboundMetadata", () => {
     const input = `${CONV_BLOCK}\n\nActual message`;
     expect(stripInboundMetadata(input)).toBe("Actual message");
   });
+
+  it("preserves leading spaces in user content after stripping", () => {
+    const input = `${CONV_BLOCK}\n\n  Indented message`;
+    expect(stripInboundMetadata(input)).toBe("  Indented message");
+  });
 });

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -85,5 +85,5 @@ export function stripInboundMetadata(text: string): string {
     result.push(line);
   }
 
-  return result.join("\n").trimStart();
+  return result.join("\n").replace(/^\n+/, "");
 }

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -1,0 +1,89 @@
+/**
+ * Strips OpenClaw-injected inbound metadata blocks from a user-role message
+ * text before it is displayed in any UI surface (TUI, webchat, macOS app).
+ *
+ * Background: `buildInboundUserContextPrefix` in `inbound-meta.ts` prepends
+ * structured metadata blocks (Conversation info, Sender info, reply context,
+ * etc.) directly to the stored user message content so the LLM can access
+ * them. These blocks are AI-facing only and must never surface in user-visible
+ * chat history.
+ */
+
+/**
+ * Sentinel strings that identify the start of an injected metadata block.
+ * Must stay in sync with `buildInboundUserContextPrefix` in `inbound-meta.ts`.
+ */
+const INBOUND_META_SENTINELS = [
+  "Conversation info (untrusted metadata):",
+  "Sender (untrusted metadata):",
+  "Thread starter (untrusted, for context):",
+  "Replied message (untrusted, for context):",
+  "Forwarded message context (untrusted metadata):",
+  "Chat history since last reply (untrusted, for context):",
+] as const;
+
+// Pre-compiled fast-path regex — avoids line-by-line parse when no blocks present.
+const SENTINEL_FAST_RE = new RegExp(
+  INBOUND_META_SENTINELS.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|"),
+);
+
+/**
+ * Remove all injected inbound metadata prefix blocks from `text`.
+ *
+ * Each block has the shape:
+ *
+ * ```
+ * <sentinel-line>
+ * ```json
+ * { … }
+ * ```
+ * ```
+ *
+ * Returns the original string reference unchanged when no metadata is present
+ * (fast path — zero allocation).
+ */
+export function stripInboundMetadata(text: string): string {
+  if (!text || !SENTINEL_FAST_RE.test(text)) {
+    return text;
+  }
+
+  const lines = text.split("\n");
+  const result: string[] = [];
+  let inMetaBlock = false;
+  let inFencedJson = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Detect start of a metadata block.
+    if (!inMetaBlock && INBOUND_META_SENTINELS.some((s) => line.startsWith(s))) {
+      inMetaBlock = true;
+      inFencedJson = false;
+      continue;
+    }
+
+    if (inMetaBlock) {
+      if (!inFencedJson && line.trim() === "```json") {
+        inFencedJson = true;
+        continue;
+      }
+      if (inFencedJson) {
+        if (line.trim() === "```") {
+          inMetaBlock = false;
+          inFencedJson = false;
+        }
+        continue;
+      }
+      // Blank separator lines between consecutive blocks are dropped.
+      if (line.trim() === "") {
+        continue;
+      }
+      // Unexpected non-blank line outside a fence — treat as user content.
+      inMetaBlock = false;
+    }
+
+    result.push(line);
+  }
+
+  return result.join("\n").trimStart();
+}

--- a/src/discord/send.components.test.ts
+++ b/src/discord/send.components.test.ts
@@ -1,0 +1,53 @@
+import { ChannelType } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerDiscordComponentEntries } from "./components-registry.js";
+import { sendDiscordComponentMessage } from "./send.components.js";
+import { makeDiscordRest } from "./send.test-harness.js";
+
+const loadConfigMock = vi.hoisted(() => vi.fn(() => ({ session: { dmScope: "main" } })));
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    loadConfig: (...args: Parameters<typeof actual.loadConfig>) => loadConfigMock(...args),
+  };
+});
+
+vi.mock("./components-registry.js", () => ({
+  registerDiscordComponentEntries: vi.fn(),
+}));
+
+describe("sendDiscordComponentMessage", () => {
+  const registerMock = vi.mocked(registerDiscordComponentEntries);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps DM channel targets to direct-session component entries", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.DM,
+      recipients: [{ id: "user-1" }],
+    });
+    postMock.mockResolvedValueOnce({ id: "msg1", channel_id: "dm-1" });
+
+    await sendDiscordComponentMessage(
+      "channel:dm-1",
+      {
+        blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }],
+      },
+      {
+        rest,
+        token: "t",
+        sessionKey: "agent:main:discord:channel:dm-1",
+        agentId: "main",
+      },
+    );
+
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    const args = registerMock.mock.calls[0]?.[0];
+    expect(args?.entries[0]?.sessionKey).toBe("agent:main:main");
+  });
+});

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -8,6 +8,7 @@ import {
 import type { ChatLog } from "./components/chat-log.js";
 import type { GatewayAgentsList, GatewayChatClient } from "./gateway-chat.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
+import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { TuiOptions, TuiStateAccess } from "./tui-types.js";
 
 type SessionActionContext = {
@@ -326,7 +327,7 @@ export function createSessionActions(context: SessionActionContext) {
         if (message.role === "user") {
           const text = extractTextFromMessage(message);
           if (text) {
-            chatLog.addUser(text);
+            chatLog.addUser(stripInboundMetadata(text));
           }
           continue;
         }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -1,4 +1,5 @@
 import type { TUI } from "@mariozechner/pi-tui";
+import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import {
   normalizeAgentId,
@@ -8,7 +9,6 @@ import {
 import type { ChatLog } from "./components/chat-log.js";
 import type { GatewayAgentsList, GatewayChatClient } from "./gateway-chat.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
-import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { TuiOptions, TuiStateAccess } from "./tui-types.js";
 
 type SessionActionContext = {

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -3,6 +3,7 @@
  */
 
 import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
+import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 
 /**
  * Normalize a raw message object into a consistent structure.
@@ -49,6 +50,16 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
 
   const timestamp = typeof m.timestamp === "number" ? m.timestamp : Date.now();
   const id = typeof m.id === "string" ? m.id : undefined;
+
+  // Strip AI-injected metadata prefix blocks from user messages before display.
+  if (role === "user" || role === "User") {
+    content = content.map((item) => {
+      if (item.type === "text" && typeof item.text === "string") {
+        return { ...item, text: stripInboundMetadata(item.text) };
+      }
+      return item;
+    });
+  }
 
   return { role, content, timestamp, id };
 }

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -2,8 +2,8 @@
  * Message normalization utilities for chat rendering.
  */
 
-import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 
 /**
  * Normalize a raw message object into a consistent structure.


### PR DESCRIPTION
## Summary

Fixes #21106, #21109, #22116

OpenClaw prepends structured metadata blocks (`Conversation info`, `Sender:`, reply-context) to user messages before sending them to the LLM. These blocks are intentionally AI-context-only and must never reach the chat history that users see.

## Root Cause

`buildInboundUserContextPrefix` in `inbound-meta.ts` prepends the blocks directly to the stored user message content string, so they are persisted verbatim and later shown in webchat, TUI, and every other rendering surface.

## Fix

**`src/auto-reply/reply/strip-inbound-meta.ts`** — new utility with a 6-sentinel fast-path strip (zero-alloc on miss) + 9-test suite.

**`src/tui/tui-session-actions.ts`** — wraps `chatLog.addUser(...)` with `stripInboundMetadata()` so the TUI never stores the prefix.

**`ui/src/ui/chat/message-normalizer.ts`** — strips user-role text content items during normalisation so webchat renders clean messages.

## Change Type

- [x] Bug fix

## Scope

- [x] UI/UX
- [x] TUI

## Linked Issues

Fixes #21106
Fixes #21109
Fixes #22116

🤖 AI-Assisted: Yes (via OpenClaw / MIST)

> Note: This is a clean resubmission of the previously closed PR #21138. The original branch had accumulated unrelated commits from the fork — this branch contains only the 4 relevant files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements metadata stripping across all UI surfaces (TUI, webchat, Swift) to prevent AI-context-only metadata blocks from appearing in user-visible chat history.

**Key Changes:**
- Created `stripInboundMetadata()` utility with fast-path optimization (zero-alloc when no metadata present) and comprehensive test suite
- Applied stripping in 4 locations: TUI session actions, webchat message normalizer, webchat message extractor, and Swift ChatViewModel
- Swift and TypeScript implementations use identical line-by-line state machine parsers
- Strips 6 sentinel types: Conversation info, Sender, Thread starter, Replied message, Forwarded message, Chat history

**Observations:**
- TypeScript version splits on `\n` only, while Swift normalizes `\r\n` to `\n` first - potential inconsistency if messages contain CRLF line endings
- All 6 sentinels match those defined in `buildInboundUserContextPrefix()` in `inbound-meta.ts:103-189`
- Fast-path regex prevents unnecessary parsing when no sentinels are present

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor concerns around line ending handling
- The implementation correctly strips metadata from user messages across all platforms (TypeScript, Swift, TUI, webchat). The core logic is sound with comprehensive test coverage (9 tests for TS, 3 tests for Swift). However, the TypeScript implementation lacks CRLF normalization that the Swift version includes, which could cause issues if messages contain Windows-style line endings.
- Pay attention to `src/auto-reply/reply/strip-inbound-meta.ts` for potential line ending edge case

<sub>Last reviewed commit: deb3674</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->