### PR TITLE
docs: finalize onboarding option heading normalization

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -236,7 +236,7 @@ This is often easier than hand-editing JSON manifests.
 2. Find the bot in Teams and send a DM
 3. Check gateway logs for incoming activity
 
-## Setup (minimal)
+## Onboarding (minimal)
 
 
 1. **Install the Microsoft Teams plugin**

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -76,7 +76,7 @@ Disable with:
 - If you run the bot on **your personal Signal account**, it will ignore your own messages (loop protection).
 - For "I text the bot and it replies," use a **separate bot number**.
 
-## Setup (option A): link existing Signal account (QR)
+## Onboarding (option A): link existing Signal account (QR)
 
 1. Install `signal-cli` (JVM or native build).
 2. Link a bot account:
@@ -101,7 +101,7 @@ Example:
 
 Multi-account support: use `channels.signal.accounts` with per-account config and optional `name`. See [`gateway/configuration`](/gateway/configuration#telegramaccounts--discordaccounts--slackaccounts--signalaccounts--imessageaccounts) for the shared pattern.
 
-## Setup (option B): register dedicated bot number (SMS, Linux)
+## Onboarding (option B): register dedicated bot number (SMS, Linux)
 
 Use this when you want a dedicated bot number instead of linking an existing Signal app account.
 

--- a/docs/channels/twitch.md
+++ b/docs/channels/twitch.md
@@ -67,7 +67,7 @@ Minimal config:
 - Each account maps to an isolated session key `agent:<agentId>:twitch:<accountName>`.
 - `username` is the bot's account (who authenticates), `channel` is which chat room to join.
 
-## Setup (detailed, recommended)
+## Onboarding (detailed, recommended)
 
 ### Generate credentials
 

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -53,7 +53,7 @@ It is a good fit for support or notifications where you want deterministic routi
 - DMs share the agent's main session.
 - Groups are not yet supported (Zalo docs state "coming soon").
 
-## Setup (quick path)
+## Onboarding (quick path)
 
 ### 1) Create a bot token (Zalo Bot Platform)
 


### PR DESCRIPTION
## Summary
- Promote Signal option setup headings to onboarding wording.
- Rename Microsoft Teams minimal setup section to onboarding wording.
- Standardize Zalo and Twitch onboarding option setup headings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renames remaining `## Setup (...)` headings to `## Onboarding (...)` across four channel docs (`msteams.md`, `signal.md`, `twitch.md`, `zalo.md`), aligning them with the convention already established in Telegram, Discord, Slack, and iMessage docs.

- `msteams.md`: `Setup (minimal)` → `Onboarding (minimal)`
- `signal.md`: `Setup (option A/B)` → `Onboarding (option A/B)`
- `twitch.md`: `Setup (detailed, recommended)` → `Onboarding (detailed, recommended)`
- `zalo.md`: `Setup (quick path)` → `Onboarding (quick path)`
- No internal links reference the old `#setup-*` anchors, so no broken links are introduced

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk — it only renames documentation headings.
- All changes are single-word heading renames in markdown docs (Setup → Onboarding). No code changes, no content modifications, and no internal or external links reference the old anchors. The new headings align with the established convention in other channel docs.
- No files require special attention.

<sub>Last reviewed commit: 37a6165</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->