### PR TITLE
CI: enforce explicit workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,6 +13,8 @@ on:
       - ".agents/**"
       - "skills/**"
 
+permissions: {}
+
 concurrency:
   group: docker-release-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: install-smoke-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -13,6 +13,9 @@ on:
       - Dockerfile.sandbox-common
       - scripts/sandbox-common-setup.sh
 
+permissions:
+  contents: read
+
 concurrency:
   group: sandbox-common-smoke-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: workflow-sanity-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -65,3 +68,6 @@ jobs:
 
       - name: Disallow direct inputs interpolation in composite run blocks
         run: python3 scripts/check-composite-action-input-interpolation.py
+
+      - name: Require explicit workflow token permissions
+        run: python3 scripts/check-workflow-permissions.py

--- a/scripts/check-workflow-permissions.py
+++ b/scripts/check-workflow-permissions.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+def iter_workflow_files(root: pathlib.Path) -> list[pathlib.Path]:
+    files = list(root.glob("*.yml")) + list(root.glob("*.yaml"))
+    return sorted(files)
+
+
+def find_top_level_permissions_line(lines: list[str]) -> tuple[int, str] | None:
+    for index, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if line.startswith(" ") or line.startswith("\t"):
+            continue
+        if stripped.startswith("permissions:"):
+            return (index, stripped)
+    return None
+
+
+def main() -> int:
+    workflows_root = pathlib.Path(".github/workflows")
+    files = iter_workflow_files(workflows_root)
+    violations: list[str] = []
+
+    for workflow_path in files:
+        lines = workflow_path.read_text(encoding="utf-8").splitlines()
+        top_level_permissions = find_top_level_permissions_line(lines)
+        if top_level_permissions is None:
+            violations.append(f"{workflow_path}: missing top-level permissions declaration")
+            continue
+
+        line_no, declaration = top_level_permissions
+        if declaration == "permissions: write-all":
+            violations.append(f"{workflow_path}:{line_no}: top-level permissions must not be write-all")
+
+    if violations:
+        print("Workflow permissions policy violations:")
+        for violation in violations:
+            print(f"- {violation}")
+        print("Add an explicit top-level `permissions:` block to every workflow.")
+        return 1
+
+    print("All workflows declare explicit top-level permissions.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add explicit top-level `permissions` declarations to workflows that previously inherited repository defaults (`ci.yml`, `install-smoke.yml`, `workflow-sanity.yml`, `sandbox-common-smoke.yml`, `docker-release.yml`)
- keep release workflows least-privileged by default with `permissions: {}` and preserve existing job-scoped write grants
- add `scripts/check-workflow-permissions.py` and wire it into `workflow-sanity.yml` to enforce explicit top-level workflow permissions going forward

## Why
This addresses the least-privilege gap tracked in #11763 by removing implicit token scope inheritance in CI workflows.

## Validation
- `python3 scripts/check-workflow-permissions.py`
- `python3 scripts/check-composite-action-input-interpolation.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces explicit workflow token permissions as a security hardening measure. All workflows now declare top-level `permissions` blocks (either `contents: read` for read-only workflows or `permissions: {}` for release workflows with job-scoped grants). A new enforcement script prevents future workflows from inheriting implicit repository-default permissions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are purely additive security hardening with no behavioral changes to existing workflows. The permission declarations match the actual requirements of each workflow, and the enforcement script correctly validates top-level permissions declarations without false positives.
- No files require special attention

<sub>Last reviewed commit: 73efd1d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->