### PR TITLE
fix: preselect Telegram-supported status reaction variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/Streaming: always clean up draft previews even when dispatch throws before fallback handling, preventing orphaned preview messages during failed runs. (#19041) thanks @mudrii.
 - Telegram/Streaming: split reasoning and answer draft preview lanes to prevent cross-lane overwrites, and ignore literal `<think>` tags inside inline/fenced code snippets so sample markup is not misrouted as reasoning. (#20774) Thanks @obviyus.
 - Telegram/Status reactions: refresh stall timers on repeated phase updates and honor ack-reaction scope when lifecycle reactions are enabled, preventing false stall emojis and unwanted group reactions. Thanks @wolly-tundracube and @thewilloftheshadow.
+- Telegram/Status reactions: keep lifecycle reactions active when available-reactions lookup fails by falling back to unrestricted variant selection instead of suppressing reaction updates. (#22380) thanks @obviyus.
 - Discord/Streaming: apply `replyToMode: first` only to the first Discord chunk so block-streamed replies do not spam mention pings. (#20726) Thanks @thewilloftheshadow for the report.
 - Discord/Components: map DM channel targets back to user-scoped component sessions so button/select interactions stay in the main DM session. Thanks @thewilloftheshadow.
 - Discord/Allowlist: lazy-load guild lists when resolving Discord user allowlists so ID-only entries resolve even if guild fetch fails. (#20208) Thanks @zhangjunmengyang.

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -562,7 +562,7 @@ export const buildTelegramMessageContext = async ({
                     logVerbose(
                       `telegram status-reaction available_reactions lookup failed for chat ${chatId}: ${String(err)}`,
                     );
-                    return new Set<string>();
+                    return null;
                   });
                 }
                 const allowedStatusReactionEmojis = await allowedStatusReactionEmojisPromise;

--- a/src/telegram/status-reaction-variants.test.ts
+++ b/src/telegram/status-reaction-variants.test.ts
@@ -97,6 +97,20 @@ describe("resolveTelegramAllowedEmojiReactions", () => {
 
     expect(result ? Array.from(result) : null).toEqual(["👍"]);
   });
+
+  it("falls back to unrestricted reactions when getChat lookup fails", async () => {
+    const getChat = async () => {
+      throw new Error("lookup failed");
+    };
+
+    const result = await resolveTelegramAllowedEmojiReactions({
+      chat: { id: 1 },
+      chatId: 1,
+      getChat,
+    });
+
+    expect(result).toBeNull();
+  });
 });
 
 describe("resolveTelegramReactionVariant", () => {

--- a/src/telegram/status-reaction-variants.test.ts
+++ b/src/telegram/status-reaction-variants.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_EMOJIS } from "../channels/status-reactions.js";
+import {
+  buildTelegramStatusReactionVariants,
+  isTelegramSupportedReactionEmoji,
+  resolveTelegramReactionVariant,
+  resolveTelegramStatusReactionEmojis,
+} from "./status-reaction-variants.js";
+
+describe("resolveTelegramStatusReactionEmojis", () => {
+  it("falls back to Telegram-safe defaults for empty overrides", () => {
+    const result = resolveTelegramStatusReactionEmojis({
+      initialEmoji: "👀",
+      overrides: {
+        thinking: "   ",
+        done: "\n",
+      },
+    });
+
+    expect(result.queued).toBe("👀");
+    expect(result.thinking).toBe(DEFAULT_EMOJIS.thinking);
+    expect(result.done).toBe(DEFAULT_EMOJIS.done);
+  });
+
+  it("preserves explicit non-empty overrides", () => {
+    const result = resolveTelegramStatusReactionEmojis({
+      initialEmoji: "👀",
+      overrides: {
+        thinking: "🫡",
+        done: "🎉",
+      },
+    });
+
+    expect(result.thinking).toBe("🫡");
+    expect(result.done).toBe("🎉");
+  });
+});
+
+describe("buildTelegramStatusReactionVariants", () => {
+  it("puts requested emoji first and appends Telegram fallbacks", () => {
+    const variants = buildTelegramStatusReactionVariants({
+      ...DEFAULT_EMOJIS,
+      coding: "🛠️",
+    });
+
+    expect(variants.get("🛠️")).toEqual(["🛠️", "👨‍💻", "🔥", "⚡"]);
+  });
+});
+
+describe("isTelegramSupportedReactionEmoji", () => {
+  it("accepts Telegram-supported reaction emojis", () => {
+    expect(isTelegramSupportedReactionEmoji("👀")).toBe(true);
+    expect(isTelegramSupportedReactionEmoji("👨‍💻")).toBe(true);
+  });
+
+  it("rejects unsupported emojis", () => {
+    expect(isTelegramSupportedReactionEmoji("🫠")).toBe(false);
+  });
+});
+
+describe("resolveTelegramReactionVariant", () => {
+  it("returns requested emoji when already Telegram-supported", () => {
+    const variantsByEmoji = buildTelegramStatusReactionVariants({
+      ...DEFAULT_EMOJIS,
+      coding: "👨‍💻",
+    });
+
+    const result = resolveTelegramReactionVariant({
+      requestedEmoji: "👨‍💻",
+      variantsByRequestedEmoji: variantsByEmoji,
+    });
+
+    expect(result).toBe("👨‍💻");
+  });
+
+  it("returns first Telegram-supported fallback for unsupported requested emoji", () => {
+    const variantsByEmoji = buildTelegramStatusReactionVariants({
+      ...DEFAULT_EMOJIS,
+      coding: "🛠️",
+    });
+
+    const result = resolveTelegramReactionVariant({
+      requestedEmoji: "🛠️",
+      variantsByRequestedEmoji: variantsByEmoji,
+    });
+
+    expect(result).toBe("👨‍💻");
+  });
+
+  it("uses generic Telegram fallbacks for unknown emojis", () => {
+    const result = resolveTelegramReactionVariant({
+      requestedEmoji: "🫠",
+      variantsByRequestedEmoji: new Map(),
+    });
+
+    expect(result).toBe("👍");
+  });
+
+  it("returns undefined for empty requested emoji", () => {
+    const result = resolveTelegramReactionVariant({
+      requestedEmoji: "   ",
+      variantsByRequestedEmoji: new Map(),
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/telegram/status-reaction-variants.ts
+++ b/src/telegram/status-reaction-variants.ts
@@ -1,0 +1,179 @@
+import { DEFAULT_EMOJIS, type StatusReactionEmojis } from "../channels/status-reactions.js";
+
+type StatusReactionEmojiKey = keyof Required<StatusReactionEmojis>;
+
+const TELEGRAM_GENERIC_REACTION_FALLBACKS = ["👍", "👀", "🔥"] as const;
+
+const TELEGRAM_SUPPORTED_REACTION_EMOJIS = new Set<string>([
+  "❤",
+  "👍",
+  "👎",
+  "🔥",
+  "🥰",
+  "👏",
+  "😁",
+  "🤔",
+  "🤯",
+  "😱",
+  "🤬",
+  "😢",
+  "🎉",
+  "🤩",
+  "🤮",
+  "💩",
+  "🙏",
+  "👌",
+  "🕊",
+  "🤡",
+  "🥱",
+  "🥴",
+  "😍",
+  "🐳",
+  "❤‍🔥",
+  "🌚",
+  "🌭",
+  "💯",
+  "🤣",
+  "⚡",
+  "🍌",
+  "🏆",
+  "💔",
+  "🤨",
+  "😐",
+  "🍓",
+  "🍾",
+  "💋",
+  "🖕",
+  "😈",
+  "😴",
+  "😭",
+  "🤓",
+  "👻",
+  "👨‍💻",
+  "👀",
+  "🎃",
+  "🙈",
+  "😇",
+  "😨",
+  "🤝",
+  "✍",
+  "🤗",
+  "🫡",
+  "🎅",
+  "🎄",
+  "☃",
+  "💅",
+  "🤪",
+  "🗿",
+  "🆒",
+  "💘",
+  "🙉",
+  "🦄",
+  "😘",
+  "💊",
+  "🙊",
+  "😎",
+  "👾",
+  "🤷‍♂",
+  "🤷",
+  "🤷‍♀",
+  "😡",
+]);
+
+export const TELEGRAM_STATUS_REACTION_VARIANTS: Record<StatusReactionEmojiKey, string[]> = {
+  queued: ["👀", "👍", "🔥"],
+  thinking: ["🤔", "🤓", "👀"],
+  tool: ["🔥", "⚡", "👍"],
+  coding: ["👨‍💻", "🔥", "⚡"],
+  web: ["⚡", "🔥", "👍"],
+  done: ["👍", "🎉", "💯"],
+  error: ["😱", "😨", "🤯"],
+  stallSoft: ["🥱", "😴", "🤔"],
+  stallHard: ["😨", "😱", "⚡"],
+};
+
+const STATUS_REACTION_EMOJI_KEYS: StatusReactionEmojiKey[] = [
+  "queued",
+  "thinking",
+  "tool",
+  "coding",
+  "web",
+  "done",
+  "error",
+  "stallSoft",
+  "stallHard",
+];
+
+function normalizeEmoji(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function toUniqueNonEmpty(values: string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+export function resolveTelegramStatusReactionEmojis(params: {
+  initialEmoji: string;
+  overrides?: StatusReactionEmojis;
+}): Required<StatusReactionEmojis> {
+  const { overrides } = params;
+  const queuedFallback = normalizeEmoji(params.initialEmoji) ?? DEFAULT_EMOJIS.queued;
+  return {
+    queued: normalizeEmoji(overrides?.queued) ?? queuedFallback,
+    thinking: normalizeEmoji(overrides?.thinking) ?? DEFAULT_EMOJIS.thinking,
+    tool: normalizeEmoji(overrides?.tool) ?? DEFAULT_EMOJIS.tool,
+    coding: normalizeEmoji(overrides?.coding) ?? DEFAULT_EMOJIS.coding,
+    web: normalizeEmoji(overrides?.web) ?? DEFAULT_EMOJIS.web,
+    done: normalizeEmoji(overrides?.done) ?? DEFAULT_EMOJIS.done,
+    error: normalizeEmoji(overrides?.error) ?? DEFAULT_EMOJIS.error,
+    stallSoft: normalizeEmoji(overrides?.stallSoft) ?? DEFAULT_EMOJIS.stallSoft,
+    stallHard: normalizeEmoji(overrides?.stallHard) ?? DEFAULT_EMOJIS.stallHard,
+  };
+}
+
+export function buildTelegramStatusReactionVariants(
+  emojis: Required<StatusReactionEmojis>,
+): Map<string, string[]> {
+  const variantsByRequested = new Map<string, string[]>();
+  for (const key of STATUS_REACTION_EMOJI_KEYS) {
+    const requested = normalizeEmoji(emojis[key]);
+    if (!requested) {
+      continue;
+    }
+    const fallbackVariants = TELEGRAM_STATUS_REACTION_VARIANTS[key] ?? [];
+    const candidates = toUniqueNonEmpty([requested, ...fallbackVariants]);
+    variantsByRequested.set(requested, candidates);
+  }
+  return variantsByRequested;
+}
+
+export function isTelegramSupportedReactionEmoji(emoji: string): boolean {
+  return TELEGRAM_SUPPORTED_REACTION_EMOJIS.has(emoji);
+}
+
+export function resolveTelegramReactionVariant(params: {
+  requestedEmoji: string;
+  variantsByRequestedEmoji: Map<string, string[]>;
+}): string | undefined {
+  const requestedEmoji = normalizeEmoji(params.requestedEmoji);
+  if (!requestedEmoji) {
+    return undefined;
+  }
+
+  const configuredVariants = params.variantsByRequestedEmoji.get(requestedEmoji) ?? [
+    requestedEmoji,
+  ];
+  const variants = toUniqueNonEmpty([
+    ...configuredVariants,
+    ...TELEGRAM_GENERIC_REACTION_FALLBACKS,
+  ]);
+
+  for (const candidate of variants) {
+    if (isTelegramSupportedReactionEmoji(candidate)) {
+      return candidate;
+    }
+  }
+
+  return variants[0];
+}

--- a/src/telegram/status-reaction-variants.ts
+++ b/src/telegram/status-reaction-variants.ts
@@ -200,10 +200,14 @@ export async function resolveTelegramAllowedEmojiReactions(params: {
   }
 
   if (params.getChat) {
-    const chatInfo = await params.getChat(params.chatId);
-    const fromLookup = extractTelegramAllowedEmojiReactions(chatInfo);
-    if (fromLookup !== undefined) {
-      return fromLookup;
+    try {
+      const chatInfo = await params.getChat(params.chatId);
+      const fromLookup = extractTelegramAllowedEmojiReactions(chatInfo);
+      if (fromLookup !== undefined) {
+        return fromLookup;
+      }
+    } catch {
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary
- add Telegram-only status-reaction variant resolver with a Bot API supported emoji set
- normalize configured status reaction emojis and resolve to a Telegram-supported variant before sending
- remove REACTION_INVALID retry loop for status reactions; send once with preselected variant
- add unit tests for emoji normalization, support checks, and variant resolution

## Validation
- pnpm test src/telegram/status-reaction-variants.test.ts src/channels/status-reactions.test.ts
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Telegram-specific status reaction emoji variant resolution to prevent `REACTION_INVALID` errors by preselecting Bot API-supported emojis before sending reactions. The implementation normalizes configured status reaction emojis and resolves them to Telegram-supported variants using a fallback chain, eliminating the need for retry loops when reactions fail.

Key changes:
- Created `status-reaction-variants.ts` with hardcoded set of 81 Telegram-supported reaction emojis from the Bot API
- Added `resolveTelegramReactionVariant` that walks through candidate emojis (requested → configured fallbacks → generic fallbacks) and returns the first Telegram-supported match
- Integrated variant resolution into `bot-message-context.ts` status reaction adapter's `setReaction` method
- Added comprehensive unit tests covering normalization, support checks, and variant resolution logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-isolated to the Telegram status reaction feature with a clear improvement in reliability. The implementation follows a defensive design pattern with proper normalization, fallback chains, and comprehensive test coverage. No breaking changes to existing APIs, and the logic gracefully degrades by returning undefined when no suitable emoji is found.
- No files require special attention

<sub>Last reviewed commit: 4116400</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->