### PR TITLE
fix(ui): strip inbound metadata blocks and guard reply-tag streaming (clean rewrite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.
 - Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.
 - Security/OpenClawKit/UI: prevent injected inbound user context metadata blocks from leaking into chat history in TUI, webchat, and macOS surfaces by stripping all untrusted metadata prefixes at display boundaries. (#22142) Thanks @Mellowambience, @vincentkoc.
+- Security/OpenClawKit/UI: prevent inbound metadata leaks and reply-tag streaming artifacts in TUI rendering by stripping untrusted metadata prefixes at display boundaries. (#22346) Thanks @akramcodez, @vincentkoc.
 - Agents/System Prompt: label allowlisted senders as authorized senders to avoid implying ownership. Thanks @thewilloftheshadow.
 - Gateway/Auth: allow trusted-proxy mode with loopback bind for same-host reverse-proxy deployments, while still requiring configured `gateway.trustedProxies`. (#20097) thanks @xinhuagu.
 - Gateway/Auth: allow authenticated clients across roles/scopes to call `health` while preserving role and scope enforcement for non-health methods. (#19699) thanks @Nachx639.

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -1,5 +1,4 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
-import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -8,6 +7,7 @@ import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { appendRawStream } from "./pi-embedded-subscribe.raw-stream.js";
 import {
   extractAssistantText,

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -7,7 +8,6 @@ import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
-import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { appendRawStream } from "./pi-embedded-subscribe.raw-stream.js";
 import {
   extractAssistantText,
@@ -21,6 +21,9 @@ import {
 const stripTrailingDirective = (text: string): string => {
   const openIndex = text.lastIndexOf("[[");
   if (openIndex < 0) {
+    if (text.endsWith("[")) {
+      return text.slice(0, -1);
+    }
     return text;
   }
   const closeIndex = text.indexOf("]]", openIndex + 2);

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -39,4 +39,35 @@ describe("stripEnvelopeFromMessage", () => {
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("note\n[message_id: 123]");
   });
+  test("removes inbound un-bracketed conversation info blocks from user messages", () => {
+    const input = {
+      role: "user",
+      content:
+        'Conversation info (untrusted metadata):\n```json\n{\n  "message_id": "123"\n}\n```\n\nHello there',
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("Hello there");
+  });
+
+  test("removes all inbound metadata blocks before user text", () => {
+    const input = {
+      role: "user",
+      content:
+        "Thread starter (untrusted, for context):\n```json\n{\"seed\": 1}\n```\n\nSender (untrusted metadata):\n```json\n{\"name\": \"alice\"}\n```\n\nActual user message",
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("Actual user message");
+  });
+
+  test("does not strip metadata-like blocks that are not a prefix", () => {
+    const input = {
+      role: "user",
+      content:
+        "Actual text\nConversation info (untrusted metadata):\n```json\n{\"message_id\": \"123\"}\n```\n\nFollow-up",
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe(
+      "Actual text\nConversation info (untrusted metadata):\n```json\n{\"message_id\": \"123\"}\n```\n\nFollow-up",
+    );
+  });
 });

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -53,7 +53,7 @@ describe("stripEnvelopeFromMessage", () => {
     const input = {
       role: "user",
       content:
-        "Thread starter (untrusted, for context):\n```json\n{\"seed\": 1}\n```\n\nSender (untrusted metadata):\n```json\n{\"name\": \"alice\"}\n```\n\nActual user message",
+        'Thread starter (untrusted, for context):\n```json\n{"seed": 1}\n```\n\nSender (untrusted metadata):\n```json\n{"name": "alice"}\n```\n\nActual user message',
     };
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("Actual user message");
@@ -63,11 +63,11 @@ describe("stripEnvelopeFromMessage", () => {
     const input = {
       role: "user",
       content:
-        "Actual text\nConversation info (untrusted metadata):\n```json\n{\"message_id\": \"123\"}\n```\n\nFollow-up",
+        'Actual text\nConversation info (untrusted metadata):\n```json\n{"message_id": "123"}\n```\n\nFollow-up',
     };
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe(
-      "Actual text\nConversation info (untrusted metadata):\n```json\n{\"message_id\": \"123\"}\n```\n\nFollow-up",
+      'Actual text\nConversation info (untrusted metadata):\n```json\n{"message_id": "123"}\n```\n\nFollow-up',
     );
   });
 });

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,4 +1,8 @@
-import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
+import {
+  stripEnvelope,
+  stripInboundMetadataBlocks,
+  stripMessageIdHints,
+} from "../shared/chat-envelope.js";
 
 export { stripEnvelope };
 
@@ -12,7 +16,7 @@ function stripEnvelopeFromContent(content: unknown[]): { content: unknown[]; cha
     if (entry.type !== "text" || typeof entry.text !== "string") {
       return item;
     }
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripMessageIdHints(stripEnvelope(stripInboundMetadataBlocks(entry.text)));
     if (stripped === entry.text) {
       return item;
     }
@@ -39,7 +43,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   const next: Record<string, unknown> = { ...entry };
 
   if (typeof entry.content === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.content));
+    const stripped = stripMessageIdHints(
+      stripEnvelope(stripInboundMetadataBlocks(entry.content)),
+    );
     if (stripped !== entry.content) {
       next.content = stripped;
       changed = true;
@@ -51,7 +57,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const stripped = stripMessageIdHints(stripEnvelope(entry.text));
+    const stripped = stripMessageIdHints(
+      stripEnvelope(stripInboundMetadataBlocks(entry.text)),
+    );
     if (stripped !== entry.text) {
       next.text = stripped;
       changed = true;

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -43,9 +43,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   const next: Record<string, unknown> = { ...entry };
 
   if (typeof entry.content === "string") {
-    const stripped = stripMessageIdHints(
-      stripEnvelope(stripInboundMetadataBlocks(entry.content)),
-    );
+    const stripped = stripMessageIdHints(stripEnvelope(stripInboundMetadataBlocks(entry.content)));
     if (stripped !== entry.content) {
       next.content = stripped;
       changed = true;
@@ -57,9 +55,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const stripped = stripMessageIdHints(
-      stripEnvelope(stripInboundMetadataBlocks(entry.text)),
-    );
+    const stripped = stripMessageIdHints(stripEnvelope(stripInboundMetadataBlocks(entry.text)));
     if (stripped !== entry.text) {
       next.text = stripped;
       changed = true;

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -16,6 +16,18 @@ const ENVELOPE_CHANNELS = [
 ];
 
 const MESSAGE_ID_LINE = /^\s*\[message_id:\s*[^\]]+\]\s*$/i;
+const INBOUND_METADATA_HEADERS = [
+  "Conversation info (untrusted metadata):",
+  "Sender (untrusted metadata):",
+  "Thread starter (untrusted, for context):",
+  "Replied message (untrusted, for context):",
+  "Forwarded message context (untrusted metadata):",
+  "Chat history since last reply (untrusted, for context):",
+];
+const REGEX_ESCAPE_RE = /[.*+?^${}()|[\]\\]/g;
+const INBOUND_METADATA_PREFIX_RE = new RegExp(
+  `^\\s*(?:${INBOUND_METADATA_HEADERS.map((header) => header.replace(REGEX_ESCAPE_RE, "\\$&")).join("|")})\\r?\\n```json\\r?\\n[\\s\\S]*?\\r?\\n```(?:\\r?\\n)*`,
+);
 
 function looksLikeEnvelopeHeader(header: string): boolean {
   if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z\b/.test(header)) {
@@ -46,4 +58,16 @@ export function stripMessageIdHints(text: string): string {
   const lines = text.split(/\r?\n/);
   const filtered = lines.filter((line) => !MESSAGE_ID_LINE.test(line));
   return filtered.length === lines.length ? text : filtered.join("\n");
+}
+
+export function stripInboundMetadataBlocks(text: string): string {
+  let remaining = text;
+  for (;;) {
+    const match = INBOUND_METADATA_PREFIX_RE.exec(remaining);
+    if (!match) {
+      break;
+    }
+    remaining = remaining.slice(match[0].length).replace(/^\r?\n+/, "");
+  }
+  return remaining.trim();
 }

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -24,7 +24,7 @@ const INBOUND_METADATA_HEADERS = [
   "Forwarded message context (untrusted metadata):",
   "Chat history since last reply (untrusted, for context):",
 ];
-const REGEX_ESCAPE_RE = /[.*+?^${}()|[\]\\]/g;
+const REGEX_ESCAPE_RE = /[.*+?^${}()|[\]\\\-]/g;
 const INBOUND_METADATA_PREFIX_RE = new RegExp(
   "^\\s*(?:" +
     INBOUND_METADATA_HEADERS.map((header) => header.replace(REGEX_ESCAPE_RE, "\\$&")).join("|") +

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -26,7 +26,9 @@ const INBOUND_METADATA_HEADERS = [
 ];
 const REGEX_ESCAPE_RE = /[.*+?^${}()|[\]\\]/g;
 const INBOUND_METADATA_PREFIX_RE = new RegExp(
-  `^\\s*(?:${INBOUND_METADATA_HEADERS.map((header) => header.replace(REGEX_ESCAPE_RE, "\\$&")).join("|")})\\r?\\n```json\\r?\\n[\\s\\S]*?\\r?\\n```(?:\\r?\\n)*`,
+  "^\\s*(?:" +
+    INBOUND_METADATA_HEADERS.map((header) => header.replace(REGEX_ESCAPE_RE, "\\$&")).join("|") +
+    ")\\r?\\n```json\\r?\\n[\\s\\S]*?\\r?\\n```(?:\\r?\\n)*",
 );
 
 function looksLikeEnvelopeHeader(header: string): boolean {


### PR DESCRIPTION
This is a clean reroute of the closed PR for this change.

- Reuses the final intended payload from the previously closed work.
- Rebased onto `origin/main` and squashed to a single clean commit.
- This branch is clean and ready for normal review.

This supersedes #21643. The original PR became stale due a detached/dirty head after history churn while attempting rebase/cleanup.

Closes #21548.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances security by preventing inbound metadata blocks from leaking into chat history and fixes streaming artifacts when reply tags are being processed.

**Key changes:**
- Added `stripInboundMetadataBlocks()` function to remove untrusted metadata prefixes (like "Conversation info (untrusted metadata):", "Sender (untrusted metadata):", etc.) from user messages at display boundaries
- Integrated the new stripping function into the sanitization pipeline in `chat-sanitize.ts`, applying it before envelope and message ID stripping
- Added guard in `stripTrailingDirective()` to handle incomplete reply-tag streaming by removing trailing `[` characters that haven't formed complete `[[directive]]` tags yet
- Added comprehensive test coverage for the new metadata stripping behavior, including prefix-only matching (doesn't strip metadata blocks that appear mid-message)

The implementation correctly strips multiple consecutive metadata blocks at the start of messages using a loop with regex matching, then trims the result. The regex pattern properly escapes special characters in the header strings before building the alternation pattern.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor risk
- The changes are well-tested with comprehensive test coverage for the new stripping behavior. The security fix is straightforward and addresses a real vulnerability (metadata injection/leakage). The regex implementation is sound and the integration into existing sanitization pipeline is minimal and follows existing patterns. One minor logic concern was flagged regarding regex escaping, but this doesn't affect the current headers. The trailing `[` guard is a simple defensive check that prevents streaming artifacts.
- Review `src/shared/chat-envelope.ts` line 27 to verify regex escape pattern is complete

<sub>Last reviewed commit: 900afd4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->