### PR TITLE
feat(agent): auto-refresh tool schema on unknown tool invocation

### DIFF
--- a/extensions/msteams/src/media-helpers.ts
+++ b/extensions/msteams/src/media-helpers.ts
@@ -69,18 +69,14 @@ export function isLocalPath(url: string): boolean {
     return true;
   }
 
-  // Windows rooted path on current drive (e.g. \tmp\file.txt)
-  if (url.startsWith("\\") && !url.startsWith("\\\\")) {
+  // Windows root-relative paths (e.g. \tmp\file.txt) and UNC paths
+  // (e.g. \\server\share\file.txt) both start with a backslash.
+  if (url.startsWith("\\")) {
     return true;
   }
 
   // Windows drive-letter absolute path (e.g. C:\foo\bar.txt or C:/foo/bar.txt)
   if (/^[a-zA-Z]:[\\/]/.test(url)) {
-    return true;
-  }
-
-  // Windows UNC path (e.g. \\server\share\file.txt)
-  if (url.startsWith("\\\\")) {
     return true;
   }
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -65,6 +65,8 @@ export function createOpenClawTools(options?: {
   requesterSenderId?: string | null;
   /** Whether the requesting sender is an owner. */
   senderIsOwner?: boolean;
+  /** Force plugin tool schema refresh by bypassing plugin loader cache once. */
+  refreshToolSchema?: boolean;
 }): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
   const imageTool = options?.agentDir?.trim()
@@ -181,6 +183,7 @@ export function createOpenClawTools(options?: {
     },
     existingToolNames: new Set(tools.map((tool) => tool.name)),
     toolAllowlist: options?.pluginToolAllowlist,
+    refreshToolSchema: options?.refreshToolSchema,
   });
 
   return [...tools, ...pluginTools];

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -892,6 +892,9 @@ export async function runEmbeddedPiAgent(
                       source: "promptError" as const,
                     };
                   }
+                  // Prompt submission failed with a non-unknown-tool error. Do not
+                  // inspect prior assistant errors from history for this attempt.
+                  return null;
                 }
                 if (assistantErrorText && isUnknownToolFailure(assistantErrorText)) {
                   return {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs/promises";
 import crypto from "node:crypto";
+import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -109,7 +109,7 @@ function snapshotToolSchema(report?: SessionSystemPromptReport): ToolSchemaSnaps
         propertiesCount: entry.propertiesCount ?? null,
       }),
     )
-    .sort();
+    .toSorted();
   const fingerprint = crypto
     .createHash("sha256")
     .update(serializedEntries.join("|"))

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
+import crypto from "node:crypto";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -73,6 +75,52 @@ function scrubAnthropicRefusalMagic(prompt: string): string {
     ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL,
     ANTHROPIC_MAGIC_STRING_REPLACEMENT,
   );
