### PR TITLE
CI: format github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,6 @@ jobs:
       - name: Check types and lint and oxfmt
         run: pnpm check
 
-
   # Report-only dead-code scans. Runs after scope detection and stores machine-readable
   # results as artifacts for later triage before we enable hard gates.
   # Temporarily disabled in CI while we process initial findings.


### PR DESCRIPTION
Fixes format:check failure in .github/workflows/ci.yml by running oxfmt.

Validation:
- pnpm format:check
- pnpm tsgo
- pnpm lint

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes two blank lines after the "Check types and lint and oxfmt" step in `.github/workflows/ci.yml` to fix `format:check` failure. This is a formatting-only change with no functional impact.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - formatting-only change with no functional impact
- The change only removes excess blank lines to comply with oxfmt formatting standards. No logic, configuration, or behavior is affected. The author validated with `pnpm format:check`, `pnpm tsgo`, and `pnpm lint`.
- No files require special attention

<sub>Last reviewed commit: b0cd781</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->