### PR TITLE
fix(cli): redirect plugin logs to stderr during completion

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -79,6 +79,14 @@ export async function runCli(argv: string[] = process.argv) {
   // Capture all console output into structured logs while keeping stdout/stderr behavior.
   enableConsoleCapture();
 
+  // For completion command, route all logs to stderr immediately to prevent
+  // plugin/config logs from corrupting the generated completion script.
+  const [primaryCmd] = getCommandPath(normalizedArgv, 1);
+  if (primaryCmd === "completion") {
+    const { routeLogsToStderr } = await import("../logging/console.js");
+    routeLogsToStderr();
+  }
+
   const { buildProgram } = await import("./program.js");
   const program = buildProgram();
 


### PR DESCRIPTION
Closes #22449

## Problem

When running `source <(openclaw completion zsh)`, any logs generated during CLI initialization would pollute stdout and corrupt the generated completion script. This broke process substitution because the shell would try to source invalid syntax.

The root cause was a timing issue: `enableConsoleCapture()` was called early in `run-main.ts`, but `routeLogsToStderr()` wasn't called until the completion command action ran. Any logs from config loading, plugin discovery, or other initialization would escape to stdout in between.

## Solution

Detect the completion command early (right after `enableConsoleCapture()`) and immediately route all logs to stderr before any other initialization happens. This keeps stdout clean for the generated completion script while still capturing all logs to the log files.

The fix is minimal and focused: just a simple check for the completion command that calls `routeLogsToStderr()` before program building or command registration.

## Testing

Verified that `source <(openclaw completion zsh)` now works without any log pollution corrupting the output.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stdout pollution during shell completion generation by detecting the `completion` command early and routing logs to stderr before any initialization occurs. The fix prevents plugin discovery and config loading logs from corrupting the completion script output when using process substitution patterns like `source <(openclaw completion zsh)`.

The change adds a simple check immediately after `enableConsoleCapture()` that detects when the primary command is "completion" and calls `routeLogsToStderr()` before `buildProgram()` or any plugin/config loading happens. This ensures all subsequent logs go to stderr, keeping stdout clean for the completion script.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-scoped, and directly addresses the stated problem. It adds a simple guard that routes logs to stderr for the completion command only, maintaining existing behavior for all other commands. The implementation correctly uses existing utility functions (`getCommandPath`, `routeLogsToStderr`) and is placed at the optimal location in the execution flow.
- No files require special attention

<sub>Last reviewed commit: f270369</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->