### PR TITLE
fix(post-compaction-audit): show readable label for missing regex requirements

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.test.ts
+++ b/src/auto-reply/reply/post-compaction-audit.test.ts
@@ -122,7 +122,7 @@ describe("auditPostCompactionReads", () => {
 
     expect(result.passed).toBe(false);
     expect(result.missingPatterns).toContain("WORKFLOW_AUTO.md");
-    expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
+    expect(result.missingPatterns).toContain("memory/YYYY-MM-DD.md");
   });
 
   it("reports only missing files", () => {
@@ -131,7 +131,7 @@ describe("auditPostCompactionReads", () => {
 
     expect(result.passed).toBe(false);
     expect(result.missingPatterns).not.toContain("WORKFLOW_AUTO.md");
-    expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
+    expect(result.missingPatterns).toEqual(["memory/YYYY-MM-DD.md"]);
   });
 
   it("matches RegExp patterns against relative paths", () => {
@@ -169,6 +169,18 @@ describe("auditPostCompactionReads", () => {
 
     expect(result.passed).toBe(true);
     expect(result.missingPatterns).toEqual([]);
+  });
+
+  it("supports custom regex labels for missing patterns", () => {
+    const readPaths = ["WORKFLOW_AUTO.md"];
+    const customRequired = [
+      "WORKFLOW_AUTO.md",
+      { pattern: /memory\/\d{4}-\d{2}-\d{2}\.md/, label: "memory/YYYY-MM-DD.md" },
+    ];
+    const result = auditPostCompactionReads(readPaths, workspaceDir, customRequired);
+
+    expect(result.passed).toBe(false);
+    expect(result.missingPatterns).toEqual(["memory/YYYY-MM-DD.md"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- replace raw regex `.source` output in post-compaction audit warnings with human-readable labels
- add label-aware required-read handling for regex entries
- update tests to assert readable output (`memory/YYYY-MM-DD.md`) and cover custom labeled regex entries

## Testing
- `pnpm vitest run src/auto-reply/reply/post-compaction-audit.test.ts`

## AI Transparency
- [x] AI-assisted
- [x] Lightly tested (targeted tests only)

Fixes #22339

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced raw regex `.source` output in post-compaction audit warnings with human-readable labels like `memory/YYYY-MM-DD.md` instead of `memory\/\d{4}-\d{2}-\d{2}\.md`. The implementation introduces a `RequiredRead` union type supporting strings, RegExp, or objects with `{pattern: RegExp, label?: string}` and a `resolveRequiredReadMatcher` helper that extracts the appropriate label for display while preserving the matching logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and well-tested. The code introduces proper type safety with the `RequiredRead` union type, cleanly separates matching logic from display labels, and maintains backward compatibility. All existing tests pass with updated assertions, and a new test specifically validates the custom label feature. The implementation is simple, focused, and improves user experience without affecting core logic.
- No files require special attention

<sub>Last reviewed commit: 651cc21</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->