### PR TITLE
fix: prevent crash when onUpdate is truthy but not callable (fixes #22206)

### DIFF
--- a/src/agents/bash-tools.exec-runtime.guard.test.ts
+++ b/src/agents/bash-tools.exec-runtime.guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { runExecProcess } from "./bash-tools.exec-runtime.js";
+
+describe("exec runtime onUpdate guard (issue #22206)", () => {
+  it("should not crash when onUpdate is truthy but not a function", async () => {
+    // Reproduces issue #22206: onUpdate can be set to `true` or an object during
+    // teardown/race, causing TypeError when the falsy check passes but the call fails.
+    // Before fix: TypeError: opts.onUpdate is not a function at line 340
+    // After fix: typeof check prevents the call
+
+    await expect(
+      runExecProcess({
+        command: "echo hello",
+        // @ts-expect-error - Testing invalid type to reproduce crash
+        onUpdate: true, // Truthy but not callable
+        workdir: process.cwd(),
+        allowElevated: false,
+        env: {},
+        warnings: [],
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("should not crash when onUpdate is an object", async () => {
+    await expect(
+      runExecProcess({
+        command: "echo test",
+        // @ts-expect-error - Testing invalid type
+        onUpdate: {}, // Another truthy non-function value
+        workdir: process.cwd(),
+        allowElevated: false,
+        env: {},
+        warnings: [],
+      }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -323,7 +323,7 @@ export async function runExecProcess(opts: {
   addSession(session);
 
   const emitUpdate = () => {
-    if (!opts.onUpdate) {
+    if (typeof opts.onUpdate !== "function") {
       return;
     }
     const tailText = session.tail || session.aggregated;


### PR DESCRIPTION
## Summary

Fixes #22206 — prevents gateway crash when `opts.onUpdate` is truthy but not a function during exec runtime.

## Problem

The crash occurred during boot-md gateway startup when:
1. Embedded agent run starts
2. Skills-remote probe times out
3. Supervisor stdout handler fires `emitUpdate()` after the `onUpdate` callback has been invalidated
4. The guard at line 335 used `if (!opts.onUpdate)` — a falsy check that doesn't catch truthy non-functions like `true` or `{}`
5. Line 340 attempts to call `opts.onUpdate({...})` → TypeError

## Root Cause Analysis

After extensive investigation, I could not find explicit code that sets `onUpdate` to `true` or `{}`. The issue appears to occur during race conditions in cleanup/teardown scenarios where:
- The process continues running and generating stdout
- The callback has been invalidated (possibly during abort/timeout/cleanup)
- But stdout arrives after invalidation

## History

This bug was introduced in b47fa9e71 (about 2 months ago) but remained latent until PR #20569 merged. That PR changed boot-md to run per-agent, significantly increasing the probability of hitting this race condition during gateway startup.

## Solution

Changed the guard from falsy check to typeof check:

```diff
- if (!opts.onUpdate) return;
+ if (typeof opts.onUpdate !== "function") return;
```

This is a defensive fix that prevents the crash regardless of how the callback becomes invalid. The trade-off (lost progress updates when callback is invalidated) is acceptable compared to the crash (restart loop until stale locks clear).

## Test Plan

- [x] Added regression tests in `bash-tools.exec-runtime.guard.test.ts`
- [x] Tests reproduce the crash with `onUpdate: true` and `onUpdate: {}`
- [x] Tests verify the fix prevents the crash
- [x] CI gate passed (pnpm build && pnpm check)

## Impact

- Eliminates restart loop on gateway startup when boot-md encounters timeouts
- No functional changes to normal operation (guard only triggers when callback is already corrupted)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash in the bash exec runtime that occurred when `onUpdate` callback was truthy but not callable. The fix changes the guard from a falsy check (`if (!opts.onUpdate)`) to a proper type check (`if (typeof opts.onUpdate !== "function")`), preventing `TypeError` when the callback becomes invalidated during race conditions in cleanup/teardown scenarios.

- Fixed critical crash bug in `bash-tools.exec-runtime.ts:335` affecting gateway startup
- Added comprehensive regression tests covering `onUpdate: true` and `onUpdate: {}` scenarios
- Aligns with existing codebase patterns (27+ other `typeof ... !== "function"` checks found)
- Other file changes are formatting-only (import order via `oxfmt`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, defensive guard change that prevents a crash without altering any functional behavior. The typeof check aligns with 27+ existing patterns in the codebase. Comprehensive regression tests verify the fix prevents the crash scenarios. The only substantive change is a single-line guard improvement; other changes are formatting-only.
- No files require special attention

<sub>Last reviewed commit: 1712851</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->