### PR TITLE
Docs: add changelog entry for PR #19009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Docs: https://docs.openclaw.ai
 - Discord: ingest inbound stickers as media so sticker-only messages and forwarded stickers are visible to agents. Thanks @thewilloftheshadow.
 - Security/Net: strip sensitive headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Cookie2`) on cross-origin redirects in `fetchWithSsrFGuard` to prevent credential forwarding across origin boundaries. (#20313) Thanks @afurm.
 - Security/Systemd: reject CR/LF in systemd unit environment values and fix argument escaping so generated units cannot be injected with extra directives. Thanks @thewilloftheshadow.
+- Security/Tools: add per-wrapper random IDs to untrusted-content markers from `wrapExternalContent`/`wrapWebContent`, preventing marker spoofing from escaping content boundaries. (#19009) Thanks @Whoaa512.
 - Skills/Security: sanitize skill env overrides to block unsafe runtime injection variables and only allow sensitive keys when declared in skill metadata, with warnings for suspicious values. Thanks @thewilloftheshadow.
 - Skills/SonosCLI: add troubleshooting guidance for `sonos discover` failures on macOS direct mode (`sendto: no route to host`) and sandbox network restrictions (`bind: operation not permitted`). (#21316) Thanks @huntharo.
 - Auto-reply/Runner: emit `onAgentRunStart` only after agent lifecycle or tool activity begins (and only once per run), so fallback preflight errors no longer mark runs as started. (#21165) Thanks @shakkernerd.


### PR DESCRIPTION
Add changelog entry for security hardening in #19009 (fake untrusted-content markers).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added changelog entry documenting the security hardening from PR #19009, which prevents marker spoofing attacks in untrusted content boundaries by adding per-wrapper random IDs to `wrapExternalContent`/`wrapWebContent` markers.

- Entry is properly placed in the Fixes section under Security entries
- Follows consistent formatting with category prefix, description, PR reference, and contributor credit
- Description accurately reflects the security improvement implemented in the referenced PR

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a documentation-only change that adds a single changelog entry. The entry is well-formatted, accurately describes the security fix from PR #19009, follows the repository's changelog conventions, and is placed in the correct section. No code changes or functional modifications are involved.
- No files require special attention

<sub>Last reviewed commit: a87312c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->