### PR TITLE
Hooks: add message-filter bundled hook with inbound message pre-filter

### DIFF
--- a/src/hooks/bundled/message-filter/HOOK.md
+++ b/src/hooks/bundled/message-filter/HOOK.md
@@ -1,0 +1,121 @@
+---
+name: message-filter
+description: "Filter out automated/junk inbound messages (OTP codes, marketing, reminders, etc.)"
+homepage: https://docs.openclaw.ai/hooks#message-filter
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🚫",
+        "events": ["message:inbound"],
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Message Filter Hook
+
+Silently filters out automated/junk inbound messages so the AI agent doesn't waste tokens responding to OTP codes, marketing texts, appointment reminders, and similar automated notifications.
+
+## What It Does
+
+When an inbound message arrives (after deduplication, before model work):
+
+1. **Checks opt-in** - Does nothing unless explicitly enabled in config
+2. **Command bypass** - Never filters messages starting with `/`
+3. **Allowed senders bypass** - Never filters messages from allowed senders
+4. **Blocked senders** - Always filters messages from blocked senders
+5. **Category matching** - Tests message body against regex patterns for 6 built-in categories
+6. **Custom patterns** - Tests against user-defined regex patterns
+7. **Sets skip flag** - If matched, sets `skip=true` on the hook context so the dispatcher drops the message
+
+## Built-in Categories
+
+| Category       | Examples                                  |
+| -------------- | ----------------------------------------- |
+| `otp`          | Verification codes, 2FA, PINs             |
+| `marketing`    | "Reply STOP", promos, coupons, % off      |
+| `appointments` | Doctor/dentist reminders, confirm reply   |
+| `fitness`      | Gym class, workout reminders              |
+| `delivery`     | Package shipped/delivered, tracking       |
+| `banking`      | Transaction alerts, balance notifications |
+
+All categories are enabled by default. Disable individual categories via config.
+
+## Configuration
+
+This hook is **opt-in only**. Add to `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "message-filter": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}
+```
+
+### Full Configuration
+
+| Option             | Type     | Default    | Description                               |
+| ------------------ | -------- | ---------- | ----------------------------------------- |
+| `enabled`          | boolean  | `false`    | Must be `true` to activate                |
+| `categories`       | object   | all `true` | Enable/disable built-in categories        |
+| `customPatterns`   | string[] | `[]`       | Additional regex patterns to match        |
+| `blockedSenders`   | string[] | `[]`       | Always filter messages from these senders |
+| `allowedSenders`   | string[] | `[]`       | Never filter messages from these senders  |
+| `filterShortcodes` | boolean  | `true`     | Filter 5-6 digit shortcode senders        |
+| `logBody`          | boolean  | `false`    | Log redacted message body at debug level  |
+
+### Example with all options
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "message-filter": {
+          "enabled": true,
+          "categories": {
+            "otp": true,
+            "marketing": true,
+            "appointments": true,
+            "fitness": true,
+            "delivery": true,
+            "banking": true
+          },
+          "customPatterns": ["prescription .* is ready"],
+          "blockedSenders": ["22395"],
+          "allowedSenders": ["+14046637573"],
+          "logBody": false
+        }
+      }
+    }
+  }
+}
+```
+
+## Logging
+
+By default, only metadata is logged (channel, senderId, messageId, skipReason) at debug level. Message body is **never** logged unless `logBody: true`, in which case digits are redacted.
+
+## Disabling
+
+Remove the entry or set `enabled: false`:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "message-filter": { "enabled": false }
+      }
+    }
+  }
+}
+```

