### PR TITLE
docs(plugins): add askpi and askcodex to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -42,3 +42,15 @@ Use this format when adding entries:
   npm: `@scope/package`
   repo: `https://github.com/org/repo`
   install: `openclaw plugins install @scope/package`
+
+## Listed plugins
+
+- **askcodex** — Per-chat Codex PTY sessions with handoff/resume/reset/new workflow.
+  npm: `@dougvk/askcodex`
+  repo: `https://github.com/dougvk/askcodex-public`
+  install: `openclaw plugins install @dougvk/askcodex`
+
+- **askpi** — Per-chat Pi RPC + tmux sessions with handoff/resume/reset/new workflow.
+  npm: `@dougvk/askpi`
+  repo: `https://github.com/dougvk/askpi-public`
+  install: `openclaw plugins install @dougvk/askpi`


### PR DESCRIPTION
## Summary
- add `askcodex` entry to `docs/plugins/community.md`
- add `askpi` entry to `docs/plugins/community.md`
- include npm package names, public GitHub repos, and install commands in the documented candidate format

## Why
Both plugins are publicly maintained and installable with `openclaw plugins install`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added two community plugins (`askcodex` and `askpi`) to the documentation following the established format. Both plugins provide per-chat session management with handoff/resume/reset workflows for Codex PTY and Pi RPC+tmux respectively. The entries include all required fields (npm package, GitHub repo, and install command) as specified in the candidate format section.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a documentation-only change
- Documentation-only PR that adds two plugin entries following the exact template format. No code changes, no logic changes, no dependencies modified. The formatting matches the established pattern perfectly with proper markdown structure, backticks for code elements, and all required fields present.
- No files require special attention

<sub>Last reviewed commit: 557d617</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->