### PR TITLE
feat(feishu): support card action callback handler

### DIFF
--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -1,0 +1,133 @@
+import { execSync } from "child_process";
+import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
+import { getFeishuRuntime } from "./runtime.js";
+import { resolveFeishuAccount } from "./accounts.js";
+
+/**
+ * Feishu card action callback event payload.
+ * Delivered as `card.action.trigger` via EventDispatcher.
+ */
+export interface FeishuCardActionEvent {
+  operator: {
+    tenant_key: string;
+    user_id: string;
+    open_id: string;
+    union_id?: string;
+  };
+  action: {
+    value: Record<string, unknown>;
+    tag: string;
+    option?: string;
+    /** For date_picker / picker actions */
+    timezone?: string;
+  };
+  host: string;
+  context: {
+    open_message_id: string;
+    open_chat_id: string;
+  };
+  /** Additional fields from the event envelope */
+  token?: string;
+  event_type?: string;
+}
+
+/**
+ * Card action callback response.
+ * Return this to update the card and/or show a toast.
+ * @see https://open.larkoffice.com/document/feishu-cards/card-callback-communication
+ */
+export interface CardActionResponse {
+  toast?: {
+    type: "info" | "success" | "warning" | "error";
+    content: string;
+    i18n?: Record<string, string>;
+  };
+  card?: {
+    type: "raw";
+    data: Record<string, unknown>;
+  };
+}
+
+export interface HandleCardActionParams {
+  cfg: ClawdbotConfig;
+  event: FeishuCardActionEvent;
+  runtime?: RuntimeEnv;
+  accountId: string;
+}
+
+/**
+ * Handle a Feishu card action callback.
+ *
+ * 1. Emits a system event so the agent is notified of the action.
+ * 2. If `cardActionHandler` is configured, invokes the external script
+ *    synchronously to produce a callback response (card update + toast).
+ *
+ * The handler script receives the event payload as a base64-encoded JSON
+ * argument and must print a JSON response to stdout.
+ */
+export async function handleFeishuCardAction(
+  params: HandleCardActionParams,
+): Promise<CardActionResponse | undefined> {
+  const { cfg, event, runtime, accountId } = params;
+  const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
+
+  const operatorId = event.operator?.open_id ?? "unknown";
+  const messageId = event.context?.open_message_id ?? "unknown";
+  const chatId = event.context?.open_chat_id ?? "unknown";
+  const actionValue = event.action?.value;
+
+  log(
+    `feishu[${accountId}]: card action from ${operatorId} on message ${messageId}: ${JSON.stringify(actionValue)}`,
+  );
+
+  // Emit system event so the agent sees the card action
+  try {
+    const core = getFeishuRuntime();
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId,
+      peer: {
+        kind: "direct",
+        id: operatorId,
+      },
+    });
+
+    const actionSummary = JSON.stringify(actionValue);
+    core.system.enqueueSystemEvent(
+      `Feishu[${accountId}] card action from ${operatorId} on message ${messageId}: ${actionSummary}`,
+      {
+        sessionKey: route.sessionKey,
+        contextKey: `feishu:card_action:${chatId}:${messageId}`,
+      },
+    );
+  } catch (err) {
+    error(`feishu[${accountId}]: failed to emit card action system event: ${String(err)}`);
+  }
+
+  // If a card action handler script is configured, invoke it synchronously
+  const feishuCfg = cfg.channels?.feishu as Record<string, unknown> | undefined;
+  const handlerPath = feishuCfg?.cardActionHandler as string | undefined;
+
+  if (handlerPath) {
+    try {
+      const b64 = Buffer.from(JSON.stringify(event)).toString("base64");
+      const result = execSync(`node "${handlerPath}" "${b64}"`, {
+        timeout: 15_000,
+        encoding: "utf-8",
+        env: { ...process.env },
+      }).trim();
+
+      if (result) {
+        const parsed = JSON.parse(result) as CardActionResponse;
+        log(`feishu[${accountId}]: card action handler returned response`);
+        return parsed;
+      }
+    } catch (err) {
+      error(`feishu[${accountId}]: card action handler error: ${String(err)}`);
+    }
+  }
+
+  return undefined;
+}

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -105,6 +105,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         chunkMode: { type: "string", enum: ["length", "newline"] },
         mediaMaxMb: { type: "number", minimum: 0 },
         renderMode: { type: "string", enum: ["auto", "raw", "card"] },
