### PR TITLE
feat(telegram): support sending original quality images

### DIFF
--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -1,3 +1,4 @@
+import { resolveTelegramAccount } from "openclaw/plugin-sdk";
 import type { TelegramInlineButtons } from "../../../telegram/button-types.js";
 import { markdownToTelegramHtmlChunks } from "../../../telegram/format.js";
 import {
@@ -34,10 +35,19 @@ export const telegramOutbound: ChannelOutboundAdapter = {
     deps,
     replyToId,
     threadId,
+    cfg,
   }) => {
     const send = deps?.sendTelegram ?? sendMessageTelegram;
     const replyToMessageId = parseTelegramReplyToMessageId(replyToId);
     const messageThreadId = parseTelegramThreadId(threadId);
+
+    // Get mediaOptimize config - if false, send as file to preserve quality
+    let asFile = false;
+    if (cfg && accountId) {
+      const resolved = resolveTelegramAccount({ cfg, accountId: accountId ?? undefined });
+      asFile = resolved.config.mediaOptimize === false;
+    }
+
     const result = await send(to, text, {
       verbose: false,
       mediaUrl,
@@ -46,10 +56,20 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       replyToMessageId,
       accountId: accountId ?? undefined,
       mediaLocalRoots,
+      asFile,
     });
     return { channel: "telegram", ...result };
   },
-  sendPayload: async ({ to, payload, mediaLocalRoots, accountId, deps, replyToId, threadId }) => {
+  sendPayload: async ({
+    to,
+    payload,
+    mediaLocalRoots,
+    accountId,
+    deps,
+    replyToId,
+    threadId,
+    cfg,
+  }) => {
     const send = deps?.sendTelegram ?? sendMessageTelegram;
     const replyToMessageId = parseTelegramReplyToMessageId(replyToId);
     const messageThreadId = parseTelegramThreadId(threadId);
@@ -64,6 +84,14 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       : payload.mediaUrl
         ? [payload.mediaUrl]
         : [];
+
+    // Get mediaOptimize config - if false, send as file to preserve quality
+    let asFile = false;
+    if (cfg && accountId) {
+      const resolved = resolveTelegramAccount({ cfg, accountId: accountId ?? undefined });
+      asFile = resolved.config.mediaOptimize === false;
+    }
+
     const baseOpts = {
       verbose: false,
       textMode: "html" as const,
@@ -72,6 +100,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       quoteText,
       accountId: accountId ?? undefined,
       mediaLocalRoots,
+      asFile,
     };
 
     if (mediaUrls.length === 0) {

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -1,4 +1,4 @@
-import { resolveTelegramAccount } from "openclaw/plugin-sdk";
+import { resolveTelegramAccount } from "../../../telegram/accounts.js";
 import type { TelegramInlineButtons } from "../../../telegram/button-types.js";
 import { markdownToTelegramHtmlChunks } from "../../../telegram/format.js";
 import {

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -104,6 +104,8 @@ export type TelegramAccountConfig = {
   /** Telegram stream preview mode (off|partial|block). Default: partial. */
   streamMode?: "off" | "partial" | "block";
   mediaMaxMb?: number;
+  /** Disable image compression when sending to preserve original quality. Defaults to false (compress). */
+  mediaOptimize?: boolean;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;
   /** Retry policy for outbound Telegram API calls. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -127,6 +127,8 @@ export const TelegramAccountSchemaBase = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     streamMode: z.enum(["off", "partial", "block"]).optional().default("partial"),
     mediaMaxMb: z.number().positive().optional(),
+    /** Disable image compression when sending to preserve original quality. Defaults to false (compress). */
+    mediaOptimize: z.boolean().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,
     network: z

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -50,6 +50,8 @@ type TelegramSendOpts = {
   asVoice?: boolean;
   /** Send video as video note (voice bubble) instead of regular video. Defaults to false. */
   asVideoNote?: boolean;
+  /** Send media as file (document) instead of media type to preserve original quality. Defaults to false. */
+  asFile?: boolean;
   /** Send message silently (no notification). Defaults to false. */
   silent?: boolean;
   /** Message ID to reply to (for threading) */
@@ -587,6 +589,18 @@ export async function sendMessageTelegram(
         };
       }
       if (kind === "image") {
+        // Use sendDocument to preserve original quality when asFile is true
+        if (opts.asFile === true) {
+          return {
+            label: "document",
+            sender: (effectiveParams: Record<string, unknown> | undefined) =>
+              api.sendDocument(
+                chatId,
+                file,
+                effectiveParams as Parameters<typeof api.sendDocument>[2],
+              ) as Promise<TelegramMessageLike>,
+          };
+        }
         return {
           label: "photo",
           sender: (effectiveParams: Record<string, unknown> | undefined) =>


### PR DESCRIPTION
Add mediaOptimize config option to Telegram channel. When mediaOptimize is set to false, images are sent as documents instead of compressed photos to preserve original quality.

- Add asFile option to TelegramSendOpts
- Update image sending logic to use sendDocument when asFile is true
- Add mediaOptimize option to TelegramAccountSchemaBase
- Update outbound adapter to read config and pass asFile flag

Closes #22014

## Summary
- Problem: Images sent via Telegram are compressed to 800px + quality 40, resulting in significant quality loss
- Why it matters: Users need to send high-quality images (posters, designs) but cannot preserve original quality
- What changed: Added mediaOptimize config option - when set to false, images are sent as Documents (no compression)
- What did NOT change: Default behavior remains the same (compression enabled by default)

## Change Type (select all)
- [x] Feature

## Scope (select all touched areas)
- [x] Integrations

## Linked Issue/PR
- Closes #22014

## User-visible / Behavior Changes
- New config option: `channels.telegram.mediaOptimize`
- When set to `false`, images are sent as Documents (files) to preserve original quality

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification (required)
- Verified scenarios: Code implemented and pushed to fork
- Edge cases checked: Default behavior unchanged (mediaOptimize defaults to true)
- What you did NOT verify: Actual runtime testing

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? Yes (new optional config option)
- Migration needed? No

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `mediaOptimize` config option to the Telegram channel that, when set to `false`, sends images as documents (via `sendDocument`) instead of compressed photos (via `sendPhoto`), preserving original quality. The implementation touches the Zod schema, the outbound adapter (both `sendMedia` and `sendPayload` paths), and the send function's media routing logic.

- The Zod schema in `TelegramAccountSchemaBase` was updated, but the corresponding manual TypeScript type `TelegramAccountConfig` in `src/config/types.telegram.ts` was **not updated** — this will cause a TypeScript compilation error when accessing `resolved.config.mediaOptimize`.
- The import of `resolveTelegramAccount` in the outbound adapter uses `"openclaw/plugin-sdk"` instead of a relative import, which is inconsistent with all other core `src/` files.
- The `asFile` handling in `send.ts` is clean and correctly scoped to the `kind === "image"` branch only.

<h3>Confidence Score: 2/5</h3>

- This PR will likely fail TypeScript compilation due to a missing type update, blocking mergeability.
- The core feature logic is sound, but the `TelegramAccountConfig` type in `src/config/types.telegram.ts` was not updated to include `mediaOptimize`, which means `resolved.config.mediaOptimize` will be a type error. This is a build-blocking issue. The import convention issue is minor but worth fixing.
- Pay close attention to `src/config/types.telegram.ts` (missing type update) and `src/channels/plugins/outbound/telegram.ts` (import convention).

<sub>Last reviewed commit: f501418</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->