### PR TITLE
fix: default to PTY on Windows for proper PowerShell output capture

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -56,12 +56,9 @@ export type {
  * On Windows (PowerShell), PTY is needed for proper output capture, so we default to true.
  * On other platforms, PTY is opt-in via explicit param.pty=true.
  */
-function shouldUsePty(
-  paramPty: boolean | undefined,
-  inSandbox: boolean,
-): boolean {
+function shouldUsePty(paramPty: boolean | undefined, inSandbox: boolean): boolean {
   if (paramPty !== undefined) {
-    return paramPty === true && !inSandbox;
+    return paramPty && !inSandbox;
   }
   // Default to PTY on Windows when not in sandbox
   return !inSandbox && process.platform === "win32";

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -56,12 +56,15 @@ export type {
  * On Windows (PowerShell), PTY is needed for proper output capture, so we default to true.
  * On other platforms, PTY is opt-in via explicit param.pty=true.
  */
-function shouldUsePty(paramPty: boolean | undefined, sandbox: boolean): boolean {
+function shouldUsePty(
+  paramPty: boolean | undefined,
+  inSandbox: boolean,
+): boolean {
   if (paramPty !== undefined) {
-    return paramPty === true && !sandbox;
+    return paramPty === true && !inSandbox;
   }
   // Default to PTY on Windows when not in sandbox
-  return !sandbox && process.platform === "win32";
+  return !inSandbox && process.platform === "win32";
 }
 
 function extractScriptTargetFromCommand(
@@ -398,7 +401,7 @@ export function createExecTool(
           command: params.command,
           workdir,
           env,
-          pty: shouldUsePty(params.pty, sandbox),
+          pty: shouldUsePty(params.pty, !!sandbox),
           timeoutSec: params.timeout,
           defaultTimeoutSec,
           security,
@@ -423,7 +426,7 @@ export function createExecTool(
       const effectiveTimeout =
         typeof params.timeout === "number" ? params.timeout : defaultTimeoutSec;
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
-      const usePty = shouldUsePty(params.pty, sandbox);
+      const usePty = shouldUsePty(params.pty, !!sandbox);
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.


### PR DESCRIPTION
## 🤖 AI-Assisted Contribution

- **Tool**: Claude (Anthropic) via OpenClaw
- **Testing**: Lightly tested on Windows 11 with PowerShell 5.1
- **Understanding**: Code adds a `shouldUsePty()` helper that defaults PTY mode on Windows to fix stdout capture issues with PowerShell. The logic respects explicit user overrides and sandbox restrictions.

## Problem

On Windows, PowerShell does not flush stdout properly when spawned without a PTY, resulting in `(no output)` for exec commands. This makes the exec tool unusable on Windows unless users explicitly set `pty=true` on every call.

## Solution

This PR defaults `pty=true` on Windows (`process.platform === 'win32'`) while maintaining:
- Explicit `param.pty` control (user can still override)
- Sandbox restrictions (no PTY in sandbox mode)
- Fallback behavior (existing PTY failure handling remains)

## Implementation

Added `shouldUsePty()` helper function that:
1. Respects explicit `params.pty` when provided
2. Defaults to `true` on Windows (outside sandbox)
3. Defaults to `false` on other platforms (existing behavior)

## Testing

Tested on Windows 11 with PowerShell 5.1:
- `echo "test"` now returns output without `pty=true`
- `Get-ChildItem` commands work as expected
- Explicit `pty=false` still respected

## Related

Discovered while diagnosing exec output issues during setup and testing of GitHub CLI integration.

---

### Session Context

The issue was discovered while implementing GitHub CLI integration for OpenClaw. During testing, exec commands like `echo "test"` and `Get-ChildItem` returned no output. Investigation revealed PowerShell doesn't flush stdout properly in non-PTY mode on Windows, unlike bash/sh on Unix systems.
