### PR TITLE
fix(nostr): enforce inbound DM policy and persist last route

### DIFF
--- a/extensions/nostr/src/channel.dispatch.test.ts
+++ b/extensions/nostr/src/channel.dispatch.test.ts
@@ -46,6 +46,8 @@ describe("nostr inbound dispatch", () => {
     const readAllowFromStoreMock = vi.fn(async () => []);
     const upsertPairingRequestMock = vi.fn(async () => ({ code: "PAIRING", created: true }));
     const buildPairingReplyMock = vi.fn(() => "pairing reply");
+    const shouldComputeCommandAuthorizedMock = vi.fn(() => false);
+    const resolveCommandAuthorizedFromAuthorizersMock = vi.fn(() => false);
 
     getNostrRuntimeMock.mockReturnValue({
       config: {
@@ -83,6 +85,10 @@ describe("nostr inbound dispatch", () => {
           readAllowFromStore: readAllowFromStoreMock,
           upsertPairingRequest: upsertPairingRequestMock,
           buildPairingReply: buildPairingReplyMock,
+        },
+        commands: {
+          shouldComputeCommandAuthorized: shouldComputeCommandAuthorizedMock,
+          resolveCommandAuthorizedFromAuthorizers: resolveCommandAuthorizedFromAuthorizersMock,
         },
       },
     });
@@ -169,6 +175,11 @@ describe("nostr inbound dispatch", () => {
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
     expect(upsertPairingRequestMock).not.toHaveBeenCalled();
     expect(buildPairingReplyMock).not.toHaveBeenCalled();
+    expect(shouldComputeCommandAuthorizedMock).toHaveBeenCalledWith(
+      "incoming text",
+      expect.any(Object),
+    );
+    expect(resolveCommandAuthorizedFromAuthorizersMock).not.toHaveBeenCalled();
   });
 
   it("enforces pairing policy before dispatching unauthorized DMs", async () => {
@@ -183,6 +194,8 @@ describe("nostr inbound dispatch", () => {
     const recordInboundSessionMock = vi.fn(async () => {});
     const readAllowFromStoreMock = vi.fn(async () => []);
     const upsertPairingRequestMock = vi.fn(async () => ({ code: "PAIR123", created: true }));
+    const shouldComputeCommandAuthorizedMock = vi.fn(() => false);
+    const resolveCommandAuthorizedFromAuthorizersMock = vi.fn(() => false);
 
     getNostrRuntimeMock.mockReturnValue({
       config: {
@@ -221,6 +234,10 @@ describe("nostr inbound dispatch", () => {
           upsertPairingRequest: upsertPairingRequestMock,
           buildPairingReply: ({ code, idLine }: { code: string; idLine: string }) =>
             `OpenClaw: access not configured.\n${idLine}\nPairing code: ${code}`,
+        },
+        commands: {
+          shouldComputeCommandAuthorized: shouldComputeCommandAuthorizedMock,
+          resolveCommandAuthorizedFromAuthorizers: resolveCommandAuthorizedFromAuthorizersMock,
         },
       },
     });
@@ -299,5 +316,146 @@ describe("nostr inbound dispatch", () => {
     expect(recordInboundSessionMock).not.toHaveBeenCalled();
     expect(dispatchMock).not.toHaveBeenCalled();
     expect(replySpy).toHaveBeenCalledWith(expect.stringContaining("Pairing code: PAIR123"));
+    expect(shouldComputeCommandAuthorizedMock).toHaveBeenCalledWith(
+      "incoming text",
+      expect.any(Object),
+    );
+    expect(resolveCommandAuthorizedFromAuthorizersMock).not.toHaveBeenCalled();
+  });
+
+  it("sets CommandAuthorized=true for allowlisted DM control commands", async () => {
+    type OnMessageHandler = (
+      senderPubkey: string,
+      text: string,
+      reply: (text: string) => Promise<void>,
+    ) => Promise<void>;
+    let onMessageHandler: OnMessageHandler | null = null;
+
+    const dispatchMock = vi.fn(async () => {});
+    const recordInboundSessionMock = vi.fn(async () => {});
+    const readAllowFromStoreMock = vi.fn(async () => []);
+    const shouldComputeCommandAuthorizedMock = vi.fn(() => true);
+    const resolveCommandAuthorizedFromAuthorizersMock = vi.fn(
+      (params: { authorizers: Array<{ configured: boolean; allowed: boolean }> }) =>
+        params.authorizers.some((entry) => entry.configured && entry.allowed),
+    );
+
+    getNostrRuntimeMock.mockReturnValue({
+      config: {
+        loadConfig: () => ({
+          agents: {
+            main: {},
+          },
+        }),
+      },
+      channel: {
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "main",
+            accountId: "default",
+            sessionKey: "nostr:session:1",
+            mainSessionKey: "agent:main:main",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/sessions",
+          readSessionUpdatedAt: () => undefined,
+          recordInboundSession: recordInboundSessionMock,
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({ mode: "compact" }),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          finalizeInboundContext: (ctx: Record<string, unknown>) => ctx,
+          dispatchReplyWithBufferedBlockDispatcher: dispatchMock,
+        },
+        text: {
+          resolveMarkdownTableMode: () => "off",
+          convertMarkdownTables: (text: string) => text,
+        },
+        pairing: {
+          readAllowFromStore: readAllowFromStoreMock,
+          upsertPairingRequest: vi.fn(async () => ({ code: "PAIR", created: true })),
+          buildPairingReply: vi.fn(() => "pairing reply"),
+        },
+        commands: {
+          shouldComputeCommandAuthorized: shouldComputeCommandAuthorizedMock,
+          resolveCommandAuthorizedFromAuthorizers: resolveCommandAuthorizedFromAuthorizersMock,
+        },
+      },
+    });
+
+    startNostrBusMock.mockImplementation(async (options: { onMessage: OnMessageHandler }) => {
+      onMessageHandler = options.onMessage;
+      return {
+        close: vi.fn(),
+        publicKey: "bot-public-key",
+        sendDm: vi.fn(async () => {}),
+        getMetrics: vi.fn(() => ({ counters: {}, relays: {}, snapshots: [] })),
+        publishProfile: vi.fn(async () => ({
+          successes: [],
+          failures: [],
+          eventId: "",
+          createdAt: 0,
+        })),
+        getProfileState: vi.fn(async () => ({
+          lastPublishedAt: null,
+          lastPublishedEventId: null,
+          lastPublishResults: null,
+        })),
+      };
+    });
+
+    const startAccount = nostrPlugin.gateway?.startAccount;
+    if (!startAccount) {
+      throw new Error("startAccount not available");
+    }
+
+    const gatewayContext = {
+      cfg: {},
+      account: {
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        privateKey: "private-key",
+        publicKey: "bot-public-key",
+        relays: ["wss://relay.example"],
+        config: {
+          dmPolicy: "allowlist",
+          allowFrom: ["sender-pubkey"],
+        },
+      },
+      setStatus: vi.fn(),
+      getStatus: vi.fn(() => ({})),
+      accountId: "default",
+      runtime: {
+        running: true,
+      },
+      abortSignal: new AbortController().signal,
+      log: {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      },
+    } as unknown as Parameters<typeof startAccount>[0];
+
+    await startAccount(gatewayContext);
+
+    expect(onMessageHandler).toBeTypeOf("function");
+    if (!onMessageHandler) {
+      throw new Error("onMessage handler was not captured");
+    }
+
+    const replySpy = vi.fn(async () => {});
+    await onMessageHandler("sender-pubkey", "/model openai/gpt-4.1-mini", replySpy);
+
+    expect(resolveCommandAuthorizedFromAuthorizersMock).toHaveBeenCalledWith({
+      useAccessGroups: true,
+      authorizers: [{ configured: true, allowed: true }],
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    const dispatchArg = dispatchMock.mock.calls[0]?.[0];
+    expect(dispatchArg?.ctx?.CommandAuthorized).toBe(true);
+    expect(replySpy).not.toHaveBeenCalled();
   });
 });

--- a/extensions/nostr/src/channel.dispatch.test.ts
+++ b/extensions/nostr/src/channel.dispatch.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { startNostrBusMock, getNostrRuntimeMock } = vi.hoisted(() => ({
+  startNostrBusMock: vi.fn(),
+  getNostrRuntimeMock: vi.fn(),
+}));
+
+vi.mock("./nostr-bus.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./nostr-bus.js")>();
+  return {
+    ...actual,
+    startNostrBus: startNostrBusMock,
+  };
+});
+
+vi.mock("./runtime.js", () => ({
+  getNostrRuntime: getNostrRuntimeMock,
+}));
+
+import { nostrPlugin } from "./channel.js";
+
+describe("nostr inbound dispatch", () => {
+  beforeEach(() => {
+    startNostrBusMock.mockReset();
+    getNostrRuntimeMock.mockReset();
+  });
+
+  it("routes inbound DMs via dispatchReplyWithBufferedBlockDispatcher", async () => {
+    type OnMessageHandler = (
+      senderPubkey: string,
+      text: string,
+      reply: (text: string) => Promise<void>,
+    ) => Promise<void>;
+    let onMessageHandler: OnMessageHandler | null = null;
+
+    const dispatchMock = vi.fn(
+      async (params: {
+        ctx?: Record<string, unknown>;
+        dispatcherOptions: { deliver: (payload: { text?: string }) => Promise<void> };
+      }) => {
+        await params.dispatcherOptions.deliver({ text: "model-reply" });
+      },
+    );
+
+    const recordInboundSessionMock = vi.fn(async () => {});
+
+    getNostrRuntimeMock.mockReturnValue({
+      config: {
+        loadConfig: () => ({
+          agents: {
+            main: {},
+          },
+        }),
+      },
+      channel: {
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "main",
+            accountId: "default",
+            sessionKey: "nostr:session:1",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/sessions",
+          readSessionUpdatedAt: () => undefined,
+          recordInboundSession: recordInboundSessionMock,
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({ mode: "compact" }),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          finalizeInboundContext: (ctx: Record<string, unknown>) => ctx,
+          dispatchReplyWithBufferedBlockDispatcher: dispatchMock,
+        },
+        text: {
+          resolveMarkdownTableMode: () => "off",
+          convertMarkdownTables: (text: string) => text,
+        },
+      },
+    });
+
+    startNostrBusMock.mockImplementation(async (options: { onMessage: OnMessageHandler }) => {
+      onMessageHandler = options.onMessage;
+      return {
+        close: vi.fn(),
+        publicKey: "bot-public-key",
+        sendDm: vi.fn(async () => {}),
+        getMetrics: vi.fn(() => ({ counters: {}, relays: {}, snapshots: [] })),
+        publishProfile: vi.fn(async () => ({
+          successes: [],
+          failures: [],
+          eventId: "",
+          createdAt: 0,
+        })),
+        getProfileState: vi.fn(async () => ({
+          lastPublishedAt: null,
+          lastPublishedEventId: null,
+          lastPublishResults: null,
+        })),
+      };
+    });
+
+    const startAccount = nostrPlugin.gateway?.startAccount;
+    if (!startAccount) {
+      throw new Error("startAccount not available");
+    }
+
+    const gatewayContext = {
+      cfg: {},
+      account: {
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        privateKey: "private-key",
+        publicKey: "bot-public-key",
+        relays: ["wss://relay.example"],
+        config: {},
+      },
+      setStatus: vi.fn(),
+      getStatus: vi.fn(() => ({})),
+      accountId: "default",
+      runtime: {
+        running: true,
+      },
+      abortSignal: new AbortController().signal,
+      log: {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      },
+    } as unknown as Parameters<typeof startAccount>[0];
+
+    await startAccount(gatewayContext);
+
+    expect(onMessageHandler).toBeTypeOf("function");
+    if (!onMessageHandler) {
+      throw new Error("onMessage handler was not captured");
+    }
+    const runOnMessage: OnMessageHandler = onMessageHandler;
+
+    const replySpy = vi.fn(async () => {});
+    await runOnMessage("sender-pubkey", "incoming text", replySpy);
+
+    expect(recordInboundSessionMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    const dispatchArg = dispatchMock.mock.calls[0]?.[0];
+    expect(dispatchArg?.ctx?.Provider).toBe("nostr");
+    expect(dispatchArg?.ctx?.ChatType).toBe("direct");
+    expect(dispatchArg?.ctx?.SenderId).toBe("sender-pubkey");
+    expect(replySpy).toHaveBeenCalledWith("model-reply");
+  });
+});

--- a/extensions/nostr/src/channel.dispatch.test.ts
+++ b/extensions/nostr/src/channel.dispatch.test.ts
@@ -61,6 +61,7 @@ describe("nostr inbound dispatch", () => {
             agentId: "main",
             accountId: "default",
             sessionKey: "nostr:session:1",
+            mainSessionKey: "agent:main:main",
           }),
         },
         session: {
@@ -154,7 +155,7 @@ describe("nostr inbound dispatch", () => {
     expect(recordInboundSessionMock).toHaveBeenCalledTimes(1);
     const recordArg = recordInboundSessionMock.mock.calls[0]?.[0];
     expect(recordArg?.updateLastRoute).toEqual({
-      sessionKey: "nostr:session:1",
+      sessionKey: "agent:main:main",
       channel: "nostr",
       to: "sender-pubkey",
       accountId: "default",
@@ -197,6 +198,7 @@ describe("nostr inbound dispatch", () => {
             agentId: "main",
             accountId: "default",
             sessionKey: "nostr:session:1",
+            mainSessionKey: "agent:main:main",
           }),
         },
         session: {

--- a/extensions/nostr/src/channel.dispatch.test.ts
+++ b/extensions/nostr/src/channel.dispatch.test.ts
@@ -43,6 +43,9 @@ describe("nostr inbound dispatch", () => {
     );
 
     const recordInboundSessionMock = vi.fn(async () => {});
+    const readAllowFromStoreMock = vi.fn(async () => []);
+    const upsertPairingRequestMock = vi.fn(async () => ({ code: "PAIRING", created: true }));
+    const buildPairingReplyMock = vi.fn(() => "pairing reply");
 
     getNostrRuntimeMock.mockReturnValue({
       config: {
@@ -74,6 +77,11 @@ describe("nostr inbound dispatch", () => {
         text: {
           resolveMarkdownTableMode: () => "off",
           convertMarkdownTables: (text: string) => text,
+        },
+        pairing: {
+          readAllowFromStore: readAllowFromStoreMock,
+          upsertPairingRequest: upsertPairingRequestMock,
+          buildPairingReply: buildPairingReplyMock,
         },
       },
     });
@@ -113,7 +121,9 @@ describe("nostr inbound dispatch", () => {
         privateKey: "private-key",
         publicKey: "bot-public-key",
         relays: ["wss://relay.example"],
-        config: {},
+        config: {
+          dmPolicy: "open",
+        },
       },
       setStatus: vi.fn(),
       getStatus: vi.fn(() => ({})),
@@ -142,11 +152,150 @@ describe("nostr inbound dispatch", () => {
     await runOnMessage("sender-pubkey", "incoming text", replySpy);
 
     expect(recordInboundSessionMock).toHaveBeenCalledTimes(1);
+    const recordArg = recordInboundSessionMock.mock.calls[0]?.[0];
+    expect(recordArg?.updateLastRoute).toEqual({
+      sessionKey: "nostr:session:1",
+      channel: "nostr",
+      to: "sender-pubkey",
+      accountId: "default",
+    });
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     const dispatchArg = dispatchMock.mock.calls[0]?.[0];
     expect(dispatchArg?.ctx?.Provider).toBe("nostr");
     expect(dispatchArg?.ctx?.ChatType).toBe("direct");
     expect(dispatchArg?.ctx?.SenderId).toBe("sender-pubkey");
     expect(replySpy).toHaveBeenCalledWith("model-reply");
+    expect(readAllowFromStoreMock).not.toHaveBeenCalled();
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+    expect(buildPairingReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("enforces pairing policy before dispatching unauthorized DMs", async () => {
+    type OnMessageHandler = (
+      senderPubkey: string,
+      text: string,
+      reply: (text: string) => Promise<void>,
+    ) => Promise<void>;
+    let onMessageHandler: OnMessageHandler | null = null;
+
+    const dispatchMock = vi.fn();
+    const recordInboundSessionMock = vi.fn(async () => {});
+    const readAllowFromStoreMock = vi.fn(async () => []);
+    const upsertPairingRequestMock = vi.fn(async () => ({ code: "PAIR123", created: true }));
+
+    getNostrRuntimeMock.mockReturnValue({
+      config: {
+        loadConfig: () => ({
+          agents: {
+            main: {},
+          },
+        }),
+      },
+      channel: {
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "main",
+            accountId: "default",
+            sessionKey: "nostr:session:1",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/sessions",
+          readSessionUpdatedAt: () => undefined,
+          recordInboundSession: recordInboundSessionMock,
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({ mode: "compact" }),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          finalizeInboundContext: (ctx: Record<string, unknown>) => ctx,
+          dispatchReplyWithBufferedBlockDispatcher: dispatchMock,
+        },
+        text: {
+          resolveMarkdownTableMode: () => "off",
+          convertMarkdownTables: (text: string) => text,
+        },
+        pairing: {
+          readAllowFromStore: readAllowFromStoreMock,
+          upsertPairingRequest: upsertPairingRequestMock,
+          buildPairingReply: ({ code, idLine }: { code: string; idLine: string }) =>
+            `OpenClaw: access not configured.\n${idLine}\nPairing code: ${code}`,
+        },
+      },
+    });
+
+    startNostrBusMock.mockImplementation(async (options: { onMessage: OnMessageHandler }) => {
+      onMessageHandler = options.onMessage;
+      return {
+        close: vi.fn(),
+        publicKey: "bot-public-key",
+        sendDm: vi.fn(async () => {}),
+        getMetrics: vi.fn(() => ({ counters: {}, relays: {}, snapshots: [] })),
+        publishProfile: vi.fn(async () => ({
+          successes: [],
+          failures: [],
+          eventId: "",
+          createdAt: 0,
+        })),
+        getProfileState: vi.fn(async () => ({
+          lastPublishedAt: null,
+          lastPublishedEventId: null,
+          lastPublishResults: null,
+        })),
+      };
+    });
+
+    const startAccount = nostrPlugin.gateway?.startAccount;
+    if (!startAccount) {
+      throw new Error("startAccount not available");
+    }
+
+    const gatewayContext = {
+      cfg: {},
+      account: {
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        privateKey: "private-key",
+        publicKey: "bot-public-key",
+        relays: ["wss://relay.example"],
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+        },
+      },
+      setStatus: vi.fn(),
+      getStatus: vi.fn(() => ({})),
+      accountId: "default",
+      runtime: {
+        running: true,
+      },
+      abortSignal: new AbortController().signal,
+      log: {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      },
+    } as unknown as Parameters<typeof startAccount>[0];
+
+    await startAccount(gatewayContext);
+
+    expect(onMessageHandler).toBeTypeOf("function");
+    if (!onMessageHandler) {
+      throw new Error("onMessage handler was not captured");
+    }
+
+    const replySpy = vi.fn(async () => {});
+    await onMessageHandler("sender-pubkey", "incoming text", replySpy);
+
+    expect(readAllowFromStoreMock).toHaveBeenCalledWith("nostr", undefined, "default");
+    expect(upsertPairingRequestMock).toHaveBeenCalledWith({
+      channel: "nostr",
+      id: "sender-pubkey",
+      accountId: "default",
+    });
+    expect(recordInboundSessionMock).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(replySpy).toHaveBeenCalledWith(expect.stringContaining("Pairing code: PAIR123"));
   });
 });

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -334,7 +334,7 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
             sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
             ctx: ctxPayload,
             updateLastRoute: {
-              sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+              sessionKey: route.mainSessionKey,
               channel: "nostr",
               to: normalizedSenderPubkey,
               accountId: route.accountId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Inbound Nostr DMs were routed directly into `dispatchReplyWithBufferedBlockDispatcher` without checking `dmPolicy`, `allowFrom`, or pairing state, so unauthorized senders could still trigger replies. Inbound session recording also omitted `updateLastRoute`, so last-target delivery context was not persisted.
- Why it matters: This breaks the expected behavior of `dmPolicy=disabled|allowlist|pairing` and can allow model replies to unauthorized DMs. It also breaks session-based routing features (for example `--channel last` and heartbeat follow-ups) because Nostr target resolution is missing after inbound traffic.
- What changed: Added DM policy enforcement before inbound dispatch in `extensions/nostr/src/channel.ts` (drop on `disabled`; validate config+store allowlist for `allowlist/pairing`; send pairing reply for unauthorized senders in `pairing`). Also added `updateLastRoute` to `recordInboundSession` so `lastChannel/lastTo` are saved. Added regression tests in `extensions/nostr/src/channel.dispatch.test.ts`.
- What did NOT change (scope boundary): Nostr outbound send flow, other channel implementations, config schema, external API contracts, and CLI command behavior were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A

## User-visible / Behavior Changes

- When `channels.nostr.dmPolicy` is `disabled`, inbound DMs are dropped with no response.
- When `channels.nostr.dmPolicy` is `allowlist` or `pairing`, unauthorized senders no longer receive normal auto-replies (`pairing` still sends a pairing instruction message).
- After inbound Nostr DM traffic, session last-route context is persisted (`lastChannel=nostr`, `lastTo=<sender pubkey>`), enabling session-based outbound targeting.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
  - No
- Secrets/tokens handling changed? (`Yes/No`)
  - No
- New/changed network calls? (`Yes/No`)
  - No
- Command/tool execution surface changed? (`Yes/No`)
  - No
- Data access scope changed? (`Yes/No`)
  - No
- If any `Yes`, explain risk + mitigation:
  - None

## Repro + Verification

### Environment

- OS: Linux (dev worktree environment)
- Runtime/container: Node.js 22 / pnpm / Vitest
- Model/provider: N/A (channel dispatch test)
- Integration/channel (if any): Nostr extension
- Relevant config (redacted): `channels.nostr.dmPolicy` (`open` / `pairing`), `channels.nostr.allowFrom`

### Steps

1. Implement DM policy enforcement and `updateLastRoute` in the inbound handler in `extensions/nostr/src/channel.ts`.
2. Add tests in `extensions/nostr/src/channel.dispatch.test.ts` for:
   - `recordInboundSession(...updateLastRoute...)` being called on normal dispatch.
   - Unauthorized sender under `dmPolicy=pairing` being blocked from dispatch and receiving pairing reply.
3. Run `pnpm exec oxfmt --check extensions/nostr/src/channel.ts extensions/nostr/src/channel.dispatch.test.ts` and `pnpm vitest extensions/nostr/src/channel.dispatch.test.ts`.

### Expected

- Unauthorized inbound DMs are blocked according to policy (pairing mode still returns pairing guidance).
- Only authorized inbound DMs reach the dispatcher.
- Session last-route is persisted after inbound processing.
- Added tests pass.

### Actual

- Behavior matched expectations.
- `extensions/nostr/src/channel.dispatch.test.ts` passed (2/2 tests).

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Test output snippet:
  - `✓ extensions/nostr/src/channel.dispatch.test.ts (2 tests)`
  - `Test Files  1 passed (1)`
  - `Tests  2 passed (2)`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Inbound DM dispatch path still works under `dmPolicy=open`.
  - Under `dmPolicy=pairing` with unauthorized sender, pairing request/upsert and pairing reply occur, and dispatcher is not called.
  - `recordInboundSession` includes `updateLastRoute`.
- Edge cases checked:
  - Early return path for `dmPolicy=disabled` in implementation.
  - Allowlist normalization path (`nostr:` prefix, hex/pubkey normalization, wildcard) used in matching flow.
- What you did **not** verify:
  - Live relay end-to-end behavior on real infrastructure (this PR verification is unit/dispatch-test level).

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
  - Yes
- Config/env changes? (`Yes/No`)
  - No
- Migration needed? (`Yes/No`)
  - No
- If yes, exact upgrade steps:
  - N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - `git revert 06b14dd29`
- Files/config to restore:
  - `extensions/nostr/src/channel.ts`
  - `extensions/nostr/src/channel.dispatch.test.ts`
- Known bad symptoms reviewers should watch for:
  - Legitimate senders are incorrectly treated as unauthorized and DM replies stop.
  - `--channel last` cannot resolve Nostr recipient after inbound traffic.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Normalization differences may cause existing `allowFrom` entries to mismatch unexpectedly.
  - Mitigation: Merge both config and pairing-store allowlists, and apply unified normalization (`nostr:` prefix handling, pubkey normalization, wildcard support).
- Risk: With policy enforcement, previously-answered unauthorized senders are now blocked immediately.
  - Mitigation: In `pairing` mode, return pairing instructions to guide owner approval flow.
