### PR TITLE
feat(hooks): add channel:connected hook event

### DIFF
--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -9,7 +9,21 @@ import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message" | "channel";
+
+export type ChannelConnectedHookContext = {
+  /** Channel identifier (e.g., "whatsapp", "telegram", "discord") */
+  channel: string;
+  /** Account identifier within the channel */
+  accountId: string;
+};
+
+export type ChannelConnectedHookEvent = InternalHookEvent & {
+  type: "channel";
+  action: "connected";
+  context: ChannelConnectedHookContext;
+};
+
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -281,4 +295,17 @@ export function isMessageSentEvent(event: InternalHookEvent): event is MessageSe
     typeof context.channelId === "string" &&
     typeof context.success === "boolean"
   );
+}
+
+export function isChannelConnectedEvent(
+  event: InternalHookEvent,
+): event is ChannelConnectedHookEvent {
+  if (event.type !== "channel" || event.action !== "connected") {
+    return false;
+  }
+  const context = event.context as Partial<ChannelConnectedHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.channel === "string" && typeof context.accountId === "string";
 }

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -9,7 +9,13 @@ import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message" | "channel";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "channel";
 
 export type ChannelConnectedHookContext = {
   channel: string;

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -12,9 +12,7 @@ import type { OpenClawConfig } from "../config/config.js";
 export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message" | "channel";
 
 export type ChannelConnectedHookContext = {
-  /** Channel identifier (e.g., "whatsapp", "telegram", "discord") */
   channel: string;
-  /** Account identifier within the channel */
   accountId: string;
 };
 
@@ -23,7 +21,6 @@ export type ChannelConnectedHookEvent = InternalHookEvent & {
   action: "connected";
   context: ChannelConnectedHookContext;
 };
-
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;


### PR DESCRIPTION
## Summary

Adds a `channel:connected` hook event that fires when a WhatsApp channel successfully connects.

This enables custom automation on reconnect — for example, sending a "bot is back online" notification to the user.

## Changes

- `src/hooks/internal-hooks.ts`: Add `ChannelConnectedHookContext`, `ChannelConnectedHookEvent` types and `isChannelConnectedEvent` guard
- `src/web/auto-reply/monitor.ts`: Fire `channel:connected` hook on successful WhatsApp connect

## Usage

```ts
// In a hook handler:
if (isChannelConnectedEvent(event)) {
  // event.context.channel === "whatsapp"
  // event.context.accountId === the account that connected
  await sendMessage({ message: "Bot reconnected! 🤖" });
}
```

Fixes the motivation from #7405 — allows agents to react to channel reconnects proactively.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `channel:connected` hook event that fires when a WhatsApp channel successfully connects, enabling custom automation on reconnect (e.g., sending "bot is back online" notifications).

- Added type definitions for `ChannelConnectedHookContext` and `ChannelConnectedHookEvent` with proper JSDoc documentation
- Implemented `isChannelConnectedEvent` guard function following existing validation patterns
- Integrated hook trigger in `monitor.ts` after successful WhatsApp connection, consistent with other event patterns
- All types are properly exported and match the documented API in the PR description

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns precisely, adds well-documented types, and integrates cleanly at the appropriate location. The changes are focused, non-breaking, and purely additive.
- No files require special attention

<sub>Last reviewed commit: cc9db95</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->