### PR TITLE
fix(webchat): strip inbound metadata preamble from displayed messages

### DIFF
--- a/src/shared/chat-envelope.test.ts
+++ b/src/shared/chat-envelope.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { stripEnvelope, stripInboundMeta, stripMessageIdHints } from "./chat-envelope.js";
+
+describe("stripInboundMeta", () => {
+  it("strips conversation info metadata block", () => {
+    const input = `Hello world
+
+Conversation info (untrusted metadata):
+\`\`\`json
+{
+  "schema": "openclaw.inbound_meta.v1",
+  "channel": "webchat"
+}
+\`\`\``;
+    expect(stripInboundMeta(input)).toBe("Hello world");
+  });
+
+  it("strips sender metadata block", () => {
+    const input = `Hi there
+Sender (untrusted metadata):
+\`\`\`json
+{"name": "Alice"}
+\`\`\``;
+    expect(stripInboundMeta(input)).toBe("Hi there");
+  });
+
+  it("strips forwarded message context block", () => {
+    const input = `Check this out
+Forwarded message context (untrusted metadata):
+\`\`\`json
+{"from": "Bob"}
+\`\`\``;
+    expect(stripInboundMeta(input)).toBe("Check this out");
+  });
+
+  it("strips multiple metadata blocks", () => {
+    const input = `Hello
+Conversation info (untrusted metadata):
+\`\`\`json
+{"channel": "webchat"}
+\`\`\`
+Sender (untrusted metadata):
+\`\`\`json
+{"name": "Alice"}
+\`\`\``;
+    expect(stripInboundMeta(input)).toBe("Hello");
+  });
+
+  it("returns text unchanged when no metadata present", () => {
+    const input = "Just a normal message with no metadata";
+    expect(stripInboundMeta(input)).toBe(input);
+  });
+
+  it("handles metadata-only messages", () => {
+    const input = `Conversation info (untrusted metadata):
+\`\`\`json
+{"channel": "webchat"}
+\`\`\``;
+    expect(stripInboundMeta(input)).toBe("");
+  });
+});
+
+describe("stripEnvelope", () => {
+  it("strips WebChat envelope prefix", () => {
+    expect(stripEnvelope("[WebChat 2026-02-20 12:00Z] Hello")).toBe("Hello");
+  });
+
+  it("leaves non-envelope text unchanged", () => {
+    expect(stripEnvelope("Hello world")).toBe("Hello world");
+  });
+});

--- a/src/shared/chat-envelope.test.ts
+++ b/src/shared/chat-envelope.test.ts
@@ -51,6 +51,33 @@ Sender (untrusted metadata):
     expect(stripInboundMeta(input)).toBe(input);
   });
 