--- a/src/hooks/bundled/message-filter/handler.test.ts
+++ b/src/hooks/bundled/message-filter/handler.test.ts
@@ -1,0 +1,264 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { HookHandler } from "../../hooks.js";
+import { createHookEvent } from "../../hooks.js";
+import type { InboundMessageHookContext } from "../../internal-hooks.js";
+
+let handler: HookHandler;
+
+beforeAll(async () => {
+  ({ default: handler } = await import("./handler.js"));
+});
+
+function makeMessageEvent(
+  body: string,
+  opts?: {
+    senderId?: string;
+    channel?: string;
+    cfg?: OpenClawConfig;
+  },
+) {
+  const context: InboundMessageHookContext = {
+    bodyForCommands: body,
+    senderId: opts?.senderId ?? "+15551234567",
+    channel: opts?.channel ?? "imessage",
+    cfg: opts?.cfg,
+  };
+  return {
+    event: createHookEvent(
+      "message",
+      "inbound",
+      "agent:main:main",
+      context as unknown as Record<string, unknown>,
+    ),
+    context,
+  };
+}
+
+function enabledConfig(overrides?: Record<string, unknown>): OpenClawConfig {
+  return {
+    hooks: {
+      internal: {
+        entries: {
+          "message-filter": { enabled: true, ...overrides },
+        },
+      },
+    },
+  };
+}
+
+describe("message-filter hook", () => {
+  it("skips non-message events", async () => {
+    const event = createHookEvent("command", "new", "agent:main:main", {});
+    await handler(event);
+    // Should not throw or set skip
+    expect(event.context.skip).toBeUndefined();
+  });
+
+  it("does nothing when not enabled in config", async () => {
+    const { event, context } = makeMessageEvent("Your verification code is 483920");
+    await handler(event);
+    expect(context.skip).toBeUndefined();
+  });
+
+  it("does nothing when config has enabled=false", async () => {
+    const cfg: OpenClawConfig = {
+      hooks: {
+        internal: {
+          entries: {
+            "message-filter": { enabled: false },
+          },
+        },
+      },
+    };
+    const { event, context } = makeMessageEvent("Your verification code is 483920", { cfg });
+    await handler(event);
+    expect(context.skip).toBeUndefined();
+  });
+
+  it("sets skip=true for OTP message", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent("Your verification code is 483920", { cfg });
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:otp");
+  });
+
+  it("sets skip=true for marketing message", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent(
+      "Get 50% off your next order! Reply STOP to unsubscribe",
+      { cfg },
+    );
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:marketing");
+  });
+
+  it("sets skip=true for appointment reminder", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent(
+      "Reminder: Your appointment with Dr. Smith is tomorrow at 2pm. Reply C to confirm.",
+      { cfg },
+    );
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:appointments");
+  });
+
+  it("sets skip=true for fitness notification", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent("Your gym class starts in 30 minutes", { cfg });
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:fitness");
+  });
+
+  it("passes through normal conversational message", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent("Hey, what's the weather today?", { cfg });
+    await handler(event);
+    expect(context.skip).toBeUndefined();
+  });
+
+  it("never filters messages starting with /", async () => {
+    const cfg = enabledConfig();
+    // Even though body contains "verification code", the / prefix should bypass
+    const { event, context } = makeMessageEvent("/help verification code is 123456", { cfg });
+    await handler(event);
+    expect(context.skip).toBeUndefined();
+  });
+
+  it("never filters allowed senders", async () => {
+    const cfg = enabledConfig({ allowedSenders: ["+14046637573"] });
+    const { event, context } = makeMessageEvent("Your verification code is 483920", {
+      cfg,
+      senderId: "+14046637573",
+    });
+    await handler(event);
+    expect(context.skip).toBeUndefined();
+  });
+
+  it("always filters blocked senders", async () => {
+    const cfg = enabledConfig({ blockedSenders: ["22395"] });
+    const { event, context } = makeMessageEvent("Hello, how are you?", {
+      cfg,
+      senderId: "22395",
+    });
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:blocked-sender");
+  });
+
+  it("respects disabled categories", async () => {
+    const cfg = enabledConfig({ categories: { otp: false } });
+    const { event, context } = makeMessageEvent("Your verification code is 483920", { cfg });
+    await handler(event);
+    // OTP category disabled, should pass through
+    expect(context.skip).toBeUndefined();
+  });
+
+  it("matches custom patterns", async () => {
+    const cfg = enabledConfig({ customPatterns: ["prescription .* is ready"] });
+    const { event, context } = makeMessageEvent(
+      "Your prescription refill is ready for pickup at CVS",
+      { cfg },
+    );
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:custom");
+  });
+
+  it("handles invalid custom patterns gracefully", async () => {
+    const cfg = enabledConfig({ customPatterns: ["[invalid(regex"] });
+    const { event, context } = makeMessageEvent("Hello there", { cfg });
+    // Should not throw
+    await handler(event);
+    expect(context.skip).toBeUndefined();
+  });
+
+  it("detects delivery notifications", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent("Your package has been delivered to front door", {
+      cfg,
+    });
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:delivery");
+  });
+
+  it("detects banking alerts", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent("Transaction alert: Purchase of $42.50 at Amazon", {
+      cfg,
+    });
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:banking");
+  });
+
+  it("filters shortcode senders (5-6 digit numbers)", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent(
+      "Tiffany & Co.: There's still time to make it an unforgettable Valentine's Day. Shop now: tiffany.attn.tv/abc",
+      { cfg, senderId: "74640" },
+    );
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:shortcode");
+  });
+
+  it("does not filter normal phone numbers as shortcodes", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent("Hey, what's up?", {
+      cfg,
+      senderId: "+14046637573",
+    });
+    await handler(event);
+    expect(context.skip).toBeUndefined();
+  });
+
+  it("allows shortcodes when filterShortcodes is false", async () => {
+    const cfg = enabledConfig({ filterShortcodes: false });
+    const { event, context } = makeMessageEvent("Some message from shortcode", {
+      cfg,
+      senderId: "74640",
+    });
+    await handler(event);
+    // Shortcode filtering disabled, passes through (unless content matches)
+    expect(context.skipReason).not.toBe("message-filter:shortcode");
+  });
+
+  it("detects 'Shop now' marketing (Tiffany real-world example)", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent(
+      "Tiffany & Co.: There's still time to make it an unforgettable Valentine's Day. Explore quintessential expressions of love. Shop now: tiffany.attn.tv/abc",
+      { cfg },
+    );
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:marketing");
+  });
+
+  it("detects appointment with 'reserved' phrasing (dentist real-world example)", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent(
+      "Christopher, you have an appointment reserved with New Face Dentistry on Thursday, Feb 12th at 11:00 AM.",
+      { cfg },
+    );
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:appointments");
+  });
+
+  it("detects 'you have an appointment' phrasing", async () => {
+    const cfg = enabledConfig();
+    const { event, context } = makeMessageEvent(
+      "You have an appointment at 3pm tomorrow with Dr. Lee",
+      { cfg },
+    );
+    await handler(event);
+    expect(context.skip).toBe(true);
+    expect(context.skipReason).toBe("message-filter:appointments");
+  });
+});

