### PR TITLE
ci: fix oxfmt formatting in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,6 @@ jobs:
       - name: Check types and lint and oxfmt
         run: pnpm check
 
-
   # Report-only dead-code scans. Runs after scope detection and stores machine-readable
   # results as artifacts for later triage before we enable hard gates.
   # Temporarily disabled in CI while we process initial findings.


### PR DESCRIPTION
The recent deadcode scanning PR (#22468) introduced an extra blank line in ci.yml that fails the oxfmt check. This is blocking the check job on every open PR right now.

One-line fix: remove the extra blank line.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes an extra blank line in `.github/workflows/ci.yml` that was causing oxfmt formatting checks to fail. The change corrects the spacing between the `check` job and the `deadcode` job comment, aligning with the consistent single-blank-line pattern used throughout the workflow file.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with zero risk
- The change is a trivial formatting fix that removes a single blank line to comply with oxfmt standards. The fix is consistent with formatting patterns throughout the file, addresses a blocking CI issue, and has no functional impact on the workflow behavior.
- No files require special attention

<sub>Last reviewed commit: 04b0705</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->