### PR TITLE
fix: memory leak, silent WS failures, and connection error handling

### DIFF
--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -94,9 +94,6 @@ function shouldDropDuplicateVoiceTranscript(params: {
       if (value.ts < cutoff) {
         recentVoiceTranscripts.delete(key);
       }
-      if (recentVoiceTranscripts.size <= MAX_RECENT_VOICE_TRANSCRIPTS) {
-        break;
-      }
     }
     while (recentVoiceTranscripts.size > MAX_RECENT_VOICE_TRANSCRIPTS) {
       const oldestKey = recentVoiceTranscripts.keys().next().value;

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -154,8 +154,9 @@ export function attachGatewayWsConnectionHandler(params: {
     const send = (obj: unknown) => {
       try {
         socket.send(JSON.stringify(obj));
-      } catch {
-        /* ignore */
+      } catch (err) {
+        logWsControl.warn(`send failed conn=${connId}: ${formatError(err)}`);
+        setCloseCause("send-error");
       }
     };
 
@@ -182,7 +183,7 @@ export function attachGatewayWsConnectionHandler(params: {
       }
     };
 
-    socket.once("error", (err) => {
+    socket.on("error", (err) => {
       logWsControl.warn(`error conn=${connId} remote=${remoteAddr ?? "?"}: ${formatError(err)}`);
       close();
     });

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -48,10 +48,12 @@ export function getAgentRunContext(runId: string) {
 
 export function clearAgentRunContext(runId: string) {
   runContextById.delete(runId);
+  seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {
   runContextById.clear();
+  seqByRun.clear();
 }
 
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {


### PR DESCRIPTION
## Summary

- **Fix memory leak in `seqByRun` map** (`src/infra/agent-events.ts`): The `seqByRun` map grew unboundedly with every agent run but was never cleaned up. Now `clearAgentRunContext()` and `resetAgentRunContextForTest()` also clean up the corresponding `seqByRun` entries, preventing memory exhaustion in long-running gateway instances.

- **Log WebSocket send failures** (`src/gateway/server/ws-connection.ts`): The `send()` function was silently swallowing all errors with an empty catch block. Now it logs a warning with connection ID and error details, and records `"send-error"` as the close cause for diagnostics.

- **Handle all socket errors, not just the first** (`src/gateway/server/ws-connection.ts`): Changed `socket.once("error")` to `socket.on("error")` so subsequent socket errors are also caught and trigger connection cleanup. The `close()` function is already idempotent (guards with `if (closed) return`), so repeated calls are safe.

- **Fix voice transcript deduplication cleanup** (`src/gateway/server-node-events.ts`): The cleanup loop had an early `break` that stopped pruning expired entries as soon as the map dropped below `MAX_RECENT_VOICE_TRANSCRIPTS`, leaving stale entries behind. Removed the early break so all expired entries are pruned before falling through to the eviction-by-insertion-order loop.

## Test plan

- [x] `vitest run src/infra/agent-events` — 3/3 tests pass
- [x] `vitest run src/gateway/gateway-misc.test.ts src/gateway/client.test.ts src/gateway/chat-sanitize.test.ts` — 31/31 tests pass
- [x] `tsc --noEmit` — no new type errors
- [ ] Verify gateway stability under sustained load (memory usage should plateau instead of growing)
- [ ] Verify WebSocket send failures now appear in logs with `send failed conn=` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes three critical infrastructure issues in the gateway WebSocket handling and agent event management:

- **Memory leak in `seqByRun` map**: The map tracked sequence numbers for all agent runs but was never cleaned up. Now properly deleted in both `clearAgentRunContext()` and `resetAgentRunContextForTest()`, preventing unbounded memory growth in long-running gateway instances.

- **Silent WebSocket send failures**: Previously swallowed all errors with an empty catch block, making debugging impossible. Now logs warnings with connection ID and error details, and records `"send-error"` as close cause for diagnostics.

- **Incomplete socket error handling**: Changed from `socket.once("error")` to `socket.on("error")` to handle all socket errors, not just the first one. The existing `close()` function is already idempotent (guards with `if (closed) return`), so repeated calls are safe.

- **Voice transcript deduplication cleanup bug**: The cleanup loop had an early `break` that stopped pruning as soon as the map size dropped below `MAX_RECENT_VOICE_TRANSCRIPTS`, leaving expired entries behind. Removing the early break ensures all expired entries are pruned before falling through to the eviction-by-insertion-order loop.

All changes are well-tested and follow the repository's coding conventions. The fixes address real production issues that would cause memory leaks and silent failures.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk - fixes critical production bugs
- All changes are simple, well-reasoned bug fixes with clear benefits. The memory leak fix properly mirrors the cleanup pattern used for `runContextById`. The WebSocket error handling improvements add observability without changing behavior. The voice transcript cleanup fix removes a logic error. Tests pass and the changes are minimal and focused.
- No files require special attention

<sub>Last reviewed commit: 64a049c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->