### PR TITLE
docs(feishu): add cardkit:card:write permission for streaming card output

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -109,6 +109,7 @@ On **Permissions**, click **Batch import** and paste:
       "application:application.app_message_stats.overview:readonly",
       "application:application:self_manage",
       "application:bot.menu:write",
+      "cardkit:card:write",
       "contact:user.employee_id:readonly",
       "corehr:file:download",
       "event:ip_list",


### PR DESCRIPTION
Closes #23366

## Problem

The Feishu setup documentation is missing the required `cardkit:card:write` permission for streaming card functionality.

When using streaming card (流式卡片) output, if this permission is not granted:
- Streaming card output fails
- Backend errors occur

This permission is required for OpenClaw to configure card streaming capabilities via the Card Kit API.

## Solution

Add the `cardkit:card:write` permission to the Feishu setup documentation, placed in alphabetical order in the permissions list.

## Changes

- `docs/channels/feishu.mdx`: Add `cardkit:card:write` permission to the required permissions table

## Verification

- [x] Feishu app has `cardkit:card:write` permission enabled
- [x] Streaming card output works without backend errors

---

### Greptile Summary

Added the cardkit:card:write permission to the Feishu setup documentation. This permission is required for the Card Kit API used in streaming card replies, which were introduced in a previous PR. Without this permission, the streaming card functionality will fail when creating and updating interactive cards.

**Confidence Score: 5/5**

- This PR is safe to merge with no risk
- This is a simple, necessary documentation update that adds a required permission for an existing feature (streaming card output). The permission is correctly placed in alphabetical order and matches what the code actually needs. No code changes are involved, only documentation.

Last reviewed commit: 52f6737