### PR TITLE
dev(watch): make gateway watch portable on native Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ pnpm openclaw onboard --install-daemon
 
 # Dev loop (auto-reload on TS changes)
 pnpm gateway:watch
+
+# Windows (native PowerShell/cmd, no WSL2)
+node scripts/watch-node.mjs gateway run --bind loopback --port 18789 --allow-unconfigured
 ```
 
 Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` produces `dist/` for running via Node / the packaged `openclaw` binary.

--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ pnpm openclaw onboard --install-daemon
 # Dev loop (auto-reload on TS changes)
 pnpm gateway:watch
 
-# Windows (native PowerShell/cmd, no WSL2)
-openclaw gateway stop
-node scripts/watch-node.mjs gateway run --bind loopback --port 18789 --allow-unconfigured
+# Windows (native PowerShell/cmd, no WSL2) uses a compatible fallback automatically.
 ```
 
 Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` produces `dist/` for running via Node / the packaged `openclaw` binary.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ pnpm openclaw onboard --install-daemon
 pnpm gateway:watch
 
 # Windows (native PowerShell/cmd, no WSL2)
+openclaw gateway stop
 node scripts/watch-node.mjs gateway run --bind loopback --port 18789 --allow-unconfigured
 ```
 

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -40,11 +40,14 @@ pnpm gateway:watch
 This maps to:
 
 ```bash
-node --watch-path src --watch-path tsconfig.json --watch-path package.json --watch-preserve-output scripts/run-node.mjs gateway --force
+node scripts/gateway-watch.mjs
 ```
 
 Add any gateway CLI flags after `gateway:watch` and they will be passed through
 on each restart.
+
+On native Windows, `gateway:watch` uses a compatible fallback (`gateway run ... --allow-unconfigured`)
+and runs `openclaw gateway stop` best-effort first to avoid port conflicts with an installed daemon.
 
 ## Dev profile + dev gateway (--dev)
 

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -97,6 +97,7 @@ pnpm gateway:watch
 ```
 
 `gateway:watch` runs the gateway in watch mode and reloads on TypeScript changes.
+On native Windows, it automatically switches to a compatible gateway start path.
 
 ### 2) Point the macOS app at your running Gateway
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "format:swift": "swiftformat --lint --config .swiftformat apps/macos/Sources apps/ios/Sources apps/shared/OpenClawKit/Sources",
     "gateway:dev": "OPENCLAW_SKIP_CHANNELS=1 CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway",
     "gateway:dev:reset": "OPENCLAW_SKIP_CHANNELS=1 CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --reset",
-    "gateway:watch": "node scripts/watch-node.mjs gateway --force",
+    "gateway:watch": "node scripts/gateway-watch.mjs",
     "gen:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --write",
     "ghsa:patch": "node scripts/ghsa-patch.mjs",
     "ios:build": "bash -lc './scripts/ios-configure-signing.sh && cd apps/ios && xcodegen generate && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination \"${IOS_DEST:-platform=iOS Simulator,name=iPhone 17}\" -configuration Debug build'",

--- a/scripts/gateway-watch.mjs
+++ b/scripts/gateway-watch.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const WATCH_SCRIPT = "scripts/watch-node.mjs";
+const RUN_SCRIPT = "scripts/run-node.mjs";
+const WINDOWS_WATCH_ARGS = [
+  "gateway",
+  "run",
+  "--bind",
+  "loopback",
+  "--port",
+  "18789",
+  "--allow-unconfigured",
+];
+const DEFAULT_WATCH_ARGS = ["gateway", "--force"];
+
+function runNode(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: "inherit",
+    });
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        resolve(1);
+        return;
+      }
+      resolve(code ?? 1);
+    });
+    child.once("error", () => {
+      resolve(1);
+    });
+  });
+}
+
+async function main() {
+  const passthroughArgs = process.argv.slice(2);
+  const isWindows = process.platform === "win32";
+
+  if (isWindows) {
+    // Windows developer flow commonly has a scheduled daemon running.
+    // Stop it best-effort to avoid port conflicts in watch mode.
+    await runNode([RUN_SCRIPT, "gateway", "stop"]);
+  }
+
+  const baseArgs = isWindows ? WINDOWS_WATCH_ARGS : DEFAULT_WATCH_ARGS;
+  const exitCode = await runNode([WATCH_SCRIPT, ...baseArgs, ...passthroughArgs]);
+  process.exit(exitCode);
+}
+
+void main();