+  it("strips thread starter block", () => {
+    const input = `Hello
+Thread starter (untrusted, for context):
+\`\`\`json
+{"text": "original message"}
+\`\`\``;
+    expect(stripInboundMeta(input)).toBe("Hello");
+  });
+
+  it("strips replied message block", () => {
+    const input = `My reply
+Replied message (untrusted, for context):
+\`\`\`json
+{"text": "what was replied to"}
+\`\`\``;
+    expect(stripInboundMeta(input)).toBe("My reply");
+  });
+
+  it("strips chat history block", () => {
+    const input = `New message
+Chat history since last reply (untrusted, for context):
+\`\`\`
+Some history here
+\`\`\``;
+    expect(stripInboundMeta(input)).toBe("New message");
+  });
+
   it("handles metadata-only messages", () => {
     const input = `Conversation info (untrusted metadata):
 \`\`\`json

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -39,6 +39,28 @@ export function stripEnvelope(text: string): string {
   return text.slice(match[0].length);
 }
 
+/**
+ * Strip the inbound metadata preamble injected by the gateway for agent context.
+ * This block is not intended for display in chat UIs.
+ *
+ * Matches patterns like:
+ *   Conversation info (untrusted metadata):
+ *   ```json
+ *   { ... }
+ *   ```
+ *
+ * Also strips "Sender (untrusted metadata):" and "Forwarded message context (untrusted metadata):" blocks.
+ */
+const INBOUND_META_BLOCK =
+  /(?:^|\n)\s*(?:Conversation info|Sender|Forwarded message context)\s*\(untrusted metadata\):?\s*\n```json\n[\s\S]*?\n```/g;
+
+export function stripInboundMeta(text: string): string {
+  if (!text.includes("(untrusted metadata)")) {
+    return text;
+  }
+  return text.replace(INBOUND_META_BLOCK, "").trim();
+}
+
 export function stripMessageIdHints(text: string): string {
   if (!text.includes("[message_id:")) {
     return text;

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -49,13 +49,14 @@ export function stripEnvelope(text: string): string {
  *   { ... }
  *   ```
  *
- * Also strips "Sender (untrusted metadata):" and "Forwarded message context (untrusted metadata):" blocks.
+ * Also strips other gateway-injected blocks: Sender, Forwarded message context,
+ * Thread starter, Replied message, and Chat history since last reply.
  */
 const INBOUND_META_BLOCK =
-  /(?:^|\n)\s*(?:Conversation info|Sender|Forwarded message context)\s*\(untrusted metadata\):?\s*\n```json\n[\s\S]*?\n```/g;
+  /(?:^|\n)\s*(?:Conversation info|Sender|Forwarded message context|Thread starter|Replied message|Chat history since last reply)\s*\(untrusted[^)]*\):?\s*\n```(?:json)?\n[\s\S]*?\n```/g;
 
 export function stripInboundMeta(text: string): string {
-  if (!text.includes("(untrusted metadata)")) {
+  if (!text.includes("(untrusted")) {
     return text;
   }
   return text.replace(INBOUND_META_BLOCK, "").trim();

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,4 +1,4 @@
-import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
+import { stripEnvelope, stripInboundMeta } from "../../../../src/shared/chat-envelope.js";
 import { stripThinkingTags } from "../format.ts";
 
 const textCache = new WeakMap<object, string | null>();
@@ -9,7 +9,7 @@ export function extractText(message: unknown): string | null {
   const role = typeof m.role === "string" ? m.role : "";
   const content = m.content;
   if (typeof content === "string") {
-    const processed = role === "assistant" ? stripThinkingTags(content) : stripEnvelope(content);
+    const processed = role === "assistant" ? stripThinkingTags(content) : stripInboundMeta(stripEnvelope(content));
     return processed;
   }
   if (Array.isArray(content)) {
@@ -24,12 +24,12 @@ export function extractText(message: unknown): string | null {
       .filter((v): v is string => typeof v === "string");
     if (parts.length > 0) {
       const joined = parts.join("\n");
-      const processed = role === "assistant" ? stripThinkingTags(joined) : stripEnvelope(joined);
+      const processed = role === "assistant" ? stripThinkingTags(joined) : stripInboundMeta(stripEnvelope(joined));
       return processed;
     }
   }
   if (typeof m.text === "string") {
-    const processed = role === "assistant" ? stripThinkingTags(m.text) : stripEnvelope(m.text);
+    const processed = role === "assistant" ? stripThinkingTags(m.text) : stripInboundMeta(stripEnvelope(m.text));
     return processed;
   }
   return null;


### PR DESCRIPTION
## Summary

The webchat UI was rendering the gateway-injected inbound metadata blocks as visible message content. These blocks (`Conversation info (untrusted metadata)`, `Sender (untrusted metadata)`, `Forwarded message context (untrusted metadata)`) are intended as agent context and should not be displayed to users.

## Changes

- **`src/shared/chat-envelope.ts`**: Added `stripInboundMeta()` function that removes metadata blocks matching the `(untrusted metadata)` pattern with their associated JSON code blocks. Uses a fast early-exit check to avoid regex processing on normal messages.
- **`ui/src/ui/chat/message-extract.ts`**: Integrated `stripInboundMeta()` into the user-message text extraction pipeline (after `stripEnvelope()`).
- **`src/shared/chat-envelope.test.ts`**: Added tests covering single blocks, multiple blocks, different metadata types, and no-op for normal messages.

## Notes

- Other clients (Telegram, Signal, etc.) are not affected as they handle message rendering independently.
- Could not run tests locally due to VM memory constraints; CI should validate.

Fixes #22162

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes webchat UI rendering gateway-injected metadata blocks as visible content by adding `stripInboundMeta()` to remove these blocks before display. 

**Key Changes:**
- Added `stripInboundMeta()` in `chat-envelope.ts` with fast-path optimization
- Integrated into message-extract pipeline for user messages  
- Added comprehensive test coverage

**Issue Found:**
- Regex pattern incomplete - only strips 3 of 6 metadata block types the gateway generates (missing "Thread starter", "Replied message", "Chat history since last reply"). iOS implementation strips all 6.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one fix - incomplete regex pattern needs update
- The implementation is well-structured with good test coverage and performance optimization (early-exit check), but the regex pattern only handles 3 of 6 metadata block types that the gateway actually generates. This means some metadata blocks will still leak through to the webchat UI. The fix is straightforward (update the regex alternation).
- Fix `src/shared/chat-envelope.ts:54-55` to include all metadata block types

<sub>Last reviewed commit: c92763a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->