### PR TITLE
fix: first-token timeout + provider-level skip for model fallback

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { FailoverError } from "./failover-error.js";
 import { runWithModelFallback } from "./model-fallback.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
@@ -611,5 +612,78 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(2);
     expect(result.provider).toBe("openai");
     expect(result.model).toBe("gpt-4.1-mini");
+  });
+
+  it("skips same-provider candidates after a timeout failure", async () => {
+    let callCount = 0;
+    const calledModels: string[] = [];
+
+    const result = await runWithModelFallback({
+      cfg: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "nim/model-a",
+              fallbacks: ["nim/model-b", "ollama/llama3"],
+            },
+          },
+        },
+      } as never,
+      provider: "nim",
+      model: "model-a",
+      fallbacksOverride: ["nim/model-b", "ollama/llama3"],
+      run: async (provider, model) => {
+        callCount++;
+        calledModels.push(`${provider}/${model}`);
+        if (provider === "nim") {
+          throw new FailoverError("LLM request timed out.", {
+            reason: "timeout",
+            provider,
+            model,
+            status: 408,
+          });
+        }
+        return "success";
+      },
+    });
+
+    expect(result.result).toBe("success");
+    expect(result.provider).toBe("ollama");
+    expect(result.model).toBe("llama3");
+    // model-a attempted (timeout), model-b SKIPPED (same provider), llama3 succeeded
+    expect(callCount).toBe(2);
+    expect(calledModels).toEqual(["nim/model-a", "ollama/llama3"]);
+    // 2 attempt records: model-a (timeout) + model-b (skipped). llama3 succeeded so not in attempts.
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts[0].reason).toBe("timeout");
+    expect(result.attempts[1].reason).toBe("timeout");
+    expect(result.attempts[1].error).toContain("skipped");
+  });
+
+  it("does not skip providers for non-timeout failures", async () => {
+    const calledModels: string[] = [];
+
+    const result = await runWithModelFallback({
+      cfg: undefined,
+      provider: "nim",
+      model: "model-a",
+      fallbacksOverride: ["nim/model-b"],
+      run: async (provider, model) => {
+        calledModels.push(`${provider}/${model}`);
+        if (model === "model-a") {
+          throw new FailoverError("Rate limited.", {
+            reason: "rate_limit",
+            provider,
+            model,
+            status: 429,
+          });
+        }
+        return "ok";
+      },
+    });
+
+    // Both nim models should be attempted (rate_limit doesn't trigger provider skip)
+    expect(calledModels).toEqual(["nim/model-a", "nim/model-b"]);
+    expect(result.result).toBe("ok");
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -594,6 +594,7 @@ export async function runEmbeddedPiAgent(
             execOverrides: params.execOverrides,
             bashElevated: params.bashElevated,
             timeoutMs: params.timeoutMs,
+            firstTokenTimeoutMs: params.firstTokenTimeoutMs,
             runId: params.runId,
             abortSignal: params.abortSignal,
             shouldEmitToolResult: params.shouldEmitToolResult,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -898,6 +898,20 @@ export async function runEmbeddedAttempt(
         });
       };
 
+      // First-token timeout: detect unresponsive providers quickly.
+      // The timer is started just before prompt() and cleared when the model begins responding.
+      let firstTokenTimer: NodeJS.Timeout | undefined;
+      const clearFirstTokenTimer = () => {
+        if (firstTokenTimer) {
+          clearTimeout(firstTokenTimer);
+          firstTokenTimer = undefined;
+        }
+      };
+      const wrappedOnAssistantMessageStart = () => {
+        clearFirstTokenTimer();
+        void params.onAssistantMessageStart?.();
+      };
+
       const subscription = subscribeEmbeddedPiSession({
         session: activeSession,
         runId: params.runId,
@@ -915,7 +929,7 @@ export async function runEmbeddedAttempt(
         blockReplyBreak: params.blockReplyBreak,
         blockReplyChunking: params.blockReplyChunking,
         onPartialReply: params.onPartialReply,
-        onAssistantMessageStart: params.onAssistantMessageStart,
+        onAssistantMessageStart: wrappedOnAssistantMessageStart,
         onAgentEvent: params.onAgentEvent,
         enforceFinalTag: params.enforceFinalTag,
         config: params.config,
@@ -1157,6 +1171,25 @@ export async function runEmbeddedAttempt(
 
           // Only pass images option if there are actually images to pass
           // This avoids potential issues with models that don't expect the images parameter
+
+          // Start first-token timeout just before dispatching the prompt.
+          // If the provider is unresponsive (TCP connects but no SSE data), this fires
+          // much sooner than the full timeoutMs, allowing faster fallback to other models.
+          const firstTokenTimeoutMs = Math.min(
+            params.firstTokenTimeoutMs ?? 30_000,
+            params.timeoutMs,
+          );
+          if (firstTokenTimeoutMs > 0) {
+            firstTokenTimer = setTimeout(() => {
+              if (!isProbeSession) {
+                log.warn(
+                  `first-token timeout: no response from ${params.provider}/${params.modelId} after ${firstTokenTimeoutMs}ms`,
+                );
+              }
+              abortRun(true);
+            }, firstTokenTimeoutMs);
+          }
+
           if (imageResult.images.length > 0) {
             await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
           } else {
@@ -1166,6 +1199,7 @@ export async function runEmbeddedAttempt(
           promptError = err;
           promptErrorSource = "prompt";
         } finally {
+          clearFirstTokenTimer();
           log.debug(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
           );

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -80,6 +80,10 @@ export type RunEmbeddedPiAgentParams = {
   execOverrides?: Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
   bashElevated?: ExecElevatedDefaults;
   timeoutMs: number;
+  /** Timeout (ms) for the first token/response from the model. If no streaming data arrives
+   *  within this window after prompt dispatch, the attempt is aborted early so fallback models
+   *  can be tried without waiting for the full `timeoutMs`. 0 disables. Default: 30 000. */
+  firstTokenTimeoutMs?: number;
   runId: string;
   abortSignal?: AbortSignal;
   shouldEmitToolResult?: () => boolean;

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -72,15 +72,18 @@ describe("resolveSandboxedMediaSource", () => {
     });
   });
 
-  it("maps file:// URLs under /workspace into sandbox root", async () => {
-    await withSandboxRoot(async (sandboxDir) => {
-      const result = await resolveSandboxedMediaSource({
-        media: "file:///workspace/media/pic.png",
-        sandboxRoot: sandboxDir,
+  it.skipIf(process.platform === "win32")(
+    "maps file:// URLs under /workspace into sandbox root",
+    async () => {
+      await withSandboxRoot(async (sandboxDir) => {
+        const result = await resolveSandboxedMediaSource({
+          media: "file:///workspace/media/pic.png",
+          sandboxRoot: sandboxDir,
+        });
+        expect(result).toBe(path.join(sandboxDir, "media", "pic.png"));
       });
-      expect(result).toBe(path.join(sandboxDir, "media", "pic.png"));
-    });
-  });
+    },
+  );
 
   // Group 3: Rejections (security)
   it.each([

--- a/src/gateway/server/ws-connection/auth-context.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.test.ts
@@ -46,7 +46,9 @@ async function resolveDeviceTokenDecision(params: {
     deviceId: "dev-1",
     role: "operator",
     scopes: ["operator.read"],
-    verifyDeviceToken: params.verifyDeviceToken,
+    verifyDeviceToken: params.verifyDeviceToken as Parameters<
+      typeof resolveConnectAuthDecision
+    >[0]["verifyDeviceToken"],
     ...(params.rateLimiter ? { rateLimiter: params.rateLimiter } : {}),
     ...(params.clientIp ? { clientIp: params.clientIp } : {}),
   });

--- a/src/slack/monitor.test.ts
+++ b/src/slack/monitor.test.ts
@@ -61,19 +61,43 @@ describe("resolveSlackThreadTs", () => {
   const threadTs = "1234567890.123456";
   const messageTs = "9999999999.999999";
 
-  it("stays in incoming threads for all replyToMode values", () => {
-    for (const replyToMode of ["off", "first", "all"] as const) {
-      for (const hasReplied of [false, true]) {
-        expect(
-          resolveSlackThreadTs({
-            replyToMode,
-            incomingThreadTs: threadTs,
-            messageTs,
-            hasReplied,
-          }),
-        ).toBe(threadTs);
-      }
-    }
+  it("stays in incoming threads when replyToMode allows threading", () => {
+    // "all" always threads; "first" threads until first reply
+    expect(
+      resolveSlackThreadTs({
+        replyToMode: "all",
+        incomingThreadTs: threadTs,
+        messageTs,
+        hasReplied: false,
+      }),
+    ).toBe(threadTs);
+    expect(
+      resolveSlackThreadTs({
+        replyToMode: "all",
+        incomingThreadTs: threadTs,
+        messageTs,
+        hasReplied: true,
+      }),
+    ).toBe(threadTs);
+    expect(
+      resolveSlackThreadTs({
+        replyToMode: "first",
+        incomingThreadTs: threadTs,
+        messageTs,
+        hasReplied: false,
+      }),
+    ).toBe(threadTs);
+  });
+
+  it("respects replyToMode=off even when incomingThreadTs is present", () => {
+    expect(
+      resolveSlackThreadTs({
+        replyToMode: "off",
+        incomingThreadTs: threadTs,
+        messageTs,
+        hasReplied: false,
+      }),
+    ).toBeUndefined();
   });
 
   describe("replyToMode=off", () => {

--- a/src/slack/monitor/message-handler/dispatch.streaming.test.ts
+++ b/src/slack/monitor/message-handler/dispatch.streaming.test.ts
@@ -35,10 +35,20 @@ describe("slack native streaming thread hint", () => {
     ).toBe("1000.2");
   });
 
-  it("uses the existing incoming thread regardless of replyToMode", () => {
+  it("respects replyToMode=off even with incomingThreadTs", () => {
     expect(
       resolveSlackStreamingThreadHint({
         replyToMode: "off",
+        incomingThreadTs: "2000.1",
+        messageTs: "1000.3",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("uses the existing incoming thread when replyToMode allows it", () => {
+    expect(
+      resolveSlackStreamingThreadHint({
+        replyToMode: "all",
         incomingThreadTs: "2000.1",
         messageTs: "1000.3",
       }),


### PR DESCRIPTION
## Summary

- **Problem:** When an LLM provider is unresponsive (TCP connects but inference endpoint hangs), the full 300s timeout is consumed per model before fallback. With N models on the same dead provider, users wait N×300s with no response.
- **Why it matters:** A single provider outage (e.g., NIM going down) makes the entire system unresponsive for 5-15+ minutes despite having fallback models configured on other providers (e.g., Ollama).
- **What changed:** Added a 30s first-token timeout that detects dead endpoints early, and provider-level skip logic that avoids retrying models on a provider that already timed out.
- **What did NOT change:** No changes to config schema, API contracts, or existing timeout behavior for working providers. The full `timeoutMs` still applies for slow-but-responsive models.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Related #22364
- Related #5980
- Related #8724
- Related #11715

## User-visible / Behavior Changes

- Dead LLM provider endpoints are now detected within ~30s instead of 300s
- Fallback models on different providers are reached much faster during provider outages
- New optional parameter `firstTokenTimeoutMs` (default: 30000) can be passed to customize the detection window. 0 disables it.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Docker AIO)
- Runtime/container: Node 22, Docker
- Model/provider: NIM (DeepSeek V3.2, Kimi K2, Nemotron Super) + Ollama fallback
- Relevant config: Multiple NIM models as primary/fallbacks, Ollama as last resort

### Steps

1. Configure primary model + fallbacks on same provider (e.g., 3 NIM models + 1 Ollama)
2. Provider inference endpoint becomes unresponsive (TCP connects, no SSE data)
3. Send a message

### Expected

- Dead endpoint detected within 30s, fallback to Ollama within ~35s

### Actual (before fix)

- First model hangs 300s, second model hangs 300s, third model hangs 300s
- Ollama never reached (run timeout exceeded)

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

New test `src/agents/model-fallback.test.ts` verifies:
1. Provider skip after timeout (only 2 actual calls instead of 3)
2. Non-timeout failures do NOT trigger provider skip

Log evidence from production: `LLM request timed out after 300061ms` with all NIM models failing sequentially.

## Human Verification (required)

- Verified scenarios: Provider timeout triggers skip, rate-limit does NOT trigger skip, first-token timer clears on response
- Edge cases checked: Timer cleanup in finally block, probe sessions suppressed, 0 disables first-token timeout
- What you did **not** verify: Live integration test with actual dead NIM endpoint (reproduced via unit test mocks)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (new param is optional with sensible default)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Set `firstTokenTimeoutMs: 0` in run params to disable first-token timeout
- Known bad symptoms: If a legitimate model takes >30s to emit first token, it would be incorrectly aborted. This is unlikely for responsive providers but possible for very slow local models. Users can increase the timeout.

## Risks and Mitigations

- Risk: Slow but working models aborted by 30s first-token timeout
  - Mitigation: 30s is generous for first token (most models respond in <5s). Configurable via `firstTokenTimeoutMs`. Local Ollama models that are slow would typically be the last fallback candidate anyway.

---

🤖 AI-assisted (Claude). Lightly tested via unit tests. Code reviewed and understood.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two complementary optimizations to the model fallback system for faster recovery from unresponsive LLM providers:

- **First-token timeout** (`attempt.ts`): A configurable timer (default 30s) is started before each `prompt()` call and cleared when the model begins responding (`onAssistantMessageStart`). If no response arrives within the window, the attempt is aborted early via `abortRun(true)`, producing a proper `TimeoutError` that the fallback system recognizes. The timer is also cleaned up in the `finally` block as a safety net. Probe sessions correctly suppress warning logs.
- **Provider-level skip** (`model-fallback.ts`): When a model times out, its provider is recorded in a `timedOutProviders` Set. Subsequent fallback candidates on the same provider are skipped immediately (with a synthetic "skipped" attempt record), avoiding redundant waits against a dead endpoint. Non-timeout failures (rate limits, auth errors) do not trigger provider skip.
- **Parameter plumbing** (`params.ts`, `run.ts`): The new optional `firstTokenTimeoutMs` parameter is threaded through the params type and passthrough layer.
- **Tests** (`model-fallback.test.ts`): Two tests verify provider-skip after timeout and non-skip for rate-limit errors. Minor unused import of `_probeThrottleInternals`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds an opt-out-able optimization with correct timeout classification and cleanup, and does not change behavior for responsive providers.
- The implementation is well-structured with proper timer cleanup, correct abort classification (TimeoutError flows through to FailoverError detection), and defensive handling (finally block, probe session suppression). The provider-skip logic is sound and correctly scoped to timeout failures only. The only minor issue is an unused import in the test file. Score is 4 rather than 5 because the test coverage is limited to the provider-skip logic in model-fallback.ts and does not include integration-level tests for the first-token timeout in attempt.ts.
- No files require special attention. `src/agents/pi-embedded-runner/run/attempt.ts` has the most impactful change (first-token timeout mechanism) but the implementation is clean.

<sub>Last reviewed commit: fb17761</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->