### PR TITLE
fix(status): detect node-only mode and show remote gateway info

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -14,6 +14,7 @@ import {
   resolveMemoryVectorState,
   type Tone,
 } from "../memory/status-format.js";
+import { loadNodeHostConfig } from "../node-host/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { runSecurityAudit } from "../security/audit.js";
 import { renderTable } from "../terminal/table.js";
@@ -203,7 +204,36 @@ export async function statusCommand(
     return links.httpUrl;
   })();
 
+  const agentsValue = (() => {
+    const pending =
+      agentStatus.bootstrapPendingCount > 0
+        ? `${agentStatus.bootstrapPendingCount} bootstrapping`
+        : "no bootstraps";
+    const def = agentStatus.agents.find((a) => a.id === agentStatus.defaultId);
+    const defActive = def?.lastActiveAgeMs != null ? formatTimeAgo(def.lastActiveAgeMs) : "unknown";
+    const defSuffix = def ? ` · default ${def.id} active ${defActive}` : "";
+    return `${agentStatus.agents.length} · ${pending} · sessions ${agentStatus.totalSessions}${defSuffix}`;
+  })();
+
+  const [daemon, nodeDaemon] = await Promise.all([
+    getDaemonStatusSummary(),
+    getNodeDaemonStatusSummary(),
+  ]);
+  const nodeHostConfig = await loadNodeHostConfig().catch(() => null);
+  const nodeDaemonLoaded =
+    nodeDaemon.loaded === true ||
+    (nodeDaemon.loaded === null && nodeDaemon.loadedText.includes("loaded"));
+  const isNodeOnlyMode =
+    nodeDaemon.installed === true && nodeDaemonLoaded && daemon.installed === false;
+
   const gatewayValue = (() => {
+    if (isNodeOnlyMode) {
+      const gateway = nodeHostConfig?.gateway;
+      const target = gateway?.host
+        ? `${gateway.host}:${gateway.port ?? 18789}`
+        : "(gateway address unknown)";
+      return `node → ${target} · node service running`;
+    }
     const target = remoteUrlMissing
       ? `fallback ${gatewayConnection.url}`
       : `${gatewayConnection.url}${gatewayConnection.urlSource ? ` (${gatewayConnection.urlSource})` : ""}`;
@@ -230,22 +260,6 @@ export async function statusCommand(
     const suffix = self ? ` · ${self}` : "";
     return `${gatewayMode} · ${target} · ${reach}${auth}${suffix}`;
   })();
-
-  const agentsValue = (() => {
-    const pending =
-      agentStatus.bootstrapPendingCount > 0
-        ? `${agentStatus.bootstrapPendingCount} bootstrapping`
-        : "no bootstraps";
-    const def = agentStatus.agents.find((a) => a.id === agentStatus.defaultId);
-    const defActive = def?.lastActiveAgeMs != null ? formatTimeAgo(def.lastActiveAgeMs) : "unknown";
-    const defSuffix = def ? ` · default ${def.id} active ${defActive}` : "";
-    return `${agentStatus.agents.length} · ${pending} · sessions ${agentStatus.totalSessions}${defSuffix}`;
-  })();
-
-  const [daemon, nodeDaemon] = await Promise.all([
-    getDaemonStatusSummary(),
-    getNodeDaemonStatusSummary(),
-  ]);
   const daemonValue = (() => {
     if (daemon.installed === false) {
       return `${daemon.label} not installed`;

--- a/src/commands/status.daemon.ts
+++ b/src/commands/status.daemon.ts
@@ -6,6 +6,7 @@ import { formatDaemonRuntimeShort } from "./status.format.js";
 type DaemonStatusSummary = {
   label: string;
   installed: boolean | null;
+  loaded: boolean | null;
   loadedText: string;
   runtimeShort: string | null;
 };
@@ -23,11 +24,12 @@ async function buildDaemonStatusSummary(
     const installed = command != null;
     const loadedText = loaded ? service.loadedText : service.notLoadedText;
     const runtimeShort = formatDaemonRuntimeShort(runtime);
-    return { label: service.label, installed, loadedText, runtimeShort };
+    return { label: service.label, installed, loaded, loadedText, runtimeShort };
   } catch {
     return {
       label: fallbackLabel,
       installed: null,
+      loaded: null,
       loadedText: "unknown",
       runtimeShort: null,
     };


### PR DESCRIPTION
Fixes #17271

## Problem
On a machine configured as a **node** (no local gateway), `openclaw status` showed:
```
Gateway: local · 127.0.0.1:18789 · unreachable (connect ECONNREFUSED 127.0.0.1:18789)
```
This is misleading — the node service is working correctly and connected to a remote gateway, but the output implies something is broken with no indication of node-only mode.

## Changes

**`src/commands/status.daemon.ts`**
- Exposed `loaded` field in `DaemonStatusSummary` (previously only `loadedText` was available) so callers can check service state directly

**`src/commands/status.command.ts`**
- Imported `loadNodeHostConfig` from `node-host/config` to read the node's remote gateway address from `node.json`
- Added `isNodeOnlyMode` detection: node service installed+loaded AND gateway service not installed (`daemon.installed === false`)
- In `gatewayValue` display: when in node-only mode, shows `node → <host>:<port> · node service running` instead of the ECONNREFUSED error
- Aligned `nodeDaemonLoaded` detection with `status-all.ts` — removed false-positive `|| nodeDaemon.runtimeShort != null` branch

**`src/commands/status-all.ts`**
- Same `isNodeOnlyMode` detection and `loadNodeHostConfig` integration for `openclaw status --all`
- Overrides the gateway health error block with a node-mode summary when applicable

**`src/commands/status.e2e.test.ts`**
- Promoted `resolveGatewayService` mock to a `vi.fn()` in the hoisted mock block (enables per-test override)
- Added test: when node service is loaded and gateway service is not installed, output contains `node →` and does **not** contain `unreachable`

**`apps/macos/OpenClaw/Gateway/GatewayModels.swift` (generated)**
- Regenerated to sync `CronRunLogEntry` delivery fields (`delivered`, `deliveryStatus`, `deliveryError`) — pre-existing upstream protocol drift, fixed here to unblock CI

## Example output after fix (node-only machine)
```
Gateway   node → my-gateway-host:18789 · node service running
```

## AI-assisted disclosure 🤖

- [x] Built with Claude (Sonnet 4.6) via OpenClaw
- [x] Fully tested — `vitest run status.e2e.test.ts` 8/8 passing; `pnpm build` clean; CI ✅ 19/19
- [x] Author understands what the code does and reviewed all changes