### PR TITLE
Plugins: expose resolveMainSessionKey in runtime system

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -97,6 +97,9 @@ function createMockRuntime(): PluginRuntime {
     system: {
       enqueueSystemEvent:
         mockEnqueueSystemEvent as unknown as PluginRuntime["system"]["enqueueSystemEvent"],
+      resolveMainSessionKey: vi.fn(
+        () => "agent:main:main",
+      ) as unknown as PluginRuntime["system"]["resolveMainSessionKey"],
       runCommandWithTimeout: vi.fn() as unknown as PluginRuntime["system"]["runCommandWithTimeout"],
       formatNativeDependencyHint: vi.fn(
         () => "",

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -56,6 +56,7 @@ import {
   resolveStorePath,
   updateLastRoute,
 } from "../../config/sessions.js";
+import { resolveMainSessionKey } from "../../config/sessions/main-session.js";
 import { auditDiscordChannelPermissions } from "../../discord/audit.js";
 import {
   listDiscordDirectoryGroupsLive,
@@ -260,6 +261,7 @@ function createRuntimeConfig(): PluginRuntime["config"] {
 function createRuntimeSystem(): PluginRuntime["system"] {
   return {
     enqueueSystemEvent,
+    resolveMainSessionKey,
     runCommandWithTimeout,
     formatNativeDependencyHint,
   };

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -73,6 +73,8 @@ type WriteConfigFile = typeof import("../../config/config.js").writeConfigFile;
 type RecordChannelActivity = typeof import("../../infra/channel-activity.js").recordChannelActivity;
 type GetChannelActivity = typeof import("../../infra/channel-activity.js").getChannelActivity;
 type EnqueueSystemEvent = typeof import("../../infra/system-events.js").enqueueSystemEvent;
+type ResolveMainSessionKey =
+  typeof import("../../config/sessions/main-session.js").resolveMainSessionKey;
 type RunCommandWithTimeout = typeof import("../../process/exec.js").runCommandWithTimeout;
 type FormatNativeDependencyHint = typeof import("./native-deps.js").formatNativeDependencyHint;
 type LoadWebMedia = typeof import("../../web/media.js").loadWebMedia;
@@ -184,6 +186,7 @@ export type PluginRuntime = {
   };
   system: {
     enqueueSystemEvent: EnqueueSystemEvent;
+    resolveMainSessionKey: ResolveMainSessionKey;
     runCommandWithTimeout: RunCommandWithTimeout;
     formatNativeDependencyHint: FormatNativeDependencyHint;
   };


### PR DESCRIPTION
## Summary

The `PluginRuntime["system"]` type is missing `resolveMainSessionKey`, which extensions need to resolve the primary session key from config (e.g. to bridge transcripts or correlate sessions across channels).

Several existing test mocks already reference this property on the system object (`subagent-registry.announce-loop-guard.test.ts`, `tools-invoke-http.test.ts`, `status.e2e.test.ts`), confirming it is expected at runtime but not currently provided by the implementation.

**Changes:**
- Add `ResolveMainSessionKey` type alias to `src/plugins/runtime/types.ts`
- Add `resolveMainSessionKey` to `PluginRuntime["system"]` type
- Wire existing `resolveMainSessionKey` from `config/sessions/main-session.js` into `createRuntimeSystem()`
- Update bluebubbles monitor test mock to include the new field

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm vitest --run src/plugins/runtime/` — 2 tests pass
- [x] `pnpm vitest --run extensions/bluebubbles/src/monitor.test.ts` — 60 tests pass
- [x] `pnpm vitest --run src/agents/subagent-registry.announce-loop-guard.test.ts` — 4 tests pass
- [x] Format check passes (`pnpm format:check`)
- [x] Only pre-existing TS error remains (discord `send.components.test.ts`)

🤖 AI-assisted PR (reviewed and tested manually)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes `resolveMainSessionKey` in the plugin runtime system, making it available to extensions that need to resolve the primary session key from config. The change addresses a gap where test mocks already referenced this property but the actual runtime implementation was missing it.

The implementation is straightforward and consistent:
- Adds proper type alias following existing pattern in `src/plugins/runtime/types.ts:76-77`
- Wires the function from `src/config/sessions/main-session.ts:11` into the runtime system at `src/plugins/runtime/index.ts:59,264`
- Updates the bluebubbles test mock to include the new field at `extensions/bluebubbles/src/monitor.test.ts:100-102`

The changes align with several existing test mocks that were already expecting this function (`subagent-registry.announce-loop-guard.test.ts:24`, `tools-invoke-http.test.ts:15`, `status.e2e.test.ts:92`), confirming this was an intended but missing part of the runtime API.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, non-breaking addition that fills a gap in the plugin runtime API. All modified files follow existing patterns, the implementation correctly imports and wires an existing function, and tests confirm the change works as expected. No logic changes or refactoring occurred.
- No files require special attention

<sub>Last reviewed commit: a50fe6f</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->