### PR TITLE
Add explicit ownerDisplaySecret for owner ID hash obfuscation

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -86,6 +86,11 @@ export function buildSystemPrompt(params: {
     defaultThinkLevel: params.defaultThinkLevel,
     extraSystemPrompt: params.extraSystemPrompt,
     ownerNumbers: params.ownerNumbers,
+    ownerDisplay: params.config?.commands?.ownerDisplay,
+    ownerDisplaySecret:
+      params.config?.commands?.ownerDisplaySecret ??
+      params.config?.gateway?.auth?.token ??
+      params.config?.gateway?.remote?.token,
     reasoningTagHint: false,
     heartbeatPrompt: params.heartbeatPrompt,
     docsPath: params.docsPath,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -484,6 +484,11 @@ export async function compactEmbeddedPiSessionDirect(
       reasoningLevel: params.reasoningLevel ?? "off",
       extraSystemPrompt: params.extraSystemPrompt,
       ownerNumbers: params.ownerNumbers,
+      ownerDisplay: params.config?.commands?.ownerDisplay,
+      ownerDisplaySecret:
+        params.config?.commands?.ownerDisplaySecret ??
+        params.config?.gateway?.auth?.token ??
+        params.config?.gateway?.remote?.token,
       reasoningTagHint,
       heartbeatPrompt: isDefaultAgent
         ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -443,6 +443,11 @@ export async function runEmbeddedAttempt(
       reasoningLevel: params.reasoningLevel ?? "off",
       extraSystemPrompt: params.extraSystemPrompt,
       ownerNumbers: params.ownerNumbers,
+      ownerDisplay: params.config?.commands?.ownerDisplay,
+      ownerDisplaySecret:
+        params.config?.commands?.ownerDisplaySecret ??
+        params.config?.gateway?.auth?.token ??
+        params.config?.gateway?.remote?.token,
       reasoningTagHint,
       heartbeatPrompt: isDefaultAgent
         ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -14,6 +14,8 @@ export function buildEmbeddedSystemPrompt(params: {
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
+  ownerDisplay?: "raw" | "hash";
+  ownerDisplaySecret?: string;
   reasoningTagHint: boolean;
   heartbeatPrompt?: string;
   skillsPrompt?: string;
@@ -55,6 +57,8 @@ export function buildEmbeddedSystemPrompt(params: {
     reasoningLevel: params.reasoningLevel,
     extraSystemPrompt: params.extraSystemPrompt,
     ownerNumbers: params.ownerNumbers,
+    ownerDisplay: params.ownerDisplay,
+    ownerDisplaySecret: params.ownerDisplaySecret,
     reasoningTagHint: params.reasoningTagHint,
     heartbeatPrompt: params.heartbeatPrompt,
     skillsPrompt: params.skillsPrompt,

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -5,6 +5,7 @@ import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
+import { createHmac, createHash } from "node:crypto";
 
 /**
  * Controls which hardcoded sections are included in the system prompt.
@@ -13,6 +14,7 @@ import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
  * - "none": Just basic identity line, no sections
  */
 export type PromptMode = "full" | "minimal" | "none";
+type OwnerIdDisplay = "raw" | "hash";
 
 function buildSkillsSection(params: {
   skillsPrompt?: string;
@@ -71,6 +73,30 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
     return [];
   }
   return ["## Authorized Senders", ownerLine, ""];
+}
+
+function formatOwnerDisplayId(ownerId: string, ownerDisplaySecret?: string) {
+  const hasSecret = ownerDisplaySecret?.trim();
+  const digest = hasSecret
+    ? createHmac("sha256", hasSecret).update(ownerId).digest("hex")
+    : createHash("sha256").update(ownerId).digest("hex");
+  return digest.slice(0, 12);
+}
+
+function buildOwnerIdentityLine(
+  ownerNumbers: string[],
+  ownerDisplay: OwnerIdDisplay,
+  ownerDisplaySecret?: string,
+) {
+  const normalized = ownerNumbers.map((value) => value.trim()).filter(Boolean);
+  if (normalized.length === 0) {
+    return undefined;
+  }
+  const displayOwnerNumbers =
+    ownerDisplay === "hash"
+      ? normalized.map((ownerId) => formatOwnerDisplayId(ownerId, ownerDisplaySecret))
+      : normalized;
+  return `Authorized senders: ${displayOwnerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
 }
 
 function buildTimeSection(params: { userTimezone?: string }) {
@@ -172,6 +198,8 @@ export function buildAgentSystemPrompt(params: {
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
+  ownerDisplay?: OwnerIdDisplay;
+  ownerDisplaySecret?: string;
   reasoningTagHint?: boolean;
   toolNames?: string[];
   toolSummaries?: Record<string, string>;
@@ -322,11 +350,12 @@ export function buildAgentSystemPrompt(params: {
   const execToolName = resolveToolName("exec");
   const processToolName = resolveToolName("process");
   const extraSystemPrompt = params.extraSystemPrompt?.trim();
-  const ownerNumbers = (params.ownerNumbers ?? []).map((value) => value.trim()).filter(Boolean);
-  const ownerLine =
-    ownerNumbers.length > 0
-      ? `Authorized senders: ${ownerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`
-      : undefined;
+  const ownerDisplay = params.ownerDisplay === "hash" ? "hash" : "raw";
+  const ownerLine = buildOwnerIdentityLine(
+    params.ownerNumbers ?? [],
+    ownerDisplay,
+    params.ownerDisplaySecret,
+  );
   const reasoningHint = params.reasoningTagHint
     ? [
         "ALL internal reasoning MUST be inside <think>...</think>.",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -80,7 +80,7 @@ function formatOwnerDisplayId(ownerId: string, ownerDisplaySecret?: string) {
   const digest = hasSecret
     ? createHmac("sha256", hasSecret).update(ownerId).digest("hex")
     : createHash("sha256").update(ownerId).digest("hex");
-  return digest.slice(0, 12);
+  return digest.slice(0, 16);
 }
 
 function buildOwnerIdentityLine(

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -330,6 +330,10 @@ export const FIELD_HELP: Record<string, string> = {
   "commands.useAccessGroups": "Enforce access-group allowlists/policies for commands.",
   "commands.ownerAllowFrom":
     "Explicit owner allowlist for owner-only tools/commands. Use channel-native IDs (optionally prefixed like \"whatsapp:+15551234567\"). '*' is ignored.",
+  "commands.ownerDisplay":
+    "Controls how owner IDs are rendered in the system prompt. Allowed values: raw, hash. Default: raw.",
+  "commands.ownerDisplaySecret":
+    "Optional secret used to HMAC hash owner IDs when ownerDisplay=hash. Prefer env substitution.",
   "session.dmScope":
     'DM session scoping: "main" keeps continuity; "per-peer", "per-channel-peer", or "per-account-channel-peer" isolates DM history (recommended for shared inboxes/multi-account).',
   "session.identityLinks":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -224,6 +224,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "commands.restart": "Allow Restart",
   "commands.useAccessGroups": "Use Access Groups",
   "commands.ownerAllowFrom": "Command Owners",
+  "commands.ownerDisplay": "Owner ID Display",
+  "commands.ownerDisplaySecret": "Owner ID Hash Secret",
   "ui.seamColor": "Accent Color",
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -125,6 +125,8 @@ export type MessagesConfig = {
 
 export type NativeCommandsSetting = boolean | "auto";
 
+export type CommandOwnerDisplay = "raw" | "hash";
+
 /**
  * Per-provider allowlist for command authorization.
  * Keys are channel IDs (e.g., "discord", "whatsapp") or "*" for global default.
@@ -153,6 +155,10 @@ export type CommandsConfig = {
   useAccessGroups?: boolean;
   /** Explicit owner allowlist for owner-only tools/commands (channel-native IDs). */
   ownerAllowFrom?: Array<string | number>;
+  /** How owner IDs are rendered in system prompts. */
+  ownerDisplay?: CommandOwnerDisplay;
+  /** Secret used to key owner ID hashes when ownerDisplay is "hash". */
+  ownerDisplaySecret?: string;
   /**
    * Per-provider allowlist restricting who can use slash commands.
    * If set, overrides the channel's allowFrom for command authorization.

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -3,6 +3,7 @@ import { parseByteSize } from "../cli/parse-bytes.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import { ElevatedAllowFromSchema } from "./zod-schema.agent-runtime.js";
 import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
+import { sensitive } from "./zod-schema.sensitive.js";
 import {
   GroupChatSchema,
   InboundDebounceSchema,
@@ -161,6 +162,8 @@ export const CommandsSchema = z
     restart: z.boolean().optional().default(true),
     useAccessGroups: z.boolean().optional(),
     ownerAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    ownerDisplay: z.enum(["raw", "hash"]).optional().default("raw"),
+    ownerDisplaySecret: z.string().optional().register(sensitive),
     allowFrom: ElevatedAllowFromSchema.optional(),
   })
   .strict()


### PR DESCRIPTION
## Summary
- Adds owner-id obfuscation config surface for issue #7343.
- Introduces `commands.ownerDisplaySecret` to explicitly control HMAC hashing for owner IDs in system prompts.
- Keeps backward compatibility by falling back to existing gateway token values when explicit secret is not set.
- Adds coverage for explicit secret behavior in system prompt tests.

## Changes
- Add typed config key and schema support for `commands.ownerDisplaySecret`.
- Mark new secret config key as sensitive.
- Propagate config value into CLI and embedded prompt builder flows.
- Update owner-ID hashing to use HMAC (when a secret exists), with a non-leaking short token output.
- Add test for secret-specific hash behavior.

Fixes #7343

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces `commands.ownerDisplaySecret` config field to enable explicit HMAC-based hashing of owner IDs in system prompts. When `ownerDisplay=hash`, owner phone numbers are obfuscated using HMAC-SHA256 (with explicit secret) or SHA256 (fallback), outputting 12-character hex tokens. Maintains backward compatibility by falling back to existing gateway auth tokens when no explicit secret is configured.

**Key Changes:**
- Added `ownerDisplay` and `ownerDisplaySecret` config schema fields with proper typing and sensitive field registration
- Implemented `formatOwnerDisplayId()` function using HMAC-SHA256 when secret exists, SHA256 otherwise, truncated to 12 hex characters
- Propagated config values through CLI runner, embedded runner, and system prompt builder
- Added comprehensive test coverage for hash behavior and secret-specific outputs

**Architecture:**
The implementation follows the existing config propagation pattern through `buildSystemPrompt()` → `buildOwnerIdentityLine()` → `formatOwnerDisplayId()`. The fallback chain (`ownerDisplaySecret ?? gateway.auth.token ?? gateway.remote.token`) ensures existing deployments continue working without changes.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - solid implementation of security-focused feature
- Well-implemented security feature with proper type safety, sensitive field marking, comprehensive tests, and backward compatibility. The fallback chain is correctly implemented across all call sites. Minor suggestion on hash truncation length doesn't affect correctness.
- No files require special attention

<sub>Last reviewed commit: 38b23d7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->