### PR TITLE
fix: unblock Docker build by aligning commands schema default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker/Build: include `ownerDisplay` in `CommandsSchema` object-level defaults so Docker `pnpm build` no longer fails with `TS2769` during plugin SDK d.ts generation. (#22558) Thanks @obviyus.
 - Security/Gateway/Hooks: block `__proto__`, `constructor`, and `prototype` traversal in webhook template path resolution to prevent prototype-chain payload data leakage in `messageTemplate` rendering. (#22213) Thanks @SleuthCo.
 - Cron: honor `cron.maxConcurrentRuns` in the timer loop so due jobs can execute up to the configured parallelism instead of always running serially. (#11595) Thanks @Takhoffman.
 - Agents/Compaction: restore embedded compaction safeguard/context-pruning extension loading in production by wiring bundled extension factories into the resource loader instead of runtime file-path resolution. (#22349) Thanks @Glucksberg.

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -238,7 +238,6 @@ This is often easier than hand-editing JSON manifests.
 
 ## Onboarding (minimal)
 
-
 1. **Install the Microsoft Teams plugin**
    - From npm: `openclaw plugins install @openclaw/msteams`
    - From a local checkout: `openclaw plugins install ./extensions/msteams`

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1,10 +1,10 @@
 import { createHmac, createHash } from "node:crypto";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
+import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 
 /**

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -1,5 +1,5 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { createHash } from "node:crypto";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 export type ToolCallIdMode = "strict" | "strict9";
 

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -168,4 +168,4 @@ export const CommandsSchema = z
   })
   .strict()
   .optional()
-  .default({ native: "auto", nativeSkills: "auto", restart: true });
+  .default({ native: "auto", nativeSkills: "auto", restart: true, ownerDisplay: "raw" });


### PR DESCRIPTION
## Summary
- Fix Docker build failure (`TS2769`) in `src/config/zod-schema.session.ts`.
- Add missing `ownerDisplay: "raw"` to `CommandsSchema` object default.

## Verification
- `pnpm build`
- `DOCKER_BUILDKIT=1 docker build -f Dockerfile .`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `ownerDisplay: "raw"` to `CommandsSchema` object-level default to align with field-level default and fix TypeScript compilation error (`TS2769`) during Docker builds. The change maintains consistency with other defaulted fields (`native`, `nativeSkills`, `restart`) and has no runtime behavior impact.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - trivial schema default alignment fix with no behavior changes
- The change is a minimal, correct fix for a TypeScript compilation error. It adds a missing field to the object-level default that already has a field-level default, following the exact same pattern used by other fields in the schema. No runtime behavior changes, no logic changes, and verified by the author through local `pnpm build` and Docker build tests.
- No files require special attention

<sub>Last reviewed commit: 98326f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->