### PR TITLE
fix(tests): pass localRoots to media test fixtures (#22191)

### DIFF
--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,7 +17,6 @@ vi.mock("./graph-upload.js", async () => {
   };
 });
 
-import { resolvePreferredOpenClawTmpDir } from "../../../src/infra/tmp-openclaw-dir.js";
 import {
   type MSTeamsAdapter,
   renderReplyPayloadsToMessages,
@@ -217,8 +216,12 @@ describe("msteams messenger", () => {
     });
 
     it("preserves parsed mentions when appending OneDrive fallback file links", async () => {
-      const tmpDir = await mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "msteams-mention-"));
-      const localFile = path.join(tmpDir, "note.txt");
+      const tmpStateDir = await mkdtemp(path.join(os.tmpdir(), "msteams-mention-state-"));
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = tmpStateDir;
+      const workspaceDir = path.join(tmpStateDir, "workspace");
+      await mkdir(workspaceDir, { recursive: true });
+      const localFile = path.join(workspaceDir, "note.txt");
       await writeFile(localFile, "hello");
 
       try {
@@ -268,7 +271,12 @@ describe("msteams messenger", () => {
           },
         ]);
       } finally {
-        await rm(tmpDir, { recursive: true, force: true });
+        if (previousStateDir === undefined) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = previousStateDir;
+        }
+        await rm(tmpStateDir, { recursive: true, force: true });
       }
     });
 

--- a/extensions/whatsapp/src/media.test.ts
+++ b/extensions/whatsapp/src/media.test.ts
@@ -149,7 +149,7 @@ describe("web media loading", () => {
 
   it("strips MEDIA: prefix before reading local file (including whitespace variants)", async () => {
     for (const input of [`MEDIA:${tinyPngFile}`, `  MEDIA :  ${tinyPngFile}`]) {
-      const result = await loadWebMedia(input, 1024 * 1024);
+      const result = await loadWebMedia(input, 1024 * 1024, { localRoots: [fixtureRoot] });
       expect(result.kind).toBe("image");
       expect(result.buffer.length).toBeGreaterThan(0);
     }
@@ -159,7 +159,7 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
 
     const cap = Math.floor(buffer.length * 0.8);
-    const result = await loadWebMedia(file, cap);
+    const result = await loadWebMedia(file, cap, { localRoots: [fixtureRoot] });
 
     expect(result.kind).toBe("image");
     expect(result.buffer.length).toBeLessThanOrEqual(cap);
@@ -170,7 +170,7 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
     const cap = Math.max(1, Math.floor(buffer.length * 0.8));
 
-    const result = await loadWebMedia(file, { maxBytes: cap });
+    const result = await loadWebMedia(file, { maxBytes: cap, localRoots: [fixtureRoot] });
 
     expect(result.buffer.length).toBeLessThanOrEqual(cap);
     expect(result.buffer.length).toBeLessThan(buffer.length);
@@ -180,13 +180,15 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
     const cap = Math.max(1, Math.floor(buffer.length * 0.8));
 
-    await expect(loadWebMedia(file, { maxBytes: cap, optimizeImages: false })).rejects.toThrow(
-      /Media exceeds/i,
-    );
+    await expect(
+      loadWebMedia(file, { maxBytes: cap, optimizeImages: false, localRoots: [fixtureRoot] }),
+    ).rejects.toThrow(/Media exceeds/i);
   });
 
   it("sniffs mime before extension when loading local files", async () => {
-    const result = await loadWebMedia(tinyPngWrongExtFile, 1024 * 1024);
+    const result = await loadWebMedia(tinyPngWrongExtFile, 1024 * 1024, {
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");
@@ -330,7 +332,7 @@ describe("web media loading", () => {
   });
 
   it("preserves PNG alpha when under the cap", async () => {
-    const result = await loadWebMedia(alphaPngFile, 1024 * 1024);
+    const result = await loadWebMedia(alphaPngFile, 1024 * 1024, { localRoots: [fixtureRoot] });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/png");
@@ -339,7 +341,9 @@ describe("web media loading", () => {
   });
 
   it("falls back to JPEG when PNG alpha cannot fit under cap", async () => {
-    const result = await loadWebMedia(fallbackPngFile, fallbackPngCap);
+    const result = await loadWebMedia(fallbackPngFile, fallbackPngCap, {
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -16,6 +16,21 @@ const ENVELOPE_CHANNELS = [
 ];
 
 const MESSAGE_ID_LINE = /^\s*\[message_id:\s*[^\]]+\]\s*$/i;
+const INBOUND_METADATA_HEADERS = [
+  "Conversation info (untrusted metadata):",
+  "Sender (untrusted metadata):",
+  "Thread starter (untrusted, for context):",
+  "Replied message (untrusted, for context):",
+  "Forwarded message context (untrusted metadata):",
+  "Chat history since last reply (untrusted, for context):",
+];
+const REGEX_ESCAPE_RE = /[.*+?^${}()|[\]\\-]/g;
+const INBOUND_METADATA_PREFIX_RE = new RegExp(
+  "^\\s*(?:" +
+    INBOUND_METADATA_HEADERS.map((header) => header.replace(REGEX_ESCAPE_RE, "\\$&")).join("|") +
+    ")\\r?\\n```json\\r?\\n[\\s\\S]*?\\r?\\n```(?:\\r?\\n)*",
+);
+
 function looksLikeEnvelopeHeader(header: string): boolean {
   if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z\b/.test(header)) {
     return true;


### PR DESCRIPTION
## Summary

Fixes #22191 — `src/web/media.test.ts` fails on CI with `LocalMediaAccessError` because test fixtures in `/tmp` are blocked by the default allowed-roots policy.

## Problem

After recent path-hardening changes to `loadWebMedia`, local file access is restricted to explicitly allowed directories by default. The 7 affected tests write image fixtures to a temp directory but call `loadWebMedia(file, cap)` without passing `localRoots`, so the path guard rejects them:

```
LocalMediaAccessError: Local media path is not under an allowed directory:
  /tmp/openclaw-media-test-xIlyyu/media-1.png
```

## Fix

Pass `{ localRoots: [fixtureRoot] }` to each of the 7 `loadWebMedia` calls that load from the temp fixture directory. This explicitly allows the test fixture path without weakening production restrictions.

**Tests fixed (all in `src/web/media.test.ts`):**
- `strips MEDIA: prefix before reading local file`
- `compresses large local images under the provided cap`
- `optimizes images when options object omits optimizeImages`
- `allows callers to disable optimization via options object`
- `sniffs mime before extension when loading local files`
- `preserves PNG alpha when under the cap`
- `falls back to JPEG when PNG alpha cannot fit under cap`

## Verification

```bash
npx vitest run src/web/media.test.ts
# 24 tests passed (24)
```

The existing `local media root guard` tests (which explicitly test the `localRoots` mechanism) are untouched and continue to pass.
