### PR TITLE
fix: merge before_agent_start hook systemPrompt into session system prompt

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -493,7 +493,7 @@ export async function runEmbeddedAttempt(
       tools,
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
-    const systemPromptText = systemPromptOverride();
+    let systemPromptText = systemPromptOverride();
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
@@ -595,7 +595,43 @@ export async function runEmbeddedAttempt(
         : [];
 
       const allCustomTools = [...customTools, ...clientToolDefs];
+      let cachedBeforeAgentStartResult:
+        | {
+            systemPrompt?: string;
+            prependContext?: string;
+          }
+        | undefined;
 
+      // Run before_agent_start hooks before createAgentSession so systemPrompt injection is used by the agent.
+      if (hookRunner?.hasHooks("before_agent_start")) {
+        try {
+          const sessionContext = sessionManager.buildSessionContext();
+          cachedBeforeAgentStartResult = await hookRunner.runBeforeAgentStart(
+            {
+              prompt: params.prompt,
+              messages: sessionContext?.messages ?? [],
+            },
+            {
+              agentId: params.sessionKey?.split(":")[0] ?? "main",
+              sessionKey: params.sessionKey,
+              workspaceDir: params.workspaceDir,
+              messageProvider: params.messageProvider ?? undefined,
+            },
+          );
+          if (
+            cachedBeforeAgentStartResult?.systemPrompt &&
+            typeof cachedBeforeAgentStartResult.systemPrompt === "string" &&
+            cachedBeforeAgentStartResult.systemPrompt.trim()
+          ) {
+            systemPromptText = `${systemPromptText}\n\n${cachedBeforeAgentStartResult.systemPrompt.trim()}`;
+            log.debug(
+              `hooks: appended systemPrompt (${cachedBeforeAgentStartResult.systemPrompt.length} chars)`,
+            );
+          }
+        } catch (hookErr) {
+          log.warn(`before_agent_start hook failed: ${String(hookErr)}`);
+        }
+      }
       ({ session } = await createAgentSession({
         cwd: resolvedWorkspace,
         agentDir,
@@ -948,22 +984,7 @@ export async function runEmbeddedAttempt(
                 return undefined;
               })
           : undefined;
-        const legacyResult = hookRunner?.hasHooks("before_agent_start")
-          ? await hookRunner
-              .runBeforeAgentStart(
-                {
-                  prompt: params.prompt,
-                  messages: activeSession.messages,
-                },
-                hookCtx,
-              )
-              .catch((hookErr: unknown) => {
-                log.warn(
-                  `before_agent_start hook (legacy prompt build path) failed: ${String(hookErr)}`,
-                );
-                return undefined;
-              })
-          : undefined;
+        const legacyResult = cachedBeforeAgentStartResult;
         const hookResult = {
           systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
           prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -7,8 +7,8 @@ import type {
   Response,
 } from "playwright-core";
 import { chromium } from "playwright-core";
-import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { appendCdpPath, fetchJson, getHeadersWithAuth, withCdpSocket } from "./cdp.helpers.js";
 import { normalizeCdpWsUrl } from "./cdp.js";
 import { getChromeWebSocketUrl } from "./chrome.js";

--- a/src/browser/server-context.remote-tab-ops.test.ts
+++ b/src/browser/server-context.remote-tab-ops.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BrowserServerState } from "./server-context.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import * as cdpModule from "./cdp.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import * as pwAiModule from "./pw-ai-module.js";
+import type { BrowserServerState } from "./server-context.js";
 import "./server-context.chrome-test-harness.js";
 import { createBrowserRouteContext } from "./server-context.js";
 

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -1,15 +1,4 @@
 import fs from "node:fs";
-import type { ResolvedBrowserProfile } from "./config.js";
-import type { PwAiModule } from "./pw-ai-module.js";
-import type {
-  BrowserServerState,
-  BrowserRouteContext,
-  BrowserTab,
-  ContextOptions,
-  ProfileContext,
-  ProfileRuntimeState,
-  ProfileStatus,
-} from "./server-context.types.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import { fetchJson, fetchOk } from "./cdp.helpers.js";
 import { appendCdpPath, createTargetViaCdp, normalizeCdpWsUrl } from "./cdp.js";
@@ -20,6 +9,7 @@ import {
   resolveOpenClawUserDataDir,
   stopOpenClawChrome,
 } from "./chrome.js";
+import type { ResolvedBrowserProfile } from "./config.js";
 import { resolveProfile } from "./config.js";
 import {
   ensureChromeExtensionRelayServer,
@@ -30,11 +20,21 @@ import {
   InvalidBrowserNavigationUrlError,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
+import type { PwAiModule } from "./pw-ai-module.js";
 import { getPwAiModule } from "./pw-ai-module.js";
 import {
   refreshResolvedBrowserConfigFromDisk,
   resolveBrowserProfileWithHotReload,
 } from "./resolved-config-refresh.js";
+import type {
+  BrowserServerState,
+  BrowserRouteContext,
+  BrowserTab,
+  ContextOptions,
+  ProfileContext,
+  ProfileRuntimeState,
+  ProfileStatus,
+} from "./server-context.types.js";
 import { resolveTargetIdFromTabs } from "./target-id.js";
 import { movePathToTrash } from "./trash.js";
 


### PR DESCRIPTION
Previously, the before_agent_start hook's systemPrompt return value was collected but never actually merged into the session's system prompt. This prevented extensions like memory-flex from injecting user profiles and memories into the AI model's system context.

Changes:
- Change systemPromptText from const to let to allow modification
- Call before_agent_start hook before createAgentSession
- Merge hookResult.systemPrompt into systemPromptText if provided
- Add debug logging for successful systemPrompt injection
- Add error handling for hook failures

This enables memory-flex and other extensions to inject context into the system prompt that affects model behavior without appearing in the user-visible message list.

Fixes the issue where before_agent_start hook's systemPrompt was ignored, requiring post-build patching scripts for bundled versions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where the `before_agent_start` hook's `systemPrompt` return value was collected but never merged into the session's system prompt. The fix moves the hook execution to before `createAgentSession` and properly merges the returned `systemPrompt` into `systemPromptText`.

**Key Changes:**
- Changed `systemPromptText` from `const` to `let` to enable modification
- Moved `before_agent_start` hook execution before `createAgentSession` call (lines 606-634)
- Added proper `systemPrompt` merging with validation and trimming
- Cached the hook result to avoid duplicate execution in the legacy prompt build path
- Added debug logging for successful injection and error handling for hook failures
- Import reordering in browser files (auto-formatter changes, no functional impact)

**Impact:**
This enables extensions like memory-flex to inject context into the system prompt that properly affects model behavior. Previously, the `systemPrompt` was returned by hooks but never actually used.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped and fix a clear bug. The implementation correctly validates the hook result, handles errors gracefully, and caches the result to avoid duplicate execution. The logic moves the hook execution earlier in the flow (before session creation) which is the correct approach for system prompt injection. Import reordering changes are cosmetic. One minor style suggestion about debug logging exists but doesn't affect functionality.
- No files require special attention

<sub>Last reviewed commit: 742b2c1</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->