### PR TITLE
fix(signal): join debounced messages with actual newline instead of literal \\n

### DIFF
--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -301,7 +301,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       const combinedText = entries
         .map((entry) => entry.bodyText)
         .filter(Boolean)
-        .join("\\n");
+        .join("\n");
       if (!combinedText.trim()) {
         return;
       }


### PR DESCRIPTION
## Summary

The Signal debounce flush handler joins buffered message texts with a literal
two-character string `\n` instead of an actual newline character. Users receiving
debounced messages see `hello\nworld` as-is, rather than messages separated by
line breaks.

## Bug

```ts
// src/signal/monitor/event-handler.ts, line 304
const combinedText = entries
  .map((entry) => entry.bodyText)
  .filter(Boolean)
  .join("\\n");   // ← escaped backslash-n: produces literal "\n"
```

In JavaScript, `"\\n"` is a two-character string (backslash + n), not a newline.
When the debounce timer fires with multiple queued messages, they are concatenated
with the literal text `\n` instead of a line break.

## Fix

```ts
  .join("\n");    // ← actual newline character
```

## Test plan

- [x] `npx oxfmt --check src/signal/monitor/event-handler.ts` — pass
- [x] `npx oxlint src/signal/monitor/event-handler.ts` — 0 warnings, 0 errors
- [x] `npx vitest run src/signal/monitor/event-handler.inbound-contract.test.ts --config vitest.unit.config.ts` — 2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Signal debounced messages to use actual newlines instead of literal `\n` characters when combining multiple messages.

- Changed `.join("\\n")` to `.join("\n")` in the debounce flush handler (line 304)
- Aligns with Telegram and Discord implementations, which already use actual newlines
- Follows repository guideline from `AGENTS.md`: "never embed `\\n`" for message content

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-character fix that corrects an obvious bug (escaped backslash-n to actual newline). The change matches the pattern used in other channel handlers (Telegram, Discord) and follows the repository's style guidelines. Tests pass and the fix is clearly correct.
- No files require special attention

<sub>Last reviewed commit: 9cbc957</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->