### PR TITLE
fix: preserve case of target ID in normalizeTargetId

### DIFF
--- a/src/channels/targets.ts
+++ b/src/channels/targets.ts
@@ -16,7 +16,7 @@ export type MessagingTargetParseOptions = {
 };
 
 export function normalizeTargetId(kind: MessagingTargetKind, id: string): string {
-  return `${kind}:${id}`.toLowerCase();
+  return `${kind.toLowerCase()}:${id}`;
 }
 
 export function buildMessagingTarget(


### PR DESCRIPTION
## Summary
Fixes #22217

Slack user IDs are case-sensitive (e.g. `U3UR2BMQ8`). `normalizeTargetId()` was lowercasing the entire `kind:id` string, converting `channel:U3UR2BMQ8` to `channel:u3ur2bmq8`, causing Slack API `channel_not_found` errors when opening DM channels.

## Changes
- Only lowercase the `kind` prefix, preserve the original case of `id`

## Before / After
| | Result |
|---|---|
| Before | `channel:u3ur2bmq8` ❌ |
| After | `channel:U3UR2BMQ8` ✅ |

---
🤖 Generated with Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Slack API `channel_not_found` errors by preserving case-sensitivity in user/channel IDs. The `normalizeTargetId()` function now only lowercases the `kind` prefix (`user`/`channel`) while maintaining the original case of the ID portion (e.g., `U3UR2BMQ8`).

- Changed normalization from `"channel:u3ur2bmq8"` to `"channel:U3UR2BMQ8"`
- Fixes integration with Slack API which requires case-sensitive IDs
- Tests in `src/slack/targets.test.ts` need updating to reflect new normalized format

<h3>Confidence Score: 4/5</h3>

- Safe to merge after updating test expectations
- The fix correctly addresses the Slack API case-sensitivity issue with a minimal, focused change. However, the existing tests expect lowercase normalized IDs and will fail without updates. Once tests are updated to reflect the new behavior, this should be safe to merge.
- Check `src/slack/targets.test.ts` - test expectations need updating

<sub>Last reviewed commit: ddd78e6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->