### PR TITLE
fix: allow empty string for edit tool newText parameter

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -351,6 +351,7 @@ export const CLAUDE_PARAM_GROUPS = {
     {
       keys: ["newText", "new_string"],
       label: "newText (newText or new_string)",
+      allowEmpty: true,
     },
   ],
 } as const;


### PR DESCRIPTION
## Summary

Allows the edit tool to accept an empty string for `newText`/`new_string`, enabling text deletion (replacing a block with nothing).

## Problem

When a model calls the edit tool with `newText: ""` to delete a text block, `assertRequiredParams` rejects it with "Missing required parameter: newText" because empty strings are treated as missing by default.

## Fix

Added `allowEmpty: true` to the `newText` parameter group in `src/agents/pi-tools.read.ts`. The `allowEmpty` flag is already supported by the validation logic (line 510) and used elsewhere in the codebase.

**1 file changed**, 1 property added.

Fixes #19085

## Local Validation

- Verified `allowEmpty` is already used in 6+ other locations
- Confirmed the validation logic at line 510 handles the flag correctly

## Scope

Single property addition in `src/agents/pi-tools.read.ts`.

## Author

**Miloud Belarebia** — [@miloudbelarebia](https://github.com/miloudbelarebia)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `allowEmpty: true` to the `newText` parameter in the edit tool configuration, enabling text deletion by allowing empty strings as valid input. The validation logic at line 511 already handles this flag correctly, and the pattern is consistently used throughout the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single property addition that enables an already-supported feature. The validation logic at line 511 correctly handles the `allowEmpty` flag, and the pattern is used consistently in 6+ other locations in the codebase. No breaking changes or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 2a1be57</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->