### PR TITLE
Fix missing ownerDisplay in elevated schema default

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -238,7 +238,6 @@ This is often easier than hand-editing JSON manifests.
 
 ## Onboarding (minimal)
 
-
 1. **Install the Microsoft Teams plugin**
    - From npm: `openclaw plugins install @openclaw/msteams`
    - From a local checkout: `openclaw plugins install ./extensions/msteams`

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1,10 +1,10 @@
 import { createHmac, createHash } from "node:crypto";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
+import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 
 /**

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -1,5 +1,5 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { createHash } from "node:crypto";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 export type ToolCallIdMode = "strict" | "strict9";
 

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -168,4 +168,4 @@ export const CommandsSchema = z
   })
   .strict()
   .optional()
-  .default({ native: "auto", nativeSkills: "auto", restart: true });
+  .default({ native: "auto", nativeSkills: "auto", restart: true, ownerDisplay: "raw" });


### PR DESCRIPTION
## Summary
- Add missing `ownerDisplay: "raw"` to the default object for the elevated schema
- Fixes TypeScript build error where the default object didn't satisfy type requirements

## Test plan
- [x] Verify build passes with `pnpm build`
- [x] Run `pnpm check` locally

## AI Disclosure
- [x] AI-assisted (Claude Code)
- [x] Lightly tested (build and type-check verified)
- [x] I understand what the code does: The elevated schema's `.default()` was missing the required `ownerDisplay` field, causing TypeScript to error because the default object didn't match the schema's type requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)