### PR TITLE
feat(tts): add OpenAI TTS speed parameter support

### DIFF
--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -215,6 +215,7 @@ export const TtsConfigSchema = z
         apiKey: z.string().optional().register(sensitive),
         model: z.string().optional(),
         voice: z.string().optional(),
+        speed: z.number().min(0.25).max(4).optional(),
       })
       .strict()
       .optional(),

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -254,6 +254,11 @@ export function parseTtsDirectives(
                 ...overrides.elevenlabs,
                 voiceSettings: { ...overrides.elevenlabs?.voiceSettings, speed: value },
               };
+              // Also set OpenAI speed (API supports 0.25–4.0, we use same 0.5–2.0 range for consistency)
+              overrides.openai = {
+                ...overrides.openai,
+                speed: value,
+              };
             }
             break;
           case "speakerboost":
@@ -594,9 +599,10 @@ export async function openaiTTS(params: {
   model: string;
   voice: string;
   responseFormat: "mp3" | "opus" | "pcm";
+  speed?: number;
   timeoutMs: number;
 }): Promise<Buffer> {
-  const { text, apiKey, model, voice, responseFormat, timeoutMs } = params;
+  const { text, apiKey, model, voice, responseFormat, speed, timeoutMs } = params;
 
   if (!isValidOpenAIModel(model)) {
     throw new Error(`Invalid model: ${model}`);
@@ -620,6 +626,7 @@ export async function openaiTTS(params: {
         input: text,
         voice,
         response_format: responseFormat,
+        ...(speed != null && speed !== 1 && { speed }),
       }),
       signal: controller.signal,
     });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -114,6 +114,7 @@ export type ResolvedTtsConfig = {
     apiKey?: string;
     model: string;
     voice: string;
+    speed: number;
   };
   edge: {
     enabled: boolean;
@@ -160,6 +161,7 @@ export type TtsDirectiveOverrides = {
   openai?: {
     voice?: string;
     model?: string;
+    speed?: number;
   };
   elevenlabs?: {
     voiceId?: string;
@@ -288,6 +290,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       apiKey: raw.openai?.apiKey,
       model: raw.openai?.model ?? DEFAULT_OPENAI_MODEL,
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
+      speed: typeof raw.openai?.speed === "number" ? raw.openai.speed : 1,
     },
     edge: {
       enabled: raw.edge?.enabled ?? true,
@@ -660,12 +663,14 @@ export async function textToSpeech(params: {
       } else {
         const openaiModelOverride = params.overrides?.openai?.model;
         const openaiVoiceOverride = params.overrides?.openai?.voice;
+        const openaiSpeedOverride = params.overrides?.openai?.speed;
         audioBuffer = await openaiTTS({
           text: params.text,
           apiKey,
           model: openaiModelOverride ?? config.openai.model,
           voice: openaiVoiceOverride ?? config.openai.voice,
           responseFormat: output.openai,
+          speed: openaiSpeedOverride ?? config.openai.speed,
           timeoutMs: config.timeoutMs,
         });
       }
@@ -765,6 +770,7 @@ export async function textToSpeechTelephony(params: {
         model: config.openai.model,
         voice: config.openai.voice,
         responseFormat: output.format,
+        speed: config.openai.speed,
         timeoutMs: config.timeoutMs,
       });
 


### PR DESCRIPTION
Adds support for the speed parameter when using OpenAI TTS provider.

The OpenAI TTS API supports a speed field (0.25–4.0) but it was never passed through — the parameter was silently dropped even when set via config or [[tts:speed=X]] directive.

**Changes:**
- ResolvedTtsConfig.openai + TtsDirectiveOverrides.openai: add speed field
- Zod config schema: messages.tts.openai.speed (0.25–4.0, optional)
- esolveTtsConfig(): read aw.openai?.speed, default 1
- openaiTTS() in 	ts-core.ts: accept speed param, include in API body
- 	extToSpeech() + telephony path: pass speed through
- parseTtsDirectives(): [[tts:speed=X]] now sets OpenAI speed alongside ElevenLabs

Closes #12163

> Replaces #12177 (branch was accidentally deleted during rebase attempt)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds OpenAI TTS speed parameter support (0.25–4.0) across config schema, type definitions, and runtime execution paths. The implementation correctly defaults to 1.0, validates config values, passes speed through both `textToSpeech()` and `textToSpeechTelephony()`, and only includes speed in the API request when it differs from the default (avoiding unnecessary API payload).

- Config schema validation added with correct OpenAI range (0.25–4.0)
- `ResolvedTtsConfig.openai.speed` and `TtsDirectiveOverrides.openai.speed` typed correctly
- `resolveTtsConfig()` defaults to 1 when not specified
- `openaiTTS()` accepts optional speed, conditionally includes in API body
- `textToSpeech()` and `textToSpeechTelephony()` both pass speed to OpenAI
- `[[tts:speed=X]]` directive now sets both ElevenLabs and OpenAI speed (constrained to 0.5–2.0 for consistency)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, follows existing patterns, adds proper type safety, includes appropriate validation, and only extends functionality without breaking changes. The speed parameter defaults to 1.0 (OpenAI's default), is properly typed throughout, and correctly passes through all code paths. The only consideration is a minor design choice about directive range constraints.
- No files require special attention

<sub>Last reviewed commit: a6f1cd2</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->