### PR TITLE
fix: warn on IEEE-754 precision loss for large numeric owner IDs (fail closed)

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -112,6 +112,14 @@ function resolveOwnerAllowFromList(params: {
   }
   const filtered: string[] = [];
   for (const entry of raw) {
+    // Large integers lose IEEE-754 precision silently in JSON (e.g. Discord snowflake
+    // 1048693844750901359 → 1048693844750901400). Warn so users know to quote as a string.
+    if (typeof entry === "number" && !Number.isSafeInteger(entry)) {
+      console.warn(
+        `[command-auth] ownerAllowFrom entry (${entry}) exceeds MAX_SAFE_INTEGER and may have ` +
+          `lost precision. Quote it as a string in your config: "${entry}"`,
+      );
+    }
     const trimmed = String(entry ?? "").trim();
     if (!trimmed) {
       continue;


### PR DESCRIPTION
Related: #22284 (core senderIsOwner threading fix already merged in #22296)

## What this does

Discord snowflake IDs are ~10^18, which exceeds `Number.MAX_SAFE_INTEGER`. If someone stores
one as an unquoted number in their JSON config:

```json
{ "ownerAllowFrom": [1048693844750901359] }
```

...JavaScript's JSON parser silently rounds it to `1048693844750901400` before any of our code
runs. The rounded string doesn't match the real sender ID, so the user gets locked out of
owner-only tools with no indication of why.

This adds a `console.warn` in `resolveOwnerAllowFromList` when a numeric entry exceeds
`MAX_SAFE_INTEGER`, telling the user to quote it as a string. No attempt to silently compensate
for the bad config — matching fails closed, which is the correct security posture for owner
gating.

## Changes
- `command-auth.ts` — 8-line warn block in `resolveOwnerAllowFromList`
- `command-control.test.ts` — test asserting `senderIsOwner === false` for precision-lost IDs