### PR TITLE
fix(cron): honor maxConcurrentRuns in timer loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: honor `cron.maxConcurrentRuns` in the timer loop so due jobs can execute up to the configured parallelism instead of always running serially. (#11595) Thanks @Takhoffman.
 - Agents/Compaction: restore embedded compaction safeguard/context-pruning extension loading in production by wiring bundled extension factories into the resource loader instead of runtime file-path resolution. (#22349) Thanks @Glucksberg.
 - Auto-reply/Tools: forward `senderIsOwner` through embedded queued/followup runner params so owner-only tools remain available for authorized senders. (#22296) thanks @hcoj.
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -755,4 +755,61 @@ describe("Cron issue regressions", () => {
     expect(secondDone?.state.lastDurationMs).toBe(20);
     expect(startedAtEvents).toEqual([dueAt, dueAt + 50]);
   });
+
+  it("honors cron maxConcurrentRuns for due jobs", async () => {
+    vi.useRealTimers();
+    const store = await makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:01.000Z");
+    const first = createDueIsolatedJob({ id: "parallel-first", nowMs: dueAt, nextRunAtMs: dueAt });
+    const second = createDueIsolatedJob({
+      id: "parallel-second",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify({ version: 1, jobs: [first, second] }, null, 2),
+      "utf-8",
+    );
+
+    let now = dueAt;
+    let activeRuns = 0;
+    let peakActiveRuns = 0;
+    const firstRun = createDeferred<{ status: "ok"; summary: string }>();
+    const secondRun = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      cronConfig: { maxConcurrentRuns: 2 },
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async (params: { job: { id: string } }) => {
+        activeRuns += 1;
+        peakActiveRuns = Math.max(peakActiveRuns, activeRuns);
+        try {
+          const result =
+            params.job.id === first.id ? await firstRun.promise : await secondRun.promise;
+          now += 10;
+          return result;
+        } finally {
+          activeRuns -= 1;
+        }
+      }),
+    });
+
+    const timerPromise = onTimer(state);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(peakActiveRuns).toBe(2);
+
+    firstRun.resolve({ status: "ok", summary: "first done" });
+    secondRun.resolve({ status: "ok", summary: "second done" });
+    await timerPromise;
+
+    const jobs = state.store?.jobs ?? [];
+    expect(jobs.find((job) => job.id === first.id)?.state.lastStatus).toBe("ok");
+    expect(jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("ok");
+  });
 });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -38,6 +38,13 @@ type TimedCronRunOutcome = CronRunOutcome &
     endedAt: number;
   };
 
