### PR TITLE
fix(discord): allow messages from other instance bots in multi-account setups

### DIFF
--- a/src/discord/monitor/instance-bot-registry.test.ts
+++ b/src/discord/monitor/instance-bot-registry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  registerInstanceBotUserId,
+  unregisterInstanceBotUserId,
+  isInstanceBotUserId,
+  clearInstanceBotUserIds,
+} from "./instance-bot-registry.js";
+
+describe("instance-bot-registry", () => {
+  beforeEach(() => {
+    clearInstanceBotUserIds();
+  });
+
+  it("should register and detect instance bot user IDs", () => {
+    registerInstanceBotUserId("bot-a");
+    registerInstanceBotUserId("bot-b");
+
+    expect(isInstanceBotUserId("bot-a")).toBe(true);
+    expect(isInstanceBotUserId("bot-b")).toBe(true);
+    expect(isInstanceBotUserId("external-bot")).toBe(false);
+  });
+
+  it("should exclude own bot ID from instance check", () => {
+    registerInstanceBotUserId("bot-a");
+    registerInstanceBotUserId("bot-b");
+
+    // bot-a checking if bot-a is an "instance bot" should return false
+    // (it's the caller's own bot, handled by self-message check)
+    expect(isInstanceBotUserId("bot-a", "bot-a")).toBe(false);
+    // bot-a checking if bot-b is an instance bot should return true
+    expect(isInstanceBotUserId("bot-b", "bot-a")).toBe(true);
+  });
+
+  it("should unregister bot user IDs", () => {
+    registerInstanceBotUserId("bot-a");
+    expect(isInstanceBotUserId("bot-a")).toBe(true);
+
+    unregisterInstanceBotUserId("bot-a");
+    expect(isInstanceBotUserId("bot-a")).toBe(false);
+  });
+
+  it("should handle empty/falsy inputs gracefully", () => {
+    expect(isInstanceBotUserId("")).toBe(false);
+    expect(isInstanceBotUserId("", "bot-a")).toBe(false);
+  });
+
+  it("should clear all registrations", () => {
+    registerInstanceBotUserId("bot-a");
+    registerInstanceBotUserId("bot-b");
+    clearInstanceBotUserIds();
+
+    expect(isInstanceBotUserId("bot-a")).toBe(false);
+    expect(isInstanceBotUserId("bot-b")).toBe(false);
+  });
+});

--- a/src/discord/monitor/instance-bot-registry.ts
+++ b/src/discord/monitor/instance-bot-registry.ts
@@ -1,0 +1,45 @@
+/**
+ * Module-level registry of bot user IDs for all Discord accounts
+ * managed by this OpenClaw instance.
+ *
+ * Used to distinguish "own instance" bots from external bots when
+ * filtering inbound messages. Messages from other bots in the same
+ * instance should not be blocked by the allowBots=false default,
+ * enabling agent-to-agent communication via Discord.
+ *
+ * Fixes: https://github.com/openclaw/openclaw/issues/11199
+ */
+
+const instanceBotUserIds = new Set<string>();
+
+/** Register a bot user ID belonging to this OpenClaw instance. */
+export function registerInstanceBotUserId(botUserId: string): void {
+  if (botUserId) {
+    instanceBotUserIds.add(botUserId);
+  }
+}
+
+/** Unregister a bot user ID (e.g. on account shutdown). */
+export function unregisterInstanceBotUserId(botUserId: string): void {
+  instanceBotUserIds.delete(botUserId);
+}
+
+/**
+ * Check if a given user ID belongs to another bot in this OpenClaw instance
+ * (excluding the caller's own bot ID).
+ */
+export function isInstanceBotUserId(userId: string, ownBotUserId?: string): boolean {
+  if (!userId) {
+    return false;
+  }
+  // Don't match the caller's own bot — that's handled by the self-message check
+  if (ownBotUserId && userId === ownBotUserId) {
+    return false;
+  }
+  return instanceBotUserIds.has(userId);
+}
+
+/** Clear all registered bot user IDs (for testing). */
+export function clearInstanceBotUserIds(): void {
+  instanceBotUserIds.clear();
+}

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -44,6 +44,7 @@ import {
   resolveDiscordSystemLocation,
   resolveTimestampMs,
 } from "./format.js";
