### PR TITLE
Android: security hardening to prevent screenshots of manual gateway settings

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
+import android.view.WindowManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -45,6 +46,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -55,6 +57,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.window.DialogWindowProvider
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
@@ -411,6 +415,11 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
     item {
       AnimatedVisibility(visible = advancedExpanded) {
+        val sheetWindow = (LocalView.current.parent as? DialogWindowProvider)?.window
+        DisposableEffect(Unit) {
+          sheetWindow?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+          onDispose { sheetWindow?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE) }
+        }
         Column(verticalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
           ListItem(
             headlineContent = { Text("Use Manual Gateway") },


### PR DESCRIPTION
## Summary
- Set `FLAG_SECURE` on the bottom sheet window while the Advanced manual gateway section is expanded
- Prevents screenshots and screen recording of sensitive connection credentials (host, port, gateway token, TLS config)
- Flag is scoped to the `AnimatedVisibility` composable — automatically clears when the section collapses or the sheet is dismissed

## Test plan
- [x] Open Settings → expand Advanced manual gateway section → verify screenshots are blocked
- [x] Collapse the section or dismiss the sheet → verify screenshots work again
- [x] Verify no regressions in other settings sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds screenshot prevention to the Advanced manual gateway settings section by setting `FLAG_SECURE` on the bottom sheet window. The flag is scoped to the `AnimatedVisibility` block containing sensitive connection details (host, port, gateway token, TLS config) and automatically clears when the section collapses.

**Key changes:**
- Adds `DisposableEffect` inside `AnimatedVisibility` to manage `FLAG_SECURE` lifecycle
- Uses `LocalView.current.parent as? DialogWindowProvider` to access the `ModalBottomSheet` window
- Safe null handling ensures graceful fallback if window reference is unavailable

**Implementation notes:**
- The window reference retrieval uses safe casting and null-safe calls, so if the `DialogWindowProvider` cast fails, the feature silently degrades without crashes
- `DisposableEffect(Unit)` correctly triggers when content enters/exits composition as `AnimatedVisibility` adds/removes content based on visibility state

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it adds a security hardening feature with proper error handling
- The implementation follows Android best practices for screenshot prevention using `FLAG_SECURE`, includes proper lifecycle management via `DisposableEffect`, and uses defensive null-safe programming. The approach gracefully degrades if the window reference is unavailable. The only minor concern is that the window reference retrieval pattern (`LocalView.current.parent as? DialogWindowProvider`) may not work in all Compose contexts, but the safe casting ensures this won't cause crashes - it will simply fail silently without blocking screenshots
- No files require special attention

<sub>Last reviewed commit: 1b72ff0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->