### PR TITLE
feat(browser): add Browserless.reconnect session persistence

### DIFF
--- a/src/browser/browserless-session.test.ts
+++ b/src/browser/browserless-session.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  _clearAllForTesting,
+  clearReconnectUrl,
+  extractReconnectUrl,
+  getReconnectUrl,
+  storeReconnectUrl,
+} from "./browserless-session.js";
+
+describe("browserless-session", () => {
+  afterEach(() => {
+    _clearAllForTesting();
+    vi.useRealTimers();
+  });
+
+  // ── Store and retrieve ──────────────────────────────────────────────
+
+  it("stores and retrieves a reconnect URL", () => {
+    storeReconnectUrl("http://remote:9222", "ws://remote:9222/devtools/browser/A", 60_000);
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://remote:9222/devtools/browser/A");
+  });
+
+  // ── One-time use ────────────────────────────────────────────────────
+
+  it("returns null on second retrieval (one-time use)", () => {
+    storeReconnectUrl("http://remote:9222", "ws://remote:9222/devtools/browser/B", 60_000);
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://remote:9222/devtools/browser/B");
+    expect(getReconnectUrl("http://remote:9222")).toBeNull();
+  });
+
+  // ── Key normalization ───────────────────────────────────────────────
+
+  it("normalizes trailing slashes on the key", () => {
+    storeReconnectUrl("http://remote:9222/", "ws://remote:9222/devtools/browser/C", 60_000);
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://remote:9222/devtools/browser/C");
+  });
+
+  it("normalizes trailing slashes on lookup", () => {
+    storeReconnectUrl("http://remote:9222", "ws://remote:9222/devtools/browser/D", 60_000);
+    expect(getReconnectUrl("http://remote:9222/")).toBe("ws://remote:9222/devtools/browser/D");
+  });
+
+  it("normalizes case on the key", () => {
+    storeReconnectUrl("HTTP://REMOTE:9222", "ws://remote:9222/devtools/browser/E", 60_000);
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://remote:9222/devtools/browser/E");
+  });
+
+  it("normalizes case on lookup", () => {
+    storeReconnectUrl("http://remote:9222", "ws://remote:9222/devtools/browser/F", 60_000);
+    expect(getReconnectUrl("HTTP://REMOTE:9222")).toBe("ws://remote:9222/devtools/browser/F");
+  });
+
+  it("normalizes both case and trailing slashes together", () => {
+    storeReconnectUrl("HTTP://REMOTE:9222///", "ws://val", 60_000);
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://val");
+  });
+
+  // ── Expired entry ──────────────────────────────────────────────────
+
+  it("returns null when the entry has expired", () => {
+    vi.useFakeTimers();
+    storeReconnectUrl("http://remote:9222", "ws://remote:9222/devtools/browser/G", 5_000);
+
+    // Advance past expiry
+    vi.advanceTimersByTime(6_000);
+
+    expect(getReconnectUrl("http://remote:9222")).toBeNull();
+  });
+
+  it("returns the URL when still within the timeout minus safety buffer", () => {
+    vi.useFakeTimers();
+    storeReconnectUrl("http://remote:9222", "ws://remote:9222/devtools/browser/H", 10_000);
+
+    // Advance to 7s — well within the 10s timeout minus 2s safety buffer
+    vi.advanceTimersByTime(7_000);
+
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://remote:9222/devtools/browser/H");
+  });
+
+  // ── Safety buffer ──────────────────────────────────────────────────
+
+  it("returns null when current time + 2s safety buffer >= expiresAt", () => {
+    vi.useFakeTimers();
+    storeReconnectUrl("http://remote:9222", "ws://remote:9222/devtools/browser/I", 5_000);
+
+    // Advance to 3001ms — now Date.now() + 2000 = 5001 >= expiresAt (5000)
+    vi.advanceTimersByTime(3_001);
+
+    expect(getReconnectUrl("http://remote:9222")).toBeNull();
+  });
+
+  it("returns null when exactly at the safety buffer boundary", () => {
+    vi.useFakeTimers();
+    storeReconnectUrl("http://remote:9222", "ws://val", 5_000);
+
+    // Advance to 3000ms — Date.now() + 2000 = 5000 >= expiresAt (5000)
+    vi.advanceTimersByTime(3_000);
+
+    expect(getReconnectUrl("http://remote:9222")).toBeNull();
+  });
+
+  it("returns the URL at 1ms before the safety buffer boundary", () => {
+    vi.useFakeTimers();
+    storeReconnectUrl("http://remote:9222", "ws://val", 5_000);
+
+    // Advance to 2999ms — Date.now() + 2000 = 4999 < expiresAt (5000)
+    vi.advanceTimersByTime(2_999);
+
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://val");
+  });
+
+  // ── Expired entry is also removed from the store ───────────────────
+
+  it("removes expired entries from the store on get", () => {
+    vi.useFakeTimers();
+    storeReconnectUrl("http://remote:9222", "ws://val", 1_000);
+    vi.advanceTimersByTime(5_000);
+
+    // First get: returns null (expired), entry removed
+    expect(getReconnectUrl("http://remote:9222")).toBeNull();
+
+    // Store a fresh entry to confirm the old one is truly gone
+    storeReconnectUrl("http://remote:9222", "ws://new-val", 60_000);
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://new-val");
+  });
+
+  // ── clearReconnectUrl ──────────────────────────────────────────────
+
+  it("clears a stored entry", () => {
+    storeReconnectUrl("http://remote:9222", "ws://val", 60_000);
+    clearReconnectUrl("http://remote:9222");
+    expect(getReconnectUrl("http://remote:9222")).toBeNull();
+  });
+
+  it("does not throw when clearing a non-existent entry", () => {
+    expect(() => clearReconnectUrl("http://nonexistent:9222")).not.toThrow();
+  });
+
+  it("normalizes the key when clearing", () => {
+    storeReconnectUrl("http://remote:9222", "ws://val", 60_000);
+    clearReconnectUrl("HTTP://REMOTE:9222/");
+    expect(getReconnectUrl("http://remote:9222")).toBeNull();
+  });
+
+  // ── Overwrite ──────────────────────────────────────────────────────
+
+  it("overwrites an existing entry for the same key", () => {
+    storeReconnectUrl("http://remote:9222", "ws://first", 60_000);
+    storeReconnectUrl("http://remote:9222", "ws://second", 60_000);
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://second");
+  });
+
+  it("overwrites via a normalized key variant", () => {
+    storeReconnectUrl("http://remote:9222/", "ws://first", 60_000);
+    storeReconnectUrl("HTTP://REMOTE:9222", "ws://second", 60_000);
+    expect(getReconnectUrl("http://remote:9222")).toBe("ws://second");
+  });
+
+  // ── extractReconnectUrl ────────────────────────────────────────────
+
+  describe("extractReconnectUrl", () => {
+    it("extracts browserWSEndpoint", () => {
+      expect(
+        extractReconnectUrl({ browserWSEndpoint: "ws://host:9222/devtools/browser/X" }),
+      ).toBe("ws://host:9222/devtools/browser/X");
+    });
+
+    it("extracts wsEndpoint", () => {
+      expect(extractReconnectUrl({ wsEndpoint: "ws://host:9222/ws" })).toBe(
+        "ws://host:9222/ws",
+      );
+    });
+
+    it("extracts webSocketDebuggerUrl", () => {
+      expect(
+        extractReconnectUrl({ webSocketDebuggerUrl: "ws://host:9222/devtools/browser/Y" }),
+      ).toBe("ws://host:9222/devtools/browser/Y");
+    });
+
+    it("prefers browserWSEndpoint over wsEndpoint", () => {
+      expect(
+        extractReconnectUrl({
+          browserWSEndpoint: "ws://preferred",
+          wsEndpoint: "ws://fallback",
+        }),
+      ).toBe("ws://preferred");
+    });
+
+    it("prefers wsEndpoint over webSocketDebuggerUrl", () => {
+      expect(
+        extractReconnectUrl({
+          wsEndpoint: "ws://preferred",
+          webSocketDebuggerUrl: "ws://fallback",
+        }),
+      ).toBe("ws://preferred");
+    });
+
+    it("trims whitespace from extracted URL", () => {
+      expect(
+        extractReconnectUrl({ browserWSEndpoint: "  ws://host:9222/devtools/browser/Z  " }),
+      ).toBe("ws://host:9222/devtools/browser/Z");
+    });
+
+    // Null cases
+    it("returns null for null input", () => {
+      expect(extractReconnectUrl(null)).toBeNull();
+    });
+
+    it("returns null for undefined input", () => {
+      expect(extractReconnectUrl(undefined)).toBeNull();
+    });
+
+    it("returns null for non-object input (string)", () => {
+      expect(extractReconnectUrl("ws://something")).toBeNull();
+    });
+
+    it("returns null for non-object input (number)", () => {
+      expect(extractReconnectUrl(42)).toBeNull();
+    });
+
+    it("returns null for non-object input (boolean)", () => {
+      expect(extractReconnectUrl(true)).toBeNull();
+    });
+
+    it("returns null for empty object", () => {
+      expect(extractReconnectUrl({})).toBeNull();
+    });
+
+    it("returns null when known keys have empty string values", () => {
+      expect(extractReconnectUrl({ browserWSEndpoint: "" })).toBeNull();
+    });
+
+    it("returns null when known keys have whitespace-only values", () => {
+      expect(extractReconnectUrl({ browserWSEndpoint: "   " })).toBeNull();
+    });
+
+    it("returns null when known keys have non-string values", () => {
+      expect(extractReconnectUrl({ browserWSEndpoint: 123 })).toBeNull();
+    });
+
+    it("returns null for object with unrecognized keys only", () => {
+      expect(extractReconnectUrl({ someOtherKey: "ws://something" })).toBeNull();
+    });
+  });
+
+  // ── _clearAllForTesting ────────────────────────────────────────────
+
+  it("clears all stored entries", () => {
+    storeReconnectUrl("http://host-a:9222", "ws://a", 60_000);
+    storeReconnectUrl("http://host-b:9222", "ws://b", 60_000);
+    storeReconnectUrl("http://host-c:9222", "ws://c", 60_000);
+
+    _clearAllForTesting();
+
+    expect(getReconnectUrl("http://host-a:9222")).toBeNull();
+    expect(getReconnectUrl("http://host-b:9222")).toBeNull();
+    expect(getReconnectUrl("http://host-c:9222")).toBeNull();
+  });
+
+  // ── get returns null for missing key ───────────────────────────────
+
+  it("returns null when no entry exists for the key", () => {
+    expect(getReconnectUrl("http://never-stored:9222")).toBeNull();
+  });
+});

