### PR TITLE
feat(cli): expose Discord channel lifecycle management through unified CLI interface (#22512)

### DIFF
--- a/src/cli/program/message/register.discord-admin.test.ts
+++ b/src/cli/program/message/register.discord-admin.test.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import type { MessageCliHelpers } from "./helpers.js";
+import { registerMessageDiscordAdminCommands } from "./register.discord-admin.js";
+
+function createStubHelpers(): MessageCliHelpers {
+  const identity = (cmd: Command) => cmd;
+  const runMessageAction = vi.fn();
+  return {
+    withMessageBase: identity,
+    withMessageTarget: identity,
+    withRequiredMessageTarget: identity,
+    runMessageAction,
+  } as MessageCliHelpers;
+}
+
+function getSubcommandNames(parent: Command): string[] {
+  return parent.commands.map((c) => c.name());
+}
+
+describe("registerMessageDiscordAdminCommands", () => {
+  it("registers channel create/edit/delete/move subcommands", () => {
+    const message = new Command("message");
+    const helpers = createStubHelpers();
+    registerMessageDiscordAdminCommands(message, helpers);
+
+    const channel = message.commands.find((c) => c.name() === "channel");
+    expect(channel).toBeDefined();
+
+    const channelSubs = getSubcommandNames(channel!);
+    expect(channelSubs).toContain("info");
+    expect(channelSubs).toContain("list");
+    expect(channelSubs).toContain("create");
+    expect(channelSubs).toContain("edit");
+    expect(channelSubs).toContain("delete");
+    expect(channelSubs).toContain("move");
+  });
+
+  it("channel create requires --guild-id and --name", () => {
+    const message = new Command("message");
+    registerMessageDiscordAdminCommands(message, createStubHelpers());
+
+    const channel = message.commands.find((c) => c.name() === "channel")!;
+    const create = channel.commands.find((c) => c.name() === "create")!;
+    const help = create.helpInformation();
+    expect(help).toContain("--guild-id");
+    expect(help).toContain("--name");
+  });
+
+  it("channel delete requires --channel-id", () => {
+    const message = new Command("message");
+    registerMessageDiscordAdminCommands(message, createStubHelpers());
+
+    const channel = message.commands.find((c) => c.name() === "channel")!;
+    const del = channel.commands.find((c) => c.name() === "delete")!;
+    const help = del.helpInformation();
+    expect(help).toContain("--channel-id");
+  });
+
+  it("channel move requires --guild-id and --channel-id", () => {
+    const message = new Command("message");
+    registerMessageDiscordAdminCommands(message, createStubHelpers());
+
+    const channel = message.commands.find((c) => c.name() === "channel")!;
+    const move = channel.commands.find((c) => c.name() === "move")!;
+    const help = move.helpInformation();
+    expect(help).toContain("--guild-id");
+    expect(help).toContain("--channel-id");
+  });
+});

--- a/src/cli/program/message/register.discord-admin.ts
+++ b/src/cli/program/message/register.discord-admin.ts
@@ -57,6 +57,64 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
       await helpers.runMessageAction("channel-list", opts);
     });
 
+  helpers
+    .withMessageBase(
+      channel
+        .command("create")
+        .description("Create a channel")
+        .requiredOption("--guild-id <id>", "Guild id")
+        .requiredOption("--name <name>", "Channel name"),
+    )
+    .option("--type <n>", "Channel type (0=text, 2=voice, 4=category, 15=forum)")
+    .option("--parent-id <id>", "Parent category id")
+    .option("--topic <text>", "Channel topic")
+    .option("--position <n>", "Sort position")
+    .option("--nsfw", "Mark as NSFW")
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-create", opts);
+    });
+
+  helpers
+    .withMessageBase(
+      channel
+        .command("edit")
+        .description("Edit a channel")
+        .requiredOption("--channel-id <id>", "Channel id"),
+    )
+    .option("--name <name>", "New channel name")
+    .option("--topic <text>", "New channel topic")
+    .option("--position <n>", "Sort position")
+    .option("--parent-id <id>", "Parent category id")
+    .option("--nsfw", "Mark as NSFW")
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-edit", opts);
+    });
+
+  helpers
+    .withMessageBase(
+      channel
+        .command("delete")
+        .description("Delete a channel")
+        .requiredOption("--channel-id <id>", "Channel id"),
+    )
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-delete", opts);
+    });
+
+  helpers
+    .withMessageBase(
+      channel
+        .command("move")
+        .description("Move a channel")
+        .requiredOption("--guild-id <id>", "Guild id")
+        .requiredOption("--channel-id <id>", "Channel id"),
+    )
+    .option("--parent-id <id>", "Target parent category id")
+    .option("--position <n>", "Sort position")
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-move", opts);
+    });
+
   const member = message.command("member").description("Member actions");
   helpers
     .withMessageBase(


### PR DESCRIPTION
## Summary

`openclaw message channel` only had `info` and `list`, but the backend already handles `channel-create`, `channel-edit`, `channel-delete`, and `channel-move` — agents use them all the time via the `message` tool. This wires up the missing CLI subcommands so you can script channel management without an agent session.

Closes #22512

lobster-biscuit

## Changes

- Before: creating/editing/moving/deleting a Discord channel required an agent tool call
- After: `openclaw message channel create/edit/delete/move` works from the CLI

New subcommands on the existing `channel` command group in `register.discord-admin.ts`:
- `channel create` — requires `--guild-id`, `--name`; optional `--type`, `--parent-id`, `--topic`, `--position`, `--nsfw`
- `channel edit` — requires `--channel-id`; optional `--name`, `--topic`, `--position`, `--parent-id`, `--nsfw`
- `channel delete` — requires `--channel-id`
- `channel move` — requires `--guild-id`, `--channel-id`; optional `--parent-id`, `--position`

Follows the same pattern as `role add`/`role remove`/`event create` — pure commander wiring, no new logic.

## Tests

- `register.discord-admin.test.ts` — 4 new tests verifying subcommand registration and required options
- `actions.test.ts` — 44 existing backend handler tests still pass (covers the actual `channel-create`/`channel-edit` param forwarding)
- `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds four new CLI subcommands to `openclaw message channel` for managing Discord channels: `create`, `edit`, `delete`, and `move`. These commands wire up existing backend handlers (`channel-create`, `channel-edit`, `channel-delete`, `channel-move`) that were previously only accessible via agent tool calls.

**Key changes:**
- `channel create`: requires `--guild-id` and `--name`, with optional `--type`, `--parent-id`, `--topic`, `--position`, `--nsfw`
- `channel edit`: requires `--channel-id`, with optional `--name`, `--topic`, `--position`, `--parent-id`, `--nsfw`
- `channel delete`: requires `--channel-id`
- `channel move`: requires `--guild-id` and `--channel-id`, with optional `--parent-id` and `--position`

The implementation follows the existing pattern used for `role add`/`remove` and `event create`. The new test file verifies subcommand registration and required options. Backend handlers in `handle-action.guild-admin.ts` already exist and accept these parameters (Commander.js automatically converts `--guild-id` to `guildId` in the options object).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Pure CLI wiring that follows established patterns - no new logic, backend handlers already exist and tested, parameter names align correctly via Commander's automatic camelCase conversion
- No files require special attention

<sub>Last reviewed commit: 4178d65</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->