### PR TITLE
fix: guard against undefined file.path in system-prompt-report

### DIFF
--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -43,6 +43,9 @@ function buildInjectedWorkspaceFiles(params: {
   const injectedByPath = new Map(params.injectedFiles.map((f) => [f.path, f.content]));
   const injectedByBaseName = new Map<string, string>();
   for (const file of params.injectedFiles) {
+    if (!file.path) {
+      continue;
+    }
     const normalizedPath = file.path.replace(/\\/g, "/");
     const baseName = path.posix.basename(normalizedPath);
     if (!injectedByBaseName.has(baseName)) {


### PR DESCRIPTION
## Summary
- Adds a null/undefined guard for `file.path` in `buildInjectedWorkspaceFiles()` to prevent `TypeError: Cannot read properties of undefined (reading 'replace')` when workspace bootstrap files have missing paths

Fixes #22693

## Local Validation
- [x] Code review: guard prevents crash when `file.path` is `undefined`
- [x] Existing tests pass (the guard simply skips entries with no path)

## Scope
XS — 3-line guard addition in one file

## Author
@miloudbelarebia

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a defensive guard to prevent crashes when `file.path` is undefined in workspace bootstrap files. The fix prevents `TypeError: Cannot read properties of undefined (reading 'replace')` by skipping files with missing paths when building the injected basename map.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - defensive guard prevents crash without changing behavior
- The fix is minimal, defensive, and correctly prevents the crash by skipping problematic entries. The guard only affects the basename map building, and files with undefined paths will still be processed by the main map lookup on line 58. The logic is sound and follows defensive programming practices.
- No files require special attention

<sub>Last reviewed commit: f92821b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->