### PR TITLE
fix(ios): support Xcode 16+ team detection and fix ntohl build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,12 @@ skills-lock.json
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
+
+# Xcode build directories (xcodebuild output)
+apps/ios/build/
+apps/shared/OpenClawKit/build/
+Swabble/build/
+
 # Generated protocol schema (produced via pnpm protocol:gen)
 dist/protocol.schema.json
 .ant-colony/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: treat bare allowlist `*` as a true wildcard for parsed executables, including unresolved PATH lookups, so global opt-in allowlists work as configured. (#25250) Thanks @widingmarcus-cyber.
 - Gateway/Auth: allow trusted-proxy authenticated Control UI websocket sessions to skip device pairing when device identity is absent, preventing false `pairing required` failures behind trusted reverse proxies. (#25428) Thanks @SidQin-cyber.
 - Agents/Tool dispatch: await block-reply flush before tool execution starts so buffered block replies preserve message ordering around tool calls. (#25427) Thanks @SidQin-cyber.
+- iOS/Signing: improve `scripts/ios-team-id.sh` for Xcode 16+ by falling back to Xcode-managed provisioning profiles, add actionable guidance when an Apple account exists but no Team ID can be resolved, and ignore Xcode `xcodebuild` output directories (`apps/ios/build`, `apps/shared/OpenClawKit/build`, `Swabble/build`). (#22773) Thanks @brianleach.
 - macOS/Menu bar: stop reusing the injector delegate for the "Usage cost (30 days)" submenu to prevent recursive submenu injection loops when opening cost history. (#25341) Thanks @yingchunbai.
 - Control UI/Chat images: harden image-open clicks against reverse tabnabbing by using opener isolation (`noopener,noreferrer` plus `window.opener = null`). (#18685) Thanks @Mariana-Codebase.
 - CLI/Doctor: correct stale recovery hints to use valid commands (`openclaw gateway status --deep` and `openclaw configure --section model`). (#24485) Thanks @chilu18.

--- a/scripts/ios-team-id.sh
+++ b/scripts/ios-team-id.sh
@@ -10,6 +10,8 @@ preferred_team="${IOS_PREFERRED_TEAM_ID:-${OPENCLAW_IOS_DEFAULT_TEAM_ID:-Y5PE65H
 preferred_team_name="${IOS_PREFERRED_TEAM_NAME:-}"
 allow_keychain_fallback="${IOS_ALLOW_KEYCHAIN_TEAM_FALLBACK:-0}"
 prefer_non_free_team="${IOS_PREFER_NON_FREE_TEAM:-1}"
+preferred_team="${preferred_team//$'\r'/}"
+preferred_team_name="${preferred_team_name//$'\r'/}"
 
 declare -a team_ids=()
 declare -a team_is_free=()
@@ -34,6 +36,9 @@ append_team() {
   local candidate_id="$1"
   local candidate_is_free="$2"
   local candidate_name="$3"
+  candidate_id="${candidate_id//$'\r'/}"
+  candidate_is_free="${candidate_is_free//$'\r'/}"
+  candidate_name="${candidate_name//$'\r'/}"
   [[ -z "$candidate_id" ]] && return
 
   local i

--- a/scripts/ios-team-id.sh
+++ b/scripts/ios-team-id.sh
@@ -80,8 +80,44 @@ load_teams_from_legacy_defaults_key() {
   )
 }
 
+load_teams_from_xcode_managed_profiles() {
+  local profiles_dir="${HOME}/Library/MobileDevice/Provisioning Profiles"
+  [[ -d "$profiles_dir" ]] || return 0
+
+  while IFS= read -r team; do
+    [[ -z "$team" ]] && continue
+    append_team "$team" "0" ""
+  done < <(
+    for p in "${profiles_dir}"/*.mobileprovision; do
+      [[ -f "$p" ]] || continue
+      security cms -D -i "$p" 2>/dev/null \
+        | /usr/bin/python3 -c '
+import plistlib, sys
+try:
+    d = plistlib.load(sys.stdin.buffer)
+    for tid in d.get("TeamIdentifier", []):
+        print(tid)
+except Exception:
+    pass
+' 2>/dev/null
+    done | sort -u
+  )
+}
+
+has_xcode_account() {
+  local plist_path="${HOME}/Library/Preferences/com.apple.dt.Xcode.plist"
+  [[ -f "$plist_path" ]] || return 1
+  local accts
+  accts="$(defaults read com.apple.dt.Xcode DVTDeveloperAccountManagerAppleIDLists 2>/dev/null || true)"
+  [[ -n "$accts" ]] && [[ "$accts" != *"does not exist"* ]] && grep -q 'identifier' <<< "$accts"
+}
+
 load_teams_from_xcode_preferences
 load_teams_from_legacy_defaults_key
+
+if [[ ${#team_ids[@]} -eq 0 ]]; then
+  load_teams_from_xcode_managed_profiles
+fi
 
 if [[ ${#team_ids[@]} -eq 0 && "$allow_keychain_fallback" == "1" ]]; then
   while IFS= read -r team; do
@@ -95,7 +131,19 @@ if [[ ${#team_ids[@]} -eq 0 && "$allow_keychain_fallback" == "1" ]]; then
 fi
 
 if [[ ${#team_ids[@]} -eq 0 ]]; then
-  if [[ "$allow_keychain_fallback" == "1" ]]; then
+  if has_xcode_account; then
+    echo "An Apple account is signed in to Xcode, but no Team ID could be resolved." >&2
+    echo "" >&2
+    echo "On Xcode 16+, team data is not written until you build a project." >&2
+    echo "To fix this, do ONE of the following:" >&2
+    echo "" >&2
+    echo "  1. Open the iOS project in Xcode, select your Team in Signing &" >&2
+    echo "     Capabilities, and build once. Then re-run this script." >&2
+    echo "" >&2
+    echo "  2. Set your Team ID directly:" >&2
+    echo "       export IOS_DEVELOPMENT_TEAM=<your-10-char-team-id>" >&2
+    echo "     Find your Team ID at: https://developer.apple.com/account#MembershipDetailsCard" >&2
+  elif [[ "$allow_keychain_fallback" == "1" ]]; then
     echo "No Apple Team ID found. Open Xcode or install signing certificates first." >&2
   else
     echo "No Apple Team ID found in Xcode accounts. Open Xcode → Settings → Accounts and sign in, then retry." >&2

--- a/scripts/ios-team-id.sh
+++ b/scripts/ios-team-id.sh
@@ -94,7 +94,10 @@ load_teams_from_xcode_managed_profiles() {
         | /usr/bin/python3 -c '
 import plistlib, sys
 try:
-    d = plistlib.load(sys.stdin.buffer)
+    raw = sys.stdin.buffer.read()
+    if not raw:
+        raise SystemExit(0)
+    d = plistlib.loads(raw)
     for tid in d.get("TeamIdentifier", []):
         print(tid)
 except Exception:

--- a/test/scripts/ios-team-id.test.ts
+++ b/test/scripts/ios-team-id.test.ts
@@ -1,0 +1,195 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT = path.join(process.cwd(), "scripts", "ios-team-id.sh");
+
+async function writeExecutable(filePath: string, body: string): Promise<void> {
+  await writeFile(filePath, body, "utf8");
+  chmodSync(filePath, 0o755);
+}
+
+function runScript(
+  homeDir: string,
+  extraEnv: Record<string, string> = {},
+): {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+} {
+  const binDir = path.join(homeDir, "bin");
+  const env = {
+    ...process.env,
+    HOME: homeDir,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    ...extraEnv,
+  };
+  try {
+    const stdout = execFileSync("bash", [SCRIPT], {
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: true, stdout: stdout.trim(), stderr: "" };
+  } catch (error) {
+    const e = error as {
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+    };
+    const stdout = typeof e.stdout === "string" ? e.stdout : (e.stdout?.toString("utf8") ?? "");
+    const stderr = typeof e.stderr === "string" ? e.stderr : (e.stderr?.toString("utf8") ?? "");
+    return { ok: false, stdout: stdout.trim(), stderr: stderr.trim() };
+  }
+}
+
+describe("scripts/ios-team-id.sh", () => {
+  it("falls back to Xcode-managed provisioning profiles when preference teams are empty", async () => {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-ios-team-id-"));
+    const binDir = path.join(homeDir, "bin");
+    await mkdir(binDir, { recursive: true });
+    await mkdir(path.join(homeDir, "Library", "Preferences"), { recursive: true });
+    await mkdir(path.join(homeDir, "Library", "MobileDevice", "Provisioning Profiles"), {
+      recursive: true,
+    });
+    await writeFile(path.join(homeDir, "Library", "Preferences", "com.apple.dt.Xcode.plist"), "");
+    await writeFile(
+      path.join(homeDir, "Library", "MobileDevice", "Provisioning Profiles", "one.mobileprovision"),
+      "stub",
+    );
+
+    await writeExecutable(
+      path.join(binDir, "plutil"),
+      `#!/usr/bin/env bash
+echo '{}'`,
+    );
+    await writeExecutable(
+      path.join(binDir, "defaults"),
+      `#!/usr/bin/env bash
+if [[ "$3" == "DVTDeveloperAccountManagerAppleIDLists" ]]; then
+  echo '(identifier = "dev@example.com";)'
+  exit 0
+fi
+exit 0`,
+    );
+    await writeExecutable(
+      path.join(binDir, "security"),
+      `#!/usr/bin/env bash
+if [[ "$1" == "cms" && "$2" == "-D" ]]; then
+  cat <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>TeamIdentifier</key>
+  <array>
+    <string>ABCDE12345</string>
+  </array>
+</dict>
+</plist>
+PLIST
+  exit 0
+fi
+exit 0`,
+    );
+
+    const result = runScript(homeDir);
+    expect(result.ok).toBe(true);
+    expect(result.stdout).toBe("ABCDE12345");
+  });
+
+  it("prints actionable guidance when Xcode account exists but no Team ID is resolvable", async () => {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-ios-team-id-"));
+    const binDir = path.join(homeDir, "bin");
+    await mkdir(binDir, { recursive: true });
+    await mkdir(path.join(homeDir, "Library", "Preferences"), { recursive: true });
+    await writeFile(path.join(homeDir, "Library", "Preferences", "com.apple.dt.Xcode.plist"), "");
+
+    await writeExecutable(
+      path.join(binDir, "plutil"),
+      `#!/usr/bin/env bash
+echo '{}'`,
+    );
+    await writeExecutable(
+      path.join(binDir, "defaults"),
+      `#!/usr/bin/env bash
+if [[ "$3" == "DVTDeveloperAccountManagerAppleIDLists" ]]; then
+  echo '(identifier = "dev@example.com";)'
+  exit 0
+fi
+echo "Domain/default pair of (com.apple.dt.Xcode, $3) does not exist" >&2
+exit 1`,
+    );
+    await writeExecutable(
+      path.join(binDir, "security"),
+      `#!/usr/bin/env bash
+exit 1`,
+    );
+
+    const result = runScript(homeDir);
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain("An Apple account is signed in to Xcode");
+    expect(result.stderr).toContain("IOS_DEVELOPMENT_TEAM");
+  });
+
+  it("honors IOS_PREFERRED_TEAM_ID when multiple profile teams are available", async () => {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-ios-team-id-"));
+    const binDir = path.join(homeDir, "bin");
+    await mkdir(binDir, { recursive: true });
+    await mkdir(path.join(homeDir, "Library", "Preferences"), { recursive: true });
+    await mkdir(path.join(homeDir, "Library", "MobileDevice", "Provisioning Profiles"), {
+      recursive: true,
+    });
+    await writeFile(path.join(homeDir, "Library", "Preferences", "com.apple.dt.Xcode.plist"), "");
+    await writeFile(
+      path.join(homeDir, "Library", "MobileDevice", "Provisioning Profiles", "one.mobileprovision"),
+      "stub1",
+    );
+    await writeFile(
+      path.join(homeDir, "Library", "MobileDevice", "Provisioning Profiles", "two.mobileprovision"),
+      "stub2",
+    );
+
+    await writeExecutable(
+      path.join(binDir, "plutil"),
+      `#!/usr/bin/env bash
+echo '{}'`,
+    );
+    await writeExecutable(
+      path.join(binDir, "defaults"),
+      `#!/usr/bin/env bash
+if [[ "$3" == "DVTDeveloperAccountManagerAppleIDLists" ]]; then
+  echo '(identifier = "dev@example.com";)'
+  exit 0
+fi
+exit 0`,
+    );
+    await writeExecutable(
+      path.join(binDir, "security"),
+      `#!/usr/bin/env bash
+if [[ "$1" == "cms" && "$2" == "-D" ]]; then
+  if [[ "$4" == *"one.mobileprovision" ]]; then
+    cat <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>TeamIdentifier</key><array><string>AAAAA11111</string></array></dict></plist>
+PLIST
+    exit 0
+  fi
+  cat <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>TeamIdentifier</key><array><string>BBBBB22222</string></array></dict></plist>
+PLIST
+  exit 0
+fi
+exit 0`,
+    );
+
+    const result = runScript(homeDir, { IOS_PREFERRED_TEAM_ID: "BBBBB22222" });
+    expect(result.ok).toBe(true);
+    expect(result.stdout).toBe("BBBBB22222");
+  });
+});


### PR DESCRIPTION
## Summary

- **`scripts/ios-team-id.sh`**: Xcode 16+/26 no longer writes the `IDEProvisioningTeams` key to `com.apple.dt.Xcode.plist`, causing `ios-configure-signing.sh` to silently fail for any newly signed-in developer account. This adds a provisioning profile fallback (`load_teams_from_xcode_managed_profiles`) and detects when an Apple account is present but no team ID can be resolved, providing actionable guidance instead of a generic error.
- **`GatewayConnectionController.swift`**: `ntohl()` is not visible in Swift 6 strict concurrency mode on Xcode 26. Replaced with the equivalent `UInt32(bigEndian:)` which is pure Swift and works across all toolchain versions.
- **`.gitignore`**: Added `apps/ios/build/`, `apps/shared/OpenClawKit/build/`, and `Swabble/build/` — Xcode's `xcodebuild` output directories were not covered by the existing `.build/` entries (which only match SwiftPM output).

## Test plan

- [ ] Run `scripts/ios-team-id.sh` on Xcode 16+ with a signed-in Apple account — should resolve team ID or show actionable instructions
- [ ] Run `scripts/ios-team-id.sh` on Xcode 15 — existing behavior unchanged (IDEProvisioningTeams path still works)
- [ ] Build iOS target with Xcode 26 / Swift 6 — `GatewayConnectionController.swift` compiles without error
- [ ] Verify `xcodebuild` output in `build/` dirs is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed iOS build compatibility with Xcode 16+ and Swift 6. The PR addresses team detection failure on Xcode 16+ by adding a provisioning profile fallback and improves error messaging. Replaced deprecated `ntohl()` with Swift's `UInt32(bigEndian:)` for Swift 6 compatibility. Added appropriate Xcode build directory entries to `.gitignore`.

- **`scripts/ios-team-id.sh`**: Added `load_teams_from_xcode_managed_profiles()` fallback that parses local provisioning profiles when Xcode preferences don't contain team data (Xcode 16+ behavior). Enhanced error messages with actionable guidance when Apple account is present but team ID cannot be resolved.
- **`GatewayConnectionController.swift`**: Replaced C function `ntohl()` with native Swift `UInt32(bigEndian:)` to fix compilation under Swift 6 strict concurrency mode.
- **`.gitignore`**: Added `xcodebuild` output directories for `apps/ios/build/`, `apps/shared/OpenClawKit/build/`, and `Swabble/build/` (distinct from existing SwiftPM `.build/` patterns).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Changes are targeted and well-motivated. The Swift change is a straightforward API replacement that's functionally equivalent. The bash script additions follow existing patterns and add useful fallback logic. The .gitignore entries are standard build artifact patterns. Score is 4 (not 5) due to the complexity of the bash script's provisioning profile parsing logic, which would benefit from manual testing on Xcode 16+.
- No files require special attention

<sub>Last reviewed commit: 3cdd0c4</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->