### PR TITLE
fix(discord): preserve user ID precision by treating as strings

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -210,13 +210,17 @@ export const TelegramConfigSchema = TelegramAccountSchemaBase.extend({
   }
 });
 
+// Discord IDs (user, channel, role, guild) are large integers that can exceed
+// Number.MAX_SAFE_INTEGER. Always treat them as strings to avoid precision loss.
+const DiscordIdSchema = z.union([z.string(), z.number()]).transform(String);
+
 export const DiscordDmSchema = z
   .object({
     enabled: z.boolean().optional(),
     policy: DmPolicySchema.optional(),
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowFrom: z.array(DiscordIdSchema).optional(),
     groupEnabled: z.boolean().optional(),
-    groupChannels: z.array(z.union([z.string(), z.number()])).optional(),
+    groupChannels: z.array(DiscordIdSchema).optional(),
   })
   .strict();
 
@@ -228,8 +232,8 @@ export const DiscordGuildChannelSchema = z
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
-    users: z.array(z.union([z.string(), z.number()])).optional(),
-    roles: z.array(z.union([z.string(), z.number()])).optional(),
+    users: z.array(DiscordIdSchema).optional(),
+    roles: z.array(DiscordIdSchema).optional(),
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
@@ -243,8 +247,8 @@ export const DiscordGuildSchema = z
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
-    users: z.array(z.union([z.string(), z.number()])).optional(),
-    roles: z.array(z.union([z.string(), z.number()])).optional(),
+    users: z.array(DiscordIdSchema).optional(),
+    roles: z.array(DiscordIdSchema).optional(),
     channels: z.record(z.string(), DiscordGuildChannelSchema.optional()).optional(),
   })
   .strict();
@@ -311,14 +315,14 @@ export const DiscordAccountSchema = z
     // Aliases for channels.discord.dm.policy / channels.discord.dm.allowFrom. Prefer these for
     // inheritance in multi-account setups (shallow merge works; nested dm object doesn't).
     dmPolicy: DmPolicySchema.optional(),
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowFrom: z.array(DiscordIdSchema).optional(),
     dm: DiscordDmSchema.optional(),
     guilds: z.record(z.string(), DiscordGuildSchema.optional()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     execApprovals: z
       .object({
         enabled: z.boolean().optional(),
-        approvers: z.array(z.union([z.string(), z.number()])).optional(),
+        approvers: z.array(DiscordIdSchema).optional(),
         agentFilter: z.array(z.string()).optional(),
         sessionFilter: z.array(z.string()).optional(),
         cleanupAfterResolve: z.boolean().optional(),


### PR DESCRIPTION
## Problem

Discord user IDs, channel IDs, role IDs, and guild IDs are large integers that can exceed JavaScript's `Number.MAX_SAFE_INTEGER` (9007199254740991). When these IDs are parsed from config files as numbers, JavaScript's floating-point representation causes precision loss, resulting in the last two digits being truncated to '00'.

This issue was particularly noticeable in `channels.discord.execApprovals.approvers`, where users couldn't receive approval requests because their user IDs were being corrupted during config writes.

## Solution

Modified the Zod schema validation in `src/config/zod-schema.providers-core.ts` to use `.transform(String)` on all Discord ID fields. This ensures that even if IDs are initially parsed as numbers from the config file, they are immediately converted to strings and remain strings throughout the application.

The fix applies to:
- `execApprovals.approvers` (user IDs for approval prompts)
- `allowFrom` (DM allowlists)
- `groupChannels` (channel ID allowlists)
- `users` (user ID allowlists in guilds/channels)
- `roles` (role ID allowlists)

## Testing

The changes maintain backward compatibility since the schema accepts both strings and numbers, but always outputs strings. Existing string IDs continue to work, and numeric IDs are now preserved with full precision.

Closes #22437

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical precision loss bug for Discord IDs by changing the Zod schema from validation (`.refine()`) to transformation (`.transform(String)`). This ensures all Discord IDs are consistently stored and used as strings throughout the application, preventing the loss of precision that occurs when large integers exceed JavaScript's `Number.MAX_SAFE_INTEGER` (9007199254740991).

**Key changes:**
- Replaces the previous `.refine()` approach (which rejected numeric IDs) with `.transform(String)` (which converts them)
- Applies to all Discord ID fields: `execApprovals.approvers`, `allowFrom`, `groupChannels`, `users`, and `roles`
- Maintains full backward compatibility - both string and numeric IDs are accepted and normalized to strings
- The runtime code already handles IDs as strings (e.g., `String(approver)` in exec-approvals.ts:526), so this aligns the schema with actual usage

**Impact:**
This fix is particularly important for `execApprovals.approvers`, where precision loss would cause approval requests to be sent to the wrong Discord users (IDs ending in '00' instead of the actual digits).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The change is a straightforward schema modification that fixes a real precision bug while maintaining backward compatibility. The `.transform(String)` approach is superior to the previous `.refine()` validation because it accepts both strings and numbers (converting numbers to strings), whereas the old approach would have rejected numeric IDs. The runtime code already treats IDs as strings, so this change aligns the schema with actual usage patterns.
- No files require special attention

<sub>Last reviewed commit: 2631435</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->