### PR TITLE
fix: resolve TS2556 in discord components test

### DIFF
--- a/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.e2e.test.ts
+++ b/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.e2e.test.ts
@@ -17,7 +17,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
   return {
     ...actual,
-    loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+    loadConfig: () => loadConfigMock(),
   };
 });
 

--- a/src/discord/send.components.test.ts
+++ b/src/discord/send.components.test.ts
@@ -10,7 +10,7 @@ vi.mock("../config/config.js", async () => {
   const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
   return {
     ...actual,
-    loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+    loadConfig: () => loadConfigMock(),
   };
 });
 


### PR DESCRIPTION
## Summary

- Fix TypeScript error `TS2556: A spread argument must either have a tuple type or be passed to a rest parameter` in `src/discord/send.components.test.ts:13`
- `loadConfig()` takes zero parameters, so the mock wrapper `(...args: unknown[]) => loadConfigMock(...args)` is invalid — simplified to `() => loadConfigMock()`
- This error is currently breaking the `check` job on `main`

## Test plan

- [ ] `pnpm check` passes (format + types + lint)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Correctly fixes TypeScript error TS2556 in `send.components.test.ts` by simplifying the `loadConfig` mock wrapper from `(...args: unknown[]) => loadConfigMock(...args)` to `() => loadConfigMock()`, matching the actual zero-parameter signature of `loadConfig()`.

- Fixed mock signature in `src/discord/send.components.test.ts:13`
- Note: `src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.e2e.test.ts:20` has the same pattern and may need the same fix

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple, focused fix that resolves a TypeScript compilation error
- The change correctly fixes a TypeScript error by matching the mock signature to the actual `loadConfig()` function which takes zero parameters. The fix is minimal, well-understood, and directly addresses the stated issue without introducing any new logic or side effects
- No files require special attention

<sub>Last reviewed commit: f0f7939</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->