### PR TITLE
fix(whatsapp): skip pairing store merge when dmPolicy is allowlist (#…

### DIFF
--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -40,11 +40,10 @@ export async function checkInboundAccessControl(params: {
   });
   const dmPolicy = account.dmPolicy ?? "pairing";
   const configuredAllowFrom = account.allowFrom;
-  const storeAllowFrom = await readChannelAllowFromStore(
-    "whatsapp",
-    process.env,
-    account.accountId,
-  ).catch(() => []);
+  const storeAllowFrom =
+    dmPolicy === "pairing"
+      ? await readChannelAllowFromStore("whatsapp", process.env, account.accountId).catch(() => [])
+      : [];
   // Without user config, default to self-only DM access so the owner can talk to themselves.
   const combinedAllowFrom = Array.from(
     new Set([...(configuredAllowFrom ?? []), ...storeAllowFrom]),


### PR DESCRIPTION
Fixes #22599

## Problem
When `dmPolicy: "allowlist"` was configured, messages from previously 
paired numbers were still being accepted. The pairing store was being 
read and merged into the effective allowlist unconditionally, regardless 
of dmPolicy.

## Root Cause
In `src/web/inbound/access-control.ts`, `readChannelAllowFromStore` was 
called before `dmPolicy` was consulted, so persisted pairings always 
expanded the allowlist.

## Fix
Only read the pairing store when `dmPolicy === "pairing"`. Under 
`allowlist`, `open`, or `disabled`, the store is skipped entirely and 
only explicitly configured `allowFrom` entries are trusted.

## Changes
- `src/web/inbound/access-control.ts` — guard store read behind dmPolicy check
- `src/web/inbound/access-control.test.ts` — 4 new test cases covering the fix and regression

## Testing
All 8 tests pass including 4 new cases:
- blocks store number not in allowFrom
- does not call store under allowlist mode  
- allows explicitly configured number
- regression: store still works under pairing mode

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed security issue where pairing store was incorrectly merged into allowlist when `dmPolicy: "allowlist"` was configured, allowing previously paired numbers to bypass the allowlist. The store is now only read when `dmPolicy === "pairing"`, ensuring that `allowlist`, `open`, and `disabled` modes respect only explicitly configured entries.

- Changed `src/web/inbound/access-control.ts:43-46` to conditionally read pairing store based on dmPolicy
- Added 4 comprehensive test cases covering the fix and regression scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, targeted, and addresses a specific security issue. The change is a simple conditional check that properly isolates the pairing store from other dmPolicy modes. The test coverage is comprehensive with 4 new test cases verifying both the fix and regression scenarios. The logic is straightforward and doesn't introduce any new complexity or side effects.
- No files require special attention

<sub>Last reviewed commit: 4cd6c3b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->