### PR TITLE
docs: more channel onboarding naming cleanup

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -21,7 +21,7 @@ Status: ready for DMs and guild channels via the official Discord gateway.
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 You will need to create a new application with a bot, add the bot to your server, and pair it to OpenClaw. We recommend adding your bot to your own private server. If you don't have one yet, [create one first](https://support.discord.com/hc/en-us/articles/204849977-How-do-I-create-a-server) (choose **Create My Own > For me and my friends**).
 

--- a/docs/channels/googlechat.md
+++ b/docs/channels/googlechat.md
@@ -9,7 +9,7 @@ title: "Google Chat"
 
 Status: ready for DMs + spaces via Google Chat API webhooks (HTTP only).
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Create a Google Cloud project and enable the **Google Chat API**.
    - Go to: [Google Chat API Credentials](https://console.cloud.google.com/apis/api/chat.googleapis.com/credentials)

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -28,7 +28,7 @@ Status: legacy external CLI integration. Gateway spawns `imsg rpc` and communica
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Tabs>
   <Tab title="Local Mac (fast path)">
@@ -358,7 +358,7 @@ imsg send <handle> "test"
   </Accordion>
 </AccordionGroup>
 
-## Configuration reference pointers
+## Configuration
 
 - [Configuration reference - iMessage](/gateway/configuration-reference#imessage)
 - [Gateway configuration](/gateway/configuration)

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -31,7 +31,7 @@ Local checkout (when running from a git repo):
 openclaw plugins install ./extensions/line
 ```
 
-## Setup
+## Onboarding
 
 1. Create a LINE Developers account and open the Console:
    [https://developers.line.biz/console/](https://developers.line.biz/console/)
@@ -48,7 +48,7 @@ The gateway responds to LINE’s webhook verification (GET) and inbound events (
 If you need a custom path, set `channels.line.webhookPath` or
 `channels.line.accounts.<id>.webhookPath` and update the URL accordingly.
 
-## Configure
+## Configuration
 
 Minimal config:
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -36,7 +36,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Setup
+## Onboarding
 
 1. Install the Matrix plugin:
    - From npm: `openclaw plugins install @openclaw/matrix`

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -33,7 +33,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup
+## Onboarding
 
 1. Install the Mattermost plugin.
 2. Create a Mattermost bot account and copy the **bot token**.

--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -30,7 +30,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Install the Nextcloud Talk plugin.
 2. On your Nextcloud server, create a bot:
@@ -106,7 +106,7 @@ Minimal config:
 | Reactions       | Supported     |
 | Native commands | Not supported |
 
-## Configuration reference (Nextcloud Talk)
+## Configuration
 
 Full configuration: [Configuration](/gateway/configuration)
 

--- a/docs/channels/nostr.md
+++ b/docs/channels/nostr.md
@@ -40,7 +40,7 @@ openclaw plugins install --link <path-to-openclaw>/extensions/nostr
 
 Restart the Gateway after installing or enabling plugins.
 
-## Quick setup
+## Onboarding
 
 1. Generate a Nostr keypair (if needed):
 
@@ -69,7 +69,7 @@ export NOSTR_PRIVATE_KEY="nsec1..."
 
 4. Restart the Gateway.
 
-## Configuration reference
+## Configuration
 
 | Key          | Type     | Default                                     | Description                         |
 | ------------ | -------- | ------------------------------------------- | ----------------------------------- |

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -17,7 +17,7 @@ Status: external CLI integration. Gateway talks to `signal-cli` over HTTP JSON-R
 - A phone number that can receive one verification SMS (for SMS registration path).
 - Browser access for Signal captcha (`signalcaptchas.org`) during registration.
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Use a **separate Signal number** for the bot (recommended).
 2. Install `signal-cli` (Java required if you use the JVM build).

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -21,7 +21,7 @@ Status: production-ready for DMs + channels via Slack app integrations. Default 
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Tabs>
   <Tab title="Socket Mode (default)">
@@ -487,7 +487,7 @@ channels:
 - Media and non-text payloads fall back to normal delivery.
 - If streaming fails mid-reply, OpenClaw falls back to normal delivery for remaining payloads.
 
-## Configuration reference pointers
+## Configuration
 
 Primary reference:
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -21,7 +21,7 @@ Status: production-ready for bot DMs + groups via grammY. Long polling is the de
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Steps>
   <Step title="Create the bot token in BotFather">

--- a/docs/channels/twitch.md
+++ b/docs/channels/twitch.md
@@ -27,7 +27,7 @@ openclaw plugins install ./extensions/twitch
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Create a dedicated Twitch account for the bot (or use an existing account).
 2. Generate credentials: [Twitch Token Generator](https://twitchtokengenerator.com/)

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -21,7 +21,7 @@ Status: production-ready via WhatsApp Web (Baileys). Gateway owns linked session
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Steps>
   <Step title="Configure WhatsApp access policy">

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -17,7 +17,7 @@ Zalo ships as a plugin and is not bundled with the core install.
 - Or select **Zalo** during onboarding and confirm the install prompt
 - Details: [Plugins](/tools/plugin)
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Install the Zalo plugin:
    - From a source checkout: `openclaw plugins install ./extensions/zalo`
@@ -161,7 +161,7 @@ Multi-account support: use `channels.zalo.accounts` with per-account tokens and 
 - Confirm the gateway HTTP endpoint is reachable on the configured path
 - Check that getUpdates polling is not running (they're mutually exclusive)
 
-## Configuration reference (Zalo)
+## Configuration
 
 Full configuration: [Configuration](/gateway/configuration)
 

--- a/docs/channels/zalouser.md
+++ b/docs/channels/zalouser.md
@@ -27,7 +27,7 @@ The Gateway machine must have the `zca` binary available in `PATH`.
 - Verify: `zca --version`
 - If missing, install zca-cli (see `extensions/zalouser/README.md` or the upstream zca-cli docs).
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Install the plugin (see above).
 2. Login (QR, on the Gateway machine):

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -61,6 +61,7 @@ title: "Thinking Levels"
 ## Related
 
 - Elevated mode docs live in [Elevated mode](/tools/elevated).
+- Reasoning visibility behavior is documented in [Reasoning visibility](/tools/thinking#reasoning-visibility-reasoning).
 
 ## Heartbeats
 


### PR DESCRIPTION
## Summary
- Convert quick setup headings to Onboarding for Google Chat, Mattermost, and Zalo Personal docs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR continues the ongoing effort to standardize channel documentation headings by converting various "Quick setup" headings to "Onboarding" across 16 channel documentation files.

- Converted headings in 14 channel docs: Discord, Google Chat, iMessage, LINE, Matrix, Mattermost, Nextcloud Talk, Nostr, Signal, Slack, Telegram, Twitch, WhatsApp, Zalo, and Zalo Personal
- Most changes also standardized related "Configuration reference" headings to just "Configuration"
- Added one line to `docs/tools/thinking.md` creating a self-referential link
- Note: `docs/channels/msteams.md` still contains "Quick setup (beginner)" and was not updated in this PR

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it only contains documentation heading changes
- All changes are purely cosmetic documentation updates that standardize heading names across channel documentation files. No code, configuration, or functional changes are present. The only minor issue is a self-referential link in thinking.md which is a style preference rather than a functional problem.
- No files require special attention

<sub>Last reviewed commit: 64f76e8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->