### PR TITLE
fix(audit): use human-readable labels for RegExp patterns in post-compaction audit

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.test.ts
+++ b/src/auto-reply/reply/post-compaction-audit.test.ts
@@ -170,6 +170,24 @@ describe("auditPostCompactionReads", () => {
     expect(result.passed).toBe(true);
     expect(result.missingPatterns).toEqual([]);
   });
+
+  it("uses human-readable label for labeled RegExp entries", () => {
+    const result = auditPostCompactionReads(["WORKFLOW_AUTO.md"], workspaceDir);
+
+    expect(result.passed).toBe(false);
+    // Should show readable label, not raw regex source
+    expect(result.missingPatterns).toContain("memory/YYYY-MM-DD.md");
+    expect(result.missingPatterns).not.toContain("memory\\/\\d{4}-\\d{2}-\\d{2}\\.md");
+  });
+
+  it("falls back to regex source for plain RegExp entries", () => {
+    const readPaths: string[] = [];
+    const customRequired = [/custom\/\d+\.md/];
+    const result = auditPostCompactionReads(readPaths, workspaceDir, customRequired);
+
+    expect(result.passed).toBe(false);
+    expect(result.missingPatterns).toContain("custom\\/\\d+\\.md");
+  });
 });
 
 describe("formatAuditWarning", () => {


### PR DESCRIPTION
Fixes #22339

## Problem

Post-compaction audit warnings display raw `.source` output for RegExp entries:

```
memory\/\d{4}-\d{2}-\d{2}\.md
```

This is confusing and has been mistaken for prompt injection.

## Fix

- Add `RequiredReadEntry` type supporting `{ pattern: RegExp, label: string }` objects alongside plain strings and RegExp
- `DEFAULT_REQUIRED_READS` now uses a labeled entry for the daily memory pattern → displays `memory/YYYY-MM-DD.md`
- Plain `RegExp` entries still fall back to `.source` for backward compatibility
- Added tests verifying labeled display and plain RegExp fallback

## Testing

- All 17 tests pass (`vitest run post-compaction-audit.test.ts`)
- 2 new tests: labeled entry display + plain RegExp fallback

AI-assisted (Claude)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced raw regex `.source` output with human-readable labels for post-compaction audit warnings. The daily memory pattern now displays as `memory/YYYY-MM-DD.md` instead of the confusing escaped regex `memory\/\d{4}-\d{2}-\d{2}\.md`. Implementation adds a new `RequiredReadEntry` union type supporting labeled patterns while maintaining backward compatibility with plain RegExp entries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple, well-tested change that improves UX without altering core logic. Type-safe implementation with backward compatibility and comprehensive test coverage (2 new tests verify both labeled and plain RegExp behavior).
- No files require special attention

<sub>Last reviewed commit: 12a6bf7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->