+import { isInstanceBotUserId } from "./instance-bot-registry.js";
 import type {
   DiscordMessagePreflightContext,
   DiscordMessagePreflightParams,
@@ -107,7 +108,11 @@ export async function preflightDiscordMessage(
   });
 
   if (author.bot) {
-    if (!allowBots && !sender.isPluralKit) {
+    // Allow messages from other bots in this OpenClaw instance (agent-to-agent
+    // communication) even when allowBots is false. Each account's own bot is
+    // already filtered by the self-message check above.
+    const fromInstanceBot = isInstanceBotUserId(author.id, params.botUserId);
+    if (!allowBots && !sender.isPluralKit && !fromInstanceBot) {
       logVerbose("discord: drop bot message (allowBots=false)");
       return null;
     }

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -58,6 +58,7 @@ import { resolveDiscordSlashCommandConfig } from "./commands.js";
 import { createExecApprovalButton, DiscordExecApprovalHandler } from "./exec-approvals.js";
 import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
+import { registerInstanceBotUserId, unregisterInstanceBotUserId } from "./instance-bot-registry.js";
 import {
   DiscordMessageListener,
   DiscordPresenceListener,
@@ -584,6 +585,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   try {
     const botUser = await client.fetchUser("@me");
     botUserId = botUser?.id;
+    if (botUserId) {
+      registerInstanceBotUserId(botUserId);
+    }
   } catch (err) {
     runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
   }
@@ -747,6 +751,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     }
   } finally {
     unregisterGateway(account.accountId);
+    if (botUserId) {
+      unregisterInstanceBotUserId(botUserId);
+    }
     stopGatewayLogging();
     if (helloTimeoutId) {
       clearTimeout(helloTimeoutId);


### PR DESCRIPTION
## Summary

Fixes #11199

In multi-agent setups with multiple Discord bot accounts (one per agent), messages from Bot A were incorrectly filtered by Bot B's handler because `allowBots` defaults to `false`, which blocks **all** bot messages — including those from other agents in the same OpenClaw instance.

## Root Cause

The `allowBots` check in `message-handler.preflight.ts` treats all bot messages uniformly. When `allowBots: false` (default), it drops messages from ANY bot, including sibling agent bots in the same instance. The self-message check (`author.id === params.botUserId`) correctly only filters the current account's own bot, but the broader `allowBots` gate blocks inter-agent messages before they can be processed.

## Fix

Introduces a module-level **instance bot user ID registry** that tracks all bot accounts managed by this OpenClaw instance:

- **`instance-bot-registry.ts`**: A `Set<string>` that stores bot user IDs registered by each account on startup
- **`provider.ts`**: Registers bot user ID after `fetchUser('@me')`, unregisters on shutdown
- **`message-handler.preflight.ts`**: When `allowBots: false`, skips the filter for messages from other bots in the same instance (`isInstanceBotUserId()`), while still blocking external bot messages

### Behavior Matrix

| Message From | `allowBots: false` (before) | `allowBots: false` (after) |
|---|---|---|
| Own bot | ✅ Filtered | ✅ Filtered |
| Other instance bot | ❌ Filtered (bug) | ✅ Allowed |
| External bot | ✅ Filtered | ✅ Filtered |

## Tests

5 unit tests in `instance-bot-registry.test.ts`:
- Register and detect instance bot user IDs
- Exclude own bot ID from instance check
- Unregister bot user IDs
- Handle empty/falsy inputs
- Clear all registrations

All tests passing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a module-level bot user ID registry to enable multi-agent Discord communication. When `allowBots: false` (default), messages from bots in the same OpenClaw instance are now correctly allowed while external bot messages remain filtered. The fix properly distinguishes between same-instance bots (Bot A → Bot B communication) and external bots by tracking all bot user IDs in a shared `Set`. Registration happens during provider startup after `fetchUser('@me')` and before message listeners are attached, preventing race conditions. Cleanup is handled in the finally block during shutdown.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean, focused solution with proper lifecycle management, comprehensive test coverage, and no race conditions. The module-level registry pattern is appropriate for tracking cross-instance state, and the implementation correctly distinguishes between self-messages (already filtered), instance bots (now allowed), and external bots (still filtered).
- No files require special attention

<sub>Last reviewed commit: 7b976ec</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->