### PR TITLE
fix(security): enable gateway auth rate limiting by default (CWE-307)

### DIFF
--- a/src/gateway/auth-rate-limit-config.test.ts
+++ b/src/gateway/auth-rate-limit-config.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { resolveGatewayAuthRateLimitConfig } from "./auth-rate-limit-config.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+
+describe("resolveGatewayAuthRateLimitConfig", () => {
+  it("enables defaults for token auth when token is configured", () => {
+    const auth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "secret",
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    const out = resolveGatewayAuthRateLimitConfig({ auth });
+    expect(out).toEqual({
+      maxAttempts: undefined,
+      windowMs: undefined,
+      lockoutMs: undefined,
+      exemptLoopback: undefined,
+    });
+  });
+
+  it("enables defaults for password auth when password is configured", () => {
+    const auth: ResolvedGatewayAuth = {
+      mode: "password",
+      token: undefined,
+      password: "secret",
+      allowTailscale: false,
+    };
+
+    const out = resolveGatewayAuthRateLimitConfig({ auth });
+    expect(out).toEqual({
+      maxAttempts: undefined,
+      windowMs: undefined,
+      lockoutMs: undefined,
+      exemptLoopback: undefined,
+    });
+  });
+
+  it("returns undefined when shared secret auth is not configured", () => {
+    const auth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: undefined,
+      password: undefined,
+      allowTailscale: true,
+    };
+
+    const out = resolveGatewayAuthRateLimitConfig({ auth });
+    expect(out).toBeUndefined();
+  });
+
+  it("preserves explicit gateway.auth.rateLimit values", () => {
+    const auth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "secret",
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    const out = resolveGatewayAuthRateLimitConfig({
+      auth,
+      config: {
+        maxAttempts: 3,
+        windowMs: 15_000,
+        lockoutMs: 120_000,
+        exemptLoopback: false,
+      },
+    });
+
+    expect(out).toEqual({
+      maxAttempts: 3,
+      windowMs: 15_000,
+      lockoutMs: 120_000,
+      exemptLoopback: false,
+    });
+  });
+});

--- a/src/gateway/auth-rate-limit-config.ts
+++ b/src/gateway/auth-rate-limit-config.ts
@@ -1,0 +1,32 @@
+import type { GatewayAuthRateLimitConfig } from "../config/types.gateway.js";
+import type { RateLimitConfig } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+
+/**
+ * Resolve gateway auth rate-limit settings.
+ *
+ * Security default: whenever shared-secret gateway auth is configured
+ * (token/password), rate limiting is enabled even when gateway.auth.rateLimit
+ * is omitted. In that case createAuthRateLimiter() applies safe defaults.
+ */
+export function resolveGatewayAuthRateLimitConfig(params: {
+  auth: ResolvedGatewayAuth;
+  config?: GatewayAuthRateLimitConfig;
+}): RateLimitConfig | undefined {
+  const { auth, config } = params;
+
+  const hasSharedSecretAuth =
+    (auth.mode === "token" && Boolean(auth.token)) ||
+    (auth.mode === "password" && Boolean(auth.password));
+
+  if (!hasSharedSecretAuth) {
+    return undefined;
+  }
+
+  return {
+    maxAttempts: config?.maxAttempts,
+    windowMs: config?.windowMs,
+    lockoutMs: config?.lockoutMs,
+    exemptLoopback: config?.exemptLoopback,
+  };
+}


### PR DESCRIPTION
## Summary
Enable gateway authentication rate limiting by default whenever shared-secret auth is configured (`gateway.auth.token` or `gateway.auth.password`).

Previously, rate limiting only applied when `gateway.auth.rateLimit` was explicitly set, leaving token/password auth vulnerable to brute-force attempts by default.

## Changes
- Add `resolveGatewayAuthRateLimitConfig()` helper (`src/gateway/auth-rate-limit-config.ts`)
  - returns `undefined` when no shared secret auth is configured
  - returns explicit `gateway.auth.rateLimit` values when provided
  - otherwise returns default config object so `createAuthRateLimiter()` applies secure defaults
- Wire resolver into `startGatewayServer()` (`src/gateway/server.impl.ts`)
- Add unit tests (`src/gateway/auth-rate-limit-config.test.ts`)

## Security impact
- Closes default-on brute-force gap for gateway token/password auth (CWE-307)
- Maintains backward compatibility for explicit `gateway.auth.rateLimit` tuning

## Validation
- `pnpm exec vitest run src/gateway/auth-rate-limit-config.test.ts src/gateway/auth-rate-limit.test.ts`

Closes #14137

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Closes a CWE-307 brute-force gap by enabling gateway auth rate limiting by default whenever shared-secret auth (`token` or `password`) is configured, rather than requiring explicit `gateway.auth.rateLimit` configuration.

- Adds `resolveGatewayAuthRateLimitConfig()` helper that returns a `RateLimitConfig` with `undefined` fields (letting `createAuthRateLimiter()` apply its safe defaults) when shared-secret auth is active, and `undefined` (no limiter) when it isn't
- Wires the resolver into `startGatewayServer()` replacing the previous direct config read
- Preserves backward compatibility: explicit `gateway.auth.rateLimit` values still take precedence
- Import reordering in `server.impl.ts` is cosmetic (alphabetical sort), no imports added or removed beyond the new resolver

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a secure default without breaking existing configurations.
- The change is small, well-scoped, and purely additive in terms of security posture. The new resolver correctly matches auth mode to credential presence, preserves explicit user config, and the existing rate limiter creation path is unchanged. Import reordering is cosmetic. Tests cover all meaningful branches. No regressions or logical errors identified.
- No files require special attention.

<sub>Last reviewed commit: 75ec00d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->