### PR TITLE
docs: more channel heading consistency updates

### DIFF
--- a/docs/channels/bluebubbles.md
+++ b/docs/channels/bluebubbles.md
@@ -284,7 +284,7 @@ Control whether responses are sent as a single message or streamed in blocks:
 - Media cap via `channels.bluebubbles.mediaMaxMb` (default: 8 MB).
 - Outbound text is chunked to `channels.bluebubbles.textChunkLimit` (default: 4000 chars).
 
-## Configuration reference
+## Configuration
 
 Full configuration: [Configuration](/gateway/configuration)
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -963,7 +963,7 @@ openclaw logs --follow
   </Accordion>
 </AccordionGroup>
 
-## Configuration reference pointers
+## Configuration
 
 Primary reference:
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -21,7 +21,7 @@ Status: ready for DMs and guild channels via the official Discord gateway.
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 You will need to create a new application with a bot, add the bot to your server, and pair it to OpenClaw. We recommend adding your bot to your own private server. If you don't have one yet, [create one first](https://support.discord.com/hc/en-us/articles/204849977-How-do-I-create-a-server) (choose **Create My Own > For me and my friends**).
 

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -523,7 +523,7 @@ See [Get group/user IDs](#get-groupuser-ids) for lookup tips.
 
 ---
 
-## Configuration reference
+## Configuration
 
 Full configuration: [Gateway configuration](/gateway/configuration)
 

--- a/docs/channels/googlechat.md
+++ b/docs/channels/googlechat.md
@@ -9,7 +9,7 @@ title: "Google Chat"
 
 Status: ready for DMs + spaces via Google Chat API webhooks (HTTP only).
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Create a Google Cloud project and enable the **Google Chat API**.
    - Go to: [Google Chat API Credentials](https://console.cloud.google.com/apis/api/chat.googleapis.com/credentials)

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -28,7 +28,7 @@ Status: legacy external CLI integration. Gateway spawns `imsg rpc` and communica
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Tabs>
   <Tab title="Local Mac (fast path)">
@@ -358,7 +358,7 @@ imsg send <handle> "test"
   </Accordion>
 </AccordionGroup>
 
-## Configuration reference pointers
+## Configuration
 
 - [Configuration reference - iMessage](/gateway/configuration-reference#imessage)
 - [Gateway configuration](/gateway/configuration)

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -31,7 +31,7 @@ Local checkout (when running from a git repo):
 openclaw plugins install ./extensions/line
 ```
 
-## Setup
+## Onboarding
 
 1. Create a LINE Developers account and open the Console:
    [https://developers.line.biz/console/](https://developers.line.biz/console/)
@@ -48,7 +48,7 @@ The gateway responds to LINE’s webhook verification (GET) and inbound events (
 If you need a custom path, set `channels.line.webhookPath` or
 `channels.line.accounts.<id>.webhookPath` and update the URL accordingly.
 
-## Configure
+## Configuration
 
 Minimal config:
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -270,7 +270,7 @@ Common failures:
 
 For triage flow: [/channels/troubleshooting](/channels/troubleshooting).
 
-## Configuration reference (Matrix)
+## Configuration
 
 Full configuration: [Configuration](/gateway/configuration)
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -36,7 +36,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Setup
+## Onboarding
 
 1. Install the Matrix plugin:
    - From npm: `openclaw plugins install @openclaw/matrix`

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -33,7 +33,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup
+## Onboarding
 
 1. Install the Mattermost plugin.
 2. Create a Mattermost bot account and copy the **bot token**.

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -38,7 +38,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Install the Microsoft Teams plugin.
 2. Create an **Azure Bot** (App ID + client secret + tenant ID).

--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -30,7 +30,7 @@ OpenClaw will offer the local install path automatically.
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Install the Nextcloud Talk plugin.
 2. On your Nextcloud server, create a bot:
@@ -106,7 +106,7 @@ Minimal config:
 | Reactions       | Supported     |
 | Native commands | Not supported |
 
-## Configuration reference (Nextcloud Talk)
+## Configuration
 
 Full configuration: [Configuration](/gateway/configuration)
 

--- a/docs/channels/nostr.md
+++ b/docs/channels/nostr.md
@@ -40,7 +40,7 @@ openclaw plugins install --link <path-to-openclaw>/extensions/nostr
 
 Restart the Gateway after installing or enabling plugins.
 
-## Quick setup
+## Onboarding
 
 1. Generate a Nostr keypair (if needed):
 
@@ -69,7 +69,7 @@ export NOSTR_PRIVATE_KEY="nsec1..."
 
 4. Restart the Gateway.
 
-## Configuration reference
+## Configuration
 
 | Key          | Type     | Default                                     | Description                         |
 | ------------ | -------- | ------------------------------------------- | ----------------------------------- |

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -17,7 +17,7 @@ Status: external CLI integration. Gateway talks to `signal-cli` over HTTP JSON-R
 - A phone number that can receive one verification SMS (for SMS registration path).
 - Browser access for Signal captcha (`signalcaptchas.org`) during registration.
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Use a **separate Signal number** for the bot (recommended).
 2. Install `signal-cli` (Java required if you use the JVM build).

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -76,7 +76,7 @@ Disable with:
 - If you run the bot on **your personal Signal account**, it will ignore your own messages (loop protection).
 - For "I text the bot and it replies," use a **separate bot number**.
 
-## Setup path A: link existing Signal account (QR)
+## Setup (option A): link existing Signal account (QR)
 
 1. Install `signal-cli` (JVM or native build).
 2. Link a bot account:
@@ -101,7 +101,7 @@ Example:
 
 Multi-account support: use `channels.signal.accounts` with per-account config and optional `name`. See [`gateway/configuration`](/gateway/configuration#telegramaccounts--discordaccounts--slackaccounts--signalaccounts--imessageaccounts) for the shared pattern.
 
-## Setup path B: register dedicated bot number (SMS, Linux)
+## Setup (option B): register dedicated bot number (SMS, Linux)
 
 Use this when you want a dedicated bot number instead of linking an existing Signal app account.
 

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -290,7 +290,7 @@ For triage flow: [/channels/troubleshooting](/channels/troubleshooting).
 - Keep `channels.signal.dmPolicy: "pairing"` unless you explicitly want broader DM access.
 - SMS verification is only needed for registration or recovery flows, but losing control of the number/account can complicate re-registration.
 
-## Configuration reference (Signal)
+## Configuration
 
 Full configuration: [Configuration](/gateway/configuration)
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -21,7 +21,7 @@ Status: production-ready for DMs + channels via Slack app integrations. Default 
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Tabs>
   <Tab title="Socket Mode (default)">
@@ -487,7 +487,7 @@ channels:
 - Media and non-text payloads fall back to normal delivery.
 - If streaming fails mid-reply, OpenClaw falls back to normal delivery for remaining payloads.
 
-## Configuration reference pointers
+## Configuration
 
 Primary reference:
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -21,7 +21,7 @@ Status: production-ready for bot DMs + groups via grammY. Long polling is the de
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Steps>
   <Step title="Create the bot token in BotFather">

--- a/docs/channels/twitch.md
+++ b/docs/channels/twitch.md
@@ -27,7 +27,7 @@ openclaw plugins install ./extensions/twitch
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Create a dedicated Twitch account for the bot (or use an existing account).
 2. Generate credentials: [Twitch Token Generator](https://twitchtokengenerator.com/)

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -422,7 +422,7 @@ Behavior notes:
   </Accordion>
 </AccordionGroup>
 
-## Configuration reference pointers
+## Configuration
 
 Primary reference:
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -21,7 +21,7 @@ Status: production-ready via WhatsApp Web (Baileys). Gateway owns linked session
   </Card>
 </CardGroup>
 
-## Quick setup
+## Onboarding
 
 <Steps>
   <Step title="Configure WhatsApp access policy">

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -17,7 +17,7 @@ Zalo ships as a plugin and is not bundled with the core install.
 - Or select **Zalo** during onboarding and confirm the install prompt
 - Details: [Plugins](/tools/plugin)
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Install the Zalo plugin:
    - From a source checkout: `openclaw plugins install ./extensions/zalo`
@@ -161,7 +161,7 @@ Multi-account support: use `channels.zalo.accounts` with per-account tokens and 
 - Confirm the gateway HTTP endpoint is reachable on the configured path
 - Check that getUpdates polling is not running (they're mutually exclusive)
 
-## Configuration reference (Zalo)
+## Configuration
 
 Full configuration: [Configuration](/gateway/configuration)
 

--- a/docs/channels/zalouser.md
+++ b/docs/channels/zalouser.md
@@ -27,7 +27,7 @@ The Gateway machine must have the `zca` binary available in `PATH`.
 - Verify: `zca --version`
 - If missing, install zca-cli (see `extensions/zalouser/README.md` or the upstream zca-cli docs).
 
-## Quick setup (beginner)
+## Onboarding
 
 1. Install the plugin (see above).
 2. Login (QR, on the Gateway machine):

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -49,7 +49,7 @@ title: "Thinking Levels"
 - When verbose is on, agents that emit structured tool results (Pi, other JSON agents) send each tool call back as its own metadata-only message, prefixed with `<emoji> <tool-name>: <arg>` when available (path/command). These tool summaries are sent as soon as each tool starts (separate bubbles), not as streaming deltas.
 - When verbose is `full`, tool outputs are also forwarded after completion (separate bubble, truncated to a safe length). If you toggle `/verbose on|full|off` while a run is in-flight, subsequent tool bubbles honor the new setting.
 
-## Reasoning visibility (/reasoning)
+## Reasoning visibility (/tools/thinking#reasoning-visibility-reasoning)
 
 - Levels: `on|off|stream`.
 - Directive-only message toggles whether thinking blocks are shown in replies.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -61,6 +61,7 @@ title: "Thinking Levels"
 ## Related
 
 - Elevated mode docs live in [Elevated mode](/tools/elevated).
+- Reasoning visibility behavior is documented in [Reasoning visibility](/tools/thinking#reasoning-visibility-reasoning).
 
 ## Heartbeats
 


### PR DESCRIPTION
## Summary
- Normalize BlueBubbles and Feishu configuration section heading.
- Standardize Signal setup option heading labels to a consistent "Setup (option X)" style.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalizes channel documentation headings for consistency across the codebase. Changes include:

- Standardized onboarding section heading from variations of "Quick setup" to "Onboarding" (16 files)
- Unified configuration section heading from "Configuration reference", "Configuration reference pointers", "Configure" to simply "Configuration" (12 files)
- Updated Signal.md to use consistent "Setup (option A)" and "Setup (option B)" format instead of "Setup path A/B"

However, `docs/tools/thinking.md` introduces a problematic self-referential heading that creates a circular anchor reference, and adds a "Related" link that points to the same section.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with fixes to the self-referential heading issue
- Documentation consistency improvements are correct, but the thinking.md heading change introduces a logical error (circular reference) that should be fixed before merging
- Pay close attention to `docs/tools/thinking.md` - fix the self-referential heading and remove the circular link in the Related section

<sub>Last reviewed commit: 8b5d610</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->