### PR TITLE
fix(security): add missing entries to environment variable blocklist

### DIFF
--- a/apps/macos/Sources/OpenClaw/HostEnvSanitizer.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSanitizer.swift
@@ -4,25 +4,30 @@ enum HostEnvSanitizer {
     /// Keep in sync with src/infra/host-env-security-policy.json.
     /// Parity is validated by src/infra/host-env-security.policy-parity.test.ts.
     private static let blockedKeys: Set<String> = [
-        "NODE_OPTIONS",
-        "NODE_PATH",
-        "PYTHONHOME",
-        "PYTHONPATH",
-        "PERL5LIB",
-        "PERL5OPT",
-        "RUBYLIB",
-        "RUBYOPT",
         "BASH_ENV",
         "ENV",
         "GCONV_PATH",
+        "GLIBC_TUNABLES",
         "IFS",
+        "JAVA_TOOL_OPTIONS",
+        "JDK_JAVA_OPTIONS",
+        "LD_AUDIT",
+        "NODE_OPTIONS",
+        "NODE_PATH",
+        "PERL5LIB",
+        "PERL5OPT",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "RUBYLIB",
+        "RUBYOPT",
         "SSLKEYLOGFILE",
     ]
 
     private static let blockedPrefixes: [String] = [
+        "BASH_FUNC_",
         "DYLD_",
         "LD_",
-        "BASH_FUNC_",
+        "OPENCLAW_",
     ]
 
     private static func isBlocked(_ upperKey: String) -> Bool {

--- a/src/infra/host-env-security-policy.json
+++ b/src/infra/host-env-security-policy.json
@@ -1,18 +1,22 @@
 {
   "blockedKeys": [
-    "NODE_OPTIONS",
-    "NODE_PATH",
-    "PYTHONHOME",
-    "PYTHONPATH",
-    "PERL5LIB",
-    "PERL5OPT",
-    "RUBYLIB",
-    "RUBYOPT",
     "BASH_ENV",
     "ENV",
     "GCONV_PATH",
+    "GLIBC_TUNABLES",
     "IFS",
+    "JAVA_TOOL_OPTIONS",
+    "JDK_JAVA_OPTIONS",
+    "LD_AUDIT",
+    "NODE_OPTIONS",
+    "NODE_PATH",
+    "PERL5LIB",
+    "PERL5OPT",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "RUBYLIB",
+    "RUBYOPT",
     "SSLKEYLOGFILE"
   ],
-  "blockedPrefixes": ["DYLD_", "LD_", "BASH_FUNC_"]
+  "blockedPrefixes": ["BASH_FUNC_", "DYLD_", "LD_", "OPENCLAW_"]
 }


### PR DESCRIPTION
## Summary

Adds 5 missing dangerous environment variables to the host-env security policy blocklist that can be exploited for code injection or behavior modification.

## Problem

The current blocklist in `host-env-security-policy.json` misses several well-known injection vectors:

| Variable | Risk | Description |
|----------|------|-------------|
| `GLIBC_TUNABLES` | Code injection | glibc dynamic linker behavior modification |
| `JAVA_TOOL_OPTIONS` | Code injection | JVM options injection (all Java versions) |
| `JDK_JAVA_OPTIONS` | Code injection | Java 9+ JVM options injection |
| `LD_AUDIT` | Code injection | Dynamic linker audit library loading |
| `OPENCLAW_*` (prefix) | Behavior modification | Could affect OpenClaw behavior from user-provided env |

## Fix

Added 4 keys to `blockedKeys` and 1 prefix to `blockedPrefixes` in `src/infra/host-env-security-policy.json`. Keys are kept in alphabetical order.

**1 file changed**

Fixes #22681

## Local Validation

- Verified JSON is valid
- Confirmed alphabetical ordering of blockedKeys
- Checked no duplicate entries

## Scope

Single JSON file. Zero code logic changes.

## Author

**Miloud Belarebia** — [@miloudbelarebia](https://github.com/miloudbelarebia)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 4 dangerous environment variables (`GLIBC_TUNABLES`, `JAVA_TOOL_OPTIONS`, `JDK_JAVA_OPTIONS`, `LD_AUDIT`) and 1 prefix (`OPENCLAW_`) to the host environment security blocklist.

**Critical issue:**
- The corresponding Swift implementation (`apps/macos/Sources/OpenClaw/HostEnvSanitizer.swift`) was not updated with these changes
- The parity test (`src/infra/host-env-security.policy-parity.test.ts`) enforces synchronization between the JSON policy and Swift code, so this PR will break the build

**Minor issues:**
- `blockedKeys` array is not fully alphabetically ordered despite the PR description claiming it is

<h3>Confidence Score: 1/5</h3>

- This PR will break the build due to missing Swift implementation updates
- The changes are security-focused and the environment variables correctly identified as dangerous injection vectors, but the Swift implementation at `apps/macos/Sources/OpenClaw/HostEnvSanitizer.swift` was not updated. The parity test will fail, breaking CI.
- `apps/macos/Sources/OpenClaw/HostEnvSanitizer.swift` must be updated to include the same 4 keys and 1 prefix

<sub>Last reviewed commit: 4d5cdc1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->