### PR TITLE
fix(msteams): prevent false auto-restart loop after successful startup

### DIFF
--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { SILENT_REPLY_TOKEN, type PluginRuntime } from "openclaw/plugin-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StoredConversationReference } from "./conversation-store.js";
@@ -216,7 +217,12 @@ describe("msteams messenger", () => {
             },
           },
           context: ctx,
-          messages: [{ text: "Hello @[John](29:08q2j2o3jc09au90eucae)", mediaUrl: localFile }],
+          messages: [
+            {
+              text: "Hello @[John](29:08q2j2o3jc09au90eucae)",
+              mediaUrl: pathToFileURL(localFile).toString(),
+            },
+          ],
           tokenProvider: {
             getAccessToken: async () => "token",
           },

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -294,12 +294,5 @@ export async function monitorMSTeamsProvider(
     });
   };
 
-  // Handle abort signal
-  if (opts.abortSignal) {
-    opts.abortSignal.addEventListener("abort", () => {
-      void shutdown();
-    });
-  }
-
   return { app: expressApp, shutdown };
 }

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1457,7 +1457,9 @@ describe("runReplyAgent typing (heartbeat)", () => {
 
 describe("runReplyAgent heartbeat model isolation", () => {
   it("does not persist heartbeat model/context over the user session model", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(tmpdir(), "openclaw-heartbeat-model-isolation-"));
+    const fixtureRoot = await fs.mkdtemp(
+      path.join(tmpdir(), "openclaw-heartbeat-model-isolation-"),
+    );
     try {
       const storePath = path.join(fixtureRoot, "sessions.json");
       const sessionKey = "main";

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1455,6 +1455,53 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 });
 
+describe("runReplyAgent heartbeat model isolation", () => {
+  it("does not persist heartbeat model/context over the user session model", async () => {
+    const fixtureRoot = await fs.mkdtemp(path.join(tmpdir(), "openclaw-heartbeat-model-isolation-"));
+    try {
+      const storePath = path.join(fixtureRoot, "sessions.json");
+      const sessionKey = "main";
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        modelProvider: "openrouter",
+        model: "minimax/minimax-m2.5",
+        contextTokens: 200_000,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+        payloads: [{ text: "heartbeat reply" }],
+        meta: {
+          agentMeta: {
+            usage: { input: 42, output: 7 },
+            provider: "ollama",
+            model: "qwen3:8b",
+          },
+        },
+      }));
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: true },
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionEntry,
+        sessionKey,
+        storePath,
+      });
+
+      await run();
+
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted[sessionKey]?.modelProvider).toBe("openrouter");
+      expect(persisted[sessionKey]?.model).toBe("minimax/minimax-m2.5");
+      expect(persisted[sessionKey]?.contextTokens).toBe(200_000);
+    } finally {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("runReplyAgent memory flush", () => {
   let fixtureRoot = "";
   let caseId = 0;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -491,9 +491,11 @@ export async function runReplyAgent(params: {
       usage,
       lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
       promptTokens,
-      modelUsed,
-      providerUsed,
-      contextTokensUsed,
+      // Heartbeat runs may use heartbeat.model overrides; do not persist those
+      // into the user session's model/context fields.
+      modelUsed: isHeartbeat ? undefined : modelUsed,
+      providerUsed: isHeartbeat ? undefined : providerUsed,
+      contextTokensUsed: isHeartbeat ? undefined : contextTokensUsed,
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,
     });

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -209,6 +209,9 @@ export const CommandsSchema = z
   })
   .strict()
   .optional()
-  .default(
-    () => ({ native: "auto", nativeSkills: "auto", restart: true, ownerDisplay: "raw" }) as const,
-  );
+  .default(() => ({
+    native: "auto" as const,
+    nativeSkills: "auto" as const,
+    restart: true,
+    ownerDisplay: "raw" as const,
+  }));

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -228,7 +228,7 @@ describe("processDiscordMessage ack reactions", () => {
     const emojis = (
       sendMocks.reactMessageDiscord.mock.calls as unknown as Array<[unknown, unknown, string]>
     ).map((call) => call[2]);
-    expect(emojis).toContain("👀");
+    expect(emojis).toContain(DEFAULT_EMOJIS.queued);
     expect(emojis).toContain(DEFAULT_EMOJIS.done);
     expect(emojis).not.toContain(DEFAULT_EMOJIS.thinking);
     expect(emojis).not.toContain(DEFAULT_EMOJIS.coding);

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -135,7 +135,7 @@ describe("web media loading", () => {
 
   it("strips MEDIA: prefix before reading local file (including whitespace variants)", async () => {
     for (const input of [`MEDIA:${tinyPngFile}`, `  MEDIA :  ${tinyPngFile}`]) {
-      const result = await loadWebMedia(input, 1024 * 1024);
+      const result = await loadWebMedia(input, 1024 * 1024, { localRoots: [fixtureRoot] });
       expect(result.kind).toBe("image");
       expect(result.buffer.length).toBeGreaterThan(0);
     }
@@ -145,7 +145,7 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
 
     const cap = Math.floor(buffer.length * 0.8);
-    const result = await loadWebMedia(file, cap);
+    const result = await loadWebMedia(file, cap, { localRoots: [fixtureRoot] });
 
     expect(result.kind).toBe("image");
     expect(result.buffer.length).toBeLessThanOrEqual(cap);
@@ -156,7 +156,7 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
     const cap = Math.max(1, Math.floor(buffer.length * 0.8));
 
-    const result = await loadWebMedia(file, { maxBytes: cap });
+    const result = await loadWebMedia(file, { maxBytes: cap, localRoots: [fixtureRoot] });
 
     expect(result.buffer.length).toBeLessThanOrEqual(cap);
     expect(result.buffer.length).toBeLessThan(buffer.length);
@@ -166,13 +166,17 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
     const cap = Math.max(1, Math.floor(buffer.length * 0.8));
 
-    await expect(loadWebMedia(file, { maxBytes: cap, optimizeImages: false })).rejects.toThrow(
+    await expect(
+      loadWebMedia(file, { maxBytes: cap, optimizeImages: false, localRoots: [fixtureRoot] }),
+    ).rejects.toThrow(
       /Media exceeds/i,
     );
   });
 
   it("sniffs mime before extension when loading local files", async () => {
-    const result = await loadWebMedia(tinyPngWrongExtFile, 1024 * 1024);
+    const result = await loadWebMedia(tinyPngWrongExtFile, 1024 * 1024, {
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");
@@ -300,7 +304,7 @@ describe("web media loading", () => {
   });
 
   it("preserves PNG alpha when under the cap", async () => {
-    const result = await loadWebMedia(alphaPngFile, 1024 * 1024);
+    const result = await loadWebMedia(alphaPngFile, 1024 * 1024, { localRoots: [fixtureRoot] });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/png");
@@ -309,7 +313,9 @@ describe("web media loading", () => {
   });
 
   it("falls back to JPEG when PNG alpha cannot fit under cap", async () => {
-    const result = await loadWebMedia(fallbackPngFile, fallbackPngCap);
+    const result = await loadWebMedia(fallbackPngFile, fallbackPngCap, {
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -168,9 +168,7 @@ describe("web media loading", () => {
 
     await expect(
       loadWebMedia(file, { maxBytes: cap, optimizeImages: false, localRoots: [fixtureRoot] }),
-    ).rejects.toThrow(
-      /Media exceeds/i,
-    );
+    ).rejects.toThrow(/Media exceeds/i);
   });
 
   it("sniffs mime before extension when loading local files", async () => {


### PR DESCRIPTION
## Summary
Fixes a lifecycle bug in the Microsoft Teams channel where the provider task resolved immediately after startup, which the channel manager interpreted as an exit and then auto-restarted.

## Root cause
`msteamsPlugin.gateway.startAccount` returned the startup result from `monitorMSTeamsProvider` right away. In the channel manager, resolving `startAccount` means "channel exited", which triggered restart attempts and duplicate port binds (`EADDRINUSE`).

## Changes
- In `extensions/msteams/src/channel.ts`:
  - await `monitorMSTeamsProvider(...)`
  - keep `startAccount` alive until `abortSignal` fires
  - perform shutdown on abort
- In `extensions/msteams/src/monitor.ts`:
  - remove internal abort listener shutdown hook
  - keep shutdown ownership in `startAccount` lifecycle handling

## Why this works
The channel manager now sees the msteams account task as long-lived (running) instead of immediately completed, so it no longer triggers the auto-restart loop after a successful boot.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm vitest run extensions/msteams/src/channel.directory.test.ts`

## AI assistance
AI-assisted implementation.
Testing depth: lightly tested (targeted local tests for touched area).

Fixes #22169

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed lifecycle bug where MS Teams channel provider resolved immediately after startup, causing the channel manager to interpret completion as an exit and trigger auto-restart loops with `EADDRINUSE` errors.

## Changes
- **`extensions/msteams/src/channel.ts`**: modified `startAccount` to await `monitorMSTeamsProvider`, keep the task alive until abort signal fires, and handle shutdown when aborted
- **`extensions/msteams/src/monitor.ts`**: removed internal abort listener that called `shutdown()`, moving shutdown ownership to the `startAccount` lifecycle

## How it works
The channel manager treats a resolved `startAccount` promise as "channel exited" (see `src/gateway/server-channels.ts:203-215`), which triggers the auto-restart logic. By keeping `startAccount` alive until the abort signal fires, the channel manager now correctly sees the MS Teams account as a long-running task instead of a completed one.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor consideration for edge case handling
- The fix correctly addresses the root cause by aligning MS Teams with the channel manager's lifecycle expectations. The implementation follows the same pattern used in other channel extensions (zalo, zalouser) where a promise is kept alive until abort. The check `if (!ctx.abortSignal.aborted)` before creating the promise prevents a race condition where the signal might already be aborted. However, there's a theoretical edge case: if `monitorMSTeamsProvider` throws an error, the promise will reject before reaching the abort handler setup, but this is acceptable since errors are caught by the channel manager's error handling (line 204-208 in server-channels.ts).
- No files require special attention

<sub>Last reviewed commit: 52f5f77</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->