### PR TITLE
fix(gateway): add exponential backoff to remote node bin probes

### DIFF
--- a/src/infra/skills-remote.test.ts
+++ b/src/infra/skills-remote.test.ts
@@ -1,10 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   getRemoteSkillEligibility,
   recordRemoteNodeBins,
   recordRemoteNodeInfo,
+  refreshRemoteNodeBins,
   removeRemoteNodeInfo,
+  setSkillsRemoteRegistry,
 } from "./skills-remote.js";
 
 describe("skills-remote", () => {
@@ -24,6 +27,47 @@ describe("skills-remote", () => {
     removeRemoteNodeInfo(nodeId);
 
     expect(getRemoteSkillEligibility()?.hasBin(bin) ?? false).toBe(false);
+  });
+
+  it("backs off after repeated probe failures", async () => {
+    const nodeId = `node-${randomUUID()}`;
+    recordRemoteNodeInfo({
+      nodeId,
+      displayName: "Failing Mac",
+      platform: "darwin",
+      commands: ["system.run"],
+    });
+
+    const mockRegistry = {
+      invoke: vi.fn().mockResolvedValue({ ok: false, error: { message: "invoke timed out" } }),
+      listConnected: vi.fn().mockReturnValue([]),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setSkillsRemoteRegistry(mockRegistry as any);
+
+    const cfg = { agents: { list: [] } } as unknown as OpenClawConfig;
+
+    // First call: should invoke (and fail).
+    await refreshRemoteNodeBins({
+      nodeId,
+      platform: "darwin",
+      commands: ["system.run"],
+      cfg,
+    });
+    expect(mockRegistry.invoke).toHaveBeenCalledTimes(1);
+
+    // Second call immediately after: should be skipped due to backoff.
+    await refreshRemoteNodeBins({
+      nodeId,
+      platform: "darwin",
+      commands: ["system.run"],
+      cfg,
+    });
+    expect(mockRegistry.invoke).toHaveBeenCalledTimes(1); // still 1 — skipped
+
+    // Clean up.
+    removeRemoteNodeInfo(nodeId);
+    setSkillsRemoteRegistry(null);
   });
 
   it("supports idempotent remote node removal", () => {


### PR DESCRIPTION
## Problem

When a macOS companion node connects with only `canvas`/`screen` capabilities (no `system` shell), the gateway still probes for shell binaries via `system.run` or `system.which`. Each probe times out after 15 seconds. If the node disconnects and reconnects frequently (e.g. healthcheck stuck → disconnect → reconnect cycle), the gateway enters a near-continuous probe loop, reaching ~84% CPU on Apple Silicon (#22266).

## Fix

Add per-node exponential backoff to `refreshRemoteNodeBins()`:

- On probe failure: delay the next attempt by 30s, doubling on each consecutive failure up to 5 minutes
- On probe success: clear backoff immediately
- On node disconnect (`removeRemoteNodeInfo`): clear backoff state

This ensures transient failures are retried with reasonable spacing while persistent failures (e.g. nodes without shell support) quickly settle to a 5-minute interval instead of a tight loop.

## Changes

- `src/infra/skills-remote.ts`: Add `probeBackoff` map, `escalateProbeBackoff()` helper, backoff check at probe entry, clear on success/removal
- `src/infra/skills-remote.test.ts`: Add test verifying second probe is skipped after failure

Closes #22266

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added exponential backoff to remote node binary probes to prevent CPU overload when macOS companion nodes disconnect/reconnect frequently. On probe failure, the next attempt is delayed by 30s (doubling up to 5 min max); on success or node disconnect, backoff is cleared. The change prevents tight probe loops when nodes lack shell support, reducing gateway CPU from ~84% to near-zero during reconnect cycles.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and addresses a specific performance issue. The exponential backoff pattern is standard and correctly implemented with proper cleanup on success and node removal. The test coverage validates the core backoff behavior.
- No files require special attention

<sub>Last reviewed commit: cf6160a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->