### PR TITLE
Add ContextMemory documentation

### DIFF
--- a/docs/CONTEXTMEMORY.md
+++ b/docs/CONTEXTMEMORY.md
@@ -1,0 +1,151 @@
+![npm](https://img.shields.io/npm/v/@akashkobal/contextmemory)
+![license](https://img.shields.io/npm/l/@akashkobal/contextmemory)
+
+# ContextMemory 🧠
+
+Persistent AI coding context memory for developers and teams.
+
+Git tracks your code history. **ContextMemory tracks your intent history.**
+
+Never re-explain your architecture, decisions, or progress to AI assistants again.
+
+---
+
+## 🚀 Installation
+
+Install globally from npm:
+
+```bash
+npm install -g @akashkobal/contextmemory
+```
+
+Verify installation:
+
+```bash
+contextmemory --help
+```
+
+---
+
+## ⚡ Quick Start
+
+Initialize inside your project:
+
+```bash
+contextmemory init
+```
+
+Save your working context:
+
+```bash
+contextmemory save
+```
+
+Quick save:
+
+```bash
+contextmemory save "Implemented multi-model execution"
+```
+
+Resume your context:
+
+```bash
+contextmemory resume
+```
+
+This copies a formatted prompt to your clipboard.  
+Paste it into ChatGPT, Cursor, Claude, or any AI coding tool.
+
+---
+
+## 🧠 How It Works
+
+ContextMemory creates:
+
+```
+.contextmemory/
+├── context.json
+├── history/
+│   ├── entry-1.json
+│   ├── entry-2.json
+```
+
+Each entry captures:
+
+- Task
+- Goal
+- Approaches
+- Decisions
+- Current State
+- Next Steps
+
+---
+
+## 📦 Commands
+
+### Core
+
+```bash
+contextmemory init
+contextmemory save
+contextmemory resume
+contextmemory log
+contextmemory diff
+```
+
+### Automation
+
+```bash
+contextmemory watch
+contextmemory hook install
+contextmemory handoff @username
+```
+
+---
+
+## 🔌 MCP Integration (Optional)
+
+Add to your MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "contextmemory": {
+      "command": "npx",
+      "args": ["-y", "@akashkobal/contextmemory", "mcp"]
+    }
+  }
+}
+```
+
+---
+
+## 🏗 Works With
+
+- Spring Boot
+- React
+- Node.js
+- Python
+- Microservices
+- Monorepos
+
+AI Tools:
+
+- ChatGPT
+- Cursor
+- Claude
+- Copilot
+- Windsurf
+
+---
+
+## 📄 License
+
+MIT
+
+---
+
+## 👨‍💻 Author
+
+Akash Kobal  
+GitHub: [https://github.com/AkashKobal](https://github.com/AkashKobal)

--- a/docs/CONTEXTMEMORY.md
+++ b/docs/CONTEXTMEMORY.md
@@ -1,19 +1,25 @@
-![npm](https://img.shields.io/npm/v/@akashkobal/contextmemory)
-![license](https://img.shields.io/npm/l/@akashkobal/contextmemory)
+# ContextMemory Integration Guide
 
-# ContextMemory 🧠
+This guide explains how OpenClaw contributors can optionally use ContextMemory to persist development context across AI-assisted coding sessions.
 
-Persistent AI coding context memory for developers and teams.
+## Overview
 
-Git tracks your code history. **ContextMemory tracks your intent history.**
+ContextMemory is a CLI tool that helps developers save and restore their working context, including:
 
-Never re-explain your architecture, decisions, or progress to AI assistants again.
+- Current task
+- Goals and decisions
+- Implementation progress
+- Next planned steps
+
+This can be useful when working with AI coding assistants such as ChatGPT, Claude, or Cursor, allowing contributors to resume work without manually reconstructing project context.
+
+ContextMemory does not modify OpenClaw source code and is entirely optional.
 
 ---
 
-## 🚀 Installation
+## Installation
 
-Install globally from npm:
+Install ContextMemory globally using npm:
 
 ```bash
 npm install -g @akashkobal/contextmemory
@@ -27,85 +33,64 @@ contextmemory --help
 
 ---
 
-## ⚡ Quick Start
+## Initialize in OpenClaw Repository
 
-Initialize inside your project:
+From the OpenClaw project root directory:
 
 ```bash
 contextmemory init
 ```
 
-Save your working context:
+This creates a `.contextmemory/` directory used to store development context locally.
 
