### PR TITLE
fix: strip newlines from pasted setup-tokens

### DIFF
--- a/src/commands/auth-choice.apply.anthropic.ts
+++ b/src/commands/auth-choice.apply.anthropic.ts
@@ -5,7 +5,11 @@ import {
   validateApiKeyInput,
 } from "./auth-choice.api-key.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
-import { buildTokenProfileId, validateAnthropicSetupToken } from "./auth-token.js";
+import {
+  buildTokenProfileId,
+  normalizeSetupToken,
+  validateAnthropicSetupToken,
+} from "./auth-token.js";
 import { applyAgentDefaultModelPrimary } from "./onboard-auth.config-shared.js";
 import { applyAuthProfileConfig, setAnthropicApiKey } from "./onboard-auth.js";
 
@@ -31,7 +35,7 @@ export async function applyAuthChoiceAnthropic(
       message: "Paste Anthropic setup-token",
       validate: (value) => validateAnthropicSetupToken(String(value ?? "")),
     });
-    const token = String(tokenRaw ?? "").trim();
+    const token = normalizeSetupToken(String(tokenRaw ?? ""));
 
     const profileNameRaw = await params.prompter.text({
       message: "Token name (blank = default)",

--- a/src/commands/auth-token.test.ts
+++ b/src/commands/auth-token.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeSetupToken,
+  validateAnthropicSetupToken,
+  ANTHROPIC_SETUP_TOKEN_MIN_LENGTH,
+  ANTHROPIC_SETUP_TOKEN_PREFIX,
+} from "./auth-token.js";
+
+// Fake token with realistic structure (prefix + random base64-like chars, >80 chars)
+const FAKE_TOKEN_PART1 = "sk-ant-oat01-aaaBBBcccDDDeee-FFFgggHHHiiiJJJkkkLLLmmmNNNooo-PPPqqqRRRsss";
+const FAKE_TOKEN_PART2 = "TTTuuuVVVwwwXXXyyyZZZ123456";
+const FAKE_TOKEN = FAKE_TOKEN_PART1 + FAKE_TOKEN_PART2;
+
+describe("normalizeSetupToken", () => {
+  it("strips newlines from pasted tokens", () => {
+    const pasted = FAKE_TOKEN_PART1 + "\n" + FAKE_TOKEN_PART2;
+    expect(normalizeSetupToken(pasted)).toBe(FAKE_TOKEN);
+  });
+
+  it("strips carriage-return + newline", () => {
+    const pasted = FAKE_TOKEN_PART1 + "\r\n" + FAKE_TOKEN_PART2;
+    expect(normalizeSetupToken(pasted)).toBe(FAKE_TOKEN);
+  });
+
+  it("strips leading and trailing whitespace", () => {
+    expect(normalizeSetupToken(`  ${FAKE_TOKEN}  `)).toBe(FAKE_TOKEN);
+  });
+
+  it("passes through clean tokens unchanged", () => {
+    expect(normalizeSetupToken(FAKE_TOKEN)).toBe(FAKE_TOKEN);
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeSetupToken("")).toBe("");
+    expect(normalizeSetupToken("  \n  ")).toBe("");
+  });
+});
+
+describe("validateAnthropicSetupToken", () => {
+  it("accepts a valid token", () => {
+    expect(FAKE_TOKEN.length).toBeGreaterThanOrEqual(ANTHROPIC_SETUP_TOKEN_MIN_LENGTH);
+    expect(validateAnthropicSetupToken(FAKE_TOKEN)).toBeUndefined();
+  });
+
+  it("accepts a valid token with embedded newlines", () => {
+    const withNewline = FAKE_TOKEN_PART1 + "\n" + FAKE_TOKEN_PART2;
+    expect(validateAnthropicSetupToken(withNewline)).toBeUndefined();
+  });
+
+  it("rejects empty input", () => {
+    expect(validateAnthropicSetupToken("")).toBe("Required");
+  });
+
+  it("rejects wrong prefix", () => {
+    expect(validateAnthropicSetupToken("sk-ant-api03-" + "x".repeat(80))).toMatch(/Expected token/);
+  });
+
+  it("rejects tokens shorter than minimum length", () => {
+    const short = ANTHROPIC_SETUP_TOKEN_PREFIX + "too-short";
+    expect(validateAnthropicSetupToken(short)).toMatch(/too short/);
+  });
+
+  it("handles token split across lines during paste", () => {
+    // Simulates terminal paste where a long token wraps and introduces a newline
+    const withNewline = FAKE_TOKEN_PART1 + "\n" + FAKE_TOKEN_PART2;
+    // Validation should accept the full token after normalizing away the newline
+    expect(validateAnthropicSetupToken(withNewline)).toBeUndefined();
+    // Normalized form should be longer than the minimum
+    expect(normalizeSetupToken(withNewline).length).toBeGreaterThan(
+      ANTHROPIC_SETUP_TOKEN_MIN_LENGTH,
+    );
+  });
+});