+}
+
+type ToolSchemaSnapshot = {
+  toolCount: number;
+  schemaChars: number;
+  listChars: number;
+  fingerprint: string;
+};
+
+type UnknownToolErrorSource = "promptError" | "assistantError";
+
+function isUnknownToolFailure(text?: string): boolean {
+  const message = text?.trim();
+  if (!message) {
+    return false;
+  }
+  return (
+    /unknown tool[:\s]+["']?[a-z0-9_-]+["']?/i.test(message) ||
+    /tool\s+["']?[a-z0-9_-]+["']?\s+(?:not found|is not available)/i.test(message) ||
+    /tool_choice requested unknown tool/i.test(message)
+  );
+}
+
+function snapshotToolSchema(report?: SessionSystemPromptReport): ToolSchemaSnapshot {
+  const entries = report?.tools?.entries ?? [];
+  const serializedEntries = entries
+    .map((entry) =>
+      JSON.stringify({
+        name: entry.name,
+        summaryChars: entry.summaryChars,
+        schemaChars: entry.schemaChars,
+        propertiesCount: entry.propertiesCount ?? null,
+      }),
+    )
+    .sort();
+  const fingerprint = crypto
+    .createHash("sha256")
+    .update(serializedEntries.join("|"))
+    .digest("hex")
+    .slice(0, 12);
+  return {
+    toolCount: entries.length,
+    schemaChars: report?.tools?.schemaChars ?? 0,
+    listChars: report?.tools?.listChars ?? 0,
+    fingerprint,
+  };
 }
 
 type UsageAccumulator = {
@@ -491,6 +539,14 @@ export async function runEmbeddedPiAgent(
       const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
       let overflowCompactionAttempts = 0;
       let toolResultTruncationAttempted = false;
+      let unknownToolRefreshRetried = false;
+      let refreshToolSchema = false;
+      let pendingToolSchemaComparison:
+        | {
+            before: ToolSchemaSnapshot;
+            source: UnknownToolErrorSource;
+          }
+        | undefined;
       const usageAccumulator = createUsageAccumulator();
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
@@ -532,6 +588,8 @@ export async function runEmbeddedPiAgent(
 
           const prompt =
             provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
+          const refreshToolSchemaForAttempt = refreshToolSchema;
+          refreshToolSchema = false;
 
           const attempt = await runEmbeddedAttempt({
             sessionId: params.sessionId,
@@ -590,6 +648,7 @@ export async function runEmbeddedPiAgent(
             streamParams: params.streamParams,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
+            refreshToolSchema: refreshToolSchemaForAttempt,
           });
 
           const {
@@ -626,6 +685,20 @@ export async function runEmbeddedPiAgent(
             lastAssistant?.stopReason === "error"
               ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
+          if (refreshToolSchemaForAttempt && pendingToolSchemaComparison) {
+            const after = snapshotToolSchema(attempt.systemPromptReport);
+            const before = pendingToolSchemaComparison.before;
+            const changed = before.fingerprint !== after.fingerprint;
+            log.info(
+              `[tool-schema-refresh] source=${pendingToolSchemaComparison.source} ` +
+                `beforeFingerprint=${before.fingerprint} afterFingerprint=${after.fingerprint} ` +
+                `beforeToolCount=${before.toolCount} afterToolCount=${after.toolCount} ` +
+                `beforeSchemaChars=${before.schemaChars} afterSchemaChars=${after.schemaChars} ` +
+                `beforeListChars=${before.listChars} afterListChars=${after.listChars} ` +
+                `changed=${changed ? "yes" : "no"}`,
+            );
+            pendingToolSchemaComparison = undefined;
+          }
 
           const contextOverflowError = !aborted
             ? (() => {
@@ -807,6 +880,44 @@ export async function runEmbeddedPiAgent(
                 error: { kind, message: errorText },
               },
             };
+          }
+
+          const unknownToolError = !aborted
+            ? (() => {
+                if (promptError) {
+                  const errorText = describeUnknownError(promptError);
+                  if (isUnknownToolFailure(errorText)) {
+                    return {
+                      text: errorText,
+                      source: "promptError" as const,
+                    };
+                  }
+                }
+                if (assistantErrorText && isUnknownToolFailure(assistantErrorText)) {
+                  return {
+                    text: assistantErrorText,
+                    source: "assistantError" as const,
+                  };
+                }
+                return null;
+              })()
+            : null;
+          if (unknownToolError && !unknownToolRefreshRetried) {
+            unknownToolRefreshRetried = true;
+            refreshToolSchema = true;
+            const beforeSnapshot = snapshotToolSchema(attempt.systemPromptReport);
+            pendingToolSchemaComparison = {
+              before: beforeSnapshot,
+              source: unknownToolError.source,
+            };
+            log.warn(
+              `[tool-schema-refresh] unknown-tool detected source=${unknownToolError.source} ` +
+                `retry=1/1 bypassPluginCache=true ` +
+                `toolCount=${beforeSnapshot.toolCount} schemaChars=${beforeSnapshot.schemaChars} ` +
+                `listChars=${beforeSnapshot.listChars} fingerprint=${beforeSnapshot.fingerprint} ` +
+                `error=${unknownToolError.text.slice(0, 200)}`,
+            );
+            continue;
           }
 
           if (promptError && !aborted) {

--- a/src/agents/pi-embedded-runner/run.unknown-tool-schema-refresh.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run.unknown-tool-schema-refresh.e2e.test.ts
@@ -1,0 +1,152 @@
+import "./run.overflow-compaction.mocks.shared.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { log } from "./logger.js";
+import { runEmbeddedPiAgent } from "./run.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import { runEmbeddedAttempt } from "./run/attempt.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+
+const mockedRunEmbeddedAttempt = vi.mocked(runEmbeddedAttempt);
+
+const baseParams = {
+  sessionId: "test-session",
+  sessionKey: "test-key",
+  sessionFile: "/tmp/session.json",
+  workspaceDir: "/tmp/workspace",
+  prompt: "hello",
+  timeoutMs: 30000,
+  runId: "run-unknown-tool-refresh",
+};
+
+function makeSystemPromptReport(
+  toolNames: string[],
+): NonNullable<EmbeddedRunAttemptResult["systemPromptReport"]> {
+  const entries = toolNames.map((name, index) => ({
+    name,
+    summaryChars: name.length + 10,
+    schemaChars: 100 + index * 10,
+    propertiesCount: index + 1,
+  }));
+  return {
+    source: "run",
+    generatedAt: Date.now(),
+    sessionId: "test-session",
+    sessionKey: "test-key",
+    provider: "anthropic",
+    model: "test-model",
+    workspaceDir: "/tmp/workspace",
+    bootstrapMaxChars: 0,
+    bootstrapTotalMaxChars: 0,
+    sandbox: {
+      mode: "off",
+      sandboxed: false,
+    },
+    systemPrompt: {
+      chars: 0,
+      projectContextChars: 0,
+      nonProjectContextChars: 0,
+    },
+    injectedWorkspaceFiles: [],
+    skills: {
+      promptChars: 0,
+      entries: [],
+    },
+    tools: {
+      listChars: toolNames.join(",").length,
+      schemaChars: entries.reduce((sum, entry) => sum + entry.schemaChars, 0),
+      entries,
+    },
+  };
+}
+
+describe("runEmbeddedPiAgent unknown tool schema refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retries once with tool schema refresh after unknown tool promptError", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: new Error("unknown tool: plugin_search"),
+          systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          systemPromptReport: makeSystemPromptReport(["message", "web_search", "plugin_search"]),
+        }),
+      );
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt.mock.calls[0]?.[0]).toMatchObject({
+      refreshToolSchema: false,
+    });
+    expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]).toMatchObject({
+      refreshToolSchema: true,
+    });
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[tool-schema-refresh] unknown-tool detected"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("[tool-schema-refresh] source=promptError"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("detects unknown tool from assistant error text and retries with refresh", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          lastAssistant: {
+            stopReason: "error",
+            errorMessage: "tool \"plugin_search\" is not available",
+          } as EmbeddedRunAttemptResult["lastAssistant"],
+          systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          systemPromptReport: makeSystemPromptReport(["message", "web_search", "plugin_search"]),
+        }),
+      );
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]).toMatchObject({
+      refreshToolSchema: true,
+    });
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("[tool-schema-refresh] source=assistantError"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("retries unknown tool failure exactly once", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: new Error("unknown tool: plugin_search"),
+          systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: new Error("unknown tool: plugin_search"),
+          systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
+        }),
+      );
+
+    await expect(runEmbeddedPiAgent(baseParams)).rejects.toThrow("unknown tool: plugin_search");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]).toMatchObject({
+      refreshToolSchema: true,
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run.unknown-tool-schema-refresh.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run.unknown-tool-schema-refresh.e2e.test.ts
@@ -104,7 +104,7 @@ describe("runEmbeddedPiAgent unknown tool schema refresh", () => {
           promptError: null,
           lastAssistant: {
             stopReason: "error",
-            errorMessage: "tool \"plugin_search\" is not available",
+            errorMessage: 'tool "plugin_search" is not available',
           } as EmbeddedRunAttemptResult["lastAssistant"],
           systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
         }),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -329,6 +329,7 @@ export async function runEmbeddedAttempt(
           requireExplicitMessageTarget:
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
+          refreshToolSchema: params.refreshToolSchema,
         });
     const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
     logToolSchemasForGoogle({ tools, provider: params.provider });

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -19,6 +19,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
   thinkLevel: ThinkLevel;
+  /** Force a one-time tool schema refresh by bypassing plugin registry cache. */
+  refreshToolSchema?: boolean;
 };
 
 export type EmbeddedRunAttemptResult = {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -215,6 +215,8 @@ export function createOpenClawCodingTools(options?: {
   disableMessageTool?: boolean;
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
+  /** Force plugin tool schema refresh by bypassing plugin loader cache once. */
+  refreshToolSchema?: boolean;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -457,6 +459,7 @@ export function createOpenClawCodingTools(options?: {
       requesterAgentIdOverride: agentId,
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
+      refreshToolSchema: options?.refreshToolSchema,
     }),
   ];
   // Security: treat unknown/undefined as unauthorized (opt-in, not opt-out)

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -38,6 +38,8 @@ export type PluginLoadOptions = {
   logger?: PluginLogger;
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   cache?: boolean;
+  /** Bypass registry cache reads for this load, but keep cache writes enabled. */
+  refresh?: boolean;
   mode?: "full" | "validate";
 };
 
@@ -343,7 +345,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     plugins: normalized,
   });
   const cacheEnabled = options.cache !== false;
