### PR TITLE
fix(slack): add streamMode to Zod schema and support "off" mode

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -578,6 +578,7 @@ export const SlackAccountSchema = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     streaming: z.boolean().optional(),
+    streamMode: z.enum(["replace", "status_final", "append", "off"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -578,7 +578,7 @@ export const SlackAccountSchema = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     streaming: z.boolean().optional(),
-    streamMode: z.enum(["replace", "status_final", "append", "off"]).optional(),
+    streamMode: z.enum(["replace", "status_final", "append", "off"]).optional().default("replace"),
     mediaMaxMb: z.number().positive().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -312,6 +312,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let appendSourceText = "";
   let statusUpdateCount = 0;
   const updateDraftFromPartial = (text?: string) => {
+    if (streamMode === "off") {
+      return;
+    }
     const trimmed = text?.trimEnd();
     if (!trimmed) {
       return;

--- a/src/slack/stream-mode.test.ts
+++ b/src/slack/stream-mode.test.ts
@@ -16,6 +16,7 @@ describe("resolveSlackStreamMode", () => {
     expect(resolveSlackStreamMode("replace")).toBe("replace");
     expect(resolveSlackStreamMode("status_final")).toBe("status_final");
     expect(resolveSlackStreamMode("append")).toBe("append");
+    expect(resolveSlackStreamMode("off")).toBe("off");
   });
 });
 

--- a/src/slack/stream-mode.ts
+++ b/src/slack/stream-mode.ts
@@ -1,4 +1,4 @@
-export type SlackStreamMode = "replace" | "status_final" | "append";
+export type SlackStreamMode = "replace" | "status_final" | "append" | "off";
 
 const DEFAULT_STREAM_MODE: SlackStreamMode = "replace";
 
@@ -7,7 +7,12 @@ export function resolveSlackStreamMode(raw: unknown): SlackStreamMode {
     return DEFAULT_STREAM_MODE;
   }
   const normalized = raw.trim().toLowerCase();
-  if (normalized === "replace" || normalized === "status_final" || normalized === "append") {
+  if (
+    normalized === "replace" ||
+    normalized === "status_final" ||
+    normalized === "append" ||
+    normalized === "off"
+  ) {
     return normalized;
   }
   return DEFAULT_STREAM_MODE;


### PR DESCRIPTION
## Summary

- **Bug fix:** `streamMode` is read at runtime in `dispatch.ts` via `resolveSlackStreamMode(account.config.streamMode)` but was missing from `SlackAccountSchema` in the Zod validation schema. Since the schema uses `.strict()`, setting `streamMode` in the Slack account config caused silent validation failure and the gateway would hang during startup with no error message.
- **Feature:** Adds `"off"` mode that disables the draft stream entirely — no intermediate messages are posted, only the final reply is delivered. This is useful when `streaming: false` is set (disabling native Slack streaming) but the draft stream still progressively edits messages via `chat.postMessage` + `chat.update` (the two are independent mechanisms).

## Changes

1. `src/config/zod-schema.providers-core.ts` — Add `streamMode` enum to `SlackAccountSchema` (`"replace" | "status_final" | "append" | "off"`)
2. `src/slack/stream-mode.ts` — Add `"off"` to `SlackStreamMode` type and `resolveSlackStreamMode` resolver
3. `src/slack/monitor/message-handler/dispatch.ts` — Early return in `updateDraftFromPartial` when `streamMode === "off"`

## Context

- Discord already has `streamMode` in its schema (added in #22111)
- Telegram has `streamMode` in its schema with `"off"` as default
- Slack was the only channel where `streamMode` was referenced in runtime code but missing from the Zod schema

## Test plan

- [x] Set `streamMode: "off"` in Slack account config — verify gateway starts without validation error
- [x] Send a message to the bot — verify no draft/preview message is posted, only the final reply
- [x] Set `streamMode: "replace"` — verify progressive editing still works
- [x] Omit `streamMode` — verify default `"replace"` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds missing `streamMode` field to `SlackAccountSchema` and introduces `"off"` mode to disable draft stream updates. The field was already used at runtime via `resolveSlackStreamMode()` but missing from the Zod validation schema, causing silent validation failures due to `.strict()` mode.

- Fixed schema validation by adding `streamMode` enum with values `"replace" | "status_final" | "append" | "off"`
- Added `"off"` mode support to `SlackStreamMode` type and resolver function
- Implemented early-return in `updateDraftFromPartial()` when `streamMode === "off"` to skip all draft message updates
- Final replies still delivered correctly through `dispatchInboundMessage` (independent from draft stream)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor improvements suggested
- The core fix is correct — adds missing schema field and implements `"off"` mode properly. Early-return logic prevents draft updates while final replies are still delivered. Minor style suggestions: explicit schema default and test coverage for the new mode would improve consistency with other channels.
- No files require special attention

<sub>Last reviewed commit: 288fa30</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->