### PR TITLE
Security: disable sandbox container --no-sandbox by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 - Security/Dependencies: bump transitive `hono` usage to `4.11.10` to incorporate timing-safe authentication comparison hardening for `basicAuth`/`bearerAuth` (`GHSA-gq3j-xvxp-8hrf`). Thanks @vincentkoc.
 - Security/Gateway: parse `X-Forwarded-For` with trust-preserving semantics when requests come from configured trusted proxies, preventing proxy-chain spoofing from influencing client IP classification and rate-limit identity. Thanks @AnthonyDiSanti and @vincentkoc.
 - iOS/Gateway/Tools: prefer uniquely connected node matches when duplicate display names exist, surface actionable `nodes invoke` pairing-required guidance with request IDs, and refresh active iOS gateway registration after location-capability setting changes so capability updates apply immediately. (#22120) thanks @mbelinky.
+- Security/Sandbox: remove default `--no-sandbox` for the browser container entrypoint, add explicit opt-in via `OPENCLAW_BROWSER_NO_SANDBOX` / `CLAWDBOT_BROWSER_NO_SANDBOX`, and harden the default container security posture (`GHSA-43x4-g22p-3hrq`). Thanks @TerminalsandCoffee and @vincentkoc.
 
 ## 2026.2.19
 

--- a/scripts/sandbox-browser-entrypoint.sh
+++ b/scripts/sandbox-browser-entrypoint.sh
@@ -11,6 +11,7 @@ VNC_PORT="${OPENCLAW_BROWSER_VNC_PORT:-${CLAWDBOT_BROWSER_VNC_PORT:-5900}}"
 NOVNC_PORT="${OPENCLAW_BROWSER_NOVNC_PORT:-${CLAWDBOT_BROWSER_NOVNC_PORT:-6080}}"
 ENABLE_NOVNC="${OPENCLAW_BROWSER_ENABLE_NOVNC:-${CLAWDBOT_BROWSER_ENABLE_NOVNC:-1}}"
 HEADLESS="${OPENCLAW_BROWSER_HEADLESS:-${CLAWDBOT_BROWSER_HEADLESS:-0}}"
+ALLOW_NO_SANDBOX="${OPENCLAW_BROWSER_NO_SANDBOX:-${CLAWDBOT_BROWSER_NO_SANDBOX:-0}}"
 
 mkdir -p "${HOME}" "${HOME}/.chrome" "${XDG_CONFIG_HOME}" "${XDG_CACHE_HOME}"
 
@@ -43,8 +44,14 @@ CHROME_ARGS+=(
   "--disable-breakpad"
   "--disable-crash-reporter"
   "--metrics-recording-only"
-  "--no-sandbox"
 )
+
+if [[ "${ALLOW_NO_SANDBOX}" == "1" ]]; then
+  CHROME_ARGS+=(
+    "--no-sandbox"
+    "--disable-setuid-sandbox"
+  )
+fi
 
 chromium "${CHROME_ARGS[@]}" about:blank &
 


### PR DESCRIPTION
## Summary

- Remove hard-coded `--no-sandbox` from `scripts/sandbox-browser-entrypoint.sh` so Chromium in the sandbox browser container runs with OS sandboxing enabled by default.
- Add explicit opt-in via `OPENCLAW_BROWSER_NO_SANDBOX` / `CLAWDBOT_BROWSER_NO_SANDBOX` env flags when unsupported environments still need `--no-sandbox`.
- Update changelog with reference and contributor credits (`@TerminalsandCoffee`, `@vincentkoc`).

## Change Type (select all)
- [x] Bug fix
- [x] Security hardening
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: n/a

## Verification

- Confirmed `scripts/sandbox-browser-entrypoint.sh` no longer adds `--no-sandbox` unconditionally.
- Added `--no-sandbox` only when opt-in env var is set to `1`.

## Human Verification

- Manually inspected updated startup script and changelog entry.
- Not run container runtime validation in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes (`OPENCLAW_BROWSER_NO_SANDBOX` / `CLAWDBOT_BROWSER_NO_SANDBOX` are additive)
- Migration needed? No

## AI-assisted

- AI-assisted: Yes. (Code edit + changelog update + PR assembly)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes hard-coded `--no-sandbox` flag from Chromium in the sandbox browser container, improving default security posture by enabling OS-level sandboxing. Adds opt-in environment variables (`OPENCLAW_BROWSER_NO_SANDBOX` / `CLAWDBOT_BROWSER_NO_SANDBOX`) for environments where sandboxing is unsupported. 

- Changed `scripts/sandbox-browser-entrypoint.sh` to conditionally add `--no-sandbox` and `--disable-setuid-sandbox` only when `ALLOW_NO_SANDBOX=1`
- Updated `CHANGELOG.md` with security entry crediting `@TerminalsandCoffee` and `@vincentkoc` for GHSA-43x4-g22p-3hrq
- Default behavior now enables Chromium's security sandbox, reducing attack surface for container escapes
- Backward compatible via environment variable opt-in for legacy environments

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it hardens security defaults while maintaining backward compatibility.
- The change is straightforward, well-scoped, and improves security by removing an insecure default. The implementation correctly uses environment variable fallbacks with safe defaults (0 = sandbox enabled). The changelog entry is properly formatted and credits contributors appropriately.
- No files require special attention

<sub>Last reviewed commit: e7437fc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->