### PR TITLE
extensions: fix MSTeams OneDrive fallback mention handling

### DIFF
--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -295,7 +295,7 @@ async function buildActivity(
       // Teams only accepts base64 data URLs for images
       const conversationType = conversationRef.conversation?.conversationType?.toLowerCase();
       const isPersonal = conversationType === "personal";
-      const isImage = contentType?.startsWith("image/") ?? false;
+      const isImage = media.kind === "image";
 
       if (
         requiresFileConsent({
@@ -347,7 +347,7 @@ async function buildActivity(
         return activity;
       }
 
-      if (!isPersonal && !isImage && tokenProvider) {
+      if (!isPersonal && media.kind !== "image" && tokenProvider) {
         // Fallback: no SharePoint site configured, try OneDrive upload
         const uploaded = await uploadAndShareOneDrive({
           buffer: media.buffer,


### PR DESCRIPTION
## Summary\n- Fix MSTeams file message handling so local image media routed through OneDrive/SharePoint keeps parsed mentions intact when fallback links are appended.\n- Keep message text formatting stable for <at> mentions in mixed SharePoint fallback attachments.\n\n## Testing\n- pnpm test extensions/msteams/src/messenger.test.ts -t "preserves parsed mentions when appending OneDrive fallback file links"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switches image detection in the MSTeams `buildActivity` function from MIME-type-based (`contentType?.startsWith("image/")`) to media-kind-based (`media.kind === "image"`), which is more reliable since `media.kind` is always populated by `loadWebMedia` and won't be affected by cases where `contentType` is undefined or inaccurate. This ensures images are correctly identified as such, preventing them from being incorrectly routed through the OneDrive/SharePoint upload fallback path, which would have appended file links and potentially disrupted parsed `<at>` mention formatting in the message text.

- Replaced `contentType?.startsWith("image/")` with `media.kind === "image"` for the `isImage` variable (line 298)
- Replaced `!isImage` with inline `media.kind !== "image"` in the OneDrive fallback condition (line 350), though this introduces a minor style inconsistency with the SharePoint branch (line 320) that still uses `!isImage`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a small, targeted fix with correct logic and a matching test.
- The change is small (2 lines), logically correct, and has a corresponding test. The only note is a minor style inconsistency where `!isImage` is used on one branch but `media.kind !== "image"` is inlined on another, though both are semantically identical. No functional risk.
- No files require special attention.

<sub>Last reviewed commit: 5a8861c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->