### PR TITLE
Gateway: harden X-Forwarded-For parsing for trusted proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Watch: refresh iOS and watch app icon assets with the lobster icon set to keep phone/watch branding aligned. (#21997) Thanks @mbelinky.
 - CLI/Onboarding: fix Anthropic-compatible custom provider verification by normalizing base URLs to avoid duplicate `/v1` paths during setup checks. (#21336) Thanks @17jmumford.
 - Security/Dependencies: bump transitive `hono` usage to `4.11.10` to incorporate timing-safe authentication comparison hardening for `basicAuth`/`bearerAuth` (`GHSA-gq3j-xvxp-8hrf`). Thanks @vincentkoc.
+- Security/Gateway: parse `X-Forwarded-For` with trust-preserving semantics when requests come from configured trusted proxies, preventing proxy-chain spoofing from influencing client IP classification and rate-limit identity. Thanks @AnthonyDiSanti and @vincentkoc.
 - iOS/Gateway/Tools: prefer uniquely connected node matches when duplicate display names exist, surface actionable `nodes invoke` pairing-required guidance with request IDs, and refresh active iOS gateway registration after location-capability setting changes so capability updates apply immediately. (#22120) thanks @mbelinky.
 
 ## 2026.2.19

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -145,10 +145,19 @@ describe("resolveGatewayClientIp", () => {
   it("returns forwarded client IP when the remote is a trusted proxy", () => {
     const ip = resolveGatewayClientIp({
       remoteAddr: "127.0.0.1",
-      forwardedFor: "10.0.0.2, 127.0.0.1",
+      forwardedFor: "127.0.0.1, 10.0.0.2",
       trustedProxies: ["127.0.0.1"],
     });
     expect(ip).toBe("10.0.0.2");
+  });
+
+  it("does not trust the left-most X-Forwarded-For value when behind a trusted proxy", () => {
+    const ip = resolveGatewayClientIp({
+      remoteAddr: "127.0.0.1",
+      forwardedFor: "198.51.100.99, 10.0.0.9, 127.0.0.1",
+      trustedProxies: ["127.0.0.1"],
+    });
+    expect(ip).toBe("127.0.0.1");
   });
 
   it("fails closed when trusted proxy headers are missing", () => {

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -147,7 +147,11 @@ function stripOptionalPort(ip: string): string {
 }
 
 export function parseForwardedForClientIp(forwardedFor?: string): string | undefined {
-  const raw = forwardedFor?.split(",")[0]?.trim();
+  const entries = forwardedFor
+    ?.split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  const raw = entries?.at(-1);
   if (!raw) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- Harden trusted-proxy client IP resolution by using trust-preserving `X-Forwarded-For` parsing semantics.
- Update behavior so remote-trusted proxy requests rely on the last forwarded-hop IP instead of the first.
- Add regression coverage in `src/gateway/net.test.ts` to prevent future spoofing regressions.

## Changelog
- Added a changelog entry in `CHANGELOG.md` under Unreleased Fixes with contributor credits.

## Testing
- `pnpm vitest run src/gateway/net.test.ts` (passed)

## Notes
- This change does not include the internal advisory identifier in the PR body.
- AI-assisted: yes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens `X-Forwarded-For` parsing for trusted proxy configurations by switching from leftmost (first) to rightmost (last) entry extraction, preventing client-controlled header spoofing from bypassing IP-based security controls.

**Changes:**
- Modified `parseForwardedForClientIp` in `src/gateway/net.ts` to parse the last entry instead of the first, filtering empty entries
- Updated existing test case to match new rightmost semantics
- Added regression test for multi-hop spoofing scenario
- Added CHANGELOG entry under Security/Gateway fixes

**Key security improvement:**
The previous implementation trusted the leftmost IP (first in chain), which an attacker could control by sending `X-Forwarded-For: <spoofed-ip>` headers. The new implementation trusts the rightmost IP (last in chain), which represents the IP that the trusted proxy observed when it appended to the header - preventing attackers from influencing client IP classification used for rate limiting and local client detection.

**Note:** Documentation at `docs/gateway/security/index.md:162` recommends proxy OVERWRITE semantics, but this implementation assumes APPEND semantics. The code works correctly for both models since taking the last entry yields the correct client IP in either case, but the documentation should be updated to reflect that APPEND is the supported/expected model.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor documentation clarification needed
- The security fix correctly implements trust-preserving X-Forwarded-For parsing by trusting the rightmost entry (what the trusted proxy saw) instead of the leftmost entry (attacker-controlled). The implementation includes regression tests and properly handles edge cases like empty entries. Score is 4 (not 5) due to: 1) potential test expectation issue that needs verification (see comment on net.test.ts:154-161), and 2) documentation mismatch between code (APPEND semantics) and docs (OVERWRITE recommendation) that should be clarified to prevent misconfiguration.
- Verify test expectations in `src/gateway/net.test.ts:154-161` and align documentation in `docs/gateway/security/index.md` with APPEND semantics

<sub>Last reviewed commit: 13c2c40</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->