### PR TITLE
Fix formatting

### DIFF
--- a/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
@@ -269,7 +269,9 @@ describe("web_search external content wrapping", () => {
       results?: Array<{ description?: string }>;
     };
 
-    expect(details.results?.[0]?.description).toMatch(/<<<EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/);
+    expect(details.results?.[0]?.description).toMatch(
+      /<<<EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/,
+    );
     expect(details.results?.[0]?.description).toContain("Ignore previous instructions");
     expect(details.externalContent).toMatchObject({
       untrusted: true,

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -148,8 +148,14 @@ function replaceMarkers(content: string): string {
   const replacements: Array<{ start: number; end: number; value: string }> = [];
   // Match markers with or without id attribute (handles both legacy and spoofed markers)
   const patterns: Array<{ regex: RegExp; value: string }> = [
-    { regex: /<<<EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi, value: "[[MARKER_SANITIZED]]" },
-    { regex: /<<<END_EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi, value: "[[END_MARKER_SANITIZED]]" },
+    {
+      regex: /<<<EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi,
+      value: "[[MARKER_SANITIZED]]",
+    },
+    {
+      regex: /<<<END_EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi,
+      value: "[[END_MARKER_SANITIZED]]",
+    },
   ];
 
   for (const pattern of patterns) {


### PR DESCRIPTION
Automated formatting fixes for oxfmt check failures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Automated formatting fixes to improve code readability by splitting long lines in test files and security utilities. The changes wrap long `expect()` assertions and object literals across multiple lines, following oxfmt formatting rules.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are purely cosmetic formatting improvements from the automated oxfmt formatter. No logic, functionality, or security properties have changed - only line breaks and indentation were added to improve readability.
- No files require special attention

<sub>Last reviewed commit: 14fa026</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->