-  if (cacheEnabled) {
+  const refreshCache = options.refresh === true;
+  const cacheReadEnabled = cacheEnabled && !refreshCache;
+  if (cacheReadEnabled) {
     const cached = registryCache.get(cacheKey);
     if (cached) {
       setActivePluginRegistry(cached, cacheKey);

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -154,4 +154,25 @@ describe("resolvePluginTools optional tools", () => {
     expect(registry.diagnostics).toHaveLength(1);
     expect(registry.diagnostics[0]?.message).toContain("plugin tool name conflict");
   });
+
+  it("bypasses plugin registry cache when refreshToolSchema is requested", () => {
+    setRegistry([
+      {
+        pluginId: "optional-demo",
+        optional: true,
+        source: "/tmp/optional-demo.js",
+        factory: () => makeTool("optional_tool"),
+      },
+    ]);
+
+    resolvePluginTools({
+      context: createContext() as never,
+      toolAllowlist: ["optional_tool"],
+      refreshToolSchema: true,
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cache: false }),
+    );
+  });
 });

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -155,7 +155,7 @@ describe("resolvePluginTools optional tools", () => {
     expect(registry.diagnostics[0]?.message).toContain("plugin tool name conflict");
   });
 
-  it("bypasses plugin registry cache when refreshToolSchema is requested", () => {
+  it("requests plugin registry refresh mode when refreshToolSchema is requested", () => {
     setRegistry([
       {
         pluginId: "optional-demo",
@@ -171,6 +171,10 @@ describe("resolvePluginTools optional tools", () => {
       refreshToolSchema: true,
     });
 
-    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(expect.objectContaining({ cache: false }));
+    const loadArgs = loadOpenClawPluginsMock.mock.calls[0]?.[0] as
+      | { refresh?: boolean; cache?: boolean }
+      | undefined;
+    expect(loadArgs?.refresh).toBe(true);
+    expect(loadArgs?.cache).toBeUndefined();
   });
 });

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -171,8 +171,6 @@ describe("resolvePluginTools optional tools", () => {
       refreshToolSchema: true,
     });
 
-    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ cache: false }),
-    );
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(expect.objectContaining({ cache: false }));
   });
 });

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -46,6 +46,7 @@ export function resolvePluginTools(params: {
   context: OpenClawPluginToolContext;
   existingToolNames?: Set<string>;
   toolAllowlist?: string[];
+  refreshToolSchema?: boolean;
 }): AnyAgentTool[] {
   // Fast path: when plugins are effectively disabled, avoid discovery/jiti entirely.
   // This matters a lot for unit tests and for tool construction hot paths.
@@ -59,6 +60,7 @@ export function resolvePluginTools(params: {
     config: effectiveConfig,
     workspaceDir: params.context.workspaceDir,
     logger: createPluginLoaderLogger(log),
+    ...(params.refreshToolSchema ? { cache: false } : {}),
   });
 
   const tools: AnyAgentTool[] = [];

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -60,7 +60,7 @@ export function resolvePluginTools(params: {
     config: effectiveConfig,
     workspaceDir: params.context.workspaceDir,
     logger: createPluginLoaderLogger(log),
-    ...(params.refreshToolSchema ? { cache: false } : {}),
+    ...(params.refreshToolSchema ? { refresh: true } : {}),
   });
 
   const tools: AnyAgentTool[] = [];


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: embedded runner could fail hard on `unknown tool` when tool schema was stale/out-of-sync.
- Why it matters: user-visible agent turns can fail even when the tool is actually available after schema refresh.
- What changed:
  - add unknown-tool detection in embedded run loop and perform **exactly one** retry with `refreshToolSchema=true`;
  - plumb refresh flag through run → attempt → tool construction → plugin resolution;
  - add schema before/after diagnostic logging (fingerprint + counts);
  - harden plugin refresh behavior to bypass cache read and update cache with refreshed registry.
  - fix Windows-only path classification in MSTeams helper (`\\tmp\\file.txt` root-relative path treated as local), with regression test.
- What did NOT change (scope boundary):
  - no retry for non-unknown-tool errors;
  - no infinite retry loop (single retry only);
  - no new permissions/capabilities/tools exposed.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #22610

## User-visible / Behavior Changes

- Agent can self-heal a stale tool schema on unknown-tool failure with one refresh+retry.
- MSTeams local media fallback now correctly handles Windows root-relative paths.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No (same tools, refresh path only)
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS local + GitHub Actions Linux/Windows
- Runtime/container: Node 22.x, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): MSTeams helper tests
- Relevant config (redacted): default test configs (`vitest.e2e.config.ts`, `vitest.unit.config.ts`)

