### PR TITLE
fix(export-session): render system prompt section and payload correctly

### DIFF
--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -86,6 +86,8 @@ describe("buildExportSessionReply", () => {
     expect(html).not.toContain("MARKED_JS;");
     expect(html).not.toContain("HIGHLIGHT_JS;");
     expect(html).not.toContain("{{JS}}");
+    expect(html).toContain('class="system-prompt-full"');
+    expect(html).toContain("System Prompt");
 
     const sessionDataMatch = html.match(
       /<script id="session-data" type="application\/json">([^<]+)<\/script>/,

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -1,0 +1,116 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const resolveDefaultSessionStorePathMock = vi.fn();
+  const resolveSessionFilePathMock = vi.fn();
+  const loadSessionStoreMock = vi.fn();
+  const sessionManagerOpenMock = vi.fn();
+  const resolveCommandsSystemPromptBundleMock = vi.fn();
+
+  return {
+    resolveDefaultSessionStorePathMock,
+    resolveSessionFilePathMock,
+    loadSessionStoreMock,
+    sessionManagerOpenMock,
+    resolveCommandsSystemPromptBundleMock,
+  };
+});
+
+vi.mock("../../config/sessions/paths.js", () => ({
+  resolveDefaultSessionStorePath: hoisted.resolveDefaultSessionStorePathMock,
+  resolveSessionFilePath: hoisted.resolveSessionFilePathMock,
+}));
+
+vi.mock("../../config/sessions/store.js", () => ({
+  loadSessionStore: hoisted.loadSessionStoreMock,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+  SessionManager: {
+    open: hoisted.sessionManagerOpenMock,
+  },
+}));
+
+vi.mock("./commands-system-prompt.js", () => ({
+  resolveCommandsSystemPromptBundle: hoisted.resolveCommandsSystemPromptBundleMock,
+}));
+
+const { buildExportSessionReply } = await import("./commands-export-session.js");
+const { buildCommandTestParams } = await import("./commands-spawn.test-harness.js");
+
+describe("buildExportSessionReply", () => {
+  beforeEach(() => {
+    hoisted.resolveDefaultSessionStorePathMock.mockReset();
+    hoisted.resolveSessionFilePathMock.mockReset();
+    hoisted.loadSessionStoreMock.mockReset();
+    hoisted.sessionManagerOpenMock.mockReset();
+    hoisted.resolveCommandsSystemPromptBundleMock.mockReset();
+    hoisted.resolveDefaultSessionStorePathMock.mockReturnValue("/tmp/sessions.json");
+    hoisted.resolveSessionFilePathMock.mockReturnValue(process.cwd() + "/package.json");
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": { sessionId: "session-1234", updatedAt: 1_700_000_000_000 },
+    });
+    hoisted.sessionManagerOpenMock.mockReturnValue({
+      getEntries: vi.fn().mockReturnValue([{ id: "entry-1" }]),
+      getHeader: vi.fn().mockReturnValue({}),
+      getLeafId: vi.fn().mockReturnValue("entry-1"),
+    });
+    hoisted.resolveCommandsSystemPromptBundleMock.mockResolvedValue({
+      systemPrompt: "system prompt body",
+      tools: [{ name: "tool-a", description: "test tool" }],
+    });
+  });
+
+  it("writes an export file with resolved JS payloads and session payload data", async () => {
+    const params = buildCommandTestParams("/export-session", {});
+    params.sessionEntry = {
+      sessionId: "session-1234",
+      updatedAt: 1_700_000_000_001,
+    };
+
+    const reply = await buildExportSessionReply(params);
+
+    expect(reply.text).toContain("✅ Session exported!");
+    expect(hoisted.resolveCommandsSystemPromptBundleMock).toHaveBeenCalledOnce();
+
+    const outputPathMatch = reply.text.match(/📄 File: (.+)/);
+    expect(outputPathMatch).toBeTruthy();
+    const outputPath = outputPathMatch?.[1] ?? "";
+    const absoluteOutputPath = path.isAbsolute(outputPath)
+      ? outputPath
+      : path.join(params.workspaceDir, outputPath);
+    const html = await (await import("node:fs/promises")).readFile(absoluteOutputPath, "utf-8");
+    expect(outputPath).toContain("openclaw-session-session-");
+    expect(outputPath.endsWith(".html")).toBe(true);
+    expect(html).not.toContain("MARKED_JS;");
+    expect(html).not.toContain("HIGHLIGHT_JS;");
+    expect(html).not.toContain("{{JS}}");
+
+    const sessionDataMatch = html.match(
+      /<script id="session-data" type="application\/json">([^<]+)<\/script>/,
+    );
+    expect(sessionDataMatch).toBeTruthy();
+    const sessionData = JSON.parse(
+      Buffer.from(sessionDataMatch?.[1] ?? "", "base64").toString("utf8"),
+    );
+    expect(sessionData).toMatchObject({
+      header: {},
+      entries: [{ id: "entry-1" }],
+      leafId: "entry-1",
+      systemPrompt: "system prompt body",
+      tools: [{ name: "tool-a", description: "test tool" }],
+    });
+
+    await (await import("node:fs/promises")).unlink(absoluteOutputPath);
+  });
+
+  it("returns an error when no session is active", async () => {
+    const params = buildCommandTestParams("/export-session", {});
+    params.sessionEntry = undefined;
+
+    const reply = await buildExportSessionReply(params);
+
+    expect(reply.text).toBe("❌ No active session found.");
+  });
+});

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -70,11 +70,15 @@ describe("buildExportSessionReply", () => {
     };
 
     const reply = await buildExportSessionReply(params);
+    const replyText = reply.text;
+    if (replyText === undefined) {
+      throw new Error("Expected reply.text to be defined");
+    }
 
-    expect(reply.text).toContain("✅ Session exported!");
+    expect(replyText).toContain("✅ Session exported!");
     expect(hoisted.resolveCommandsSystemPromptBundleMock).toHaveBeenCalledOnce();
 
-    const outputPathMatch = reply.text.match(/📄 File: (.+)/);
+    const outputPathMatch = replyText.match(/📄 File: (.+)/);
     expect(outputPathMatch).toBeTruthy();
     const outputPath = outputPathMatch?.[1] ?? "";
     const absoluteOutputPath = path.isAbsolute(outputPath)

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -60,29 +60,17 @@
 
     <!-- Vendored libraries -->
     <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
+      {{MARKED_JS}}
     </script>
 
     <!-- highlight.js -->
     <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
+      {{HIGHLIGHT_JS}}
     </script>
 
     <!-- Main application code -->
     <script>
-      {
-        {
-          JS;
-        }
-      }
+      {{JS}}
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Fixes issue #22161 by replacing template placeholders in `export-html/template.html` so generated HTML contains valid embedded JS/CSS payloads.
- Ensures `MARKED_JS`, `HIGHLIGHT_JS`, and the main application script tokens are resolved before write-out.
- Adds regression coverage in `commands-export-session.test.ts` for export payload content and rendered output shape, including expected absence of unresolved template tokens.
- Tightened assertions to validate that the exported HTML includes system prompt block markers used by the viewer and confirms session payload carries `systemPrompt`.

## Why this is safe
- Narrow, local change to static export template generation and tests.
- No runtime command behavior changes outside `/export-session` output path.
- Existing export flow and command arguments are unchanged; only output reliability is improved.

## Testing
- `pnpm -s vitest run src/auto-reply/reply/commands-export-session.test.ts`
- `pnpm -s vitest run src/auto-reply/reply/commands.test.ts src/auto-reply/reply/commands-export-session.test.ts`

Fixes #22161

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes broken template placeholders in `export-html/template.html` where a formatter had mangled `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` into multi-line `{ { TOKEN; } }` blocks. Since `generateHtml()` uses exact string `.replace()` calls, these mangled tokens were never substituted, producing broken exported HTML with no JS payloads.

- **Template fix**: Restores all three `<script>` placeholders to their correct single-line `{{TOKEN}}` format so `.replace()` matches properly
- **New test coverage**: Adds `commands-export-session.test.ts` with regression assertions verifying that exported HTML contains no unresolved template tokens, includes the system prompt section, and carries correctly base64-encoded session data with `systemPrompt` and `tools` fields

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a clear template rendering bug and adds regression tests with no runtime behavior changes.
- The template fix is minimal (restoring mangled placeholders to their correct format) and the new test file provides solid regression coverage. The changes are narrowly scoped to the `/export-session` static HTML output path. No logic, dependencies, or runtime command behavior is altered.
- No files require special attention.

<sub>Last reviewed commit: 0cb41dd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->