+        cardActionHandler: {
+          type: "string",
+          description:
+            "Path to a Node.js script that handles card action callbacks. " +
+            "Receives base64-encoded event JSON as argv[1], must print JSON response to stdout. " +
+            "Response format: { toast?: { type, content }, card?: { type: 'raw', data: { schema: '2.0', ... } } }",
+        },
         accounts: {
           type: "object",
           additionalProperties: {

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent, type FeishuBotAddedEvent } from "./bot.js";
+import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 import { createFeishuWSClient, createEventDispatcher } from "./client.js";
 import { probeFeishu } from "./probe.js";
 import type { ResolvedFeishuAccount } from "./types.js";
@@ -94,6 +95,27 @@ function registerEventHandlers(
         log(`feishu[${accountId}]: bot removed from chat ${event.chat_id}`);
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
+      }
+    },
+    "card.action.trigger": async (data) => {
+      try {
+        const event = data as unknown as FeishuCardActionEvent;
+        const promise = handleFeishuCardAction({
+          cfg,
+          event,
+          runtime,
+          accountId,
+        });
+        if (fireAndForget) {
+          promise.catch((err) => {
+            error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
+          });
+          return undefined;
+        }
+        return await promise;
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
+        return undefined;
       }
     },
   });


### PR DESCRIPTION
## Summary

Add first-class support for Feishu card action callbacks (`card.action.trigger`) in the Feishu channel extension.

This PR introduces a configurable callback handler script path and wires card action events into the Feishu event dispatcher flow.

## Changes

### 1) Register card action event in monitor
- File: `extensions/feishu/src/monitor.ts`
- Add event handler for `card.action.trigger`
- Delegate handling to a dedicated module (`handleFeishuCardAction`)
- Keep existing error handling / fire-and-forget behavior consistent with other event paths

### 2) Add configurable handler path in channel config schema
- File: `extensions/feishu/src/channel.ts`
- Add `cardActionHandler` config field:
  - Type: `string`
  - Meaning: path to a Node.js script that receives base64 event payload and returns JSON response
  - Response shape supports Feishu callback format (`toast`, `card`)

### 3) New card action handling module
- File: `extensions/feishu/src/card-action.ts`
- Define event/response types:
  - `FeishuCardActionEvent`
  - `CardActionResponse`
- Implement `handleFeishuCardAction(...)`:
  - Log callback context
  - Emit a system event to the routed agent session
  - Optionally invoke external handler script (`cardActionHandler`) and return parsed callback response
  - Graceful error handling with `undefined` fallback

## Why

This enables interactive Feishu card workflows (e.g. confirm/cancel buttons) while keeping OpenClaw core behavior generic:
- event routing is native
- business logic stays in user-provided handler script

## Notes

- No behavior change unless `cardActionHandler` is configured.
- Existing message handling flow remains unchanged.

## Manual test

1. Configure `channels.feishu.cardActionHandler` to a valid Node.js script path.
2. Send an interactive card with actions.
3. Click a card action button in Feishu.
4. Verify:
   - callback event is handled
   - system event is enqueued to the correct session
   - handler output (toast/card update) is returned when script emits valid JSON

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for Feishu card action callbacks by introducing a new `cardActionHandler` config option and wiring `card.action.trigger` events through the event dispatcher. When a card action is triggered, the handler emits a system event to the agent session and optionally invokes an external Node.js script to generate a callback response (toast/card update).

- New module `card-action.ts` implements `handleFeishuCardAction` with event routing and optional script invocation
- Config schema updated in `channel.ts` to accept `cardActionHandler` script path
- Event handler registered in `monitor.ts` for `card.action.trigger` events with consistent fire-and-forget error handling

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one shell escaping fix
- The implementation follows established patterns for event handling and adds a well-scoped feature with proper error handling. However, there's a shell escaping issue with `execSync` that could cause problems if the handler path contains special characters like quotes
- Check `extensions/feishu/src/card-action.ts` line 116 for the shell escaping fix

<sub>Last reviewed commit: 702fdb0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->