### PR TITLE
fix(models): add fallback Gemini 3.1 Pro Preview catalog entry

### DIFF
--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -30,6 +30,10 @@ let importPiSdk = defaultImportPiSdk;
 const CODEX_PROVIDER = "openai-codex";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+const GOOGLE_PROVIDER = "google";
+const GOOGLE_31_MODEL_ID = "gemini-3.1-pro-preview";
+const GOOGLE_31_MODEL_NAME = "Gemini 3.1 Pro Preview";
+const GOOGLE_31_CONTEXT_WINDOW = 1_000_000;
 
 function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
   const hasSpark = models.some(
@@ -53,6 +57,24 @@ function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
     ...baseModel,
     id: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
     name: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
+  });
+}
+
+function applyGoogle31ProPreviewFallback(models: ModelCatalogEntry[]): void {
+  const hasGoogle31 = models.some(
+    (entry) => entry.provider === GOOGLE_PROVIDER && entry.id.toLowerCase() === GOOGLE_31_MODEL_ID,
+  );
+  if (hasGoogle31) {
+    return;
+  }
+
+  models.push({
+    provider: GOOGLE_PROVIDER,
+    id: GOOGLE_31_MODEL_ID,
+    name: GOOGLE_31_MODEL_NAME,
+    reasoning: true,
+    contextWindow: GOOGLE_31_CONTEXT_WINDOW,
+    input: ["text", "image"],
   });
 }
 
@@ -140,6 +162,7 @@ export async function loadModelCatalog(params?: {
         models.push({ id, name, provider, contextWindow, reasoning, input });
       }
       applyOpenAICodexSparkFallback(models);
+      applyGoogle31ProPreviewFallback(models);
 
       if (models.length === 0) {
         // If we found nothing, don't cache this result so we can try again.


### PR DESCRIPTION
## What changed
- Add a built-in fallback entry for Google provider model google/gemini-3.1-pro-preview in `src/agents/model-catalog.ts` when it is missing from discovered models.
- Keep fallback behavior aligned for runtime usage: reasoning enabled, context window set to 1,000,000, and text/image input support.
- Add tests in `src/agents/model-catalog.test.ts` covering:
  - model injection when missing,
  - no-duplicate behavior when already present.

## Why this fixes the issue
Issue 22323 is caused by discovery missing the new Gemini 3.1 Pro Preview model, which can hide it from built-in provider selection. This fallback guarantees the catalog always contains that model and does not alter discovery semantics when a matching entry already exists.

## Tests run
- `pnpm vitest run --config vitest.unit.config.ts src/agents/model-catalog.test.ts`
- `pnpm test -- src/agents/model-catalog.test.ts`

## Edge cases
- Existing entries for google/gemini-3.1-pro-preview are preserved and not duplicated.
- Existing cache-reset/retry behavior and partial discovery failure handling remain unchanged.

## Infra flake / blockers
- None known.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds fallback catalog entry for `google/gemini-3.1-pro-preview` model when it's missing from SDK discovery, following the same pattern as the existing OpenAI Codex Spark fallback.

**Key changes:**
- Implements `applyGoogle31ProPreviewFallback()` function with deduplication check
- Configures model with `reasoning: true`, 1M context window, and text+image input support
- Adds comprehensive test coverage for both insertion and deduplication scenarios
- Updates existing test to use `toContainEqual` instead of strict equality for better flexibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows an established pattern (OpenAI Codex fallback), includes proper deduplication logic, and has comprehensive test coverage validating both insertion and non-duplication scenarios. The change is isolated, well-tested, and addresses a specific discoverability issue.
- No files require special attention

<sub>Last reviewed commit: c903811</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->