### PR TITLE
Fix legacy paired metadata handling for reconnect scope compatibility

### DIFF
--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -1078,6 +1078,68 @@ describe("gateway server auth/connect", () => {
     }
   });
 
+  test("allows legacy paired devices missing scope metadata", async () => {
+    const { resolvePairingPaths, readJsonFile } = await import("../infra/pairing-files.js");
+    const { writeJsonAtomic } = await import("../infra/json-files.js");
+    const { getPairedDevice } = await import("../infra/device-pairing.js");
+    const {
+      device,
+      identity: { deviceId },
+    } = await createSignedDevice({
+      token: "secret",
+      scopes: ["operator.read"],
+      clientId: TEST_OPERATOR_CLIENT.id,
+      clientMode: TEST_OPERATOR_CLIENT.mode,
+    });
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    let ws2: WebSocket | undefined;
+    try {
+      const initial = await connectReq(ws, {
+        token: "secret",
+        scopes: ["operator.read"],
+        client: TEST_OPERATOR_CLIENT,
+        device,
+      });
+      if (!initial.ok) {
+        await approvePendingPairingIfNeeded();
+      }
+
+      const initialPaired = await getPairedDevice(deviceId);
+      expect(initialPaired?.scopes).toContain("operator.read");
+
+      const { pairedPath } = resolvePairingPaths(undefined, "devices");
+      const paired =
+        (await readJsonFile<Record<string, Record<string, unknown>>>(pairedPath)) ?? {};
+      const legacy = paired[deviceId];
+      if (!legacy) {
+        throw new Error(`Expected paired metadata for deviceId=${deviceId}`);
+      }
+
+      delete legacy.scopes;
+      await writeJsonAtomic(pairedPath, paired);
+
+      const wsReconnect = new WebSocket(`ws://127.0.0.1:${port}`);
+      ws2 = wsReconnect;
+      await new Promise<void>((resolve) => wsReconnect.once("open", resolve));
+      const reconnect = await connectReq(wsReconnect, {
+        token: "secret",
+        scopes: ["operator.read"],
+        client: TEST_OPERATOR_CLIENT,
+        device,
+      });
+      expect(reconnect.ok).toBe(true);
+
+      const repaired = await getPairedDevice(deviceId);
+      expect(repaired?.scopes).toContain("operator.read");
+      expect(repaired?.roles).toContain("operator");
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+      ws.close();
+      ws2?.close();
+    }
+  });
+
   test("rejects revoked device token", async () => {
     const { revokeDeviceToken } = await import("../infra/device-pairing.js");
     const { server, ws, port, prevToken } = await startServerWithClient("secret");

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -712,8 +712,10 @@ export function attachGatewayWsMessageHandler(params: {
               return;
             }
           } else {
+            // Older pair records may have been created before roles/scopes metadata
+            // became required for every reconnection.
             const hasLegacyPairedMetadata =
-              paired.roles === undefined && paired.scopes === undefined;
+              paired.roles === undefined || paired.scopes === undefined;
             const pairedRoles = Array.isArray(paired.roles)
               ? paired.roles
               : paired.role


### PR DESCRIPTION
## Summary

- Problem: `sessions_history` can fail with `pairing required` for already paired devices when reconnect metadata is partially missing from older pair records.
- Why it matters: cross-agent workflows are blocked even though the session token is valid and role/scope capability is effectively unchanged.
- What changed: treat paired entries with missing `roles` **or** missing `scopes` as legacy metadata during handshake upgrades, so they are repaired on reconnect instead of forcing pairing.
- What did NOT change: normal role/scope upgrade enforcement for fully populated pair metadata.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [x] Auth / tokens

## Linked Issue/PR
- Closes #22160

## User-visible / Behavior Changes

Paired devices with incomplete historical metadata reconnect successfully on role/scope-compatible calls without prompting for re-pairing.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: `Not applicable`

## Repro + Verification

### Environment

- Runtime/container: local macOS dev
- OS: local
- Model/provider: not applicable
- Integration/channel (if any): gateway auth/e2e

### Steps

1. Connect first time with a device and record paired metadata.
2. Remove one metadata field (either `roles` or `scopes`) from stored pair record.
3. Reconnect with valid token and compatible role/scope.
4. Confirm reconnect succeeds and metadata is repaired.

### Expected

Reconnect succeeds without pairing prompt.

### Actual

When partial metadata was missing, reconnect previously forced pairing.

## Evidence

- [x] Passing tests: `pnpm test:e2e src/gateway/server.auth.e2e.test.ts`

## Human Verification (required)

- Verified scenarios:
  - Existing paired device with `scopes` removed from metadata reconnects successfully.
- Edge cases checked:
  - Existing e2e coverage for fully missing role+scope metadata still passes.
- What you did not verify:
  - Real-device production reconnection in an active multi-agent deployment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: legacy detection is intentionally conservative and applies only when metadata is incomplete.
  - Mitigation: full metadata paths still enforce current role/scope upgrade checks; only repairs are applied for partial legacy compatibility.

## Confidence Score

- **5/5**
- The change is narrowly scoped and aligns with existing legacy-repair behavior already exercised by e2e tests. It restores backwards compatibility for pre-change pair records, with minimal behavioral surface area and no permission-model changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes the legacy paired metadata detection from requiring **both** `roles` and `scopes` to be missing (using `&&`) to detecting when **either** is missing (using `||`). This allows devices with partial historical metadata to reconnect and have their metadata repaired automatically instead of being forced to re-pair. The fix aligns with the existing legacy repair behavior at line 765-773 where `updatePairedDeviceMetadata` repairs missing metadata on reconnect. A new test validates reconnection with only `scopes` removed, complementing the existing test that removes both fields.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a one-character operator modification (`&&` to `||`) with clear intent and comprehensive test coverage. The logic change expands the legacy detection condition conservatively - it still requires metadata incompleteness to trigger repair mode, and the subsequent `updatePairedDeviceMetadata` call (line 765-773) repairs the missing fields. The new test specifically validates the partial-metadata scenario (missing `scopes` only), and existing tests confirm the both-missing case still works correctly
- No files require special attention

<sub>Last reviewed commit: 34d52ca</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->