### PR TITLE
fix(tools): forward senderIsOwner to embedded runner so owner-only tools work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/Tools: forward `senderIsOwner` through embedded queued/followup runner params so owner-only tools remain available for authorized senders. (#22296) thanks @hcoj.
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.
 - Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.
 - Security/OpenClawKit/UI: prevent injected inbound user context metadata blocks from leaking into chat history in TUI, webchat, and macOS surfaces by stripping all untrusted metadata prefixes at display boundaries. (#22142) Thanks @Mellowambience, @vincentkoc.

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -164,6 +164,7 @@ export function buildEmbeddedRunBaseParams(params: {
     config: params.run.config,
     skillsSnapshot: params.run.skillsSnapshot,
     ownerNumbers: params.run.ownerNumbers,
+    senderIsOwner: params.run.senderIsOwner,
     enforceFinalTag: resolveEnforceFinalTag(params.run, params.provider),
     provider: params.provider,
     model: params.model,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -152,6 +152,7 @@ export function createFollowupRunner(params: {
               senderName: queued.run.senderName,
               senderUsername: queued.run.senderUsername,
               senderE164: queued.run.senderE164,
+              senderIsOwner: queued.run.senderIsOwner,
               sessionFile: queued.run.sessionFile,
               workspaceDir: queued.run.workspaceDir,
               config: queued.run.config,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -55,6 +55,7 @@ export type FollowupRun = {
     senderName?: string;
     senderUsername?: string;
     senderE164?: string;
+    senderIsOwner?: boolean;
     sessionFile: string;
     workspaceDir: string;
     config: OpenClawConfig;

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -24,7 +24,7 @@ const INBOUND_METADATA_HEADERS = [
   "Forwarded message context (untrusted metadata):",
   "Chat history since last reply (untrusted, for context):",
 ];
-const REGEX_ESCAPE_RE = /[.*+?^${}()|[\]\\\-]/g;
+const REGEX_ESCAPE_RE = /[.*+?^${}()|[\]\\-]/g;
 const INBOUND_METADATA_PREFIX_RE = new RegExp(
   "^\\s*(?:" +
     INBOUND_METADATA_HEADERS.map((header) => header.replace(REGEX_ESCAPE_RE, "\\$&")).join("|") +


### PR DESCRIPTION
## Summary

- `senderIsOwner` was dropped when forwarding parameters to `runEmbeddedPiAgent`, causing owner-only tools (`cron`, `gateway`) to be stripped from every agent run
- Added the missing property forwarding in three locations

## Details

`resolveCommandAuthorization()` correctly determines `senderIsOwner` and `get-reply-run.ts` stores it in `followupRun.run`. However, the helper functions that construct parameters for `runEmbeddedPiAgent` omitted it:

1. **`agent-runner-utils.ts:buildEmbeddedRunBaseParams()`** — did not include `senderIsOwner`
2. **`followup-runner.ts`** — same omission in the direct `runEmbeddedPiAgent` call
3. **`queue/types.ts:FollowupRun["run"]`** — type was missing `senderIsOwner`

Because `senderIsOwner` arrived as `undefined`, the guard `options?.senderIsOwner === true` in `pi-tools.ts` evaluated to `false`, and `applyOwnerOnlyToolPolicy` stripped all owner-only tools.

Fixes #22295

## Test plan

- [ ] Verify owner-only tools (cron, gateway) are available when sender matches `commands.ownerAllowFrom`
- [ ] Verify owner-only tools are still stripped for non-owner senders
- [ ] Verify followup/queued runs also preserve `senderIsOwner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the missing `senderIsOwner` property forwarding in three locations where parameters are constructed for `runEmbeddedPiAgent`, fixing a bug where owner-only tools (`cron`, `gateway`) were incorrectly stripped from all embedded agent runs.

**Changes made:**
- `agent-runner-utils.ts:buildEmbeddedRunBaseParams()` — now forwards `senderIsOwner` from `params.run`
- `followup-runner.ts` — now includes `senderIsOwner` when calling `runEmbeddedPiAgent` for queued runs
- `queue/types.ts:FollowupRun["run"]` — added `senderIsOwner?: boolean` to the type definition

The fix ensures that authorization context determined by `resolveCommandAuthorization()` is properly propagated through the entire embedded agent execution pipeline, so `applyOwnerOnlyToolPolicy` in `pi-tools.ts` correctly evaluates `options?.senderIsOwner === true`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward property forwarding fixes that restore intended functionality. All three changes add the same missing property (`senderIsOwner`) in parallel code paths, with consistent typing. The fix aligns with the existing authorization infrastructure and doesn't introduce new logic or side effects.
- No files require special attention

<sub>Last reviewed commit: 29c23f7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->