### PR TITLE
fix: pass agentDir to runEmbeddedPiAgent in cron isolated sessions

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -480,6 +480,7 @@ export async function runCronIsolatedAgentTurn(params: {
           agentAccountId: resolvedDelivery.accountId,
           sessionFile,
           workspaceDir,
+          agentDir,
           config: cfgWithAgentDefaults,
           skillsSnapshot,
           prompt: commandBody,


### PR DESCRIPTION
**Problem:**
When a cron job with `agentId: "healthcoach"` runs in an isolated session, the agent's auth credentials are loaded from the wrong directory. The code correctly resolves the agent-specific directory using `resolveAgentDir()`, but fails to pass it to `runEmbeddedPiAgent()`.

This causes `runEmbeddedPiAgent` to fall back to `resolveOpenClawAgentDir()`, which always returns the main agent's directory
(`~/.openclaw/agents/main/agent/`), regardless of the job's `agentId`.

**Impact:**
Multi-agent setups break for cron jobs. For example:
- Job specifies `agentId: "healthcoach"`
- Job tries to load auth from `/Users/openclaw/.openclaw/agents/main/agent/auth-profiles.json`
- Error: "No API key found for provider \"anthropic\""
- Job fails even though healthcoach has valid credentials in its own directory

**Root Cause:**
In `src/cron/isolated-agent/run.ts`, line 187 correctly resolves:
```typescript
const agentDir = resolveAgentDir(params.cfg, agentId);
```

But on line 476, `runEmbeddedPiAgent()` is called without the `agentDir` parameter, causing it to default to the main agent's directory.

**Fix:**
Add `agentDir` to the parameters passed to `runEmbeddedPiAgent()` on line 484. This ensures cron isolated sessions use the correct agent-specific directory for auth profiles, workspace files, and other agent configuration.

**Testing:**
Tested with a healthcoach agent running cron jobs:
- Before: All jobs failed with "No API key found" error
- After: Jobs load credentials from the correct agent directory and run successfully

Fixes multi-agent cron job auth resolution.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed cron jobs with non-default `agentId` values to load auth credentials from the correct agent-specific directory instead of always falling back to the main agent's directory.

- Added missing `agentDir` parameter to `runEmbeddedPiAgent()` call on line 483
- The `agentDir` was already correctly resolved on line 204 using `resolveAgentDir(params.cfg, agentId)`, but wasn't being passed through
- Without this fix, multi-agent cron jobs failed with "No API key found" errors because `runEmbeddedPiAgent` defaulted to `resolveOpenClawAgentDir()` which always returns `~/.openclaw/agents/main/agent/`
- The fix ensures auth profiles, workspace files, and agent configuration are loaded from the correct per-agent directory (e.g., `~/.openclaw/agents/healthcoach/agent/`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a targeted one-line fix that adds a missing parameter
- The fix is straightforward, well-scoped, and addresses a clear bug. The `agentDir` parameter was already being resolved correctly (line 204) and was already being passed to other functions (line 454 to `runWithModelFallback`), so adding it to the `runEmbeddedPiAgent` call is the obvious correct solution. The parameter is optional in the function signature and has a safe fallback, so this change only improves behavior without introducing breaking changes. Other callers of `runEmbeddedPiAgent` in the codebase (like `src/commands/agent.ts` and `src/auto-reply/reply/agent-runner-utils.ts`) already pass this parameter correctly.
- No files require special attention

<sub>Last reviewed commit: bf54397</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->