### PR TITLE
fix: auto-approve local loopback pairing for role/scope upgrades

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -664,7 +664,7 @@ export function attachGatewayWsMessageHandler(params: {
               role,
               scopes,
               remoteIp: reportedClientIp,
-              silent: isLocalClient && reason === "not-paired",
+              silent: isLocalClient,
             });
             const context = buildRequestContext();
             if (pairing.request.silent === true) {


### PR DESCRIPTION
Local loopback connections (127.0.0.1) now auto-approve device pairing for all upgrade reasons (not-paired, role-upgrade, scope-upgrade), instead of only auto-approving for 'not-paired'.\n\nThis fixes sessions_spawn failing with 'gateway closed (1008): pairing required' when spawning subagents, because subagents connect via loopback and may request scopes/roles beyond what the device was originally paired with.\n\nFixes #12210\nFixes #21445

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends auto-approval of device pairing for loopback connections (127.0.0.1) to include role and scope upgrades, not just initial pairing. Previously, only `not-paired` requests were auto-approved for local clients, but `role-upgrade` and `scope-upgrade` still required manual approval, causing subagent spawning to fail with "pairing required" errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security policy adjustment for trusted loopback connections
- The change is minimal (one line), well-scoped, and logically sound. It removes an unnecessary restriction where local loopback connections (already authenticated and trusted) still required manual pairing approval for role/scope upgrades. The security boundary is maintained since `isLocalClient` validates the connection originates from 127.0.0.1, and authentication is still required before reaching this code path
- No files require special attention

<sub>Last reviewed commit: 8e1e789</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->