### PR TITLE
fix(routing): normalize input peer.kind in resolveAgentRoute

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -291,7 +291,7 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
-  const peer = input.peer ? { kind: input.peer.kind, id: normalizeId(input.peer.id) } : null;
+  const peer = input.peer ? { kind: normalizeChatType(input.peer.kind), id: normalizeId(input.peer.id) } : null;
   const guildId = normalizeId(input.guildId);
   const teamId = normalizeId(input.teamId);
   const memberRoleIds = input.memberRoleIds ?? [];

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -351,7 +351,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   }
   // Thread parent inheritance: if peer (thread) didn't match, check parent peer binding
   const parentPeer = input.parentPeer
-    ? { kind: input.parentPeer.kind, id: normalizeId(input.parentPeer.id) }
+    ? { kind: normalizeChatType(input.parentPeer.kind), id: normalizeId(input.parentPeer.id) }
     : null;
   const baseScope = {
     guildId,


### PR DESCRIPTION
## Summary

Fixes a routing mismatch where `resolveAgentRoute` fails to normalize the input `peer.kind`, causing DM routing to break when a plugin passes `kind: "dm"` but the binding config uses `kind: "direct"`.

## Problem

In `resolveAgentRoute()`, the binding's `peer.kind` is normalized via `normalizeChatType()` (which maps `"dm"` → `"direct"`), but the **input** `peer.kind` is used raw:

```typescript
// Before (broken): input not normalized
const peer = input.peer ? { kind: input.peer.kind, id: normalizeId(input.peer.id) } : null;
```

This causes `matchesBindingScope` to fail because `"dm" !== "direct"`.

## Fix

```typescript
// After: input normalized consistently with bindings
const peer = input.peer ? { kind: normalizeChatType(input.peer.kind), id: normalizeId(input.peer.id) } : null;
```

**1 file changed**, 1 line modified in `src/routing/resolve-route.ts`.

Fixes #22730

## Local Validation

- `normalizeChatType` was already imported and used in the same file (line 224, for binding normalization)
- Existing test suite includes `"backward compatibility: peer.kind dm → direct"` test case

## Scope

Single line change in `src/routing/resolve-route.ts`. Uses existing `normalizeChatType()` function already imported in the file.

## Author

**Miloud Belarebia** — [@miloudbelarebia](https://github.com/miloudbelarebia)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes DM routing mismatch by normalizing `input.peer.kind` to map `"dm"` → `"direct"`, ensuring consistency with binding normalization.

**Key changes:**
- Applied `normalizeChatType()` to `input.peer.kind` in `resolveAgentRoute()` (line 294)
- Uses existing imported function already applied to binding peer kinds (line 224)
- Enables plugins passing `kind: "dm"` to match bindings configured with `kind: "direct"`

**Issue found:**
- `parentPeer.kind` (line 354) has the same normalization gap and should be fixed for consistency

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one additional fix recommended for `parentPeer.kind` normalization
- The change correctly fixes the reported issue and has test coverage. However, `parentPeer.kind` (line 354) has the same normalization gap that should be addressed for consistency. The fix uses an existing, well-tested function and follows the same pattern already applied to bindings.
- Pay attention to line 354 in `src/routing/resolve-route.ts` - `parentPeer.kind` needs the same normalization treatment

<sub>Last reviewed commit: ff75918</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->