### PR TITLE
Add runtime.stt.transcribeAudioFile for plugin STT access

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -120,6 +120,9 @@ function createMockRuntime(): PluginRuntime {
     tts: {
       textToSpeechTelephony: vi.fn() as unknown as PluginRuntime["tts"]["textToSpeechTelephony"],
     },
+    stt: {
+      transcribeAudioFile: vi.fn() as unknown as PluginRuntime["stt"]["transcribeAudioFile"],
+    },
     tools: {
       createMemoryGetTool: vi.fn() as unknown as PluginRuntime["tools"]["createMemoryGetTool"],
       createMemorySearchTool:

--- a/src/media-understanding/transcribe-audio.ts
+++ b/src/media-understanding/transcribe-audio.ts
@@ -1,0 +1,51 @@
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  buildProviderRegistry,
+  createMediaAttachmentCache,
+  normalizeMediaAttachments,
+  runCapability,
+} from "./runner.js";
+
+/**
+ * Transcribe an audio file using the configured media-understanding provider.
+ *
+ * Reads provider/model/apiKey from `tools.media.audio` in the openclaw config,
+ * falling back through configured models until one succeeds.
+ *
+ * This is the runtime-exposed entry point for external plugins (e.g. marmot)
+ * that need STT without importing internal media-understanding modules directly.
+ */
+export async function transcribeAudioFile(params: {
+  filePath: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  mime?: string;
+}): Promise<{ text: string | undefined }> {
+  const ctx = {
+    MediaPath: params.filePath,
+    MediaType: params.mime ?? "audio/wav",
+  };
+  const attachments = normalizeMediaAttachments(ctx);
+  if (attachments.length === 0) {
+    return { text: undefined };
+  }
+  const cache = createMediaAttachmentCache(attachments);
+  const providerRegistry = buildProviderRegistry();
+  try {
+    const result = await runCapability({
+      capability: "audio",
+      cfg: params.cfg,
+      ctx,
+      attachments: cache,
+      media: attachments,
+      agentDir: params.agentDir,
+      providerRegistry,
+      config: params.cfg.tools?.media?.audio,
+    });
+    const output = result.outputs.find((entry) => entry.kind === "audio.transcription");
+    const text = output?.text?.trim();
+    return { text: text || undefined };
+  } finally {
+    await cache.cleanup();
+  }
+}

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -95,6 +95,7 @@ import { buildTemplateMessageFromPayload } from "../../line/template-messages.js
 import { getChildLogger } from "../../logging.js";
 import { normalizeLogLevel } from "../../logging/levels.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
+import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
 import { isVoiceCompatibleAudio } from "../../media/audio.js";
 import { mediaKindFromMime } from "../../media/constants.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
@@ -244,6 +245,7 @@ export function createPluginRuntime(): PluginRuntime {
     system: createRuntimeSystem(),
     media: createRuntimeMedia(),
     tts: { textToSpeechTelephony },
+    stt: { transcribeAudioFile },
     tools: createRuntimeTools(),
     channel: createRuntimeChannel(),
     logging: createRuntimeLogging(),

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -25,6 +25,8 @@ type UpsertChannelPairingRequestForAccount = (
 type FetchRemoteMedia = typeof import("../../media/fetch.js").fetchRemoteMedia;
 type SaveMediaBuffer = typeof import("../../media/store.js").saveMediaBuffer;
 type TextToSpeechTelephony = typeof import("../../tts/tts.js").textToSpeechTelephony;
+type TranscribeAudioFile =
+  typeof import("../../media-understanding/transcribe-audio.js").transcribeAudioFile;
 type BuildMentionRegexes = typeof import("../../auto-reply/reply/mentions.js").buildMentionRegexes;
 type MatchesMentionPatterns =
   typeof import("../../auto-reply/reply/mentions.js").matchesMentionPatterns;
@@ -206,6 +208,9 @@ export type PluginRuntime = {
   };
   tts: {
     textToSpeechTelephony: TextToSpeechTelephony;
+  };
+  stt: {
+    transcribeAudioFile: TranscribeAudioFile;
   };
   tools: {
     createMemoryGetTool: CreateMemoryGetTool;


### PR DESCRIPTION
## Summary

- Add `runtime.stt.transcribeAudioFile()` to `PluginRuntime` so external plugins can use openclaw's media-understanding provider framework for speech-to-text
- New `src/media-understanding/transcribe-audio.ts` wraps `runCapability({capability: "audio"})` — same pattern as the Discord VC implementation in #18774
- Reads provider/model/apiKey from `tools.media.audio` in the config, with automatic provider fallback

## Motivation

The marmot plugin needs to transcribe call audio chunks but can't import internal media-understanding modules (`ERR_PACKAGE_PATH_NOT_EXPORTED`). This mirrors how `runtime.tts.textToSpeechTelephony` already exposes TTS to plugins.

## Usage (from a plugin)

```typescript
const result = await runtime.stt.transcribeAudioFile({
  filePath: "/tmp/audio-chunk.wav",
  cfg: runtime.config.loadConfig(),
});
if (result.text) {
  // dispatch transcript to agent
}
```

## Test plan

- [ ] TypeScript compiles
- [ ] Existing media-understanding tests still pass
- [ ] Marmot plugin can call `runtime.stt.transcribeAudioFile()` after openclaw is rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `runtime.stt.transcribeAudioFile()` to expose speech-to-text functionality to external plugins. The implementation follows the same pattern as the Discord voice manager's `transcribeAudio()` function, wrapping `runCapability({capability: "audio"})` from the media-understanding framework.

Key changes:
- New `src/media-understanding/transcribe-audio.ts` provides a standalone wrapper function
- Function exported via `PluginRuntime.stt.transcribeAudioFile`
- Uses same provider/model/apiKey resolution from `tools.media.audio` config
- Properly handles cleanup via `cache.cleanup()` in finally block

The implementation is clean and matches established patterns in the codebase.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward implementation following existing patterns
- The implementation directly mirrors the proven Discord voice manager pattern, properly handles resource cleanup, and uses the existing media-understanding provider framework without introducing new dependencies or risks. The only minor suggestion is around MIME type flexibility.
- No files require special attention

<sub>Last reviewed commit: 70009ce</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->