### PR TITLE
fix(security): harden gateway auth — audit logging, pairing, mode validation

### DIFF
--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -107,6 +107,17 @@ export async function resolveGatewayRuntimeConfig(params: {
   const trustedProxies = params.cfg.gateway?.trustedProxies ?? [];
 
   assertGatewayAuthConfigured(resolvedAuth);
+
+  // CRITICAL-3: Block auth mode "none" on non-loopback binds.
+  // The resolved type only allows "token"|"password", but untyped JSON config
+  // could smuggle "none" at runtime — this is defense-in-depth.
+  if ((authMode as string) === "none" && !isLoopbackHost(bindHost)) {
+    throw new Error(
+      `refusing to bind gateway to ${bindHost}:${params.port} with auth.mode=none ` +
+        `(mode "none" is only allowed with bind=loopback; set gateway.auth.token/password)`,
+    );
+  }
+
   if (tailscaleMode === "funnel" && authMode !== "password") {
     throw new Error(
       "tailscale funnel requires gateway auth mode=password (set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)",

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -108,10 +108,8 @@ export async function resolveGatewayRuntimeConfig(params: {
 
   assertGatewayAuthConfigured(resolvedAuth);
 
-  // CRITICAL-3: Block auth mode "none" on non-loopback binds.
-  // The resolved type only allows "token"|"password", but untyped JSON config
-  // could smuggle "none" at runtime — this is defense-in-depth.
-  if ((authMode as string) === "none" && !isLoopbackHost(bindHost)) {
+  // CRITICAL-3: Block auth mode "none" on non-loopback binds (defense-in-depth).
+  if (authMode === "none" && !isLoopbackHost(bindHost)) {
     throw new Error(
       `refusing to bind gateway to ${bindHost}:${params.port} with auth.mode=none ` +
         `(mode "none" is only allowed with bind=loopback; set gateway.auth.token/password)`,


### PR DESCRIPTION
## Summary

- **CRITICAL-1**: Add audit logging to loopback request classification in `isLocalDirectRequest()` to detect potential auth bypass when gateway is LAN-bound
- **CRITICAL-2**: Remove silent auto-approval of device pairing for local clients — all pairing now requires explicit user confirmation
- **CRITICAL-3**: Block auth mode "none" on non-loopback binds at startup (defense-in-depth against untyped JSON config)

## Test plan

- [ ] Verify gateway startup rejects `auth.mode=none` on LAN bind
- [ ] Verify device pairing always prompts for confirmation (no silent auto-approve for local clients)
- [ ] Verify loopback requests emit `[SECURITY AUDIT]` log line
- [ ] `pnpm check` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens gateway authentication with three defense-in-depth security improvements: adds audit logging for loopback request classification to detect potential auth bypass, removes silent auto-approval of device pairing for local clients requiring explicit user confirmation for all pairing requests, and blocks `auth.mode=none` on non-loopback binds at startup.

- **CRITICAL-1** (auth.ts:116-121): audit logging detects loopback requests classified as local/trusted, helping identify potential auth bypass when gateway is LAN-bound
- **CRITICAL-2** (message-handler.ts:656-676): removed automatic pairing approval for local clients — all device pairing now requires explicit user confirmation, preventing co-located processes from pairing without authorization
- **CRITICAL-3** (server-runtime-config.ts:111-119): prevents `auth.mode=none` on non-loopback binds, providing defense-in-depth against untyped JSON config smuggling insecure auth mode

Minor style issue: comment on line 112 is inaccurate (type actually includes `"none"`) and type cast on line 114 is unnecessary but harmless.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — implements critical security hardening for gateway authentication
- Three well-scoped security improvements with clear defense-in-depth benefits. The changes are additive (audit logging), restrictive (blocking insecure configs), and correctness-focused (removing unsafe auto-approval). Only minor style issues with an inaccurate comment and unnecessary type cast that don't affect functionality. No breaking changes to secure configurations.
- No files require special attention — all changes are security improvements

<sub>Last reviewed commit: c877c51</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->