### PR TITLE
fix: handle host:port format in gateway port parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,5 +97,9 @@ package-lock.json
 .agents
 .agent/
 
+# Local workspace and OMC state
+workspace/
+.omc/
+
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig

--- a/src/config/config.nix-integration-u3-u5-u9.e2e.test.ts
+++ b/src/config/config.nix-integration-u3-u5-u9.e2e.test.ts
@@ -207,6 +207,22 @@ describe("Nix integration (U3, U5, U9)", () => {
         ),
       ).toBe(19003);
     });
+
+    it("extracts port from host:port format (Docker Compose bind)", () => {
+      expect(resolveGatewayPort({}, envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:18789" }))).toBe(
+        18789,
+      );
+    });
+
+    it("extracts port from 0.0.0.0:port format", () => {
+      expect(resolveGatewayPort({}, envWith({ OPENCLAW_GATEWAY_PORT: "0.0.0.0:19001" }))).toBe(
+        19001,
+      );
+    });
+
+    it("handles plain port number unchanged", () => {
+      expect(resolveGatewayPort({}, envWith({ OPENCLAW_GATEWAY_PORT: "18789" }))).toBe(18789);
+    });
   });
 
   describe("U9: telegram.tokenFile schema validation", () => {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { expandHomePrefix, resolveRequiredHomeDir } from "../infra/home-dir.js";
 import type { OpenClawConfig } from "./types.js";
+import { expandHomePrefix, resolveRequiredHomeDir } from "../infra/home-dir.js";
 
 /**
  * Nix mode detection: When OPENCLAW_NIX_MODE=1, the gateway is running under Nix.
@@ -260,7 +260,9 @@ export function resolveGatewayPort(
 ): number {
   const envRaw = env.OPENCLAW_GATEWAY_PORT?.trim() || env.CLAWDBOT_GATEWAY_PORT?.trim();
   if (envRaw) {
-    const parsed = Number.parseInt(envRaw, 10);
+    // Handle "host:port" format (e.g. "127.0.0.1:18789" from Docker Compose)
+    const portPart = envRaw.includes(":") ? envRaw.split(":").at(-1)! : envRaw;
+    const parsed = Number.parseInt(portPart, 10);
     if (Number.isFinite(parsed) && parsed > 0) {
       return parsed;
     }

--- a/src/macos/gateway-daemon.ts
+++ b/src/macos/gateway-daemon.ts
@@ -88,7 +88,9 @@ async function main() {
     process.env.CLAWDBOT_GATEWAY_PORT ??
     (typeof cfg.gateway?.port === "number" ? String(cfg.gateway.port) : "") ??
     "18789";
-  const port = Number.parseInt(portRaw, 10);
+  // Handle "host:port" format (e.g. "127.0.0.1:18789" from Docker Compose)
+  const portPart = portRaw.includes(":") ? portRaw.split(":").at(-1)! : portRaw;
+  const port = Number.parseInt(portPart, 10);
   if (Number.isNaN(port) || port <= 0) {
     defaultRuntime.error(`Invalid --port (${portRaw})`);
     process.exit(1);

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -89,7 +89,9 @@ function normalizeUrl(raw: string, schemeFallback: "ws" | "wss"): string | null 
 function resolveGatewayPort(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): number {
   const envRaw = env.OPENCLAW_GATEWAY_PORT?.trim() || env.CLAWDBOT_GATEWAY_PORT?.trim();
   if (envRaw) {
-    const parsed = Number.parseInt(envRaw, 10);
+    // Handle "host:port" format (e.g. "127.0.0.1:18789" from Docker Compose)
+    const portPart = envRaw.includes(":") ? envRaw.split(":").at(-1)! : envRaw;
+    const parsed = Number.parseInt(portPart, 10);
     if (Number.isFinite(parsed) && parsed > 0) {
       return parsed;
     }


### PR DESCRIPTION
## Summary

- Fix `Number.parseInt` incorrectly parsing `127.0.0.1:18789` as port `127` when `OPENCLAW_GATEWAY_PORT` contains a `host:port` bind address (common in Docker Compose `ports:` mappings)
- Extract the port portion after the last colon before parsing, handling plain port, `host:port`, and `0.0.0.0:port` formats
- Apply the fix to all three `resolveGatewayPort` call sites (`src/config/paths.ts`, `src/pairing/setup-code.ts`, `src/macos/gateway-daemon.ts`)
- Add test coverage for `host:port` and plain port formats
- Add `workspace/` and `.omc/` to `.gitignore`

## Root Cause

`Number.parseInt("127.0.0.1:18789", 10)` returns `127` because `parseInt` stops at the first non-numeric character (the dot). This caused the CLI inside Docker containers to connect to `ws://127.0.0.1:127` instead of `ws://127.0.0.1:18789`.

## Test plan

- [x] Existing 19 tests pass
- [x] 3 new tests cover `host:port`, `0.0.0.0:port`, and plain port formats
- [x] Verified `openclaw channels status` shows `Gateway reachable` inside Docker container with `OPENCLAW_GATEWAY_PORT=127.0.0.1:18789`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `Number.parseInt` incorrectly parsing `host:port` format in `OPENCLAW_GATEWAY_PORT` by extracting the port portion after the last colon. The fix correctly handles Docker Compose bind addresses like `127.0.0.1:18789` and `0.0.0.0:18789`.

**Changes:**
- Applied fix to three `resolveGatewayPort` call sites in `src/config/paths.ts`, `src/pairing/setup-code.ts`, and `src/macos/gateway-daemon.ts`
- Added comprehensive test coverage for `host:port`, `0.0.0.0:port`, and plain port formats
- Updated `.gitignore` to exclude `workspace/` and `.omc/` directories

**Issues Found:**
- `scripts/test-force.ts:47` has the same parsing bug and needs the same fix
- Minor: unintentional import reordering in `src/config/paths.ts`

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing `scripts/test-force.ts` parsing bug
- The core fix is correct and well-tested, but `scripts/test-force.ts` has the identical parsing bug that needs to be addressed for consistency. The fix handles IPv4 `host:port` formats correctly (using `.at(-1)` handles IPv6 bracket notation like `[::1]:18789` correctly too). Test coverage is comprehensive.
- `scripts/test-force.ts` needs the same `host:port` parsing fix applied

<sub>Last reviewed commit: ffb61e7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->