### PR TITLE
telegram: stabilize multi-account webhook mode

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -375,11 +375,14 @@ describe("monitorTelegramProvider (grammY)", () => {
   });
 
   it("passes configured webhookHost to webhook listener", async () => {
+    const abort = new AbortController();
+    abort.abort();
     await monitorTelegramProvider({
       token: "tok",
       useWebhook: true,
       webhookUrl: "https://example.test/telegram",
       webhookSecret: "secret",
+      abortSignal: abort.signal,
       config: {
         agents: { defaults: { maxConcurrent: 2 } },
         channels: {
@@ -437,10 +440,13 @@ describe("monitorTelegramProvider (grammY)", () => {
   });
 
   it("falls back to configured webhookSecret when not passed explicitly", async () => {
+    const abort = new AbortController();
+    abort.abort();
     await monitorTelegramProvider({
       token: "tok",
       useWebhook: true,
       webhookUrl: "https://example.test/telegram",
+      abortSignal: abort.signal,
       config: {
         agents: { defaults: { maxConcurrent: 2 } },
         channels: {

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -35,6 +35,7 @@ describe("startTelegramWebhook", () => {
   it("starts server, registers webhook, and serves health", async () => {
     createTelegramBotSpy.mockClear();
     webhookCallbackSpy.mockClear();
+    setWebhookSpy.mockClear();
     const abort = new AbortController();
     const cfg = { bindings: [] };
     const { server } = await startTelegramWebhook({
@@ -80,6 +81,7 @@ describe("startTelegramWebhook", () => {
   it("invokes webhook handler on matching path", async () => {
     handlerSpy.mockClear();
     createTelegramBotSpy.mockClear();
+    setWebhookSpy.mockClear();
     const abort = new AbortController();
     const cfg = { bindings: [] };
     const { server } = await startTelegramWebhook({
@@ -103,6 +105,81 @@ describe("startTelegramWebhook", () => {
     }
     await fetch(`http://127.0.0.1:${addr.port}/hook`, { method: "POST" });
     expect(handlerSpy).toHaveBeenCalled();
+    abort.abort();
+  });
+
+  it("uses account-specific default path for non-default accounts", async () => {
+    setWebhookSpy.mockClear();
+    const abort = new AbortController();
+
+    await startTelegramWebhook({
+      token: "tok",
+      secret: "secret",
+      accountId: "work",
+      port: 0,
+      abortSignal: abort.signal,
+    });
+
+    const webhookUrl = String(setWebhookSpy.mock.calls[0]?.[0] ?? "");
+    expect(webhookUrl).toContain("/telegram-webhook/work");
+    abort.abort();
+  });
+
+  it("shares one listener for multiple accounts with distinct paths", async () => {
+    handlerSpy.mockClear();
+    setWebhookSpy.mockClear();
+    const abortDefault = new AbortController();
+    const abortWork = new AbortController();
+
+    const first = await startTelegramWebhook({
+      token: "tok-default",
+      secret: "secret-default",
+      accountId: "default",
+      port: 0,
+      abortSignal: abortDefault.signal,
+    });
+    const second = await startTelegramWebhook({
+      token: "tok-work",
+      secret: "secret-work",
+      accountId: "work",
+      port: 0,
+      abortSignal: abortWork.signal,
+    });
+
+    expect(first.server).toBe(second.server);
+    const addr = first.server.address();
+    if (!addr || typeof addr === "string") {
+      throw new Error("no addr");
+    }
+    await fetch(`http://127.0.0.1:${addr.port}/telegram-webhook`, { method: "POST" });
+    await fetch(`http://127.0.0.1:${addr.port}/telegram-webhook/work`, { method: "POST" });
+    expect(handlerSpy).toHaveBeenCalledTimes(2);
+
+    abortWork.abort();
+    abortDefault.abort();
+  });
+
+  it("rejects path conflicts between accounts on the same listener", async () => {
+    const abort = new AbortController();
+    await startTelegramWebhook({
+      token: "tok-default",
+      secret: "secret-default",
+      accountId: "default",
+      path: "/same",
+      port: 0,
+      abortSignal: abort.signal,
+    });
+
+    await expect(
+      startTelegramWebhook({
+        token: "tok-work",
+        secret: "secret-work",
+        accountId: "work",
+        path: "/same",
+        port: 0,
+      }),
+    ).rejects.toThrow(/path conflict/i);
+
     abort.abort();
   });
 

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -1,4 +1,8 @@
 import { createServer } from "node:http";
+import type {
+  IncomingMessage as NodeIncomingMessage,
+  ServerResponse as NodeServerResponse,
+} from "node:http";
 import { webhookCallback } from "grammy";
 import type { OpenClawConfig } from "../config/config.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
@@ -26,10 +30,7 @@ const DEFAULT_TELEGRAM_ACCOUNT_ID = "default";
 type WebhookRoute = {
   accountId: string;
   diagnosticsEnabled: boolean;
-  handle: (
-    req: Parameters<Parameters<typeof createServer>[0]>[0],
-    res: Parameters<Parameters<typeof createServer>[0]>[1],
-  ) => void;
+  handle: (req: NodeIncomingMessage, res: NodeServerResponse) => void;
   stopBot: () => void;
 };
 

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -20,6 +20,132 @@ import { createTelegramBot } from "./bot.js";
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
 const TELEGRAM_WEBHOOK_CALLBACK_TIMEOUT_MS = 10_000;
+const DEFAULT_WEBHOOK_PATH = "/telegram-webhook";
+const DEFAULT_TELEGRAM_ACCOUNT_ID = "default";
+
+type WebhookRoute = {
+  accountId: string;
+  diagnosticsEnabled: boolean;
+  handle: (
+    req: Parameters<Parameters<typeof createServer>[0]>[0],
+    res: Parameters<Parameters<typeof createServer>[0]>[1],
+  ) => void;
+  stopBot: () => void;
+};
+
+type SharedWebhookServer = {
+  server: ReturnType<typeof createServer>;
+  routes: Map<string, WebhookRoute>;
+  diagnosticsRefs: number;
+  listenPromise: Promise<void> | null;
+};
+
+const sharedWebhookServers = new Map<string, SharedWebhookServer>();
+
+function resolveRequestPath(url: string | undefined): string {
+  const raw = typeof url === "string" ? url : "";
+  const question = raw.indexOf("?");
+  return question === -1 ? raw : raw.slice(0, question);
+}
+
+function normalizeWebhookPath(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return DEFAULT_WEBHOOK_PATH;
+  }
+  const rawPath = resolveRequestPath(trimmed);
+  if (!rawPath) {
+    return DEFAULT_WEBHOOK_PATH;
+  }
+  return rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+}
+
+function resolveWebhookPath(path: string | undefined, accountId: string): string {
+  if (typeof path === "string" && path.trim()) {
+    return normalizeWebhookPath(path);
+  }
+  if (accountId !== DEFAULT_TELEGRAM_ACCOUNT_ID) {
+    return `${DEFAULT_WEBHOOK_PATH}/${encodeURIComponent(accountId)}`;
+  }
+  return DEFAULT_WEBHOOK_PATH;
+}
+
+function buildServerKey(host: string, port: number, healthPath: string): string {
+  return `${host}:${port}:${healthPath}`;
+}
+
+function createSharedWebhookServer(params: { healthPath: string }): SharedWebhookServer {
+  const routes = new Map<string, WebhookRoute>();
+  const server = createServer((req, res) => {
+    const reqPath = resolveRequestPath(req.url);
+    if (reqPath === params.healthPath) {
+      res.writeHead(200);
+      res.end("ok");
+      return;
+    }
+    const route = routes.get(reqPath);
+    if (!route || req.method !== "POST") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    route.handle(req, res);
+  });
+  return {
+    server,
+    routes,
+    diagnosticsRefs: 0,
+    listenPromise: null,
+  };
+}
+
+async function ensureServerListening(params: {
+  shared: SharedWebhookServer;
+  port: number;
+  host: string;
+  key: string;
+}): Promise<void> {
+  if (params.shared.server.listening) {
+    return;
+  }
+  if (!params.shared.listenPromise) {
+    params.shared.listenPromise = new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => {
+        params.shared.server.off("listening", onListening);
+        params.shared.listenPromise = null;
+        sharedWebhookServers.delete(params.key);
+        reject(err);
+      };
+      const onListening = () => {
+        params.shared.server.off("error", onError);
+        resolve();
+      };
+      params.shared.server.once("error", onError);
+      params.shared.server.once("listening", onListening);
+      params.shared.server.listen(params.port, params.host);
+    });
+  }
+  await params.shared.listenPromise;
+}
+
+function resolveListeningPort(
+  server: ReturnType<typeof createServer>,
+  fallbackPort: number,
+): number {
+  const address = server.address();
+  if (address && typeof address === "object" && typeof address.port === "number") {
+    return address.port;
+  }
+  return fallbackPort;
+}
+
+function closeServerSafe(server: ReturnType<typeof createServer>): void {
+  try {
+    server.close();
+  } catch {
+    // no-op
+  }
+}
 
 export async function startTelegramWebhook(opts: {
   token: string;
@@ -35,8 +161,9 @@ export async function startTelegramWebhook(opts: {
   healthPath?: string;
   publicUrl?: string;
 }) {
-  const path = opts.path ?? "/telegram-webhook";
-  const healthPath = opts.healthPath ?? "/healthz";
+  const accountId = opts.accountId?.trim() || DEFAULT_TELEGRAM_ACCOUNT_ID;
+  const path = resolveWebhookPath(opts.path, accountId);
+  const healthPath = normalizeWebhookPath(opts.healthPath ?? "/healthz");
   const port = opts.port ?? 8787;
   const host = opts.host ?? "127.0.0.1";
   const secret = typeof opts.secret === "string" ? opts.secret.trim() : "";
@@ -53,7 +180,7 @@ export async function startTelegramWebhook(opts: {
     runtime,
     proxyFetch: opts.fetch,
     config: opts.config,
-    accountId: opts.accountId,
+    accountId,
   });
   const handler = webhookCallback(bot, "http", {
     secretToken: secret,
@@ -61,97 +188,155 @@ export async function startTelegramWebhook(opts: {
     timeoutMilliseconds: TELEGRAM_WEBHOOK_CALLBACK_TIMEOUT_MS,
   });
 
-  if (diagnosticsEnabled) {
-    startDiagnosticHeartbeat();
+  const serverKey = buildServerKey(host, port, healthPath);
+  let shared = sharedWebhookServers.get(serverKey);
+  if (!shared) {
+    shared = createSharedWebhookServer({ healthPath });
+    sharedWebhookServers.set(serverKey, shared);
+  }
+  const conflictingRoute = shared.routes.get(path);
+  if (conflictingRoute && conflictingRoute.accountId !== accountId) {
+    throw new Error(
+      [
+        `Telegram webhook path conflict on ${host}:${port}${path}.`,
+        `Account "${accountId}" collides with account "${conflictingRoute.accountId}".`,
+        "Set unique webhookPath per account.",
+      ].join(" "),
+    );
+  }
+  if (conflictingRoute && conflictingRoute.accountId === accountId) {
+    throw new Error(
+      `Telegram webhook path ${path} is already active for account "${accountId}" on ${host}:${port}.`,
+    );
   }
 
-  const server = createServer((req, res) => {
-    if (req.url === healthPath) {
-      res.writeHead(200);
-      res.end("ok");
+  const route: WebhookRoute = {
+    accountId,
+    diagnosticsEnabled,
+    stopBot: () => {
+      void bot.stop();
+    },
+    handle: (req, res) => {
+      const startTime = Date.now();
+      if (diagnosticsEnabled) {
+        logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
+      }
+      const guard = installRequestBodyLimitGuard(req, res, {
+        maxBytes: TELEGRAM_WEBHOOK_MAX_BODY_BYTES,
+        timeoutMs: TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS,
+        responseFormat: "text",
+      });
+      if (guard.isTripped()) {
+        return;
+      }
+      const handled = handler(req, res);
+      if (handled && typeof handled.catch === "function") {
+        void handled
+          .then(() => {
+            if (diagnosticsEnabled) {
+              logWebhookProcessed({
+                channel: "telegram",
+                updateType: "telegram-post",
+                durationMs: Date.now() - startTime,
+              });
+            }
+          })
+          .catch((err) => {
+            if (guard.isTripped()) {
+              return;
+            }
+            const errMsg = formatErrorMessage(err);
+            if (diagnosticsEnabled) {
+              logWebhookError({
+                channel: "telegram",
+                updateType: "telegram-post",
+                error: errMsg,
+              });
+            }
+            runtime.log?.(`webhook handler failed: ${errMsg}`);
+            if (!res.headersSent) {
+              res.writeHead(500);
+            }
+            res.end();
+          })
+          .finally(() => {
+            guard.dispose();
+          });
+        return;
+      }
+      guard.dispose();
+    },
+  };
+
+  shared.routes.set(path, route);
+  if (diagnosticsEnabled) {
+    shared.diagnosticsRefs += 1;
+    if (shared.diagnosticsRefs === 1) {
+      startDiagnosticHeartbeat();
+    }
+  }
+
+  const cleanupRoute = () => {
+    const active = sharedWebhookServers.get(serverKey);
+    if (!active) {
+      route.stopBot();
       return;
     }
-    if (req.url !== path || req.method !== "POST") {
-      res.writeHead(404);
-      res.end();
-      return;
+    const registered = active.routes.get(path);
+    if (registered === route) {
+      active.routes.delete(path);
+      if (route.diagnosticsEnabled) {
+        active.diagnosticsRefs = Math.max(0, active.diagnosticsRefs - 1);
+        if (active.diagnosticsRefs === 0) {
+          stopDiagnosticHeartbeat();
+        }
+      }
+      route.stopBot();
     }
-    const startTime = Date.now();
-    if (diagnosticsEnabled) {
-      logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
+    if (active.routes.size === 0) {
+      sharedWebhookServers.delete(serverKey);
+      closeServerSafe(active.server);
     }
-    const guard = installRequestBodyLimitGuard(req, res, {
-      maxBytes: TELEGRAM_WEBHOOK_MAX_BODY_BYTES,
-      timeoutMs: TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS,
-      responseFormat: "text",
+  };
+
+  try {
+    await ensureServerListening({
+      shared,
+      host,
+      port,
+      key: serverKey,
     });
-    if (guard.isTripped()) {
-      return;
-    }
-    const handled = handler(req, res);
-    if (handled && typeof handled.catch === "function") {
-      void handled
-        .then(() => {
-          if (diagnosticsEnabled) {
-            logWebhookProcessed({
-              channel: "telegram",
-              updateType: "telegram-post",
-              durationMs: Date.now() - startTime,
-            });
-          }
-        })
-        .catch((err) => {
-          if (guard.isTripped()) {
-            return;
-          }
-          const errMsg = formatErrorMessage(err);
-          if (diagnosticsEnabled) {
-            logWebhookError({
-              channel: "telegram",
-              updateType: "telegram-post",
-              error: errMsg,
-            });
-          }
-          runtime.log?.(`webhook handler failed: ${errMsg}`);
-          if (!res.headersSent) {
-            res.writeHead(500);
-          }
-          res.end();
-        })
-        .finally(() => {
-          guard.dispose();
-        });
-      return;
-    }
-    guard.dispose();
-  });
+    const resolvedPort = resolveListeningPort(shared.server, port);
+    const publicUrl =
+      opts.publicUrl ?? `http://${host === "0.0.0.0" ? "localhost" : host}:${resolvedPort}${path}`;
 
-  const publicUrl =
-    opts.publicUrl ?? `http://${host === "0.0.0.0" ? "localhost" : host}:${port}${path}`;
+    await withTelegramApiErrorLogging({
+      operation: "setWebhook",
+      runtime,
+      fn: () =>
+        bot.api.setWebhook(publicUrl, {
+          secret_token: secret,
+          allowed_updates: resolveTelegramAllowedUpdates(),
+        }),
+    });
 
-  await withTelegramApiErrorLogging({
-    operation: "setWebhook",
-    runtime,
-    fn: () =>
-      bot.api.setWebhook(publicUrl, {
-        secret_token: secret,
-        allowed_updates: resolveTelegramAllowedUpdates(),
-      }),
-  });
+    runtime.log?.(`webhook listening on ${publicUrl}`);
+  } catch (err) {
+    cleanupRoute();
+    throw err;
+  }
 
-  await new Promise<void>((resolve) => server.listen(port, host, resolve));
-  runtime.log?.(`webhook listening on ${publicUrl}`);
-
+  let stopped = false;
   const shutdown = () => {
-    server.close();
-    void bot.stop();
-    if (diagnosticsEnabled) {
-      stopDiagnosticHeartbeat();
+    if (stopped) {
+      return;
     }
+    stopped = true;
+    cleanupRoute();
   };
   if (opts.abortSignal) {
     opts.abortSignal.addEventListener("abort", shutdown, { once: true });
   }
 
-  return { server, bot, stop: shutdown };
+  return { server: shared.server, bot, stop: shutdown };
 }


### PR DESCRIPTION
## Summary
- keep `monitorTelegramProvider` alive in webhook mode until abort, so channel manager does not auto-restart a healthy webhook worker
- support multi-account webhook mode on one listener by routing per-path and sharing the HTTP server
- derive account-specific default webhook paths (`/telegram-webhook/<accountId>`) for non-default accounts and fail fast on path conflicts

## Why
- in webhook mode, the provider task returned immediately after startup, which made gateway think the channel exited and trigger restart loops
- repeated restarts in multi-account setups caused `listen EADDRINUSE 127.0.0.1:8787`

## Testing
- `corepack pnpm vitest src/telegram/webhook.test.ts src/telegram/monitor.test.ts`

Fixes #22672

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored Telegram webhook mode to fix restart loops and enable multi-account support on a shared HTTP server. The key changes prevent the gateway manager from treating successful webhook startup as an exit (which triggered restarts) and eliminate `EADDRINUSE` errors when multiple accounts try to bind to the same port.

- **monitor.ts**: Added await on abort signal to keep the webhook provider task alive until explicitly stopped
- **webhook.ts**: Introduced shared server pool with per-path routing, auto-generated account-specific default paths (`/telegram-webhook/<accountId>`), and fail-fast validation for path conflicts
- **Tests**: Added coverage for webhook task lifecycle, multi-account server sharing, and conflict detection

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one edge case fix needed
- The implementation correctly addresses the restart loop issue and multi-account webhook support with good test coverage. However, there's a logical gap when `abortSignal` is not provided - the webhook task will return immediately instead of staying alive, which could cause the same restart loop the PR aims to fix. This edge case needs to be handled.
- Pay attention to src/telegram/monitor.ts lines 170-178 for the abortSignal edge case

<sub>Last reviewed commit: c203a02</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->