### PR TITLE
Gateway: trust-proxy-aware X-Forwarded-For resolution

### DIFF
--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -146,16 +146,37 @@ function stripOptionalPort(ip: string): string {
   return ip;
 }
 
-export function parseForwardedForClientIp(forwardedFor?: string): string | undefined {
+export function parseForwardedForClientIp(
+  forwardedFor?: string,
+  trustedProxies?: string[],
+): string | undefined {
   const entries = forwardedFor
     ?.split(",")
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
-  const raw = entries?.at(-1);
-  if (!raw) {
+  if (!entries?.length) {
     return undefined;
   }
-  return normalizeIp(stripOptionalPort(raw));
+
+  if (!trustedProxies?.length) {
+    const raw = entries.at(-1);
+    if (!raw) {
+      return undefined;
+    }
+    return normalizeIp(stripOptionalPort(raw));
+  }
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const normalized = normalizeIp(stripOptionalPort(entries[index]));
+    if (!normalized) {
+      continue;
+    }
+    if (!isTrustedProxyAddress(normalized, trustedProxies)) {
+      return normalized;
+    }
+  }
+
+  return undefined;
 }
 
 function parseRealIp(realIp?: string): string | undefined {
@@ -247,7 +268,10 @@ export function resolveGatewayClientIp(params: {
   // Fail closed when traffic comes from a trusted proxy but client-origin headers
   // are missing or invalid. Falling back to the proxy's own IP can accidentally
   // treat unrelated requests as local/trusted.
-  return parseForwardedForClientIp(params.forwardedFor) ?? parseRealIp(params.realIp);
+  return (
+    parseForwardedForClientIp(params.forwardedFor, params.trustedProxies) ??
+    parseRealIp(params.realIp)
+  );
 }
 
 export function isLocalGatewayAddress(ip: string | undefined): boolean {


### PR DESCRIPTION
Fixes: none\n\nUse trusted-proxy-aware X-Forwarded-For parsing in gateway client IP resolution so the left-most forwarded value is not trusted through a proxy chain.\n\n-  now skips trusted hops from the right side when trusted proxy config is present.\n-  now passes trusted proxy list into parser.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added trust-proxy-aware X-Forwarded-For resolution to prevent trusting spoofed IPs through a proxy chain. When trusted proxies are configured, the implementation now walks the X-Forwarded-For chain from right to left, skipping trusted hops and returning the first untrusted IP.

- Improved security by properly handling X-Forwarded-For chains with trusted proxies
- Maintains backward compatibility by preserving rightmost-IP behavior when no trusted proxies are configured
- Test coverage confirms the expected behavior for trusted proxy chains

One call site in `auth.ts:76` (`resolveTailscaleClientIp`) still calls `parseForwardedForClientIp` without the new `trustedProxies` parameter, which may leave the Tailscale authentication flow without the trusted proxy parsing benefits.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor inconsistency that should be addressed
- The implementation correctly handles trusted proxy X-Forwarded-For parsing with proper validation, backward compatibility, and test coverage. The logic is sound and the security improvement is significant. Score reduced by 1 due to the inconsistent usage in auth.ts that leaves the Tailscale flow without trusted proxy support
- Check `src/gateway/auth.ts:76` to ensure `resolveTailscaleClientIp` also passes trusted proxies if needed

<sub>Last reviewed commit: 3693a99</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->