### PR TITLE
fix(security): harden plugin hooks and installation scanning

### DIFF
--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -42,6 +42,7 @@ import type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginOrigin,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -92,6 +93,16 @@ export type HookRunnerOptions = {
   /** If true, errors in hooks will be caught and logged instead of thrown */
   catchErrors?: boolean;
 };
+
+/**
+ * CRITICAL-10: Origins considered trusted for system prompt / tool param modification.
+ * Only bundled and config-defined plugins may modify these sensitive values.
+ */
+const TRUSTED_HOOK_ORIGINS: ReadonlySet<PluginOrigin> = new Set(["bundled", "config"]);
+
+function isTrustedHookOrigin(origin?: PluginOrigin): boolean {
+  return origin !== undefined && TRUSTED_HOOK_ORIGINS.has(origin);
+}
 
 /**
  * Get hooks for a specific hook name, sorted by priority (higher first).
@@ -253,15 +264,47 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     event: PluginHookBeforeAgentStartEvent,
     ctx: PluginHookAgentContext,
   ): Promise<PluginHookBeforeAgentStartResult | undefined> {
-    return runModifyingHook<"before_agent_start", PluginHookBeforeAgentStartResult>(
-      "before_agent_start",
-      event,
-      ctx,
-      (acc, next) => ({
-        ...mergeBeforePromptBuild(acc, next),
-        ...mergeBeforeModelResolve(acc, next),
-      }),
-    );
+    const hooks = getHooksForName(registry, "before_agent_start");
+    if (hooks.length === 0) {
+      return undefined;
+    }
+
+    let result: PluginHookBeforeAgentStartResult | undefined;
+
+    for (const hook of hooks) {
+      try {
+        const handlerResult = await (
+          hook.handler as (
+            event: unknown,
+            ctx: unknown,
+          ) => Promise<PluginHookBeforeAgentStartResult>
+        )(event, ctx);
+
+        if (handlerResult !== undefined && handlerResult !== null) {
+          // CRITICAL-10: Block system prompt modification from untrusted plugins.
+          if (handlerResult.systemPrompt !== undefined && !isTrustedHookOrigin(hook.origin)) {
+            logger?.warn(
+              `[SECURITY] BLOCKED: untrusted plugin "${hook.pluginId}" (origin=${hook.origin ?? "unknown"}) attempted system prompt modification — stripped`,
+            );
+            handlerResult.systemPrompt = undefined;
+          }
+
+          result = {
+            ...mergeBeforePromptBuild(result, handlerResult),
+            ...mergeBeforeModelResolve(result, handlerResult),
+          };
+        }
+      } catch (err) {
+        const msg = `[hooks] before_agent_start handler from ${hook.pluginId} failed: ${String(err)}`;
+        if (catchErrors) {
+          logger?.error(msg);
+        } else {
+          throw new Error(msg, { cause: err });
+        }
+      }
+    }
+
+    return result;
   }
 
   /**
@@ -385,16 +428,46 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     event: PluginHookBeforeToolCallEvent,
     ctx: PluginHookToolContext,
   ): Promise<PluginHookBeforeToolCallResult | undefined> {
-    return runModifyingHook<"before_tool_call", PluginHookBeforeToolCallResult>(
-      "before_tool_call",
-      event,
-      ctx,
-      (acc, next) => ({
-        params: next.params ?? acc?.params,
-        block: next.block ?? acc?.block,
-        blockReason: next.blockReason ?? acc?.blockReason,
-      }),
-    );
+    const hooks = getHooksForName(registry, "before_tool_call");
+    if (hooks.length === 0) {
+      return undefined;
+    }
+
+    let result: PluginHookBeforeToolCallResult | undefined;
+
+    for (const hook of hooks) {
+      try {
+        const handlerResult = await (
+          hook.handler as (event: unknown, ctx: unknown) => Promise<PluginHookBeforeToolCallResult>
+        )(event, ctx);
+
+        if (handlerResult !== undefined && handlerResult !== null) {
+          // CRITICAL-10: Block tool parameter modification from untrusted plugins.
+          // Untrusted plugins may still block tools (defensive) but cannot rewrite params.
+          if (handlerResult.params !== undefined && !isTrustedHookOrigin(hook.origin)) {
+            logger?.warn(
+              `[SECURITY] BLOCKED: untrusted plugin "${hook.pluginId}" (origin=${hook.origin ?? "unknown"}) attempted tool param modification for "${event.toolName}" — stripped`,
+            );
+            handlerResult.params = undefined;
+          }
+
+          result = {
+            params: handlerResult.params ?? result?.params,
+            block: handlerResult.block ?? result?.block,
+            blockReason: handlerResult.blockReason ?? result?.blockReason,
+          };
+        }
+      } catch (err) {
+        const msg = `[hooks] before_tool_call handler from ${hook.pluginId} failed: ${String(err)}`;
+        if (catchErrors) {
+          logger?.error(msg);
+        } else {
+          throw new Error(msg, { cause: err });
+        }
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -26,6 +26,86 @@ import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-
 import * as skillScanner from "../security/skill-scanner.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 
+// ---------------------------------------------------------------------------
+// CRITICAL-11: Plugin Security Scan
+// ---------------------------------------------------------------------------
+
+type PluginScanSummary = {
+  critical: number;
+  high: number;
+  findings: string[];
+};
+
+/**
+ * Critical patterns in plugin code that indicate dangerous capability usage.
+ * These cannot be overridden with --force.
+ */
+const CRITICAL_SCAN_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /child_process/g, label: "uses child_process (arbitrary command execution)" },
+  { pattern: /\beval\s*\(/g, label: "uses eval() (arbitrary code execution)" },
+  { pattern: /Function\s*\(/g, label: "uses Function() constructor (code generation)" },
+  { pattern: /process\.env/g, label: "accesses process.env (environment variable read)" },
+  {
+    pattern: /require\s*\(\s*["'](?:fs|node:fs)/g,
+    label: "requires fs module (filesystem access)",
+  },
+  {
+    pattern: /require\s*\(\s*["'](?:net|node:net|http|node:http|https|node:https)/g,
+    label: "requires network module (network access)",
+  },
+];
+
+async function scanPluginDir(dir: string): Promise<PluginScanSummary> {
+  const findings: string[] = [];
+  let critical = 0;
+  let high = 0;
+
+  async function walkDir(current: string): Promise<void> {
+    let dirents: Awaited<ReturnType<typeof fs.readdir>>;
+    try {
+      dirents = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of dirents) {
+      const name = String(entry.name);
+      const fullPath = path.join(current, name);
+      if (entry.isDirectory()) {
+        if (name === "node_modules" || name === ".git") {
+          continue;
+        }
+        await walkDir(fullPath);
+      } else if (/\.(js|ts|mjs|cjs|mts|cts)$/.test(name)) {
+        let content: string;
+        try {
+          content = await fs.readFile(fullPath, "utf-8");
+        } catch {
+          continue;
+        }
+        for (const { pattern, label } of CRITICAL_SCAN_PATTERNS) {
+          pattern.lastIndex = 0;
+          if (pattern.test(content)) {
+            const relative = path.relative(dir, fullPath);
+            findings.push(`${relative}: ${label}`);
+            critical += 1;
+          }
+        }
+      }
+    }
+  }
+
+  await walkDir(dir);
+  return { critical, high, findings };
+}
+
+/**
+ * Scan a plugin directory for security issues.
+ * Critical findings cannot be overridden and will block installation.
+ */
+export async function scanPluginSecurity(dir: string): Promise<PluginScanSummary> {
+  return scanPluginDir(dir);
+}
+
 type PluginInstallLogger = {
   info?: (message: string) => void;
   warn?: (message: string) => void;
@@ -186,6 +266,19 @@ async function installPluginFromPackageDir(params: {
     return {
       ok: false,
       error: `plugin id mismatch: expected ${params.expectedPluginId}, got ${pluginId}`,
+    };
+  }
+
+  // CRITICAL-11: Run security scan before installation.
+  // Critical findings block installation and cannot be overridden.
+  const scanResult = await scanPluginDir(params.packageDir);
+  if (scanResult.critical > 0) {
+    return {
+      ok: false,
+      error:
+        `plugin installation blocked: ${scanResult.critical} critical security finding(s) detected. ` +
+        `Critical findings cannot be overridden.\n` +
+        scanResult.findings.map((f) => `  - ${f}`).join("\n"),
     };
   }
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -459,6 +459,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       handler,
       priority: opts?.priority,
       source: record.source,
+      origin: record.origin,
     } as TypedPluginHookRegistration);
   };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -649,4 +649,5 @@ export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = 
   handler: PluginHookHandlerMap[K];
   priority?: number;
   source: string;
+  origin?: PluginOrigin;
 };


### PR DESCRIPTION
## Summary

- **CRITICAL-10**: Block untrusted plugins from modifying system prompts (\`before_agent_start\`) and tool parameters (\`before_tool_call\`). Only bundled and config-origin plugins are trusted for these operations. Adds \`origin\` field to \`PluginHookRegistration\` type.
- **CRITICAL-11**: Add security scanning to plugin installation that detects critical patterns (\`child_process\`, \`eval\`, \`Function\`, \`process.env\`, fs/net requires). Critical findings block installation unconditionally.

## Test plan

- [ ] Verify untrusted plugin hooks cannot modify system prompts
- [ ] Verify untrusted plugin hooks cannot modify tool parameters
- [ ] Verify plugin install blocks packages with \`child_process\`/\`eval\` patterns
- [ ] Verify bundled plugins can still modify prompts normally
- [ ] \`pnpm check\` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two security hardening features: (1) CRITICAL-10 blocks untrusted plugins from modifying system prompts and tool parameters via `before_agent_start` and `before_tool_call` hooks, and (2) CRITICAL-11 adds a regex-based security scanner that blocks plugin installation when dangerous code patterns are detected.

The approach and intent are sound, but the implementation has gaps that undermine the security guarantees:

- **`before_prompt_build` hook not guarded (CRITICAL-10 bypass)**: The `before_prompt_build` hook exposes the same `systemPrompt` modification capability as `before_agent_start`, and its result actually takes *priority* in `attempt.ts:919`. An untrusted plugin can bypass the new guard by registering a `before_prompt_build` handler instead.
- **Single-file plugin install skips scan (CRITICAL-11 bypass)**: `installPluginFromFile` copies the plugin without running the security scan, while all other install paths are covered.
- **Scan patterns miss ESM imports**: The `fs`/`net`/`http`/`https` patterns only match `require()` calls but this is an ESM-first codebase — standard `import` statements for these modules bypass the scanner.

<h3>Confidence Score: 2/5</h3>

- This PR has security bypass gaps that weaken the intended protections — it should not be merged until `before_prompt_build` and single-file installs are also guarded.
- The PR introduces important security controls but has three bypass vectors: the `before_prompt_build` hook is unguarded for system prompt modification, single-file plugins skip the CRITICAL-11 scan entirely, and ESM import patterns evade the fs/net/http module detection. These gaps mean the security guarantees described in the PR are incomplete.
- Pay close attention to `src/plugins/hooks.ts` (missing trust check on `before_prompt_build`) and `src/plugins/install.ts` (scan bypass via `installPluginFromFile` and ESM import patterns).

<sub>Last reviewed commit: dfe18ac</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->