### PR TITLE
test(memory): fix TS typing regressions in memory tests

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1303,7 +1303,7 @@ describe("QmdMemoryManager", () => {
     };
     inner.db = {
       prepare: () => ({
-        all: () => {
+        get: () => {
           throw new Error("SQLITE_BUSY: database is locked");
         },
       }),


### PR DESCRIPTION
Fix CI typecheck failures after recent TS/Vitest changes.

Changes:
- Fix src/memory/manager.async-search.test.ts mock typing so vi.fn doesn’t infer never[] and break mockImplementation.
- Fix src/memory/qmd-manager.test.ts sqlite busy mock to match resolveDocLocation, which calls stmt.all().

Verification:
- pnpm check
