### PR TITLE
docs: small docs sweep consistency updates

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -31,7 +31,7 @@ Local checkout (when running from a git repo):
 openclaw plugins install ./extensions/line
 ```
 
-## Setup
+## Onboarding
 
 1. Create a LINE Developers account and open the Console:
    [https://developers.line.biz/console/](https://developers.line.biz/console/)
@@ -48,7 +48,7 @@ The gateway responds to LINE’s webhook verification (GET) and inbound events (
 If you need a custom path, set `channels.line.webhookPath` or
 `channels.line.accounts.<id>.webhookPath` and update the URL accordingly.
 
-## Configure
+## Configuration
 
 Minimal config:
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -36,7 +36,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Setup
+## Onboarding
 
 1. Install the Matrix plugin:
    - From npm: `openclaw plugins install @openclaw/matrix`

--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -30,7 +30,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Install the Nextcloud Talk plugin.
 2. On your Nextcloud server, create a bot:
@@ -106,7 +106,7 @@ Minimal config:
 | Reactions       | Supported     |
 | Native commands | Not supported |
 
-## Configuration reference (Nextcloud Talk)
+## Configuration
 
 Full configuration: [Configuration](/gateway/configuration)
 

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -61,6 +61,7 @@ title: "Thinking Levels"
 ## Related
 
 - Elevated mode docs live in [Elevated mode](/tools/elevated).
+- Reasoning visibility behavior is documented in [Reasoning visibility](/tools/thinking#reasoning-visibility-reasoning).
 
 ## Heartbeats
 


### PR DESCRIPTION
## Summary
- Fix broken internal link reference in Thinking docs.
- Standardize onboarding/configuration section headings in 3 channel docs for consistency.

## Linked Issues
- none

## Verification
- No behavior or runtime code touched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only sweep that standardizes section headings across three plugin channel docs (LINE, Matrix, Nextcloud Talk) and adds a missing cross-reference in the Thinking docs.

- **Channel docs heading normalization**: Renames `## Setup` / `## Quick setup (beginner)` to `## Onboarding` and `## Configure` / `## Configuration reference (Nextcloud Talk)` to `## Configuration` across the LINE, Matrix, and Nextcloud Talk plugin docs for consistency.
- **Thinking docs cross-reference**: Adds a link to the `## Reasoning visibility (/reasoning)` section in the Related section of `docs/tools/thinking.md`. Note: this is a self-referential link (same page), which is slightly unusual for a "Related" section but functions as a quick-jump anchor.
- No runtime code or behavior changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only renames documentation headings and adds a cross-reference link with no runtime code changes.
- All changes are limited to Markdown documentation files (heading renames and one added link). No code, configuration, or behavior is affected. The heading renames are consistent with the stated goal and the anchor link appears correctly formed for Mintlify.
- No files require special attention.

<sub>Last reviewed commit: d033d57</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->