### PR TITLE
test(web): fix media test fixture local root handling

### DIFF
--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -136,7 +136,10 @@ describe("web media loading", () => {
 
   it("strips MEDIA: prefix before reading local file (including whitespace variants)", async () => {
     for (const input of [`MEDIA:${tinyPngFile}`, `  MEDIA :  ${tinyPngFile}`]) {
-      const result = await loadWebMedia(input, 1024 * 1024);
+      const result = await loadWebMedia(input, {
+        maxBytes: 1024 * 1024,
+        localRoots: [fixtureRoot],
+      });
       expect(result.kind).toBe("image");
       expect(result.buffer.length).toBeGreaterThan(0);
     }
@@ -146,7 +149,10 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
 
     const cap = Math.floor(buffer.length * 0.8);
-    const result = await loadWebMedia(file, cap);
+    const result = await loadWebMedia(file, {
+      maxBytes: cap,
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.buffer.length).toBeLessThanOrEqual(cap);
@@ -157,7 +163,7 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
     const cap = Math.max(1, Math.floor(buffer.length * 0.8));
 
-    const result = await loadWebMedia(file, { maxBytes: cap });
+    const result = await loadWebMedia(file, { maxBytes: cap, localRoots: [fixtureRoot] });
 
     expect(result.buffer.length).toBeLessThanOrEqual(cap);
     expect(result.buffer.length).toBeLessThan(buffer.length);
@@ -167,13 +173,16 @@ describe("web media loading", () => {
     const { buffer, file } = await createLargeTestJpeg();
     const cap = Math.max(1, Math.floor(buffer.length * 0.8));
 
-    await expect(loadWebMedia(file, { maxBytes: cap, optimizeImages: false })).rejects.toThrow(
-      /Media exceeds/i,
-    );
+    await expect(
+      loadWebMedia(file, { maxBytes: cap, optimizeImages: false, localRoots: [fixtureRoot] }),
+    ).rejects.toThrow(/Media exceeds/i);
   });
 
   it("sniffs mime before extension when loading local files", async () => {
-    const result = await loadWebMedia(tinyPngWrongExtFile, 1024 * 1024);
+    const result = await loadWebMedia(tinyPngWrongExtFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");
@@ -287,7 +296,10 @@ describe("web media loading", () => {
   });
 
   it("preserves PNG alpha when under the cap", async () => {
-    const result = await loadWebMedia(alphaPngFile, 1024 * 1024);
+    const result = await loadWebMedia(alphaPngFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/png");
@@ -296,7 +308,10 @@ describe("web media loading", () => {
   });
 
   it("falls back to JPEG when PNG alpha cannot fit under cap", async () => {
-    const result = await loadWebMedia(fallbackPngFile, fallbackPngCap);
+    const result = await loadWebMedia(fallbackPngFile, {
+      maxBytes: fallbackPngCap,
+      localRoots: [fixtureRoot],
+    });
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");


### PR DESCRIPTION
## What changed
- Updated `src/web/media.test.ts` to pass explicit `localRoots` for local fixture files created in `/tmp`.
- Kept production path restrictions unchanged while making unit tests robust to tightened default allowed-root behavior.

## Why this fixes issue #22191
- The failing tests create fixture media files under `/tmp/openclaw-media-test-*`, which are no longer allowed by default hardened media root policy.
- Explicitly scoping fixture reads to `localRoots: [fixtureRoot]` lets the same fixture paths pass validation deterministically without relaxing security logic in `loadWebMedia`.

## Tests run
- `pnpm vitest run src/web/media.test.ts`
- `pnpm test:fast src/web/media.test.ts`

## Edge cases / notes
- No production behavior changes were made.
- If broader acceptance for `/tmp` fixtures is required outside tests, provide explicit roots at call sites instead of widening defaults.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated `media.test.ts` to explicitly pass `localRoots: [fixtureRoot]` when calling `loadWebMedia()` for test fixture files created in `/tmp/openclaw-media-test-*`.

The tests were failing after hardened default media root restrictions were introduced. The test fixtures are created under `/tmp`, which is no longer in the default allowed roots. By explicitly scoping fixture reads to `localRoots: [fixtureRoot]`, the tests pass validation deterministically without relaxing security logic in production code.

- Updated 8 test cases to use the options object format with explicit `localRoots`
- No production behavior changes
- Maintains security boundaries while allowing test fixtures to work

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are test-only updates that explicitly scope fixture file access to match hardened security defaults. No production code was modified, and the fix correctly addresses the failing tests by providing explicit `localRoots` for `/tmp` fixtures rather than weakening the security policy.
- No files require special attention

<sub>Last reviewed commit: d0e6a18</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->