### PR TITLE
Discord/Telegram: emit edit system events

### DIFF
--- a/src/discord/monitor/message-update.test.ts
+++ b/src/discord/monitor/message-update.test.ts
@@ -1,0 +1,113 @@
+import { ChannelType } from "@buape/carbon";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { DiscordMessageUpdateListener, type DiscordMessageUpdateEvent } from "./listeners.js";
+import { __resetDiscordChannelInfoCacheForTest } from "./message-utils.js";
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: vi.fn(),
+}));
+
+describe("DiscordMessageUpdateListener", () => {
+  const enqueueSystemEventMock = vi.mocked(enqueueSystemEvent);
+
+  beforeEach(() => {
+    enqueueSystemEventMock.mockReset();
+    __resetDiscordChannelInfoCacheForTest();
+  });
+
+  it("enqueues system event for edited DMs", async () => {
+    const cfg = { channels: { discord: {} } } as OpenClawConfig;
+    const listener = new DiscordMessageUpdateListener({
+      cfg,
+      accountId: "default",
+      runtime: { error: vi.fn() } as unknown as import("../../runtime.js").RuntimeEnv,
+      botUserId: "bot-1",
+      guildEntries: undefined,
+      logger: { error: vi.fn(), warn: vi.fn() } as unknown as ReturnType<
+        typeof import("../../logging/subsystem.js").createSubsystemLogger
+      >,
+      dmEnabled: true,
+      dmPolicy: "open",
+      allowFrom: [],
+      groupPolicy: "open",
+      groupDmEnabled: false,
+      groupDmChannels: undefined,
+      allowBots: false,
+    });
+
+    const message = {
+      id: "msg-1",
+      channelId: "dm-1",
+      editedTimestamp: "2026-02-20T00:00:00.000Z",
+      author: { id: "user-1", username: "Ada", discriminator: "0001", bot: false },
+    } as unknown as import("@buape/carbon").Message;
+
+    const client = {
+      fetchChannel: vi.fn(async () => ({ type: ChannelType.DM })),
+    } as unknown as import("@buape/carbon").Client;
+
+    await listener.handle(
+      {
+        channel_id: "dm-1",
+        message,
+      } as DiscordMessageUpdateEvent,
+      client,
+    );
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Discord message edited in DM.",
+      expect.objectContaining({
+        contextKey: "discord:message:edited:dm-1:msg-1",
+      }),
+    );
+  });
+
+  it("skips system event when guild allowlist blocks sender", async () => {
+    const cfg = { channels: { discord: {} } } as OpenClawConfig;
+    const listener = new DiscordMessageUpdateListener({
+      cfg,
+      accountId: "default",
+      runtime: { error: vi.fn() } as unknown as import("../../runtime.js").RuntimeEnv,
+      botUserId: "bot-1",
+      guildEntries: {
+        "guild-1": { users: ["user-allowed"] },
+      },
+      logger: { error: vi.fn(), warn: vi.fn() } as unknown as ReturnType<
+        typeof import("../../logging/subsystem.js").createSubsystemLogger
+      >,
+      dmEnabled: true,
+      dmPolicy: "open",
+      allowFrom: [],
+      groupPolicy: "open",
+      groupDmEnabled: false,
+      groupDmChannels: undefined,
+      allowBots: false,
+    });
+
+    const message = {
+      id: "msg-2",
+      channelId: "channel-1",
+      editedTimestamp: "2026-02-20T00:00:00.000Z",
+      author: { id: "user-blocked", username: "Ada", discriminator: "0001", bot: false },
+    } as unknown as import("@buape/carbon").Message;
+
+    const client = {
+      fetchChannel: vi.fn(async () => ({ type: ChannelType.GuildText })),
+    } as unknown as import("@buape/carbon").Client;
+
+    await listener.handle(
+      {
+        channel_id: "channel-1",
+        guild_id: "guild-1",
+        guild: { id: "guild-1", name: "Test Guild" },
+        member: { roles: [] },
+        message,
+      } as DiscordMessageUpdateEvent,
+      client,
+    );
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -59,6 +59,7 @@ import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
 import {
   DiscordMessageListener,
+  DiscordMessageUpdateListener,
   DiscordPresenceListener,
   DiscordReactionListener,
   DiscordReactionRemoveListener,
@@ -605,6 +606,24 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   });
 
   registerDiscordListener(client.listeners, new DiscordMessageListener(messageHandler, logger));
+  registerDiscordListener(
+    client.listeners,
+    new DiscordMessageUpdateListener({
+      cfg,
+      accountId: account.accountId,
+      runtime,
+      botUserId,
+      guildEntries,
+      logger,
+      dmEnabled,
+      dmPolicy,
+      allowFrom,
+      groupPolicy,
+      groupDmEnabled,
+      groupDmChannels,
+      allowBots: discordCfg.allowBots ?? false,
+    }),
+  );
   registerDiscordListener(
     client.listeners,
     new DiscordReactionListener({


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds system event notifications for message edits in Discord and Telegram channels. When a user edits a message, the system now enqueues an event like "Discord message edited in DM" or "Telegram message edited in DM with Ada (`@ada_bot`)."

**Changes:**
- Discord: Added `DiscordMessageUpdateListener` that handles `MessageUpdateListener` events and emits system events for edited messages
- Discord: Applied the same access control logic (DM policies, guild allowlists, channel configs, role-based access) used for new messages to edit events
- Telegram: Added handlers for `edited_message` and `edited_channel_post` events that emit system events
- Telegram: Applied the same access control and filtering logic used for new messages to edit events
- Both platforms: Added comprehensive test coverage for edit event handling

**Implementation consistency:**
The implementation properly mirrors the existing message handling logic for access control, respecting DM policies, group policies, allowlists, and channel-specific configurations. Both platforms filter bot messages appropriately (Discord uses configurable `allowBots`, Telegram hard-codes bot filtering).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns for message handling, includes comprehensive test coverage, and properly applies all access control logic. The code mirrors existing message handler implementations, reducing the risk of introducing new bugs. No security or logical issues were found.
- No files require special attention

<sub>Last reviewed commit: 181ba35</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->