### PR TITLE
fix(gateway): silently auto-approve local paired-device scope upgrades

### DIFF
--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -1079,6 +1079,72 @@ describe("gateway server auth/connect", () => {
     restoreGatewayToken(prevToken);
   });
 
+  test("silently auto-approves local CLI scope upgrades", async () => {
+    const { mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { buildDeviceAuthPayload } = await import("./device-auth.js");
+    const { loadOrCreateDeviceIdentity, publicKeyRawBase64UrlFromPem, signDevicePayload } =
+      await import("../infra/device-identity.js");
+    const { listDevicePairing } = await import("../infra/device-pairing.js");
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    const identityDir = await mkdtemp(join(tmpdir(), "openclaw-device-scope-"));
+    const identity = loadOrCreateDeviceIdentity(join(identityDir, "device.json"));
+    const client = {
+      id: GATEWAY_CLIENT_NAMES.CLI,
+      version: "1.0.0",
+      platform: "test",
+      mode: GATEWAY_CLIENT_MODES.CLI,
+    };
+    const buildDevice = (scopes: string[]) => {
+      const signedAtMs = Date.now();
+      const payload = buildDeviceAuthPayload({
+        deviceId: identity.deviceId,
+        clientId: client.id,
+        clientMode: client.mode,
+        role: "operator",
+        scopes,
+        signedAtMs,
+        token: "secret",
+      });
+      return {
+        id: identity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+        signature: signDevicePayload(identity.privateKeyPem, payload),
+        signedAt: signedAtMs,
+      };
+    };
+
+    const initial = await connectReq(ws, {
+      token: "secret",
+      scopes: ["operator.read"],
+      client,
+      device: buildDevice(["operator.read"]),
+    });
+    if (!initial.ok) {
+      await approvePendingPairingIfNeeded();
+    }
+
+    ws.close();
+
+    const ws2 = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((resolve) => ws2.once("open", resolve));
+    const upgraded = await connectReq(ws2, {
+      token: "secret",
+      scopes: ["operator.admin"],
+      client,
+      device: buildDevice(["operator.admin"]),
+    });
+    expect(upgraded.ok).toBe(true);
+
+    const pairing = await listDevicePairing();
+    expect(pairing.pending).toEqual([]);
+
+    ws2.close();
+    await server.close();
+    restoreGatewayToken(prevToken);
+  });
+
   test("allows operator.read connect when device is paired with operator.admin", async () => {
     const { mkdtemp } = await import("node:fs/promises");
     const { tmpdir } = await import("node:os");


### PR DESCRIPTION
## Summary\n- auto-approve silent pairing requests for local clients when requesting not-paired or upgrade pairing paths\n- preserve explicit pairing-required responses for non-local requests\n- add/adjust gateway auth e2e coverage around local silent scope upgrades and pairing upgrade flows\n\n## Testing\n- corepack pnpm lint\n- corepack pnpm vitest run --config vitest.e2e.config.ts src/gateway/server.auth.e2e.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Silently auto-approves local paired-device scope upgrades by modifying the pairing approval logic. When a local client requests a scope upgrade with an existing pairing, the gateway now auto-approves the request instead of requiring manual approval. The change adds a `hasExistingPairing` parameter to `requirePairing()` to distinguish between initial pairing (`not-paired`) and upgrade scenarios (`role-upgrade`/`scope-upgrade`), enabling silent approval for local clients in both initial pairing and upgrade cases.

**Key changes:**
- Modified `shouldSilentPair` logic to auto-approve when `isLocalClient` AND either `reason === "not-paired"` OR `hasExistingPairing === true`
- Added `hasExistingPairing` boolean parameter to `requirePairing()` function 
- Updated all `requirePairing()` call sites to pass appropriate `hasExistingPairing` value
- Added E2E test coverage for local CLI scope upgrade flow (`operator.read` → `operator.admin`)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - focused security enhancement for local clients
- The logic is straightforward and well-tested, with E2E coverage for the new behavior. The change correctly preserves security by only auto-approving for local clients (verified via `isLocalClient` check). All existing pairing flows remain unchanged for non-local clients. Minor deduction because the test relies on `approvePendingPairingIfNeeded()` for initial setup which could mask whether the initial pairing is also being auto-approved as expected.
- No files require special attention

<sub>Last reviewed commit: 7f32ec5</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->