### PR TITLE
fix(gateway): silently auto-approve local paired-device scope upgrades

### DIFF
--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -1079,6 +1079,72 @@ describe("gateway server auth/connect", () => {
     restoreGatewayToken(prevToken);
   });
 
+  test("silently auto-approves local CLI scope upgrades", async () => {
+    const { mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { buildDeviceAuthPayload } = await import("./device-auth.js");
+    const { loadOrCreateDeviceIdentity, publicKeyRawBase64UrlFromPem, signDevicePayload } =
+      await import("../infra/device-identity.js");
+    const { listDevicePairing } = await import("../infra/device-pairing.js");
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    const identityDir = await mkdtemp(join(tmpdir(), "openclaw-device-scope-"));
+    const identity = loadOrCreateDeviceIdentity(join(identityDir, "device.json"));
+    const client = {
+      id: GATEWAY_CLIENT_NAMES.CLI,
+      version: "1.0.0",
+      platform: "test",
+      mode: GATEWAY_CLIENT_MODES.CLI,
+    };
+    const buildDevice = (scopes: string[]) => {
+      const signedAtMs = Date.now();
+      const payload = buildDeviceAuthPayload({
+        deviceId: identity.deviceId,
+        clientId: client.id,
+        clientMode: client.mode,
+        role: "operator",
+        scopes,
+        signedAtMs,
+        token: "secret",
+      });
+      return {
+        id: identity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+        signature: signDevicePayload(identity.privateKeyPem, payload),
+        signedAt: signedAtMs,
+      };
+    };
+
+    const initial = await connectReq(ws, {
+      token: "secret",
+      scopes: ["operator.read"],
+      client,
+      device: buildDevice(["operator.read"]),
+    });
+    if (!initial.ok) {
+      await approvePendingPairingIfNeeded();
+    }
+
+    ws.close();
+
+    const ws2 = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((resolve) => ws2.once("open", resolve));
+    const upgraded = await connectReq(ws2, {
+      token: "secret",
+      scopes: ["operator.admin"],
+      client,
+      device: buildDevice(["operator.admin"]),
+    });
+    expect(upgraded.ok).toBe(true);
+
+    const pairing = await listDevicePairing();
+    expect(pairing.pending).toEqual([]);
+
+    ws2.close();
+    await server.close();
+    restoreGatewayToken(prevToken);
+  });
+
   test("allows operator.read connect when device is paired with operator.admin", async () => {
     const { mkdtemp } = await import("node:fs/promises");
     const { tmpdir } = await import("node:os");


### PR DESCRIPTION
## Summary
Fix local paired-device reconnect regressions where role/scope upgrades could return `pairing required` instead of silently proceeding.

## What changed
- Gateway pairing decision now allows silent pairing for local upgrade paths only when there is an existing paired-device context.
- Keeps silent behavior for `not-paired` local flow.
- Adds an e2e regression test: `silently auto-approves local CLI scope upgrades`.

## Security rationale
- Avoids trusting client-claimed `client.id` / `client.mode` for privileged silent behavior.
- Uses gateway-observed locality plus existing paired-device context for upgrade silent path.

## Validation
- Added targeted e2e test in `src/gateway/server.auth.e2e.test.ts`.
- Verified behavior:
  - test fails without patch (`expected true, received false`)
  - test passes with patch

## Related issue
- Closes #22279

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes local paired-device reconnect regression by allowing silent auto-approval for scope/role upgrades when a device is already paired and connecting locally.

- Modified `requirePairing` function to accept `hasExistingPairing` parameter
- Silent pairing now allowed for: `not-paired` reason OR when `hasExistingPairing=true` (both require `isLocalClient`)
- All upgrade path calls (`role-upgrade`, `scope-upgrade`) now pass `hasExistingPairing=true`
- Added e2e regression test verifying CLI scope upgrade (`operator.read` → `operator.admin`) succeeds silently for local connections
- Security model preserved: relies on gateway-observed locality (`isLocalDirectRequest`) rather than client-claimed attributes

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Fix is well-targeted with clear security rationale, comprehensive test coverage, and preserves existing security model by using server-validated locality rather than client claims
- No files require special attention

<sub>Last reviewed commit: d52bbde</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->