### PR TITLE
fix: replace memo with simple-memo in apple-notes skill (license violation)

### DIFF
--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: apple-notes
-description: Manage Apple Notes via the `memo` CLI on macOS (create, view, edit, delete, search, move, and export notes). Use when a user asks OpenClaw to add a note, list notes, search notes, or manage note folders.
-homepage: https://github.com/antoniorodr/memo
+description: Manage Apple Notes via the `simple-memo` CLI on macOS (create, view, edit, delete, search, move, and export notes). Use when a user asks OpenClaw to add a note, list notes, search notes, or manage note folders.
+homepage: https://github.com/inkolin/simple-memo
 metadata:
   {
     "openclaw":
       {
         "emoji": "📝",
         "os": ["darwin"],
-        "requires": { "bins": ["memo"] },
+        "requires": { "bins": ["simple-memo"] },
         "install":
           [
             {
               "id": "brew",
               "kind": "brew",
-              "formula": "antoniorodr/memo/memo",
-              "bins": ["memo"],
-              "label": "Install memo via Homebrew",
+              "formula": "inkolin/tap/simple-memo",
+              "bins": ["simple-memo"],
+              "label": "Install simple-memo via Homebrew",
             },
           ],
       },
@@ -25,44 +25,44 @@ metadata:
 
 # Apple Notes CLI
 
-Use `memo notes` to manage Apple Notes directly from the terminal. Create, view, edit, delete, search, move notes between folders, and export to HTML/Markdown.
+Use `simple-memo notes` to manage Apple Notes directly from the terminal. Create, view, edit, delete, search, move notes between folders, and export to HTML/Markdown.
 
 Setup
 
-- Install (Homebrew): `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
-- Manual (pip): `pip install .` (after cloning the repo)
+- Install (Homebrew): `brew install inkolin/tap/simple-memo`
+- Manual (pip): `pip install simple-memo`
 - macOS-only; if prompted, grant Automation access to Notes.app.
 
 View Notes
 
-- List all notes: `memo notes`
-- Filter by folder: `memo notes -f "Folder Name"`
-- Search notes (fuzzy): `memo notes -s "query"`
+- List all notes: `simple-memo notes`
+- Filter by folder: `simple-memo notes -f "Folder Name"`
+- Search notes (fuzzy): `simple-memo notes -s "query"`
 
 Create Notes
 
-- Add a new note: `memo notes -a`
+- Add a new note: `simple-memo notes -a`
   - Opens an interactive editor to compose the note.
-- Quick add with title: `memo notes -a "Note Title"`
+- Quick add with title: `simple-memo notes -a "Note Title"`
 
 Edit Notes
 
-- Edit existing note: `memo notes -e`
+- Edit existing note: `simple-memo notes -e`
   - Interactive selection of note to edit.
 
 Delete Notes
 
-- Delete a note: `memo notes -d`
+- Delete a note: `simple-memo notes -d`
   - Interactive selection of note to delete.
 
 Move Notes
 
-- Move note to folder: `memo notes -m`
+- Move note to folder: `simple-memo notes -m`
   - Interactive selection of note and destination folder.
 
 Export Notes
 
-- Export to HTML/Markdown: `memo notes -ex`
+- Export to HTML/Markdown: `simple-memo notes -ex`
   - Exports selected note; uses Mistune for markdown processing.
 
 Limitations


### PR DESCRIPTION
## License violation in apple-notes skill

The apple-notes skill depends on memo CLI (github.com/antoniorodr/memo), which is licensed under the Apache NON-AI License:

"You may not use the Licensed Work as part of or in connection with any AI System."

OpenClaw is an AI agent. Every macOS user who uses this skill is unknowingly violating the memo license. This is a bundled skill shipped in the main repo — users assume these are vetted and legal to use.

### The fix

Replaced memo with simple-memo, an MIT-licensed CLI for Apple Notes with equivalent functionality. No AI usage restrictions.

    brew install inkolin/tap/simple-memo
    # or
    pip install simple-memo

If anything needs adjusting for better compatibility with OpenClaw, I maintain simple-memo and can update it quickly.

### Evidence

- memo license (NON-AI): https://github.com/antoniorodr/memo/blob/main/LICENSE
- Apache NON-AI License spec: https://github.com/non-ai-licenses/non-ai-licenses
- simple-memo license (MIT): https://github.com/inkolin/simple-memo/blob/main/LICENSE

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `memo` CLI with `simple-memo` to resolve Apache NON-AI license violation. The previous dependency prohibited use "as part of or in connection with any AI System," making it incompatible with OpenClaw.

- Updated all references from `memo` to `simple-memo` throughout the skill documentation
- Changed Homebrew formula from `antoniorodr/memo/memo` to `inkolin/tap/simple-memo`
- Updated pip installation from manual clone to `pip install simple-memo`
- Verified all command examples use the new `simple-memo` CLI name

The replacement tool provides equivalent functionality under an MIT license with no AI usage restrictions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it resolves a critical license compliance issue
- The change is a straightforward find-and-replace of one CLI tool with a functionally equivalent alternative. All references have been comprehensively updated (tool name, homepage URL, installation instructions, and all command examples). The replacement tool uses MIT license, eliminating the AI usage restriction. No logic changes, no new code, just documentation updates.
- No files require special attention

<sub>Last reviewed commit: a0dd9f0</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->