### PR TITLE
fix(voice-call): hardcode thinkLevel to off for latency-sensitive voice responses (#22423)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,6 @@ jobs:
       - name: Check types and lint and oxfmt
         run: pnpm check
 
-
   # Report-only dead-code scans. Runs after scope detection and stores machine-readable
   # results as artifacts for later triage before we enable hard gates.
   # Temporarily disabled in CI while we process initial findings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Cron: honor `cron.maxConcurrentRuns` in the timer loop so due jobs can execute up to the configured parallelism instead of always running serially. (#11595) Thanks @Takhoffman.
 - Agents/Compaction: restore embedded compaction safeguard/context-pruning extension loading in production by wiring bundled extension factories into the resource loader instead of runtime file-path resolution. (#22349) Thanks @Glucksberg.
 - Auto-reply/Tools: forward `senderIsOwner` through embedded queued/followup runner params so owner-only tools remain available for authorized senders. (#22296) thanks @hcoj.
+- Voice-call: always disable extended thinking for voice responses to avoid latency. (#22423)
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.
 - Gateway/Auth: require `gateway.trustedProxies` to include a loopback proxy address when `auth.mode="trusted-proxy"` and `bind="loopback"`, preventing same-host proxy misconfiguration from silently blocking auth. (#22082, follow-up to #20097) thanks @mbelinky.
 - Security/OpenClawKit/UI: prevent injected inbound user context metadata blocks from leaking into chat history in TUI, webchat, and macOS surfaces by stripping all untrusted metadata prefixes at display boundaries. (#22142) Thanks @Mellowambience, @vincentkoc.

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockRunEmbeddedPiAgent = vi.fn().mockResolvedValue({
+  payloads: [{ text: "Hello", isError: false }],
+  meta: {},
+});
+
+const mockResolveThinkingDefault = vi.fn().mockReturnValue("medium");
+
+vi.mock("./core-bridge.js", () => ({
+  loadCoreAgentDeps: vi.fn().mockResolvedValue({
+    resolveStorePath: () => "/tmp/test-store",
+    resolveAgentDir: () => "/tmp/test-agent",
+    resolveAgentWorkspaceDir: () => "/tmp/test-workspace",
+    ensureAgentWorkspace: vi.fn().mockResolvedValue(undefined),
+    loadSessionStore: () => ({
+      "voice:1234567890": { sessionId: "test-session", updatedAt: Date.now() },
+    }),
+    saveSessionStore: vi.fn().mockResolvedValue(undefined),
+    resolveSessionFilePath: () => "/tmp/test-session.json",
+    resolveAgentIdentity: () => ({ name: "TestBot" }),
+    resolveThinkingDefault: (...args: unknown[]) => mockResolveThinkingDefault(...args),
+    runEmbeddedPiAgent: (...args: unknown[]) => mockRunEmbeddedPiAgent(...args),
+    resolveAgentTimeoutMs: () => 30000,
+    DEFAULT_PROVIDER: "openai",
+    DEFAULT_MODEL: "gpt-4o-mini",
+  }),
+}));
+
+import { generateVoiceResponse } from "./response-generator.js";
+
+describe("voice-call response-generator thinkLevel (#22423)", () => {
+  beforeEach(() => {
+    mockRunEmbeddedPiAgent.mockClear();
+    mockResolveThinkingDefault.mockClear();
+    mockResolveThinkingDefault.mockReturnValue("medium");
+  });
+
+  it("should pass thinkLevel 'off' to runEmbeddedPiAgent, not the global default", async () => {
+    const cfg = {
+      agents: { defaults: { thinkingDefault: "medium" } },
+    };
+
+    await generateVoiceResponse({
+      voiceConfig: {},
+      coreConfig: cfg,
+      callId: "test-call",
+      from: "+1234567890",
+      transcript: [],
+      userMessage: "Hello",
+    });
+
+    expect(mockRunEmbeddedPiAgent).toHaveBeenCalledOnce();
+    const callArgs = mockRunEmbeddedPiAgent.mock.calls[0][0];
+
+    // Bug: thinkLevel should be "off" for voice calls (latency-sensitive),
+    // but currently it uses resolveThinkingDefault() which returns the global default
+    expect(callArgs.thinkLevel).toBe("off");
+  });
+});

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { VoiceCallConfig } from "./config.js";
 
 const mockRunEmbeddedPiAgent = vi.fn().mockResolvedValue({
   payloads: [{ text: "Hello", isError: false }],
@@ -42,7 +43,7 @@ describe("voice-call response-generator thinkLevel (#22423)", () => {
     };
 
     await generateVoiceResponse({
-      voiceConfig: {},
+      voiceConfig: {} as VoiceCallConfig,
       coreConfig: cfg,
       callId: "test-call",
       from: "+1234567890",

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -94,8 +94,8 @@ export async function generateVoiceResponse(
   const provider = slashIndex === -1 ? deps.DEFAULT_PROVIDER : modelRef.slice(0, slashIndex);
   const model = slashIndex === -1 ? modelRef : modelRef.slice(slashIndex + 1);
 
-  // Resolve thinking level
-  const thinkLevel = deps.resolveThinkingDefault({ cfg, provider, model });
+  // Voice calls are latency-sensitive — always disable extended thinking
+  const thinkLevel = "off" as const;
 
   // Resolve agent identity for personalized prompt
   const identity = deps.resolveAgentIdentity(cfg, agentId);


### PR DESCRIPTION
## Summary

- **Bug**: Voice call responses use the global `thinkingDefault` instead of always disabling extended thinking
- **Root cause**: `generateVoiceResponse` in `response-generator.ts` called `resolveThinkingDefault()` which returns the user's global config default (e.g. `medium`)
- **Fix**: Hardcode `thinkLevel = "off"` for voice calls since they are latency-sensitive

Fixes #22423

## Problem

Voice calls are latency-sensitive — users expect near-instant spoken responses. However, `generateVoiceResponse()` was calling `deps.resolveThinkingDefault({ cfg, provider, model })` to determine the thinking level, which returns whatever the user configured globally (e.g. `"medium"`). This caused the LLM to spend time on extended thinking during voice calls, adding unnecessary latency.

**Before fix:**
```
thinkLevel = deps.resolveThinkingDefault({ cfg, provider, model })
// Returns "medium" (or whatever global default is) → slow voice responses
```

## Changes

- `extensions/voice-call/src/response-generator.ts` — Replace `resolveThinkingDefault()` call with hardcoded `"off" as const`
- `extensions/voice-call/src/response-generator.test.ts` — Add regression test verifying thinkLevel is always `"off"`
- `CHANGELOG.md` — Add fix entry

**After fix:**
```
thinkLevel = "off" as const
// Always "off" for voice calls → fast responses
```

## Test plan

- [x] New test: verifies `thinkLevel` passed to `runEmbeddedPiAgent` is `"off"` even when global default is `"medium"`
- [x] Test passes on fix branch
- [x] Test fails on main (confirmed bug: `expected 'medium' to be 'off'`)
- [x] Format check passes
- [x] Lint passes

## Effect on User Experience

**Before:** Voice call responses could be slow because the LLM spent time on extended thinking (e.g. `medium` level), adding latency to an inherently real-time interaction.
**After:** Voice calls always use `thinkLevel: "off"`, ensuring the fastest possible response time for phone conversations.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardcoded `thinkLevel` to `"off"` in voice call responses to eliminate latency from extended thinking. The fix replaces a dynamic call to `resolveThinkingDefault()` (which returned user's global config like `"medium"`) with a hardcoded constant, ensuring voice calls always use the fastest response mode. Added regression test confirming `thinkLevel` is always `"off"` even when global default is `"medium"`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The fix is a single-line change with clear intent, well-documented rationale, and comprehensive test coverage. The change correctly addresses the latency issue by hardcoding `thinkLevel` to `"off"` for voice calls. The test validates the fix and would catch any regression. No syntax errors, no security concerns, and the change aligns with the stated goal of optimizing voice call latency.
- No files require special attention.

<sub>Last reviewed commit: 7a53a5e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->