### PR TITLE
fix/sandbox manage default agent main

### DIFF
--- a/src/agents/sandbox/manage.ts
+++ b/src/agents/sandbox/manage.ts
@@ -49,7 +49,7 @@ async function listSandboxRegistryItems<
         // ignore
       }
     }
-    const agentId = resolveSandboxAgentId(entry.sessionKey);
+    const agentId = resolveSandboxAgentId(entry.sessionKey) ?? "main";
     const configuredImage = params.resolveConfiguredImage(agentId);
     results.push({
       ...entry,


### PR DESCRIPTION
- **fix(gateway): avoid scope-upgrade pairing for admin-scoped devices**
- **fix(sandbox): default agent id to main when session key has no agent**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two bugs: defaulted sandbox agent ID to "main" when session key has no agent, and prevented unnecessary scope-upgrade pairing prompts for devices that already have `operator.admin` scope.

- **sandbox/manage.ts**: added null coalescing to default agent ID to "main" when `resolveSandboxAgentId()` returns undefined
- **message-handler.ts**: bypassed scope-upgrade requirement when paired device already has `operator.admin` (which grants all permissions per the authorization logic in `server-methods.ts`)
- **test**: added comprehensive test simulating real-world scenario where admin-scoped device reconnects with least-privilege scope request

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested and logically sound. The sandbox fix is a simple null coalescing guard, and the gateway authorization logic correctly recognizes that `operator.admin` is a superset permission (confirmed by checking `server-methods.ts` where admin scope bypasses all other checks). The test coverage is comprehensive and simulates the real-world scenario described in the PR. One minor suggestion for test completeness (verifying scope preservation) was noted but doesn't affect correctness due to the existing `mergeScopes` implementation.
- No files require special attention

<sub>Last reviewed commit: 2ed630a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->