### PR TITLE
fix: strip untrusted metadata blocks and system event lines from webchat UI

### DIFF
--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -31,6 +31,66 @@ describe("stripEnvelopeFromMessage", () => {
     expect(result.content).toBe("I typed [message_id: 123] on purpose");
   });
 
+  test("should strip 'Conversation info' untrusted metadata block", () => {
+    const input = {
+      role: "user",
+      content:
+        'Conversation info (untrusted metadata):\n```json\n{"message_id": "abc", "sender": "+1234"}\n```\n\nHello',
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content?.trim()).toBe("Hello");
+  });
+
+  test("should strip 'Sender' untrusted metadata block", () => {
+    const input = {
+      role: "user",
+      content:
+        'Sender (untrusted metadata):\n```json\n{"label": "Alice", "name": "Alice"}\n```\n\nHi there',
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content?.trim()).toBe("Hi there");
+  });
+
+  test("should strip multiple untrusted metadata blocks together", () => {
+    const input = {
+      role: "user",
+      content: [
+        'Conversation info (untrusted metadata):\n```json\n{"message_id": "x"}\n```\n\nSender (untrusted metadata):\n```json\n{"label": "Bob"}\n```\n\nThread starter (untrusted, for context):\n```json\n{"body": "original post"}\n```\n\nWhat do you think?',
+      ].join(""),
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content?.trim()).toBe("What do you think?");
+  });
+
+  test("should strip System event lines from user messages", () => {
+    const input = {
+      role: "user",
+      content: "System: [2026-02-20 11:15:40 PST] WhatsApp gateway connected.\n\nHello",
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("Hello");
+  });
+
+  test("should strip multiple System event lines", () => {
+    const input = {
+      role: "user",
+      content:
+        "System: [2026-02-20 11:15:40 PST] WhatsApp gateway connected.\nSystem: [2026-02-20 11:15:41 PST] Telegram bot started.\n\nHow are you?",
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("How are you?");
+  });
+
+  test("should strip System lines + untrusted blocks + envelope together", () => {
+    const input = {
+      role: "user",
+      content:
+        'System: [2026-02-20 11:15:40 PST] WhatsApp gateway connected.\n\n[WhatsApp 2026-02-20 11:16] Conversation info (untrusted metadata):\n```json\n{"message_id": "abc"}\n```\n\nHi',
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content?.trim()).toBe("Hi");
+  });
+
   test("does not strip assistant messages", () => {
     const input = {
       role: "assistant",

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,4 +1,9 @@
-import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
+import {
+  stripEnvelope,
+  stripMessageIdHints,
+  stripSystemEventLines,
+  stripUntrustedMetadataBlocks,
+} from "../shared/chat-envelope.js";
 
 export { stripEnvelope };
 
@@ -12,7 +17,9 @@ function stripEnvelopeFromContent(content: unknown[]): { content: unknown[]; cha
     if (entry.type !== "text" || typeof entry.text !== "string") {
       return item;
     }
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripMessageIdHints(
+      stripUntrustedMetadataBlocks(stripEnvelope(stripSystemEventLines(entry.text))),
+    );
     if (stripped === entry.text) {
       return item;
     }
@@ -39,7 +46,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   const next: Record<string, unknown> = { ...entry };
 
   if (typeof entry.content === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.content));
+    const stripped = stripMessageIdHints(
+      stripUntrustedMetadataBlocks(stripEnvelope(stripSystemEventLines(entry.content))),
+    );
     if (stripped !== entry.content) {
       next.content = stripped;
       changed = true;
@@ -51,7 +60,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripMessageIdHints(
+      stripUntrustedMetadataBlocks(stripEnvelope(stripSystemEventLines(entry.text))),
+    );
     if (stripped !== entry.text) {
       next.text = stripped;
       changed = true;

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -39,6 +39,36 @@ export function stripEnvelope(text: string): string {
   return text.slice(match[0].length);
 }
 
+const UNTRUSTED_BLOCK = /^[A-Z][^\n]*\(untrusted[^)]*\):\n```json\n[\s\S]*?\n```\s*/gm;
+
+export function stripUntrustedMetadataBlocks(text: string): string {
+  if (!text.includes("(untrusted")) {
+    return text;
+  }
+  UNTRUSTED_BLOCK.lastIndex = 0;
+  const stripped = text.replace(UNTRUSTED_BLOCK, "");
+  return stripped === text ? text : stripped.trimStart();
+}
+
+const SYSTEM_EVENT_LINE = /^System: \[.+\].*$/;
+
+export function stripSystemEventLines(text: string): string {
+  if (!text.startsWith("System: [")) {
+    return text;
+  }
+  const lines = text.split(/\r?\n/);
+  // Drop leading System: lines and any blank lines immediately after them
+  let i = 0;
+  while (i < lines.length && SYSTEM_EVENT_LINE.test(lines[i])) {
+    i++;
+  }
+  // Skip blank lines between system block and actual content
+  while (i < lines.length && lines[i].trim() === "") {
+    i++;
+  }
+  return i === 0 ? text : lines.slice(i).join("\n");
+}
+
 export function stripMessageIdHints(text: string): string {
   if (!text.includes("[message_id:")) {
     return text;


### PR DESCRIPTION
## Summary

Fixes #20297

The webchat UI was rendering raw internal metadata in chat bubbles. This PR adds stripping for two categories of leaked metadata:

- **Untrusted metadata blocks** — `Conversation info (untrusted metadata):`, `Sender (untrusted metadata):`, `Thread starter (untrusted, for context):`, `Replied message (untrusted, for context):`, `Forwarded message context (untrusted metadata):`, and `Chat history since last reply (untrusted, for context):` followed by ```json code fences
- **System event lines** — `System: [timestamp] event description` lines prepended by `prependSystemEvents()`

### Changes

| File | What |
|------|------|
| `src/shared/chat-envelope.ts` | Added `stripUntrustedMetadataBlocks()` and `stripSystemEventLines()` |
| `src/gateway/chat-sanitize.ts` | Wired new functions into the gateway sanitization pipeline |
| `ui/src/ui/chat/message-extract.ts` | Wired new functions into UI extraction as defense-in-depth |
| `src/gateway/chat-sanitize.test.ts` | Added 6 test cases covering all metadata block types |

### Sanitization pipeline (after this fix)

```
raw message text
  → stripSystemEventLines()        — remove "System: [...]..." lines
  → stripEnvelope()                — remove [WhatsApp 2026-01-24 13:36] headers
  → stripUntrustedMetadataBlocks() — remove (untrusted ...) JSON blocks
  → stripMessageIdHints()          — remove [message_id: xxx] lines
clean user message text
```

## Test plan

- [x] `npx vitest run src/gateway/chat-sanitize.test.ts` — 10/10 pass
- [x] `npx vitest run src/auto-reply/reply/inbound-meta.test.ts` — 13/13 pass
- [x] `pnpm build` — pass
- [x] `pnpm lint` — 0 errors, 0 warnings
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds stripping for untrusted metadata blocks and system event lines that were leaking into webchat UI. The implementation correctly removes internal metadata like "Conversation info (untrusted metadata):" JSON blocks, "Sender (untrusted metadata):" blocks, and "System: [timestamp]" event lines. The fix is applied at both the gateway sanitization pipeline and the UI extraction layer for defense-in-depth.

- Adds `stripUntrustedMetadataBlocks()` with regex pattern to match all untrusted metadata block variants
- Adds `stripSystemEventLines()` to remove leading system event lines and trailing blank lines
- Wires both functions into the sanitization pipeline in the correct order: system events → envelope → untrusted blocks → message ID hints
- Includes comprehensive test coverage for all metadata block types and combined scenarios
- Defense-in-depth approach ensures metadata is stripped at multiple layers

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper defense-in-depth, comprehensive test coverage covering all metadata block types and combined scenarios, correct regex patterns without ReDoS vulnerabilities, and appropriate sanitization order. The fix addresses a real metadata leakage issue without introducing new risks.
- No files require special attention

<sub>Last reviewed commit: efd894b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->