--- a/src/commands/auth-token.ts
+++ b/src/commands/auth-token.ts
@@ -23,15 +23,24 @@ export function buildTokenProfileId(params: { provider: string; name: string }):
   return `${provider}:${name}`;
 }
 
+/**
+ * Strip all whitespace (including newlines) from a pasted token.
+ * `claude setup-token` may output tokens that wrap across lines,
+ * and terminal paste can introduce newlines that silently truncate the value.
+ */
+export function normalizeSetupToken(raw: string): string {
+  return raw.replace(/\s+/g, "");
+}
+
 export function validateAnthropicSetupToken(raw: string): string | undefined {
-  const trimmed = raw.trim();
-  if (!trimmed) {
+  const normalized = normalizeSetupToken(raw);
+  if (!normalized) {
     return "Required";
   }
-  if (!trimmed.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX)) {
+  if (!normalized.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX)) {
     return `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_PREFIX}`;
   }
-  if (trimmed.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH) {
+  if (normalized.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH) {
     return "Token looks too short; paste the full setup-token";
   }
   return undefined;

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -16,7 +16,7 @@ import type { ProviderAuthResult, ProviderPlugin } from "../../plugins/types.js"
 import type { RuntimeEnv } from "../../runtime.js";
 import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
-import { validateAnthropicSetupToken } from "../auth-token.js";
+import { normalizeSetupToken, validateAnthropicSetupToken } from "../auth-token.js";
 import { isRemoteEnvironment } from "../oauth-env.js";
 import { createVpsAwareOAuthHandlers } from "../oauth-flow.js";
 import { applyAuthProfileConfig } from "../onboard-auth.js";
@@ -93,7 +93,7 @@ export async function modelsAuthSetupTokenCommand(
     message: "Paste Anthropic setup-token",
     validate: (value) => validateAnthropicSetupToken(String(value ?? "")),
   });
-  const token = String(tokenInput ?? "").trim();
+  const token = normalizeSetupToken(String(tokenInput ?? ""));
   const profileId = resolveDefaultTokenProfileId(provider);
 
   upsertAuthProfile({
@@ -136,7 +136,7 @@ export async function modelsAuthPasteTokenCommand(
     message: `Paste token for ${provider}`,
     validate: (value) => (value?.trim() ? undefined : "Required"),
   });
-  const token = String(tokenInput ?? "").trim();
+  const token = normalizeSetupToken(String(tokenInput ?? ""));
 
   const expires =
     opts.expiresIn?.trim() && opts.expiresIn.trim().length > 0


### PR DESCRIPTION
## Summary
- `claude setup-token` outputs tokens that may wrap across terminal lines
- When pasted into the onboard wizard or `models auth` commands, embedded newlines silently truncate the token value, causing persistent 401 authentication failures
- Added `normalizeSetupToken()` that strips all whitespace (including `\n`, `\r\n`) before validation and storage
- Applied normalization in all three token-paste paths: onboard wizard, `models auth setup-token`, and `models auth paste-token`

## Root Cause

Long OAuth tokens (`sk-ant-oat01-*`) exceed typical terminal line width. When a user pastes a token that wraps across lines, the `@clack/prompts` text input captures only the first line, silently truncating the token. The truncated token passes prefix validation but fails API authentication with a 401.

## Related Issues

This fix addresses or partially addresses the following open issues:

- Fixes #8733 — **Claude token paste incomplete** (exact same root cause: newline in pasted token truncates the value)
- Fixes #9141 — **Configure wizard fails to save Anthropic setup token** (token truncation during onboard wizard)
- Related to #9938 — **Anthropic OAuth tokens stopped working** (many 401 reports likely caused by truncated tokens)
- Related to #6732 — **Anthropic token authentication misverification** (token validation issues)
- Related to #17274 — **Anthropic OAuth not saving refresh token** (auth profile appears saved but token is incomplete)
- Related to #19938 — **Setup-token auth broken after update** (401 errors with setup-token auth)

## Changes

| File | Change |
|------|--------|
| `src/commands/auth-token.ts` | Added `normalizeSetupToken()` — strips all whitespace; `validateAnthropicSetupToken()` now normalizes before validating |
| `src/commands/auth-choice.apply.anthropic.ts` | Use `normalizeSetupToken()` instead of `.trim()` when storing token |
| `src/commands/models/auth.ts` | Same fix in `modelsAuthSetupTokenCommand` and `modelsAuthPasteTokenCommand` |
| `src/commands/auth-token.test.ts` | 11 unit tests covering newline stripping, CR+LF, whitespace trim, passthrough, empty input, and full validation flow |

## Test plan
- [x] 11 unit tests pass (`vitest run src/commands/auth-token.test.ts`)
- [x] `pnpm check` passes (format, types, lint — zero warnings)
- [x] `pnpm build` succeeds
- [x] Manual: paste a token with embedded newline during `openclaw models auth setup-token` — token stored correctly with full value
- [x] Manual: verified stored token in `auth-profiles.json` contains no newline and matches expected full token