### PR TITLE
feat(cli): add --omit-system-prompt flag to agent --json

### DIFF
--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -43,6 +43,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     )
     .option("--deliver", "Send the agent's reply back to the selected channel", false)
     .option("--json", "Output result as JSON", false)
+    .option("--omit-system-prompt", "Omit meta.systemPromptReport from --json output", false)
     .option(
       "--timeout <seconds>",
       "Override agent command timeout (seconds, default 600 or config value)",

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -41,6 +41,7 @@ export type AgentCliOpts = {
   thinking?: string;
   verbose?: string;
   json?: boolean;
+  omitSystemPrompt?: boolean;
   timeout?: string;
   deliver?: boolean;
   channel?: string;
@@ -156,7 +157,12 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   );
 
   if (opts.json) {
-    writeRuntimeJson(runtime, response);
+    let output = response;
+    if (opts.omitSystemPrompt && output?.result?.meta?.systemPromptReport != null) {
+      output = structuredClone(response);
+      delete output.result.meta.systemPromptReport;
+    }
+    writeRuntimeJson(runtime, output);
     return response;
   }
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -158,9 +158,12 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
 
   if (opts.json) {
     let output = response;
-    if (opts.omitSystemPrompt && output?.result?.meta?.systemPromptReport != null) {
+    if (opts.omitSystemPrompt) {
       output = structuredClone(response);
-      delete output.result.meta.systemPromptReport;
+      const meta = output?.result?.meta;
+      if (meta != null && typeof meta === "object" && "systemPromptReport" in meta) {
+        delete (meta as Record<string, unknown>).systemPromptReport;
+      }
     }
     writeRuntimeJson(runtime, output);
     return response;
@@ -191,9 +194,6 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     replyAccountId: opts.replyAccount,
   };
   if (opts.local === true) {
-    if (opts.omitSystemPrompt) {
-      runtime.error?.("--omit-system-prompt is only supported in gateway mode (--json); ignored in --local mode.");
-    }
     return await agentCommand(localOpts, runtime, deps);
   }
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -191,6 +191,9 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     replyAccountId: opts.replyAccount,
   };
   if (opts.local === true) {
+    if (opts.omitSystemPrompt) {
+      runtime.error?.("--omit-system-prompt is only supported in gateway mode (--json); ignored in --local mode.");
+    }
     return await agentCommand(localOpts, runtime, deps);
   }
 


### PR DESCRIPTION
Adds `--omit-system-prompt` flag to `openclaw agent --json` that strips `meta.systemPromptReport` from the JSON output.

When piping agent output to other tools, the system prompt report is often unwanted noise. This flag lets users opt out.

## Changes
- `src/cli/program/register.agent.ts`: Register `--omit-system-prompt` option
- `src/commands/agent-via-gateway.ts`: Add `omitSystemPrompt` to `AgentCliOpts`, filter output when flag is set
- `src/commands/agent-via-gateway.e2e.test.ts`: Two new tests

Closes #21607

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `--omit-system-prompt` flag to `openclaw agent --json` for filtering out `meta.systemPromptReport` from JSON output. This is useful when piping agent output to other tools where the system prompt report is unwanted noise.

**Key changes:**
- Registers new `--omit-system-prompt` CLI option in `register.agent.ts:44`
- Adds `omitSystemPrompt` field to `AgentCliOpts` type
- Implements filtering via `structuredClone` + `delete` in gateway path (lines 159-163)
- Includes comprehensive test coverage for both enabled and default behavior

**Issue found:**
- The flag only works for gateway mode. When using `--local` mode, the flag is silently ignored because the local agent path doesn't implement the filtering logic.

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge with one logical inconsistency that should be addressed
- Score reflects clean implementation with good test coverage, but the flag only works in gateway mode and silently fails in local mode. This creates inconsistent behavior that could confuse users. The gateway path implementation is correct and well-tested.
- Pay attention to `src/commands/agent-via-gateway.ts` where the local mode fallback doesn't handle the new flag

<sub>Last reviewed commit: 18419e3</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->