### PR TITLE
fix(browser): respect fullPage option in screenshot captureBeyondViewport

### DIFF
--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -72,7 +72,7 @@ export async function captureScreenshot(opts: {
       format,
       ...(quality !== undefined ? { quality } : {}),
       fromSurface: true,
-      captureBeyondViewport: true,
+      captureBeyondViewport: opts.fullPage ?? false,
       ...(clip ? { clip } : {}),
     })) as { data?: string };
 


### PR DESCRIPTION
## Summary

Fixes viewport-only screenshots capturing the entire page because `captureBeyondViewport` was hardcoded to `true`.

## Problem

In `src/browser/cdp.ts`, the CDP `Page.captureScreenshot` call always uses `captureBeyondViewport: true`, ignoring the `fullPage` option. This means `fullPage: false` screenshots still capture content beyond the viewport.

## Fix

Changed `captureBeyondViewport: true` to `captureBeyondViewport: opts.fullPage ?? false`.

**1 file changed**, 1 line modified.

Fixes #17476

## Scope

Single line change in `src/browser/cdp.ts`.

## Author

**Miloud Belarebia** — [@miloudbelarebia](https://github.com/miloudbelarebia)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug where viewport-only screenshots (`fullPage: false`) were incorrectly capturing the entire page. The `captureScreenshot` function in `src/browser/cdp.ts:75` was hardcoded with `captureBeyondViewport: true`, which caused it to ignore the `fullPage` option. The fix changes this to `captureBeyondViewport: opts.fullPage ?? false`, ensuring that:
- When `fullPage: true` → captures beyond viewport with full page dimensions
- When `fullPage: false` or undefined → captures only the visible viewport

This is a minimal, targeted fix that directly addresses the root cause.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line fix that corrects a clear logic error where a hardcoded boolean value was preventing the `fullPage` option from working as intended. The fix properly respects the `fullPage` parameter using standard nullish coalescing, maintains backward compatibility (defaults to false when undefined), and aligns with the existing logic that sets clip regions based on `fullPage`. No new dependencies, no breaking changes, and addresses the reported issue #17476 directly.
- No files require special attention

<sub>Last reviewed commit: 5e59b43</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->