### PR TITLE
docs: continue channel onboarding/config naming cleanup

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -21,7 +21,7 @@ Status: ready for DMs and guild channels via the official Discord gateway.
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 You will need to create a new application with a bot, add the bot to your server, and pair it to OpenClaw. We recommend adding your bot to your own private server. If you don't have one yet, [create one first](https://support.discord.com/hc/en-us/articles/204849977-How-do-I-create-a-server) (choose **Create My Own > For me and my friends**).
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -28,7 +28,7 @@ Status: legacy external CLI integration. Gateway spawns `imsg rpc` and communica
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Tabs>
   <Tab title="Local Mac (fast path)">
@@ -358,7 +358,7 @@ imsg send <handle> "test"
   </Accordion>
 </AccordionGroup>
 
-## Configuration reference pointers
+## Configuration
 
 - [Configuration reference - iMessage](/gateway/configuration-reference#imessage)
 - [Gateway configuration](/gateway/configuration)

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -31,7 +31,7 @@ Local checkout (when running from a git repo):
 openclaw plugins install ./extensions/line
 ```
 
-## Setup
+## Onboarding
 
 1. Create a LINE Developers account and open the Console:
    [https://developers.line.biz/console/](https://developers.line.biz/console/)
@@ -48,7 +48,7 @@ The gateway responds to LINE’s webhook verification (GET) and inbound events (
 If you need a custom path, set `channels.line.webhookPath` or
 `channels.line.accounts.<id>.webhookPath` and update the URL accordingly.
 
-## Configure
+## Configuration
 
 Minimal config:
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -36,7 +36,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Setup
+## Onboarding
 
 1. Install the Matrix plugin:
    - From npm: `openclaw plugins install @openclaw/matrix`

--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -30,7 +30,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Install the Nextcloud Talk plugin.
 2. On your Nextcloud server, create a bot:
@@ -106,7 +106,7 @@ Minimal config:
 | Reactions       | Supported     |
 | Native commands | Not supported |
 
-## Configuration reference (Nextcloud Talk)
+## Configuration
 
 Full configuration: [Configuration](/gateway/configuration)
 

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -17,7 +17,7 @@ Status: external CLI integration. Gateway talks to `signal-cli` over HTTP JSON-R
 - A phone number that can receive one verification SMS (for SMS registration path).
 - Browser access for Signal captcha (`signalcaptchas.org`) during registration.
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Use a **separate Signal number** for the bot (recommended).
 2. Install `signal-cli` (Java required if you use the JVM build).

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -21,7 +21,7 @@ Status: production-ready for DMs + channels via Slack app integrations. Default 
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Tabs>
   <Tab title="Socket Mode (default)">
@@ -487,7 +487,7 @@ channels:
 - Media and non-text payloads fall back to normal delivery.
 - If streaming fails mid-reply, OpenClaw falls back to normal delivery for remaining payloads.
 
-## Configuration reference pointers
+## Configuration
 
 Primary reference:
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -21,7 +21,7 @@ Status: production-ready for bot DMs + groups via grammY. Long polling is the de
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Steps>
   <Step title="Create the bot token in BotFather">

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -21,7 +21,7 @@ Status: production-ready via WhatsApp Web (Baileys). Gateway owns linked session
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Steps>
   <Step title="Configure WhatsApp access policy">

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -61,6 +61,7 @@ title: "Thinking Levels"
 ## Related
 
 - Elevated mode docs live in [Elevated mode](/tools/elevated).
+- Reasoning visibility behavior is documented in [Reasoning visibility](/tools/thinking#reasoning-visibility-reasoning).
 
 ## Heartbeats
 


### PR DESCRIPTION
## Summary
- Rename channel headings to consistent Onboarding/Configuration terms for iMessage, Slack, and Signal docs.
- Docs-only consistency pass for per-channel docs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renamed channel documentation headings to use consistent `Onboarding` and `Configuration` terminology across nine channel docs (Discord, iMessage, LINE, Matrix, Nextcloud Talk, Signal, Slack, Telegram, WhatsApp). Also added a self-referential link in `docs/tools/thinking.md` on line 64.

- Discord: `Quick setup` → `Onboarding` (line 24)
- iMessage: `Quick setup` → `Onboarding` (line 31), `Configuration reference pointers` → `Configuration` (line 361)
- LINE: `Setup` → `Onboarding` (line 34), `Configure` → `Configuration` (line 51)
- Matrix: `Setup` → `Onboarding` (line 39)
- Nextcloud Talk: `Quick setup (beginner)` → `Onboarding` (line 33), `Configuration reference (Nextcloud Talk)` → `Configuration` (line 109)
- Signal: `Quick setup (beginner)` → `Onboarding` (line 20)
- Slack: `Quick setup` → `Onboarding` (line 24), `Configuration reference pointers` → `Configuration` (line 490)
- Telegram: `Quick setup` → `Onboarding` (line 24)
- WhatsApp: `Quick setup` → `Onboarding` (line 24)
- thinking.md: added circular reference link pointing to itself (line 64)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only changes that standardize heading terminology across channel files. All changes are purely cosmetic text updates with no functional impact. The one style suggestion addresses a minor circular reference in thinking.md.
- No files require special attention

<sub>Last reviewed commit: a3bc5b5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->