### PR TITLE
fix(security): redact sensitive data in session transcripts

### DIFF
--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import { redactSensitiveText } from "../../logging/redact.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { resolveDefaultSessionStorePath, resolveSessionFilePath } from "./paths.js";
 import { loadSessionStore, updateSessionStore } from "./store.js";
@@ -121,10 +122,15 @@ export async function appendAssistantMessageToSessionTranscript(params: {
 
   await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
 
+  // CRITICAL-4: Redact sensitive data (API keys, tokens, etc.) from transcripts
+  // before persisting to disk. OS-level encryption (BitLocker/FileVault/LUKS) is
+  // recommended as an additional layer of protection.
+  const redactedText = redactSensitiveText(mirrorText);
+
   const sessionManager = SessionManager.open(sessionFile);
   sessionManager.appendMessage({
     role: "assistant",
-    content: [{ type: "text", text: mirrorText }],
+    content: [{ type: "text", text: redactedText }],
     api: "openai-responses",
     provider: "openclaw",
     model: "delivery-mirror",


### PR DESCRIPTION
## Summary

- **CRITICAL-4**: Apply `redactSensitiveText()` to session transcript content before writing to disk, preventing credentials and API keys from being persisted in plaintext

Reuses the existing `redactSensitiveText` utility from `src/logging/redact.ts`.

## Test plan

- [ ] Verify transcripts no longer contain raw API keys / tokens
- [ ] `pnpm check` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Applied `redactSensitiveText()` to assistant messages before writing to session transcripts, preventing API keys, tokens, and other credentials from being persisted in plaintext.

- Redaction happens at the right abstraction layer inside `appendAssistantMessageToSessionTranscript()` in `src/config/sessions/transcript.ts:128`, ensuring all call sites automatically benefit
- Reuses the existing, well-tested `redactSensitiveText` utility from `src/logging/redact.ts` which handles various token formats (API keys, bearer tokens, private keys, Telegram tokens, etc.)
- Added clear comment explaining the security measure and recommending OS-level encryption as an additional layer

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security improvement with no behavioral changes
- The change is a straightforward security enhancement that applies redaction to session transcripts using a well-tested utility function. The implementation is at the correct layer, has no side effects, and the `redactSensitiveText` function has comprehensive test coverage
- No files require special attention

<sub>Last reviewed commit: 750c3c3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->