### PR TITLE
fix: support xai tool stream and compat flags

### DIFF
--- a/src/agents/model-compat.e2e.test.ts
+++ b/src/agents/model-compat.e2e.test.ts
@@ -45,4 +45,17 @@ describe("normalizeModelCompat", () => {
       (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
     ).toBe(false);
   });
+
+  it("forces supportsDeveloperRole off for xai models", () => {
+    const model = {
+      ...baseModel(),
+      provider: "xai",
+      baseUrl: "https://api.x.ai/v1",
+    } as Model<Api>;
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
+  });
 });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -7,7 +7,8 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
   const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  const isXai = model.provider === "xai" || baseUrl.includes("api.x.ai");
+  if (!(isZai || isXai) || !isOpenAiCompletionsModel(model)) {
     return model;
   }
 

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -288,6 +288,7 @@ function createOpenRouterHeadersWrapper(baseStreamFn: StreamFn | undefined): Str
  * progressive tool_call deltas, allowing users to see tool execution in real-time.
  *
  * @see https://docs.z.ai/api-reference#streaming
+ * @see https://docs.x.ai/docs/api-reference#streaming
  */
 function createZaiToolStreamWrapper(
   baseStreamFn: StreamFn | undefined,
@@ -358,12 +359,12 @@ export function applyExtraParamsToAgent(
     agent.streamFn = createOpenRouterHeadersWrapper(agent.streamFn);
   }
 
-  // Enable Z.AI tool_stream for real-time tool call streaming.
-  // Enabled by default for Z.AI provider, can be disabled via params.tool_stream: false
-  if (provider === "zai" || provider === "z-ai") {
+  // Enable Z.AI/xAI tool_stream for real-time tool call streaming.
+  // Enabled by default for these providers, can be disabled via params.tool_stream: false
+  if (provider === "zai" || provider === "z-ai" || provider === "xai") {
     const toolStreamEnabled = merged?.tool_stream !== false;
     if (toolStreamEnabled) {
-      log.debug(`enabling Z.AI tool_stream for ${provider}/${modelId}`);
+      log.debug(`enabling Z.AI/xAI tool_stream for ${provider}/${modelId}`);
       agent.streamFn = createZaiToolStreamWrapper(agent.streamFn, true);
     }
   }

--- a/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
@@ -64,6 +64,20 @@ describe("extra-params: Z.AI tool_stream support", () => {
     expect(payload).not.toHaveProperty("tool_stream");
   });
 
+  it("injects tool_stream=true for xai provider by default", () => {
+    const payload = runToolStreamCase({
+      applyProvider: "xai",
+      applyModelId: "grok-4",
+      model: {
+        api: "openai-completions",
+        provider: "xai",
+        id: "grok-4",
+      } as Model<"openai-completions">,
+    });
+
+    expect(payload.tool_stream).toBe(true);
+  });
+
   it("allows disabling tool_stream via params", () => {
     const payload = runToolStreamCase({
       applyProvider: "zai",


### PR DESCRIPTION
## Summary
- Treat xai provider as z.ai-like for OpenAI-completions compatibility.
- Apply default tool_stream=true for xai providers in pi-embedded-runner extra params.
- Add regression tests for model-compat and tool_stream behavior.

## Why
xAI via OpenClaw sometimes returned 403/streaming incompatibility due to missing Z.AI parity handling.

## Testing
- Not run in this environment per instruction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends xAI (provider `"xai"`, baseUrl `api.x.ai`) to receive the same OpenAI-completions compatibility treatment previously limited to Z.AI (`"zai"`). Two specific behaviors are added: (1) `supportsDeveloperRole` is forced to `false` in `normalizeModelCompat`, and (2) `tool_stream=true` is injected by default in `applyExtraParamsToAgent`. Both changes are minimal, well-targeted, and consistent with existing patterns.

- `model-compat.ts`: xAI models now get `supportsDeveloperRole: false` alongside Z.AI, fixing 403/streaming incompatibility
- `extra-params.ts`: `tool_stream=true` is injected for `"xai"` provider, enabling real-time tool call streaming
- Regression tests added for both behaviors, following existing test patterns
- No issues found — the changes are clean and narrowly scoped

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it extends existing, well-tested behavior to a new provider with no architectural changes.
- The changes are minimal and follow existing patterns exactly. The xai provider is already a first-class citizen in the codebase (onboarding, auth, model discovery). The two behavioral changes (compat flags and tool_stream) are narrowly scoped, well-tested, and match the proven zai implementation. No new APIs, no security implications, no breaking changes.
- No files require special attention.

<sub>Last reviewed commit: 2054ce8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->