### PR TITLE
Fix merge-test regressions around media path roots and status emojis

### DIFF
--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -50,14 +50,14 @@ export type StatusReactionController = {
 
 export const DEFAULT_EMOJIS: Required<StatusReactionEmojis> = {
   queued: "👀",
-  thinking: "🤔",
-  tool: "🔥",
-  coding: "👨‍💻",
-  web: "⚡",
-  done: "👍",
-  error: "😱",
-  stallSoft: "🥱",
-  stallHard: "😨",
+  thinking: "🧠",
+  tool: "🛠️",
+  coding: "💻",
+  web: "🌐",
+  done: "✅",
+  error: "❌",
+  stallSoft: "⏳",
+  stallHard: "⚠️",
 };
 
 export const DEFAULT_TIMING: Required<StatusReactionTiming> = {

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -24,7 +24,9 @@ async function withAudioFixture(
   await fs.writeFile(tmpPath, Buffer.from("RIFF"));
   const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
   const media = normalizeMediaAttachments(ctx);
-  const cache = createMediaAttachmentCache(media);
+  const cache = createMediaAttachmentCache(media, {
+    localPathRoots: [os.tmpdir()],
+  });
 
   try {
     await run({ ctx, media, cache });

--- a/src/media-understanding/runner.deepgram.test.ts
+++ b/src/media-understanding/runner.deepgram.test.ts
@@ -17,7 +17,9 @@ describe("runCapability deepgram provider options", () => {
     await fs.writeFile(tmpPath, Buffer.from("RIFF"));
     const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
     const media = normalizeMediaAttachments(ctx);
-    const cache = createMediaAttachmentCache(media);
+    const cache = createMediaAttachmentCache(media, {
+      localPathRoots: [os.tmpdir()],
+    });
 
     let seenQuery: Record<string, string | number | boolean> | undefined;
     let seenBaseUrl: string | undefined;

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import { resolveStateDir } from "../config/paths.js";
 import { sendVoiceMessageDiscord } from "../discord/send.js";
 import * as ssrf from "../infra/net/ssrf.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { optimizeImageToPng } from "../media/image-ops.js";
 import { captureEnv } from "../test-utils/env.js";
 import {
@@ -50,7 +51,9 @@ async function createLargeTestJpeg(): Promise<{ buffer: Buffer; file: string }> 
 }
 
 beforeAll(async () => {
-  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-test-"));
+  fixtureRoot = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-media-test-"),
+  );
   largeJpegBuffer = await sharp({
     create: {
       width: 400,
@@ -334,7 +337,9 @@ describe("local media root guard", () => {
   });
 
   it("allows local paths under an explicit root", async () => {
-    const result = await loadWebMedia(tinyPngFile, 1024 * 1024, { localRoots: [os.tmpdir()] });
+    const result = await loadWebMedia(tinyPngFile, 1024 * 1024, {
+      localRoots: [resolvePreferredOpenClawTmpDir()],
+    });
     expect(result.kind).toBe("image");
   });
 


### PR DESCRIPTION
## Summary
- restore status reaction default emojis to match existing Discord expectations and comments
- update media-understanding audio tests to allow temp fixtures via localPathRoots
- update web media tests to create fixtures under OpenClaw's allowed temp root
- update MSTeams mention fallback test to place local media under a configured state workspace root

## Why
PR #22223 merged after rebase, but merge-test failures were still reproducible on main for these tests. This patch makes the tests consistent with the new local media path hardening and restores expected reaction defaults.

## Validation
- pnpm lint
- pnpm build
- pnpm test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes merge-test regressions introduced after PR #22223 rebased, making tests consistent with the new local media path hardening and restoring expected status reaction emoji defaults.

- **Status reaction emojis restored**: `DEFAULT_EMOJIS` in `src/channels/status-reactions.ts` updated to match the semantic emoji set documented in the `StatusReactionEmojis` type comments (e.g. `🧠` for thinking, `✅` for done, `❌` for error). Tests reference the constant by name, so they adapt automatically.
- **Media-understanding audio tests fixed**: `runner.auto-audio.test.ts` and `runner.deepgram.test.ts` now pass `localPathRoots: [os.tmpdir()]` to `createMediaAttachmentCache` so temporary WAV fixtures pass the new path validation.
- **Web media tests use managed temp root**: `media.test.ts` creates fixtures under `resolvePreferredOpenClawTmpDir()` instead of raw `os.tmpdir()`, ensuring they land under an allowed directory for the hardened local media root guard.
- **MSTeams mention fallback test fixed**: The test now sets `OPENCLAW_STATE_DIR` to a temp directory and places local media under `$STATE_DIR/workspace/` to satisfy the default allowed-path rules, with proper env var save/restore in the finally block.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only test fixes and a cosmetic emoji constant restoration with no production logic changes.
- All changes are limited to test files (4 out of 5 files) and one constants-only source file. The test fixes correctly adapt to the new local media path hardening by using proper allowed directories. The emoji restoration aligns DEFAULT_EMOJIS with the already-documented type comment defaults. No production logic, API behavior, or security boundaries are altered.
- No files require special attention.

<sub>Last reviewed commit: a2c7e37</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->