### PR TITLE
fix: merge before_agent_start hook systemPrompt into session system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ New install? Start here: [Getting started](https://docs.openclaw.ai/start/gettin
 
 ## Sponsors
 
+<!-- markdownlint-disable MD033 -->
 <table align="center">
   <tr>
     <td align="center" valign="middle" bgcolor="#111827" width="240" height="72">
@@ -47,6 +48,7 @@ New install? Start here: [Getting started](https://docs.openclaw.ai/start/gettin
     </td>
   </tr>
 </table>
+<!-- markdownlint-enable MD033 -->
 
 **Subscriptions (OAuth):**
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -493,7 +493,7 @@ export async function runEmbeddedAttempt(
       tools,
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
-    const systemPromptText = systemPromptOverride();
+    let systemPromptText = systemPromptOverride();
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
@@ -595,7 +595,43 @@ export async function runEmbeddedAttempt(
         : [];
 
       const allCustomTools = [...customTools, ...clientToolDefs];
+      let cachedBeforeAgentStartResult:
+        | {
+            systemPrompt?: string;
+            prependContext?: string;
+          }
+        | undefined;
 
+      // Run before_agent_start hooks before createAgentSession so systemPrompt injection is used by the agent.
+      if (hookRunner?.hasHooks("before_agent_start")) {
+        try {
+          const sessionContext = sessionManager.buildSessionContext();
+          cachedBeforeAgentStartResult = await hookRunner.runBeforeAgentStart(
+            {
+              prompt: params.prompt,
+              messages: sessionContext?.messages ?? [],
+            },
+            {
+              agentId: params.sessionKey?.split(":")[0] ?? "main",
+              sessionKey: params.sessionKey,
+              workspaceDir: params.workspaceDir,
+              messageProvider: params.messageProvider ?? undefined,
+            },
+          );
+          if (
+            cachedBeforeAgentStartResult?.systemPrompt &&
+            typeof cachedBeforeAgentStartResult.systemPrompt === "string" &&
+            cachedBeforeAgentStartResult.systemPrompt.trim()
+          ) {
+            systemPromptText = `${systemPromptText}\n\n${cachedBeforeAgentStartResult.systemPrompt.trim()}`;
+            log.debug(
+              `hooks: appended systemPrompt (${cachedBeforeAgentStartResult.systemPrompt.trim().length} chars)`,
+            );
+          }
+        } catch (hookErr) {
+          log.warn(`before_agent_start hook failed: ${String(hookErr)}`);
+        }
+      }
       ({ session } = await createAgentSession({
         cwd: resolvedWorkspace,
         agentDir,
@@ -948,22 +984,7 @@ export async function runEmbeddedAttempt(
                 return undefined;
               })
           : undefined;
-        const legacyResult = hookRunner?.hasHooks("before_agent_start")
-          ? await hookRunner
-              .runBeforeAgentStart(
-                {
-                  prompt: params.prompt,
-                  messages: activeSession.messages,
-                },
-                hookCtx,
-              )
-              .catch((hookErr: unknown) => {
-                log.warn(
-                  `before_agent_start hook (legacy prompt build path) failed: ${String(hookErr)}`,
-                );
-                return undefined;
-              })
-          : undefined;
+        const legacyResult = cachedBeforeAgentStartResult;
         const hookResult = {
           systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
           prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]


### PR DESCRIPTION
Previously, the before_agent_start hook's systemPrompt return value was collected but never actually merged into the session's system prompt. This prevented extensions like memory-flex from injecting user profiles and memories into the AI model's system context.

Changes:
- Change systemPromptText from const to let to allow modification
- Call before_agent_start hook before createAgentSession
- Merge hookResult.systemPrompt into systemPromptText if provided
- Add debug logging for successful systemPrompt injection
- Add error handling for hook failures

This enables memory-flex and other extensions to inject context into the system prompt that affects model behavior without appearing in the user-visible message list.

Fixes the issue where before_agent_start hook's systemPrompt was ignored, requiring post-build patching scripts for bundled versions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an important bug where the `before_agent_start` hook's `systemPrompt` return value was collected but never merged into the session's system prompt. The fix moves the hook execution earlier in the flow (before `createAgentSession`) and properly merges the hook's `systemPrompt` into `systemPromptText`, which is then applied to the session via `applySystemPromptOverrideToSession`.

**Key changes:**
- Changed `systemPromptText` from `const` to `let` to allow modification (line 496)
- Moved `before_agent_start` hook execution to before `createAgentSession` (lines 598-634)
- Added proper systemPrompt merging with validation and debug logging
- Cached hook result as `cachedBeforeAgentStartResult` to avoid duplicate execution
- Reused cached result in the legacy prompt build path (line 987)
- Added markdownlint disable/enable comments in `README.md` (formatting fix)

**How it works:**
The hook is now called before the agent session is created, allowing extensions like memory-flex to inject user profiles and memories into the system context. The injected content is appended to the base system prompt with proper spacing (`\n\n` separator) and only if the value is a non-empty string after trimming.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-structured and follows the existing patterns in the codebase. The change properly handles the timing issue by moving hook execution earlier, includes appropriate error handling (try-catch with warning log), validates the systemPrompt value before merging (type and trim checks), and reuses the cached result to avoid duplicate execution. The logic is straightforward and the PR description clearly explains the problem and solution.
- No files require special attention

<sub>Last reviewed commit: 36a76cb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->