### PR TITLE
fix: preserve session model and contextTokens after compaction

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -428,6 +428,9 @@ export async function runReplyAgent(params: {
     const usage = runResult.meta?.agentMeta?.usage;
     const promptTokens = runResult.meta?.agentMeta?.promptTokens;
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
+    const sessionModel = autoCompactionCompleted
+      ? (activeSessionEntry?.model ?? defaultModel)
+      : modelUsed;
     const providerUsed =
       runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
     const verboseEnabled = resolvedVerboseLevel !== "off";
@@ -471,7 +474,7 @@ export async function runReplyAgent(params: {
       : undefined;
     const contextTokensUsed =
       agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
+      lookupContextTokens(sessionModel) ??
       activeSessionEntry?.contextTokens ??
       DEFAULT_CONTEXT_TOKENS;
 
@@ -481,7 +484,7 @@ export async function runReplyAgent(params: {
       usage,
       lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
       promptTokens,
-      modelUsed,
+      modelUsed: sessionModel,
       providerUsed,
       contextTokensUsed,
       systemPromptReport: runResult.meta?.systemPromptReport,


### PR DESCRIPTION
Fixes #22395

After auto-compaction, runResult.meta.agentMeta.model contains the
compaction model instead of the session's primary model. This was being
passed to persistRunSessionUsage() which overwrote the session entry's
model and contextTokens fields.

Fix: introduce sessionModel which preserves the original session model
(from activeSessionEntry) when autoCompactionCompleted is true.
contextTokensUsed and persistRunSessionUsage now use sessionModel
instead of modelUsed, so the session entry always reflects the
session's configured model, not the compaction model.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where auto-compaction overwrote the session's model and contextTokens with the compaction model instead of preserving the user's configured model. The fix introduces a `sessionModel` variable that correctly preserves the original session model from `activeSessionEntry` when compaction completes, ensuring `persistRunSessionUsage()` always reflects the session's configured model rather than the temporary compaction model.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, targeted, and correctly addresses the root cause. The logic preserves the session model only when compaction completes, using a simple ternary that falls back to the existing behavior otherwise. No edge cases or security concerns identified.
- No files require special attention

<sub>Last reviewed commit: ff6d985</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->