+function resolveRunConcurrency(state: CronServiceState): number {
+  const raw = state.deps.cronConfig?.maxConcurrentRuns;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return 1;
+  }
+  return Math.max(1, Math.floor(raw));
+}
 /**
  * Exponential backoff delays (in ms) indexed by consecutive error count.
  * After the last entry the delay stays constant.
@@ -236,9 +243,11 @@ export async function onTimer(state: CronServiceState) {
       }));
     });
 
-    const results: TimedCronRunOutcome[] = [];
-
-    for (const { id, job } of dueJobs) {
+    const runDueJob = async (params: {
+      id: string;
+      job: CronJob;
+    }): Promise<TimedCronRunOutcome> => {
+      const { id, job } = params;
       const startedAt = state.deps.nowMs();
       job.state.runningAtMs = startedAt;
       emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
@@ -276,27 +285,50 @@ export async function onTimer(state: CronServiceState) {
                 }
               })()
             : await executeJobCore(state, job);
-        results.push({ jobId: id, ...result, startedAt, endedAt: state.deps.nowMs() });
+        return { jobId: id, ...result, startedAt, endedAt: state.deps.nowMs() };
       } catch (err) {
         state.deps.log.warn(
           { jobId: id, jobName: job.name, timeoutMs: jobTimeoutMs ?? null },
           `cron: job failed: ${String(err)}`,
         );
-        results.push({
+        return {
           jobId: id,
           status: "error",
           error: String(err),
           startedAt,
           endedAt: state.deps.nowMs(),
-        });
+        };
       }
-    }
+    };
 
-    if (results.length > 0) {
+    const concurrency = Math.min(resolveRunConcurrency(state), Math.max(1, dueJobs.length));
+    const results: (TimedCronRunOutcome | undefined)[] = Array.from({ length: dueJobs.length });
+    let cursor = 0;
+    const workers = Array.from({ length: concurrency }, async () => {
+      for (;;) {
+        const index = cursor;
+        cursor += 1;
+        if (index >= dueJobs.length) {
+          return;
+        }
+        const due = dueJobs[index];
+        if (!due) {
+          return;
+        }
+        results[index] = await runDueJob(due);
+      }
+    });
+    await Promise.all(workers);
+
+    const completedResults: TimedCronRunOutcome[] = results.filter(
+      (entry): entry is TimedCronRunOutcome => entry !== undefined,
+    );
+
+    if (completedResults.length > 0) {
       await locked(state, async () => {
         await ensureLoaded(state, { forceReload: true, skipRecompute: true });
 
-        for (const result of results) {
+        for (const result of completedResults) {
           const job = state.store?.jobs.find((j) => j.id === result.jobId);
           if (!job) {
             continue;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -306,8 +306,7 @@ export async function onTimer(state: CronServiceState) {
     let cursor = 0;
     const workers = Array.from({ length: concurrency }, async () => {
       for (;;) {
-        const index = cursor;
-        cursor += 1;
+        const index = cursor++;
         if (index >= dueJobs.length) {
           return;
         }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Cron scheduler executed due jobs serially in the timer loop even when `cron.maxConcurrentRuns` was configured.
- Why it matters: Long-running due jobs can delay subsequent due jobs and increase timeout/backlog risk.
- What changed: Added bounded worker execution in `onTimer` so due jobs run with concurrency capped by `cron.maxConcurrentRuns` (default remains 1).
- What did NOT change (scope boundary): No timeout-cancellation logic changes; no CLI/API contract changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #11595
- Related PR #8554
- Related PR #17064

## User-visible / Behavior Changes

- Cron due-job execution now honors `cron.maxConcurrentRuns` in scheduler timer processing.
- With default config (`maxConcurrentRuns` unset), behavior remains serial (`1`).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (darwin-arm64)
- Runtime/container: Node + Vitest
- Model/provider: N/A (unit/integration tests)
- Integration/channel (if any): Cron service internals
- Relevant config (redacted): `cronConfig.maxConcurrentRuns=2` in regression test

### Steps

1. Seed two due isolated jobs.
2. Configure cron service with `maxConcurrentRuns: 2`.
3. Trigger timer tick and observe peak simultaneous active runs.

### Expected

- Peak concurrent runs reaches 2, and both jobs complete successfully.

### Actual

- Matches expected after fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- `pnpm vitest run src/cron/service.issue-regressions.test.ts src/cron/service.rearm-timer-when-running.test.ts src/cron/service.restart-catchup.test.ts --maxWorkers=1`
- `pnpm vitest run src/cron/service.delivery-plan.test.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts --maxWorkers=1`
- Edge cases checked:
- default behavior still works with serial semantics when not configured
- existing cron timer/rearm/restart regression tests remain green
- What you did **not** verify:
- Large-scale perf benchmarking under high cron job volume in production-like environment

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Set `cron.maxConcurrentRuns` to `1` (default serial) or revert this commit.
- Files/config to restore:
- `src/cron/service/timer.ts`, `src/cron/service.issue-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
- Unexpected duplicate run execution or out-of-order state updates under concurrency.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Concurrency can expose race assumptions in due-job state transitions.
  - Mitigation:
  - Bounded worker pool, existing state writeback flow retained, and dedicated regression test for concurrent execution path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added concurrent execution support for cron jobs in the timer loop, honoring the `cron.maxConcurrentRuns` configuration. The implementation refactors the previous serial loop into a bounded worker pool pattern that processes due jobs concurrently while maintaining backward compatibility (defaults to 1 for serial execution).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly adds bounded concurrency to cron job execution using a worker pool pattern. The code is well-structured with proper error handling, maintains backward compatibility with serial execution as the default, and includes a comprehensive regression test. The single minor style suggestion about cursor increment is a micro-optimization that doesn't affect correctness in JavaScript's single-threaded environment.
- No files require special attention

<sub>Last reviewed commit: 414338a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->