### PR TITLE
Add filterReasoningContent config option for Xiaomi Mimo v2 flash

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -263,7 +263,8 @@ export function handleMessageEnd(
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   promoteThinkingTagsToBlocks(assistantMessage);
 
-  const rawText = extractAssistantText(assistantMessage);
+  const filterReasoningContent = ctx.params.config?.agents?.defaults?.filterReasoningContent ?? false;
+  const rawText = extractAssistantText(assistantMessage, { filterReasoningContent });
   appendRawStream({
     ts: Date.now(),
     event: "assistant_message_end",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -166,6 +166,13 @@ export type AgentDefaultsConfig = {
   memorySearch?: MemorySearchConfig;
   /** Default thinking level when no /think directive is present. */
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  /**
+   * Filter out reasoning content from model responses.
+   * When enabled, removes reasoning_content fields from models like Xiaomi Mimo v2 flash
+   * that return internal reasoning as part of the response.
+   * @default false
+   */
+  filterReasoningContent?: boolean;
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
   /** Default elevated level when no /elevated directive is present. */


### PR DESCRIPTION
## Problem

Xiaomi Mimo v2 flash model returns an annoying `reasoning_content` field in responses when in thinking mode:

```json
"reasoning_content": "Okay, the user just asked me to introduce myself. That is a pretty straightforward request..."
```

This content appears unnatural and clutters responses.

## Solution

This PR adds a new config option `filterReasoningContent` that strips `reasoning_content` from model responses when enabled.

### Usage

Add to your `~/.openclaw/openclaw.json`:

```json
{
  "agents": {
    "defaults": {
      "filterReasoningContent": true
    }
  }
}
```

### Changes

1. **`src/config/types.agent-defaults.ts`** - Added `filterReasoningContent?: boolean` to `AgentDefaultsConfig`
2. **`src/agents/pi-embedded-utils.ts`** - Added `stripReasoningContent()` function and updated `extractAssistantText()`
3. **`src/agents/pi-embedded-subscribe.handlers.messages.ts`** - Wired up config option
4. **`src/agents/tools/sessions-helpers.ts`** - Updated helper to support filtering

The default is `false` to maintain backward compatibility.

## Testing

Tested locally with the Xiaomi Mimo v2 flash model. When `filterReasoningContent: true`, the reasoning content is properly filtered from responses.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `filterReasoningContent` config option to strip `reasoning_content` fields from Xiaomi Mimo v2 flash model responses

**Key changes:**
- Added boolean config field `filterReasoningContent` to `AgentDefaultsConfig` (defaults to `false`)
- Implemented `stripReasoningContent()` function using regex pattern to remove JSON `reasoning_content` fields
- Wired up filtering in `extractAssistantText()` functions across message handlers and session helpers
- Filtering applies during text sanitization pipeline alongside existing filters for thinking tags and tool calls

**Issue found:**
- Regex pattern for stripping `reasoning_content` uses `[^"']*` which won't handle escaped quotes correctly - will fail if reasoning content contains `\"escaped\"` quotes within the string value

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical issue that may cause problems if reasoning content contains escaped quotes
- Implementation is straightforward and maintains backward compatibility with default `false`. However, the regex pattern has a clear bug that will fail to correctly strip `reasoning_content` if the value contains escaped quotes. Whether this is critical depends on whether Xiaomi actually returns such content - if reasoning text is always simple prose without quotes, it may work fine in practice.
- Pay attention to `src/agents/pi-embedded-utils.ts` line 223 - the regex pattern needs review

<sub>Last reviewed commit: 2ffd5a4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->