### PR TITLE
chore: format files for oxfmt

### DIFF
--- a/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
@@ -269,7 +269,9 @@ describe("web_search external content wrapping", () => {
       results?: Array<{ description?: string }>;
     };
 
-    expect(details.results?.[0]?.description).toMatch(/<<<EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/);
+    expect(details.results?.[0]?.description).toMatch(
+      /<<<EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/,
+    );
     expect(details.results?.[0]?.description).toContain("Ignore previous instructions");
     expect(details.externalContent).toMatchObject({
       untrusted: true,

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -148,8 +148,14 @@ function replaceMarkers(content: string): string {
   const replacements: Array<{ start: number; end: number; value: string }> = [];
   // Match markers with or without id attribute (handles both legacy and spoofed markers)
   const patterns: Array<{ regex: RegExp; value: string }> = [
-    { regex: /<<<EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi, value: "[[MARKER_SANITIZED]]" },
-    { regex: /<<<END_EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi, value: "[[END_MARKER_SANITIZED]]" },
+    {
+      regex: /<<<EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi,
+      value: "[[MARKER_SANITIZED]]",
+    },
+    {
+      regex: /<<<END_EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]{1,128}")?\s*>>>/gi,
+      value: "[[END_MARKER_SANITIZED]]",
+    },
   ];
 
   for (const pattern of patterns) {


### PR DESCRIPTION
This is a formatter-only follow-up for the CI `pnpm format:check` failure.

- `src/agents/tools/web-tools.enabled-defaults.e2e.test.ts`
- `src/security/external-content.ts`

Both files are normalized via `pnpm format:fix` and should now pass `oxfmt --check` in CI.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Formatting-only PR that wraps long lines in two files to pass the `oxfmt --check` CI gate. No logic, behavior, or semantic changes.

- `src/agents/tools/web-tools.enabled-defaults.e2e.test.ts`: Wrapped a long `expect().toMatch()` call across multiple lines
- `src/security/external-content.ts`: Expanded two inline regex pattern objects into multi-line format

Both changes are consistent with the project's oxfmt configuration and the formatting conventions described in `AGENTS.md`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only whitespace formatting changes with zero risk of behavioral impact.
- Both files contain only line-wrapping changes produced by the project's official formatter (oxfmt). No logic, imports, types, or values were modified. The regex patterns and test assertions are byte-identical before and after formatting.
- No files require special attention.

<sub>Last reviewed commit: a17e6c9</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->