### PR TITLE
(fix): fix description so the food-order skill gets included

### DIFF
--- a/skills/food-order/SKILL.md
+++ b/skills/food-order/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: food-order
-description: Reorder Foodora orders + track ETA/status with ordercli. Never confirm without explicit user approval. Triggers: order food, reorder, track ETA.
+description: "Reorder Foodora orders + track ETA/status with ordercli. Never confirm without explicit user approval. Triggers: order food, reorder, track ETA."
 homepage: https://ordercli.sh
 metadata: {"openclaw":{"emoji":"🥡","requires":{"bins":["ordercli"]},"install":[{"id":"go","kind":"go","module":"github.com/steipete/ordercli/cmd/ordercli@latest","bins":["ordercli"],"label":"Install ordercli (go)"}]}}
 ---


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: food-order skill's description is an unquoted string containing colon (:) "Triggers: …" so it fails during decode and never gets added to the skill list. 
- Why it matters: The food-order skill was never loaded, so it did not appear in the merged skills list or in the system prompt. The agent had no indication that the skill existed: it did not see “food-order” in the list of available skills, had no description to decide when to use it (e.g. “order food”, “reorder”, “track ETA”), and could not follow the skill’s commands (e.g. ordercli foodora reorder, ordercli foodora orders). Users could not use OpenClaw to reorder Foodora orders or track delivery status via this skill until the description was fixed (by quoting it so the colon is not parsed as YAML).
- What changed: adds quote to the description string.
- What did NOT change (scope boundary): the rest of the SKILL.md file of food-order skill.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

## User-visible / Behavior Changes

List user-visible changes (including defaults/config). 
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A - change is limited to YAML frontmatter quoting in skills/food-order/SKILL.md so the skill loads; no runtime or permission changes.

## Repro + Verification

### Environment

- OS: MacOS
- Runtime/container: Node v23.10.0, pnpm v10.23.0
- Model/provider: Macbook Air M4
- Integration/channel (if any): 
- Relevant config (redacted): 

### Steps

1.Use a tree where skills/food-order/SKILL.md has an unquoted description containing Triggers: ….
2.Run openclaw skills list.
3.Observe: food-order missing from list

<img width="1671" height="206" alt="image" src="https://github.com/user-attachments/assets/43670bff-7c3c-4f24-94e0-79a90003e7c2" />

### Expected
1.Use a tree where skills/food-order/SKILL.md has an unquoted description containing Triggers: ….
2.Run openclaw skills list.
3.Observe: food-order is in the list

<img width="775" height="95" alt="image" src="https://github.com/user-attachments/assets/552bb1b3-e02b-4834-961b-d30062256c43" />

### Actual

- food-order is missing from the list, also from onboard wizard as well (of course as it cannot parse the file)

## Evidence

main branch

<img width="1671" height="206" alt="image" src="https://github.com/user-attachments/assets/43670bff-7c3c-4f24-94e0-79a90003e7c2" />

fix branch

<img width="775" height="95" alt="image" src="https://github.com/user-attachments/assets/552bb1b3-e02b-4834-961b-d30062256c43" />

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
main branch, asking agent, it does not have access to `food-order` skill

<img width="1340" height="1081" alt="image" src="https://github.com/user-attachments/assets/6ebe6817-c943-40bf-9d36-9ed96559ec41" />

it does have access to other working skill such as weather

<img width="1406" height="749" alt="image" src="https://github.com/user-attachments/assets/4f201091-41c1-4d16-b71d-c69690fb17b1" />

fix branch, after installing the food-order skill, asking agent, now it has access to food-order skill

<img width="942" height="648" alt="image" src="https://github.com/user-attachments/assets/b0b6dd63-bfd8-4fcc-81c1-6b74bce5fa1d" />

- Edge cases checked: yes. There should be no other edge case on the fixed behaviour.
- What you did **not** verify: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed YAML parsing error in `food-order` skill by quoting the description field. The unquoted description containing `Triggers:` was being misinterpreted as YAML structure (colon after "Triggers" treated as key-value separator), causing `YAML.parse()` in `src/markdown/frontmatter.ts:37` to fail and preventing the skill from loading into the skill list.

- Added double quotes around the description field to escape the embedded colon
- Fix is consistent with other skills that have special YAML characters in descriptions (e.g., `weather`, `codex`, `discord`, `gh-issues`)
- No other changes to the skill file or functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-character change (adding quotes) fixes a clear YAML parsing bug. The fix follows established patterns in the codebase (other skills use quoted descriptions for strings containing colons), and the PR author has provided thorough before/after verification showing the skill now loads correctly. No runtime logic or security implications.
- No files require special attention

<sub>Last reviewed commit: 58607b5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->