--- a/scripts/gateway-watch.mjs
+++ b/scripts/gateway-watch.mjs
@@ -4,11 +4,7 @@ import process from "node:process";
 
 const WATCH_SCRIPT = "scripts/watch-node.mjs";
 const RUN_SCRIPT = "scripts/run-node.mjs";
-const WINDOWS_WATCH_ARGS = [
-  "gateway",
-  "run",
-  "--allow-unconfigured",
-];
+const WINDOWS_WATCH_ARGS = ["gateway", "run", "--allow-unconfigured"];
 const DEFAULT_WATCH_ARGS = ["gateway", "--force"];
 
 function runNode(args) {

--- a/scripts/gateway-watch.mjs
+++ b/scripts/gateway-watch.mjs
@@ -7,10 +7,6 @@ const RUN_SCRIPT = "scripts/run-node.mjs";
 const WINDOWS_WATCH_ARGS = [
   "gateway",
   "run",
-  "--bind",
-  "loopback",
-  "--port",
-  "18789",
   "--allow-unconfigured",
 ];
 const DEFAULT_WATCH_ARGS = ["gateway", "--force"];

--- a/src/gateway/server-methods-consistency.test.ts
+++ b/src/gateway/server-methods-consistency.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
+import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { CORE_GATEWAY_METHODS, listGatewayMethods } from "./server-methods-list.js";
+import { coreGatewayHandlers } from "./server-methods.js";
+import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
+
+const INTERNAL_ONLY_METHODS = new Set([
+  "connect",
+  "chat.inject",
+  "web.login.start",
+  "web.login.wait",
+  "sessions.resolve",
+  "push.test",
+  "poll",
+  "sessions.usage",
+  "sessions.usage.timeseries",
+  "sessions.usage.logs",
+]);
+
+describe("gateway method catalog consistency", () => {
+  let previousRegistry = getActivePluginRegistry();
+
+  beforeEach(() => {
+    previousRegistry = getActivePluginRegistry();
+  });
+
+  afterEach(() => {
+    if (previousRegistry) {
+      setActivePluginRegistry(previousRegistry);
+      return;
+    }
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("matches listed public methods to implemented handlers", () => {
+    const supplementalHandlers = createExecApprovalHandlers(new ExecApprovalManager());
+    const implementedHandlers = new Set([
+      ...Object.keys(coreGatewayHandlers),
+      ...Object.keys(supplementalHandlers),
+    ]);
+
+    const missingPublicMethods = CORE_GATEWAY_METHODS.filter(
+      (method) => !implementedHandlers.has(method),
+    );
+    expect(missingPublicMethods).toEqual([]);
+
+    const unexpectedPublicMethods = Array.from(implementedHandlers).filter(
+      (method) => !CORE_GATEWAY_METHODS.includes(method) && !INTERNAL_ONLY_METHODS.has(method),
+    );
+    expect(unexpectedPublicMethods).toEqual([]);
+  });
+
+  it("returns only core catalog methods when no channel plugins register extras", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    expect(listGatewayMethods()).toEqual(CORE_GATEWAY_METHODS);
+  });
+});

--- a/src/gateway/server-methods-consistency.test.ts
+++ b/src/gateway/server-methods-consistency.test.ts
@@ -5,6 +5,7 @@ import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { CORE_GATEWAY_METHODS, listGatewayMethods } from "./server-methods-list.js";
 import { coreGatewayHandlers } from "./server-methods.js";
 import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
+import { createSecretsHandlers } from "./server-methods/secrets.js";
 
 const INTERNAL_ONLY_METHODS = new Set([
   "connect",
@@ -36,9 +37,13 @@ describe("gateway method catalog consistency", () => {
 
   it("matches listed public methods to implemented handlers", () => {
     const supplementalHandlers = createExecApprovalHandlers(new ExecApprovalManager());
+    const secretsHandlers = createSecretsHandlers({
+      reloadSecrets: async () => ({ warningCount: 0 }),
+    });
     const implementedHandlers = new Set([
       ...Object.keys(coreGatewayHandlers),
       ...Object.keys(supplementalHandlers),
+      ...Object.keys(secretsHandlers),
     ]);
 
     const missingPublicMethods = CORE_GATEWAY_METHODS.filter(

--- a/src/gateway/server-methods-consistency.test.ts
+++ b/src/gateway/server-methods-consistency.test.ts
@@ -39,6 +39,11 @@ describe("gateway method catalog consistency", () => {
     const supplementalHandlers = createExecApprovalHandlers(new ExecApprovalManager());
     const secretsHandlers = createSecretsHandlers({
       reloadSecrets: async () => ({ warningCount: 0 }),
+      resolveSecrets: async () => ({
+        assignments: [],
+        diagnostics: [],
+        inactiveRefPaths: [],
+      }),
     });
     const implementedHandlers = new Set([
       ...Object.keys(coreGatewayHandlers),

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -1,7 +1,7 @@
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 
-const BASE_METHODS = [
+export const CORE_GATEWAY_METHODS = [
   "health",
   "doctor.memory.status",
   "logs.tail",
@@ -101,7 +101,7 @@ const BASE_METHODS = [
 
 export function listGatewayMethods(): string[] {
   const channelMethods = listChannelPlugins().flatMap((plugin) => plugin.gatewayMethods ?? []);
-  return Array.from(new Set([...BASE_METHODS, ...channelMethods]));
+  return Array.from(new Set([...CORE_GATEWAY_METHODS, ...channelMethods]));
 }
 
 export const GATEWAY_EVENTS = [


### PR DESCRIPTION
## Summary

- Problem: `pnpm gateway:watch` depended on `gateway --force` (requires `lsof`), which fails on native Windows; docs also drifted from real behavior.
- Why it matters: Windows contributors hit avoidable startup/port-conflict failures in the core dev loop.
- What changed:
  - Added cross-platform watch wrapper: `scripts/gateway-watch.mjs`.
  - Updated `package.json` so `gateway:watch` now uses the wrapper.
  - On native Windows, wrapper does best-effort `openclaw gateway stop` then runs a compatible watch command (`gateway run --bind loopback --port 18789 --allow-unconfigured`).
  - Updated docs (`README.md`, `docs/help/debugging.md`, `docs/start/setup.md`) to reflect portable watch behavior.
  - Added gateway method consistency guard test to catch drift between listed public methods and implemented handlers.
  - Refactored gateway startup config bootstrap out of `server.impl.ts` into `src/gateway/startup-config.ts` (no intended behavior change).
- What did NOT change (scope boundary): no protocol/schema changes, no channel behavior changes, no auth/pairing model changes, and no plugin API contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #22091

## User-visible / Behavior Changes

- `pnpm gateway:watch` now works in native Windows setups without requiring `lsof`.
- Docs now describe the portable watch flow and Windows-specific handling.
- Developer experience is improved for local iteration; no runtime behavior changes expected for existing Linux/macOS flows.

## Security Impact (required)

- New permissions/capabilities? `(No)`
- Secrets/tokens handling changed? `(No)`
- New/changed network calls? `(No)`
- Command/tool execution surface changed? `(Yes)`
- Data access scope changed? `(No)`
- If any `Yes`, explain risk + mitigation:
  - `gateway:watch` now runs a best-effort local `openclaw gateway stop` on native Windows to avoid port conflicts from installed daemon sessions.
  - Scope is local dev workflow only; no remote command execution paths were added.
  - Existing gateway auth/authorization flows are unchanged.

## Repro + Verification

Steps:
1. Native Windows (PowerShell), with daemon previously installed or active.
2. Run `pnpm gateway:watch`.
3. Confirm watcher starts gateway without `lsof` dependency errors.
4. Modify a TS file under `src/` and verify restart-on-change behavior.
5. Run method consistency test:
   - `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server-methods-consistency.test.ts`

Expected:
- Watch mode starts successfully on Windows without `lsof`.
- No persistent port conflict from previously running daemon in common dev path.
- Consistency test passes.

Actual:
- Verified in local Windows native environment.
- Consistency test passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds cross-platform watch wrapper to enable `pnpm gateway:watch` on native Windows without `lsof` dependency. On Windows, wrapper runs best-effort `openclaw gateway stop` then starts gateway with compatible fallback arguments (`gateway run --bind loopback --port 18789 --allow-unconfigured`). Linux/macOS flows remain unchanged. 

Key changes:
- New `scripts/gateway-watch.mjs` wrapper detects platform and adjusts gateway start command
- Refactored startup config bootstrap from `server.impl.ts` into `src/gateway/startup-config.ts` (clean extraction, no behavior change)
- Added method consistency guard test to prevent drift between public method catalog and implemented handlers
- Updated docs (README, debugging, setup) to reflect portable watch behavior and Windows handling

No runtime behavior changes for existing Linux/macOS dev workflows.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring with well-scoped changes: the startup config extraction is a straightforward move with no logic changes, the Windows watch wrapper has clear platform detection and fallback behavior, the consistency test adds guardrails, and documentation accurately reflects the changes. No protocol/schema/API contract changes.
- No files require special attention

<sub>Last reviewed commit: c1bc62c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->