### PR TITLE
fix: allow local clients to auto-pair without manual approval

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -734,7 +734,7 @@ export function attachGatewayWsMessageHandler(params: {
               role,
               scopes,
               remoteIp: reportedClientIp,
-              silent: isLocalClient && reason === "not-paired",
+              silent: isLocalClient,
             });
             const context = buildRequestContext();
             if (pairing.request.silent === true) {
@@ -753,6 +753,7 @@ export function attachGatewayWsMessageHandler(params: {
                   },
                   { dropIfSlow: true },
                 );
+                return true;
               }
             } else if (pairing.created) {
               context.broadcast("device.pair.requested", pairing.request, { dropIfSlow: true });


### PR DESCRIPTION
When a local client (127.0.0.1/loopback) connects and needs pairing or scope/role upgrade, the silent mode should auto-approve. This fix:

1. Changes silent=true for ALL local client pairing requests (not just not-paired)
2. Adds return true after successful auto-approval to prevent rejection

This resolves issues where local sub-agents cannot connect because they get stuck in pairing loop.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends auto-pairing for local clients from just initial pairing to include role and scope upgrades, preventing local sub-agents from getting stuck in pairing loops. Changes `silent` flag to apply to all local client pairing scenarios (not just "not-paired"), enabling automatic approval without manual intervention.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it's a focused fix for local client auto-pairing
- The changes correctly extend silent mode auto-approval to all local client pairing scenarios (not just initial pairing). The added early return on line 756 makes the control flow explicit. One minor consideration: when `approveDevicePairing` returns null (request doesn't exist), local clients still proceed with connection, which appears intentional for the local trust model but could mask edge cases where the pairing state is inconsistent
- No files require special attention - the single-file change is straightforward and well-scoped

<sub>Last reviewed commit: 2a913e1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->