### Steps

1. Trigger unknown-tool scenario in embedded runner.
2. Observe one-time schema refresh retry.
3. Validate plugin cache refresh behavior and MSTeams Windows local-path handling.

### Expected

- Unknown-tool failure triggers one refresh+retry only.
- Refreshed schema is visible in diagnostics and reused on subsequent turns.
- Windows root-relative path is treated as local in MSTeams media handling.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence links/examples:
- Windows failure before: run `22256120199`, job `64387264957` (msteams assertion failure)
- Windows pass after fix: run `22256400090`, job `64387879699`
- Local verification:
  - `pnpm vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-runner/run.unknown-tool-schema-refresh.e2e.test.ts`
  - `pnpm vitest run --config vitest.unit.config.ts src/plugins/tools.optional.test.ts`
  - `pnpm vitest run extensions/msteams/src/media-helpers.test.ts extensions/msteams/src/messenger.test.ts`
  - `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - unknown-tool detection and single retry path;
  - schema refresh plumbing through plugin loader;
  - MSTeams Windows root-relative local-path classification.
- Edge cases checked:
  - non-unknown prompt errors do not trigger retry fallback;
  - retry is capped at one;
  - cache refresh updates subsequent reads.
- What you did **not** verify:
  - exhaustive end-to-end behavior for unrelated upstream baseline failures in `check`/`check-docs` jobs.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert commits in this PR (feature + hardening + msteams fix).
- Files/config to restore:
  - `src/agents/pi-embedded-runner/run.ts`
  - `src/plugins/loader.ts`
  - `src/plugins/tools.ts`
  - `extensions/msteams/src/media-helpers.ts`
- Known bad symptoms reviewers should watch for:
  - repeated retries on non-unknown errors;
  - stale schema not updating after refresh;
  - MSTeams local media treated as remote on Windows.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: false-positive unknown-tool detection could trigger unnecessary retry.
  - Mitigation: strict detection + prompt-error precedence + single retry guard.
- Risk: refresh path could bypass cache without persisting new registry.
  - Mitigation: explicit refresh mode with cache update + loader tests.
- Risk: Windows path rule broadening could misclassify some strings.
  - Mitigation: URL/data URL checks remain first; regression tests added.
