### PR TITLE
fix(telegram): split streaming preview per assistant block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Docs: https://docs.openclaw.ai
 - Memory: return empty snippets when `memory_get`/QMD read files that have not been created yet, and harden memory indexing/session helpers against ENOENT races so missing Markdown no longer crashes tools. (#20680) Thanks @pahdo.
 - Telegram/Streaming: always clean up draft previews even when dispatch throws before fallback handling, preventing orphaned preview messages during failed runs. (#19041) thanks @mudrii.
 - Telegram/Streaming: split reasoning and answer draft preview lanes to prevent cross-lane overwrites, and ignore literal `<think>` tags inside inline/fenced code snippets so sample markup is not misrouted as reasoning. (#20774) Thanks @obviyus.
+- Telegram/Streaming: restore 30-char first-preview debounce and scope `NO_REPLY` prefix suppression to partial sentinel fragments so normal `No...` text is not filtered. (#22613) thanks @obviyus.
 - Telegram/Status reactions: refresh stall timers on repeated phase updates and honor ack-reaction scope when lifecycle reactions are enabled, preventing false stall emojis and unwanted group reactions. Thanks @wolly-tundracube and @thewilloftheshadow.
 - Telegram/Status reactions: keep lifecycle reactions active when available-reactions lookup fails by falling back to unrestricted variant selection instead of suppressing reaction updates. (#22380) thanks @obviyus.
 - Discord/Streaming: apply `replyToMode: first` only to the first Discord chunk so block-streamed replies do not spam mention pings. (#20726) Thanks @thewilloftheshadow for the report.

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -138,10 +138,7 @@ export async function runAgentTurnWithFallback(params: {
           }
           text = stripped.text;
         }
-        if (
-          isSilentReplyText(text, SILENT_REPLY_TOKEN) ||
-          isSilentReplyPrefixText(text, SILENT_REPLY_TOKEN)
-        ) {
+        if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
           return { skip: true };
         }
         if (!text) {
@@ -160,6 +157,9 @@ export async function runAgentTurnWithFallback(params: {
         return { text: sanitized, skip: false };
       };
       const handlePartialForTyping = async (payload: ReplyPayload): Promise<string | undefined> => {
+        if (isSilentReplyPrefixText(payload.text, SILENT_REPLY_TOKEN)) {
+          return undefined;
+        }
         const { text, skip } = normalizeStreamingText(payload);
         if (skip || !text) {
           return undefined;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -28,7 +28,7 @@ import {
 import { stripHeartbeatToken } from "../heartbeat.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildEmbeddedRunBaseParams,
@@ -138,7 +138,10 @@ export async function runAgentTurnWithFallback(params: {
           }
           text = stripped.text;
         }
-        if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+        if (
+          isSilentReplyText(text, SILENT_REPLY_TOKEN) ||
+          isSilentReplyPrefixText(text, SILENT_REPLY_TOKEN)
+        ) {
           return { skip: true };
         }
         if (!text) {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -18,3 +18,17 @@ export function isSilentReplyText(
   const suffix = new RegExp(`\\b${escaped}\\b\\W*$`);
   return suffix.test(text);
 }
+
+export function isSilentReplyPrefixText(
+  text: string | undefined,
+  token: string = SILENT_REPLY_TOKEN,
+): boolean {
+  if (!text) {
+    return false;
+  }
+  const normalized = text.trimStart().toUpperCase();
+  if (!normalized) {
+    return false;
+  }
+  return token.toUpperCase().startsWith(normalized);
+}

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -30,5 +30,11 @@ export function isSilentReplyPrefixText(
   if (!normalized) {
     return false;
   }
+  if (!normalized.includes("_")) {
+    return false;
+  }
+  if (/[^A-Z_]/.test(normalized)) {
+    return false;
+  }
   return token.toUpperCase().startsWith(normalized);
 }

--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -3,6 +3,7 @@ export type DraftStreamLoop = {
   flush: () => Promise<void>;
   stop: () => void;
   resetPending: () => void;
+  resetThrottleWindow: () => void;
   waitForInFlight: () => Promise<void>;
 };
 
@@ -86,6 +87,13 @@ export function createDraftStreamLoop(params: {
     },
     resetPending: () => {
       pendingText = "";
+    },
+    resetThrottleWindow: () => {
+      lastSentAt = 0;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
     },
     waitForInFlight: async () => {
       if (inFlightPromise) {

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.e2e.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.e2e.test.ts
@@ -378,11 +378,11 @@ describe("legacy config detection", () => {
       expect(res.config.channels?.telegram?.groupPolicy).toBe("allowlist");
     }
   });
-  it("defaults telegram.streaming to true when telegram section exists", async () => {
+  it("defaults telegram.streaming to false when telegram section exists", async () => {
     const res = validateConfigObject({ channels: { telegram: {} } });
     expect(res.ok).toBe(true);
     if (res.ok) {
-      expect(res.config.channels?.telegram?.streaming).toBe(true);
+      expect(res.config.channels?.telegram?.streaming).toBe(false);
       expect(res.config.channels?.telegram?.streamMode).toBeUndefined();
     }
   });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -392,7 +392,7 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.telegram.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
   "channels.telegram.streaming":
-    "Enable Telegram live stream preview via message edits (default: true; legacy streamMode auto-maps here).",
+    "Enable Telegram live stream preview via message edits (default: false; legacy streamMode auto-maps here).",
   "channels.discord.streamMode":
     "Live stream preview mode for Discord replies (off | partial | block). Separate from block streaming; uses sendMessage + editMessage.",
   "channels.discord.draftChunk.minChars":

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -117,7 +117,7 @@ function normalizeTelegramStreamingConfig(value: {
     delete value.streamMode;
     return;
   }
-  value.streaming = true;
+  value.streaming = false;
 }
 
 export const TelegramAccountSchemaBase = z

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -63,6 +63,25 @@ describe("dispatchTelegramMessage draft streaming", () => {
     };
   }
 
+  function createSequencedDraftStream(startMessageId = 1001) {
+    let activeMessageId: number | undefined;
+    let nextMessageId = startMessageId;
+    return {
+      update: vi.fn().mockImplementation(() => {
+        if (activeMessageId == null) {
+          activeMessageId = nextMessageId++;
+        }
+      }),
+      flush: vi.fn().mockResolvedValue(undefined),
+      messageId: vi.fn().mockImplementation(() => activeMessageId),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      forceNewMessage: vi.fn().mockImplementation(() => {
+        activeMessageId = undefined;
+      }),
+    };
+  }
+
   function setupDraftStreams(params?: { answerMessageId?: number; reasoningMessageId?: number }) {
     const answerDraftStream = createDraftStream(params?.answerMessageId);
     const reasoningDraftStream = createDraftStream(params?.reasoningMessageId);
@@ -506,6 +525,56 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     // First message start shouldn't trigger forceNewMessage (no previous output)
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+  });
+
+  it("finalizes multi-message assistant stream to matching preview messages in order", async () => {
+    const answerDraftStream = createSequencedDraftStream(1001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message B partial" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message C partial" });
+
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Message C final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(2);
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      1,
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      2,
+      123,
+      1002,
+      "Message B final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      3,
+      123,
+      1003,
+      "Message C final",
+      expect.any(Object),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it.each(["block", "partial"] as const)(

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -445,7 +445,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("does not force new message for legacy block stream mode", async () => {
+  it("forces new message for next assistant block in legacy block stream mode", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -464,10 +464,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
-    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("does not force new message in partial mode when assistant message restarts", async () => {
+  it("forces new message in partial mode when assistant message restarts", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -483,7 +483,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext(), streamMode: "partial" });
 
-    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
   });
 
   it("does not force new message on first assistant message start", async () => {

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -82,6 +82,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
     };
   }
 
+  function createFlushSequencedDraftStream(startMessageId = 2001) {
+    let activeMessageId: number | undefined;
+    let nextMessageId = startMessageId;
+    let pendingText = "";
+    return {
+      update: vi.fn().mockImplementation((text: string) => {
+        pendingText = text;
+      }),
+      flush: vi.fn().mockImplementation(async () => {
+        if (pendingText && activeMessageId == null) {
+          activeMessageId = nextMessageId++;
+        }
+      }),
+      messageId: vi.fn().mockImplementation(() => activeMessageId),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      forceNewMessage: vi.fn().mockImplementation(() => {
+        activeMessageId = undefined;
+        pendingText = "";
+      }),
+    };
+  }
+
   function setupDraftStreams(params?: { answerMessageId?: number; reasoningMessageId?: number }) {
     const answerDraftStream = createDraftStream(params?.answerMessageId);
     const reasoningDraftStream = createDraftStream(params?.reasoningMessageId);
@@ -575,6 +598,55 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.any(Object),
     );
     expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("flushes each assistant message boundary so previews stream separately before final delivery", async () => {
+    const answerDraftStream = createFlushSequencedDraftStream(2001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "First chunk" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Second chunk" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Third chunk" });
+
+        await dispatcherOptions.deliver({ text: "First final" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Second final" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Third final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "2001" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(answerDraftStream.flush).toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      1,
+      123,
+      2001,
+      "First final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      2,
+      123,
+      2002,
+      "Second final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      3,
+      123,
+      2003,
+      "Third final",
+      expect.any(Object),
+    );
   });
 
   it.each(["block", "partial"] as const)(

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -191,7 +191,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({
         chatId: 123,
         thread: { id: 777, scope: "dm" },
-        minInitialChars: 1,
+        minInitialChars: 30,
       }),
     );
     expect(draftStream.update).toHaveBeenCalledWith("Hello");
@@ -212,7 +212,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
-  it("uses immediate preview updates for legacy block stream mode", async () => {
+  it("uses 30-char preview debounce for legacy block stream mode", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -228,7 +228,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(createTelegramDraftStream).toHaveBeenCalledWith(
       expect.objectContaining({
-        minInitialChars: 1,
+        minInitialChars: 30,
       }),
     );
   });

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -672,7 +672,6 @@ export const dispatchTelegramMessage = async ({
           ? async () => {
               reasoningStepState.resetForNextStep();
               if (answerLane.hasStreamedMessage) {
-                await answerLane.stream?.flush();
                 const previewMessageId = answerLane.stream?.messageId();
                 if (typeof previewMessageId === "number") {
                   archivedAnswerPreviews.push({

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -147,8 +147,7 @@ export const dispatchTelegramMessage = async ({
   const canStreamReasoningDraft = canStreamAnswerDraft || streamReasoningDraft;
   const draftReplyToMessageId =
     replyToMode !== "off" && typeof msg.message_id === "number" ? msg.message_id : undefined;
-  const draftMinInitialChars =
-    previewStreamingEnabled || streamReasoningDraft ? 1 : DRAFT_MIN_INITIAL_CHARS;
+  const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   type LaneName = "answer" | "reasoning";
   type DraftLaneState = {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -630,6 +630,9 @@ export const dispatchTelegramMessage = async ({
         onAssistantMessageStart: answerLane.stream
           ? () => {
               reasoningStepState.resetForNextStep();
+              if (answerLane.hasStreamedMessage) {
+                answerLane.stream?.forceNewMessage();
+              }
               resetDraftLaneState(answerLane);
             }
           : undefined,

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -669,9 +669,10 @@ export const dispatchTelegramMessage = async ({
             }
           : undefined,
         onAssistantMessageStart: answerLane.stream
-          ? () => {
+          ? async () => {
               reasoningStepState.resetForNextStep();
               if (answerLane.hasStreamedMessage) {
+                await answerLane.stream?.flush();
                 const previewMessageId = answerLane.stream?.messageId();
                 if (typeof previewMessageId === "number") {
                   archivedAnswerPreviews.push({

--- a/src/telegram/bot.helpers.test.ts
+++ b/src/telegram/bot.helpers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveTelegramStreamMode } from "./bot/helpers.js";
+
+describe("resolveTelegramStreamMode", () => {
+  it("defaults to off when telegram streaming is unset", () => {
+    expect(resolveTelegramStreamMode(undefined)).toBe("off");
+    expect(resolveTelegramStreamMode({})).toBe("off");
+  });
+
+  it("prefers explicit streaming boolean", () => {
+    expect(resolveTelegramStreamMode({ streaming: true })).toBe("partial");
+    expect(resolveTelegramStreamMode({ streaming: false })).toBe("off");
+  });
+
+  it("maps legacy streamMode values", () => {
+    expect(resolveTelegramStreamMode({ streamMode: "off" })).toBe("off");
+    expect(resolveTelegramStreamMode({ streamMode: "partial" })).toBe("partial");
+    expect(resolveTelegramStreamMode({ streamMode: "block" })).toBe("partial");
+  });
+});

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -167,7 +167,7 @@ export function resolveTelegramStreamMode(telegramCfg?: {
   if (raw === "partial" || raw === "block") {
     return "partial";
   }
-  return "partial";
+  return "off";
 }
 
 export function buildTelegramGroupPeerId(chatId: number | string, messageThreadId?: number) {

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -167,6 +167,7 @@ export function createTelegramDraftStream(params: {
     lastSentText = "";
     lastSentParseMode = undefined;
     loop.resetPending();
+    loop.resetThrottleWindow();
   };
 
   params.log?.(`telegram stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);


### PR DESCRIPTION
## Summary
- fix Telegram draft streaming to rotate to a fresh preview message when a new assistant message starts after prior partial output
- keep first-message start behavior unchanged (no forced rotation before any streamed content)
- update Telegram dispatch tests for block and partial stream modes

## Root Cause
`onAssistantMessageStart` reset lane text state but did not reset the underlying draft stream message id. Subsequent assistant blocks kept editing the same Telegram preview message.

## Testing
- pnpm test src/telegram/bot-message-dispatch.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Telegram draft streaming to create fresh preview messages when new assistant blocks start after prior output. Previously, `onAssistantMessageStart` reset lane text state but not the draft stream message ID, causing subsequent blocks to edit the same Telegram message instead of rotating to new ones.

**Key changes:**
- Added conditional `forceNewMessage()` call when `hasStreamedMessage` is true before resetting lane state
- Preserves first-message behavior (no rotation before any content streamed)
- Updated tests to expect `forceNewMessage` calls for multi-block scenarios

**Dockerfile note:** The Dockerfile changes shown in the diff are already present in the base branch (commit 985ffacb) and appear to be a rebase artifact from catching up with main.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is targeted and follows the existing pattern used for reasoning lane splits. The logic correctly guards `forceNewMessage()` with the `hasStreamedMessage` flag to preserve first-message behavior. Tests comprehensively cover the new behavior including edge cases (first message, multi-block, both stream modes). The Dockerfile changes are already in the base branch, making them a non-issue.
- No files require special attention

<sub>Last reviewed commit: 8da54b8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->