### PR TITLE
fix(failover): add word boundary to 429 pattern in ERROR_PATTERNS

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -576,7 +576,7 @@ type ErrorPattern = RegExp | string;
 
 const ERROR_PATTERNS = {
   rateLimit: [
-    /rate[_ ]limit|too many requests|429/,
+    /rate[_ ]limit|too many requests|\b429\b/,
     "exceeded your current quota",
     "resource has been exhausted",
     "quota exceeded",


### PR DESCRIPTION
## Summary
- Adds `` word boundary to the `429` alternative in `ERROR_PATTERNS.rateLimit` regex, preventing false-positive rate-limit classification when `429` appears as a substring (e.g. in temp directory names like `openclaw-agent-429gnJ`)

The top-level `RATE_LIMIT_HINT_RE` (line 61) already uses `429`, and the `billing`/`auth` patterns use `` around their HTTP status codes (`402`, `401`, `403`). This aligns `ERROR_PATTERNS.rateLimit` with the same convention.

Fixes #11183

## Local Validation
- [x] Verified the regex change is consistent with other status code patterns in the same file
- [x] No other occurrences of bare `429` in error classification patterns

## Scope
XS — 1-line regex change in one file

## Author
@miloudbelarebia

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds word boundary `` to the `429` pattern in `ERROR_PATTERNS.rateLimit` regex, preventing false-positive rate-limit classification when `429` appears as a substring in unrelated text (e.g., temp directory names like `openclaw-agent-429gnJ`).

The fix aligns with existing patterns in the same file:
- `RATE_LIMIT_HINT_RE` (line 61) already uses `429`
- Auth patterns use `401` and `403` (lines 622-623)
- Billing patterns use `402` (line 603)

This is a targeted, low-risk fix that improves error classification accuracy.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-character regex change that fixes a legitimate bug (false-positive matching). The fix is consistent with existing patterns in the same file, well-documented in the PR description, and has minimal blast radius - it only affects error classification logic for rate-limit detection. The change makes the pattern more precise without removing any legitimate matches.
- No files require special attention

<sub>Last reviewed commit: d8427ea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->