### PR TITLE
fix(doctor): preserve logging config in doctor --fix

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -80,6 +80,10 @@ function stripUnknownConfigKeys(config: OpenClawConfig): {
 
   const next = structuredClone(config);
   const removed: string[] = [];
+  
+  // Known valid config keys that should not be removed (fix #19432)
+  const preservedKeys = new Set(["logging"]);
+  
   for (const issue of parsed.error.issues) {
     if (!isUnrecognizedKeysIssue(issue)) {
       continue;
@@ -95,6 +99,10 @@ function stripUnknownConfigKeys(config: OpenClawConfig): {
         continue;
       }
       if (!(key in record)) {
+        continue;
+      }
+      // Fix #19432: Preserve known valid config keys
+      if (preservedKeys.has(key)) {
         continue;
       }
       delete record[key];


### PR DESCRIPTION
Fixes #19432

The `openclaw doctor --fix` command was incorrectly removing the valid `logging` configuration section from `openclaw.json`, treating it as an "unknown config key".

## Changes
- Added `preservedKeys` set in `stripUnknownConfigKeys()` function
- Known valid config keys (like `logging`) are now preserved during the fix process

## Testing
1. Add logging config to openclaw.json:
   ```json
   "logging": {
     "file": "/path/to/gateway.log",
     "redactSensitive": "tools"
   }
   ```
2. Run `openclaw doctor --fix`
3. Verify logging section is preserved

---
This is my first contribution to OpenClaw. Please let me know if any adjustments are needed!

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a `preservedKeys` set to prevent `openclaw doctor --fix` from removing the valid `logging` configuration section. The fix ensures that known valid config keys like `logging` are preserved during the config repair process, preventing data loss during doctor operations.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor consideration about hardcoded approach
- The fix correctly addresses the reported issue by preserving the `logging` config key. However, the hardcoded `preservedKeys` set approach may need expansion if other valid config keys face the same issue in the future. The `logging` key is confirmed to be valid in the OpenClawSchema (zod-schema.ts:160-192), so this fix is functionally correct.
- No files require special attention

<sub>Last reviewed commit: e601c6b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->