### PR TITLE
chore: format files blocking CI checks

### DIFF
--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -1,7 +1,7 @@
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import fs from "node:fs/promises";
-import type { ImageSanitizationLimits } from "../image-sanitization.js";
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { detectMime } from "../../media/mime.js";
+import type { ImageSanitizationLimits } from "../image-sanitization.js";
 import { sanitizeToolResultImages } from "../tool-images.js";
 
 // oxlint-disable-next-line typescript/no-explicit-any

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -1,5 +1,4 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import type { ChannelMessageActionContext } from "../../types.js";
 import {
   parseAvailableTags,
   readNumberParam,
@@ -11,6 +10,7 @@ import {
   readDiscordModerationCommand,
 } from "../../../../agents/tools/discord-actions-moderation-shared.js";
 import { handleDiscordAction } from "../../../../agents/tools/discord-actions.js";
+import type { ChannelMessageActionContext } from "../../types.js";
 
 type Ctx = Pick<
   ChannelMessageActionContext,

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -1,5 +1,6 @@
 import type { APIChannel } from "discord-api-types/v10";
 import { Routes } from "discord-api-types/v10";
+import { resolveDiscordRest } from "./send.shared.js";
 import type {
   DiscordChannelCreate,
   DiscordChannelEdit,
@@ -7,7 +8,6 @@ import type {
   DiscordChannelPermissionSet,
   DiscordReactOpts,
 } from "./send.types.js";
-import { resolveDiscordRest } from "./send.shared.js";
 
 export async function createChannelDiscord(
   payload: DiscordChannelCreate,


### PR DESCRIPTION
This PR fixes formatting-only drift introduced by formatter state outside the scope of metadata PRs.

It addresses:
- src/agents/tools/common.ts
- src/channels/plugins/actions/discord/handle-action.guild-admin.ts
- src/discord/send.channels.ts

Changes are import-order only and have no behavior impact.

Why:
- CI for PR #22345 is blocked by oxfmt --check failures in these files.

Once merged, PR #22345 should no longer fail CI due to unrelated formatting checks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorders imports in three files to fix `oxfmt --check` failures blocking CI checks. All changes are formatting-only with zero behavioral impact - the imports follow consistent ordering with Node.js built-ins first, external packages second, and local imports last.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- The changes are purely cosmetic import reordering with no functional modifications - no logic changes, no new dependencies, no altered behavior. The formatter-driven changes ensure consistency and unblock CI for other PRs.
- No files require special attention

<sub>Last reviewed commit: 2890c59</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->