### PR TITLE
fix(signal): preserve original filename in outbound attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Signal: preserve original filename in outbound attachments instead of UUID-only temp names. (#22487)
 - Security/Gateway/Hooks: block `__proto__`, `constructor`, and `prototype` traversal in webhook template path resolution to prevent prototype-chain payload data leakage in `messageTemplate` rendering. (#22213) Thanks @SleuthCo.
 - Cron: honor `cron.maxConcurrentRuns` in the timer loop so due jobs can execute up to the configured parallelism instead of always running serially. (#11595) Thanks @Takhoffman.
 - Agents/Compaction: restore embedded compaction safeguard/context-pruning extension loading in production by wiring bundled extension factories into the resource loader instead of runtime file-path resolution. (#22349) Thanks @Glucksberg.

--- a/src/media/outbound-attachment.test.ts
+++ b/src/media/outbound-attachment.test.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+
+describe("resolveOutboundAttachmentFromUrl", () => {
+  let tempHome: TempHomeEnv;
+  let home: string;
+
+  beforeAll(async () => {
+    tempHome = await createTempHomeEnv("openclaw-test-outbound-attachment-");
+    home = tempHome.home;
+  });
+
+  afterAll(async () => {
+    try {
+      await tempHome.restore();
+    } catch {
+      // ignore cleanup failures
+    }
+  });
+
+  it("preserves original filename in saved path", async () => {
+    const srcDir = path.join(home, "files");
+    await fs.mkdir(srcDir, { recursive: true });
+    const srcFile = path.join(srcDir, "MyDocument.txt");
+    await fs.writeFile(srcFile, "hello world");
+
+    const { resolveOutboundAttachmentFromUrl } = await import("./outbound-attachment.js");
+
+    const result = await resolveOutboundAttachmentFromUrl(srcFile, 5 * 1024 * 1024, {
+      localRoots: [srcDir],
+    });
+
+    const basename = path.basename(result.path);
+    expect(basename).toMatch(/^MyDocument---[a-f0-9-]{36}\.txt$/);
+  });
+
+  it("handles files without extension", async () => {
+    const srcDir = path.join(home, "files");
+    await fs.mkdir(srcDir, { recursive: true });
+    const srcFile = path.join(srcDir, "Makefile");
+    await fs.writeFile(srcFile, "all: build");
+
+    const { resolveOutboundAttachmentFromUrl } = await import("./outbound-attachment.js");
+
+    const result = await resolveOutboundAttachmentFromUrl(srcFile, 5 * 1024 * 1024, {
+      localRoots: [srcDir],
+    });
+
+    const basename = path.basename(result.path);
+    expect(basename).toContain("Makefile");
+  });
+});

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -15,6 +15,7 @@ export async function resolveOutboundAttachmentFromUrl(
     media.contentType ?? undefined,
     "outbound",
     maxBytes,
+    media.fileName,
   );
   return { path: saved.path, contentType: saved.contentType };
 }


### PR DESCRIPTION
## Summary

- **Bug**: Signal outbound attachments arrive with UUID-only filenames instead of the original filename
- **Root cause**: `resolveOutboundAttachmentFromUrl` in `src/media/outbound-attachment.ts` discards `media.fileName` returned by `loadWebMedia`, never passing it to `saveMediaBuffer`
- **Fix**: Pass `media.fileName` as the `originalFilename` parameter to `saveMediaBuffer`

Fixes #22487

## Problem

When sending a file via Signal, the file arrives in the recipient's client with a UUID name (e.g. `533d51fb-ca5b-42ef-ab0d-a1bc68e10892.zip`) instead of the original filename.

The root cause is in `resolveOutboundAttachmentFromUrl`:
1. `loadWebMedia()` returns `{ buffer, contentType, kind, fileName }` — `fileName` is populated from `path.basename(mediaUrl)`
2. `saveMediaBuffer()` already supports an `originalFilename` parameter (5th arg) that embeds the name in the stored path as `{sanitized}---{uuid}.ext`
3. But `resolveOutboundAttachmentFromUrl` never passes `media.fileName` through — it calls `saveMediaBuffer` with only 4 args

**Before fix:**
```
Input:  mediaUrl = "/path/to/MyDocument.txt"
Output: saved path = "07ea27ef-66d6-4da8-918d-bcef93d25a5c.txt"
```

## Changes

- `src/media/outbound-attachment.ts` — pass `media.fileName` to `saveMediaBuffer` as the 5th argument
- `src/media/outbound-attachment.test.ts` — new regression test

**After fix:**
```
Input:  mediaUrl = "/path/to/MyDocument.txt"
Output: saved path = "MyDocument---711c4d08-d9f5-4b7e-82d3-ee49bdebce7d.txt"
```

## Test plan

- [x] New test: `outbound-attachment.test.ts` — verifies filename preservation for normal files and extensionless files
- [x] All 18 existing `store.test.ts` tests pass
- [x] Format check passes (`oxfmt --check`)

## Effect on User Experience

**Before:** Every file sent via Signal arrives with a UUID filename (e.g. `533d51fb-...-.zip`), confusing recipients who download the file.
**After:** Files arrive with their original filename preserved (e.g. `MyDocument.zip`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Signal outbound attachments to preserve original filenames instead of UUID-only names. The fix passes `media.fileName` from `loadWebMedia` through to `saveMediaBuffer` as the 5th argument (`originalFilename`), enabling the existing filename-embedding feature that creates paths like `MyDocument---{uuid}.txt` instead of just `{uuid}.txt`.

- Fixed `src/media/outbound-attachment.ts:18` by adding `media.fileName` as the 5th parameter to `saveMediaBuffer`
- Added regression tests in `src/media/outbound-attachment.test.ts` covering normal files and extensionless files
- Updated `CHANGELOG.md` with user-facing fix description

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple one-line change that passes an existing parameter to an already-tested function. The `saveMediaBuffer` function already has comprehensive test coverage for the `originalFilename` parameter (lines 236-303 in `store.test.ts`), and the new regression tests verify the end-to-end behavior. The change is backwards-compatible (passing `undefined` falls back to UUID-only behavior), and the logic matches the PR description perfectly.
- No files require special attention

<sub>Last reviewed commit: 5505e23</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->