### PR TITLE
Voice-call: add onCallEnded lifecycle callback

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { VoiceCallConfig } from "./config.js";
-import type { CallManagerContext } from "./manager/context.js";
+import type { CallManagerContext, CallManagerHooks } from "./manager/context.js";
 import { processEvent as processManagerEvent } from "./manager/events.js";
 import { getCallByProviderCallId as getCallByProviderCallIdFromMaps } from "./manager/lookup.js";
 import {
@@ -57,10 +57,16 @@ export class CallManager {
     }
   >();
   private maxDurationTimers = new Map<CallId, NodeJS.Timeout>();
+  private onCallEnded?: CallManagerHooks["onCallEnded"];
 
-  constructor(config: VoiceCallConfig, storePath?: string) {
+  constructor(
+    config: VoiceCallConfig,
+    storePath?: string,
+    onCallEnded?: (call: CallRecord) => void,
+  ) {
     this.config = config;
     this.storePath = resolveDefaultStoreBase(config, storePath);
+    this.onCallEnded = onCallEnded;
   }
 
   /**
@@ -144,6 +150,7 @@ export class CallManager {
       onCallAnswered: (call) => {
         this.maybeSpeakInitialMessageOnAnswered(call);
       },
+      onCallEnded: this.onCallEnded,
     };
   }
 

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -32,6 +32,8 @@ export type CallManagerTransientState = {
 export type CallManagerHooks = {
   /** Optional runtime hook invoked after an event transitions a call into answered state. */
   onCallAnswered?: (call: CallRecord) => void;
+  /** Optional runtime hook invoked when a call ends (completed, error, or bot hangup). */
+  onCallEnded?: (call: CallRecord) => void;
 };
 
 export type CallManagerContext = CallManagerRuntimeState &

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -25,6 +25,7 @@ type EventContext = Pick<
   | "transcriptWaiters"
   | "maxDurationTimers"
   | "onCallAnswered"
+  | "onCallEnded"
 >;
 
 function shouldAcceptInbound(config: EventContext["config"], from: string | undefined): boolean {
@@ -208,6 +209,14 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
       if (call.providerCallId) {
         ctx.providerCallIdMap.delete(call.providerCallId);
       }
+      try {
+        ctx.onCallEnded?.(call);
+      } catch (err) {
+        console.error(
+          "[voice-call] onCallEnded callback error:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
       break;
 
     case "call.error":
@@ -220,6 +229,14 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
         ctx.activeCalls.delete(call.callId);
         if (call.providerCallId) {
           ctx.providerCallIdMap.delete(call.providerCallId);
+        }
+        try {
+          ctx.onCallEnded?.(call);
+        } catch (err) {
+          console.error(
+            "[voice-call] onCallEnded callback error:",
+            err instanceof Error ? err.message : String(err),
+          );
         }
       }
       break;

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -49,6 +49,7 @@ type EndCallContext = Pick<
   | "storePath"
   | "transcriptWaiters"
   | "maxDurationTimers"
+  | "onCallEnded"
 >;
 
 export async function initiateCall(
@@ -331,6 +332,15 @@ export async function endCall(
     ctx.activeCalls.delete(callId);
     if (call.providerCallId) {
       ctx.providerCallIdMap.delete(call.providerCallId);
+    }
+
+    try {
+      ctx.onCallEnded?.(call);
+    } catch (cbErr) {
+      console.error(
+        "[voice-call] onCallEnded callback error:",
+        cbErr instanceof Error ? cbErr.message : String(cbErr),
+      );
     }
 
     return { success: true };

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -10,6 +10,7 @@ import { TwilioProvider } from "./providers/twilio.js";
 import type { TelephonyTtsRuntime } from "./telephony-tts.js";
 import { createTelephonyTtsProvider } from "./telephony-tts.js";
 import { startTunnel, type TunnelResult } from "./tunnel.js";
+import type { CallRecord } from "./types.js";
 import {
   cleanupTailscaleExposure,
   setupTailscaleExposure,
@@ -97,8 +98,9 @@ export async function createVoiceCallRuntime(params: {
   coreConfig: CoreConfig;
   ttsRuntime?: TelephonyTtsRuntime;
   logger?: Logger;
+  onCallEnded?: (call: CallRecord) => void;
 }): Promise<VoiceCallRuntime> {
-  const { config: rawConfig, coreConfig, ttsRuntime, logger } = params;
+  const { config: rawConfig, coreConfig, ttsRuntime, logger, onCallEnded } = params;
   const log = logger ?? {
     info: console.log,
     warn: console.warn,
@@ -124,7 +126,7 @@ export async function createVoiceCallRuntime(params: {
   }
 
   const provider = resolveProvider(config);
-  const manager = new CallManager(config);
+  const manager = new CallManager(config, undefined, onCallEnded);
   const webhookServer = new VoiceCallWebhookServer(config, manager, provider, coreConfig);
 
   const localUrl = await webhookServer.start();


### PR DESCRIPTION
## Summary

Adds an optional `onCallEnded` lifecycle callback to the voice-call extension. The callback fires once when a call terminates through any path:

- Provider `call.ended` event (normal completion, remote hangup)
- Non-retryable `call.error` event
- Bot-initiated `endCall()` hangup

The callback is wrapped in try/catch so a misbehaving consumer cannot break the call teardown flow.

This enables extensions to react to call completion — for example, bridging call transcripts into the main agent session, logging call metrics, or triggering follow-up workflows.

**Changes:**
- `context.ts` — add `onCallEnded` to `CallManagerHooks` type
- `manager.ts` — accept callback in constructor, thread to context
- `events.ts` — fire on `call.ended` and non-retryable `call.error`
- `outbound.ts` — fire on bot hangup via `endCall()`
- `runtime.ts` — thread `onCallEnded` param through `createVoiceCallRuntime`
- `manager.test.ts` — 5 new tests covering all end paths + error resilience

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm vitest --run extensions/voice-call/src/manager.test.ts` — 16 tests pass (11 existing + 5 new)
- [x] Format check passes (`pnpm format:check`)
- [x] No new TS errors (only pre-existing discord `send.components.test.ts`)
- [x] Callback fires on `call.ended`, `endCall()`, and non-retryable `call.error`
- [x] Callback does NOT fire on retryable `call.error`
- [x] Throwing callback does not break call teardown

🤖 AI-assisted PR (reviewed and tested manually)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added optional `onCallEnded` lifecycle callback to voice-call extension. The callback fires when a call terminates through normal completion, non-retryable errors, or bot-initiated hangup. Implementation follows the existing `onCallAnswered` hook pattern with try/catch protection to prevent callback errors from breaking call teardown.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested (5 new tests covering all paths), follows existing architectural patterns (`onCallAnswered` hook), and includes proper error handling with try/catch blocks to prevent callback errors from breaking teardown. The changes are backward-compatible (optional parameter) and touch only the necessary files.
- No files require special attention

<sub>Last reviewed commit: 7e1b38a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->