### PR TITLE
fix(gateway): auto-approve all device pairing for localhost connections

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -734,7 +734,7 @@ export function attachGatewayWsMessageHandler(params: {
               role,
               scopes,
               remoteIp: reportedClientIp,
-              silent: isLocalClient && reason === "not-paired",
+              silent: isLocalClient,
             });
             const context = buildRequestContext();
             if (pairing.request.silent === true) {


### PR DESCRIPTION
Fixes #22688

## Problem
CLI tools like `openclaw tui` and `openclaw gateway status` were stuck in an infinite "pairing required" loop when using token auth mode, even from localhost. The gateway auto-approved initial device pairing but required manual approval for scope/role upgrades, causing CLI tools to fail when requesting elevated scopes.

## Root Cause
Device pairing auto-approval was conditional on both `isLocalClient` AND `reason === 'not-paired'`. Subsequent connections with scope upgrades (`reason === 'scope-upgrade'` or `'role-upgrade'`) required manual pairing approval even from localhost.

## Solution
Changed silent pairing condition from:
```typescript
silent: isLocalClient && reason === "not-paired"
```
to:
```typescript
silent: isLocalClient
```

This auto-approves ALL device pairing requests from localhost (initial pairing, role upgrades, scope upgrades), eliminating the pairing loop for local CLI tools while maintaining security for remote connections.

## Testing
- Updated test "requires pairing for scope upgrades" to "auto-approves scope upgrades for local clients"
- Test now expects scope upgrade to succeed immediately for localhost
- All quality gate checks pass:
  - ✅ pnpm build
  - ✅ pnpm tsgo
  - ✅ pnpm lint
  - ✅ pnpm test

## Files Changed
- `src/gateway/server/ws-connection/message-handler.ts`: Updated silent pairing logic
- `src/gateway/server.auth.e2e.test.ts`: Updated test expectations

---
*AI-assisted contribution*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed silent pairing condition to auto-approve all device pairing requests from localhost (initial pairing, role upgrades, scope upgrades), fixing an infinite pairing loop for CLI tools while maintaining security for remote connections.

- Simplified `silent` pairing logic in `message-handler.ts:737` from `isLocalClient && reason === "not-paired"` to just `isLocalClient`
- Updated test expectations to verify scope upgrades now succeed immediately for local clients
- Security boundary properly maintained: `isLocalClient` returns false for connections with proxy headers (like `x-forwarded-for`) unless from trusted proxies, ensuring remote connections still require manual pairing approval

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change correctly solves the CLI tool pairing issue by simplifying the auto-approval logic for localhost connections. Security is maintained because `isLocalClient` properly validates that connections are truly local (checks client IP is loopback AND verifies no proxy headers or only trusted proxies). The existing test on line 746 confirms remote connections still require pairing. Test updates are appropriate and all quality gates pass.
- No files require special attention

<sub>Last reviewed commit: b180dd8</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->