### PR TITLE
test(memory): fix sqlite busy mock in qmd-manager.test

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1307,15 +1307,17 @@ describe("QmdMemoryManager", () => {
       } | null;
       resolveDocLocation: (docid?: string) => Promise<unknown>;
     };
+    const busyStmt: { all: () => never; get: () => never } = {
+      all: () => {
+        throw new Error("SQLITE_BUSY: database is locked");
+      },
+      get: () => {
+        throw new Error("SQLITE_BUSY: database is locked");
+      },
+    };
+
     inner.db = {
-      prepare: () => ({
-        all: () => {
-          throw new Error("SQLITE_BUSY: database is locked");
-        },
-        get: () => {
-          throw new Error("SQLITE_BUSY: database is locked");
-        },
-      }),
+      prepare: () => busyStmt,
       close: () => {},
     };
     await expect(inner.resolveDocLocation("abc123")).rejects.toThrow(

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1298,12 +1298,12 @@ describe("QmdMemoryManager", () => {
   it("throws when sqlite index is busy", async () => {
     const { manager } = await createManager();
     const inner = manager as unknown as {
-      db: { prepare: () => { get: () => never }; close: () => void } | null;
+      db: { prepare: () => { all: () => never }; close: () => void } | null;
       resolveDocLocation: (docid?: string) => Promise<unknown>;
     };
     inner.db = {
       prepare: () => ({
-        get: () => {
+        all: () => {
           throw new Error("SQLITE_BUSY: database is locked");
         },
       }),

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1298,12 +1298,21 @@ describe("QmdMemoryManager", () => {
   it("throws when sqlite index is busy", async () => {
     const { manager } = await createManager();
     const inner = manager as unknown as {
-      db: { prepare: () => { all: () => never }; close: () => void } | null;
+      db: {
+        prepare: () => {
+          all: () => never;
+          get: () => never;
+        };
+        close: () => void;
+      } | null;
       resolveDocLocation: (docid?: string) => Promise<unknown>;
     };
     inner.db = {
       prepare: () => ({
         all: () => {
+          throw new Error("SQLITE_BUSY: database is locked");
+        },
+        get: () => {
           throw new Error("SQLITE_BUSY: database is locked");
         },
       }),


### PR DESCRIPTION
Fix CI failure on Windows: qmd-manager test mock should match resolveDocLocation implementation (uses stmt.all()).

Changes:
- Update sqlite-busy test in src/memory/qmd-manager.test.ts to mock stmt.all() (and annotate accordingly).

Verification:
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes CI failures by correcting test mocks and TypeScript types in two memory test files.

- In `qmd-manager.test.ts`, the sqlite-busy test mock is updated from `stmt.get()` to `stmt.all()` to match the actual `resolveDocLocation` implementation, which uses `.all()` for its SQL queries.
- In `manager.async-search.test.ts`, explicit parameter types, return type annotations, and `as unknown as` casts are added to `vi.fn()` mocks to satisfy stricter TypeScript/Vitest type checking. The `releaseSync` variable is changed to use a definite assignment assertion (`!:`) instead of a nullable union, which is safe given the synchronous `Promise` constructor assignment pattern.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only fixes test mocks and TypeScript types with no production code changes.
- All changes are confined to test files. The sqlite mock fix correctly aligns the test with the actual implementation (stmt.all()), and the TypeScript type fixes are standard adjustments for stricter type checking. No behavioral changes, no production code touched.
- No files require special attention.

<sub>Last reviewed commit: ffc0c48</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->