### PR TITLE
feat: masked secrets — prevent agents from accessing raw API keys

### DIFF
--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -1,4 +1,5 @@
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
+import type { MaskedSecrets } from "../security/masked-secrets/index.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 
 export type ExecToolDefaults = {
@@ -21,6 +22,7 @@ export type ExecToolDefaults = {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   cwd?: string;
+  maskedSecrets?: MaskedSecrets;
 };
 
 export type ExecElevatedDefaults = {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -508,6 +508,11 @@ export async function compactEmbeddedPiSessionDirect(
       userTimeFormat,
       contextFiles,
       memoryCitationsMode: params.config?.memory?.citations,
+      maskedSecretNames: (
+        (params.config as Record<string, unknown> | undefined)?.security as
+          | { maskedSecrets?: { mask?: string[] } }
+          | undefined
+      )?.maskedSecrets?.mask,
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -16,6 +16,7 @@ import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
+import { createMaskedSecrets, type MaskedSecrets } from "../../security/masked-secrets/index.js";
 import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
@@ -478,6 +479,13 @@ export async function compactEmbeddedPiSessionDirect(
       moduleUrl: import.meta.url,
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    // Create MaskedSecrets instance to get actual loaded secret names for the system prompt.
+    const maskedSecretsConfig = (params.config as Record<string, unknown> | undefined)?.security as
+      | { maskedSecrets?: Record<string, unknown> }
+      | undefined;
+    const maskedSecretsInstance: MaskedSecrets | undefined = maskedSecretsConfig?.maskedSecrets
+      ? createMaskedSecrets(maskedSecretsConfig.maskedSecrets)
+      : undefined;
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,
       defaultThinkLevel: params.thinkLevel,
@@ -508,11 +516,7 @@ export async function compactEmbeddedPiSessionDirect(
       userTimeFormat,
       contextFiles,
       memoryCitationsMode: params.config?.memory?.citations,
-      maskedSecretNames: (
-        (params.config as Record<string, unknown> | undefined)?.security as
-          | { maskedSecrets?: { mask?: string[] } }
-          | undefined
-      )?.maskedSecrets?.mask,
+      maskedSecretNames: maskedSecretsInstance?.listSecretNames(),
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -468,6 +468,11 @@ export async function runEmbeddedAttempt(
       userTimeFormat,
       contextFiles,
       memoryCitationsMode: params.config?.memory?.citations,
+      maskedSecretNames: (
+        (params.config as Record<string, unknown> | undefined)?.security as
+          | { maskedSecrets?: { mask?: string[] } }
+          | undefined
+      )?.maskedSecrets?.mask,
     });
     const systemPromptReport = buildSystemPromptReport({
       source: "run",

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -50,6 +50,7 @@ export function buildEmbeddedSystemPrompt(params: {
   userTimeFormat?: ResolvedTimeFormat;
   contextFiles?: EmbeddedContextFile[];
   memoryCitationsMode?: MemoryCitationsMode;
+  maskedSecretNames?: string[];
 }): string {
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
@@ -78,6 +79,7 @@ export function buildEmbeddedSystemPrompt(params: {
     userTimeFormat: params.userTimeFormat,
     contextFiles: params.contextFiles,
     memoryCitationsMode: params.memoryCitationsMode,
+    maskedSecretNames: params.maskedSecretNames,
   });
 }
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -249,6 +249,8 @@ export function buildAgentSystemPrompt(params: {
     channel: string;
   };
   memoryCitationsMode?: MemoryCitationsMode;
+  /** Names of masked secrets available via {{secret:NAME}} syntax. */
+  maskedSecretNames?: string[];
 }) {
   const coreToolSummaries: Record<string, string> = {
     read: "Read file contents",
@@ -625,6 +627,21 @@ export function buildAgentSystemPrompt(params: {
     for (const file of validContextFiles) {
       lines.push(`## ${file.path}`, "", file.content, "");
     }
+  }
+
+  // Masked secrets: inform agent about {{secret:NAME}} syntax.
+  const secretNames = params.maskedSecretNames ?? [];
+  if (secretNames.length > 0 && !isMinimal) {
+    lines.push(
+      "## Secrets",
+      "To use API keys or secrets in shell commands, use the reference syntax:",
+      '  curl -H "Authorization: Bearer {{secret:MY_API_KEY}}" https://api.example.com',
+      "",
+      `Available secrets: ${secretNames.join(", ")}`,
+      "",
+      "Do NOT try to read .env files or print environment variables directly.",
+      "",
+    );
   }
 
   // Skip silent replies for subagent/none modes

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -294,6 +294,22 @@ export const OpenClawSchema = z
     nodeHost: NodeHostSchema,
     agents: AgentsSchema,
     tools: ToolsSchema,
+    security: z
+      .object({
+        maskedSecrets: z
+          .object({
+            enabled: z.boolean().default(true),
+            mask: z.array(z.string()).default([]),
+            outputPatterns: z.array(z.string()).optional(),
+            blockedCommands: z.array(z.string()).optional(),
+            blockSecretFileReads: z.boolean().default(true),
+            secretFilePaths: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
     bindings: BindingsSchema,
     broadcast: BroadcastSchema,
     audio: AudioSchema,

--- a/src/security/masked-secrets/INTEGRATION.md
+++ b/src/security/masked-secrets/INTEGRATION.md
@@ -3,6 +3,7 @@
 ## Overview
 
 This module provides three layers of secret protection:
+
 1. **Preflight** — Block dangerous commands, substitute `{{secret:NAME}}` refs
 2. **Redaction** — Scrub leaked secret values from command output
 3. **Store** — Load and manage secrets from .env / process.env / config
@@ -93,18 +94,13 @@ const { text: safeChunk } = maskedSecrets.redact(rawChunk);
 ```json5
 // openclaw.json
 {
-  "security": {
-    "maskedSecrets": {
-      "enabled": true,
-      "mask": [
-        "OPENAI_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "GITHUB_TOKEN",
-        "BRAVE_API_KEY"
-      ],
-      "blockSecretFileReads": true
-    }
-  }
+  security: {
+    maskedSecrets: {
+      enabled: true,
+      mask: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GITHUB_TOKEN", "BRAVE_API_KEY"],
+      blockSecretFileReads: true,
+    },
+  },
 }
 ```
 
@@ -117,15 +113,15 @@ npx vitest run src/security/masked-secrets/
 
 ## Files
 
-| File | Purpose |
-|------|---------|
-| `types.ts` | Type definitions |
-| `secret-store.ts` | Secret loading, storage, and matching |
-| `substitution.ts` | `{{secret:NAME}}` → real value replacement |
-| `redaction.ts` | Output scrubbing (exact match + pattern match) |
-| `preflight.ts` | Pre-execution command checks |
-| `index.ts` | Public API facade |
-| `*.test.ts` | Unit tests for each module |
+| File              | Purpose                                        |
+| ----------------- | ---------------------------------------------- |
+| `types.ts`        | Type definitions                               |
+| `secret-store.ts` | Secret loading, storage, and matching          |
+| `substitution.ts` | `{{secret:NAME}}` → real value replacement     |
+| `redaction.ts`    | Output scrubbing (exact match + pattern match) |
+| `preflight.ts`    | Pre-execution command checks                   |
+| `index.ts`        | Public API facade                              |
+| `*.test.ts`       | Unit tests for each module                     |
 
 ## Security Notes
 

--- a/src/security/masked-secrets/INTEGRATION.md
+++ b/src/security/masked-secrets/INTEGRATION.md
@@ -1,0 +1,142 @@
+# Masked Secrets — Integration Guide
+
+## Overview
+
+This module provides three layers of secret protection:
+1. **Preflight** — Block dangerous commands, substitute `{{secret:NAME}}` refs
+2. **Redaction** — Scrub leaked secret values from command output
+3. **Store** — Load and manage secrets from .env / process.env / config
+
+## Integration Points
+
+### 1. Gateway Startup (`src/daemon/` or `src/gateway/`)
+
+Initialize the MaskedSecrets instance when the gateway starts:
+
+```ts
+import { createMaskedSecrets } from "../security/masked-secrets/index.js";
+
+// Read config from openclaw.json
+const maskedSecrets = createMaskedSecrets(config.security?.maskedSecrets);
+```
+
+The instance should be a singleton, accessible to the exec tool.
+
+### 2. Shell Command Execution (`src/agents/bash-tools.exec.ts`)
+
+**Before execution** — in the `runExecProcess` flow or wherever the command string
+is finalized before being passed to `spawn`:
+
+```ts
+// Preflight: check + substitute
+const preflight = maskedSecrets.preflight(command);
+if (!preflight.allowed) {
+  return { error: preflight.reason };
+}
+const realCommand = preflight.processedCommand ?? command;
+
+// Execute realCommand (agent never sees this)
+```
+
+**After execution** — before output is returned to the agent:
+
+```ts
+// Redact any leaked secrets from output
+const { text: safeStdout } = maskedSecrets.redact(rawStdout);
+const { text: safeStderr } = maskedSecrets.redact(rawStderr);
+
+// Return safeStdout/safeStderr to the agent
+```
+
+### 3. Config Schema (`src/config/zod-schema.ts`)
+
+Add masked secrets config to the schema:
+
+```ts
+maskedSecrets: z.object({
+  enabled: z.boolean().default(true),
+  mask: z.array(z.string()).default([]),
+  outputPatterns: z.array(z.string()).optional(),
+  blockedCommands: z.array(z.string()).optional(),
+  blockSecretFileReads: z.boolean().default(true),
+  secretFilePaths: z.array(z.string()).optional(),
+}).optional(),
+```
+
+### 4. System Prompt (`src/auto-reply/reply/prompt-builder.ts`)
+
+Inform the agent about the `{{secret:NAME}}` syntax:
+
+```
+## Secrets
+
+To use API keys or secrets in commands, use the reference syntax:
+  curl -H "Authorization: Bearer {{secret:MY_API_KEY}}" https://api.example.com
+
+Available secrets: ${secretNames.join(", ")}
+
+Do NOT try to read .env files or print environment variables directly.
+```
+
+### 5. Process Output Streaming (`src/agents/bash-tools.process.ts`)
+
+For background processes that stream output, redaction needs to happen
+on each chunk before it reaches the agent:
+
+```ts
+// In the log/poll output handler:
+const { text: safeChunk } = maskedSecrets.redact(rawChunk);
+```
+
+## Config Example
+
+```json5
+// openclaw.json
+{
+  "security": {
+    "maskedSecrets": {
+      "enabled": true,
+      "mask": [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GITHUB_TOKEN",
+        "BRAVE_API_KEY"
+      ],
+      "blockSecretFileReads": true
+    }
+  }
+}
+```
+
+## Testing
+
+```bash
+cd ~/Projects/openclaw
+npx vitest run src/security/masked-secrets/
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `types.ts` | Type definitions |
+| `secret-store.ts` | Secret loading, storage, and matching |
+| `substitution.ts` | `{{secret:NAME}}` → real value replacement |
+| `redaction.ts` | Output scrubbing (exact match + pattern match) |
+| `preflight.ts` | Pre-execution command checks |
+| `index.ts` | Public API facade |
+| `*.test.ts` | Unit tests for each module |
+
+## Security Notes
+
+- Secret values are held in memory only (SecretStore). They are never written
+  to disk, logs, or chat history.
+- The `{{secret:NAME}}` reference syntax is designed to be safe to store in
+  chat history — it contains no sensitive data.
+- Pattern-based redaction catches common API key formats even if they're not
+  in the store (defense in depth).
+- Short values (< 8 chars) are excluded from exact-match redaction to prevent
+  false positives.
+- This is NOT a perfect security boundary — a determined attacker could encode
+  secrets (base64, hex, etc.) to bypass redaction. It's a safety net, not a
+  sandbox. For true isolation, use SkillSandbox-style OS-level enforcement.

--- a/src/security/masked-secrets/index.ts
+++ b/src/security/masked-secrets/index.ts
@@ -39,9 +39,9 @@ export type {
   PreflightResult,
 } from "./types.js";
 
-import { SecretStore } from "./secret-store.js";
 import { preflightCheck } from "./preflight.js";
 import { redactOutput } from "./redaction.js";
+import { SecretStore } from "./secret-store.js";
 import type { MaskedSecretsConfig, PreflightResult, RedactionResult } from "./types.js";
 
 /**
@@ -101,8 +101,6 @@ export class MaskedSecrets {
  * Factory function for creating a MaskedSecrets instance.
  * Preferred over direct constructor for clarity.
  */
-export function createMaskedSecrets(
-  config?: Partial<MaskedSecretsConfig>,
-): MaskedSecrets {
+export function createMaskedSecrets(config?: Partial<MaskedSecretsConfig>): MaskedSecrets {
   return new MaskedSecrets(config);
 }

--- a/src/security/masked-secrets/index.ts
+++ b/src/security/masked-secrets/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Masked Secrets — Public API
+ *
+ * Prevents agents from accessing raw API keys and secrets.
+ * Provides three layers of protection:
+ *
+ * 1. **Substitution**: Agent writes {{secret:NAME}}, runtime injects real value
+ * 2. **Preflight**: Block commands that dump env vars or read secret files
+ * 3. **Redaction**: Scrub leaked secrets from command output before agent sees it
+ *
+ * @example
+ * ```ts
+ * import { createMaskedSecrets } from "./security/masked-secrets/index.js";
+ *
+ * const ms = createMaskedSecrets({ mask: ["OPENAI_API_KEY", "GITHUB_TOKEN"] });
+ *
+ * // Before command execution:
+ * const preflight = ms.preflight("curl -H 'Auth: {{secret:OPENAI_API_KEY}}' ...");
+ * if (!preflight.allowed) { reject(preflight.reason); }
+ * const realCommand = preflight.processedCommand;
+ *
+ * // After command output:
+ * const { text: safeOutput } = ms.redact(rawOutput);
+ * // safeOutput has all secret values replaced with [REDACTED]
+ * ```
+ *
+ * @see https://github.com/openclaw/openclaw/issues/10659
+ */
+
+export { SecretStore } from "./secret-store.js";
+export { substituteSecrets, hasSecretRefs, extractSecretRefs } from "./substitution.js";
+export { redactOutput } from "./redaction.js";
+export { preflightCheck } from "./preflight.js";
+export type {
+  MaskedSecret,
+  MaskedSecretsConfig,
+  SubstitutionResult,
+  RedactionResult,
+  PreflightResult,
+} from "./types.js";
+
+import { SecretStore } from "./secret-store.js";
+import { preflightCheck } from "./preflight.js";
+import { redactOutput } from "./redaction.js";
+import type { MaskedSecretsConfig, PreflightResult, RedactionResult } from "./types.js";
+
+/**
+ * High-level facade for the masked secrets system.
+ * Create one instance at gateway startup, use it throughout the lifecycle.
+ */
+export class MaskedSecrets {
+  private store: SecretStore;
+
+  constructor(config?: Partial<MaskedSecretsConfig>) {
+    this.store = new SecretStore(config);
+    this.store.load();
+  }
+
+  /** Run preflight checks and substitution on a command */
+  preflight(command: string): PreflightResult {
+    if (!this.store.getConfig().enabled) {
+      return { allowed: true, processedCommand: command };
+    }
+    return preflightCheck(command, this.store);
+  }
+
+  /** Redact secrets from command output */
+  redact(output: string): RedactionResult {
+    if (!this.store.getConfig().enabled) {
+      return { text: output, count: 0, redactedSecrets: [] };
+    }
+    return redactOutput(output, this.store);
+  }
+
+  /** Get list of masked secret names (not values!) */
+  listSecretNames(): string[] {
+    return this.store.listNames();
+  }
+
+  /** Check if the system is enabled */
+  isEnabled(): boolean {
+    return this.store.getConfig().enabled;
+  }
+
+  /** Reload secrets (e.g., after config change) */
+  reload(config?: Partial<MaskedSecretsConfig>): void {
+    if (config) {
+      this.store.updateConfig(config);
+    } else {
+      this.store.load();
+    }
+  }
+
+  /** Get the underlying store (for testing) */
+  getStore(): SecretStore {
+    return this.store;
+  }
+}
+
+/**
+ * Factory function for creating a MaskedSecrets instance.
+ * Preferred over direct constructor for clarity.
+ */
+export function createMaskedSecrets(
+  config?: Partial<MaskedSecretsConfig>,
+): MaskedSecrets {
+  return new MaskedSecrets(config);
+}

--- a/src/security/masked-secrets/integration.test.ts
+++ b/src/security/masked-secrets/integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createMaskedSecrets } from "./index.js";
+import { createMaskedSecrets, type MaskedSecrets } from "./index.js";
 
 /**
  * Integration tests for masked-secrets wiring into exec/process pipelines.
@@ -95,7 +95,7 @@ describe("MaskedSecrets integration", () => {
       const result = ms.preflight("curl -H '{{secret:NONEXISTENT}}'");
       expect(result.allowed).toBe(true);
       expect(result.warnings).toBeDefined();
-      expect(result.warnings!.some((w) => w.includes("NONEXISTENT"))).toBe(true);
+      expect(result.warnings!.some((w: string) => w.includes("NONEXISTENT"))).toBe(true);
     });
 
     it("redaction scrubs secret values from output", () => {

--- a/src/security/masked-secrets/integration.test.ts
+++ b/src/security/masked-secrets/integration.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createMaskedSecrets } from "./index.js";
+
+/**
+ * Integration tests for masked-secrets wiring into exec/process pipelines.
+ * These test the MaskedSecrets facade end-to-end (preflight + redaction)
+ * as it would be used in bash-tools.exec.ts and bash-tools.process.ts.
+ */
+
+describe("MaskedSecrets integration", () => {
+  const TEST_SECRETS: Record<string, string> = {
+    TEST_API_KEY: "sk-ant-test-1234567890abcdef",
+    TEST_GITHUB_TOKEN: "ghp_test0123456789abcdef0123456789abcdef",
+    TEST_AWS_KEY: "AKIAIOSFODNN7EXAMPLE1",
+  };
+
+  function setupEnvAndCreate(): MaskedSecrets {
+    for (const [key, value] of Object.entries(TEST_SECRETS)) {
+      process.env[key] = value;
+    }
+    const ms = createMaskedSecrets({
+      enabled: true,
+      mask: Object.keys(TEST_SECRETS),
+      blockSecretFileReads: true,
+      secretFilePaths: [".env", "credentials.json"],
+    });
+    for (const key of Object.keys(TEST_SECRETS)) {
+      delete process.env[key];
+    }
+    return ms;
+  }
+
+  afterEach(() => {
+    for (const key of Object.keys(TEST_SECRETS)) {
+      delete process.env[key];
+    }
+  });
+
+  describe("exec pipeline simulation", () => {
+    it("preflight blocks env dump commands", () => {
+      const ms = setupEnvAndCreate();
+
+      const result = ms.preflight("env");
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBeDefined();
+    });
+
+    it("preflight blocks printenv", () => {
+      const ms = setupEnvAndCreate();
+
+      expect(ms.preflight("printenv").allowed).toBe(false);
+      expect(ms.preflight("export -p").allowed).toBe(false);
+    });
+
+    it("preflight blocks reading .env files", () => {
+      const ms = setupEnvAndCreate();
+
+      expect(ms.preflight("cat .env").allowed).toBe(false);
+      expect(ms.preflight("cat /app/.env").allowed).toBe(false);
+      expect(ms.preflight("less credentials.json").allowed).toBe(false);
+    });
+
+    it("preflight allows safe commands", () => {
+      const ms = setupEnvAndCreate();
+
+      const result = ms.preflight("ls -la");
+      expect(result.allowed).toBe(true);
+    });
+
+    it("preflight substitutes {{secret:NAME}} refs", () => {
+      const ms = setupEnvAndCreate();
+
+      const result = ms.preflight(
+        'curl -H "Authorization: Bearer {{secret:TEST_API_KEY}}" https://api.example.com',
+      );
+      expect(result.allowed).toBe(true);
+      expect(result.processedCommand).toContain("sk-ant-test-1234567890abcdef");
+      expect(result.processedCommand).not.toContain("{{secret:");
+    });
+
+    it("preflight substitutes multiple secrets in one command", () => {
+      const ms = setupEnvAndCreate();
+
+      const result = ms.preflight(
+        "GH_TOKEN={{secret:TEST_GITHUB_TOKEN}} AWS_KEY={{secret:TEST_AWS_KEY}} ./deploy.sh",
+      );
+      expect(result.allowed).toBe(true);
+      expect(result.processedCommand).toContain(TEST_SECRETS.TEST_GITHUB_TOKEN);
+      expect(result.processedCommand).toContain(TEST_SECRETS.TEST_AWS_KEY);
+    });
+
+    it("preflight warns about unknown secret references", () => {
+      const ms = setupEnvAndCreate();
+
+      const result = ms.preflight("curl -H '{{secret:NONEXISTENT}}'");
+      expect(result.allowed).toBe(true);
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings!.some((w) => w.includes("NONEXISTENT"))).toBe(true);
+    });
+
+    it("redaction scrubs secret values from output", () => {
+      const ms = setupEnvAndCreate();
+
+      const output = `API key is: sk-ant-test-1234567890abcdef\nGitHub: ghp_test0123456789abcdef0123456789abcdef`;
+      const result = ms.redact(output);
+
+      expect(result.text).not.toContain("sk-ant-test-1234567890abcdef");
+      expect(result.text).not.toContain("ghp_test0123456789abcdef0123456789abcdef");
+      expect(result.count).toBeGreaterThan(0);
+      expect(result.text).toContain("[REDACTED]");
+    });
+
+    it("redaction leaves clean output untouched", () => {
+      const ms = setupEnvAndCreate();
+
+      const output = "Hello, world!\nSuccess: 200 OK";
+      const result = ms.redact(output);
+
+      expect(result.text).toBe(output);
+      expect(result.count).toBe(0);
+    });
+
+    it("full exec flow: preflight + execute + redact", () => {
+      const ms = setupEnvAndCreate();
+
+      // Step 1: Preflight (substitute secrets in command)
+      const preflight = ms.preflight(
+        'curl -H "Auth: {{secret:TEST_API_KEY}}" https://api.test.com',
+      );
+      expect(preflight.allowed).toBe(true);
+      const realCommand = preflight.processedCommand!;
+      expect(realCommand).toContain("sk-ant-test-1234567890abcdef");
+
+      // Step 2: Simulate command output that accidentally leaks the secret
+      const simulatedOutput = `> GET /api HTTP/1.1
+> Host: api.test.com
+> Auth: sk-ant-test-1234567890abcdef
+< HTTP/1.1 200 OK
+{"status": "ok"}`;
+
+      // Step 3: Redact before returning to agent
+      const redacted = ms.redact(simulatedOutput);
+      expect(redacted.text).not.toContain("sk-ant-test-1234567890abcdef");
+      expect(redacted.text).toContain("[REDACTED]");
+      expect(redacted.text).toContain('{"status": "ok"}');
+    });
+  });
+
+  describe("process pipeline simulation (poll/log output)", () => {
+    it("redacts secrets from poll drain output", () => {
+      const ms = setupEnvAndCreate();
+
+      // Simulate what bash-tools.process.ts does on poll
+      const stdout = `Deploying with key sk-ant-test-1234567890abcdef...\nDone.`;
+      const stderr = "";
+      const output = [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n").trim();
+      const safeOutput = ms.redact(output).text;
+
+      expect(safeOutput).not.toContain("sk-ant-test-1234567890abcdef");
+      expect(safeOutput).toContain("Deploying with key");
+      expect(safeOutput).toContain("Done.");
+    });
+
+    it("redacts secrets from log slice output", () => {
+      const ms = setupEnvAndCreate();
+
+      const logSlice = `Line 1: normal output
+Line 2: token=ghp_test0123456789abcdef0123456789abcdef
+Line 3: continuing work
+Line 4: AWS key AKIAIOSFODNN7EXAMPLE1 used`;
+      const safeSlice = ms.redact(logSlice).text;
+
+      expect(safeSlice).not.toContain("ghp_test0123456789abcdef0123456789abcdef");
+      expect(safeSlice).not.toContain("AKIAIOSFODNN7EXAMPLE1");
+      expect(safeSlice).toContain("Line 1: normal output");
+      expect(safeSlice).toContain("Line 3: continuing work");
+    });
+
+    it("redacts from finished session tail", () => {
+      const ms = setupEnvAndCreate();
+
+      const tail = `Last 5 lines:\nConfig loaded with sk-ant-test-1234567890abcdef\nServer started on :8080`;
+      const safeTail = ms.redact(tail).text;
+
+      expect(safeTail).not.toContain("sk-ant-test-1234567890abcdef");
+      expect(safeTail).toContain("Server started on :8080");
+    });
+  });
+
+  describe("disabled mode", () => {
+    it("passes through everything when disabled", () => {
+      for (const [key, value] of Object.entries(TEST_SECRETS)) {
+        process.env[key] = value;
+      }
+      const ms = createMaskedSecrets({
+        enabled: false,
+        mask: Object.keys(TEST_SECRETS),
+      });
+      for (const key of Object.keys(TEST_SECRETS)) {
+        delete process.env[key];
+      }
+
+      // Preflight should allow everything
+      expect(ms.preflight("env").allowed).toBe(true);
+      expect(ms.preflight("cat .env").allowed).toBe(true);
+
+      // Redaction should be a no-op
+      const output = `secret: sk-ant-test-1234567890abcdef`;
+      expect(ms.redact(output).text).toBe(output);
+      expect(ms.redact(output).count).toBe(0);
+    });
+
+    it("isEnabled returns false when disabled", () => {
+      const ms = createMaskedSecrets({ enabled: false });
+      expect(ms.isEnabled()).toBe(false);
+    });
+  });
+
+  describe("listSecretNames", () => {
+    it("returns configured secret names without values", () => {
+      const ms = setupEnvAndCreate();
+      const names = ms.listSecretNames();
+
+      expect(names).toContain("TEST_API_KEY");
+      expect(names).toContain("TEST_GITHUB_TOKEN");
+      expect(names).toContain("TEST_AWS_KEY");
+      // Must not contain actual values
+      expect(names.join(",")).not.toContain("sk-ant-");
+      expect(names.join(",")).not.toContain("ghp_");
+    });
+  });
+
+  describe("config schema integration", () => {
+    it("creates instance from config-shaped object", () => {
+      // Simulate what pi-tools.ts does: extract config and create instance
+      const config = {
+        security: {
+          maskedSecrets: {
+            enabled: true,
+            mask: ["SOME_KEY"],
+            blockSecretFileReads: true,
+          },
+        },
+      };
+
+      const maskedSecretsConfig = (config as Record<string, unknown>).security as
+        | { maskedSecrets?: Record<string, unknown> }
+        | undefined;
+
+      expect(maskedSecretsConfig?.maskedSecrets).toBeDefined();
+      const ms = createMaskedSecrets(maskedSecretsConfig!.maskedSecrets);
+      expect(ms.isEnabled()).toBe(true);
+    });
+
+    it("handles missing security config gracefully", () => {
+      const config = {};
+      const maskedSecretsConfig = (config as Record<string, unknown>).security as
+        | { maskedSecrets?: Record<string, unknown> }
+        | undefined;
+
+      expect(maskedSecretsConfig).toBeUndefined();
+      // This is the path pi-tools.ts takes — no MaskedSecrets created
+    });
+  });
+
+  describe("system prompt integration", () => {
+    it("listSecretNames provides names for system prompt", () => {
+      const ms = setupEnvAndCreate();
+      const names = ms.listSecretNames();
+
+      // Simulate what system-prompt.ts does
+      const promptSection = `Available secrets: ${names.join(", ")}`;
+      expect(promptSection).toContain("TEST_API_KEY");
+      expect(promptSection).toContain("TEST_GITHUB_TOKEN");
+      expect(promptSection).not.toContain("sk-ant-");
+    });
+  });
+
+  describe("pattern-based redaction (defense in depth)", () => {
+    it("catches common API key patterns even without explicit config", () => {
+      const ms = createMaskedSecrets({ enabled: true, mask: [] });
+
+      // These should be caught by built-in patterns
+      const output = `Found key: sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890`;
+      const result = ms.redact(output);
+
+      // Pattern-based redaction should catch sk-ant- prefix
+      expect(result.text).not.toContain("sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890");
+    });
+
+    it("catches GitHub token patterns", () => {
+      const ms = createMaskedSecrets({ enabled: true, mask: [] });
+
+      const output = `token=ghp_abcdefghijklmnopqrstuvwxyz1234567890`;
+      const result = ms.redact(output);
+
+      expect(result.text).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz1234567890");
+    });
+
+    it("catches AWS key patterns", () => {
+      const ms = createMaskedSecrets({ enabled: true, mask: [] });
+
+      const output = `AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE2`;
+      const result = ms.redact(output);
+
+      expect(result.text).not.toContain("AKIAIOSFODNN7EXAMPLE2");
+    });
+  });
+});

--- a/src/security/masked-secrets/preflight.test.ts
+++ b/src/security/masked-secrets/preflight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { SecretStore } from "./secret-store.js";
 import { preflightCheck } from "./preflight.js";
+import { SecretStore } from "./secret-store.js";
 
 describe("preflightCheck", () => {
   function makeStore(
@@ -85,10 +85,7 @@ describe("preflightCheck", () => {
     });
 
     it("respects blockSecretFileReads=false", () => {
-      const store = makeStore(
-        { KEY: "secret-value-123456" },
-        { blockSecretFileReads: false },
-      );
+      const store = makeStore({ KEY: "secret-value-123456" }, { blockSecretFileReads: false });
       const result = preflightCheck("cat .env", store);
 
       expect(result.allowed).toBe(true);
@@ -111,10 +108,7 @@ describe("preflightCheck", () => {
 
     it("warns about missing secret references", () => {
       const store = makeStore({});
-      const result = preflightCheck(
-        "curl -H '{{secret:UNKNOWN}}'",
-        store,
-      );
+      const result = preflightCheck("curl -H '{{secret:UNKNOWN}}'", store);
 
       expect(result.allowed).toBe(true);
       expect(result.warnings).toBeDefined();

--- a/src/security/masked-secrets/preflight.test.ts
+++ b/src/security/masked-secrets/preflight.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { SecretStore } from "./secret-store.js";
+import { preflightCheck } from "./preflight.js";
+
+describe("preflightCheck", () => {
+  function makeStore(
+    secrets: Record<string, string>,
+    opts?: { blockSecretFileReads?: boolean },
+  ): SecretStore {
+    const store = new SecretStore({
+      mask: Object.keys(secrets),
+      blockSecretFileReads: opts?.blockSecretFileReads ?? true,
+      secretFilePaths: [".env", "credentials.json", "auth-profiles.json"],
+    });
+    for (const [key, value] of Object.entries(secrets)) {
+      process.env[key] = value;
+    }
+    store.load();
+    for (const key of Object.keys(secrets)) {
+      delete process.env[key];
+    }
+    return store;
+  }
+
+  describe("env dump blocking", () => {
+    it("blocks standalone 'env' command", () => {
+      const store = makeStore({ KEY: "secret-value-123456" });
+      const result = preflightCheck("env", store);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("environment variables");
+    });
+
+    it("blocks 'printenv'", () => {
+      const store = makeStore({ KEY: "secret-value-123456" });
+      const result = preflightCheck("printenv", store);
+
+      expect(result.allowed).toBe(false);
+    });
+
+    it("blocks 'export -p'", () => {
+      const store = makeStore({ KEY: "secret-value-123456" });
+      const result = preflightCheck("export -p", store);
+
+      expect(result.allowed).toBe(false);
+    });
+
+    it("allows 'env' as part of a longer command (env VAR=val cmd)", () => {
+      const store = makeStore({ KEY: "secret-value-123456" });
+      const result = preflightCheck("env FOO=bar python script.py", store);
+
+      // "env FOO=bar python script.py" does NOT match "^\s*env\s*$"
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe("secret file read blocking", () => {
+    it("blocks 'cat .env'", () => {
+      const store = makeStore({ KEY: "secret-value-123456" });
+      const result = preflightCheck("cat .env", store);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("secrets");
+    });
+
+    it("blocks 'cat ~/.openclaw/.env'", () => {
+      const store = makeStore({ KEY: "secret-value-123456" });
+      const result = preflightCheck("cat ~/.openclaw/.env", store);
+
+      expect(result.allowed).toBe(false);
+    });
+
+    it("blocks 'less credentials.json'", () => {
+      const store = makeStore({ KEY: "secret-value-123456" });
+      const result = preflightCheck("less credentials.json", store);
+
+      expect(result.allowed).toBe(false);
+    });
+
+    it("allows reading non-secret files", () => {
+      const store = makeStore({ KEY: "secret-value-123456" });
+      const result = preflightCheck("cat README.md", store);
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("respects blockSecretFileReads=false", () => {
+      const store = makeStore(
+        { KEY: "secret-value-123456" },
+        { blockSecretFileReads: false },
+      );
+      const result = preflightCheck("cat .env", store);
+
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe("secret substitution", () => {
+    it("substitutes {{secret:NAME}} in allowed commands", () => {
+      const store = makeStore({ MY_KEY: "real-api-key-12345" });
+      const result = preflightCheck(
+        'curl -H "Auth: {{secret:MY_KEY}}" https://api.example.com',
+        store,
+      );
+
+      expect(result.allowed).toBe(true);
+      expect(result.processedCommand).toBe(
+        'curl -H "Auth: real-api-key-12345" https://api.example.com',
+      );
+    });
+
+    it("warns about missing secret references", () => {
+      const store = makeStore({});
+      const result = preflightCheck(
+        "curl -H '{{secret:UNKNOWN}}'",
+        store,
+      );
+
+      expect(result.allowed).toBe(true);
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings!.length).toBeGreaterThan(0);
+      expect(result.warnings![0]).toContain("Unknown secret");
+    });
+  });
+
+  describe("env var echo detection", () => {
+    it("warns when command references masked env vars with $", () => {
+      const store = makeStore({ SECRET_KEY: "my-secret-12345678" });
+      const result = preflightCheck("echo $SECRET_KEY", store);
+
+      expect(result.allowed).toBe(true); // Warn, don't block
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings!.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/security/masked-secrets/preflight.ts
+++ b/src/security/masked-secrets/preflight.ts
@@ -41,10 +41,7 @@ function buildEnvEchoPattern(secretNames: string[]): RegExp | null {
   }
   const names = secretNames.map((n) => escapeRegex(n)).join("|");
   // Match: echo $NAME, echo ${NAME}, printf ... $NAME, etc.
-  return new RegExp(
-    `\\$\\{?(${names})\\}?`,
-    "g",
-  );
+  return new RegExp(`\\$\\{?(${names})\\}?`, "g");
 }
 
 /**
@@ -64,10 +61,7 @@ const FILE_READ_COMMANDS = [
   "code",
 ];
 
-function isSecretFileRead(
-  command: string,
-  secretFilePaths: string[],
-): boolean {
+function isSecretFileRead(command: string, secretFilePaths: string[]): boolean {
   const lowerCmd = command.toLowerCase().trim();
 
   for (const readCmd of FILE_READ_COMMANDS) {
@@ -78,9 +72,7 @@ function isSecretFileRead(
     for (const secretPath of secretFilePaths) {
       // Handle glob patterns
       if (secretPath.includes("*")) {
-        const regex = new RegExp(
-          secretPath.replace(/\./g, "\\.").replace(/\*/g, ".*"),
-        );
+        const regex = new RegExp(secretPath.replace(/\./g, "\\.").replace(/\*/g, ".*"));
         if (regex.test(lowerCmd)) {
           return true;
         }
@@ -97,10 +89,7 @@ function isSecretFileRead(
  * Run preflight checks on a command before execution.
  * Returns whether the command is allowed and the processed command.
  */
-export function preflightCheck(
-  command: string,
-  store: SecretStore,
-): PreflightResult {
+export function preflightCheck(command: string, store: SecretStore): PreflightResult {
   const config = store.getConfig();
   const warnings: string[] = [];
 
@@ -137,28 +126,23 @@ export function preflightCheck(
     // or the agent might be doing something legitimate
     warnings.push(
       "Command references masked environment variables directly. " +
-      "Consider using {{secret:NAME}} syntax instead for better security.",
+        "Consider using {{secret:NAME}} syntax instead for better security.",
     );
-    log.warn(
-      `Command references masked env vars: ${command.slice(0, 80)}`,
-    );
+    log.warn(`Command references masked env vars: ${command.slice(0, 80)}`);
   }
 
   // Check 4: Substitute {{secret:NAME}} references
-  const { text: processedCommand, substituted, missing } =
-    substituteSecrets(command, store);
+  const { text: processedCommand, substituted, missing } = substituteSecrets(command, store);
 
   if (missing.length > 0) {
     warnings.push(
       `Unknown secret reference(s): ${missing.join(", ")}. ` +
-      `Available secrets: ${store.listNames().join(", ")}`,
+        `Available secrets: ${store.listNames().join(", ")}`,
     );
   }
 
   if (substituted.length > 0) {
-    log.info(
-      `Substituted ${substituted.length} secret(s) in command: ${substituted.join(", ")}`,
-    );
+    log.info(`Substituted ${substituted.length} secret(s) in command: ${substituted.join(", ")}`);
   }
 
   return {

--- a/src/security/masked-secrets/preflight.ts
+++ b/src/security/masked-secrets/preflight.ts
@@ -1,0 +1,173 @@
+/**
+ * Masked Secrets — Command Preflight Checks
+ *
+ * Before a shell command executes, the preflight checker:
+ * 1. Blocks commands that dump environment variables (env, printenv, export, set)
+ * 2. Blocks direct reads of known secret files (cat .env, less credentials.json)
+ * 3. Blocks echo/printf of env vars that are masked ($SECRET, ${SECRET})
+ * 4. Substitutes {{secret:NAME}} references with real values
+ * 5. Returns the processed command or a rejection
+ */
+
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { SecretStore } from "./secret-store.js";
+import { substituteSecrets } from "./substitution.js";
+import type { PreflightResult } from "./types.js";
+
+const log = createSubsystemLogger("security/masked-secrets");
+
+/**
+ * Patterns that match commands which dump the full environment.
+ * These are blocked entirely — there's no safe way to filter them.
+ */
+const ENV_DUMP_PATTERNS: RegExp[] = [
+  // Standalone env/printenv/set/export commands
+  /^\s*(env|printenv)\s*$/,
+  /^\s*set\s*$/,
+  /^\s*export\s+-p\s*$/,
+  /^\s*export\s*$/,
+  // Python/Node/Ruby one-liners that print env
+  /\bos\.environ\b/,
+  /\bprocess\.env\b/,
+];
+
+/**
+ * Patterns matching commands that try to read/echo specific secret env vars.
+ * e.g., "echo $MY_API_KEY", "printf '%s' ${SECRET}"
+ */
+function buildEnvEchoPattern(secretNames: string[]): RegExp | null {
+  if (secretNames.length === 0) {
+    return null;
+  }
+  const names = secretNames.map((n) => escapeRegex(n)).join("|");
+  // Match: echo $NAME, echo ${NAME}, printf ... $NAME, etc.
+  return new RegExp(
+    `\\$\\{?(${names})\\}?`,
+    "g",
+  );
+}
+
+/**
+ * Patterns matching direct reads of secret files.
+ * e.g., "cat .env", "less ~/.openclaw/.env", "head credentials.json"
+ */
+const FILE_READ_COMMANDS = [
+  "cat",
+  "less",
+  "more",
+  "head",
+  "tail",
+  "bat",
+  "view",
+  "vim",
+  "nano",
+  "code",
+];
+
+function isSecretFileRead(
+  command: string,
+  secretFilePaths: string[],
+): boolean {
+  const lowerCmd = command.toLowerCase().trim();
+
+  for (const readCmd of FILE_READ_COMMANDS) {
+    if (!lowerCmd.startsWith(readCmd)) {
+      continue;
+    }
+
+    for (const secretPath of secretFilePaths) {
+      // Handle glob patterns
+      if (secretPath.includes("*")) {
+        const regex = new RegExp(
+          secretPath.replace(/\./g, "\\.").replace(/\*/g, ".*"),
+        );
+        if (regex.test(lowerCmd)) {
+          return true;
+        }
+      } else if (lowerCmd.includes(secretPath.toLowerCase())) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Run preflight checks on a command before execution.
+ * Returns whether the command is allowed and the processed command.
+ */
+export function preflightCheck(
+  command: string,
+  store: SecretStore,
+): PreflightResult {
+  const config = store.getConfig();
+  const warnings: string[] = [];
+
+  // Check 1: Block env dump commands
+  for (const pattern of ENV_DUMP_PATTERNS) {
+    if (pattern.test(command)) {
+      log.warn(`Blocked env dump command: ${command.slice(0, 80)}`);
+      return {
+        allowed: false,
+        reason:
+          "This command would expose environment variables containing secrets. " +
+          "Use {{secret:NAME}} to reference secrets in your commands instead.",
+      };
+    }
+  }
+
+  // Check 2: Block reading of secret files
+  if (config.blockSecretFileReads) {
+    if (isSecretFileRead(command, config.secretFilePaths ?? [])) {
+      log.warn(`Blocked secret file read: ${command.slice(0, 80)}`);
+      return {
+        allowed: false,
+        reason:
+          "This file contains secrets and cannot be read directly. " +
+          "Use {{secret:NAME}} to reference specific secrets.",
+      };
+    }
+  }
+
+  // Check 3: Detect and warn about $SECRET references
+  const echoPattern = buildEnvEchoPattern(store.listNames());
+  if (echoPattern && echoPattern.test(command)) {
+    // Don't block, but warn — the env var might be filtered by the shell
+    // or the agent might be doing something legitimate
+    warnings.push(
+      "Command references masked environment variables directly. " +
+      "Consider using {{secret:NAME}} syntax instead for better security.",
+    );
+    log.warn(
+      `Command references masked env vars: ${command.slice(0, 80)}`,
+    );
+  }
+
+  // Check 4: Substitute {{secret:NAME}} references
+  const { text: processedCommand, substituted, missing } =
+    substituteSecrets(command, store);
+
+  if (missing.length > 0) {
+    warnings.push(
+      `Unknown secret reference(s): ${missing.join(", ")}. ` +
+      `Available secrets: ${store.listNames().join(", ")}`,
+    );
+  }
+
+  if (substituted.length > 0) {
+    log.info(
+      `Substituted ${substituted.length} secret(s) in command: ${substituted.join(", ")}`,
+    );
+  }
+
+  return {
+    allowed: true,
+    processedCommand,
+    warnings,
+  };
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/security/masked-secrets/redaction.test.ts
+++ b/src/security/masked-secrets/redaction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { SecretStore } from "./secret-store.js";
 import { redactOutput } from "./redaction.js";
+import { SecretStore } from "./secret-store.js";
 
 describe("redactOutput", () => {
   function makeStore(secrets: Record<string, string>): SecretStore {
@@ -25,9 +25,7 @@ describe("redactOutput", () => {
         store,
       );
 
-      expect(result.text).toBe(
-        'Response: {"key": "[REDACTED]", "status": "ok"}',
-      );
+      expect(result.text).toBe('Response: {"key": "[REDACTED]", "status": "ok"}');
       expect(result.count).toBeGreaterThan(0);
       expect(result.redactedSecrets).toContain("API_KEY");
     });
@@ -50,10 +48,7 @@ describe("redactOutput", () => {
         SHORT: "secret-12345678",
         LONG: "secret-1234567890abcdef",
       });
-      const result = redactOutput(
-        "the value is secret-1234567890abcdef here",
-        store,
-      );
+      const result = redactOutput("the value is secret-1234567890abcdef here", store);
 
       expect(result.text).toBe("the value is [REDACTED] here");
     });
@@ -70,10 +65,7 @@ describe("redactOutput", () => {
   describe("pattern-based redaction", () => {
     it("redacts Anthropic API keys", () => {
       const store = makeStore({});
-      const result = redactOutput(
-        "key: sk-ant-api03-abcdefghijklmnopqrstuvwxyz",
-        store,
-      );
+      const result = redactOutput("key: sk-ant-api03-abcdefghijklmnopqrstuvwxyz", store);
 
       expect(result.text).toContain("[REDACTED]");
       expect(result.text).not.toContain("sk-ant-");
@@ -81,10 +73,7 @@ describe("redactOutput", () => {
 
     it("redacts GitHub tokens", () => {
       const store = makeStore({});
-      const result = redactOutput(
-        "token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-        store,
-      );
+      const result = redactOutput("token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", store);
 
       expect(result.text).toContain("[REDACTED]");
       expect(result.text).not.toContain("ghp_");
@@ -92,10 +81,7 @@ describe("redactOutput", () => {
 
     it("redacts AWS access keys", () => {
       const store = makeStore({});
-      const result = redactOutput(
-        "aws_key: AKIAIOSFODNN7EXAMPLE",
-        store,
-      );
+      const result = redactOutput("aws_key: AKIAIOSFODNN7EXAMPLE", store);
 
       expect(result.text).toContain("[REDACTED]");
       expect(result.text).not.toContain("AKIA");
@@ -103,14 +89,9 @@ describe("redactOutput", () => {
 
     it("does not redact normal text", () => {
       const store = makeStore({});
-      const result = redactOutput(
-        "Hello, this is normal output with no secrets",
-        store,
-      );
+      const result = redactOutput("Hello, this is normal output with no secrets", store);
 
-      expect(result.text).toBe(
-        "Hello, this is normal output with no secrets",
-      );
+      expect(result.text).toBe("Hello, this is normal output with no secrets");
       expect(result.count).toBe(0);
     });
   });

--- a/src/security/masked-secrets/redaction.test.ts
+++ b/src/security/masked-secrets/redaction.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { SecretStore } from "./secret-store.js";
+import { redactOutput } from "./redaction.js";
+
+describe("redactOutput", () => {
+  function makeStore(secrets: Record<string, string>): SecretStore {
+    const store = new SecretStore({ mask: Object.keys(secrets) });
+    for (const [key, value] of Object.entries(secrets)) {
+      process.env[key] = value;
+    }
+    store.load();
+    for (const key of Object.keys(secrets)) {
+      delete process.env[key];
+    }
+    return store;
+  }
+
+  describe("exact value redaction", () => {
+    it("redacts known secret values from output", () => {
+      const store = makeStore({
+        API_KEY: "sk-very-secret-key-12345678",
+      });
+      const result = redactOutput(
+        'Response: {"key": "sk-very-secret-key-12345678", "status": "ok"}',
+        store,
+      );
+
+      expect(result.text).toBe(
+        'Response: {"key": "[REDACTED]", "status": "ok"}',
+      );
+      expect(result.count).toBeGreaterThan(0);
+      expect(result.redactedSecrets).toContain("API_KEY");
+    });
+
+    it("redacts multiple occurrences of the same secret", () => {
+      const store = makeStore({
+        TOKEN: "my-secret-token-value-1234",
+      });
+      const result = redactOutput(
+        "token=my-secret-token-value-1234 also my-secret-token-value-1234",
+        store,
+      );
+
+      expect(result.text).toBe("token=[REDACTED] also [REDACTED]");
+      expect(result.count).toBe(2);
+    });
+
+    it("redacts longest values first to avoid partial matches", () => {
+      const store = makeStore({
+        SHORT: "secret-12345678",
+        LONG: "secret-1234567890abcdef",
+      });
+      const result = redactOutput(
+        "the value is secret-1234567890abcdef here",
+        store,
+      );
+
+      expect(result.text).toBe("the value is [REDACTED] here");
+    });
+
+    it("does not redact very short values (< 8 chars)", () => {
+      const store = makeStore({ SHORT: "abc" });
+      const result = redactOutput("abc is in the output", store);
+
+      // Short values are excluded by getValues()
+      expect(result.text).toBe("abc is in the output");
+    });
+  });
+
+  describe("pattern-based redaction", () => {
+    it("redacts Anthropic API keys", () => {
+      const store = makeStore({});
+      const result = redactOutput(
+        "key: sk-ant-api03-abcdefghijklmnopqrstuvwxyz",
+        store,
+      );
+
+      expect(result.text).toContain("[REDACTED]");
+      expect(result.text).not.toContain("sk-ant-");
+    });
+
+    it("redacts GitHub tokens", () => {
+      const store = makeStore({});
+      const result = redactOutput(
+        "token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+        store,
+      );
+
+      expect(result.text).toContain("[REDACTED]");
+      expect(result.text).not.toContain("ghp_");
+    });
+
+    it("redacts AWS access keys", () => {
+      const store = makeStore({});
+      const result = redactOutput(
+        "aws_key: AKIAIOSFODNN7EXAMPLE",
+        store,
+      );
+
+      expect(result.text).toContain("[REDACTED]");
+      expect(result.text).not.toContain("AKIA");
+    });
+
+    it("does not redact normal text", () => {
+      const store = makeStore({});
+      const result = redactOutput(
+        "Hello, this is normal output with no secrets",
+        store,
+      );
+
+      expect(result.text).toBe(
+        "Hello, this is normal output with no secrets",
+      );
+      expect(result.count).toBe(0);
+    });
+  });
+});

--- a/src/security/masked-secrets/redaction.ts
+++ b/src/security/masked-secrets/redaction.ts
@@ -112,7 +112,7 @@ function compileCustomPatterns(patterns: string[]): RegExp[] {
     try {
       compiled.push(new RegExp(pattern, "g"));
     } catch (err) {
-      log.warn(`Invalid output redaction pattern: ${pattern}`, err);
+      log.warn(`Invalid output redaction pattern: ${pattern}`, err as Record<string, unknown>);
     }
   }
   return compiled;

--- a/src/security/masked-secrets/redaction.ts
+++ b/src/security/masked-secrets/redaction.ts
@@ -46,10 +46,7 @@ const BUILT_IN_PATTERNS: RegExp[] = [
 /**
  * Redact known secret values and common patterns from text.
  */
-export function redactOutput(
-  text: string,
-  store: SecretStore,
-): RedactionResult {
+export function redactOutput(text: string, store: SecretStore): RedactionResult {
   let result = text;
   let count = 0;
   const redactedSecrets: string[] = [];

--- a/src/security/masked-secrets/redaction.ts
+++ b/src/security/masked-secrets/redaction.ts
@@ -1,0 +1,122 @@
+/**
+ * Masked Secrets — Output Redaction
+ *
+ * Scans command output (stdout/stderr) for leaked secret values and
+ * replaces them with [REDACTED]. This is the safety net — if a secret
+ * somehow appears in output (e.g., a program prints its config, an error
+ * message includes the key), the agent never sees the real value.
+ *
+ * Strategy:
+ * 1. Exact match: replace known secret values (longest-first to avoid partials)
+ * 2. Pattern match: catch common API key formats that might not be in the store
+ *    (e.g., sk-ant-..., sk-..., ghp_..., etc.)
+ */
+
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { SecretStore } from "./secret-store.js";
+import type { RedactionResult } from "./types.js";
+
+const log = createSubsystemLogger("security/masked-secrets");
+
+const REDACTED_PLACEHOLDER = "[REDACTED]";
+
+/**
+ * Well-known API key patterns. These catch secrets even if they're not
+ * in the store (e.g., printed by a third-party tool).
+ */
+const BUILT_IN_PATTERNS: RegExp[] = [
+  // Anthropic
+  /sk-ant-[A-Za-z0-9_-]{20,}/g,
+  // OpenAI
+  /sk-[A-Za-z0-9]{32,}/g,
+  // GitHub tokens
+  /gh[ps]_[A-Za-z0-9]{36,}/g,
+  /github_pat_[A-Za-z0-9_]{20,}/g,
+  // AWS
+  /AKIA[A-Z0-9]{16}/g,
+  // Stripe
+  /sk_live_[A-Za-z0-9]{24,}/g,
+  /sk_test_[A-Za-z0-9]{24,}/g,
+  // Slack
+  /xox[bpras]-[A-Za-z0-9-]{10,}/g,
+  // Generic bearer tokens (very long base64-like strings after "Bearer ")
+  /Bearer\s+[A-Za-z0-9+/=_-]{40,}/g,
+];
+
+/**
+ * Redact known secret values and common patterns from text.
+ */
+export function redactOutput(
+  text: string,
+  store: SecretStore,
+): RedactionResult {
+  let result = text;
+  let count = 0;
+  const redactedSecrets: string[] = [];
+
+  // Phase 1: Exact value replacement (longest first)
+  const values = store.getValues();
+  values.sort((a, b) => b.length - a.length);
+
+  for (const value of values) {
+    if (result.includes(value)) {
+      const occurrences = result.split(value).length - 1;
+      result = result.replaceAll(value, REDACTED_PLACEHOLDER);
+      count += occurrences;
+
+      // Find which secret this value belongs to
+      for (const name of store.listNames()) {
+        if (store.resolve(name) === value) {
+          redactedSecrets.push(name);
+          break;
+        }
+      }
+    }
+  }
+
+  // Phase 2: Pattern-based redaction
+  const allPatterns = [
+    ...BUILT_IN_PATTERNS,
+    ...compileCustomPatterns(store.getConfig().outputPatterns ?? []),
+  ];
+
+  for (const pattern of allPatterns) {
+    // Reset lastIndex for global patterns
+    pattern.lastIndex = 0;
+    const matches = result.match(pattern);
+    if (matches) {
+      for (const match of matches) {
+        // Don't double-redact already-redacted text
+        if (match.includes(REDACTED_PLACEHOLDER)) {
+          continue;
+        }
+        result = result.replaceAll(match, REDACTED_PLACEHOLDER);
+        count++;
+      }
+    }
+  }
+
+  if (count > 0) {
+    log.warn(
+      `Redacted ${count} secret occurrence(s) from output (${redactedSecrets.length} known secrets)`,
+    );
+  }
+
+  return { text: result, count, redactedSecrets };
+}
+
+/**
+ * Compile user-provided regex strings into RegExp objects.
+ * Invalid patterns are logged and skipped.
+ */
+function compileCustomPatterns(patterns: string[]): RegExp[] {
+  const compiled: RegExp[] = [];
+  for (const pattern of patterns) {
+    try {
+      compiled.push(new RegExp(pattern, "g"));
+    } catch (err) {
+      log.warn(`Invalid output redaction pattern: ${pattern}`, err);
+    }
+  }
+  return compiled;
+}

--- a/src/security/masked-secrets/secret-store.test.ts
+++ b/src/security/masked-secrets/secret-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { SecretStore } from "./secret-store.js";
 
 describe("SecretStore", () => {

--- a/src/security/masked-secrets/secret-store.test.ts
+++ b/src/security/masked-secrets/secret-store.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SecretStore } from "./secret-store.js";
+
+describe("SecretStore", () => {
+  let store: SecretStore;
+
+  describe("auto-detection mode (empty mask list)", () => {
+    beforeEach(() => {
+      store = new SecretStore({ mask: [] });
+    });
+
+    it("detects common API key env var names", () => {
+      process.env.OPENAI_API_KEY = "sk-test-1234567890";
+      process.env.GITHUB_TOKEN = "ghp_abc123";
+      process.env.SOME_NORMAL_VAR = "not-a-secret";
+
+      store.load();
+
+      expect(store.has("OPENAI_API_KEY")).toBe(true);
+      expect(store.has("GITHUB_TOKEN")).toBe(true);
+      expect(store.has("SOME_NORMAL_VAR")).toBe(false);
+
+      delete process.env.OPENAI_API_KEY;
+      delete process.env.GITHUB_TOKEN;
+      delete process.env.SOME_NORMAL_VAR;
+    });
+
+    it("detects *_SECRET, *_PASSWORD, *_TOKEN patterns", () => {
+      process.env.MY_APP_SECRET = "supersecret";
+      process.env.DB_PASSWORD = "hunter2";
+      process.env.AUTH_TOKEN = "tok_123";
+
+      store.load();
+
+      expect(store.has("MY_APP_SECRET")).toBe(true);
+      expect(store.has("DB_PASSWORD")).toBe(true);
+      expect(store.has("AUTH_TOKEN")).toBe(true);
+
+      delete process.env.MY_APP_SECRET;
+      delete process.env.DB_PASSWORD;
+      delete process.env.AUTH_TOKEN;
+    });
+  });
+
+  describe("explicit mask list", () => {
+    beforeEach(() => {
+      store = new SecretStore({ mask: ["MY_KEY", "CUSTOM_*"] });
+    });
+
+    it("masks explicitly named secrets", () => {
+      process.env.MY_KEY = "secret-value";
+      process.env.UNMASKED = "visible";
+
+      store.load();
+
+      expect(store.has("MY_KEY")).toBe(true);
+      expect(store.has("UNMASKED")).toBe(false);
+
+      delete process.env.MY_KEY;
+      delete process.env.UNMASKED;
+    });
+
+    it("supports glob patterns", () => {
+      process.env.CUSTOM_API_KEY = "key1";
+      process.env.CUSTOM_SECRET = "key2";
+      process.env.OTHER_KEY = "key3";
+
+      store.load();
+
+      expect(store.has("CUSTOM_API_KEY")).toBe(true);
+      expect(store.has("CUSTOM_SECRET")).toBe(true);
+      expect(store.has("OTHER_KEY")).toBe(false);
+
+      delete process.env.CUSTOM_API_KEY;
+      delete process.env.CUSTOM_SECRET;
+      delete process.env.OTHER_KEY;
+    });
+  });
+
+  describe("resolve", () => {
+    it("returns the secret value for known secrets", () => {
+      store = new SecretStore({ mask: ["TEST_SECRET"] });
+      process.env.TEST_SECRET = "my-secret-value";
+
+      store.load();
+
+      expect(store.resolve("TEST_SECRET")).toBe("my-secret-value");
+
+      delete process.env.TEST_SECRET;
+    });
+
+    it("returns undefined for unknown secrets", () => {
+      store = new SecretStore({ mask: [] });
+      store.load();
+
+      expect(store.resolve("NONEXISTENT")).toBeUndefined();
+    });
+  });
+
+  describe("getValues", () => {
+    it("excludes very short values (< 8 chars) to prevent false positives", () => {
+      store = new SecretStore({ mask: ["SHORT", "LONG"] });
+      process.env.SHORT = "abc";
+      process.env.LONG = "this-is-a-long-secret-value";
+
+      store.load();
+
+      const values = store.getValues();
+      expect(values).toContain("this-is-a-long-secret-value");
+      expect(values).not.toContain("abc");
+
+      delete process.env.SHORT;
+      delete process.env.LONG;
+    });
+  });
+
+  describe("disabled mode", () => {
+    it("loads nothing when disabled", () => {
+      store = new SecretStore({ enabled: false, mask: ["ANYTHING"] });
+      process.env.ANYTHING = "secret";
+
+      store.load();
+
+      expect(store.listNames()).toHaveLength(0);
+
+      delete process.env.ANYTHING;
+    });
+  });
+});

--- a/src/security/masked-secrets/secret-store.ts
+++ b/src/security/masked-secrets/secret-store.ts
@@ -24,13 +24,13 @@ const log = createSubsystemLogger("security/masked-secrets");
  * Used for auto-detection when config.mask is empty.
  */
 const AUTO_DETECT_PATTERNS = [
-  /^[A-Z_]*API[_]?KEY$/i,
-  /^[A-Z_]*SECRET$/i,
-  /^[A-Z_]*TOKEN$/i,
-  /^[A-Z_]*PASSWORD$/i,
-  /^[A-Z_]*CREDENTIALS?$/i,
-  /^[A-Z_]*AUTH$/i,
-  /^[A-Z_]*PRIVATE[_]?KEY$/i,
+  /^[A-Z_]+API[_]?KEY$/i,
+  /^[A-Z_]+SECRET$/i,
+  /^[A-Z_]+TOKEN$/i,
+  /^[A-Z_]+PASSWORD$/i,
+  /^[A-Z_]+CREDENTIALS?$/i,
+  /^[A-Z_]+AUTH$/i,
+  /^[A-Z_]+PRIVATE[_]?KEY$/i,
   // Common specific keys
   /^OPENAI_API_KEY$/,
   /^ANTHROPIC_API_KEY$/,

--- a/src/security/masked-secrets/secret-store.ts
+++ b/src/security/masked-secrets/secret-store.ts
@@ -53,12 +53,7 @@ export class SecretStore {
       enabled: config?.enabled ?? true,
       mask: config?.mask ?? [],
       outputPatterns: config?.outputPatterns ?? [],
-      blockedCommands: config?.blockedCommands ?? [
-        "env",
-        "printenv",
-        "set",
-        "export",
-      ],
+      blockedCommands: config?.blockedCommands ?? ["env", "printenv", "set", "export"],
       blockSecretFileReads: config?.blockSecretFileReads ?? true,
       secretFilePaths: config?.secretFilePaths ?? [
         ".env",
@@ -123,10 +118,7 @@ export class SecretStore {
     if (this.config.mask.length > 0) {
       return this.config.mask.some((pattern) => {
         if (pattern.includes("*")) {
-          const regex = new RegExp(
-            `^${pattern.replace(/\*/g, ".*")}$`,
-            "i",
-          );
+          const regex = new RegExp(`^${pattern.replace(/\*/g, ".*")}$`, "i");
           return regex.test(name);
         }
         return pattern === name;

--- a/src/security/masked-secrets/secret-store.ts
+++ b/src/security/masked-secrets/secret-store.ts
@@ -1,0 +1,173 @@
+/**
+ * Masked Secrets — Secret Store
+ *
+ * Loads, stores, and manages masked secrets. Secrets are loaded from:
+ * 1. ~/.openclaw/.env (dotenv file)
+ * 2. Process environment variables matching configured patterns
+ * 3. Config file (openclaw.json secrets section)
+ *
+ * The store holds the real values but never exposes them to the agent.
+ * Only the gateway/runtime can access real values for substitution.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import dotenv from "dotenv";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveConfigDir } from "../../utils.js";
+import type { MaskedSecret, MaskedSecretsConfig } from "./types.js";
+
+const log = createSubsystemLogger("security/masked-secrets");
+
+/**
+ * Well-known env var patterns that typically contain secrets.
+ * Used for auto-detection when config.mask is empty.
+ */
+const AUTO_DETECT_PATTERNS = [
+  /^[A-Z_]*API[_]?KEY$/i,
+  /^[A-Z_]*SECRET$/i,
+  /^[A-Z_]*TOKEN$/i,
+  /^[A-Z_]*PASSWORD$/i,
+  /^[A-Z_]*CREDENTIALS?$/i,
+  /^[A-Z_]*AUTH$/i,
+  /^[A-Z_]*PRIVATE[_]?KEY$/i,
+  // Common specific keys
+  /^OPENAI_API_KEY$/,
+  /^ANTHROPIC_API_KEY$/,
+  /^GOOGLE_API_KEY$/,
+  /^GITHUB_TOKEN$/,
+  /^GITHUB_PAT$/,
+  /^AWS_SECRET_ACCESS_KEY$/,
+  /^AWS_SESSION_TOKEN$/,
+  /^BRAVE_API_KEY$/,
+  /^FIRECRAWL_API_KEY$/,
+  /^ELEVENLABS_API_KEY$/,
+];
+
+export class SecretStore {
+  private secrets: Map<string, MaskedSecret> = new Map();
+  private config: MaskedSecretsConfig;
+
+  constructor(config?: Partial<MaskedSecretsConfig>) {
+    this.config = {
+      enabled: config?.enabled ?? true,
+      mask: config?.mask ?? [],
+      outputPatterns: config?.outputPatterns ?? [],
+      blockedCommands: config?.blockedCommands ?? [
+        "env",
+        "printenv",
+        "set",
+        "export",
+      ],
+      blockSecretFileReads: config?.blockSecretFileReads ?? true,
+      secretFilePaths: config?.secretFilePaths ?? [
+        ".env",
+        "*.key",
+        "*.pem",
+        "credentials.json",
+        "auth-profiles.json",
+      ],
+    };
+  }
+
+  /** Load secrets from all configured sources */
+  load(): void {
+    if (!this.config.enabled) {
+      return;
+    }
+
+    this.loadFromDotEnv();
+    this.loadFromProcessEnv();
+
+    log.info(`Loaded ${this.secrets.size} masked secrets`);
+  }
+
+  /** Load secrets from ~/.openclaw/.env */
+  private loadFromDotEnv(): void {
+    const globalEnvPath = path.join(resolveConfigDir(process.env), ".env");
+    if (!fs.existsSync(globalEnvPath)) {
+      return;
+    }
+
+    const parsed = dotenv.parse(fs.readFileSync(globalEnvPath, "utf8"));
+    for (const [key, value] of Object.entries(parsed)) {
+      if (this.shouldMask(key)) {
+        this.secrets.set(key, {
+          name: key,
+          value,
+          source: "dotenv",
+        });
+      }
+    }
+  }
+
+  /** Load secrets from process.env matching configured patterns */
+  private loadFromProcessEnv(): void {
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value && this.shouldMask(key) && !this.secrets.has(key)) {
+        this.secrets.set(key, {
+          name: key,
+          value,
+          source: "env",
+        });
+      }
+    }
+  }
+
+  /**
+   * Determine if an env var name should be masked.
+   * Checks explicit config list first, then auto-detection patterns.
+   */
+  private shouldMask(name: string): boolean {
+    // Check explicit mask list
+    if (this.config.mask.length > 0) {
+      return this.config.mask.some((pattern) => {
+        if (pattern.includes("*")) {
+          const regex = new RegExp(
+            `^${pattern.replace(/\*/g, ".*")}$`,
+            "i",
+          );
+          return regex.test(name);
+        }
+        return pattern === name;
+      });
+    }
+
+    // Auto-detect mode: check against known patterns
+    return AUTO_DETECT_PATTERNS.some((pattern) => pattern.test(name));
+  }
+
+  /** Get a secret value by name (for substitution — never expose to agent) */
+  resolve(name: string): string | undefined {
+    return this.secrets.get(name)?.value;
+  }
+
+  /** Check if a name is a registered secret */
+  has(name: string): boolean {
+    return this.secrets.has(name);
+  }
+
+  /** Get all secret names (but not values!) */
+  listNames(): string[] {
+    return Array.from(this.secrets.keys());
+  }
+
+  /** Get all secret values (for redaction matching) */
+  getValues(): string[] {
+    return Array.from(this.secrets.values())
+      .map((s) => s.value)
+      .filter((v) => v.length >= 8); // Don't redact very short values (too many false positives)
+  }
+
+  /** Get the full config */
+  getConfig(): MaskedSecretsConfig {
+    return this.config;
+  }
+
+  /** Update config at runtime */
+  updateConfig(config: Partial<MaskedSecretsConfig>): void {
+    Object.assign(this.config, config);
+    this.secrets.clear();
+    this.load();
+  }
+}

--- a/src/security/masked-secrets/substitution.test.ts
+++ b/src/security/masked-secrets/substitution.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { SecretStore } from "./secret-store.js";
-import {
-  extractSecretRefs,
-  hasSecretRefs,
-  substituteSecrets,
-} from "./substitution.js";
+import { extractSecretRefs, hasSecretRefs, substituteSecrets } from "./substitution.js";
 
 describe("substituteSecrets", () => {
   function makeStore(secrets: Record<string, string>): SecretStore {
@@ -49,10 +45,7 @@ describe("substituteSecrets", () => {
 
   it("reports missing secrets without removing the reference", () => {
     const store = makeStore({});
-    const result = substituteSecrets(
-      "curl -H '{{secret:NONEXISTENT}}'",
-      store,
-    );
+    const result = substituteSecrets("curl -H '{{secret:NONEXISTENT}}'", store);
 
     expect(result.text).toBe("curl -H '{{secret:NONEXISTENT}}'");
     expect(result.substituted).toEqual([]);
@@ -86,9 +79,7 @@ describe("hasSecretRefs", () => {
 
 describe("extractSecretRefs", () => {
   it("extracts all referenced secret names", () => {
-    const refs = extractSecretRefs(
-      "{{secret:A}} and {{secret:B}} and {{secret:A}}",
-    );
+    const refs = extractSecretRefs("{{secret:A}} and {{secret:B}} and {{secret:A}}");
     expect(refs).toEqual(["A", "B", "A"]);
   });
 

--- a/src/security/masked-secrets/substitution.test.ts
+++ b/src/security/masked-secrets/substitution.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { SecretStore } from "./secret-store.js";
+import {
+  extractSecretRefs,
+  hasSecretRefs,
+  substituteSecrets,
+} from "./substitution.js";
+
+describe("substituteSecrets", () => {
+  function makeStore(secrets: Record<string, string>): SecretStore {
+    const store = new SecretStore({ mask: Object.keys(secrets) });
+    for (const [key, value] of Object.entries(secrets)) {
+      process.env[key] = value;
+    }
+    store.load();
+    for (const key of Object.keys(secrets)) {
+      delete process.env[key];
+    }
+    return store;
+  }
+
+  it("substitutes a single secret reference", () => {
+    const store = makeStore({ MY_KEY: "real-value-123" });
+    const result = substituteSecrets(
+      'curl -H "Authorization: Bearer {{secret:MY_KEY}}" https://api.example.com',
+      store,
+    );
+
+    expect(result.text).toBe(
+      'curl -H "Authorization: Bearer real-value-123" https://api.example.com',
+    );
+    expect(result.substituted).toEqual(["MY_KEY"]);
+    expect(result.missing).toEqual([]);
+  });
+
+  it("substitutes multiple secret references", () => {
+    const store = makeStore({
+      API_KEY: "key-123",
+      API_SECRET: "secret-456",
+    });
+    const result = substituteSecrets(
+      "export KEY={{secret:API_KEY}} SECRET={{secret:API_SECRET}}",
+      store,
+    );
+
+    expect(result.text).toBe("export KEY=key-123 SECRET=secret-456");
+    expect(result.substituted).toEqual(["API_KEY", "API_SECRET"]);
+  });
+
+  it("reports missing secrets without removing the reference", () => {
+    const store = makeStore({});
+    const result = substituteSecrets(
+      "curl -H '{{secret:NONEXISTENT}}'",
+      store,
+    );
+
+    expect(result.text).toBe("curl -H '{{secret:NONEXISTENT}}'");
+    expect(result.substituted).toEqual([]);
+    expect(result.missing).toEqual(["NONEXISTENT"]);
+  });
+
+  it("handles text with no secret references", () => {
+    const store = makeStore({ KEY: "value" });
+    const result = substituteSecrets("echo hello world", store);
+
+    expect(result.text).toBe("echo hello world");
+    expect(result.substituted).toEqual([]);
+    expect(result.missing).toEqual([]);
+  });
+});
+
+describe("hasSecretRefs", () => {
+  it("returns true when text contains {{secret:...}}", () => {
+    expect(hasSecretRefs("use {{secret:MY_KEY}} here")).toBe(true);
+  });
+
+  it("returns false for plain text", () => {
+    expect(hasSecretRefs("no secrets here")).toBe(false);
+  });
+
+  it("returns false for partial patterns", () => {
+    expect(hasSecretRefs("{{secret:}}")).toBe(false);
+    expect(hasSecretRefs("{{secret}}")).toBe(false);
+  });
+});
+
+describe("extractSecretRefs", () => {
+  it("extracts all referenced secret names", () => {
+    const refs = extractSecretRefs(
+      "{{secret:A}} and {{secret:B}} and {{secret:A}}",
+    );
+    expect(refs).toEqual(["A", "B", "A"]);
+  });
+
+  it("returns empty array for no refs", () => {
+    expect(extractSecretRefs("no refs")).toEqual([]);
+  });
+});

--- a/src/security/masked-secrets/substitution.ts
+++ b/src/security/masked-secrets/substitution.ts
@@ -22,10 +22,7 @@ const SECRET_REF_PATTERN = /\{\{secret:([A-Za-z_][A-Za-z0-9_]*)\}\}/g;
  * Substitute all {{secret:NAME}} references in a string with real values.
  * Returns the substituted text and metadata about what was replaced.
  */
-export function substituteSecrets(
-  text: string,
-  store: SecretStore,
-): SubstitutionResult {
+export function substituteSecrets(text: string, store: SecretStore): SubstitutionResult {
   const substituted: string[] = [];
   const missing: string[] = [];
 

--- a/src/security/masked-secrets/substitution.ts
+++ b/src/security/masked-secrets/substitution.ts
@@ -1,0 +1,63 @@
+/**
+ * Masked Secrets — Substitution Engine
+ *
+ * Handles the {{secret:NAME}} syntax in commands. Before a shell command
+ * is executed, any {{secret:NAME}} references are replaced with the real
+ * secret value. The agent never sees the real value — it only writes the
+ * reference syntax.
+ *
+ * Example:
+ *   Agent writes:  curl -H "Authorization: Bearer {{secret:MY_API_KEY}}" https://api.example.com
+ *   Runtime sees:  curl -H "Authorization: Bearer sk-abc123..." https://api.example.com
+ *   Agent sees:    curl -H "Authorization: Bearer {{secret:MY_API_KEY}}" https://api.example.com
+ */
+
+import type { SecretStore } from "./secret-store.js";
+import type { SubstitutionResult } from "./types.js";
+
+/** Pattern to match {{secret:NAME}} references in text */
+const SECRET_REF_PATTERN = /\{\{secret:([A-Za-z_][A-Za-z0-9_]*)\}\}/g;
+
+/**
+ * Substitute all {{secret:NAME}} references in a string with real values.
+ * Returns the substituted text and metadata about what was replaced.
+ */
+export function substituteSecrets(
+  text: string,
+  store: SecretStore,
+): SubstitutionResult {
+  const substituted: string[] = [];
+  const missing: string[] = [];
+
+  const result = text.replace(SECRET_REF_PATTERN, (match, name: string) => {
+    const value = store.resolve(name);
+    if (value !== undefined) {
+      substituted.push(name);
+      return value;
+    }
+    missing.push(name);
+    return match; // Leave unresolved references as-is
+  });
+
+  return { text: result, substituted, missing };
+}
+
+/**
+ * Check if a string contains any {{secret:NAME}} references.
+ */
+export function hasSecretRefs(text: string): boolean {
+  return SECRET_REF_PATTERN.test(text);
+}
+
+/**
+ * Extract all secret names referenced in a string.
+ */
+export function extractSecretRefs(text: string): string[] {
+  const refs: string[] = [];
+  let match: RegExpExecArray | null;
+  const pattern = new RegExp(SECRET_REF_PATTERN.source, "g");
+  while ((match = pattern.exec(text)) !== null) {
+    refs.push(match[1]);
+  }
+  return refs;
+}

--- a/src/security/masked-secrets/types.ts
+++ b/src/security/masked-secrets/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Masked Secrets — Type Definitions
+ *
+ * Core types for the masked secrets system. Allows agents to *use* secrets
+ * (API keys, tokens) without being able to *see* them in plaintext.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/10659
+ */
+
+/** A single masked secret entry */
+export type MaskedSecret = {
+  /** Display name used in {{secret:NAME}} references */
+  name: string;
+  /** The actual secret value (never exposed to the agent) */
+  value: string;
+  /** Where the secret was loaded from */
+  source: "env" | "dotenv" | "config" | "keychain";
+  /** Optional description for the secret (shown to agent instead of value) */
+  description?: string;
+};
+
+/** Configuration for the masked secrets system */
+export type MaskedSecretsConfig = {
+  /** Whether the system is enabled (default: true) */
+  enabled: boolean;
+
+  /**
+   * List of secret names to mask. Can be:
+   * - Exact env var names: "MY_API_KEY"
+   * - Glob patterns: "OPENAI_*"
+   * - Auto-detect mode: if empty, auto-detects common patterns
+   */
+  mask: string[];
+
+  /**
+   * Additional patterns to detect secrets in command output.
+   * These are regex patterns matched against stdout/stderr.
+   * Built-in patterns cover common API key formats.
+   */
+  outputPatterns?: string[];
+
+  /**
+   * Commands that are blocked entirely because they expose env vars.
+   * Default: ["env", "printenv", "set", "export"]
+   */
+  blockedCommands?: string[];
+
+  /**
+   * Whether to block `cat`/`less`/`head` etc. on known secret files.
+   * Default: true
+   */
+  blockSecretFileReads?: boolean;
+
+  /**
+   * Paths considered secret files (blocked from direct reads).
+   * Default: [".env", "*.key", "*.pem", "credentials.json", "auth-profiles.json"]
+   */
+  secretFilePaths?: string[];
+};
+
+/** Result of a secret substitution attempt */
+export type SubstitutionResult = {
+  /** The command/text with secrets substituted */
+  text: string;
+  /** Names of secrets that were substituted */
+  substituted: string[];
+  /** Names referenced but not found */
+  missing: string[];
+};
+
+/** Result of output redaction */
+export type RedactionResult = {
+  /** The output with secrets redacted */
+  text: string;
+  /** Number of redactions performed */
+  count: number;
+  /** Which secrets were found in the output */
+  redactedSecrets: string[];
+};
+
+/** Pre-execution check result */
+export type PreflightResult = {
+  /** Whether the command is allowed to execute */
+  allowed: boolean;
+  /** If blocked, the reason why */
+  reason?: string;
+  /** The command after secret substitution (if allowed) */
+  processedCommand?: string;
+  /** Warnings (non-blocking) */
+  warnings?: string[];
+};


### PR DESCRIPTION
## Summary

Implements the masked secrets system proposed in #10659. Agents can **use** API keys via `{{secret:NAME}}` references without ever seeing the plaintext values.

Also addresses the output leakage described in #21457 by redacting secrets from stdout/stderr before they reach the agent.

## How it works

Three layers of protection in the exec pipeline:

1. **Preflight** — Blocks `env`/`printenv`/`cat .env` and substitutes `{{secret:NAME}}` → real value before execution
2. **Redaction** — Scrubs any leaked secret values from command output (stdout + stderr) before returning to the agent
3. **Pattern matching** — Built-in detection for common API key formats (`sk-ant-*`, `ghp_*`, `AKIA*`) as defense in depth

## Changes

**New module** (`src/security/masked-secrets/`):
- `types.ts` — Type definitions
- `secret-store.ts` — Loads secrets from `.env` + `process.env`, auto-detects common patterns
- `substitution.ts` — `{{secret:NAME}}` → real value replacement
- `redaction.ts` — Output scrubbing (exact match + pattern match)
- `preflight.ts` — Pre-execution command validation
- `index.ts` — Public API facade
- `INTEGRATION.md` — Integration guide

**Wiring** (8 files):
- `bash-tools.exec-types.ts` — Added `maskedSecrets` to `ExecToolDefaults`
- `bash-tools.exec.ts` — Preflight before exec, redaction after output
- `bash-tools.process.ts` — Redaction on poll/log output for background processes
- `pi-tools.ts` — Initialize `MaskedSecrets` from config, pass to exec/process tools
- `system-prompt.ts` + `pi-embedded-runner/` — Inform agent about `{{secret:NAME}}` syntax
- `zod-schema.ts` — Config schema under `security.maskedSecrets`

**Tests**: 59 tests (37 unit + 22 integration), all passing.

## Config

```json
{
  "security": {
    "maskedSecrets": {
      "enabled": true,
      "mask": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GITHUB_TOKEN"],
      "blockSecretFileReads": true
    }
  }
}
```

## Design decisions

- **Fully optional** — Zero behavior change when `security.maskedSecrets` is not configured. All code paths are no-ops.
- **Not a security boundary** — This is a safety net, not a sandbox. A determined attacker could encode secrets to bypass redaction. For true isolation, OS-level enforcement (seccomp, namespaces) is needed.
- **Short values excluded** — Values under 8 chars are excluded from exact-match redaction to prevent false positives.

Closes #10659
Related: #11829, #21457

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a masked secrets system that prevents agents from accessing raw API keys through a three-layer protection model: preflight command validation, secret substitution via `{{secret:NAME}}` syntax, and output redaction. The implementation is well-architected with clear separation of concerns across `secret-store.ts`, `substitution.ts`, `redaction.ts`, and `preflight.ts` modules, backed by comprehensive unit and integration tests (59 total).

**Key strengths:**
- Clean module design with proper TypeScript typing throughout
- Comprehensive test coverage including integration tests simulating the full exec pipeline
- Thoughtful defaults (blocks `env`/`printenv`, protects `.env` files, auto-detects common API key patterns)
- Proper integration into both exec and background process pipelines with consistent redaction
- Good documentation in `INTEGRATION.md`

**Issues found:**
- **Critical**: System prompt receives config mask patterns instead of actual loaded secret names, breaking auto-detection mode functionality
- **High**: Regex patterns in `secret-store.ts` match invalid strings (empty strings, single chars) due to using `*` instead of `+`
- **Medium**: Missing `os.environ` pattern bypass in preflight checks
- **Medium**: Encoding bypasses (`base64`, `xxd`) not blocked for secret file reads
- **Low**: Type casting loses type safety in `pi-tools.ts` initialization

The core security logic is sound for its intended purpose as a "safety net" (not a security boundary, as documented), but the system prompt integration bug prevents agents from knowing which secrets are available in auto-detection mode.

<h3>Confidence Score: 3/5</h3>

- This PR has solid architecture and test coverage but contains a critical bug that breaks auto-detection mode
- Score reflects well-designed security module with comprehensive tests, offset by critical system prompt integration bug (shows config patterns instead of loaded secrets), regex issues allowing false positive matches, and several bypass scenarios in preflight validation. These issues need resolution before merge to ensure the feature works as intended.
- Pay close attention to `src/agents/pi-embedded-runner/compact.ts` and `src/agents/pi-embedded-runner/run/attempt.ts` for the critical system prompt bug, and `src/security/masked-secrets/secret-store.ts` for regex pattern fixes

<sub>Last reviewed commit: 9d46e03</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->