### PR TITLE
fix(appcast): correct sparkle:version for 2026.2.13

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -212,7 +212,7 @@
             <title>2026.2.13</title>
             <pubDate>Sat, 14 Feb 2026 04:30:23 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>9846</sparkle:version>
+            <sparkle:version>202602130</sparkle:version>
             <sparkle:shortVersionString>2026.2.13</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.13</h2>

--- a/test/appcast.test.ts
+++ b/test/appcast.test.ts
@@ -24,4 +24,27 @@ describe("appcast.xml", () => {
     const sparkleMatch = matchingItem?.match(/<sparkle:version>([^<]+)<\/sparkle:version>/);
     expect(sparkleMatch?.[1]).toBe(expectedSparkleVersion(shortVersion));
   });
+
+  it("all versions use date-based sparkle:version format (YYYYMMDD0)", () => {
+    const appcast = readFileSync(APPCAST_URL, "utf8");
+    const items = Array.from(appcast.matchAll(/<item>[\s\S]*?<\/item>/g)).map((match) => match[0]);
+
+    for (const item of items) {
+      const shortMatch = item.match(
+        /<sparkle:shortVersionString>([^<]+)<\/sparkle:shortVersionString>/,
+      );
+      const sparkleMatch = item.match(/<sparkle:version>([^<]+)<\/sparkle:version>/);
+
+      if (shortMatch && sparkleMatch) {
+        const shortVersion = shortMatch[1];
+        const sparkleVersion = sparkleMatch[1];
+        const expected = expectedSparkleVersion(shortVersion);
+
+        expect(
+          sparkleVersion,
+          `Version ${shortVersion} has incorrect sparkle:version (expected ${expected}, got ${sparkleVersion})`,
+        ).toBe(expected);
+      }
+    }
+  });
 });


### PR DESCRIPTION
## 🤖 AI-Assisted (Claude via OpenClaw)

**Testing:** Fully tested — added comprehensive validation test + verified fix locally

**Understanding:** Root cause identified (legacy build number vs date-based format), fix validated with test coverage to prevent future regressions.

---

## Problem

Version 2026.2.13 in `appcast.xml` had `sparkle:version` set to `9846` instead of the expected date-based format `202602130`.

This caused Sparkle's version comparison to malfunction, potentially offering older versions as updates to users with newer builds (as reported in #22657).

## Root Cause

The `sparkle:version` must follow the date-based format:
```
YYYY + MM (zero-padded) + DD (zero-padded) + 0
```

Example:
- `2026.2.15` → `202602150` ✅
- `2026.2.13` → `202602130` ✅ (expected)
- `2026.2.13` → `9846` ❌ (actual, legacy build number)

## Solution

1. **Fix appcast.xml:** Changed `9846` → `202602130` for v2026.2.13
2. **Add validation test:** New test validates ALL versions in appcast.xml use correct date-based `sparkle:version` format, preventing future regressions

## Testing

```bash
pnpm test appcast.test.ts
# ✓ All tests passing
```

The new test would have caught this bug before it reached production.

## Fixes

Closes #22657

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `sparkle:version` for v2026.2.13 from legacy build number `9846` to correct date-based format `202602130`. Added comprehensive validation test that checks ALL versions in `appcast.xml` use the expected `YYYYMMDD0` format, preventing future regressions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is surgical and correct - it changes a single hardcoded version string from an incorrect legacy build number to the proper date-based format. The new test provides comprehensive validation coverage and would have caught this bug before production. All three versions in the appcast now follow the correct format.
- No files require special attention

<sub>Last reviewed commit: 7a156bf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->