### PR TITLE
Fix Telegram reaction emoji normalization

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -33,7 +33,7 @@ import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
 } from "./reasoning-lane-coordinator.js";
-import { editMessageTelegram } from "./send.js";
+import { buildTelegramReactionPayload, editMessageTelegram } from "./send.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
@@ -745,7 +745,9 @@ export const dispatchTelegramMessage = async ({
     removeAfterReply: removeAckAfterReply,
     ackReactionPromise,
     ackReactionValue: ackReactionPromise ? "ack" : null,
-    remove: () => reactionApi?.(chatId, msg.message_id ?? 0, []) ?? Promise.resolve(),
+    remove: () =>
+      reactionApi?.(chatId, msg.message_id ?? 0, buildTelegramReactionPayload("")) ??
+      Promise.resolve(),
     onError: (err) => {
       if (!msg.message_id) {
         return;

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1170,6 +1170,35 @@ describe("createTelegramBot", () => {
 
     expect(setMessageReactionSpy).toHaveBeenCalledWith(7, 123, [{ type: "emoji", emoji: "👀" }]);
   });
+  it("normalizes ackReaction config before sending telegram reaction", async () => {
+    resetHarnessSpies();
+
+    loadConfig.mockReturnValue({
+      messages: {
+        ackReaction: " 👀 ",
+        ackReactionScope: "group-mentions",
+        groupChat: { mentionPatterns: ["\\bbert\\b"] },
+      },
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: true } },
+        },
+      },
+    });
+
+    await dispatchMessage({
+      message: {
+        chat: { id: 7, type: "group", title: "Test Group" },
+        text: "bert hello",
+        date: 1736380800,
+        message_id: 123,
+        from: { id: 9, first_name: "Ada" },
+      },
+    });
+
+    expect(setMessageReactionSpy).toHaveBeenCalledWith(7, 123, [{ type: "emoji", emoji: "👀" }]);
+  });
   it("clears native commands when disabled", () => {
     resetHarnessSpies();
     loadConfig.mockReturnValue({

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1145,6 +1145,14 @@ describe("reactMessageTelegram", () => {
       remove: true,
       expected: [],
     },
+    {
+      testName: "normalizes reaction emoji whitespace",
+      target: " 123 ",
+      messageId: " 456 ",
+      emoji: " 👀 ",
+      remove: false,
+      expected: [{ type: "emoji", emoji: "👀" }],
+    },
   ] as const)("$testName", async (testCase) => {
     const setMessageReaction = vi.fn().mockResolvedValue(undefined);
     const api = { setMessageReaction } as unknown as {


### PR DESCRIPTION
## What changed
- Normalize Telegram reaction emoji inputs by trimming and NFC-normalizing before sending.
- Centralize reaction payload building in `src/telegram/send.ts` and reuse it for regular reactions and ack-reaction flows.
- Keep ack-reaction behavior unchanged while avoiding invalid payloads for whitespace-padded emoji values.

## Why this fixes the issue
`REACTION_INVALID` can be triggered when configured or computed reaction strings include leading/trailing whitespace (for example `" 👍 "`), which Telegram rejects as malformed. This fix ensures payloads are sanitized and empty/invalid input becomes a no-op.

## Tests run
- `pnpm vitest run --config vitest.unit.config.ts src/telegram/send.test.ts src/telegram/bot.create-telegram-bot.test.ts src/telegram/*.test.ts`

## Edge cases
- Empty/whitespace-only reaction values now produce an empty reaction payload.
- Remove-reaction flows still pass an empty array intentionally.
- Ack reaction is sent only when a non-empty, sanitized emoji value is available.

## Notes
No unresolved blockers found for these changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes Telegram reaction emoji normalization by introducing `normalizeTelegramReaction()` and `buildTelegramReactionPayload()` helper functions. The normalization applies both trimming and NFC Unicode normalization before sending reactions to Telegram's API, preventing errors from whitespace-padded or differently-composed emoji strings.

**Key changes:**
- Centralized reaction payload building in `buildTelegramReactionPayload()` function
- Added NFC Unicode normalization to handle emoji composition variations
- Applied normalization to ack reactions, remove reactions, and regular reactions
- Added test coverage for whitespace normalization

The implementation is defensive and handles edge cases (empty strings, whitespace-only values) by returning empty arrays, which Telegram interprets as reaction removal.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with 453 passing tests, including new test cases specifically for whitespace normalization. The refactoring centralizes logic into reusable functions without changing behavior, and the NFC normalization follows established patterns already used elsewhere in the codebase (chat.ts). The implementation is defensive, handling edge cases appropriately.
- No files require special attention

<sub>Last reviewed commit: 92bb311</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->