### PR TITLE
fix(bluebubbles): include iMessage subject in message text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- BlueBubbles: include iMessage subject field in message text instead of silently dropping it when body is also present. (#21976)
 - Security/Gateway/Hooks: block `__proto__`, `constructor`, and `prototype` traversal in webhook template path resolution to prevent prototype-chain payload data leakage in `messageTemplate` rendering. (#22213) Thanks @SleuthCo.
 - Cron: honor `cron.maxConcurrentRuns` in the timer loop so due jobs can execute up to the configured parallelism instead of always running serially. (#11595) Thanks @Takhoffman.
 - Agents/Compaction: restore embedded compaction safeguard/context-pruning extension loading in production by wiring bundled extension factories into the resource loader instead of runtime file-path resolution. (#22349) Thanks @Glucksberg.

--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  isAllowedParsedChatSender: vi.fn(),
+  parseChatAllowTargetPrefixes: vi.fn(),
+  parseChatTargetPrefixesOrThrow: vi.fn(),
+  resolveServicePrefixedAllowTarget: vi.fn(),
+  resolveServicePrefixedTarget: vi.fn(),
+}));
+
+import { normalizeWebhookMessage } from "./monitor-normalize.js";
+
+function makePayload(fields: Record<string, unknown>) {
+  return {
+    data: {
+      handle: { id: "+15551234567" },
+      chats: [{ guid: "iMessage;-;+15551234567" }],
+      ...fields,
+    },
+  };
+}
+
+describe("normalizeWebhookMessage subject handling", () => {
+  it("combines subject and text when both are present", () => {
+    const result = normalizeWebhookMessage(
+      makePayload({ text: "body text", subject: "Subject line" }),
+    );
+    expect(result?.text).toBe("Subject line\nbody text");
+  });
+
+  it("uses subject alone when text is absent", () => {
+    const result = normalizeWebhookMessage(makePayload({ subject: "Subject only" }));
+    expect(result?.text).toBe("Subject only");
+  });
+
+  it("uses text alone when subject is absent", () => {
+    const result = normalizeWebhookMessage(makePayload({ text: "Text only" }));
+    expect(result?.text).toBe("Text only");
+  });
+
+  it("falls back to body field when text is absent", () => {
+    const result = normalizeWebhookMessage(makePayload({ body: "Body field" }));
+    expect(result?.text).toBe("Body field");
+  });
+
+  it("combines subject with body field when text is absent", () => {
+    const result = normalizeWebhookMessage(
+      makePayload({ body: "Body field", subject: "Subject line" }),
+    );
+    expect(result?.text).toBe("Subject line\nBody field");
+  });
+
+  it("returns empty text when no text, body, or subject", () => {
+    const result = normalizeWebhookMessage(makePayload({}));
+    expect(result?.text).toBe("");
+  });
+});

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -651,11 +651,9 @@ export function normalizeWebhookMessage(
     return null;
   }
 
-  const text =
-    readString(message, "text") ??
-    readString(message, "body") ??
-    readString(message, "subject") ??
-    "";
+  const subject = readString(message, "subject");
+  const body = readString(message, "text") ?? readString(message, "body") ?? "";
+  const text = subject && body ? `${subject}\n${body}` : (subject ?? body);
 
   const { senderId, senderName } = extractSenderInfo(message);
   const { chatGuid, chatIdentifier, chatId, chatName, isGroup, participants } =


### PR DESCRIPTION
## Summary

- **Bug**: iMessage subject field is silently dropped when the message also has a text body
- **Root cause**: `normalizeWebhookMessage` in `monitor-normalize.ts` uses a fallback chain where `subject` is only read when `text` and `body` are both empty
- **Fix**: Extract subject separately and prepend it to the body text with a newline separator

Fixes #21976

## Problem

When an iMessage has both a `text` and `subject` field, the subject is silently dropped. The fallback chain at line 654-658:

```typescript
const text =
  readString(message, "text") ??
  readString(message, "body") ??
  readString(message, "subject") ??
  "";
```

Only uses `subject` when both `text` and `body` are empty/undefined.

**Before fix:**
```
Input:  { text: "196, '214, '519, '190", subject: "All seem wrong titles" }
Output: "196, '214, '519, '190"  (subject lost)
```

## Changes

- `extensions/bluebubbles/src/monitor-normalize.ts` — extract subject separately and combine with body: `subject + newline + body`
- `extensions/bluebubbles/src/monitor-normalize.test.ts` — new regression test with 6 cases

**After fix:**
```
Input:  { text: "196, '214, '519, '190", subject: "All seem wrong titles" }
Output: "All seem wrong titles\n196, '214, '519, '190"
```

## Test plan

- [x] New test: 6 cases covering subject+text, subject-only, text-only, body-only, subject+body, neither
- [x] All 79 existing bluebubbles tests pass (6 suites fail due to pre-existing `opusscript` native module issue, unrelated)
- [x] Format check passes (`oxfmt --check`)

## Effect on User Experience

**Before:** Users sending iMessages with subject lines (enabled in iOS Settings > Messages > Show Subject Field) have their subject silently dropped. The agent only sees the body text, losing context.
**After:** Subject is prepended to the message text, preserving the full message content for the agent.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where iMessage subject lines were silently dropped when a message also contained body text. The fix extracts the subject separately and prepends it to the message body with a newline separator. The implementation correctly handles all edge cases including subject-only, body-only, and combined scenarios. Six comprehensive test cases cover all permutations of subject/text/body field combinations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix with simple, well-tested logic. The implementation correctly handles all edge cases (empty strings, undefined values, and various field combinations). The six test cases provide comprehensive coverage of all scenarios, and the CHANGELOG entry is properly documented.
- No files require special attention

<sub>Last reviewed commit: 8c2a1b9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->