### PR TITLE
fix: use Opus for WhatsApp voice notes (like Telegram)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ package-lock.json
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
+*.log

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -180,6 +180,14 @@ describe("tts", () => {
       expect(output.voiceCompatible).toBe(true);
     });
 
+    it("uses Opus for WhatsApp", () => {
+      const output = resolveOutputFormat("whatsapp");
+      expect(output.openai).toBe("opus");
+      expect(output.elevenlabs).toBe("opus_48000_64");
+      expect(output.extension).toBe(".opus");
+      expect(output.voiceCompatible).toBe(true);
+    });
+
     it("uses MP3 for other channels", () => {
       const output = resolveOutputFormat("discord");
       expect(output.openai).toBe("mp3");

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -480,7 +480,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 function resolveOutputFormat(channelId?: string | null) {
-  if (channelId === "telegram") {
+  if (channelId === "telegram" || channelId === "whatsapp") {
     return TELEGRAM_OUTPUT;
   }
   return DEFAULT_OUTPUT;
@@ -910,7 +910,7 @@ export async function maybeApplyTtsToPayload(params: {
     };
 
     const channelId = resolveChannelId(params.channel);
-    const shouldVoice = channelId === "telegram" && result.voiceCompatible === true;
+    const shouldVoice = (channelId === "telegram" || channelId === "whatsapp") && result.voiceCompatible === true;
     const finalPayload = {
       ...nextPayload,
       mediaUrl: result.audioPath,


### PR DESCRIPTION
## Problem

WhatsApp requires OGG/Opus for voice notes, just like Telegram. Currently OpenClaw treats WhatsApp as a generic channel and outputs MP3, which WhatsApp rejects — users see `This audio file is not available`.

## Fix

Two changes in `src/tts/tts.ts`:

1. **`resolveOutputFormat()`** — return `TELEGRAM_OUTPUT` (Opus) for `whatsapp` channel
2. **`shouldVoice`** — include `whatsapp` alongside `telegram` so audio is sent as voice note

Also adds a test case for WhatsApp Opus output.

## Before / After

| | Before | After |
|---|---|---|
| Format | MP3 (mp3_44100_128) | Opus (opus_48000_64) |
| Voice note | ❌ sent as audio file | ✅ sent as voice note |
| Playback | `This audio file is not available` | Works correctly |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes WhatsApp voice note audio format by using Opus (OGG/Opus) instead of MP3. WhatsApp requires the same Opus format as Telegram for voice notes to play correctly.

**Changes:**
- Updated `resolveOutputFormat()` to return Opus format for both `telegram` and `whatsapp` channels
- Updated `shouldVoice` flag logic in `maybeApplyTtsToPayload()` to mark audio as voice note for both channels
- Added test coverage for WhatsApp Opus output format
- Minor `.gitignore` update to exclude `*.log` files

The implementation correctly reuses the existing `TELEGRAM_OUTPUT` constant (Opus @ 48kHz/64kbps) for WhatsApp, which is the appropriate format for both platforms' voice note requirements.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-tested, and follow existing patterns. Both critical code paths (format resolution and voice flag) have been updated consistently. The test suite now includes WhatsApp coverage, and the implementation reuses the proven Telegram Opus format. No logical errors or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 71532cd</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->