### PR TITLE
fix(exec): keep child runs attached on macOS for reliable output

### DIFF
--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -29,6 +29,10 @@ export type ChildAdapter = {
   dispose: () => void;
 };
 
+export function shouldUseDetached(platform: NodeJS.Platform = process.platform): boolean {
+  return platform !== "win32" && platform !== "darwin";
+}
+
 export async function createChildAdapter(params: {
   argv: string[];
   cwd?: string;
@@ -44,9 +48,14 @@ export async function createChildAdapter(params: {
 
   // On Windows, `detached: true` creates a new process group and can prevent
   // stdout/stderr pipes from connecting when running under a Scheduled Task
-  // (headless, no console). Default to `detached: false` on Windows; on
-  // POSIX systems keep `detached: true` so the child survives parent exit.
-  const useDetached = process.platform !== "win32";
+  // (headless, no console).
+  //
+  // On macOS LaunchAgent sessions we observed the same symptom (commands exit
+  // immediately with no captured output) when detached children are used.
+  // Keep detached mode disabled on both win32 and darwin for reliable pipe
+  // capture; Linux/other POSIX keeps detached=true so child runs can outlive
+  // the parent when needed.
+  const useDetached = shouldUseDetached();
 
   const options: SpawnOptions = {
     cwd: params.cwd,


### PR DESCRIPTION
## Summary
Fixes #22350.

On macOS LaunchAgent sessions, spawning exec child processes with `detached: true` can cause stdout/stderr pipes to behave like fire-and-forget runs (command exits quickly with no captured output). This made `exec` appear to return `(no output)` even for simple commands.

This change:
- disables detached mode on **darwin** (same as existing win32 behavior)
- keeps detached mode enabled on Linux/other POSIX
- adds a focused unit test for platform policy (`shouldUseDetached`)

## Validation
- `corepack pnpm -s vitest run src/process/supervisor/adapters/child.test.ts` ✅

## Risk
Low. Scope is limited to process spawn options in child adapter. Linux behavior remains unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Disables detached process spawning on macOS to fix stdout/stderr pipe capture issues in LaunchAgent sessions. The PR extracts the platform-specific detached-mode logic into a testable `shouldUseDetached()` function that returns false for both `win32` and `darwin`, while keeping Linux/POSIX behavior unchanged (detached=true with fallback). The fix mirrors the existing Windows Scheduled Task compatibility pattern and includes focused unit test coverage.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted fix with clear test coverage and no breaking changes to existing platforms
- The change is minimal, well-scoped, and directly addresses a documented macOS issue. The new `shouldUseDetached()` helper improves testability, tests cover all three platform cases, and Linux behavior remains unchanged. The fallback mechanism is already in place via `spawnWithFallback()`
- No files require special attention

<sub>Last reviewed commit: 4c67157</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->