### PR TITLE
Android: mask gateway token as password field with visibility toggle

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -33,10 +33,13 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -57,6 +60,8 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -432,6 +437,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
             modifier = Modifier.fillMaxWidth(),
             enabled = manualEnabled,
           )
+          var tokenVisible by remember { mutableStateOf(false) }
           OutlinedTextField(
             value = gatewayToken,
             onValueChange = viewModel::setGatewayToken,
@@ -439,6 +445,15 @@ fun SettingsSheet(viewModel: MainViewModel) {
             modifier = Modifier.fillMaxWidth(),
             enabled = manualEnabled,
             singleLine = true,
+            visualTransformation = if (tokenVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+              IconButton(onClick = { tokenVisible = !tokenVisible }) {
+                Icon(
+                  imageVector = if (tokenVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                  contentDescription = if (tokenVisible) "Hide token" else "Show token",
+                )
+              }
+            },
           )
           ListItem(
             headlineContent = { Text("Require TLS") },


### PR DESCRIPTION
## Summary
- Treats the gateway token input as a secret field using `PasswordVisualTransformation` (masked with dots by default)
- Adds a trailing eye icon (`Visibility`/`VisibilityOff`) to toggle between masked and clear-text display
- Lightweight alternative to #22238 — prevents casual shoulder-surfing of the auth token without blocking screenshots app-wide

This could be merged **instead of** or **together with** #22238. The approaches are complementary: this PR redacts the field content itself, while #22238 prevents screenshots of the entire Advanced section.

## Test plan
- [x] Open Settings → expand Advanced → verify gateway token is masked with dots
- [x] Tap the eye icon → verify token becomes visible in clear text
- [x] Tap the eye icon again → verify token is re-masked
- [x] Collapse and re-expand Advanced → verify token resets to masked state
- [x] Verify no regressions in other settings fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds password masking with visibility toggle to the gateway token field in Android settings. The token is masked by default using `PasswordVisualTransformation` and includes an eye icon to toggle visibility, protecting against shoulder-surfing while maintaining easy access when needed.

- Applied `PasswordVisualTransformation` to mask token input by default
- Added visibility toggle icon button (`Visibility`/`VisibilityOff`) with proper accessibility labels
- Token visibility state resets to masked when Advanced section is collapsed/re-expanded (state is scoped inside `AnimatedVisibility`)
- Clean implementation following Material Design 3 patterns

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward UI enhancement with no functional risks
- Simple, well-implemented UI change that adds password masking to a sensitive field. Uses standard Compose patterns, proper state management, and includes accessibility support. No logic errors, security issues, or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: c45e6b7</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->