### PR TITLE
fix(heartbeat): drain system events after event-driven heartbeat run

### DIFF
--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -30,6 +30,10 @@ let importPiSdk = defaultImportPiSdk;
 const CODEX_PROVIDER = "openai-codex";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+const GOOGLE_PROVIDER = "google";
+const GOOGLE_31_MODEL_ID = "gemini-3.1-pro-preview";
+const GOOGLE_31_MODEL_NAME = "Gemini 3.1 Pro Preview";
+const GOOGLE_31_CONTEXT_WINDOW = 1_000_000;
 
 function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
   const hasSpark = models.some(
@@ -53,6 +57,24 @@ function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
     ...baseModel,
     id: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
     name: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
+  });
+}
+
+function applyGoogle31ProPreviewFallback(models: ModelCatalogEntry[]): void {
+  const hasGoogle31 = models.some(
+    (entry) => entry.provider === GOOGLE_PROVIDER && entry.id.toLowerCase() === GOOGLE_31_MODEL_ID,
+  );
+  if (hasGoogle31) {
+    return;
+  }
+
+  models.push({
+    provider: GOOGLE_PROVIDER,
+    id: GOOGLE_31_MODEL_ID,
+    name: GOOGLE_31_MODEL_NAME,
+    reasoning: true,
+    contextWindow: GOOGLE_31_CONTEXT_WINDOW,
+    input: ["text", "image"],
   });
 }
 
@@ -140,6 +162,7 @@ export async function loadModelCatalog(params?: {
         models.push({ id, name, provider, contextWindow, reasoning, input });
       }
       applyOpenAICodexSparkFallback(models);
+      applyGoogle31ProPreviewFallback(models);
 
       if (models.length === 0) {
         // If we found nothing, don't cache this result so we can try again.


### PR DESCRIPTION
## What changed
- In `runHeartbeatOnce`, drain queued system events when an event-driven heartbeat run is processed (`exec-event`, `cron`, `wake`, `hook`, or tagged cron), instead of only peeking.
- Add a regression test to ensure an exec completion event is consumed on the first event-driven heartbeat and does not re-assert on the next event wake.

## Why this fixes the issue
`issue #22320` reports duplicate heartbeats shortly after tool completion. Heartbeat wakeups were using `peekSystemEventEntries` and did not clear consumed events, so repeated wake triggers could reprocess the same completion context and produce clustered follow-up heartbeats. Draining the queue for event-driven runs makes each tool-completion event one-shot.

## Tests
- `pnpm vitest run --config vitest.unit.config.ts src/infra/heartbeat-runner.returns-default-unset.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts`
- `pnpm test -- src/infra/heartbeat-runner.returns-default-unset.test.ts`
- `pnpm vitest run --config vitest.unit.config.ts src/infra/heartbeat-wake.test.ts src/infra/heartbeat-runner.scheduler.test.ts`

## Edge cases
- Non-event-driven heartbeats (interval) are unaffected.
- Event-driven failures continue to be retried per existing wake/scheduling behavior.
- `exec-event` events are now one-shot and consumed only after processing.

## Known infra flake / blockers
- None observed in local test runs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes duplicate heartbeat issue by draining system event queue after event-driven runs and adds Google Gemini 3.1 Pro Preview model fallback.

**Heartbeat fix (commit bb97948a):**
- Changed from `peekSystemEventEntries` to `drainSystemEventEntries` for event-driven heartbeats (`exec-event`, `cron`, `wake`, `hook`)
- Added `withDrainedPendingEvents` wrapper to ensure events are cleared only for event-driven runs
- Added regression test verifying exec completion events are consumed once

**Model catalog fix (commit c9038111):**
- Added `applyGoogle31ProPreviewFallback` to inject `gemini-3.1-pro-preview` when missing from catalog
- Updated test from `toEqual` to `toContainEqual` to handle injected fallback models

**Issues found:**
- Line 878 in `heartbeat-runner.ts` missing `withDrainedPendingEvents` wrapper (one return path after LLM call doesn't drain events)

<h3>Confidence Score: 3/5</h3>

- PR addresses reported issue but has one missed drain path that could reintroduce bug in edge case
- Core logic correctly switches from peek to drain and wraps most return paths, but line 878 (`alerts-disabled` after LLM call) bypasses the drain wrapper, potentially leaving events queued in that edge case. Model catalog changes are straightforward and properly tested.
- src/infra/heartbeat-runner.ts line 878 needs drain wrapper added

<sub>Last reviewed commit: bb97948</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->