### PR TITLE
fix: sanitize tool schemas for all Cloud Code Assist providers

### DIFF
--- a/src/agents/pi-embedded-runner/google.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/google.e2e.test.ts
@@ -66,4 +66,66 @@ describe("sanitizeToolsForGoogle", () => {
     expect(params.patternProperties).toBeUndefined();
     expect(params.properties?.foo?.format).toBeUndefined();
   });
+
+  it("strips unsupported schema keywords for openai-codex (routed via Cloud Code Assist)", () => {
+    const tool = {
+      name: "exec",
+      description: "execute shell commands",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string" },
+          env: {
+            type: "object",
+            patternProperties: {
+              "^.*$": { type: "string" },
+            },
+          },
+        },
+      },
+      execute: async () => ({ ok: true, content: [] }),
+    } as unknown as AgentTool;
+
+    const [sanitized] = sanitizeToolsForGoogle({
+      tools: [tool],
+      provider: "openai-codex",
+    });
+
+    const params = sanitized.parameters as {
+      properties?: Record<string, { patternProperties?: unknown }>;
+    };
+
+    expect(params.properties?.env?.patternProperties).toBeUndefined();
+  });
+
+  it("strips unsupported schema keywords for google/* providers", () => {
+    const tool = {
+      name: "exec",
+      description: "execute shell commands",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string" },
+          env: {
+            type: "object",
+            patternProperties: {
+              "^.*$": { type: "string" },
+            },
+          },
+        },
+      },
+      execute: async () => ({ ok: true, content: [] }),
+    } as unknown as AgentTool;
+
+    const [sanitized] = sanitizeToolsForGoogle({
+      tools: [tool],
+      provider: "google/gemini-3-pro-preview",
+    });
+
+    const params = sanitized.parameters as {
+      properties?: Record<string, { patternProperties?: unknown }>;
+    };
+
+    expect(params.properties?.env?.patternProperties).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -256,10 +256,8 @@ export function sanitizeToolsForGoogle<
   // Cloud Code Assist uses the OpenAPI 3.03 `parameters` field for both Gemini
   // AND Claude models.  This field does not support JSON Schema keywords such as
   // patternProperties, additionalProperties, $ref, etc.  We must clean schemas
-  // for every provider that routes through this path.
-  if (params.provider !== "google-gemini-cli" && params.provider !== "google-antigravity") {
-    return params.tools;
-  }
+  // for every provider that routes through this path — including openai-codex
+  // and google/* providers that also route through Cloud Code Assist.
   return params.tools.map((tool) => {
     if (!tool.parameters || typeof tool.parameters !== "object") {
       return tool;


### PR DESCRIPTION
## Summary

- `sanitizeToolsForGoogle` only stripped unsupported JSON Schema keywords (`patternProperties`, `additionalProperties`, etc.) when the provider was `google-gemini-cli` or `google-antigravity`
- Providers like `openai-codex` and `google/*` also route through Google Cloud Code Assist, which rejects these keywords with a 400 error
- The `exec` tool's `env` field (`Type.Record`) generates `patternProperties` in its schema, breaking every API call for affected providers
- Removed the provider guard so schemas are always sanitized — matching the intent already described in the comment above the function

## Reproduction

1. Configure `openai-codex/gpt-5.3-codex` or `google/gemini-3-pro-preview` as primary model
2. Send any message via Discord/Signal channel
3. API returns: `Invalid JSON payload received. Unknown name "patternProperties" at 'request.tools[0].function_declarations[3].parameters.properties[2].value': Cannot find field.`

## Test plan

- [x] Added test cases for `openai-codex` and `google/*` providers
- [x] Existing tests for `google-gemini-cli` and `google-antigravity` still pass
- [ ] Verify manually with `openai-codex` provider via Discord channel

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the provider guard in `sanitizeToolsForGoogle` so that tool schemas are always sanitized before being sent to Cloud Code Assist, fixing 400 errors for `openai-codex` and `google/*` providers whose requests were rejected due to unsupported JSON Schema keywords like `patternProperties`.

- The old guard only sanitized for `google-gemini-cli` and `google-antigravity`, contradicting the comment above it that stated schemas should be cleaned "for every provider that routes through this path"
- Providers like `openai-codex` and `google/*` also route through Cloud Code Assist and hit the same OpenAPI 3.03 schema restrictions
- The `exec` tool's `env` field (using `Type.Record`) generates `patternProperties` in its schema, which triggered the 400 on every API call for affected providers
- New tests cover `openai-codex` and `google/*` provider scenarios; existing tests continue to pass

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix that aligns behavior with the stated intent.
- The change is a 3-line removal of a provider guard that was already documented as incorrect by the comment above it. The sanitization logic (`cleanToolSchemaForGemini`) is non-destructive — it only strips optional JSON Schema constraint keywords while preserving the core schema structure. The fix is backed by new test cases and does not change behavior for previously-working providers. There are no security implications, no architectural changes, and no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 0329be4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->