### PR TITLE
fix: compaction safeguard extension not loading in production builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Compaction: restore embedded compaction safeguard/context-pruning extension loading in production by wiring bundled extension factories into the resource loader instead of runtime file-path resolution. (#22349) Thanks @Glucksberg.
 - Auto-reply/Tools: forward `senderIsOwner` through embedded queued/followup runner params so owner-only tools remain available for authorized senders. (#22296) thanks @hcoj.
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.
 - Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -61,7 +61,7 @@ import {
   compactWithSafetyTimeout,
   EMBEDDED_COMPACTION_TIMEOUT_MS,
 } from "./compaction-safety-timeout.js";
-import { buildEmbeddedExtensionPaths } from "./extensions.js";
+import { buildEmbeddedExtensionFactories } from "./extensions.js";
 import {
   logToolSchemasForGoogle,
   sanitizeSessionHistory,
@@ -534,24 +534,24 @@ export async function compactEmbeddedPiSessionDirect(
         settingsManager,
         cfg: params.config,
       });
-      // Sets compaction/pruning runtime state and returns extension paths
+      // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
-      const extensionPaths = buildEmbeddedExtensionPaths({
+      const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
         provider,
         modelId,
         model,
       });
-      // Only create an explicit resource loader when there are extension paths
+      // Only create an explicit resource loader when there are extension factories
       // to register; otherwise let createAgentSession use its built-in default.
       let resourceLoader: DefaultResourceLoader | undefined;
-      if (extensionPaths.length > 0) {
+      if (extensionFactories.length > 0) {
         resourceLoader = new DefaultResourceLoader({
           cwd: resolvedWorkspace,
           agentDir,
           settingsManager,
-          additionalExtensionPaths: extensionPaths,
+          extensionFactories,
         });
         await resourceLoader.reload();
       }

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -1,24 +1,16 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { Api, Model } from "@mariozechner/pi-ai";
-import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionFactory, SessionManager } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { setCompactionSafeguardRuntime } from "../pi-extensions/compaction-safeguard-runtime.js";
+import compactionSafeguardExtension from "../pi-extensions/compaction-safeguard.js";
+import contextPruningExtension from "../pi-extensions/context-pruning.js";
 import { setContextPruningRuntime } from "../pi-extensions/context-pruning/runtime.js";
 import { computeEffectiveSettings } from "../pi-extensions/context-pruning/settings.js";
 import { makeToolPrunablePredicate } from "../pi-extensions/context-pruning/tools.js";
 import { ensurePiCompactionReserveTokens } from "../pi-settings.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-ttl.js";
-
-function resolvePiExtensionPath(id: string): string {
-  const self = fileURLToPath(import.meta.url);
-  const dir = path.dirname(self);
-  // In dev this file is `.ts` (tsx), in production it's `.js`.
-  const ext = path.extname(self) === ".ts" ? "ts" : "js";
-  return path.join(dir, "..", "pi-extensions", `${id}.${ext}`);
-}
 
 function resolveContextWindowTokens(params: {
   cfg: OpenClawConfig | undefined;
@@ -35,24 +27,24 @@ function resolveContextWindowTokens(params: {
   }).tokens;
 }
 
-function buildContextPruningExtension(params: {
+function buildContextPruningFactory(params: {
   cfg: OpenClawConfig | undefined;
   sessionManager: SessionManager;
   provider: string;
   modelId: string;
   model: Model<Api> | undefined;
-}): { additionalExtensionPaths?: string[] } {
+}): ExtensionFactory | undefined {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
   if (raw?.mode !== "cache-ttl") {
-    return {};
+    return undefined;
   }
   if (!isCacheTtlEligibleProvider(params.provider, params.modelId)) {
-    return {};
+    return undefined;
   }
 
   const settings = computeEffectiveSettings(raw);
   if (!settings) {
-    return {};
+    return undefined;
   }
 
   setContextPruningRuntime(params.sessionManager, {
@@ -62,23 +54,21 @@ function buildContextPruningExtension(params: {
     lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager),
   });
 
-  return {
-    additionalExtensionPaths: [resolvePiExtensionPath("context-pruning")],
-  };
+  return contextPruningExtension;
 }
 
 function resolveCompactionMode(cfg?: OpenClawConfig): "default" | "safeguard" {
   return cfg?.agents?.defaults?.compaction?.mode === "safeguard" ? "safeguard" : "default";
 }
 
-export function buildEmbeddedExtensionPaths(params: {
+export function buildEmbeddedExtensionFactories(params: {
   cfg: OpenClawConfig | undefined;
   sessionManager: SessionManager;
   provider: string;
   modelId: string;
   model: Model<Api> | undefined;
-}): string[] {
-  const paths: string[] = [];
+}): ExtensionFactory[] {
+  const factories: ExtensionFactory[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {
     const compactionCfg = params.cfg?.agents?.defaults?.compaction;
     const contextWindowInfo = resolveContextWindowInfo({
@@ -92,13 +82,13 @@ export function buildEmbeddedExtensionPaths(params: {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
       contextWindowTokens: contextWindowInfo.tokens,
     });
-    paths.push(resolvePiExtensionPath("compaction-safeguard"));
+    factories.push(compactionSafeguardExtension);
   }
-  const pruning = buildContextPruningExtension(params);
-  if (pruning.additionalExtensionPaths) {
-    paths.push(...pruning.additionalExtensionPaths);
+  const pruningFactory = buildContextPruningFactory(params);
+  if (pruningFactory) {
+    factories.push(pruningFactory);
   }
-  return paths;
+  return factories;
 }
 
 export { ensurePiCompactionReserveTokens };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
-import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  SessionManager,
+  SettingsManager,
+} from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
@@ -534,14 +539,27 @@ export async function runEmbeddedAttempt(
         cfg: params.config,
       });
 
-      // Call for side effects (sets compaction/pruning runtime state)
-      buildEmbeddedExtensionPaths({
+      // Sets compaction/pruning runtime state and returns extension paths
+      // that must be passed to the resource loader for the safeguard to be active.
+      const extensionPaths = buildEmbeddedExtensionPaths({
         cfg: params.config,
         sessionManager,
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
       });
+      // Only create an explicit resource loader when there are extension paths
+      // to register; otherwise let createAgentSession use its built-in default.
+      let resourceLoader: DefaultResourceLoader | undefined;
+      if (extensionPaths.length > 0) {
+        resourceLoader = new DefaultResourceLoader({
+          cwd: resolvedWorkspace,
+          agentDir,
+          settingsManager,
+          additionalExtensionPaths: extensionPaths,
+        });
+        await resourceLoader.reload();
+      }
 
       // Get hook runner early so it's available when creating tools
       const hookRunner = getGlobalHookRunner();
@@ -584,6 +602,7 @@ export async function runEmbeddedAttempt(
         customTools: allCustomTools,
         sessionManager,
         settingsManager,
+        resourceLoader,
       }));
       applySystemPromptOverrideToSession(session, systemPromptText);
       if (!session) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -75,7 +75,7 @@ import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
-import { buildEmbeddedExtensionPaths } from "../extensions.js";
+import { buildEmbeddedExtensionFactories } from "../extensions.js";
 import { applyExtraParamsToAgent } from "../extra-params.js";
 import {
   logToolSchemasForGoogle,
@@ -539,24 +539,24 @@ export async function runEmbeddedAttempt(
         cfg: params.config,
       });
 
-      // Sets compaction/pruning runtime state and returns extension paths
+      // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
-      const extensionPaths = buildEmbeddedExtensionPaths({
+      const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
       });
-      // Only create an explicit resource loader when there are extension paths
+      // Only create an explicit resource loader when there are extension factories
       // to register; otherwise let createAgentSession use its built-in default.
       let resourceLoader: DefaultResourceLoader | undefined;
-      if (extensionPaths.length > 0) {
+      if (extensionFactories.length > 0) {
         resourceLoader = new DefaultResourceLoader({
           cwd: resolvedWorkspace,
           agentDir,
           settingsManager,
-          additionalExtensionPaths: extensionPaths,
+          extensionFactories,
         });
         await resourceLoader.reload();
       }


### PR DESCRIPTION
## The bug

When compaction runs, it sends the conversation history to an LLM asking it to generate a summary. For small/medium sessions this works fine — the history fits within the model's context window. But for long-running sessions where the history has grown past the model's 200k token limit, the summarization call itself gets rejected: `448694 prompt tokens > 200000 maximum`.

That's exactly what the `compaction.mode: "safeguard"` extension is supposed to prevent — it hooks into `session_before_compact` to truncate the history before the summarization LLM call. The config was set, the extension code existed, but it wasn't doing anything. Compaction on large sessions was guaranteed to fail.

## Impact

Roughly **~1,000 lines of extension code** were sitting idle in production — compaction safeguard (435 lines), context pruning (572 lines), and the path resolution glue (~100 lines). The runtime state was being set correctly, but the extensions that read that state were never loaded. All of it passed tests, shipped, and did nothing.

## First fix attempt (83eb996)

Digging into the code, the issue seemed straightforward: `buildEmbeddedExtensionPaths()` was being called for its side effects (setting runtime state), but its return value — the actual extension file paths — was being discarded. Neither `compact.ts` nor `run/attempt.ts` were passing the paths to `DefaultResourceLoader`, so the `session_before_compact` hook never got registered.

The fix wired the return value into a `DefaultResourceLoader` with `additionalExtensionPaths`, passed it to `createAgentSession`, and all tests passed. Deployed, tested `/compact` again — same error. 248k tokens, rejected.

## Root cause

`resolvePiExtensionPath()` computes extension file paths relative to `import.meta.url`:

```ts
const self = fileURLToPath(import.meta.url);
const dir = path.dirname(self);
return path.join(dir, "..", "pi-extensions", `${id}.${ext}`);
```

In dev (`tsx`), `import.meta.url` points to the actual `.ts` source file, so the relative path lands on `src/agents/pi-extensions/compaction-safeguard.ts` — which exists. In production, `tsdown` bundles everything into hashed chunks like `dist/pi-embedded-Df4JcLlD.js`. The path resolves to `dist/pi-extensions/compaction-safeguard.js` — a file that **doesn't exist**, because the extension code is already inlined in the bundle. The extension silently fails to load, the safeguard never fires, compaction sends the full history unguarded.

## Actual fix

`DefaultResourceLoader` supports an `extensionFactories` option that accepts `ExtensionFactory[]` — functions, not file paths. Instead of resolving paths at runtime for dynamic import, we import the extension functions directly at build time:

```ts
import compactionSafeguardExtension from "../pi-extensions/compaction-safeguard.js";
import contextPruningExtension from "../pi-extensions/context-pruning.js";
```

These get bundled inline by tsdown. No file resolution, no dynamic imports, no runtime path that can break.

`buildEmbeddedExtensionPaths` → `buildEmbeddedExtensionFactories`, returns `ExtensionFactory[]` instead of `string[]`. Both callers (`compact.ts`, `run/attempt.ts`) pass `extensionFactories` to `DefaultResourceLoader`. The dead `resolvePiExtensionPath()` helper and its `path`/`fileURLToPath` imports are removed.

After deploying this fix, `/compact` works — compaction completes and the token count drops as expected.

<!-- TODO: screenshot showing two failed compaction attempts followed by successful one -->

## Files changed

- `src/agents/pi-embedded-runner/extensions.ts` — core change: imports → factories
- `src/agents/pi-embedded-runner/compact.ts` — wire `extensionFactories` to resource loader
- `src/agents/pi-embedded-runner/run/attempt.ts` — same wiring for the run path

🤖 Generated with [Claude Code](https://claude.com/claude-code)