### PR TITLE
TUI: only strip leading inbound metadata

### DIFF
--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -87,3 +87,49 @@ export function stripInboundMetadata(text: string): string {
 
   return result.join("\n").replace(/^\n+/, "");
 }
+
+export function stripLeadingInboundMetadata(text: string): string {
+  if (!text || !SENTINEL_FAST_RE.test(text)) {
+    return text;
+  }
+
+  const lines = text.split("\n");
+  let index = 0;
+
+  while (index < lines.length && lines[index] === "") {
+    index++;
+  }
+  if (index >= lines.length) {
+    return "";
+  }
+
+  if (!INBOUND_META_SENTINELS.some((s) => lines[index].startsWith(s))) {
+    return text;
+  }
+
+  while (index < lines.length) {
+    const line = lines[index];
+    if (!INBOUND_META_SENTINELS.some((s) => line.startsWith(s))) {
+      break;
+    }
+
+    index++;
+    if (index < lines.length && lines[index].trim() === "```json") {
+      index++;
+      while (index < lines.length && lines[index].trim() !== "```") {
+        index++;
+      }
+      if (index < lines.length && lines[index].trim() === "```") {
+        index++;
+      }
+    } else {
+      return text;
+    }
+
+    while (index < lines.length && lines[index].trim() === "") {
+      index++;
+    }
+  }
+
+  return lines.slice(index).join("\n");
+}

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -1,5 +1,5 @@
 import { formatRawAssistantErrorForUi } from "../agents/pi-embedded-helpers.js";
-import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import { stripLeadingInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { stripAnsi } from "../terminal/ansi.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
@@ -275,7 +275,7 @@ export function extractTextFromMessage(
   const text = extractTextBlocks(record.content, opts);
   if (text) {
     if (record.role === "user") {
-      return stripInboundMetadata(text);
+      return stripLeadingInboundMetadata(text);
     }
     return text;
   }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -1,5 +1,4 @@
 import type { TUI } from "@mariozechner/pi-tui";
-import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import {
   normalizeAgentId,
@@ -327,7 +326,7 @@ export function createSessionActions(context: SessionActionContext) {
         if (message.role === "user") {
           const text = extractTextFromMessage(message);
           if (text) {
-            chatLog.addUser(stripInboundMetadata(text));
+            chatLog.addUser(text);
           }
           continue;
         }


### PR DESCRIPTION
## Summary
- Strip inbound user metadata only when it appears as a leading prefix block sequence.
- Keep metadata-like blocks in non-leading positions untouched in user message body.
- Update TUI formatter path to use leading-only stripping and remove redundant stripping in session actions.

## Testing
- pnpm test src/tui/tui-formatters.test.ts
- pnpm test src/auto-reply/reply/strip-inbound-meta.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines metadata stripping to only remove leading metadata blocks, preserving metadata-like content elsewhere in user messages.

- Adds `stripLeadingInboundMetadata()` function that only strips metadata blocks appearing as a leading prefix sequence
- Updates `tui-formatters.ts` to use the new leading-only stripper instead of the global stripper
- Removes redundant stripping call in `tui-session-actions.ts` since `extractTextFromMessage()` now handles it internally
- The new logic is defensive: if a sentinel is not followed by the expected json fence structure, it assumes the content is legitimate user text and preserves it
- Correctly handles multiple consecutive metadata blocks and skips leading/trailing blank lines

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a well-contained refinement of metadata stripping logic.
- The implementation is correct and defensive, with clear test coverage. The changes improve the system by preserving user content that legitimately resembles metadata when it appears in non-leading positions. The logic correctly handles all edge cases (empty strings, blank lines, malformed metadata, multiple blocks). The removal of redundant stripping in `tui-session-actions.ts` is also correct since the stripping now happens inside `extractTextFromMessage()`.
- No files require special attention

<sub>Last reviewed commit: cde85f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->