### PR TITLE
chore: make prepare git hooks setup cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "openclaw:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
     "plugins:sync": "node --import tsx scripts/sync-plugin-versions.ts",
     "prepack": "pnpm build && pnpm ui:build",
-    "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0",
+    "prepare": "node scripts/setup-git-hooks.mjs",
     "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+function run(cmd, args) {
+  const r = spawnSync(cmd, args, { stdio: "pipe", encoding: "utf8" });
+  return {
+    code: r.status ?? 1,
+    out: (r.stdout || "").trim(),
+    err: (r.stderr || "").trim(),
+  };
+}
+
+function hasGit() {
+  return run("git", ["--version"]).code === 0;
+}
+
+if (!hasGit()) {
+  process.exit(0);
+}
+
+const inside = run("git", ["rev-parse", "--is-inside-work-tree"]);
+if (inside.code !== 0 || inside.out !== "true") {
+  process.exit(0);
+}
+
+const hooksDir = resolve(process.cwd(), "git-hooks");
+if (!existsSync(hooksDir)) {
+  process.exit(0);
+}
+
+const set = run("git", ["config", "core.hooksPath", "git-hooks"]);
+if (set.code !== 0) {
+  // Non-fatal: never block install
+  console.warn("prepare: unable to set git core.hooksPath (non-fatal).");
+  if (set.err) {
+    console.warn(set.err);
+  }
+  process.exit(0);
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

- Problem: The existing prepare script uses POSIX shell syntax which produces confusing output on Windows during pnpm install.
- Why it matters: Windows contributors see misleading "The system cannot find the path specified." messages even though installation succeeds.
- What changed: Replaced the shell-based prepare command with a small Node script (scripts/setup-git-hooks.mjs) that performs the same checks in a cross-platform way.
- What did NOT change (scope boundary): Behavior and scope remain identical — core.hooksPath is only set when git is available, inside a work tree, and git-hooks/ exists. The install process remains non-fatal.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
None — improvement discovered during Windows setup.

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:
None.

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node v24.13.0, pnpm v10.23.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Default repo configuration

### Steps

1. Run pnpm install on Windows before this change.
2. Observe misleading shell-related error message.
3. Apply this PR and run pnpm install again.

### Expected

Clean install output with no POSIX shell error messages.

### Actual

Install succeeds without confusing Windows-specific shell error output.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: Fresh install on Windows inside a git work tree.
- Edge cases checked: Non-git directory; git not available; git-hooks directory missing.
- What you did **not** verify: macOS/Linux environments (behavior unchanged by design).

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:
None.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: Restore previous prepare script in package.json.
- Known bad symptoms reviewers should watch for: git hooks not being configured automatically.

## Risks and Mitigations

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced POSIX shell-based git hooks setup with a cross-platform Node.js script (`scripts/setup-git-hooks.mjs`) to eliminate confusing error messages on Windows during `pnpm install`.

The changes successfully achieve the stated goal of cross-platform compatibility. The new script properly checks for git availability, work tree status, and sets `core.hooksPath` with appropriate error handling.

**Key observations:**
- The new script adds a check for `git-hooks/` directory existence (lines 27-30) that the original shell command did not have
- This is actually an improvement (avoids setting hooks path to non-existent directory in npm package installations), but represents a minor behavior change beyond just "cross-platform translation"
- The PR description states "Behavior and scope remain identical" but this added check is technically a scope enhancement, albeit a sensible one
- All error paths correctly exit with code 0 to maintain non-fatal install behavior
- The implementation is clean, well-structured, and follows Node.js best practices

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained to the prepare script, properly handle all edge cases, maintain backward compatibility, and improve cross-platform support. The added directory existence check is a minor enhancement that makes the behavior cleaner without breaking existing functionality.
- No files require special attention

<sub>Last reviewed commit: baa711b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->