### PR TITLE
Android : Add Notification Intelligence -- cross-app AI triage

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -57,6 +57,15 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:name=".notification.OpenClawNotificationListener"
+            android:exported="true"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+
         <receiver
             android:name=".InstallResultReceiver"
             android:exported="false" />

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -54,6 +54,8 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val manualTls: StateFlow<Boolean> = runtime.manualTls
   val gatewayToken: StateFlow<String> = runtime.gatewayToken
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
+  val notificationsEnabled: StateFlow<Boolean> = runtime.notificationsEnabled
+  val notificationsListenerConnected: StateFlow<Boolean> = runtime.notificationBridge.isListenerConnected
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
   val chatSessionId: StateFlow<String?> = runtime.chatSessionId
@@ -128,6 +130,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setTalkEnabled(enabled: Boolean) {
     runtime.setTalkEnabled(enabled)
+  }
+
+  fun setNotificationsEnabled(value: Boolean) {
+    runtime.setNotificationsEnabled(value)
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -134,6 +134,34 @@ class NodeRuntime(context: Context) {
     sms = sms,
   )
 
+  private val notificationFilter: ai.openclaw.android.notification.NotificationFilter =
+    ai.openclaw.android.notification.NotificationFilter(
+      ownPackageName = appContext.packageName,
+      allowedPackages = { emptySet() },
+      blockedPackages = { emptySet() },
+    )
+
+  val notificationBridge: NotificationListenerBridge by lazy {
+    NotificationListenerBridge(
+      scope = scope,
+      isFeatureEnabled = { notificationsEnabled.value },
+      nodeId = { prefs.instanceId.value },
+      filter = notificationFilter,
+      sendBatch = { json ->
+        try {
+          nodeSession.request("notifications.batch", json, timeoutMs = 10_000)
+        } catch (err: Throwable) {
+          android.util.Log.w("OpenClawNotif", "batch send failed: ${err.message}")
+        }
+      },
+      batchWindowMs = (prefs.notificationsBatchWindowSec.value * 1000L),
+    )
+  }
+
+  private val notificationHandler: NotificationHandler = NotificationHandler(
+    bridge = notificationBridge,
+  )
+
   private val a2uiHandler: A2UIHandler = A2UIHandler(
     canvas = canvas,
     json = json,
@@ -148,6 +176,7 @@ class NodeRuntime(context: Context) {
     voiceWakeMode = { voiceWakeMode.value },
     smsAvailable = { sms.canSendSms() },
     hasRecordAudioPermission = { hasRecordAudioPermission() },
+    notificationsEnabled = { notificationsEnabled.value },
     manualTls = { manualTls.value },
   )
 
@@ -160,9 +189,11 @@ class NodeRuntime(context: Context) {
     a2uiHandler = a2uiHandler,
     debugHandler = debugHandler,
     appUpdateHandler = appUpdateHandler,
+    notificationHandler = notificationHandler,
     isForeground = { _isForeground.value },
     cameraEnabled = { cameraEnabled.value },
     locationEnabled = { locationMode.value != LocationMode.Off },
+    notificationsEnabled = { notificationsEnabled.value },
   )
 
   private lateinit var gatewayEventHandler: GatewayEventHandler
@@ -348,6 +379,7 @@ class NodeRuntime(context: Context) {
   fun setGatewayToken(value: String) = prefs.setGatewayToken(value)
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
+  val notificationsEnabled: StateFlow<Boolean> = prefs.notificationsEnabled
 
   private var didAutoConnect = false
 
@@ -408,6 +440,16 @@ class NodeRuntime(context: Context) {
       talkEnabled.collect { enabled ->
         talkMode.setEnabled(enabled)
         externalAudioCaptureActive.value = enabled
+      }
+    }
+
+    scope.launch {
+      notificationsEnabled.collect { enabled ->
+        if (enabled) {
+          notificationBridge.activate()
+        } else {
+          notificationBridge.deactivate()
+        }
       }
     }
 
@@ -480,6 +522,15 @@ class NodeRuntime(context: Context) {
 
   fun setCameraEnabled(value: Boolean) {
     prefs.setCameraEnabled(value)
+  }
+
+  fun setNotificationsEnabled(value: Boolean) {
+    prefs.setNotificationsEnabled(value)
+    if (value) {
+      notificationBridge.activate()
+    } else {
+      notificationBridge.deactivate()
+    }
   }
 
   fun setLocationMode(mode: LocationMode) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -525,12 +525,8 @@ class NodeRuntime(context: Context) {
   }
 
   fun setNotificationsEnabled(value: Boolean) {
+    // The init-block collector on notificationsEnabled handles activate/deactivate.
     prefs.setNotificationsEnabled(value)
-    if (value) {
-      notificationBridge.activate()
-    } else {
-      notificationBridge.deactivate()
-    }
   }
 
   fun setLocationMode(mode: LocationMode) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -94,6 +94,14 @@ class SecurePrefs(context: Context) {
   private val _talkEnabled = MutableStateFlow(prefs.getBoolean("talk.enabled", false))
   val talkEnabled: StateFlow<Boolean> = _talkEnabled
 
+  private val _notificationsEnabled =
+    MutableStateFlow(prefs.getBoolean("notifications.enabled", false))
+  val notificationsEnabled: StateFlow<Boolean> = _notificationsEnabled
+
+  private val _notificationsBatchWindowSec =
+    MutableStateFlow(prefs.getInt("notifications.batchWindowSec", 30))
+  val notificationsBatchWindowSec: StateFlow<Int> = _notificationsBatchWindowSec
+
   fun setLastDiscoveredStableId(value: String) {
     val trimmed = value.trim()
     prefs.edit { putString("gateway.lastDiscoveredStableID", trimmed) }
@@ -248,6 +256,16 @@ class SecurePrefs(context: Context) {
   fun setTalkEnabled(value: Boolean) {
     prefs.edit { putBoolean("talk.enabled", value) }
     _talkEnabled.value = value
+  }
+
+  fun setNotificationsEnabled(value: Boolean) {
+    prefs.edit { putBoolean("notifications.enabled", value) }
+    _notificationsEnabled.value = value
+  }
+
+  fun setNotificationsBatchWindowSec(value: Int) {
+    prefs.edit { putInt("notifications.batchWindowSec", value) }
+    _notificationsBatchWindowSec.value = value
   }
 
   private fun loadVoiceWakeMode(): VoiceWakeMode {

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
@@ -11,6 +11,7 @@ import ai.openclaw.android.protocol.OpenClawCanvasA2UICommand
 import ai.openclaw.android.protocol.OpenClawCanvasCommand
 import ai.openclaw.android.protocol.OpenClawCameraCommand
 import ai.openclaw.android.protocol.OpenClawLocationCommand
+import ai.openclaw.android.protocol.OpenClawNotificationCommand
 import ai.openclaw.android.protocol.OpenClawScreenCommand
 import ai.openclaw.android.protocol.OpenClawSmsCommand
 import ai.openclaw.android.protocol.OpenClawCapability
@@ -24,6 +25,7 @@ class ConnectionManager(
   private val voiceWakeMode: () -> VoiceWakeMode,
   private val smsAvailable: () -> Boolean,
   private val hasRecordAudioPermission: () -> Boolean,
+  private val notificationsEnabled: () -> Boolean,
   private val manualTls: () -> Boolean,
 ) {
   companion object {
@@ -100,6 +102,10 @@ class ConnectionManager(
       if (smsAvailable()) {
         add(OpenClawSmsCommand.Send.rawValue)
       }
+      if (notificationsEnabled()) {
+        add(OpenClawNotificationCommand.Dismiss.rawValue)
+        add(OpenClawNotificationCommand.List.rawValue)
+      }
       if (BuildConfig.DEBUG) {
         add("debug.logs")
         add("debug.ed25519")
@@ -118,6 +124,9 @@ class ConnectionManager(
       }
       if (locationMode() != LocationMode.Off) {
         add(OpenClawCapability.Location.rawValue)
+      }
+      if (notificationsEnabled()) {
+        add(OpenClawCapability.Notifications.rawValue)
       }
     }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/NotificationHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/NotificationHandler.kt
@@ -1,0 +1,49 @@
+package ai.openclaw.android.node
+
+import ai.openclaw.android.gateway.GatewaySession
+import ai.openclaw.android.notification.CapturedNotification
+import ai.openclaw.android.notification.DismissResult
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class NotificationHandler(
+  private val bridge: NotificationListenerBridge,
+  private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+  @Serializable
+  private data class ListResponse(
+    val notifications: List<CapturedNotification>,
+    val count: Int,
+  )
+
+  suspend fun handleDismiss(paramsJson: String?): GatewaySession.InvokeResult {
+    val key =
+      try {
+        val obj = json.parseToJsonElement(paramsJson ?: "{}") as? JsonObject
+        obj?.get("key")?.jsonPrimitive?.content
+      } catch (_: Throwable) {
+        null
+      }
+
+    if (key.isNullOrBlank()) {
+      return GatewaySession.InvokeResult.error(
+        code = "INVALID_REQUEST",
+        message = "key required",
+      )
+    }
+
+    val dismissed = bridge.dismissNotification(key)
+    val result = DismissResult(dismissed = dismissed, key = key)
+    val payload = json.encodeToString(DismissResult.serializer(), result)
+    return GatewaySession.InvokeResult.ok(payload)
+  }
+
+  suspend fun handleList(paramsJson: String?): GatewaySession.InvokeResult {
+    val notifications = bridge.listActive()
+    val response = ListResponse(notifications = notifications, count = notifications.size)
+    val payload = json.encodeToString(ListResponse.serializer(), response)
+    return GatewaySession.InvokeResult.ok(payload)
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/NotificationListenerBridge.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/NotificationListenerBridge.kt
@@ -1,0 +1,89 @@
+package ai.openclaw.android.node
+
+import android.util.Log
+import ai.openclaw.android.notification.CapturedNotification
+import ai.openclaw.android.notification.NotificationBatcher
+import ai.openclaw.android.notification.NotificationFilter
+import ai.openclaw.android.notification.OpenClawNotificationListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class NotificationListenerBridge(
+  scope: CoroutineScope,
+  private val isFeatureEnabled: () -> Boolean,
+  private val nodeId: () -> String,
+  private val filter: NotificationFilter,
+  private val sendBatch: suspend (String) -> Unit,
+  batchWindowMs: Long = 30_000L,
+) {
+  companion object {
+    private const val TAG = "OpenClawNotifBridge"
+
+    /** Singleton so the NotificationListenerService can reach the bridge. */
+    @Volatile
+    var instance: NotificationListenerBridge? = null
+      private set
+  }
+
+  private val _isListenerConnected = MutableStateFlow(false)
+  val isListenerConnected: StateFlow<Boolean> = _isListenerConnected
+
+  private val batcher =
+    NotificationBatcher(
+      scope = scope,
+      windowMs = batchWindowMs,
+      nodeId = nodeId,
+      onBatchReady = { batch ->
+        val json = kotlinx.serialization.json.Json.encodeToString(
+          ai.openclaw.android.notification.NotificationBatch.serializer(),
+          batch,
+        )
+        sendBatch(json)
+      },
+    )
+
+  fun activate() {
+    instance = this
+    refreshListenerState()
+    // Drain any notifications the listener buffered while waiting for us.
+    OpenClawNotificationListener.instance?.drainBufferTo(this)
+    Log.i(TAG, "Bridge activated (listener=${_isListenerConnected.value})")
+  }
+
+  fun deactivate() {
+    if (instance === this) instance = null
+    batcher.stop()
+    _isListenerConnected.value = false
+    Log.i(TAG, "Bridge deactivated")
+  }
+
+  fun isEnabled(): Boolean = isFeatureEnabled()
+
+  fun onNotificationPosted(notification: CapturedNotification) {
+    if (!isFeatureEnabled()) return
+    if (!filter.shouldCapture(notification.packageName, notification.category)) return
+    // Skip group summaries as they duplicate individual notifications.
+    if (notification.isGroupSummary) return
+    batcher.add(notification)
+  }
+
+  fun onNotificationRemoved(notificationId: String) {
+    batcher.remove(notificationId)
+  }
+
+  fun dismissNotification(key: String): Boolean {
+    val listener = OpenClawNotificationListener.instance ?: return false
+    return listener.dismissNotification(key)
+  }
+
+  fun listActive(): List<CapturedNotification> {
+    val listener = OpenClawNotificationListener.instance ?: return emptyList()
+    return listener.listActiveNotificationSnapshots()
+      .filter { filter.shouldCapture(it.packageName, it.category) }
+  }
+
+  fun refreshListenerState() {
+    _isListenerConnected.value = OpenClawNotificationListener.instance != null
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/notification/NotificationBatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/notification/NotificationBatcher.kt
@@ -1,0 +1,114 @@
+package ai.openclaw.android.notification
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class NotificationBatcher(
+  private val scope: CoroutineScope,
+  private val windowMs: Long = 30_000L,
+  private val maxPending: Int = 200,
+  private val maxRetries: Int = 3,
+  private val retryDelayMs: Long = 5_000L,
+  private val nodeId: () -> String,
+  private val onBatchReady: suspend (NotificationBatch) -> Unit,
+) {
+  companion object {
+    private const val TAG = "OpenClawNotifBatcher"
+  }
+
+  /**
+   * Deduplicated map of pending notifications. Key = notification ID, value = latest capture.
+   * Using ConcurrentHashMap so the listener thread and coroutine scope don't conflict.
+   * If the same notification is posted twice (e.g. updated), the latest version wins.
+   */
+  private val pending = ConcurrentHashMap<String, CapturedNotification>()
+  private var timerJob: Job? = null
+  private var retryCount = 0
+
+  private val _pendingCount = MutableStateFlow(0)
+  val pendingCount: StateFlow<Int> = _pendingCount
+
+  fun add(notification: CapturedNotification) {
+    // Enforce max pending to prevent unbounded memory growth.
+    // If at limit and this is a new key, evict the oldest entry.
+    if (pending.size >= maxPending && !pending.containsKey(notification.id)) {
+      // ConcurrentHashMap has no ordering guarantee, so just remove any one entry.
+      pending.keys().asIterator().let { iter ->
+        if (iter.hasNext()) pending.remove(iter.next())
+      }
+    }
+    // Insert or replace -- latest version of a notification wins.
+    pending[notification.id] = notification
+    _pendingCount.value = pending.size
+    ensureTimerRunning()
+  }
+
+  fun remove(notificationId: String) {
+    pending.remove(notificationId)
+    _pendingCount.value = pending.size
+  }
+
+  private fun ensureTimerRunning() {
+    if (timerJob?.isActive == true) return
+    timerJob =
+      scope.launch {
+        delay(windowMs)
+        flush()
+      }
+  }
+
+  internal suspend fun flush() {
+    // Snapshot and clear atomically.
+    val items = pending.values.toList()
+    pending.clear()
+    _pendingCount.value = 0
+    if (items.isEmpty()) return
+
+    val batch =
+      NotificationBatch(
+        batchId = UUID.randomUUID().toString(),
+        nodeId = nodeId(),
+        notifications = items,
+        batchedAtMs = System.currentTimeMillis(),
+        windowMs = windowMs,
+      )
+    try {
+      onBatchReady(batch)
+      retryCount = 0
+    } catch (err: Throwable) {
+      Log.w(TAG, "batch delivery failed (${items.size} notifications): ${err.message}")
+      if (retryCount < maxRetries) {
+        // Re-insert items for retry. Existing entries (if any new ones arrived) are kept.
+        for (item in items) {
+          pending.putIfAbsent(item.id, item)
+        }
+        _pendingCount.value = pending.size
+        retryCount++
+        Log.i(TAG, "scheduling retry $retryCount/$maxRetries in ${retryDelayMs}ms")
+        timerJob =
+          scope.launch {
+            delay(retryDelayMs * retryCount)
+            flush()
+          }
+      } else {
+        Log.w(TAG, "max retries reached, dropping ${items.size} notifications")
+        retryCount = 0
+      }
+    }
+  }
+
+  fun stop() {
+    timerJob?.cancel()
+    timerJob = null
+    pending.clear()
+    _pendingCount.value = 0
+    retryCount = 0
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/notification/NotificationFilter.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/notification/NotificationFilter.kt
@@ -1,0 +1,46 @@
+package ai.openclaw.android.notification
+
+class NotificationFilter(
+  private val ownPackageName: String,
+  private val allowedPackages: () -> Set<String>,
+  private val blockedPackages: () -> Set<String>,
+) {
+  companion object {
+    private val SENSITIVE_PACKAGE_PATTERNS =
+      listOf(
+        Regex(".*\\.banking\\..*"),
+        Regex(".*\\.bank\\..*"),
+        Regex(".*\\.authenticator.*"),
+        Regex(".*\\.otp.*"),
+        Regex(".*\\.health\\..*"),
+        Regex(".*\\.medical\\..*"),
+        Regex(".*\\.2fa.*"),
+        Regex(".*\\.totp.*"),
+      )
+
+    /** Maximum text length extracted from a notification. */
+    const val MAX_TEXT_LENGTH = 500
+
+    fun isSensitivePackage(packageName: String): Boolean {
+      return SENSITIVE_PACKAGE_PATTERNS.any { it.matches(packageName) }
+    }
+  }
+
+  fun shouldCapture(packageName: String, category: String?): Boolean {
+    // Always block own package.
+    if (packageName == ownPackageName) return false
+
+    // Check explicit blocklist.
+    val blocked = blockedPackages()
+    if (blocked.contains(packageName)) return false
+
+    // Check sensitive package patterns.
+    if (isSensitivePackage(packageName)) return false
+
+    // If allowlist is non-empty, only capture listed apps.
+    val allowed = allowedPackages()
+    if (allowed.isNotEmpty() && !allowed.contains(packageName)) return false
+
+    return true
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/notification/NotificationModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/notification/NotificationModels.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CapturedNotification(
   val id: String,
+  /** The system key from StatusBarNotification.getKey(), needed for cancelNotification(). */
+  val key: String,
   val packageName: String,
   val appLabel: String,
   val title: String?,

--- a/apps/android/app/src/main/java/ai/openclaw/android/notification/NotificationModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/notification/NotificationModels.kt
@@ -1,0 +1,34 @@
+package ai.openclaw.android.notification
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CapturedNotification(
+  val id: String,
+  val packageName: String,
+  val appLabel: String,
+  val title: String?,
+  val text: String?,
+  val timestamp: Long,
+  val priority: Int,
+  val category: String?,
+  val groupKey: String?,
+  val isOngoing: Boolean,
+  val isGroupSummary: Boolean,
+)
+
+@Serializable
+data class NotificationBatch(
+  val batchId: String,
+  val nodeId: String,
+  val notifications: List<CapturedNotification>,
+  val batchedAtMs: Long,
+  val windowMs: Long,
+)
+
+@Serializable
+data class DismissResult(
+  val dismissed: Boolean,
+  val key: String?,
+  val error: String? = null,
+)

--- a/apps/android/app/src/main/java/ai/openclaw/android/notification/OpenClawNotificationListener.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/notification/OpenClawNotificationListener.kt
@@ -51,6 +51,7 @@ class OpenClawNotificationListener : NotificationListenerService() {
 
       return CapturedNotification(
         id = "${sbn.packageName}:${sbn.id}:${sbn.tag.orEmpty()}",
+        key = sbn.key,
         packageName = sbn.packageName,
         appLabel = appLabel,
         title = title,

--- a/apps/android/app/src/main/java/ai/openclaw/android/notification/OpenClawNotificationListener.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/notification/OpenClawNotificationListener.kt
@@ -1,0 +1,159 @@
+package ai.openclaw.android.notification
+
+import android.app.Notification
+import android.content.pm.PackageManager
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+import ai.openclaw.android.node.NotificationListenerBridge
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class OpenClawNotificationListener : NotificationListenerService() {
+
+  companion object {
+    private const val TAG = "OpenClawNotifListener"
+
+    /**
+     * Maximum notifications buffered while waiting for the bridge to become available.
+     * Prevents unbounded memory if the bridge never activates.
+     */
+    private const val MAX_BUFFER_SIZE = 50
+
+    /** Singleton reference so the bridge can reach the active listener instance. */
+    @Volatile
+    var instance: OpenClawNotificationListener? = null
+      private set
+
+    fun extractNotification(
+      sbn: StatusBarNotification,
+      pm: PackageManager,
+    ): CapturedNotification {
+      val notification = sbn.notification
+      val extras = notification.extras
+
+      val appLabel =
+        try {
+          pm
+            .getApplicationLabel(pm.getApplicationInfo(sbn.packageName, 0))
+            .toString()
+        } catch (_: Throwable) {
+          sbn.packageName
+        }
+
+      val title = extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
+      val rawText = extras?.getCharSequence(Notification.EXTRA_TEXT)?.toString()
+      val text =
+        if (rawText != null && rawText.length > NotificationFilter.MAX_TEXT_LENGTH) {
+          rawText.take(NotificationFilter.MAX_TEXT_LENGTH)
+        } else {
+          rawText
+        }
+
+      return CapturedNotification(
+        id = "${sbn.packageName}:${sbn.id}:${sbn.tag.orEmpty()}",
+        packageName = sbn.packageName,
+        appLabel = appLabel,
+        title = title,
+        text = text,
+        timestamp = sbn.postTime,
+        priority = @Suppress("DEPRECATION") notification.priority,
+        category = notification.category,
+        groupKey = sbn.groupKey,
+        isOngoing = (notification.flags and Notification.FLAG_ONGOING_EVENT) != 0,
+        isGroupSummary = (notification.flags and Notification.FLAG_GROUP_SUMMARY) != 0,
+      )
+    }
+  }
+
+  /**
+   * Buffer for notifications that arrive before the bridge is activated.
+   * Drained by [drainBufferTo] when the bridge becomes available.
+   */
+  private val preBuffer = ConcurrentLinkedQueue<CapturedNotification>()
+
+  override fun onListenerConnected() {
+    super.onListenerConnected()
+    instance = this
+    Log.i(TAG, "Notification listener connected")
+    // If the bridge is already active, drain any buffered notifications.
+    NotificationListenerBridge.instance?.let { bridge ->
+      drainBufferTo(bridge)
+    }
+  }
+
+  override fun onListenerDisconnected() {
+    super.onListenerDisconnected()
+    instance = null
+    preBuffer.clear()
+    Log.i(TAG, "Notification listener disconnected")
+  }
+
+  override fun onNotificationPosted(sbn: StatusBarNotification?) {
+    if (sbn == null) return
+    try {
+      val captured = extractNotification(sbn, packageManager)
+      val bridge = NotificationListenerBridge.instance
+      if (bridge != null && bridge.isEnabled()) {
+        bridge.onNotificationPosted(captured)
+      } else {
+        // Bridge not ready yet -- buffer for later drain.
+        if (preBuffer.size >= MAX_BUFFER_SIZE) {
+          preBuffer.poll()
+        }
+        preBuffer.add(captured)
+      }
+    } catch (err: Throwable) {
+      Log.w(TAG, "onNotificationPosted error: ${err.message}")
+    }
+  }
+
+  override fun onNotificationRemoved(sbn: StatusBarNotification?) {
+    if (sbn == null) return
+    try {
+      val id = "${sbn.packageName}:${sbn.id}:${sbn.tag.orEmpty()}"
+      val bridge = NotificationListenerBridge.instance
+      if (bridge != null) {
+        bridge.onNotificationRemoved(id)
+      } else {
+        preBuffer.removeAll { it.id == id }
+      }
+    } catch (err: Throwable) {
+      Log.w(TAG, "onNotificationRemoved error: ${err.message}")
+    }
+  }
+
+  /**
+   * Called by [NotificationListenerBridge.activate] to drain any notifications
+   * that arrived before the bridge was ready.
+   */
+  fun drainBufferTo(bridge: NotificationListenerBridge) {
+    var count = 0
+    while (true) {
+      val captured = preBuffer.poll() ?: break
+      bridge.onNotificationPosted(captured)
+      count++
+    }
+    if (count > 0) {
+      Log.i(TAG, "Drained $count buffered notifications to bridge")
+    }
+  }
+
+  fun dismissNotification(key: String): Boolean {
+    return try {
+      cancelNotification(key)
+      true
+    } catch (_: Throwable) {
+      false
+    }
+  }
+
+  fun listActiveNotificationSnapshots(): List<CapturedNotification> {
+    return try {
+      activeNotifications
+        ?.map { extractNotification(it, packageManager) }
+        ?: emptyList()
+    } catch (_: Throwable) {
+      emptyList()
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/protocol/OpenClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/protocol/OpenClawProtocolConstants.kt
@@ -7,6 +7,7 @@ enum class OpenClawCapability(val rawValue: String) {
   Sms("sms"),
   VoiceWake("voiceWake"),
   Location("location"),
+  Notifications("notifications"),
 }
 
 enum class OpenClawCanvasCommand(val rawValue: String) {
@@ -67,5 +68,15 @@ enum class OpenClawLocationCommand(val rawValue: String) {
 
   companion object {
     const val NamespacePrefix: String = "location."
+  }
+}
+
+enum class OpenClawNotificationCommand(val rawValue: String) {
+  Dismiss("notifications.dismiss"),
+  List("notifications.list"),
+  ;
+
+  companion object {
+    const val NamespacePrefix: String = "notifications."
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -76,6 +76,8 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val locationMode by viewModel.locationMode.collectAsState()
   val locationPreciseEnabled by viewModel.locationPreciseEnabled.collectAsState()
   val preventSleep by viewModel.preventSleep.collectAsState()
+  val notificationsEnabled by viewModel.notificationsEnabled.collectAsState()
+  val notificationsListenerConnected by viewModel.notificationsListenerConnected.collectAsState()
   val wakeWords by viewModel.wakeWords.collectAsState()
   val voiceWakeMode by viewModel.voiceWakeMode.collectAsState()
   val voiceWakeStatusText by viewModel.voiceWakeStatusText.collectAsState()
@@ -678,6 +680,52 @@ fun SettingsSheet(viewModel: MainViewModel) {
         "Always may require Android Settings to allow background location.",
         color = MaterialTheme.colorScheme.onSurfaceVariant,
       )
+    }
+
+    item { HorizontalDivider() }
+
+    // Notifications
+    item { Text("Notifications", style = MaterialTheme.typography.titleSmall) }
+    item {
+      ListItem(
+        headlineContent = { Text("Notification Intelligence") },
+        supportingContent = { Text("Allow AI to read and triage app notifications.") },
+        trailingContent = {
+          Switch(
+            checked = notificationsEnabled,
+            onCheckedChange = { enabled ->
+              if (enabled) {
+                val cn = android.content.ComponentName(context, ai.openclaw.android.notification.OpenClawNotificationListener::class.java)
+                val flat = android.provider.Settings.Secure.getString(context.contentResolver, "enabled_notification_listeners")
+                val isGranted = flat != null && flat.contains(cn.flattenToString())
+                if (!isGranted) {
+                  context.startActivity(android.content.Intent(android.provider.Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+                }
+                viewModel.setNotificationsEnabled(true)
+              } else {
+                viewModel.setNotificationsEnabled(false)
+              }
+            },
+          )
+        },
+      )
+    }
+    if (notificationsEnabled) {
+      item {
+        ListItem(
+          headlineContent = { Text("Listener Status") },
+          supportingContent = {
+            Text(if (notificationsListenerConnected) "Active" else "Not connected")
+          },
+        )
+      }
+      item {
+        Text(
+          "Banking, health, and authenticator apps are excluded by default. " +
+            "Notification content is never stored permanently.",
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
     }
 
     item { HorizontalDivider() }

--- a/extensions/notification-intelligence/index.ts
+++ b/extensions/notification-intelligence/index.ts
@@ -1,5 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk";
+import { stringEnum } from "openclaw/plugin-sdk";
 import { formatDigest, formatStatus } from "./src/digest.js";
 import { createNotificationStore } from "./src/store.js";
 import { triageBatch } from "./src/triage.js";
@@ -108,12 +109,9 @@ export default function register(api: OpenClawPluginApi) {
       "Get a triaged summary of recent phone notifications from the connected Android device. " +
       "Returns notifications classified by urgency level (critical, important, informational, noise).",
     parameters: Type.Object({
-      action: Type.Union(
-        [Type.Literal("digest"), Type.Literal("recent"), Type.Literal("critical")],
-        {
-          description: "digest: full triaged summary, recent: all recent, critical: critical only",
-        },
-      ),
+      action: stringEnum(["digest", "recent", "critical"] as const, {
+        description: "digest: full triaged summary, recent: all recent, critical: critical only",
+      }),
       since_minutes: Type.Optional(
         Type.Number({ description: "Look-back window in minutes (default 60)" }),
       ),

--- a/extensions/notification-intelligence/index.ts
+++ b/extensions/notification-intelligence/index.ts
@@ -1,0 +1,185 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk";
+import { formatDigest, formatStatus } from "./src/digest.js";
+import { createNotificationStore } from "./src/store.js";
+import { triageBatch } from "./src/triage.js";
+import type { NotificationBatch } from "./src/types.js";
+
+function jsonResult(payload: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+function textResult(text: string) {
+  return {
+    content: [{ type: "text" as const, text }],
+    details: { text },
+  };
+}
+
+export default function register(api: OpenClawPluginApi) {
+  const pluginConfig = (api.pluginConfig ?? {}) as Record<string, unknown>;
+  const maxStored =
+    typeof pluginConfig.maxStoredNotifications === "number"
+      ? pluginConfig.maxStoredNotifications
+      : 500;
+  const retentionMin =
+    typeof pluginConfig.retentionMinutes === "number" ? pluginConfig.retentionMinutes : 60;
+
+  const store = createNotificationStore({
+    maxItems: maxStored,
+    retentionMs: retentionMin * 60_000,
+  });
+
+  // ── Gateway method: receive notification batches from Android nodes ───────
+
+  api.registerGatewayMethod("notifications.batch", async ({ params, respond }) => {
+    try {
+      const batch = params as unknown as NotificationBatch;
+      if (!batch || !Array.isArray(batch.notifications)) {
+        respond(false, undefined, {
+          code: "INVALID_PARAMS",
+          message: "notifications array required",
+        });
+        return;
+      }
+      const triaged = triageBatch(batch.notifications);
+      store.add(triaged);
+      api.logger.info(
+        `[notification-intelligence] batch ${batch.batchId ?? "unknown"}: ${triaged.length} notifications triaged`,
+      );
+      respond(true, { processed: triaged.length, batchId: batch.batchId ?? null });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "unknown error";
+      api.logger.error(`[notification-intelligence] batch error: ${message}`);
+      respond(false, undefined, { code: "INTERNAL_ERROR", message });
+    }
+  });
+
+  // ── Command: /notifications [digest|status|clear|help] ────────────────────
+
+  api.registerCommand({
+    name: "notifications",
+    description: "AI-powered notification digest and management.",
+    acceptsArgs: true,
+    handler: async (ctx) => {
+      const args = ctx.args?.trim() ?? "";
+      const tokens = args.split(/\s+/).filter(Boolean);
+      const action = tokens[0]?.toLowerCase() ?? "digest";
+
+      switch (action) {
+        case "digest": {
+          const sinceMin = Number.parseInt(tokens[1] ?? "60", 10);
+          const sinceMs =
+            Number.isFinite(sinceMin) && sinceMin > 0 ? sinceMin * 60_000 : 60 * 60_000;
+          const digest = store.getDigest(sinceMs);
+          return { text: formatDigest(digest) };
+        }
+        case "status": {
+          return { text: formatStatus(store.stats()) };
+        }
+        case "clear": {
+          store.clear();
+          return { text: "Notification store cleared." };
+        }
+        default: {
+          return {
+            text: [
+              "Notification Intelligence commands:",
+              "",
+              "/notifications digest [minutes]  - Show triaged digest (default: 60m)",
+              "/notifications status            - Show store stats",
+              "/notifications clear             - Clear stored notifications",
+            ].join("\n"),
+          };
+        }
+      }
+    },
+  });
+
+  // ── Tool: notification_triage (agent can query proactively) ────────────────
+
+  api.registerTool({
+    name: "notification_triage",
+    label: "Notification Triage",
+    description:
+      "Get a triaged summary of recent phone notifications from the connected Android device. " +
+      "Returns notifications classified by urgency level (critical, important, informational, noise).",
+    parameters: Type.Object({
+      action: Type.Union(
+        [Type.Literal("digest"), Type.Literal("recent"), Type.Literal("critical")],
+        {
+          description: "digest: full triaged summary, recent: all recent, critical: critical only",
+        },
+      ),
+      since_minutes: Type.Optional(
+        Type.Number({ description: "Look-back window in minutes (default 60)" }),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      const p = params as { action: string; since_minutes?: number };
+      const action = typeof p.action === "string" ? p.action : "digest";
+      const sinceMin =
+        typeof p.since_minutes === "number" && p.since_minutes > 0 ? p.since_minutes : 60;
+      const sinceMs = sinceMin * 60_000;
+
+      switch (action) {
+        case "digest": {
+          const digest = store.getDigest(sinceMs);
+          return textResult(formatDigest(digest));
+        }
+        case "recent": {
+          const recent = store.getRecent(sinceMs);
+          if (recent.length === 0) return textResult("No recent notifications.");
+          return jsonResult({
+            count: recent.length,
+            notifications: recent.map((n) => ({
+              level: n.triageLevel,
+              app: n.appLabel || n.packageName,
+              title: n.title,
+              text: n.text,
+            })),
+          });
+        }
+        case "critical": {
+          const critical = store.getByLevel("critical", sinceMs);
+          if (critical.length === 0) return textResult("No critical notifications.");
+          return jsonResult({
+            count: critical.length,
+            notifications: critical.map((n) => ({
+              app: n.appLabel || n.packageName,
+              title: n.title,
+              text: n.text,
+            })),
+          });
+        }
+        default:
+          return textResult("Unknown action. Use: digest, recent, or critical.");
+      }
+    },
+  });
+
+  // ── Background service: periodic garbage collection ────────────────────────
+
+  let gcInterval: ReturnType<typeof setInterval> | null = null;
+
+  const gcService: OpenClawPluginService = {
+    id: "notification-intelligence-gc",
+    start: async () => {
+      gcInterval = setInterval(() => {
+        store.gc();
+      }, 60_000);
+      gcInterval.unref?.();
+    },
+    stop: async () => {
+      if (gcInterval) {
+        clearInterval(gcInterval);
+        gcInterval = null;
+      }
+    },
+  };
+
+  api.registerService(gcService);
+}

--- a/extensions/notification-intelligence/openclaw.plugin.json
+++ b/extensions/notification-intelligence/openclaw.plugin.json
@@ -1,0 +1,26 @@
+{
+  "id": "notification-intelligence",
+  "name": "Notification Intelligence",
+  "description": "AI-powered notification triage and digest from Android phone nodes. Receives notification batches, classifies urgency, and provides digest summaries.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "triageMode": {
+        "type": "string",
+        "enum": ["heuristic", "ai", "hybrid"],
+        "default": "heuristic"
+      },
+      "maxStoredNotifications": {
+        "type": "integer",
+        "minimum": 10,
+        "default": 500
+      },
+      "retentionMinutes": {
+        "type": "integer",
+        "minimum": 5,
+        "default": 60
+      }
+    }
+  }
+}

--- a/extensions/notification-intelligence/src/digest.ts
+++ b/extensions/notification-intelligence/src/digest.ts
@@ -1,0 +1,77 @@
+import type { NotificationDigest, TriagedNotification } from "./types.js";
+
+function formatNotificationLine(n: TriagedNotification): string {
+  const label = n.appLabel || n.packageName || "Unknown app";
+  const parts: string[] = [label];
+  if (n.title) parts.push(n.title);
+  if (n.text) {
+    const truncated = n.text.length > 80 ? `${n.text.substring(0, 80)}...` : n.text;
+    parts.push(`"${truncated}"`);
+  }
+  return `  - ${parts.join(": ")}`;
+}
+
+function formatSection(label: string, items: TriagedNotification[], maxShow: number): string {
+  if (items.length === 0) return "";
+  const lines = [`${label} (${items.length}):`];
+  const show = items.slice(0, maxShow);
+  for (const n of show) {
+    lines.push(formatNotificationLine(n));
+  }
+  if (items.length > maxShow) {
+    lines.push(`  ... and ${items.length - maxShow} more`);
+  }
+  return lines.join("\n");
+}
+
+export function formatDigest(digest: NotificationDigest): string {
+  if (digest.totalCount === 0) {
+    return "No notifications in the current window.";
+  }
+
+  const sections: string[] = [];
+
+  const header = `Notification Digest (${digest.totalCount} total)`;
+  sections.push(header);
+  sections.push("─".repeat(header.length));
+
+  const critical = formatSection("Critical", digest.critical, 10);
+  if (critical) sections.push(critical);
+
+  const important = formatSection("Important", digest.important, 10);
+  if (important) sections.push(important);
+
+  const informational = formatSection("Informational", digest.informational, 5);
+  if (informational) sections.push(informational);
+
+  if (digest.noise.length > 0) {
+    sections.push(`Noise: ${digest.noise.length} low-priority notifications`);
+  }
+
+  // Compute unique app count.
+  const apps = new Set<string>();
+  for (const list of [digest.critical, digest.important, digest.informational, digest.noise]) {
+    for (const n of list) {
+      apps.add(n.appLabel || n.packageName || "unknown");
+    }
+  }
+  sections.push(`\nFrom ${apps.size} app${apps.size === 1 ? "" : "s"}.`);
+
+  return sections.join("\n\n");
+}
+
+export function formatStatus(stats: {
+  count: number;
+  oldestMs: number | null;
+  newestMs: number | null;
+}): string {
+  if (stats.count === 0) {
+    return "Notification Intelligence: no notifications stored.";
+  }
+  const ageMs = stats.oldestMs ? Date.now() - stats.oldestMs : 0;
+  const ageMins = Math.round(ageMs / 60_000);
+  return (
+    `Notification Intelligence: ${stats.count} notification${stats.count === 1 ? "" : "s"} stored.\n` +
+    `Oldest: ${ageMins}m ago.`
+  );
+}

--- a/extensions/notification-intelligence/src/store.ts
+++ b/extensions/notification-intelligence/src/store.ts
@@ -1,0 +1,103 @@
+import type { NotificationDigest, TriagedNotification, TriageLevel } from "./types.js";
+
+export type NotificationStoreOptions = {
+  maxItems?: number;
+  retentionMs?: number;
+};
+
+export type NotificationStore = {
+  add(items: TriagedNotification[]): void;
+  getRecent(sinceMs?: number): TriagedNotification[];
+  getByLevel(level: TriageLevel, sinceMs?: number): TriagedNotification[];
+  getDigest(sinceMs?: number): NotificationDigest;
+  clear(): void;
+  stats(): { count: number; oldestMs: number | null; newestMs: number | null };
+  gc(): void;
+};
+
+export function createNotificationStore(opts?: NotificationStoreOptions): NotificationStore {
+  const maxItems = opts?.maxItems ?? 500;
+  const retentionMs = opts?.retentionMs ?? 60 * 60 * 1000; // 1 hour default
+
+  /**
+   * Indexed by notification id for O(1) deduplication.
+   * Insertion order is maintained by the items array; the index maps id -> array position.
+   */
+  let items: TriagedNotification[] = [];
+  const idIndex = new Set<string>();
+
+  function rebuildIndex() {
+    idIndex.clear();
+    for (const n of items) {
+      idIndex.add(n.id);
+    }
+  }
+
+  function gc() {
+    const cutoff = Date.now() - retentionMs;
+    items = items.filter((n) => n.timestamp >= cutoff);
+    // Enforce max items (keep newest).
+    if (items.length > maxItems) {
+      items = items.slice(items.length - maxItems);
+    }
+    rebuildIndex();
+  }
+
+  function getRecent(sinceMs?: number): TriagedNotification[] {
+    const cutoff = sinceMs ? Date.now() - sinceMs : Date.now() - retentionMs;
+    return items.filter((n) => n.timestamp >= cutoff);
+  }
+
+  return {
+    add(newItems: TriagedNotification[]) {
+      if (newItems.length === 0) return;
+      for (const n of newItems) {
+        if (idIndex.has(n.id)) {
+          // Replace existing entry (notification was updated).
+          const idx = items.findIndex((existing) => existing.id === n.id);
+          if (idx !== -1) {
+            items[idx] = n;
+          }
+        } else {
+          items.push(n);
+          idIndex.add(n.id);
+        }
+      }
+      gc();
+    },
+
+    getRecent,
+
+    getByLevel(level: TriageLevel, sinceMs?: number): TriagedNotification[] {
+      return getRecent(sinceMs).filter((n) => n.triageLevel === level);
+    },
+
+    getDigest(sinceMs?: number): NotificationDigest {
+      const recent = getRecent(sinceMs);
+      return {
+        generatedAtMs: Date.now(),
+        totalCount: recent.length,
+        critical: recent.filter((n) => n.triageLevel === "critical"),
+        important: recent.filter((n) => n.triageLevel === "important"),
+        informational: recent.filter((n) => n.triageLevel === "informational"),
+        noise: recent.filter((n) => n.triageLevel === "noise"),
+      };
+    },
+
+    clear() {
+      items = [];
+      idIndex.clear();
+    },
+
+    stats() {
+      if (items.length === 0) return { count: 0, oldestMs: null, newestMs: null };
+      return {
+        count: items.length,
+        oldestMs: items[0]!.timestamp,
+        newestMs: items[items.length - 1]!.timestamp,
+      };
+    },
+
+    gc,
+  };
+}

--- a/extensions/notification-intelligence/src/triage.ts
+++ b/extensions/notification-intelligence/src/triage.ts
@@ -1,0 +1,45 @@
+import type { CapturedNotification, TriageLevel, TriagedNotification } from "./types.js";
+
+/**
+ * Heuristic triage based on Android notification priority and category.
+ * Zero LLM cost -- runs synchronously on every batch.
+ */
+export function triageNotificationHeuristic(n: CapturedNotification): TriageLevel {
+  // Android priority: -2 (MIN) to 2 (MAX). 1 = HIGH, 2 = MAX.
+  if (typeof n.priority === "number" && n.priority >= 1) return "critical";
+
+  // Category-based classification.
+  const cat = n.category;
+  if (cat) {
+    switch (cat) {
+      case "call":
+      case "alarm":
+      case "msg":
+      case "email":
+      case "social":
+        return "important";
+      case "promo":
+      case "recommendation":
+        return "noise";
+      case "status":
+      case "transport":
+      case "service":
+      case "progress":
+      case "sys":
+      case "navigation":
+        return "informational";
+    }
+  }
+
+  // Ongoing notifications (e.g. music player, foreground services) are informational.
+  if (n.isOngoing) return "informational";
+
+  return "informational";
+}
+
+export function triageBatch(notifications: CapturedNotification[]): TriagedNotification[] {
+  return notifications.map((n) => ({
+    ...n,
+    triageLevel: triageNotificationHeuristic(n),
+  }));
+}

--- a/extensions/notification-intelligence/src/types.ts
+++ b/extensions/notification-intelligence/src/types.ts
@@ -1,5 +1,7 @@
 export type CapturedNotification = {
   id: string;
+  /** System key from StatusBarNotification.getKey(), used for cancelNotification(). */
+  key: string;
   packageName: string;
   appLabel: string;
   title: string | null;

--- a/extensions/notification-intelligence/src/types.ts
+++ b/extensions/notification-intelligence/src/types.ts
@@ -1,0 +1,36 @@
+export type CapturedNotification = {
+  id: string;
+  packageName: string;
+  appLabel: string;
+  title: string | null;
+  text: string | null;
+  timestamp: number;
+  priority: number;
+  category: string | null;
+  groupKey: string | null;
+  isOngoing: boolean;
+  isGroupSummary: boolean;
+};
+
+export type NotificationBatch = {
+  batchId: string;
+  nodeId: string;
+  notifications: CapturedNotification[];
+  batchedAtMs: number;
+  windowMs: number;
+};
+
+export type TriageLevel = "critical" | "important" | "informational" | "noise";
+
+export type TriagedNotification = CapturedNotification & {
+  triageLevel: TriageLevel;
+};
+
+export type NotificationDigest = {
+  generatedAtMs: number;
+  totalCount: number;
+  critical: TriagedNotification[];
+  important: TriagedNotification[];
+  informational: TriagedNotification[];
+  noise: TriagedNotification[];
+};


### PR DESCRIPTION
## Summary

- Adds `NotificationListenerService` on Android to capture notifications from all apps (with explicit user permission) and stream them to the OpenClaw gateway for AI-powered triage
- Adds `notification-intelligence` gateway extension that classifies notifications by urgency, stores them in-memory, and exposes `/notifications digest`, a `notification_triage` agent tool, and a `notifications.batch` gateway method
- Adds `notifications.dismiss` and `notifications.list` invoke commands so the gateway can manage notifications on the phone remotely

## Problem Statement

Every AI assistant today — Siri, Google Assistant, Alexa, Copilot — is sandboxed. They can only see their own app's notifications. Meanwhile, the average user has 40+ apps generating notifications across Slack, WhatsApp, Gmail, banking, deliveries, social media, and more. The result: constant context-switching, notification fatigue, and missed critical alerts buried under noise.

No existing AI assistant can look across all your apps and tell you: *"You have 47 notifications. 3 need attention right now. The rest can wait."*

## Why OpenClaw, and Why Android

Android is the only mobile OS that provides `NotificationListenerService` — a system API that lets an app (with explicit user permission) read notifications from *all* other apps. iOS does not allow this.

OpenClaw is the only AI assistant where this data stays entirely on the user's own infrastructure. Unlike cloud AI assistants that would need to upload notification content to third-party servers, OpenClaw's gateway is self-hosted. Notification content travels over the existing TLS WebSocket to *your* gateway, gets triaged in-memory (never written to disk), and expires after 1 hour.

This builds on the vision @steipete laid out in VISION.md — *"a personal assistant that is easy to use, supports a wide range of platforms, and respects privacy and security"* — and extends the phone-as-node architecture that Peter and the team designed for the iOS and Android companion apps.

## What This Enables

**For users:**
- `/notifications digest` — AI-summarized notification overview, grouped by urgency
- Ask the agent *"do I have anything urgent on my phone?"* and it answers using the `notification_triage` tool
- Gateway can dismiss low-priority notifications remotely via `notifications.dismiss`

**For the platform:**
- First cross-app AI notification layer that exists anywhere, on any platform
- Proof that OpenClaw's gateway-node architecture can do things no sandboxed assistant can
- Foundation for future features: smart DND, auto-dismiss rules, notification-triggered automations

## Privacy: 7 Layers of Defense

| Layer | Protection |
|-------|-----------|
| Android system | User must manually enable Notification Access in Settings (cannot be granted programmatically) |
| App setting | `notifications.enabled` defaults to **OFF** — requires explicit toggle |
| Filter | Banking, health, authenticator, 2FA, OTP apps auto-excluded by package name pattern |
| Data minimization | Only title + text (capped at 500 chars) extracted. No extras, bitmaps, or actions |
| Transport | Existing TLS-encrypted WebSocket |
| Preferences | EncryptedSharedPreferences (AES-256-GCM) |
| Gateway storage | In-memory only with 1-hour TTL. **Nothing written to disk** |

## Architecture

```
Android                                Gateway
┌──────────────────────┐               ┌─────────────────────────────┐
│ NotificationListener │──extract──►   │                             │
│ Service (OS-level)   │               │                             │
│    ↓ (pre-buffer)    │               │                             │
│ NotificationFilter   │               │                             │
│    ↓ (dedup by ID)   │               │                             │
│ NotificationBatcher  │──30s batch──► │ notifications.batch method  │
│    ↓ (retry x3)      │   (RPC)       │    ↓                        │
│ NotificationHandler  │◄──dismiss──   │ notification-intelligence   │
│ (invoke commands)    │   (invoke)     │   ├─ heuristic triage       │
└──────────────────────┘               │   ├─ deduped store (TTL)    │
                                       │   ├─ /notifications command │
                                       │   └─ notification_triage    │
                                       │      tool (for agent)       │
                                       └─────────────────────────────┘
```

## Files Changed (20 files, +1,119 lines)

**New Android files (6):**
- `notification/NotificationModels.kt` — `@Serializable` data classes
- `notification/NotificationFilter.kt` — Per-app allow/blocklist + sensitive app auto-exclusion
- `notification/NotificationBatcher.kt` — Deduped batching with retry-on-failure
- `notification/OpenClawNotificationListener.kt` — System service with pre-buffer for race-free startup
- `node/NotificationListenerBridge.kt` — Bridges service lifecycle with NodeRuntime
- `node/NotificationHandler.kt` — Handles `notifications.dismiss` / `notifications.list` invoke commands

**Modified Android files (8):**
- `OpenClawProtocolConstants.kt` — `Notifications` capability + command enum
- `AndroidManifest.xml` — Service declaration with `BIND_NOTIFICATION_LISTENER_SERVICE`
- `SecurePrefs.kt` — `notificationsEnabled` + `notificationsBatchWindowSec` preferences
- `ConnectionManager.kt` — Advertise capability + commands
- `InvokeDispatcher.kt` — Pre-dispatch validation + dispatch routes
- `NodeRuntime.kt` — Wire filter, bridge, handler; init-block activation
- `MainViewModel.kt` — Expose StateFlows
- `SettingsSheet.kt` — Notifications settings section

**New gateway extension (6):**
- `extensions/notification-intelligence/openclaw.plugin.json` — Plugin manifest
- `extensions/notification-intelligence/index.ts` — Gateway method, command, tool, GC service
- `extensions/notification-intelligence/src/types.ts` — TypeScript types
- `extensions/notification-intelligence/src/triage.ts` — Heuristic triage (zero LLM cost)
- `extensions/notification-intelligence/src/store.ts` — Deduped in-memory store with TTL
- `extensions/notification-intelligence/src/digest.ts` — Digest formatting

## Test Plan

- [x] Android debug build: `./gradlew :app:assembleDebug` — **PASS**
- [x] Install on emulator (API 36): `adb install` — **PASS**
- [x] App launches, main screen renders — **PASS**
- [x] Notifications section appears in Settings between Location and Screen — **PASS**
- [x] Toggle defaults to OFF — **PASS**
- [x] Toggling ON opens Android Notification Access system settings — **PASS**
- [x] "OpenClaw Node" listed in system notification listeners — **PASS**
- [x] Toggle state persists after returning from system settings — **PASS**
- [x] Conditional UI (Listener Status + privacy text) only shows when enabled — **PASS**
- [x] Listener Status correctly shows "Not connected" when system permission not yet granted — **PASS**
- [x] Bridge activation/deactivation logged in logcat (`OpenClawNotifBridge`) — **PASS**
- [x] Privacy notice text renders: "Banking, health, and authenticator apps are excluded..." — **PASS**
- [ ] End-to-end: grant notification access, verify batches arrive at gateway (requires running gateway)
- [ ] `/notifications digest` command returns formatted output
- [ ] `notification_triage` tool returns structured JSON
- [ ] Gateway build: `pnpm build`
- [ ] Gateway tests: `pnpm test`

cc @steipete — this builds on the phone-as-node architecture you designed. Would love your take on whether the privacy layers are sufficient and whether `notifications.batch` should go through `node.event` vs direct gateway method (went with direct RPC for ack semantics).