### PR TITLE
fix: allow agent turn after subagent completion message delivery

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -379,7 +379,7 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1); // Agent also called so parent can chain
     const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     const rawMessage = call?.params?.message;
     const msg = typeof rawMessage === "string" ? rawMessage : "";
@@ -697,7 +697,7 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1); // Agent also called so parent can chain
     const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     expect(call?.params?.channel).toBe("discord");
     expect(call?.params?.to).toBe("channel:12345");
@@ -735,7 +735,7 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1); // Agent also called so parent can chain
     const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     expect(call?.params?.channel).toBe("discord");
     expect(call?.params?.to).toBe("channel:12345");

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -676,11 +676,7 @@ async function sendSubagentAnnounceDirectly(params: {
           },
           timeoutMs: 15_000,
         });
-
-        return {
-          delivered: true,
-          path: "direct",
-        };
+        // Fall through to also call method: "agent" so the parent gets a turn to chain
       }
     }
 


### PR DESCRIPTION
## Problem

When `expectsCompletionMessage` is true and there's a direct target, the code path in `sendSubagentAnnounceDirectly` was returning early after calling `method: 'send'`. This prevented the parent agent from getting a turn to respond via `method: 'agent'`.

**Symptoms:**
- Subagent completions appeared in chat ✅
- Parent agent never got a turn to respond ❌
- Subagent chaining workflows were broken (e.g., bee gauntlets where one bee's completion should trigger spawning the next)

## Solution

Remove the early return after `method: 'send'` so the code falls through to also call `method: 'agent'`. Now the parent gets both:
1. The completion message delivered to chat (via `method: 'send'`)
2. A turn to respond and chain actions (via `method: 'agent'`)

## Testing

Tested locally with multi-subagent workflows. After the fix:
- Spawned subagent completes and reports back
- Parent agent immediately gets a turn to respond
- Chaining to next subagent works as expected

---
*Discovered and fixed by Noodle Princess 🍜*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug in subagent completion message delivery that prevented parent agents from getting a turn to respond after subagent completion.

**What changed:**
- Removed early return after `method: 'send'` call in `sendSubagentAnnounceDirectly`
- Added explanatory comment about fall-through behavior
- Parent agents now receive both the completion message (via `send`) AND a turn to respond (via `agent`)

**Impact:**
- Fixes broken subagent chaining workflows
- Parent agents can now properly orchestrate sequential subagent spawning
- Completion messages still reach chat as expected

The fix is minimal and surgical - removing a premature return statement allows the code to execute both delivery paths as originally intended.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with high confidence - it's a targeted fix that restores intended behavior
- Score reflects that this is a well-understood bug fix with clear symptoms and solution. The change is minimal (removing 4 lines + adding a comment) and directly addresses the reported issue. However, there's a test that may need updating to reflect the new expected behavior where both `send` and `agent` methods are called.
- Check `src/agents/subagent-announce.format.e2e.test.ts` line 344 - test expects `agentSpy` not to be called when `expectsCompletionMessage: true`, but the fix now calls both `send` and `agent` methods

<sub>Last reviewed commit: 3504125</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->