### PR TITLE
Feature request: gateway.clientUrl config to decouple client URL

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -5,6 +5,7 @@ export const FIELD_HELP: Record<string, string> = {
   "meta.lastTouchedAt": "ISO timestamp of the last config write (auto-set).",
   "update.channel": 'Update channel for git + npm installs ("stable", "beta", or "dev").',
   "update.checkOnStart": "Check for npm updates when the gateway starts (default: true).",
+  "gateway.clientUrl": "Override for local client connections (ws:// or wss://).",
   "gateway.remote.url": "Remote Gateway WebSocket URL (ws:// or wss://).",
   "gateway.remote.tlsFingerprint":
     "Expected sha256 TLS fingerprint for the remote gateway (pin to avoid MITM).",

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -76,6 +76,7 @@ const GROUP_ORDER: Record<string, number> = {
 };
 
 const FIELD_PLACEHOLDERS: Record<string, string> = {
+  "gateway.clientUrl": "ws://127.0.0.1:18789",
   "gateway.remote.url": "ws://host:18789",
   "gateway.remote.tlsFingerprint": "sha256:ab12cd34…",
   "gateway.remote.sshTarget": "user@host",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -24,6 +24,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "diagnostics.cacheTrace.includeSystem": "Cache Trace Include System",
   "agents.list.*.identity.avatar": "Identity Avatar",
   "agents.list.*.skills": "Agent Skill Filter",
+  "gateway.clientUrl": "Local Gateway Client URL",
   "gateway.remote.url": "Remote Gateway URL",
   "gateway.remote.sshTarget": "Remote Gateway SSH Target",
   "gateway.remote.sshIdentity": "Remote Gateway SSH Identity",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -279,6 +279,8 @@ export type GatewayToolsConfig = {
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
+  /** Override URL for local clients connecting to the gateway (decouples listener bind from client target). */
+  clientUrl?: string;
   /**
    * Explicit gateway mode. When set to "remote", local gateway start is disabled.
    * When set to "local", the CLI may start the gateway locally.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -394,6 +394,7 @@ export const OpenClawSchema = z
     gateway: z
       .object({
         port: z.number().int().positive().optional(),
+        clientUrl: z.string().optional(),
         mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
         bind: z
           .union([

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -44,6 +44,27 @@ describe("pairing setup code", () => {
     });
   });
 
+  it("uses gateway.clientUrl override for local connect URL", async () => {
+    const resolved = await resolvePairingSetupFromConfig({
+      gateway: {
+        bind: "lan",
+        clientUrl: "ws://localhost:18789",
+        auth: { mode: "token", token: "tok_123" },
+      },
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      payload: {
+        url: "ws://localhost:18789",
+        token: "tok_123",
+        password: undefined,
+      },
+      authLabel: "token",
+      urlSource: "gateway.clientUrl",
+    });
+  });
+
   it("honors env token override", async () => {
     const resolved = await resolvePairingSetupFromConfig(
       {

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -101,6 +101,15 @@ function resolveGatewayPort(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): number
   return DEFAULT_GATEWAY_PORT;
 }
 
+function resolveGatewayClientUrl(cfg: OpenClawConfig): string | null {
+  const raw = cfg.gateway?.clientUrl;
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 function resolveScheme(
   cfg: OpenClawConfig,
   opts?: {
@@ -304,6 +313,15 @@ async function resolveGatewayUrl(
       : null;
   if (opts.preferRemoteUrl && remoteUrl) {
     return { url: remoteUrl, source: "gateway.remote.url" };
+  }
+
+  const clientUrl = resolveGatewayClientUrl(cfg);
+  if (clientUrl) {
+    const url = normalizeUrl(clientUrl, scheme);
+    if (!url) {
+      return { error: "gateway.clientUrl is invalid." };
+    }
+    return { url, source: "gateway.clientUrl" };
   }
 
   const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";


### PR DESCRIPTION
## What changed
- Add optional `gateway.clientUrl` to config schema (`types`/`zod`) and UI metadata (`help`/`labels`/`placeholders`).
- Use `gateway.clientUrl` for pairing setup URL generation when present.
- Use `gateway.clientUrl` in local CLI/gateway connection resolution before loopback fallback.
- Keep existing remote-mode precedence and fallback order for other URL sources unchanged.
- Add/extend tests to assert configured `gateway.clientUrl` is used and surfaced via source metadata.

## Why this fixes the issue
It decouples listener binding from client connect endpoint selection. This lets local setups use a stable client-facing URL (including loopback or explicit overrides) without altering bind behaviour, avoiding brittle assumptions when the listener is non-loopback.

## Tests run
- `pnpm vitest run --config vitest.config.ts src/pairing/setup-code.test.ts src/gateway/call.test.ts src/config/schema.hints.test.ts`
- `pnpm test src/pairing/setup-code.test.ts src/gateway/call.test.ts src/config/schema.hints.test.ts`

## Edge cases and notes
- `gateway.clientUrl` is validated through existing URL normalization/validation.
- Blank/invalid values are rejected with clear error in pairing flow; otherwise local-resolution behavior follows the existing fallback order.
- Existing loopback exposure/bind reporting is preserved for source/bind detail metadata.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `gateway.clientUrl` config to decouple the client connection URL from the gateway listener bind address. When configured, `gateway.clientUrl` overrides the default loopback URL for local gateway connections in both CLI/gateway calls and pairing URL generation.

**Key Changes:**
- Added `gateway.clientUrl` field to config schema, types, help text, labels, and hints
- Modified `buildGatewayConnectionDetails` in `src/gateway/call.ts` to prefer `clientUrl` over loopback when connecting locally
- Modified `resolveGatewayUrl` in `src/pairing/setup-code.ts` to use `clientUrl` before falling back to bind-based resolution
- Added comprehensive test coverage for the new configuration option
- Security validation via `isSecureWebSocketUrl` ensures `gateway.clientUrl` is checked for plaintext ws:// to non-loopback addresses

**Implementation Quality:**
- Clean implementation that fits well with existing precedence logic
- Proper fallback behavior maintained (empty/invalid values fallback to default resolution)
- Security controls remain in place - the configured URL is validated by existing security checks
- Test coverage is thorough with tests for both gateway calls and pairing flows

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested configuration feature with proper security validation
- Clean implementation with comprehensive test coverage, proper error handling, and security validation. The change follows existing patterns, includes appropriate fallback behavior, and doesn't introduce any security risks.
- No files require special attention

<sub>Last reviewed commit: 3c43ef8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->