### PR TITLE
feat(docker): add pre-built image mode for docker-setup

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -48,6 +48,9 @@ This script:
 
 Optional env vars:
 
+- `OPENCLAW_IMAGE_SOURCE` — `local` (default) or `registry` image source.
+  - `local`: build `openclaw:local` from the repo
+  - `registry`: use pre-built image from registry (default `openclaw:latest`, overridable with `OPENCLAW_IMAGE`)
 - `OPENCLAW_DOCKER_APT_PACKAGES` — install extra apt packages during build
 - `OPENCLAW_EXTRA_MOUNTS` — add extra host bind mounts
 - `OPENCLAW_HOME_VOLUME` — persist `/home/node` in a named volume

--- a/docs/zh-CN/install/docker.md
+++ b/docs/zh-CN/install/docker.md
@@ -55,6 +55,9 @@ Docker 是**可选的**。仅当你想要容器化的 Gateway 网关或验证 Do
 
 可选环境变量：
 
+- `OPENCLAW_IMAGE_SOURCE` — `local`（默认）或 `registry` 镜像来源。
+  - `local`：从仓库构建 `openclaw:local`
+  - `registry`：使用仓库已构建镜像（默认 `openclaw:latest`，可通过 `OPENCLAW_IMAGE` 覆盖）
 - `OPENCLAW_DOCKER_APT_PACKAGES` — 在构建期间安装额外的 apt 包
 - `OPENCLAW_EXTRA_MOUNTS` — 添加额外的主机绑定挂载
 - `OPENCLAW_HOME_VOLUME` — 在命名卷中持久化 `/home/node`


### PR DESCRIPTION
## What changed
- Added `OPENCLAW_IMAGE_SOURCE` support in `docker-setup.sh` with interactive prompt for tty (1=local, 2=registry).
- Wired image naming to image source:
  - `local` -> `openclaw:local`
  - `registry` -> `OPENCLAW_IMAGE` (defaults to `openclaw:latest`)
- Skips `docker build` when `OPENCLAW_IMAGE_SOURCE=registry`; keeps onboarding/composition flow unchanged.
- Persisted new env key in `.env` via `upsert_env`: `OPENCLAW_IMAGE_SOURCE`.
- Updated Docker docs (`docs/install/docker.md`, `docs/zh-CN/install/docker.md`) to document the new option.
- Added regression tests in `src/docker-setup.test.ts` for registry source and `.env` persistence.

## Why this fixes #22316
It enables Docker setup to use a pre-built image from registry instead of forcing a local rebuild, while keeping current local build behavior as the default.

## Tests run
- `pnpm vitest run --config vitest.config.ts src/docker-setup.test.ts`
- `pnpm test src/docker-setup.test.ts`

## Edge cases
- Non-interactive shells default to `local` to avoid blocking prompts in CI.
- `OPENCLAW_IMAGE_SOURCE` only accepts `local` or `registry`; invalid values fail fast with a clear error.
- Custom image tag is supported via `OPENCLAW_IMAGE` when using registry source.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `OPENCLAW_IMAGE_SOURCE` environment variable to allow users to choose between building Docker images locally or using pre-built registry images. The implementation includes interactive prompts for TTY sessions and defaults to local builds in non-interactive environments.

- Added `choose_image_source()` function with interactive prompt for image source selection
- Conditional image naming: `registry` source uses `openclaw:latest` by default, `local` uses `openclaw:local`
- Skips docker build step when using registry source
- Persists `OPENCLAW_IMAGE_SOURCE` in `.env` file
- Added comprehensive test coverage for registry source
- Documentation updated in both English and Chinese

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean and well-tested. The logic correctly handles both interactive and non-interactive modes, validates input values, and maintains backwards compatibility by defaulting to local builds. The changes are isolated to Docker setup workflow and include appropriate test coverage.
- No files require special attention

<sub>Last reviewed commit: bdbddc9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->