### PR TITLE
fix: force store for openai-responses providers

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -136,10 +136,7 @@ function shouldForceResponsesStore(model: {
   if (!OPENAI_RESPONSES_APIS.has(model.api)) {
     return false;
   }
-  if (!OPENAI_RESPONSES_PROVIDERS.has(model.provider)) {
-    return false;
-  }
-  return isDirectOpenAIBaseUrl(model.baseUrl);
+  return true;
 }
 
 function createOpenAIResponsesStoreWrapper(baseStreamFn: StreamFn | undefined): StreamFn {


### PR DESCRIPTION
Fixes #21782

## Summary
- Force `store: true` for all `openai-responses` providers, not just direct OpenAI hosts.
- Prevents `previous_response_id` failures on Azure/OpenAI-compatible endpoints when `store` defaults to false.

## Notes
- Responses API multi-turn requires persisted items; Azure returns 400 when `store` is false.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Simplifies `shouldForceResponsesStore` to force `store=true` for all `openai-responses` API providers, removing the previous restriction to direct OpenAI hosts. This prevents 400 errors on Azure and OpenAI-compatible endpoints that require persisted items for multi-turn conversations.

- The existing test at `src/agents/pi-embedded-runner-extraparams.e2e.test.ts:267-279` expects `store=false` for proxy URLs and will need to be updated
- Comment on line 13 should be updated to reflect the new behavior (no longer limited to "direct" OpenAI)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after updating the test and comment
- The logic change is straightforward and addresses a real bug with Azure/compatible endpoints. However, there's a test that will break and a comment that needs updating, which are easy fixes but should be addressed before merging.
- Check that the existing test at `src/agents/pi-embedded-runner-extraparams.e2e.test.ts:267-279` is updated to match the new behavior

<sub>Last reviewed commit: f3e1ad3</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->