-```bash
-contextmemory save
-```
-
-Quick save:
-
-```bash
-contextmemory save "Implemented multi-model execution"
-```
-
-Resume your context:
-
-```bash
-contextmemory resume
-```
-
-This copies a formatted prompt to your clipboard.  
-Paste it into ChatGPT, Cursor, Claude, or any AI coding tool.
-
----
-
-## 🧠 How It Works
-
-ContextMemory creates:
+Example structure:
 
 ```
 .contextmemory/
 ├── context.json
 ├── history/
-│   ├── entry-1.json
-│   ├── entry-2.json
 ```
 
-Each entry captures:
-
-- Task
-- Goal
-- Approaches
-- Decisions
-- Current State
-- Next Steps
+This directory is local to your development environment.
 
 ---
 
-## 📦 Commands
+## Saving Development Context
 
-### Core
+To save your current OpenClaw development state:
 
 ```bash
-contextmemory init
-contextmemory save
+contextmemory save "Working on OpenClaw feature implementation"
+```
+
+This records relevant information such as:
+
+- Task description  
+- Current progress  
+- Development decisions  
+- Next steps  
+
+You can update context at any time during development.
+
+---
+
+## Resuming Development Context
+
+To restore previously saved context:
+
+```bash
 contextmemory resume
-contextmemory log
-contextmemory diff
 ```
 
-### Automation
+This copies a formatted context summary to your clipboard.
 
-```bash
-contextmemory watch
-contextmemory hook install
-contextmemory handoff @username
-```
+You can paste it into your AI coding assistant to restore development continuity.
 
 ---
 
-## 🔌 MCP Integration (Optional)
+## Optional MCP Integration
 
-Add to your MCP configuration:
+If using an MCP-compatible AI tool, add the following configuration:
 
 ```json
 {
@@ -118,34 +103,32 @@ Add to your MCP configuration:
 }
 ```
 
----
-
-## 🏗 Works With
-
-- Spring Boot
-- React
-- Node.js
-- Python
-- Microservices
-- Monorepos
-
-AI Tools:
-
-- ChatGPT
-- Cursor
-- Claude
-- Copilot
-- Windsurf
+This allows compatible tools to access stored context automatically.
 
 ---
 
-## 📄 License
+## Example Use Cases in OpenClaw Development
 
-MIT
+ContextMemory may be useful for:
+
+- Large feature development  
+- Multi-session contributions  
+- Refactoring tasks  
+- AI-assisted debugging  
+- Tracking architectural decisions  
 
 ---
 
-## 👨‍💻 Author
+## Notes
 
-Akash Kobal  
-GitHub: [https://github.com/AkashKobal](https://github.com/AkashKobal)
+- ContextMemory is optional  
+- It does not change OpenClaw functionality  
+- It stores context locally in your development environment  
+- It can be safely ignored if not needed  
+
+---
+
+## Related Links
+
+- npm package: https://www.npmjs.com/package/@akashkobal/contextmemory  
+- Source repository: https://github.com/AkashKobal/contextmemory


### PR DESCRIPTION
Adds documentation for ContextMemory CLI tool for persistent AI coding context memory.

npm:
https://www.npmjs.com/package/@akashkobal/contextmemory

GitHub:
https://github.com/AkashKobal/contextmemory

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds documentation for `@akashkobal/contextmemory`, a third-party npm package that appears unrelated to OpenClaw.

Key concerns:
- The package is not integrated into OpenClaw's codebase (no source code references or dependencies)
- The documentation file is not registered in `docs/docs.json` navigation
- Missing required Mintlify frontmatter metadata used by other docs (summary, read_when, title fields)
- Documentation format is promotional rather than integration-focused, unlike existing tool docs (e.g., `brave-search.md`, `perplexity.md`)
- The PR author appears to be promoting their own external package

This does not appear to be a legitimate contribution to OpenClaw's documentation.

<h3>Confidence Score: 0/5</h3>

- This PR should not be merged - it adds promotional content for an unrelated third-party tool
- Score of 0 reflects that this PR adds documentation for a third-party npm package that is not integrated into OpenClaw, is not properly registered in the docs navigation, lacks required frontmatter metadata, and appears to be promotional content rather than a legitimate contribution to the project
- docs/CONTEXTMEMORY.md requires removal - this is promotional content for an external tool

<sub>Last reviewed commit: 2c89974</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->