--- a/src/hooks/bundled/message-filter/handler.ts
+++ b/src/hooks/bundled/message-filter/handler.ts
@@ -1,0 +1,217 @@
+/**
+ * Message filter hook handler
+ *
+ * Filters out automated/junk inbound messages (OTP codes, marketing,
+ * appointment reminders, etc.) so the AI agent doesn't respond to them.
+ *
+ * Opt-in only: requires `enabled: true` in hook config.
+ * Never filters messages starting with "/" (command bypass).
+ */
+
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { resolveHookConfig } from "../../config.js";
+import type { HookHandler } from "../../hooks.js";
+import type { InboundMessageHookContext } from "../../internal-hooks.js";
+
+const log = createSubsystemLogger("hooks/message-filter");
+
+type CategoryPatterns = Record<string, RegExp[]>;
+
+const BUILTIN_CATEGORIES: CategoryPatterns = {
+  otp: [
+    /\bverification code\b/i,
+    /\bverify.{0,20}code\b/i,
+    /\b(?:your|the)\s+code\s+is\b/i,
+    /\b(?:one[- ]?time|otp)\s*(?:pass)?(?:code|password)\b/i,
+    /\b2fa\b/i,
+    /\bsecurity code\b/i,
+    /\b\d{4,8}\b.*\b(?:expires?|valid)\b/i,
+    /\benter\s+(?:this\s+)?code\b/i,
+    /\bpin\s*(?:is|:)\s*\d{4,8}\b/i,
+  ],
+  marketing: [
+    /\breply\s+stop\b/i,
+    /\btext\s+stop\b/i,
+    /\bunsubscribe\b/i,
+    /\bopt[ -]?out\b/i,
+    /\b\d+%\s*off\b/i,
+    /\bcoupon\b/i,
+    /\bpromo(?:tion(?:al)?)?\s*code\b/i,
+    /\blimited[- ]time\s+offer\b/i,
+    /\bfree\s+(?:shipping|trial|gift)\b/i,
+    /\bexclusive\s+(?:deal|offer|discount)\b/i,
+    /\bact\s+now\b/i,
+    /\bdon'?t\s+miss\s+(?:out|this)\b/i,
+    /\bshop\s+now\b/i,
+    /\bbuy\s+now\b/i,
+    /\border\s+(?:now|today)\b/i,
+    /\bsale\s+(?:ends?|starts?)\b/i,
+    /\buse\s+code\b/i,
+  ],
+  appointments: [
+    /\b(?:appointment|appt)\.?\s+(?:with|at|on|for)\b/i,
+    /\b(?:appointment|appt)\b.{0,30}\b(?:reserved|scheduled|confirmed|booked)\b/i,
+    /\byou have\s+(?:a|an)\s+(?:appointment|appt)\b/i,
+    /\breminder:\s*(?:your\s+)?(?:appointment|visit)\b/i,
+    /\b(?:doctor|dr|dentist\w*|physician|orthodont\w*)\b.*\b(?:appointment|tomorrow|today)\b/i,
+    /\b(?:appointment|appt)\b.*\b(?:dentist\w*|doctor|dr\.|physician|clinic|medical|dental)\b/i,
+    /\b(?:confirm|cancel)\s+(?:your\s+)?(?:appointment|visit)\b/i,
+    /\breply\s+(?:yes|y|c|1)\s+to\s+confirm\b/i,
+    /\bscheduled\s+(?:for|on|at)\b/i,
+  ],
+  fitness: [
+    /\bgym\s+class\b/i,
+    /\bworkout\s+(?:reminder|starts|session)\b/i,
+    /\byour\s+(?:class|session)\s+(?:starts?|begins?)\b/i,
+    /\b(?:fitness|yoga|pilates|spin|cycling)\s+class\b/i,
+    /\bclass\s+(?:starts?|begins?)\s+in\b/i,
+  ],
+  delivery: [
+    /\bpackage\s+(?:has\s+been\s+)?(?:shipped|delivered|out for delivery)\b/i,
+    /\btracking\s+(?:number|#|info)\b/i,
+    /\byour\s+(?:order|delivery)\s+(?:has|is|will)\b/i,
+    /\b(?:ups|fedex|usps|dhl)\b.*\b(?:tracking|delivery|shipped)\b/i,
+    /\bestimated\s+delivery\b/i,
+    /\bout\s+for\s+delivery\b/i,
+  ],
+  banking: [
+    /\btransaction\s+(?:alert|notification)\b/i,
+    /\baccount\s+(?:balance|ending)\b/i,
+    /\bpurchase\s+(?:of|for)\s+\$?\d/i,
+    /\b(?:debit|credit)\s+card\b.*\b(?:used|charged|transaction)\b/i,
+    /\bavailable\s+balance\b/i,
+    /\bdirect\s+deposit\b/i,
+    /\bfraud\s+alert\b/i,
+    /\bsuspicious\s+(?:activity|transaction)\b/i,
+  ],
+};
+
+type MessageFilterConfig = {
+  enabled?: boolean;
+  categories?: Record<string, boolean>;
+  customPatterns?: string[];
+  blockedSenders?: string[];
+  allowedSenders?: string[];
+  filterShortcodes?: boolean;
+  logBody?: boolean;
+};
+
+/** SMS shortcodes are 5-6 digit numbers used by automated systems */
+const SHORTCODE_RE = /^\d{4,6}$/;
+
+function redactDigits(text: string): string {
+  return text.replace(/\d/g, "*");
+}
+
+const messageFilter: HookHandler = async (event) => {
+  if (event.type !== "message" || event.action !== "inbound") {
+    return;
+  }
+
+  const context = event.context as unknown as InboundMessageHookContext;
+  if (!context || typeof context.bodyForCommands !== "string") {
+    return;
+  }
+
+  const cfg = context.cfg;
+  const hookConfig = resolveHookConfig(cfg, "message-filter") as MessageFilterConfig | undefined;
+
+  // Opt-in only: do nothing if not explicitly enabled
+  if (!hookConfig?.enabled) {
+    return;
+  }
+
+  const body = context.bodyForCommands.trim();
+
+  // Command bypass: never filter messages starting with /
+  if (body.startsWith("/")) {
+    return;
+  }
+
+  // Allowed senders bypass
+  const allowedSenders = hookConfig.allowedSenders ?? [];
+  if (allowedSenders.length > 0 && allowedSenders.includes(context.senderId)) {
+    return;
+  }
+
+  // Blocked senders: always filter
+  const blockedSenders = hookConfig.blockedSenders ?? [];
+  if (blockedSenders.length > 0 && blockedSenders.includes(context.senderId)) {
+    context.skip = true;
+    context.skipReason = "message-filter:blocked-sender";
+    log.debug("Message filtered", {
+      channel: context.channel,
+      senderId: context.senderId,
+      messageId: context.messageId,
+      skipReason: context.skipReason,
+    });
+    return;
+  }
+
+  // Shortcode senders (5-6 digit numbers like "74640") are automated systems
+  if (hookConfig.filterShortcodes !== false && SHORTCODE_RE.test(context.senderId)) {
+    context.skip = true;
+    context.skipReason = "message-filter:shortcode";
+    log.debug("Message filtered", {
+      channel: context.channel,
+      senderId: context.senderId,
+      messageId: context.messageId,
+      skipReason: context.skipReason,
+    });
+    return;
+  }
+
+  // Check built-in categories
+  const categoryConfig = hookConfig.categories ?? {};
+  for (const [category, patterns] of Object.entries(BUILTIN_CATEGORIES)) {
+    // Skip explicitly disabled categories (all enabled by default when not mentioned)
+    if (categoryConfig[category] !== undefined && !categoryConfig[category]) {
+      continue;
+    }
+
+    for (const pattern of patterns) {
+      if (pattern.test(body)) {
+        context.skip = true;
+        context.skipReason = `message-filter:${category}`;
+        const logMeta: Record<string, unknown> = {
+          channel: context.channel,
+          senderId: context.senderId,
+          messageId: context.messageId,
+          skipReason: context.skipReason,
+        };
+        if (hookConfig.logBody === true) {
+          logMeta.body = redactDigits(body);
+        }
+        log.debug("Message filtered", logMeta);
+        return;
+      }
+    }
+  }
+
+  // Check custom patterns
+  const customPatterns = hookConfig.customPatterns ?? [];
+  for (const patternStr of customPatterns) {
+    try {
+      const re = new RegExp(patternStr, "i");
+      if (re.test(body)) {
+        context.skip = true;
+        context.skipReason = "message-filter:custom";
+        const logMeta: Record<string, unknown> = {
+          channel: context.channel,
+          senderId: context.senderId,
+          messageId: context.messageId,
+          skipReason: context.skipReason,
+        };
+        if (hookConfig.logBody === true) {
+          logMeta.body = redactDigits(body);
+        }
+        log.debug("Message filtered", logMeta);
+        return;
+      }
+    } catch {
+      log.warn(`Invalid custom pattern: ${patternStr}`);
+    }
+  }
+};
+
+export default messageFilter;

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -42,6 +42,26 @@ export type GatewayStartupHookEvent = InternalHookEvent & {
 // Message Hook Events
 // ============================================================================
 
+/** Pre-processing filter hook context — runs before model work, allows vetoing. */
+export type InboundMessageHookContext = {
+  bodyForCommands: string;
+  senderId: string;
+  channel: string;
+  chatType?: string;
+  messageId?: string;
+  cfg?: OpenClawConfig;
+  /** Set to true by handlers to signal "drop this message" */
+  skip?: boolean;
+  /** Human-readable reason when skip=true (e.g., "message-filter:otp") */
+  skipReason?: string;
+};
+
+export type InboundMessageHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "inbound";
+  context: InboundMessageHookContext;
+};
+
 export type MessageReceivedHookContext = {
   /** Sender identifier (e.g., phone number, user ID) */
   from: string;
@@ -253,6 +273,17 @@ export function isGatewayStartupEvent(event: InternalHookEvent): event is Gatewa
   }
   const context = event.context as GatewayStartupHookContext | null;
   return Boolean(context && typeof context === "object");
+}
+
+export function isInboundMessageEvent(event: InternalHookEvent): event is InboundMessageHookEvent {
+  if (event.type !== "message" || event.action !== "inbound") {
+    return false;
+  }
+  const context = event.context as Partial<InboundMessageHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.bodyForCommands === "string" && typeof context.senderId === "string";
 }
 
 export function isMessageReceivedEvent(


### PR DESCRIPTION
## Summary

- Add `InboundMessageHookContext` type and `InboundMessageHookEvent` type to `internal-hooks.ts`, enabling mutable pre-processing hooks that can veto inbound messages before model work
- Wire `message:inbound` hook trigger into `dispatch-from-config.ts` (between dedup check and model invocation), with early return when `skip=true`
- Add bundled `message-filter` hook: opt-in regex-based filter that silently drops automated/junk messages (OTP codes, marketing, appointment reminders, fitness notifications, delivery updates, banking alerts)
- Features: command bypass (`/` prefix never filtered), allowed/blocked sender lists, SMS shortcode detection, custom regex patterns, per-category enable/disable, safe logging (digits redacted)

## Motivation

Messaging channels (iMessage, SMS, Telegram) receive many automated messages that waste tokens and produce confusing agent responses. This hook lets operators opt in to filtering them at zero latency and zero token cost, using only regex pattern matching.

The `InboundMessageHookContext` with mutable `skip`/`skipReason` fields provides a generic pre-filter mechanism that other hooks can also use.

## Test plan

- [x] 22 new tests in `handler.test.ts` covering all 6 categories, command bypass, allowed/blocked senders, shortcode detection, custom patterns, disabled categories, invalid patterns, and real-world message examples
- [x] All 142 existing hooks tests still pass (`pnpm vitest --run src/hooks/`)
- [x] `pnpm build` succeeds, HOOK.md copied to dist
- [x] `pnpm format:check` passes
- [x] Only pre-existing upstream TS error (`discord/send.components.test.ts`) remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a pre-processing hook system for filtering automated inbound messages before they reach the model. The implementation includes:

- New `InboundMessageHookContext` and `InboundMessageHookEvent` types in `internal-hooks.ts` for mutable pre-filter hooks
- Integration point in `dispatch-from-config.ts` between dedup check and model invocation with early return on `skip=true`
- Bundled `message-filter` hook with 6 built-in categories (OTP, marketing, appointments, fitness, delivery, banking)
- Opt-in design with command bypass, allowlist/blocklist, shortcode detection, and custom patterns
- Comprehensive test coverage with 22 new tests covering all categories and edge cases

The hook correctly runs after deduplication and before any model work, achieving zero-latency and zero-token-cost filtering as intended. The implementation follows existing hook patterns and includes proper type guards, error handling, and safe logging with digit redaction.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested opt-in feature with defensive design
- High confidence due to comprehensive test coverage (22 tests), opt-in design that won't affect existing systems, proper integration at correct lifecycle point, defensive patterns (command bypass, allowlist support), and safe handling of sensitive data (digit redaction). Only minor documentation inconsistency found regarding shortcode digit count.
- No files require special attention

<sub>Last reviewed commit: 8a1d249</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->