### PR TITLE
fix: send button hidden by long node names or small screens

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
@@ -148,9 +148,8 @@ fun ChatComposer(
         maxLines = 6,
       )
 
-      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-        ConnectionPill(sessionLabel = currentSessionLabel, healthOk = healthOk)
-        Spacer(modifier = Modifier.weight(1f))
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+        ConnectionPill(sessionLabel = currentSessionLabel, healthOk = healthOk, modifier = Modifier.weight(1f, fill = false))
 
         if (pendingRunCount > 0) {
           FilledTonalIconButton(
@@ -187,8 +186,9 @@ fun ChatComposer(
 }
 
 @Composable
-private fun ConnectionPill(sessionLabel: String, healthOk: Boolean) {
+private fun ConnectionPill(sessionLabel: String, healthOk: Boolean, modifier: Modifier = Modifier) {
   Surface(
+    modifier = modifier,
     shape = RoundedCornerShape(999.dp),
     color = MaterialTheme.colorScheme.surfaceContainerHighest,
   ) {
@@ -202,7 +202,7 @@ private fun ConnectionPill(sessionLabel: String, healthOk: Boolean) {
         shape = androidx.compose.foundation.shape.CircleShape,
         color = if (healthOk) Color(0xFF2ECC71) else Color(0xFFF39C12),
       ) {}
-      Text(sessionLabel, style = MaterialTheme.typography.labelSmall)
+      Text(sessionLabel, style = MaterialTheme.typography.labelSmall, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f, fill = false))
       Text(
         if (healthOk) "Connected" else "Connecting…",
         style = MaterialTheme.typography.labelSmall,


### PR DESCRIPTION
## Summary
- Long node/session names in the connection pill would push the send (and stop) button off screen, preventing users from sending messages
- Constrain the connection pill width so the session label truncates with ellipsis instead of overflowing
- Maintain the send button at the trailing edge via `SpaceBetween` arrangement
- Also affects small screen devices where horizontal space is limited

## Test plan
- [ ] Set a long node name and verify the send button remains visible and tappable
- [ ] Verify short node names still display fully with the button at the right edge
- [ ] Test the stop button visibility during an active run with a long node name
- [ ] Test on a small screen device/emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed send button visibility issue by constraining the connection pill width and using `SpaceBetween` arrangement. Long node/session names now truncate with ellipsis instead of pushing the send button off-screen.

- Replaced `Spacer` with `Arrangement.SpaceBetween` for proper button positioning
- Added `weight(1f, fill = false)` to ConnectionPill to allow flexible sizing
- Applied `maxLines = 1` with `TextOverflow.Ellipsis` to session label text for truncation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-implemented, and follow Compose best practices. The solution correctly addresses the layout issue by using appropriate Compose modifiers (`weight` with `fill = false`, `TextOverflow.Ellipsis`) and layout arrangements (`SpaceBetween`). No logical errors, security concerns, or breaking changes introduced.
- No files require special attention

<sub>Last reviewed commit: 69b0726</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->