### PR TITLE
Fix/telegram forum reply formatting

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -428,6 +428,9 @@ export async function runReplyAgent(params: {
     const usage = runResult.meta?.agentMeta?.usage;
     const promptTokens = runResult.meta?.agentMeta?.promptTokens;
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
+    const sessionModel = autoCompactionCompleted
+      ? (activeSessionEntry?.model ?? defaultModel)
+      : modelUsed;
     const providerUsed =
       runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
     const verboseEnabled = resolvedVerboseLevel !== "off";
@@ -471,7 +474,7 @@ export async function runReplyAgent(params: {
       : undefined;
     const contextTokensUsed =
       agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
+      lookupContextTokens(sessionModel) ??
       activeSessionEntry?.contextTokens ??
       DEFAULT_CONTEXT_TOKENS;
 
@@ -481,7 +484,7 @@ export async function runReplyAgent(params: {
       usage,
       lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
       promptTokens,
-      modelUsed,
+      modelUsed: sessionModel,
       providerUsed,
       contextTokensUsed,
       systemPromptReport: runResult.meta?.systemPromptReport,

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -225,7 +225,7 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("uses reply_to_message_id when quote text is provided", async () => {
+  it("uses reply_parameters when replyToId is provided", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 10,
@@ -245,14 +245,14 @@ describe("deliverReplies", () => {
       "123",
       expect.any(String),
       expect.objectContaining({
-        reply_to_message_id: 500,
+        reply_parameters: { message_id: 500 },
       }),
     );
     expect(sendMessage).toHaveBeenCalledWith(
       "123",
       expect.any(String),
       expect.not.objectContaining({
-        reply_parameters: expect.anything(),
+        reply_to_message_id: expect.anything(),
       }),
     );
   });

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -513,7 +513,7 @@ function buildTelegramSendParams(opts?: {
   const threadParams = buildTelegramThreadParams(opts?.thread);
   const params: Record<string, unknown> = {};
   if (opts?.replyToMessageId) {
-    params.reply_to_message_id = opts.replyToMessageId;
+    params.reply_parameters = { message_id: opts.replyToMessageId };
   }
   if (threadParams) {
     params.message_thread_id = threadParams.message_thread_id;


### PR DESCRIPTION
```
Fixes #22416

The reply dispatcher was using the deprecated reply_to_message_id field
instead of reply_parameters. In Telegram forum groups (supergroups with
is_forum: true), using reply_to_message_id causes formatting to be
silently stripped — bold, italic, and code all render as plain text.

Switching to reply_parameters preserves HTML formatting correctly in
forum group replies, matching the behavior of the message tool which
already works correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR contains two unrelated fixes:

1. **Telegram forum formatting fix**: Switches from deprecated `reply_to_message_id` to `reply_parameters` in the reply dispatcher (`delivery.ts`). In Telegram forum groups (supergroups with `is_forum: true`), `reply_to_message_id` silently strips HTML formatting (bold, italic, code), while `reply_parameters` preserves it correctly.

2. **Session model preservation after compaction**: When auto-compaction completes, the code now correctly preserves the session's original model and context tokens instead of using the model that performed the compaction. This prevents model drift in long-running sessions.

**Key finding**: There's an inconsistency between `delivery.ts` (now fixed) and `send.ts:256` (still uses `reply_to_message_id`). The `send.ts` path may have the same formatting issue in forum groups when no quote text is provided.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one potential inconsistency to address
- Both fixes are straightforward and well-tested. The Telegram fix addresses a real formatting bug in forum groups, and the session model fix prevents model drift after compaction. However, there's a potential inconsistency in `send.ts:256` that should be reviewed.
- Check `src/telegram/send.ts:256` for the same `reply_to_message_id` issue

<sub>Last reviewed commit: 73f1376</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->