--- a/src/browser/browserless-session.ts
+++ b/src/browser/browserless-session.ts
@@ -1,0 +1,88 @@
+/**
+ * In-memory store for Browserless.reconnect session URLs.
+ *
+ * When OpenClaw disconnects from a Browserless v2 instance, it can send a
+ * `Browserless.reconnect` CDP command to keep the browser alive. The command
+ * returns a reconnection WebSocket URL that can be used on the next connect
+ * to resume the same browser session instead of starting a fresh one.
+ *
+ * This module provides a simple key-value store (keyed by the profile's
+ * normalized cdpUrl) with automatic expiry handling.
+ */
+
+type ReconnectEntry = {
+  /** The WebSocket URL returned by Browserless.reconnect */
+  wsUrl: string;
+  /** Timestamp (Date.now()) when this entry expires */
+  expiresAt: number;
+};
+
+const EXPIRY_SAFETY_BUFFER_MS = 2_000;
+
+const store = new Map<string, ReconnectEntry>();
+
+function normalizeKey(cdpUrl: string): string {
+  return cdpUrl.replace(/\/+$/, "").toLowerCase();
+}
+
+/**
+ * Store a reconnect URL for a given CDP endpoint.
+ * Overwrites any existing entry for the same cdpUrl.
+ */
+export function storeReconnectUrl(cdpUrl: string, wsUrl: string, timeoutMs: number): void {
+  const key = normalizeKey(cdpUrl);
+  store.set(key, {
+    wsUrl,
+    expiresAt: Date.now() + timeoutMs,
+  });
+}
+
+/**
+ * Retrieve and consume a reconnect URL for a given CDP endpoint.
+ * Returns null if no entry exists or if it has expired (with safety buffer).
+ * The entry is deleted after retrieval (one-time use).
+ */
+export function getReconnectUrl(cdpUrl: string): string | null {
+  const key = normalizeKey(cdpUrl);
+  const entry = store.get(key);
+  if (!entry) {
+    return null;
+  }
+  // Always remove: it's either consumed or expired
+  store.delete(key);
+  if (Date.now() + EXPIRY_SAFETY_BUFFER_MS >= entry.expiresAt) {
+    return null;
+  }
+  return entry.wsUrl;
+}
+
+/**
+ * Explicitly clear a reconnect URL (e.g., on connection failure fallback).
+ */
+export function clearReconnectUrl(cdpUrl: string): void {
+  store.delete(normalizeKey(cdpUrl));
+}
+
+/**
+ * Extract a reconnect WebSocket URL from a Browserless.reconnect CDP response.
+ * The response format may vary; this handles known shapes.
+ */
+export function extractReconnectUrl(result: unknown): string | null {
+  if (!result || typeof result !== "object") {
+    return null;
+  }
+  // Browserless returns { browserWSEndpoint: "ws://..." } or similar
+  const obj = result as Record<string, unknown>;
+  for (const key of ["browserWSEndpoint", "wsEndpoint", "webSocketDebuggerUrl"]) {
+    const value = obj[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+/** Visible for testing only. */
+export function _clearAllForTesting(): void {
+  store.clear();
+}

--- a/src/browser/config.browserless.test.ts
+++ b/src/browser/config.browserless.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest";
+import { resolveBrowserConfig, resolveProfile } from "./config.js";
+
+describe("browserless reconnect config", () => {
+  // ── Default values ──────────────────────────────────────────────────
+
+  describe("defaults", () => {
+    it("defaults browserlessReconnect to false", () => {
+      const resolved = resolveBrowserConfig(undefined);
+      expect(resolved.browserlessReconnect).toBe(false);
+    });
+
+    it("defaults browserlessReconnectTimeoutMs to 60000", () => {
+      const resolved = resolveBrowserConfig(undefined);
+      expect(resolved.browserlessReconnectTimeoutMs).toBe(60_000);
+    });
+
+    it("defaults browserlessReconnect to false when browserless block is empty", () => {
+      const resolved = resolveBrowserConfig({ browserless: {} });
+      expect(resolved.browserlessReconnect).toBe(false);
+    });
+
+    it("defaults browserlessReconnectTimeoutMs to 60000 when browserless block is empty", () => {
+      const resolved = resolveBrowserConfig({ browserless: {} });
+      expect(resolved.browserlessReconnectTimeoutMs).toBe(60_000);
+    });
+  });
+
+  // ── Explicit global config ──────────────────────────────────────────
+
+  describe("explicit global config", () => {
+    it("sets browserlessReconnect to true when configured", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { reconnect: true },
+      });
+      expect(resolved.browserlessReconnect).toBe(true);
+    });
+
+    it("keeps browserlessReconnect false when explicitly set to false", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { reconnect: false },
+      });
+      expect(resolved.browserlessReconnect).toBe(false);
+    });
+
+    it("overrides timeout when configured", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { timeout: 120_000 },
+      });
+      expect(resolved.browserlessReconnectTimeoutMs).toBe(120_000);
+    });
+
+    it("falls back to default timeout for negative values", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { timeout: -1 },
+      });
+      expect(resolved.browserlessReconnectTimeoutMs).toBe(60_000);
+    });
+
+    it("falls back to default timeout for NaN", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { timeout: Number.NaN },
+      });
+      expect(resolved.browserlessReconnectTimeoutMs).toBe(60_000);
+    });
+
+    it("floors fractional timeout values", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { timeout: 45_500.7 },
+      });
+      expect(resolved.browserlessReconnectTimeoutMs).toBe(45_500);
+    });
+
+    it("allows zero timeout", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { timeout: 0 },
+      });
+      expect(resolved.browserlessReconnectTimeoutMs).toBe(0);
+    });
+  });
+
+  // ── Profile-level resolution via resolveProfile ─────────────────────
+
+  describe("profile-level resolution", () => {
+    it("profile inherits global browserlessReconnect when not overridden", () => {
+      const resolved = resolveBrowserConfig({
+        cdpUrl: "http://remote.example.com:9222",
+        browserless: { reconnect: true, timeout: 30_000 },
+        profiles: {
+          remote: { cdpUrl: "http://remote.example.com:9222", color: "#00FF00" },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "remote");
+      expect(profile).not.toBeNull();
+      expect(profile!.browserlessReconnect).toBe(true);
+      expect(profile!.browserlessReconnectTimeoutMs).toBe(30_000);
+    });
+
+    it("profile-level browserless.reconnect overrides global", () => {
+      const resolved = resolveBrowserConfig({
+        cdpUrl: "http://remote.example.com:9222",
+        browserless: { reconnect: true },
+        profiles: {
+          remote: {
+            cdpUrl: "http://remote.example.com:9222",
+            color: "#00FF00",
+            browserless: { reconnect: false },
+          },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "remote");
+      expect(profile!.browserlessReconnect).toBe(false);
+    });
+
+    it("profile-level browserless.reconnect enables when global is disabled", () => {
+      const resolved = resolveBrowserConfig({
+        cdpUrl: "http://remote.example.com:9222",
+        browserless: { reconnect: false },
+        profiles: {
+          remote: {
+            cdpUrl: "http://remote.example.com:9222",
+            color: "#00FF00",
+            browserless: { reconnect: true },
+          },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "remote");
+      expect(profile!.browserlessReconnect).toBe(true);
+    });
+
+    it("profile-level timeout overrides global timeout", () => {
+      const resolved = resolveBrowserConfig({
+        cdpUrl: "http://remote.example.com:9222",
+        browserless: { reconnect: true, timeout: 60_000 },
+        profiles: {
+          remote: {
+            cdpUrl: "http://remote.example.com:9222",
+            color: "#00FF00",
+            browserless: { timeout: 120_000 },
+          },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "remote");
+      expect(profile!.browserlessReconnectTimeoutMs).toBe(120_000);
+    });
+
+    it("profile inherits global timeout when profile timeout is not set", () => {
+      const resolved = resolveBrowserConfig({
+        cdpUrl: "http://remote.example.com:9222",
+        browserless: { reconnect: true, timeout: 45_000 },
+        profiles: {
+          remote: {
+            cdpUrl: "http://remote.example.com:9222",
+            color: "#00FF00",
+            browserless: { reconnect: true },
+          },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "remote");
+      expect(profile!.browserlessReconnectTimeoutMs).toBe(45_000);
+    });
+  });
+
+  // ── Loopback safety guard ───────────────────────────────────────────
+
+  describe("loopback safety guard", () => {
+    it("forces browserlessReconnect to false for localhost cdpUrl", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { reconnect: true },
+        profiles: {
+          local: { cdpUrl: "http://localhost:9222", color: "#00FF00" },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "local");
+      expect(profile).not.toBeNull();
+      expect(profile!.cdpIsLoopback).toBe(true);
+      expect(profile!.browserlessReconnect).toBe(false);
+    });
+
+    it("forces browserlessReconnect to false for 127.0.0.1 cdpUrl", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { reconnect: true },
+        profiles: {
+          local: { cdpUrl: "http://127.0.0.1:9222", color: "#00FF00" },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "local");
+      expect(profile!.cdpIsLoopback).toBe(true);
+      expect(profile!.browserlessReconnect).toBe(false);
+    });
+
+    it("forces browserlessReconnect to false for 127.0.0.1 even with profile-level reconnect:true", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { reconnect: true },
+        profiles: {
+          local: {
+            cdpUrl: "http://127.0.0.1:9222",
+            color: "#00FF00",
+            browserless: { reconnect: true },
+          },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "local");
+      expect(profile!.browserlessReconnect).toBe(false);
+    });
+
+    it("allows browserlessReconnect for non-loopback addresses", () => {
+      const resolved = resolveBrowserConfig({
+        cdpUrl: "http://remote.example.com:9222",
+        browserless: { reconnect: true },
+        profiles: {
+          remote: {
+            cdpUrl: "http://remote.example.com:9222",
+            color: "#00FF00",
+          },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "remote");
+      expect(profile!.cdpIsLoopback).toBe(false);
+      expect(profile!.browserlessReconnect).toBe(true);
+    });
+
+    it("allows browserlessReconnect for private network (non-loopback) addresses", () => {
+      const resolved = resolveBrowserConfig({
+        cdpUrl: "http://10.0.0.42:9222",
+        browserless: { reconnect: true },
+        profiles: {
+          lan: {
+            cdpUrl: "http://10.0.0.42:9222",
+            color: "#00FF00",
+          },
+        },
+      });
+
+      const profile = resolveProfile(resolved, "lan");
+      expect(profile!.cdpIsLoopback).toBe(false);
+      expect(profile!.browserlessReconnect).toBe(true);
+    });
+
+    it("forces reconnect to false for default openclaw profile (loopback by default)", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { reconnect: true },
+      });
+
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile).not.toBeNull();
+      expect(profile!.cdpIsLoopback).toBe(true);
+      expect(profile!.browserlessReconnect).toBe(false);
+    });
+
+    it("forces reconnect to false for default chrome extension profile (loopback)", () => {
+      const resolved = resolveBrowserConfig({
+        browserless: { reconnect: true },
+      });
+
+      const profile = resolveProfile(resolved, "chrome");
+      expect(profile).not.toBeNull();
+      expect(profile!.cdpIsLoopback).toBe(true);
+      expect(profile!.browserlessReconnect).toBe(false);
+    });
+  });
+
+  // ── Mixed profiles (loopback + remote) ──────────────────────────────
+
+  describe("mixed loopback and remote profiles", () => {
+    it("only the remote profile gets browserlessReconnect:true", () => {
+      const resolved = resolveBrowserConfig({
+        cdpUrl: "http://remote.example.com:9222",
+        browserless: { reconnect: true, timeout: 90_000 },
+        profiles: {
+          local: { cdpUrl: "http://127.0.0.1:9222", color: "#FF0000" },
+          remote: { cdpUrl: "http://remote.example.com:9222", color: "#00FF00" },
+        },
+      });
+
+      const local = resolveProfile(resolved, "local");
+      const remote = resolveProfile(resolved, "remote");
+
+      expect(local!.browserlessReconnect).toBe(false);
+      expect(local!.browserlessReconnectTimeoutMs).toBe(90_000);
+
+      expect(remote!.browserlessReconnect).toBe(true);
+      expect(remote!.browserlessReconnectTimeoutMs).toBe(90_000);
+    });
+  });
+});

--- a/src/browser/pw-ai.ts
+++ b/src/browser/pw-ai.ts
@@ -6,6 +6,7 @@ export {
   type BrowserConsoleMessage,
   closePageByTargetIdViaPlaywright,
   closePlaywrightBrowserConnection,
+  configureBrowserless,
   createPageViaPlaywright,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -7,6 +7,13 @@ export type BrowserProfileConfig = {
   driver?: "openclaw" | "extension";
   /** Profile color (hex). Auto-assigned at creation. */
   color: string;
+  /** Browserless-specific settings (session persistence). */
+  browserless?: {
+    /** Keep browser alive after disconnect using Browserless.reconnect. Default: false. */
+    reconnect?: boolean;
+    /** Timeout (ms) for Browserless to keep the browser alive. Default: 60000. */
+    timeout?: number;
+  };
 };
 export type BrowserSnapshotDefaults = {
   /** Default snapshot mode (applies when mode is not provided). */
@@ -60,4 +67,11 @@ export type BrowserConfig = {
    * Example: ["--window-size=1920,1080", "--disable-infobars"]
    */
   extraArgs?: string[];
+  /** Browserless-specific settings (session persistence). */
+  browserless?: {
+    /** Keep browser alive after disconnect using Browserless.reconnect. Default: false. */
+    reconnect?: boolean;
+    /** Timeout (ms) for Browserless to keep the browser alive. Default: 60000. */
+    timeout?: number;
+  };
 };


### PR DESCRIPTION
## Summary

Browserless v2 destroys the browser session when the CDP WebSocket disconnects, making multi-step workflows unreliable — each operation spins up a fresh browser instead of reusing the existing one.

This PR adds **opt-in** support for the [`Browserless.reconnect`](https://docs.browserless.io/open-api#tag/Chromium-APIs/paths/Browserless.reconnect/put) CDP command, which tells Browserless to keep the browser alive after disconnect and returns a reconnect URL for the next connection.

### What changed

- **Config**: New `browserless.reconnect` (bool) and `browserless.timeout` (ms) fields at both global and per-profile level in `BrowserConfig` / `BrowserProfileConfig`
- **Session store** (`browserless-session.ts`): In-memory store for reconnect URLs — one-time use with automatic expiry and 2-second safety buffer
- **CDP path** (`cdp.helpers.ts`): `withCdpSocket()` sends `Browserless.reconnect` before closing when enabled
- **Playwright path** (`pw-session.ts`):
  - `connectBrowser()` checks stored reconnect URL on first attempt
  - `closePlaywrightBrowserConnection()` sends reconnect via CDP session before closing
  - `forceDisconnectPlaywrightForTarget()` intentionally excluded (emergency abort must not block)
- **Config threading**: `server-context.ts` calls `configureBrowserless()` on profile init and passes config to `createTargetViaCdp()`
- **Safety guard**: Reconnect is forced `false` for loopback profiles (local Chrome doesn't support Browserless.reconnect)

### Example config

```json
{
  "browser": {
    "browserless": {
      "reconnect": true,
      "timeout": 60000
    },
    "profiles": {
      "remote": {
        "cdpUrl": "https://mybrowser.example.com?token=xxx",
        "browserless": {
          "reconnect": true,
          "timeout": 120000
        }
      }
    }
  }
}
```

### Design decisions

- **Opt-in only**: Zero behavior change unless `browserless.reconnect: true` is set
- **Graceful degradation**: If `Browserless.reconnect` fails (non-Browserless instance, unsupported version), the error is silently caught
- **One-time-use URLs**: Reconnect URLs are consumed on first retrieval and auto-expire with a 2s safety buffer
- **No signature changes to public functions**: Playwright config is passed via a module-level `configureBrowserless()` function to avoid cascading API changes

## Test plan

- [x] 60 unit tests added (36 session store + 24 config resolution)
- [ ] Manual testing with Browserless v2 instance
- [ ] Verify no behavior change when `browserless.reconnect` is not configured (default)
- [ ] Verify reconnect works across `openTab` → `closePlaywrightBrowserConnection` → `openTab` cycle

Refs: #4378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

adds opt-in Browserless.reconnect session persistence to prevent browser session destruction on disconnect. implementation includes in-memory reconnect URL store with expiry, CDP/Playwright integration points, and global+profile-level config resolution with loopback safety guards

- new `browserless-session.ts` module provides URL store with one-time-use semantics and 2s safety buffer
- `withCdpSocket` sends `Browserless.reconnect` before close when enabled (graceful degradation on error)
- `connectBrowser` checks for stored reconnect URL on first attempt before falling back to normal flow
- `closePlaywrightBrowserConnection` persists reconnect URL via CDP session before closing
- config adds `browserless.reconnect`/`browserless.timeout` at global+profile level with loopback forced to false
- comprehensive test coverage (60 unit tests for session store + config resolution)

issues found:
- profile-level timeout bypasses `normalizeTimeoutMs` validation (line 301 in `config.ts`)

<h3>Confidence Score: 4/5</h3>

- safe to merge after fixing timeout normalization issue
- well-structured opt-in feature with graceful degradation, comprehensive tests, and proper safety guards. one logical error found in config resolution that could allow invalid timeout values at profile level
- src/browser/config.ts (timeout normalization fix required)

<sub>Last reviewed commit: f0c77b5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->