### PR TITLE
test(web): fix media fixture tests under local-root hardening

### DIFF
--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -136,7 +136,7 @@ describe("web media loading", () => {
 
   it("strips MEDIA: prefix before reading local file (including whitespace variants)", async () => {
     for (const input of [`MEDIA:${tinyPngFile}`, `  MEDIA :  ${tinyPngFile}`]) {
-      const result = await loadWebMedia(input, 1024 * 1024);
+      const result = await loadWebMedia(input, 1024 * 1024, { localRoots: [fixtureRoot] });
       expect(result.kind).toBe("image");
       expect(result.buffer.length).toBeGreaterThan(0);
     }
@@ -146,7 +146,7 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
 
     const cap = Math.floor(buffer.length * 0.8);
-    const result = await loadWebMedia(file, cap);
+    const result = await loadWebMedia(file, cap, { localRoots: [fixtureRoot] });
 
     expect(result.kind).toBe("image");
     expect(result.buffer.length).toBeLessThanOrEqual(cap);
@@ -157,7 +157,7 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
     const cap = Math.max(1, Math.floor(buffer.length * 0.8));
 
-    const result = await loadWebMedia(file, { maxBytes: cap });
+    const result = await loadWebMedia(file, { maxBytes: cap, localRoots: [fixtureRoot] });
 
     expect(result.buffer.length).toBeLessThanOrEqual(cap);
     expect(result.buffer.length).toBeLessThan(buffer.length);
@@ -167,13 +167,17 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
     const cap = Math.max(1, Math.floor(buffer.length * 0.8));
 
-    await expect(loadWebMedia(file, { maxBytes: cap, optimizeImages: false })).rejects.toThrow(
+    await expect(
+      loadWebMedia(file, { maxBytes: cap, optimizeImages: false, localRoots: [fixtureRoot] }),
+    ).rejects.toThrow(
       /Media exceeds/i,
     );
   });
 
   it("sniffs mime before extension when loading local files", async () => {
-    const result = await loadWebMedia(tinyPngWrongExtFile, 1024 * 1024);
+    const result = await loadWebMedia(tinyPngWrongExtFile, 1024 * 1024, {
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");
@@ -287,7 +291,7 @@ describe("web media loading", () => {
   });
 
   it("preserves PNG alpha when under the cap", async () => {
-    const result = await loadWebMedia(alphaPngFile, 1024 * 1024);
+    const result = await loadWebMedia(alphaPngFile, 1024 * 1024, { localRoots: [fixtureRoot] });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/png");
@@ -296,7 +300,9 @@ describe("web media loading", () => {
   });
 
   it("falls back to JPEG when PNG alpha cannot fit under cap", async () => {
-    const result = await loadWebMedia(fallbackPngFile, fallbackPngCap);
+    const result = await loadWebMedia(fallbackPngFile, fallbackPngCap, {
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -169,9 +169,7 @@ describe("web media loading", () => {
 
     await expect(
       loadWebMedia(file, { maxBytes: cap, optimizeImages: false, localRoots: [fixtureRoot] }),
-    ).rejects.toThrow(
-      /Media exceeds/i,
-    );
+    ).rejects.toThrow(/Media exceeds/i);
   });
 
   it("sniffs mime before extension when loading local files", async () => {


### PR DESCRIPTION
## Summary
Fixes failing `src/web/media.test.ts` cases after local media path hardening by giving local fixture-based tests explicit allowed roots.

## Root cause
The tests create fixtures under `/tmp/openclaw-media-test-*`. After local media root restrictions were tightened, those paths are denied unless explicitly allowed. Tests still used default roots, causing `LocalMediaAccessError`.

## Changes
- Update local-file test cases in `src/web/media.test.ts` to pass `localRoots: [fixtureRoot]` for fixture-backed reads.
- Keep production restrictions intact (tests now opt in explicitly to fixture root).

## Validation
- `pnpm vitest run src/web/media.test.ts` ✅ (24/24)
- `pnpm exec oxlint --type-aware src/web/media.test.ts` ✅

## AI assistance
AI-assisted implementation.
Testing depth: focused local test validation for touched file.

Fixes #22191

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `src/web/media.test.ts` failures by adding explicit `localRoots: [fixtureRoot]` to local file test cases after security hardening in c3784392 tightened local media path restrictions.

- Updated 7 test cases that read from fixture files under `/tmp/openclaw-media-test-*` to pass explicit allowed roots
- Security guard tests remain unchanged (correctly testing the restriction behavior)
- All affected tests now properly opt-in to fixture directory access

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal, surgical, and exactly address the stated problem. All 7 updates follow the same pattern of adding `localRoots: [fixtureRoot]` to test cases that read local fixture files. Security tests testing the restriction behavior remain untouched. No logic changes, no production code affected.
- No files require special attention

<sub>Last reviewed commit: b515b2b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->