### PR TITLE
fix(slack): prevent duplicate final replies from draft previews

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2992,6 +2992,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
     public let publickey: String
     public let displayname: String?
     public let platform: String?
+    public let devicefamily: String?
     public let clientid: String?
     public let clientmode: String?
     public let role: String?
@@ -3008,6 +3009,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         publickey: String,
         displayname: String?,
         platform: String?,
+        devicefamily: String?,
         clientid: String?,
         clientmode: String?,
         role: String?,
@@ -3023,6 +3025,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         self.publickey = publickey
         self.displayname = displayname
         self.platform = platform
+        self.devicefamily = devicefamily
         self.clientid = clientid
         self.clientmode = clientmode
         self.role = role
@@ -3040,6 +3043,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         case publickey = "publicKey"
         case displayname = "displayName"
         case platform
+        case devicefamily = "deviceFamily"
         case clientid = "clientId"
         case clientmode = "clientMode"
         case role

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2992,6 +2992,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
     public let publickey: String
     public let displayname: String?
     public let platform: String?
+    public let devicefamily: String?
     public let clientid: String?
     public let clientmode: String?
     public let role: String?
@@ -3008,6 +3009,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         publickey: String,
         displayname: String?,
         platform: String?,
+        devicefamily: String?,
         clientid: String?,
         clientmode: String?,
         role: String?,
@@ -3023,6 +3025,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         self.publickey = publickey
         self.displayname = displayname
         self.platform = platform
+        self.devicefamily = devicefamily
         self.clientid = clientid
         self.clientmode = clientmode
         self.role = role
@@ -3040,6 +3043,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         case publickey = "publicKey"
         case displayname = "displayName"
         case platform
+        case devicefamily = "deviceFamily"
         case clientid = "clientId"
         case clientmode = "clientMode"
         case role

