### PR TITLE
fix(skills): resolve Homebrew/common binary locations

### DIFF
--- a/src/shared/config-eval.test.ts
+++ b/src/shared/config-eval.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hasBinary } from "./config-eval.js";
+
+describe("hasBinary", () => {
+  const originalPath = process.env.PATH;
+  const originalPathExt = process.env.PATHEXT;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    process.env.PATHEXT = originalPathExt;
+    vi.restoreAllMocks();
+  });
+
+  it("detects binaries that exist in PATH", () => {
+    const accessSync = vi.spyOn(fs, "accessSync");
+    accessSync.mockImplementation((target) => {
+      if (target === "/tmp/tool") {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    process.env.PATH = "/tmp";
+    expect(hasBinary("tool")).toBe(true);
+    expect(accessSync).toHaveBeenCalledWith("/tmp/tool", fs.constants.X_OK);
+  });
+
+  it("falls back to common install directories when PATH is insufficient", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const homebrewGh = path.join("/opt/homebrew/bin", "gh");
+    const accessSync = vi.spyOn(fs, "accessSync");
+    accessSync.mockImplementation((target) => {
+      if (target === homebrewGh) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    process.env.PATH = "/bin";
+    expect(hasBinary("gh")).toBe(true);
+    expect(accessSync).toHaveBeenCalledWith(homebrewGh, fs.constants.X_OK);
+  });
+});

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -118,6 +118,16 @@ let cachedHasBinaryPath: string | undefined;
 let cachedHasBinaryPathExt: string | undefined;
 const hasBinaryCache = new Map<string, boolean>();
 
+const DEFAULT_BINARY_PATHS = [
+  "/opt/homebrew/bin",
+  "/usr/local/sbin",
+  "/usr/local/bin",
+  "/usr/sbin",
+  "/usr/bin",
+  "/sbin",
+  "/bin",
+];
+
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";
   const pathExt = process.platform === "win32" ? (process.env.PATHEXT ?? "") : "";
@@ -130,7 +140,19 @@ export function hasBinary(bin: string): boolean {
     return hasBinaryCache.get(bin)!;
   }
 
-  const parts = pathEnv.split(path.delimiter).filter(Boolean);
+  const parts = new Set(
+    pathEnv
+      .split(path.delimiter)
+      .map((part) => part.trim())
+      .filter(Boolean),
+  );
+
+  if (process.platform !== "win32") {
+    for (const part of DEFAULT_BINARY_PATHS) {
+      parts.add(part);
+    }
+  }
+
   const extensions = process.platform === "win32" ? windowsPathExtensions() : [""];
   for (const part of parts) {
     for (const ext of extensions) {


### PR DESCRIPTION
## what changed
- Updated `src/shared/config-eval.ts` so `hasBinary` always checks common install directories (including `/opt/homebrew/bin`) in addition to `PATH`.
- Added `src/shared/config-eval.test.ts` covering:
  - binary detection from `PATH`
  - fallback probing when `PATH` is minimal/non-login.

## why this fixes the issue
Skill readiness checks (used by `skills`/`skills check`) run in processes where PATH may not include Homebrew binary directories. This made `gh` appear missing for `github`/`gh-issues` in Control UI even when it works in CLI. The fallback scan restores correct detection in those environments.

## tests
- `pnpm test src/shared/config-eval.test.ts`

## edge cases
- `hasBinary` cache remains keyed by PATH and PATHEXT.
- On Windows, existing `PATHEXT` + PATH behavior is preserved.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enhanced binary detection to include common install directories (`/opt/homebrew/bin`, `/usr/local/bin`, etc.) when PATH is incomplete, fixing false negatives for Homebrew-installed tools like `gh` in runtime environments with minimal PATH. Also improved gateway auth to auto-approve scope upgrades for loopback connections, reducing unnecessary pairing prompts for local paired devices.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations around the security policy change for loopback connections
- The binary detection fallback is well-tested and platform-gated (non-Windows only). The gateway auth change is logical (loopback connections are already trusted) and properly tested with new e2e tests. One test was renamed for clarity. Cache invalidation properly handles PATH changes.
- Pay close attention to `src/gateway/server/ws-connection/message-handler.ts` to ensure the loopback auto-approval logic aligns with security expectations

<sub>Last reviewed commit: 4c5d500</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->