### PR TITLE
Fix webchat visible inbound metadata preamble

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -4,6 +4,7 @@ import {
   extractTextCached,
   extractThinking,
   extractThinkingCached,
+  stripInboundMetadataPrefix,
 } from "./message-extract.ts";
 
 describe("extractTextCached", () => {
@@ -23,6 +24,15 @@ describe("extractTextCached", () => {
     expect(extractTextCached(message)).toBe("plain text");
     expect(extractTextCached(message)).toBe("plain text");
   });
+
+  it("strips inbound metadata preamble from user content", () => {
+    const message = {
+      role: "user",
+      content:
+        'Conversation info (untrusted metadata):\n```json\n{"message_id":"m1"}\n```\n\nSender (untrusted metadata):\n```json\n{"name":"Alice"}\n```\nHello there',
+    };
+    expect(extractTextCached(message)).toBe("Hello there");
+  });
 });
 
 describe("extractThinkingCached", () => {
@@ -41,5 +51,43 @@ describe("extractThinkingCached", () => {
     };
     expect(extractThinkingCached(message)).toBe("Plan A");
     expect(extractThinkingCached(message)).toBe("Plan A");
+  });
+
+  it("keeps non-user content untouched", () => {
+    const message = {
+      role: "assistant",
+      content: 'Conversation info (untrusted metadata):\n```json\n{"message_id":"m1"}\n```\nHello',
+    };
+    expect(extractTextCached(message)).toBe(
+      'Conversation info (untrusted metadata):\n```json\n{"message_id":"m1"}\n```\nHello',
+    );
+  });
+});
+
+describe("stripInboundMetadataPrefix", () => {
+  it("returns only user text when prefix is present", () => {
+    expect(
+      stripInboundMetadataPrefix(
+        'Conversation info (untrusted metadata):\n```json\n{"sender":"Alice"}\n```\n\nHello',
+      ),
+    ).toBe("Hello");
+  });
+
+  it("keeps text when no metadata prefix exists", () => {
+    expect(stripInboundMetadataPrefix("Hello there")).toBe("Hello there");
+  });
+
+  it("strips multiple metadata blocks", () => {
+    const input =
+      'Conversation info (untrusted metadata):\n```json\n{"conversation":"thread"}\n```\n\nSender (untrusted metadata):\n```json\n{"name":"Alice"}\n```\nReplied message (untrusted, for context):\n```json\n{"body":"Hi"}\n```\nHello';
+    expect(stripInboundMetadataPrefix(input)).toBe("Hello");
+  });
+
+  it("returns empty string when only metadata is present", () => {
+    expect(
+      stripInboundMetadataPrefix(
+        'Conversation info (untrusted metadata):\n```json\n{"id":"abc"}\n```',
+      ),
+    ).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- Strip inbound untrusted metadata preamble blocks from webchat user-visible text rendering.
- Added a parser that removes only known `buildInboundUserContextPrefix()` headers when they appear at the start of a user message:
  - `Conversation info (untrusted metadata):`
  - `Sender (untrusted metadata):`
  - `Thread starter (untrusted, for context):`
  - `Replied message (untrusted, for context):`
  - `Forwarded message context (untrusted metadata):`
  - `Chat history since last reply (untrusted, for context):`
- Exported a dedicated helper (`stripInboundMetadataPrefix`) and added it to user message extraction so the fix is enforced consistently in UI rendering.

## Testing
- `cd ui && pnpm test src/ui/chat/message-extract.test.ts` ✅
- `cd ui && pnpm test src/ui/chat/message-normalizer.test.ts` ✅

## Context
This addresses metadata leakage reported by users in webchat threads without touching server storage or model context flow. Only UI-side user-visible text extraction was changed, and assistant/tool message handling remains unchanged.

Closes #22162

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strips inbound metadata preamble blocks from user messages in the webchat UI. The new `stripInboundMetadataPrefix` function removes known metadata headers (like `Conversation info (untrusted metadata):`) that are added by `buildInboundUserContextPrefix` in `src/auto-reply/reply/inbound-meta.ts`. These blocks are intended for the AI model's context but should not be displayed to end users.

**Key changes:**
- Added `stripInboundMetadataPrefix` function that parses and removes metadata blocks starting with known headers
- Integrated into `extractText` pipeline for non-assistant messages (user role)
- Comprehensive test coverage for single block, multiple blocks, no metadata, and empty-content cases
- Only strips metadata from user messages; assistant messages remain untouched

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-tested with comprehensive coverage of edge cases, follows the existing code patterns, and correctly handles the metadata stripping logic. The function only affects UI rendering and doesn't modify message storage or model context.
- No files require special attention

<sub>Last reviewed commit: a8be6ed</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->