--- a/src/slack/monitor/message-handler/dispatch.test.ts
+++ b/src/slack/monitor/message-handler/dispatch.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { dispatchPreparedSlackMessage } from "./dispatch.js";
+
+const testState = vi.hoisted(() => ({
+  deliver: null as null | ((payload: Record<string, unknown>) => Promise<void>),
+  finalPayload: { text: "Final response text" } as Record<string, unknown>,
+  draft: null as null | {
+    flush: ReturnType<typeof vi.fn>;
+    clear: ReturnType<typeof vi.fn>;
+  },
+}));
+
+const chatUpdateMock = vi.hoisted(() => vi.fn(async () => ({ ok: true })));
+const dispatchInboundMessageMock = vi.hoisted(() =>
+  vi.fn(
+    async (params: {
+      replyOptions?: {
+        onPartialReply?: (payload: { text?: string }) => Promise<void> | void;
+      };
+    }) => {
+      await params.replyOptions?.onPartialReply?.({ text: "Partial draft text" });
+      if (!testState.deliver) {
+        throw new Error("missing deliver callback");
+      }
+      await testState.deliver(testState.finalPayload);
+      return { queuedFinal: false, counts: { final: 1, block: 0, tool: 0 } };
+    },
+  ),
+);
+const deliverRepliesMock = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("../../../agents/identity.js", () => ({
+  resolveHumanDelayConfig: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../auto-reply/dispatch.js", () => ({
+  dispatchInboundMessage: dispatchInboundMessageMock,
+}));
+
+vi.mock("../../../auto-reply/reply/history.js", () => ({
+  clearHistoryEntriesIfEnabled: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../auto-reply/reply/reply-dispatcher.js", () => ({
+  createReplyDispatcherWithTyping: vi.fn((params: { deliver: typeof testState.deliver }) => {
+    testState.deliver = params.deliver;
+    return { dispatcher: {}, replyOptions: {}, markDispatchIdle: vi.fn() };
+  }),
+}));
+
+vi.mock("../../../channels/ack-reactions.js", () => ({
+  removeAckReactionAfterReply: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../channels/logging.js", () => ({
+  logAckFailure: vi.fn(() => undefined),
+  logTypingFailure: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../channels/reply-prefix.js", () => ({
+  createReplyPrefixOptions: vi.fn(() => ({ onModelSelected: undefined })),
+}));
+
+vi.mock("../../../channels/typing.js", () => ({
+  createTypingCallbacks: vi.fn(() => ({
+    onReplyStart: vi.fn(),
+    onIdle: vi.fn(),
+  })),
+}));
+
+vi.mock("../../../config/sessions.js", () => ({
+  resolveStorePath: vi.fn(() => "/tmp/sessions.json"),
+  updateLastRoute: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../../globals.js", () => ({
+  danger: (message: string) => message,
+  logVerbose: vi.fn(() => undefined),
+  shouldLogVerbose: vi.fn(() => false),
+}));
+
+vi.mock("../../actions.js", () => ({
+  removeSlackReaction: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../draft-stream.js", () => ({
+  createSlackDraftStream: vi.fn((params: { onMessageSent?: () => void }) => {
+    let pendingText = "";
+    let channelId: string | undefined;
+    let messageId: string | undefined;
+    const stream = {
+      update: vi.fn((text: string) => {
+        pendingText = text;
+      }),
+      flush: vi.fn(async () => {
+        if (pendingText && !messageId) {
+          channelId = "C-preview";
+          messageId = "200.300";
+          params.onMessageSent?.();
+        }
+        pendingText = "";
+      }),
+      clear: vi.fn(async () => {
+        pendingText = "";
+        channelId = undefined;
+        messageId = undefined;
+      }),
+      stop: vi.fn(() => undefined),
+      forceNewMessage: vi.fn(() => {
+        pendingText = "";
+        channelId = undefined;
+        messageId = undefined;
+      }),
+      messageId: vi.fn(() => messageId),
+      channelId: vi.fn(() => channelId),
+    };
+    testState.draft = stream;
+    return stream;
+  }),
+}));
+
+vi.mock("../../stream-mode.js", () => ({
+  applyAppendOnlyStreamUpdate: vi.fn((params: { incoming: string }) => ({
+    rendered: params.incoming,
+    source: params.incoming,
+    changed: true,
+  })),
+  buildStatusFinalPreviewText: vi.fn(() => "Status: thinking..."),
+  resolveSlackStreamingConfig: vi.fn(() => ({
+    mode: "partial",
+    nativeStreaming: false,
+    draftMode: "replace",
+  })),
+  resolveSlackStreamMode: vi.fn(() => "replace"),
+}));
+
+vi.mock("../../streaming.js", () => ({
+  appendSlackStream: vi.fn(async () => undefined),
+  startSlackStream: vi.fn(async () => ({ stopped: false, threadTs: "100.200" })),
+  stopSlackStream: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../threading.js", () => ({
+  resolveSlackThreadTargets: vi.fn(() => ({ statusThreadTs: undefined })),
+}));
+
+vi.mock("../replies.js", () => ({
+  createSlackReplyDeliveryPlan: vi.fn(() => ({
+    nextThreadTs: vi.fn(() => "100.200"),
+    markSent: vi.fn(() => undefined),
+  })),
+  deliverReplies: deliverRepliesMock,
+  resolveSlackThreadTs: vi.fn(() => "100.200"),
+}));
+
+function createPrepared() {
+  return {
+    ctx: {
+      cfg: {},
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      },
+      replyToMode: "all",
+      setSlackThreadStatus: vi.fn(async () => undefined),
+      textLimit: 4000,
+      botToken: "xoxb-test",
+      app: {
+        client: {
+          chat: {
+            update: chatUpdateMock,
+          },
+        },
+      },
+      teamId: "T1",
+      channelHistories: new Map(),
+      historyLimit: 20,
+      removeAckAfterReply: false,
+    },
+    account: {
+      accountId: "aiden",
+      config: {
+        streaming: false,
+        streamMode: "replace",
+      },
+    },
+    message: {
+      channel: "C1",
+      user: "U1",
+      ts: "100.200",
+      event_ts: "100.200",
+    },
+    route: {
+      agentId: "main",
+      mainSessionKey: "agent:main:main",
+      accountId: "aiden",
+    },
+    channelConfig: null,
+    replyTarget: "channel:C1",
+    ctxPayload: {},
+    isDirectMessage: false,
+    isRoomish: false,
+    historyKey: "C1",
+    preview: "hello",
+    ackReactionValue: "eyes",
+    ackReactionPromise: null,
+  } as never;
+}
+
+describe("dispatchPreparedSlackMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.deliver = null;
+    testState.finalPayload = { text: "Final response text" };
+    testState.draft = null;
+  });
+
+  it("flushes pending draft before final send and edits preview instead of posting duplicate text", async () => {
+    await dispatchPreparedSlackMessage(createPrepared());
+
+    expect(testState.draft?.flush).toHaveBeenCalled();
+    expect(chatUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C-preview",
+        ts: "200.300",
+        text: "Final response text",
+      }),
+    );
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it("clears stale preview before fallback send when final payload cannot edit preview", async () => {
+    testState.finalPayload = { text: "Something failed", isError: true };
+
+    await dispatchPreparedSlackMessage(createPrepared());
+
+    expect(chatUpdateMock).not.toHaveBeenCalled();
+    expect(testState.draft?.clear).toHaveBeenCalledTimes(1);
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -250,6 +250,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         return;
       }
 
+      // Drain pending preview updates before deciding final delivery strategy.
+      // Without this, a delayed draft flush can post after final delivery and duplicate replies.
+      await draftStream.flush();
       const mediaCount = payload.mediaUrls?.length ?? (payload.mediaUrl ? 1 : 0);
       const draftMessageId = draftStream?.messageId();
       const draftChannelId = draftStream?.channelId();
@@ -297,6 +300,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       } else if (mediaCount > 0) {
         await draftStream?.clear();
         hasStreamedMessage = false;
+      } else if (streamMode !== "status_final" && draftChannelId && draftMessageId) {
+        // If we cannot finalize by editing the preview (e.g. error payload), clear it before
+        // fallback send so users do not see stale draft text plus a second final message.
+        await draftStream?.clear();
+        hasStreamedMessage = false;
+        appendRenderedText = "";
+        appendSourceText = "";
+        statusUpdateCount = 0;
       }
 
       await deliverNormally(payload);

