### PR TITLE
fix: gateway status probe uses wss:// when TLS enabled; accept self-signed cert without fingerprint (#22678)

### DIFF
--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -182,7 +182,7 @@ export async function gatherDaemonStatus(
   const probeHost = pickProbeHostForBind(bindMode, tailnetIPv4, customBindHost);
   const probeUrlOverride =
     typeof opts.rpc.url === "string" && opts.rpc.url.trim().length > 0 ? opts.rpc.url.trim() : null;
-  const probeUrl = probeUrlOverride ?? `ws://${probeHost}:${daemonPort}`;
+  const probeUrl = probeUrlOverride ?? `${(daemonCfg as { gateway?: { tls?: { enabled?: boolean } } })?.gateway?.tls?.enabled ? "wss" : "ws"}://${probeHost}:${daemonPort}`;
   const probeNote =
     !probeUrlOverride && bindMode === "lan"
       ? `bind=lan listens on 0.0.0.0 (all interfaces); probing via ${probeHost}.`

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -182,7 +182,9 @@ export async function gatherDaemonStatus(
   const probeHost = pickProbeHostForBind(bindMode, tailnetIPv4, customBindHost);
   const probeUrlOverride =
     typeof opts.rpc.url === "string" && opts.rpc.url.trim().length > 0 ? opts.rpc.url.trim() : null;
-  const probeUrl = probeUrlOverride ?? `${(daemonCfg as { gateway?: { tls?: { enabled?: boolean } } })?.gateway?.tls?.enabled ? "wss" : "ws"}://${probeHost}:${daemonPort}`;
+  const tlsEnabled =
+    (daemonCfg as { gateway?: { tls?: { enabled?: boolean } } })?.gateway?.tls?.enabled ?? false;
+  const probeUrl = probeUrlOverride ?? `${tlsEnabled ? "wss" : "ws"}://${probeHost}:${daemonPort}`;
   const probeNote =
     !probeUrlOverride && bindMode === "lan"
       ? `bind=lan listens on 0.0.0.0 (all interfaces); probing via ${probeHost}.`

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -158,6 +158,9 @@ export class GatewayClient {
         return undefined;
         // oxlint-disable-next-line typescript/no-explicit-any
       }) as any;
+    } else if (url.startsWith("wss://") && !this.opts.tlsFingerprint) {
+      // No fingerprint configured — accept self-signed cert (default gateway TLS install)
+      wsOptions.rejectUnauthorized = false;
     }
     this.ws = new WebSocket(url, wsOptions);
 


### PR DESCRIPTION
## Summary

Two separate bugs combine to make `openclaw gateway status` completely non-functional when `gateway.tls.enabled: true`. Both are fixed here.

Fixes #22678

---

## Bug 1: Probe URL ignores TLS config — always uses `ws://`

**File:** `src/cli/daemon-cli/status.gather.ts`

**Before:**
```typescript
const probeUrl = probeUrlOverride ?? `ws://${probeHost}:${daemonPort}`;
```

**After:**
```typescript
const probeUrl = probeUrlOverride ?? `${daemonCfg?.gateway?.tls?.enabled ? wss : ws}://${probeHost}:${daemonPort}`;
```

This mirrors the pattern already used correctly in `src/gateway/call.ts` (`buildGatewayConnectionDetails`).

---

## Bug 2: GatewayClient rejects self-signed certs when no fingerprint is provided

**File:** `src/gateway/client.ts`

**Before:** Only sets `rejectUnauthorized = false` when `tlsFingerprint` is present. Default TLS installs use self-signed certs and no fingerprint → 1006 abnormal closure.

**After:** Added `else if` branch that accepts self-signed certs when connecting to `wss://` without a fingerprint configured:

```typescript
} else if (url.startsWith(wss://) && !this.opts.tlsFingerprint) {
  // No fingerprint configured — accept self-signed cert (default gateway TLS install)
  wsOptions.rejectUnauthorized = false;
}
```

---

## Impact

Every user with `gateway.tls.enabled: true` sees `RPC probe: failed` + `SECURITY ERROR` even when the gateway is healthy. This fix restores correct status reporting.

## Testing

- [ ] Manually verified against a local gateway with `tls.enabled: true` — `openclaw gateway status` now shows `RPC probe: ok`
- [ ] Lightly tested

AI-assisted: implemented with Claude (Prometheus/OpenClaw agent), verified by author.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two critical bugs that prevented `openclaw gateway status` from working with TLS enabled. The status probe now correctly uses `wss://` when TLS is enabled (mirroring the pattern in `call.ts`), and `GatewayClient` now accepts self-signed certificates when no fingerprint is configured, which is the default for gateway TLS installations.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style improvement opportunity
- Both fixes address real bugs and follow existing patterns in the codebase. The logic is sound and tested. Score reduced from 5 only due to a verbose type cast that could be simplified.
- No files require special attention

<sub>Last reviewed commit: 49ace45</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->