### PR TITLE
fix: support node binaries named like `node22`

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -200,6 +200,14 @@ describe("argv helpers", () => {
         expected: ["/usr/bin/node-22.2.0", "openclaw", "status"],
       },
       {
+        rawArgs: ["node22", "openclaw", "status"],
+        expected: ["node22", "openclaw", "status"],
+      },
+      {
+        rawArgs: ["/usr/bin/node22", "openclaw", "status"],
+        expected: ["/usr/bin/node22", "openclaw", "status"],
+      },
+      {
         rawArgs: ["nodejs", "openclaw", "status"],
         expected: ["nodejs", "openclaw", "status"],
       },

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -172,7 +172,7 @@ export function buildParseArgv(params: {
   return ["node", programName || "openclaw", ...normalizedArgv];
 }
 
-const nodeExecutablePattern = /^node-\d+(?:\.\d+)*(?:\.exe)?$/;
+const nodeExecutablePattern = /^node-?\d+(?:\.\d+)*(?:\.exe)?$/;
 
 function isNodeExecutable(executable: string): boolean {
   return (


### PR DESCRIPTION
## Summary
- Problem: quite similar to #2444. but opensuse packages do not use hyphens. they re named like `node22` `npm22` etc.
- What changed: nodeExecutablePattern regex, a `?` is added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

## User-visible / Behavior Changes

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) n
- Secrets/tokens handling changed? (`Yes/No`) n
- New/changed network calls? (`Yes/No`) n
- Command/tool execution surface changed? (`Yes/No`) n
- Data access scope changed? (`Yes/No`) n
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment
- OS: opensuse tumbleweed
- Runtime/container: node24
- Model/provider: *not related*

### Steps
systemctl start

### Expected
started

### Actual
exited

## Evidence
`error: unknown command '/usr/bin/node24'`

## Human Verification (required)
- Verified scenarios: app starts
- Edge cases checked: not
- What you did **not** verify: ?

## Compatibility / Migration
- Backward compatible? (`Yes/No`) **should be yes unless `node\d+` args have other meanings in the codebase**
- Config/env changes? (`Yes/No`) n
- Migration needed? (`Yes/No`) n
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: just `git revert`

## Risks and Mitigations

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Modified the `nodeExecutablePattern` regex in `src/cli/argv.ts:175` to support node binaries without hyphens (e.g., `node22`) by making the hyphen optional with `?`. The change is minimal and well-tested with two new test cases covering both `node22` and `/usr/bin/node22` patterns. The regex change from `/^node-\d+(?:\.\d+)*(?:\.exe)?$/` to `/^node-?\d+(?:\.\d+)*(?:\.exe)?$/` correctly matches OpenSUSE Tumbleweed's naming convention while maintaining backward compatibility with existing patterns like `node-22`, `node-22.2.0`, and `node-22.2.0.exe`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a trivial one-character regex modification that adds optional hyphen support. Test coverage is comprehensive with new test cases specifically validating the new pattern. The change is backward compatible and solves a real-world issue on OpenSUSE systems without introducing any breaking changes
- No files require special attention

<sub>Last reviewed commit: 464cb9c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->