### PR TITLE
fix: Limit unsupported flags to actual unsupported leaf paths and make renderer support wildcard path matching so map parents still render. (#1749)

### DIFF
--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -96,10 +96,13 @@ function normalizeSchemaNode(
     if (!itemsSchema) {
       unsupported.add(pathLabel);
     } else {
-      const res = normalizeSchemaNode(itemsSchema, [...path, "*"]);
+      // Arrays use numeric indices at render time, which pathKey() strips,
+      // so we recurse with the same path (no "*" segment) unlike maps where
+      // string keys are preserved by pathKey().
+      const res = normalizeSchemaNode(itemsSchema, [...path]);
       normalized.items = res.schema ?? itemsSchema;
-      if (res.unsupportedPaths.length > 0) {
-        unsupported.add(pathLabel);
+      for (const entry of res.unsupportedPaths) {
+        unsupported.add(entry);
       }
     }
   } else if (

--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -86,8 +86,8 @@ function normalizeSchemaNode(
       if (!isAnySchema(schema.additionalProperties)) {
         const res = normalizeSchemaNode(schema.additionalProperties, [...path, "*"]);
         normalized.additionalProperties = res.schema ?? schema.additionalProperties;
-        if (res.unsupportedPaths.length > 0) {
-          unsupported.add(pathLabel);
+        for (const entry of res.unsupportedPaths) {
+          unsupported.add(entry);
         }
       }
     }

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -16,6 +16,10 @@ function isAnySchema(schema: JsonSchema): boolean {
   return keys.length === 0;
 }
 
+// Checks whether `key` matches any pattern in `unsupported`, supporting "*"
+// wildcards in individual path segments.  Complexity is O(n·m) where n is the
+// number of segments in `key` and m is the size of `unsupported`; this is fine
+// for typical schema sizes but worth noting for very large schemas.
 function isUnsupportedPath(key: string, unsupported: Set<string>): boolean {
   if (unsupported.has(key)) {
     return true;

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -16,6 +16,33 @@ function isAnySchema(schema: JsonSchema): boolean {
   return keys.length === 0;
 }
 
+function isUnsupportedPath(key: string, unsupported: Set<string>): boolean {
+  if (unsupported.has(key)) {
+    return true;
+  }
+  const segments = key.split(".");
+  for (const pattern of unsupported) {
+    if (!pattern.includes("*")) {
+      continue;
+    }
+    const patternSegments = pattern.split(".");
+    if (patternSegments.length !== segments.length) {
+      continue;
+    }
+    let match = true;
+    for (let i = 0; i < segments.length; i += 1) {
+      if (patternSegments[i] !== "*" && patternSegments[i] !== segments[i]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function jsonValue(value: unknown): string {
   if (value === undefined) {
     return "";
@@ -112,7 +139,7 @@ export function renderNode(params: {
   const help = hint?.help ?? schema.description;
   const key = pathKey(path);
 
-  if (unsupported.has(key)) {
+  if (isUnsupportedPath(key, unsupported)) {
     return html`<div class="cfg-field cfg-field--error">
       <div class="cfg-field__label">${label}</div>
       <div class="cfg-field__error">Unsupported schema node. Use Raw mode.</div>


### PR DESCRIPTION
## Summary
- **Problem:** The UI schema analyzer marks parent map nodes like `accounts` as unsupported when only nested child fields are unsupported.
- **What changed:** Limit unsupported flags to actual unsupported leaf paths and make renderer support wildcard path matching so map parents still render.

## Change Type
- [x] Bug fix

## Linked Issue/PR
- Closes #1749

## Security Impact
- Does this PR expose any new attack vectors? **No**
- Does this PR modify authentication or authorization logic? **No**
- Does this PR modify cryptographic code or key management? **No**
- Does this PR introduce new external dependencies? **No**
- Does this PR modify network handling or API endpoints? **No**

## AI-Assisted PR
This PR was generated by the OpenClaw auto-maintain LLM committee system.
- Claude and Codex analyzed independently and reached consensus
- Full gate validation passed (build, check, test)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where parent map and array nodes were incorrectly marked as unsupported when only nested child fields contained unsupported schemas. The fix propagates unsupported paths from children instead of marking parents, and adds wildcard pattern matching to the renderer so paths like `accounts.*.advanced` correctly match runtime paths like `accounts.default.advanced`.

- Modified schema analyzer to collect child unsupported paths instead of marking parents
- Arrays now recurse with the same path (no `*` segment) since `pathKey()` strips numeric indices
- Maps continue to use wildcard paths (`*`) since string keys are preserved
- Added `isUnsupportedPath()` helper with segment-by-segment wildcard matching
- Includes comprehensive tests for both array and map scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, logically sound, and thoroughly tested. The fix correctly addresses the reported issue by propagating unsupported paths from children rather than marking parents as unsupported. The implementation properly handles the distinction between arrays and maps based on how `pathKey()` processes their paths. Comprehensive test coverage validates both scenarios. The code includes helpful comments explaining the complexity tradeoff and implementation rationale.
- No files require special attention

<sub>Last reviewed commit: a86f224</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->