--- a/src/slack/monitor/types.ts
+++ b/src/slack/monitor/types.ts
@@ -66,7 +66,7 @@ export type SlackMessageChangedEvent = {
   type: "message";
   subtype: "message_changed";
   channel?: string;
-  message?: { ts?: string; user?: string; bot_id?: string };
+  message?: { ts?: string; user?: string; bot_id?: string; edited?: { user?: string } };
   previous_message?: { ts?: string; user?: string; bot_id?: string };
   event_ts?: string;
 };


### PR DESCRIPTION
## Summary

- Problem: Slack replies could show duplicate/stale first output when a pending draft preview flush happened after final delivery.
- Why it matters: users see confusing double responses and noisy system events while interacting in Slack.
- What changed: final delivery now flushes pending draft state first, clears stale preview before fallback send when preview-edit is not possible, and filters bot-authored `message_changed` events.
- What did NOT change (scope boundary): no Block Kit feature expansion, no routing contract changes, no non-Slack channel behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #22254
- Related #18555

## User-visible / Behavior Changes

- Slack: prevents draft preview + final reply duplication in the final send path.
- Slack: avoids stale draft preview text persisting when final payload cannot use preview-edit finalization.
- Slack: suppresses bot self-edit `message_changed` notifications that were surfacing as noisy system events.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A (channel pipeline behavior)
- Integration/channel (if any): Slack monitor + reply dispatch
- Relevant config (redacted): Slack account with streaming preview path enabled

### Steps

1. Trigger a Slack request that emits partial draft text before final output.
2. Let the final payload resolve through `dispatchPreparedSlackMessage`.
3. Observe message timeline and system events.

### Expected

- One coherent final user-facing response.
- No stale draft preview left behind on fallback paths.
- No bot self-edit message_changed system-event noise.

### Actual

- Implemented behavior now matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm build` passes.
  - `pnpm check` passes.
  - `pnpm vitest run src/slack/monitor/events/messages.test.ts src/slack/monitor/message-handler/dispatch.test.ts` passes (4 tests).
- Edge cases checked:
  - Final preview edit path after pending draft flush.
  - Fallback send path when final payload cannot use preview edit.
  - Bot-authored edit event suppression via `message.user`, `previous_message.user`, and `message.edited.user`.
- What you did **not** verify:
  - End-to-end Slack socket/manual click-through in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `7c93bf12a`.
- Files/config to restore:
  - `src/slack/monitor/message-handler/dispatch.ts`
  - `src/slack/monitor/events/messages.ts`
  - `src/slack/monitor/types.ts`
- Known bad symptoms reviewers should watch for:
  - Reappearance of duplicate first responses or bot self-edit notification spam.

## Risks and Mitigations

- Risk: filtering `message_changed` could suppress legitimate bot-originated edits a maintainer wants surfaced.
  - Mitigation: filtering is limited to self-authored bot edits and still allows non-bot edits through.
- Risk: clearing preview on fallback could remove useful interim text in rare error flows.
  - Mitigation: clear is only applied when preview-edit finalization is unavailable, preventing stale + duplicate output.

## AI Assistance

- AI-assisted: yes (Codex).
- Testing level: lightly tested locally (`build`, `check`, focused Slack regression tests) with known unrelated baseline failures in full `pnpm test`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition in the Slack message dispatch pipeline where draft preview messages could appear alongside or after final responses, causing duplicate content and confusing bot self-edit notifications.

**Key changes:**
- Added `await draftStream.flush()` before final delivery strategy decision in `dispatch.ts:233` to drain pending preview updates and prevent race conditions
- Implemented `isSelfAuthoredSlackMessageChange()` filter in `messages.ts:14-32` to suppress bot-authored `message_changed` system events by checking `message.user`, `previous_message.user`, and `message.edited.user`
- Added fallback clear logic in `dispatch.ts:280-288` to remove stale draft previews when final payload cannot use preview-edit finalization (e.g., error payloads)
- Enhanced `SlackMessageChangedEvent` type definition to include user fields needed for self-authorship detection

**Implementation approach:**
The fix addresses the duplication at two points in the pipeline: (1) preventing the draft flush from racing with final delivery by explicitly draining it first, and (2) clearing stale preview text before fallback sends when the final payload characteristics (error flag, media presence) prevent editing the preview message in place.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it fixes a clear race condition with well-tested changes
- The implementation correctly addresses the stated problem through explicit synchronization (`flush()` before decision points) and proper cleanup (`clear()` for stale drafts). The logic is straightforward with defensive checks. Tests cover both the happy path (preview-edit finalization) and error path (fallback with clear). Minor deduction because end-to-end manual Slack verification was not performed, and the self-authorship check relies on optional fields that could theoretically all be missing in edge cases.
- No files require special attention - the changes are focused and well-tested

<sub>Last reviewed commit: 7c93bf1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->