### PR TITLE
Allow operator.admin to satisfy operator scope compatibility

### DIFF
--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -183,14 +183,14 @@ describe("device pairing tokens", () => {
     });
     expect(readOk.ok).toBe(true);
 
-    const writeMismatch = await verifyDeviceToken({
+    const writeOk = await verifyDeviceToken({
       deviceId: "device-1",
       token,
       role: "operator",
       scopes: ["operator.write"],
       baseDir,
     });
-    expect(writeMismatch).toEqual({ ok: false, reason: "scope-mismatch" });
+    expect(writeOk).toEqual({ ok: true });
   });
 
   test("treats multibyte same-length token input as mismatch without throwing", async () => {

--- a/src/shared/operator-scope-compat.test.ts
+++ b/src/shared/operator-scope-compat.test.ts
@@ -33,7 +33,17 @@ describe("roleScopesAllow", () => {
         requestedScopes: ["operator.write"],
         allowedScopes: ["operator.admin"],
       }),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it("treats operator.admin as sufficient for mixed operator scope requests", () => {
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.write", "operator.approvals"],
+        allowedScopes: ["operator.admin", "operator.approvals"],
+      }),
+    ).toBe(true);
   });
 
   it("uses strict matching for non-operator roles", () => {

--- a/src/shared/operator-scope-compat.ts
+++ b/src/shared/operator-scope-compat.ts
@@ -15,12 +15,11 @@ function normalizeScopeList(scopes: readonly string[]): string[] {
 }
 
 function operatorScopeSatisfied(requestedScope: string, granted: Set<string>): boolean {
+  if (granted.has(OPERATOR_ADMIN_SCOPE)) {
+    return true;
+  }
   if (requestedScope === OPERATOR_READ_SCOPE) {
-    return (
-      granted.has(OPERATOR_READ_SCOPE) ||
-      granted.has(OPERATOR_WRITE_SCOPE) ||
-      granted.has(OPERATOR_ADMIN_SCOPE)
-    );
+    return granted.has(OPERATOR_READ_SCOPE) || granted.has(OPERATOR_WRITE_SCOPE);
   }
   return granted.has(requestedScope);
 }


### PR DESCRIPTION
## What changed
- Treat `operator.admin` as sufficient for all operator scope requests in `operatorScopeSatisfied`.
- Add/align compatibility tests in `src/shared/operator-scope-compat.test.ts`.
- Update `src/infra/device-pairing.test.ts` expectation to match the new admin behavior.

## Why it fixes the issue
`operatorScopeSatisfied` previously treated only `operator.read`/`operator.write` as admin-compatible, while some paths relied on admin satisfying any operator scope request (for example, isolated cron pairing token checks). This aligns scope compatibility behavior with full operator admin semantics used elsewhere, preventing false `scope-mismatch` failures.

## Tests run
- `pnpm vitest run src/shared/operator-scope-compat.test.ts src/infra/device-pairing.test.ts`
- `pnpm check`

## Edge cases / notes
- `operator.write` requests are now accepted with `operator.admin`.
- No unrelated behavior changes beyond operator-scope compatibility checks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends `operator.admin` scope to satisfy all operator scope requests, fixing authorization mismatches in runtime paths like isolated cron pairing.

**Key Changes:**
- `operatorScopeSatisfied` in `src/shared/operator-scope-compat.ts:17` now checks for `operator.admin` first and returns true for any requested operator scope
- Updated test expectations in `src/shared/operator-scope-compat.test.ts` and `src/infra/device-pairing.test.ts` to align with the new admin behavior
- Maintains backward compatibility for `operator.read` being satisfied by `operator.write`

The logic is sound and consistent with typical RBAC semantics where an admin role has full privileges within its domain.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused, well-tested fix that aligns authorization semantics across the codebase. The implementation follows RBAC best practices where admin scopes grant full privileges. All tests pass, including comprehensive coverage of the new behavior with admin, read, write, and mixed scope scenarios.
- No files require special attention

<sub>Last reviewed commit: 5f54cb0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->