### PR TITLE
fix: skills.allowBundled: [] should block all bundled skills

### DIFF
--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { isBundledSkillAllowed, resolveBundledAllowlist, type SkillEntry } from "./config.js";
+
+function mockSkill(name: string, source: string) {
+  return {
+    name,
+    source,
+    description: "",
+    filePath: "/virtual/SKILL.md",
+    baseDir: "/virtual",
+    disableModelInvocation: false,
+  };
+}
+
+function mockBundledEntry(name: string): SkillEntry {
+  return {
+    skill: mockSkill(name, "openclaw-bundled"),
+    frontmatter: {},
+  };
+}
+
+function mockWorkspaceEntry(name: string): SkillEntry {
+  return {
+    skill: mockSkill(name, "workspace"),
+    frontmatter: {},
+  };
+}
+
+describe("allowBundled", () => {
+  describe("resolveBundledAllowlist", () => {
+    it("returns undefined when allowBundled is not set", () => {
+      expect(resolveBundledAllowlist({})).toBeUndefined();
+      expect(resolveBundledAllowlist({ skills: {} })).toBeUndefined();
+    });
+
+    it("returns [] when allowBundled is empty array (block all bundled)", () => {
+      const cfg = { skills: { allowBundled: [] } };
+      expect(resolveBundledAllowlist(cfg)).toEqual([]);
+    });
+
+    it("returns normalized list when allowBundled has entries", () => {
+      const cfg = { skills: { allowBundled: ["github", "slack"] } };
+      expect(resolveBundledAllowlist(cfg)).toEqual(["github", "slack"]);
+    });
+  });
+
+  describe("isBundledSkillAllowed", () => {
+    it("allows all when allowlist is undefined", () => {
+      const bundled = mockBundledEntry("any-bundled");
+      expect(isBundledSkillAllowed(bundled, undefined)).toBe(true);
+    });
+
+    it("blocks all bundled when allowlist is empty array", () => {
+      const bundled = mockBundledEntry("github");
+      expect(isBundledSkillAllowed(bundled, [])).toBe(false);
+    });
+
+    it("allows non-bundled skills even when allowlist is empty", () => {
+      const workspace = mockWorkspaceEntry("my-skill");
+      expect(isBundledSkillAllowed(workspace, [])).toBe(true);
+    });
+
+    it("allows bundled skill only when listed", () => {
+      const bundled = mockBundledEntry("github");
+      expect(isBundledSkillAllowed(bundled, ["slack"])).toBe(false);
+      expect(isBundledSkillAllowed(bundled, ["github"])).toBe(true);
+    });
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -9,6 +9,8 @@ import {
 import { resolveSkillKey } from "./frontmatter.js";
 import type { SkillEligibilityContext, SkillEntry } from "./types.js";
 
+export type { SkillEntry };
+
 const DEFAULT_CONFIG_VALUES: Record<string, boolean> = {
   "browser.enabled": true,
   "browser.evaluateEnabled": true,
@@ -36,14 +38,14 @@ export function resolveSkillConfig(
 }
 
 function normalizeAllowlist(input: unknown): string[] | undefined {
-  if (!input) {
+  if (input === undefined || input === null) {
     return undefined;
   }
   if (!Array.isArray(input)) {
     return undefined;
   }
   const normalized = input.map((entry) => String(entry).trim()).filter(Boolean);
-  return normalized.length > 0 ? normalized : undefined;
+  return normalized;
 }
 
 const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
@@ -57,11 +59,14 @@ export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | und
 }
 
 export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): boolean {
-  if (!allowlist || allowlist.length === 0) {
+  if (allowlist === undefined) {
     return true;
   }
   if (!isBundledSkill(entry)) {
     return true;
+  }
+  if (allowlist.length === 0) {
+    return false;
   }
   const key = resolveSkillKey(entry.skill, entry);
   return allowlist.includes(key) || allowlist.includes(entry.skill.name);


### PR DESCRIPTION
- 修复空 allowlist 被错误处理的问题
- 空数组现在正确阻止所有 bundled skills
- 保持向后兼容（非空数组行为不变）

Fixes openclaw/openclaw#21709

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug where `skills.allowBundled: []` (empty array) was incorrectly treated as "allow all bundled skills" instead of "block all bundled skills". 

**Key changes:**
- `normalizeAllowlist()` now preserves empty arrays instead of converting them to `undefined`
- `isBundledSkillAllowed()` explicitly checks for empty allowlist and returns `false` to block bundled skills
- Non-bundled (workspace/managed) skills remain unaffected by empty allowlist
- Added comprehensive test coverage for the edge case

**Behavior:**
- `allowBundled: undefined` or not set → allows all bundled skills (unchanged)
- `allowBundled: []` → blocks all bundled skills (fixed)
- `allowBundled: ["skill1"]` → allows only listed bundled skills (unchanged)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-isolated, logically correct, and includes comprehensive test coverage. The change preserves backward compatibility for all cases except the buggy behavior (empty array). The logic distinguishes between "undefined" (allow all) and "empty array" (block all) which is semantically correct.
- No files require special attention

<sub>Last reviewed commit: 3d218d2</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->