### PR TITLE
docs: Add Agent Cloud Memory to community skills

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -293,6 +293,12 @@ copy). Workspace skills are user-owned and override both on name conflicts.
 
 See [Skills config](/tools/skills-config) for the full configuration schema.
 
+## Community Skill Libraries
+
+While ClawHub is the primary registry, you can also clone skill repositories directly into your workspace.
+
+- **[Agent Cloud Memory](https://github.com/lilyjazz/agent-cloud-memory)**: Serverless persistence skills (Teleport, Hive Mind, Knowledge Vault) powered by TiDB Zero. Give your agent long-term memory and mobility.
+
 ## Looking for more skills?
 
 Browse [https://clawhub.com](https://clawhub.com).


### PR DESCRIPTION
Adds a reference to [Agent Cloud Memory](https://github.com/lilyjazz/agent-cloud-memory) in the Skills documentation. This library provides serverless persistence capabilities (RAG, Teleport, etc.) powered by TiDB Zero.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new "Community Skill Libraries" section to the Skills documentation, introducing Agent Cloud Memory as a serverless persistence skill library. The section is well-positioned and clarifies that users can clone skill repositories directly into their workspace as an alternative to ClawHub.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found.
- This is a straightforward documentation addition that follows existing patterns, uses proper markdown formatting, and is logically positioned within the document structure. No code changes, no breaking changes, and the content accurately describes an alternative way to use skills.
- No files require special attention.

<sub>Last reviewed commit: 0d63ba8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->