### PR TITLE
Security: extend env var blocklist — add GLIBC_TUNABLES, JAVA_TOOL_OPTIONS, JDK_JAVA_OPTIONS, LD_AUDIT, OPENCLAW_ prefix (#22681)

### DIFF
--- a/src/infra/host-env-security-policy.json
+++ b/src/infra/host-env-security-policy.json
@@ -12,7 +12,11 @@
     "ENV",
     "GCONV_PATH",
     "IFS",
-    "SSLKEYLOGFILE"
+    "SSLKEYLOGFILE",
+    "GLIBC_TUNABLES",
+    "JAVA_TOOL_OPTIONS",
+    "JDK_JAVA_OPTIONS",
+    "LD_AUDIT"
   ],
-  "blockedPrefixes": ["DYLD_", "LD_", "BASH_FUNC_"]
+  "blockedPrefixes": ["DYLD_", "LD_", "BASH_FUNC_", "OPENCLAW_"]
 }


### PR DESCRIPTION
## Summary

Extends `host-env-security-policy.json` to block four additional environment variables that can be used for code injection or dynamic linker hijacking, plus the `OPENCLAW_` prefix to prevent behavior modification via environment.

## Missing variables added

| Variable | Risk |
|----------|------|
| `GLIBC_TUNABLES` | glibc dynamic linker behavior modification — code injection vector |
| `JAVA_TOOL_OPTIONS` | JVM options injection for all Java invocations |
| `JDK_JAVA_OPTIONS` | Java 9+ equivalent of `JAVA_TOOL_OPTIONS` |
| `LD_AUDIT` | Dynamic linker audit library loading |

## Prefix added

- `OPENCLAW_` — prevents user-provided env from modifying OpenClaw's own behavior via env vars

## Attack vector (from issue #22681)

Even with `exec` in allowlist mode, an attacker who can influence environment variables could inject:
```bash
GLIBC_TUNABLES=glibc.tune.hwcaps=-AVX512F some_command
JAVA_TOOL_OPTIONS=-Djava.security.manager=... java_app
```

## Testing

- [x] JSON is valid
- [ ] Lightly tested — change is additive only; no existing keys modified

Fixes #22681

AI-assisted: drafted with Claude (Prometheus/OpenClaw agent), reviewed and verified by author.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added four dangerous environment variables (`GLIBC_TUNABLES`, `JAVA_TOOL_OPTIONS`, `JDK_JAVA_OPTIONS`, `LD_AUDIT`) and the `OPENCLAW_` prefix to the security blocklist to prevent code injection and dynamic linker hijacking attacks.

**Critical Issue Found:**
- The Swift file `apps/macos/Sources/OpenClaw/HostEnvSanitizer.swift` was not updated alongside the JSON policy file. The parity test `src/infra/host-env-security.policy-parity.test.ts` will fail because it enforces synchronization between these two files.

<h3>Confidence Score: 1/5</h3>

- This PR cannot be merged because the macOS Swift implementation is out of sync with the JSON policy
- The security policy changes are valid and address real attack vectors, but the PR is incomplete. The Swift file `HostEnvSanitizer.swift` must be updated to match the JSON policy, otherwise the parity test will fail and the macOS app will have inconsistent security protections compared to the Node.js implementation.
- `apps/macos/Sources/OpenClaw/HostEnvSanitizer.swift` requires immediate attention — must be updated to match the JSON policy changes

<sub>Last reviewed commit: a787b28</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->