### PR TITLE
fix(skills): treat empty allowBundled array as block-all

### DIFF
--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, test } from "vitest";
+import { isBundledSkillAllowed, resolveBundledAllowlist } from "./config.js";
+import type { SkillEntry } from "./types.js";
+
+/**
+ * Helper: create a minimal bundled SkillEntry for testing.
+ */
+function bundledSkill(name: string): SkillEntry {
+  return {
+    skill: { name, source: "openclaw-bundled" } as SkillEntry["skill"],
+    frontmatter: {},
+  };
+}
+
+/**
+ * Helper: create a minimal workspace (non-bundled) SkillEntry for testing.
+ */
+function workspaceSkill(name: string): SkillEntry {
+  return {
+    skill: { name, source: "workspace" } as SkillEntry["skill"],
+    frontmatter: {},
+  };
+}
+
+describe("resolveBundledAllowlist", () => {
+  it("returns undefined when allowBundled is not set", () => {
+    expect(resolveBundledAllowlist({})).toBeUndefined();
+    expect(resolveBundledAllowlist(undefined)).toBeUndefined();
+    expect(resolveBundledAllowlist({ skills: {} })).toBeUndefined();
+  });
+
+  it("returns undefined for null or non-array values", () => {
+    expect(resolveBundledAllowlist({ skills: { allowBundled: null } } as any)).toBeUndefined();
+    expect(resolveBundledAllowlist({ skills: { allowBundled: "web" } } as any)).toBeUndefined();
+    expect(resolveBundledAllowlist({ skills: { allowBundled: 42 } } as any)).toBeUndefined();
+  });
+
+  it("returns a normal list for valid entries", () => {
+    expect(resolveBundledAllowlist({ skills: { allowBundled: ["web", "pdf"] } } as any)).toEqual([
+      "web",
+      "pdf",
+    ]);
+  });
+
+  it("trims whitespace from entries", () => {
+    expect(
+      resolveBundledAllowlist({ skills: { allowBundled: ["  web  ", "pdf "] } } as any),
+    ).toEqual(["web", "pdf"]);
+  });
+
+  it("returns [] for an explicit empty array (not undefined)", () => {
+    // Bug #21709: normalizeAllowlist([]) currently returns undefined instead of []
+    const result = resolveBundledAllowlist({ skills: { allowBundled: [] } } as any);
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when all entries normalize to empty strings", () => {
+    // allowBundled: ["", "  "] → after trim + filter → [] → should still be []
+    const result = resolveBundledAllowlist({
+      skills: { allowBundled: ["", "  "] },
+    } as any);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("isBundledSkillAllowed", () => {
+  const web = bundledSkill("web");
+  const pdf = bundledSkill("pdf");
+  const mySkill = workspaceSkill("my-custom-skill");
+
+  it("allows all bundled skills when allowlist is undefined (not configured)", () => {
+    expect(isBundledSkillAllowed(web, undefined)).toBe(true);
+    expect(isBundledSkillAllowed(pdf, undefined)).toBe(true);
+  });
+
+  it("allows only listed bundled skills", () => {
+    expect(isBundledSkillAllowed(web, ["web"])).toBe(true);
+    expect(isBundledSkillAllowed(pdf, ["web"])).toBe(false);
+  });
+
+  it("always allows non-bundled (workspace) skills regardless of allowlist", () => {
+    expect(isBundledSkillAllowed(mySkill, undefined)).toBe(true);
+    expect(isBundledSkillAllowed(mySkill, ["web"])).toBe(true);
+    expect(isBundledSkillAllowed(mySkill, [])).toBe(true);
+  });
+
+  it("blocks all bundled skills when allowlist is empty array", () => {
+    // Bug #21709: isBundledSkillAllowed(entry, []) currently returns true
+    // because it treats [] the same as undefined
+    expect(isBundledSkillAllowed(web, [])).toBe(false);
+    expect(isBundledSkillAllowed(pdf, [])).toBe(false);
+  });
+
+  it("blocks all bundled skills when allowlist contains only misspelled names", () => {
+    // User typo: "wbe" instead of "web" — no bundled skill matches, so all are blocked.
+    // This is correct allowlist behavior (fail closed), but the user gets no warning.
+    expect(isBundledSkillAllowed(web, ["wbe"])).toBe(false);
+    expect(isBundledSkillAllowed(pdf, ["wbe"])).toBe(false);
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -43,7 +43,7 @@ function normalizeAllowlist(input: unknown): string[] | undefined {
     return undefined;
   }
   const normalized = input.map((entry) => String(entry).trim()).filter(Boolean);
-  return normalized.length > 0 ? normalized : undefined;
+  return normalized;
 }
 
 const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
@@ -57,11 +57,14 @@ export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | und
 }
 
 export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): boolean {
-  if (!allowlist || allowlist.length === 0) {
+  if (!allowlist) {
     return true;
   }
   if (!isBundledSkill(entry)) {
     return true;
+  }
+  if (allowlist.length === 0) {
+    return false;
   }
   const key = resolveSkillKey(entry.skill, entry);
   return allowlist.includes(key) || allowlist.includes(entry.skill.name);


### PR DESCRIPTION
## Summary

Fixes #21709

Setting `skills.allowBundled: []` was silently allowing all bundled skills instead of blocking them. The root cause was a two-part logic error:

1. **`normalizeAllowlist()`** collapsed empty arrays to `undefined`
2. **`isBundledSkillAllowed()`** treated `undefined` as "no filter → allow all"

### Changes

| Before | After |
|--------|-------|
| `allowBundled: []` → all bundled skills allowed | `allowBundled: []` → all bundled skills blocked |
| `allowBundled: ["", " "]` → all bundled skills allowed | `allowBundled: ["", " "]` → all bundled skills blocked |
| `allowBundled` not set → all allowed | `allowBundled` not set → all allowed (unchanged) |
| `allowBundled: ["web"]` → only "web" allowed | `allowBundled: ["web"]` → only "web" allowed (unchanged) |
| Workspace skills always allowed | Workspace skills always allowed (unchanged) |

### What was changed

- `src/agents/skills/config.ts`: 2 lines of logic (5 insertions, 2 deletions)
  - `normalizeAllowlist()`: return `normalized` directly instead of collapsing `[]` → `undefined`
  - `isBundledSkillAllowed()`: check `isBundledSkill()` before `allowlist.length === 0`, so workspace skills always pass through; then treat empty array as "block all bundled"
- `src/agents/skills/config.test.ts`: new test file with 11 cases covering normal operation, empty arrays, whitespace-only entries, misspelled names, and workspace skill passthrough

## AI-assisted contribution

This fix was pair-programmed with [Claude Code](https://claude.com/claude-code) (claude-opus-4-6). Claude handled the codebase analysis, wrote the fix and tests; I (haitao) drove the design decisions, caught edge cases (what about malformed inputs? what about misspelled skill names?), and reviewed all changes. Claude's initial fix actually had a subtle ordering bug — the empty-array check ran before the `isBundledSkill()` check, which would have blocked workspace skills too. Our test suite caught it before commit. A good reminder that AI-generated code still needs human review and thorough tests.

## Test plan

- [x] `npx vitest run src/agents/skills/config.test.ts` — 11/11 pass
- [x] `pnpm build` — pass
- [x] `pnpm lint` — 0 errors, 0 warnings
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical security issue where `skills.allowBundled: []` silently allowed all bundled skills instead of blocking them. The two-line fix corrects the logic by preserving empty arrays through `normalizeAllowlist()` and treating them as "block all bundled" in `isBundledSkillAllowed()` while still allowing workspace skills to pass through.

**Key changes:**
- `normalizeAllowlist()` now returns `[]` instead of collapsing to `undefined` when the filtered result is empty
- `isBundledSkillAllowed()` checks `isBundledSkill()` first to ensure workspace skills always pass, then treats `allowlist.length === 0` as block-all for bundled skills
- Comprehensive test coverage with 11 test cases covering edge cases including empty arrays, whitespace-only entries, misspelled names, and workspace skill passthrough

The PR description notes that Claude's initial fix had the check ordering wrong (would have blocked workspace skills too), but the test suite caught it before commit.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal (2 lines changed), addresses a well-defined security issue, and includes comprehensive test coverage. The logic change is correct and the ordering of checks ensures workspace skills remain unaffected while properly blocking bundled skills when an empty array is specified.
- No files require special attention

<sub>Last reviewed commit: 83fb806</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->