### PR TITLE
Fix: Matrix plugin not sending images from content blocks

### DIFF
--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -2,6 +2,13 @@ import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import type { MarkdownTableMode, ReplyPayload, RuntimeEnv } from "openclaw/plugin-sdk";
 import { getMatrixRuntime } from "../../runtime.js";
 import { sendMessageMatrix } from "../send.js";
+import { writeFile, mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
 
 export async function deliverMatrixReplies(params: {
   replies: ReplyPayload[];
@@ -31,70 +38,95 @@ export async function deliverMatrixReplies(params: {
   const chunkLimit = Math.min(params.textLimit, 4000);
   const chunkMode = core.channel.text.resolveChunkMode(cfg, "matrix", params.accountId);
   let hasReplied = false;
-  for (const reply of params.replies) {
-    const hasMedia = Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0;
-    if (!reply?.text && !hasMedia) {
-      if (reply?.audioAsVoice) {
-        logVerbose("matrix reply has audioAsVoice without media/text; skipping");
-        continue;
+  let tempDir: string | undefined;
+  try {
+    for (const reply of params.replies) {
+      const contentBlocks = (reply as unknown as { content?: ContentBlock[] }).content;
+      const imageBlocks: { data: string; mimeType: string }[] = [];
+      let textFromContent = "";
+      if (contentBlocks && Array.isArray(contentBlocks)) {
+        for (const block of contentBlocks) {
+          if (block.type === "image" && "data" in block) imageBlocks.push(block);
+          else if (block.type === "text" && "text" in block) textFromContent += block.text + "\n";
+        }
       }
-      params.runtime.error?.("matrix reply missing text/media");
-      continue;
-    }
-    const replyToIdRaw = reply.replyToId?.trim();
-    const replyToId = params.threadId || params.replyToMode === "off" ? undefined : replyToIdRaw;
-    const rawText = reply.text ?? "";
-    const text = core.channel.text.convertMarkdownTables(rawText, tableMode);
-    const mediaList = reply.mediaUrls?.length
-      ? reply.mediaUrls
-      : reply.mediaUrl
-        ? [reply.mediaUrl]
-        : [];
-
-    const shouldIncludeReply = (id?: string) =>
-      Boolean(id) && (params.replyToMode === "all" || !hasReplied);
-    const replyToIdForReply = shouldIncludeReply(replyToId) ? replyToId : undefined;
-
-    if (mediaList.length === 0) {
-      let sentTextChunk = false;
-      for (const chunk of core.channel.text.chunkMarkdownTextWithMode(
-        text,
-        chunkLimit,
-        chunkMode,
-      )) {
-        const trimmed = chunk.trim();
-        if (!trimmed) {
+      const rawText = reply.text || textFromContent || "";
+      const hasMedia =
+        Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0 || imageBlocks.length > 0;
+      if (!rawText.trim() && !hasMedia) {
+        if (reply?.audioAsVoice) {
+          logVerbose("matrix reply has audioAsVoice without media/text; skipping");
           continue;
         }
-        await sendMessageMatrix(params.roomId, trimmed, {
+        params.runtime.error?.("matrix reply missing text/media");
+        continue;
+      }
+      const replyToIdRaw = reply.replyToId?.trim();
+      const replyToId = params.threadId || params.replyToMode === "off" ? undefined : replyToIdRaw;
+      const text = core.channel.text.convertMarkdownTables(rawText, tableMode);
+      const mediaList = reply.mediaUrls?.length
+        ? [...reply.mediaUrls]
+        : reply.mediaUrl
+          ? [reply.mediaUrl]
+          : [];
+      if (imageBlocks.length > 0) {
+        if (!tempDir) tempDir = await mkdtemp(join(tmpdir(), "openclaw-matrix-"));
+        for (let i = 0; i < imageBlocks.length; i++) {
+          const block = imageBlocks[i];
+          const ext = block.mimeType?.split("/")[1] || "bin";
+          const tempFile = join(tempDir, `image-${Date.now()}-${i}.${ext}`);
+          await writeFile(tempFile, Buffer.from(block.data, "base64"));
+          mediaList.push(`file://${tempFile}`);
+        }
+      }
+
+      const shouldIncludeReply = (id?: string) =>
+        Boolean(id) && (params.replyToMode === "all" || !hasReplied);
+      const replyToIdForReply = shouldIncludeReply(replyToId) ? replyToId : undefined;
+
+      if (mediaList.length === 0) {
+        let sentTextChunk = false;
+        for (const chunk of core.channel.text.chunkMarkdownTextWithMode(
+          text,
+          chunkLimit,
+          chunkMode,
+        )) {
+          const trimmed = chunk.trim();
+          if (!trimmed) {
+            continue;
+          }
+          await sendMessageMatrix(params.roomId, trimmed, {
+            client: params.client,
+            replyToId: replyToIdForReply,
+            threadId: params.threadId,
+            accountId: params.accountId,
+          });
+          sentTextChunk = true;
+        }
+        if (replyToIdForReply && !hasReplied && sentTextChunk) {
+          hasReplied = true;
+        }
+        continue;
+      }
+
+      let first = true;
+      for (const mediaUrl of mediaList) {
+        const caption = first ? text : "";
+        await sendMessageMatrix(params.roomId, caption, {
           client: params.client,
+          mediaUrl,
           replyToId: replyToIdForReply,
           threadId: params.threadId,
+          audioAsVoice: reply.audioAsVoice,
           accountId: params.accountId,
         });
-        sentTextChunk = true;
+        first = false;
       }
-      if (replyToIdForReply && !hasReplied && sentTextChunk) {
+      if (replyToIdForReply && !hasReplied) {
         hasReplied = true;
       }
-      continue;
     }
-
-    let first = true;
-    for (const mediaUrl of mediaList) {
-      const caption = first ? text : "";
-      await sendMessageMatrix(params.roomId, caption, {
-        client: params.client,
-        mediaUrl,
-        replyToId: replyToIdForReply,
-        threadId: params.threadId,
-        audioAsVoice: reply.audioAsVoice,
-        accountId: params.accountId,
-      });
-      first = false;
-    }
-    if (replyToIdForReply && !hasReplied) {
-      hasReplied = true;
-    }
+  } finally {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
## Problem

When tools return image data in the `content` array, the Matrix plugin ignores these images and only sends text.

## Solution

This fix extracts image blocks from `reply.content`, saves base64 data to temp files, and adds them to the media list for sending.

## Changes

- Extract content blocks and separate images from text
- Write base64 images to temp files with index counter to avoid collisions
- Include extracted images in the media list
- Clean up temp files after sending

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully implements support for sending images from content blocks in Matrix plugin replies. The implementation extracts image blocks from `reply.content`, converts base64 data to temporary files, and includes them in the media list for delivery.

**Key changes:**
- Adds content block extraction logic to parse image and text blocks from `reply.content`
- Creates temporary directory for storing base64-decoded images
- Properly cleans up temp files in finally block
- Maintains backward compatibility with existing `reply.text` field

**Issues found:**
- File naming uses `Date.now()` which could cause collisions if multiple images are processed within the same millisecond
- Type casting bypasses TypeScript type safety (though this is a pragmatic workaround)

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge with one minor race condition that should be addressed
- The implementation correctly handles the core functionality of extracting and sending images from content blocks. Resource cleanup is properly implemented with try-finally. However, there's a potential file name collision issue using Date.now() for temp file naming that could cause failures under rapid successive image processing. The type casting is pragmatic but not ideal.
- Pay attention to `extensions/matrix/src/matrix/monitor/replies.ts:77` for the file naming race condition

<sub>Last reviewed commit: 73ca371</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->