### PR TITLE
fix(telegram): wire up poll action in dispatch

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -337,9 +337,7 @@ export async function handleTelegramAction(
 
   if (action === "sendPoll") {
     if (!isActionEnabled("polls")) {
-      throw new Error(
-        "Telegram polls are disabled. Set channels.telegram.actions.polls to true.",
-      );
+      throw new Error("Telegram polls are disabled. Set channels.telegram.actions.polls to true.");
     }
     const to = readStringParam(params, "to", { required: true });
     const question = readStringParam(params, "question", { required: true });

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -335,6 +335,63 @@ export async function handleTelegramAction(
     });
   }
 
+  if (action === "sendPoll") {
+    if (!isActionEnabled("polls")) {
+      throw new Error(
+        "Telegram polls are disabled. Set channels.telegram.actions.polls to true.",
+      );
+    }
+    const to = readStringParam(params, "to", { required: true });
+    const question = readStringParam(params, "question", { required: true });
+    const options = params.options;
+    if (!Array.isArray(options)) {
+      throw new Error("Poll options must be an array of strings.");
+    }
+    const pollOptions = options
+      .map((opt) => (typeof opt === "string" ? opt.trim() : ""))
+      .filter(Boolean);
+    if (pollOptions.length < 2) {
+      throw new Error("Poll requires at least 2 options.");
+    }
+    const maxSelections =
+      typeof params.allowMultiselect === "boolean" && params.allowMultiselect
+        ? pollOptions.length
+        : 1;
+    const durationHours = readNumberParam(params, "durationHours", { integer: true });
+    const messageThreadId = readNumberParam(params, "messageThreadId", { integer: true });
+    const silent = typeof params.silent === "boolean" ? params.silent : undefined;
+    const isAnonymous = typeof params.isAnonymous === "boolean" ? params.isAnonymous : undefined;
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const { sendPollTelegram } = await import("../../telegram/send.js");
+    const result = await sendPollTelegram(
+      to,
+      {
+        question,
+        options: pollOptions,
+        maxSelections,
+        durationHours: durationHours ?? undefined,
+      },
+      {
+        token,
+        accountId: accountId ?? undefined,
+        messageThreadId: messageThreadId ?? undefined,
+        silent,
+        isAnonymous,
+      },
+    );
+    return jsonResult({
+      ok: true,
+      messageId: result.messageId,
+      chatId: result.chatId,
+      pollId: result.pollId,
+    });
+  }
+
   if (action === "stickerCacheStats") {
     const stats = getCacheStats();
     return jsonResult({ ok: true, ...stats });

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -174,7 +174,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       const to =
         readStringParam(params, "to") ?? readStringParam(params, "target", { required: true });
       const question = readStringParam(params, "pollQuestion", { required: true });
-      const options = readStringArrayParam(params, "pollOption", { required: true }) ?? [];
+      const options = readStringArrayParam(params, "pollOption", { required: true });
       const allowMultiselect = typeof params.pollMulti === "boolean" ? params.pollMulti : undefined;
       const durationHours = readNumberParam(params, "pollDurationHours", { integer: true });
       const threadId = readNumberParam(params, "threadId", { integer: true });

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -65,6 +65,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (gate("editMessage")) {
       actions.add("edit");
     }
+    if (gate("polls")) {
+      actions.add("poll");
+    }
     if (gate("sticker", false)) {
       actions.add("sticker");
       actions.add("sticker-search");
@@ -161,6 +164,33 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           messageId,
           content: message,
           buttons,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "poll") {
+      const to =
+        readStringParam(params, "to") ?? readStringParam(params, "target", { required: true });
+      const question = readStringParam(params, "pollQuestion", { required: true });
+      const options = readStringArrayParam(params, "pollOption", { required: true }) ?? [];
+      const allowMultiselect = typeof params.pollMulti === "boolean" ? params.pollMulti : undefined;
+      const durationHours = readNumberParam(params, "pollDurationHours", { integer: true });
+      const threadId = readNumberParam(params, "threadId", { integer: true });
+      const silent = typeof params.silent === "boolean" ? params.silent : undefined;
+      const isAnonymous = typeof params.isAnonymous === "boolean" ? params.isAnonymous : undefined;
+      return await handleTelegramAction(
+        {
+          action: "sendPoll",
+          to,
+          question,
+          options,
+          allowMultiselect,
+          durationHours: durationHours ?? undefined,
+          messageThreadId: threadId ?? undefined,
+          silent,
+          isAnonymous,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -18,6 +18,8 @@ export type TelegramActionConfig = {
   editMessage?: boolean;
   /** Enable sticker actions (send and search). */
   sticker?: boolean;
+  /** Enable poll actions (send polls). */
+  polls?: boolean;
   /** Enable forum topic creation. */
   createForumTopic?: boolean;
 };


### PR DESCRIPTION
Closes #22422

The Telegram provider has had a full poll implementation (sendPollTelegram) for a while, but the poll action was never registered in the message action adapter, making it unreachable from the message tool.

This PR wires it up by:
- Adding poll to the listActions return when the polls gate is enabled
- Adding a handler in the action dispatcher to parse poll-specific parameters (pollQuestion, pollOption, pollMulti, pollDurationHours, etc.)
- Adding a handler in telegram-actions to call sendPollTelegram with the proper parameters

Now you can actually use the message tool with action=poll for Telegram channels.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wires up the existing `sendPollTelegram` implementation to the message action dispatcher, enabling poll creation through the message tool with `action=poll`.

**Changes:**
- Added `poll` action to `listActions` when the `polls` gate is enabled (`telegram.ts:59-61`)
- Added dispatcher handler to parse poll-specific parameters (`pollQuestion`, `pollOption`, `pollMulti`, `pollDurationHours`, etc.) and forward to `handleTelegramAction` (`telegram.ts:170-195`)
- Added action handler in `telegram-actions.ts` to validate parameters, check gate, and call `sendPollTelegram` (`telegram-actions.ts:325-380`)

**Architecture:**
The implementation follows existing patterns for other Telegram actions (sticker, edit, delete). Parameters flow through the dispatcher layer which normalizes them before calling the lower-level handler. The handler validates the action is enabled, checks options array structure, and delegates to the existing `sendPollTelegram` function which has comprehensive validation via `normalizePollInput`.

**Minor issue:**
One unreachable fallback operator (`?? []`) on line 174 of `telegram.ts` where `required: true` makes it unnecessary.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly wires up existing, tested functionality (`sendPollTelegram`) following established patterns. All parameters are properly validated through existing helpers, and the action is appropriately gated. The only issue is a minor style concern with an unreachable fallback operator.
- No files require special attention

<sub>Last reviewed commit: af295d5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->