### PR TITLE
fix: model-optimizer improvements from code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,10 @@ USER.md
 # local tooling
 .serena/
 
+# Test fixtures with credentials (NEVER COMMIT)
+tests/model-optimizer/_config-fix.json
+_config-fix*.json
+
 # Agent credentials and memory (NEVER COMMIT)
 /memory/
 .agent/*.json

--- a/scripts/model-optimizer.cjs
+++ b/scripts/model-optimizer.cjs
@@ -1,0 +1,724 @@
+#!/usr/bin/env node
+/**
+ * model-optimizer.cjs - OpenClaw Model Auto-Optimizer (Core Engine)
+ *
+ * Benchmarks all configured + discovered free models using a 3-test suite,
+ * scores them on composite criteria (latency 40%, throughput 25%,
+ * correctness 20%, availability 15%), and auto-rotates the primary model
+ * when a significantly better option is found.
+ *
+ * Architecture: parallel benchmarks with semaphore, 3 tests per model
+ * (math, instruction, availability), atomic config writes with timestamped
+ * backups, append-only JSONL history, and gateway hot-reload via SIGUSR1.
+ *
+ * Usage:
+ *   node model-optimizer.cjs [options]
+ *
+ * Options:
+ *   --auto           Run benchmark and auto-rotate if improvement found
+ *   --dry-run        Benchmark only, do not update config
+ *   --discover       Include provider discovery (check env for new providers)
+ *   --timeout <ms>   Per-request timeout (default: 30000)
+ *   --concurrency <n> Max concurrent model tests (default: 10)
+ *   --threshold <n>  Rotation threshold percentage (default: 10)
+ *   --json           Output results as JSON only (for scripting)
+ *   --verbose        Detailed per-test output
+ *   --providers X    Comma-separated provider filter (e.g. nvidia,groq)
+ *   --weights JSON   Custom scoring weights JSON string
+ *   --config <path>  Config file path (env: OPENCLAW_CONFIG_PATH)
+ *   --help           Show usage
+ */
+"use strict";
+
+var https = require("https");
+var http = require("http");
+var fs = require("fs");
+var path = require("path");
+
+var scoring = require("./scoring.cjs");
+var registry = require("./provider-registry.cjs");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+var DEFAULT_CONFIG_PATH = "/home/node/.openclaw/openclaw.json";
+var CONFIG_PATH = DEFAULT_CONFIG_PATH; // may be overridden by --config or env
+
+if (process.env.OPENCLAW_CONFIG_PATH) {
+  CONFIG_PATH = process.env.OPENCLAW_CONFIG_PATH;
+}
+var RESULTS_LATEST = "/tmp/model-optimizer-latest.json";
+var RESULTS_HISTORY = "/tmp/model-optimizer-history.jsonl";
+var VERSION = "1.0.0";
+
+var DEFAULT_TIMEOUT = 30000;
+var DEFAULT_CONCURRENCY = 10;
+var DEFAULT_THRESHOLD = 10;
+var MAX_FALLBACKS = 6;
+var MIN_FALLBACKS = 3;
+var RETRY_DELAY_MS = 5000;
+
+// ---------------------------------------------------------------------------
+// Test Suite (3 prompts per model, per architecture spec)
+// ---------------------------------------------------------------------------
+
+var TEST_SUITE = [
+  {
+    name: "math",
+    prompt: "What is 2+2? Reply with only the number.",
+    maxTokens: 64,
+    temperature: 0,
+  },
+  {
+    name: "instruction",
+    prompt: "List exactly 3 colors, one per line.",
+    maxTokens: 128,
+    temperature: 0,
+  },
+  {
+    name: "availability",
+    prompt: "Say hello.",
+    maxTokens: 64,
+    temperature: 0,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// CLI Argument Parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs() {
+  var args = process.argv.slice(2);
+  var opts = {
+    auto: false,
+    dryRun: false,
+    discover: false,
+    timeout: DEFAULT_TIMEOUT,
+    concurrency: DEFAULT_CONCURRENCY,
+    threshold: DEFAULT_THRESHOLD,
+    json: false,
+    verbose: false,
+    providers: null,
+    weights: null,
+    help: false,
+  };
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--auto": opts.auto = true; break;
+      case "--dry-run": opts.dryRun = true; break;
+      case "--discover": opts.discover = true; break;
+      case "--json": opts.json = true; break;
+      case "--verbose": opts.verbose = true; break;
+      case "--help": case "-h": opts.help = true; break;
+      case "--timeout": opts.timeout = parseInt(args[++i], 10) || DEFAULT_TIMEOUT; break;
+      case "--concurrency": opts.concurrency = parseInt(args[++i], 10) || DEFAULT_CONCURRENCY; break;
+      case "--threshold": opts.threshold = parseInt(args[++i], 10) || DEFAULT_THRESHOLD; break;
+      case "--providers": opts.providers = (args[++i] || "").split(",").filter(Boolean); break;
+      case "--weights":
+        try { opts.weights = JSON.parse(args[++i]); } catch (e) {
+          console.error("Invalid --weights JSON: " + e.message);
+          process.exit(1);
+        }
+        break;
+      case "--config":
+        CONFIG_PATH = args[++i];
+        break;
+    }
+  }
+
+  return opts;
+}
+
+function showHelp() {
+  console.log("model-optimizer.cjs - OpenClaw Model Auto-Optimizer v" + VERSION);
+  console.log("");
+  console.log("Usage: node model-optimizer.cjs [options]");
+  console.log("");
+  console.log("Options:");
+  console.log("  --auto           Run benchmark and auto-rotate if improvement found");
+  console.log("  --dry-run        Benchmark only, do not update config");
+  console.log("  --discover       Include provider discovery (check env for new providers)");
+  console.log("  --timeout <ms>   Per-request timeout (default: " + DEFAULT_TIMEOUT + ")");
+  console.log("  --concurrency <n> Max concurrent model tests (default: " + DEFAULT_CONCURRENCY + ")");
+  console.log("  --threshold <n>  Rotation threshold percentage (default: " + DEFAULT_THRESHOLD + ")");
+  console.log("  --json           Output results as JSON only");
+  console.log("  --verbose        Detailed per-test output");
+  console.log("  --providers X    Comma-separated provider filter");
+  console.log("  --weights JSON   Custom scoring weights JSON");
+  console.log("  --config <path>  Config file path (default: " + DEFAULT_CONFIG_PATH + ")");
+  console.log("                   Also settable via OPENCLAW_CONFIG_PATH env var");
+  console.log("  --help           Show this help");
+}
+
+// ---------------------------------------------------------------------------
+// HTTP Request Layer
+// ---------------------------------------------------------------------------
+
+function httpRequest(url, body, apiKey, timeoutMs) {
+  return new Promise(function(resolve) {
+    var u = new URL(url);
+    var mod = u.protocol === "https:" ? https : http;
+    var headers = { "Content-Type": "application/json" };
+    if (apiKey) headers["Authorization"] = "Bearer " + apiKey;
+    var data = JSON.stringify(body);
+    headers["Content-Length"] = Buffer.byteLength(data);
+
+    var start = performance.now();
+    var ttft = null;
+    var fullBody = "";
+    var timedOut = false;
+
+    var timer = setTimeout(function() {
+      timedOut = true;
+      req.destroy();
+      resolve({ error: "TIMEOUT", latencyMs: timeoutMs, ttftMs: null, body: "", statusCode: 0 });
+    }, timeoutMs);
+
+    var req = mod.request(u, { method: "POST", headers: headers }, function(res) {
+      res.on("data", function(chunk) {
+        if (ttft === null) ttft = performance.now() - start;
+        fullBody += chunk;
+      });
+      res.on("end", function() {
+        if (timedOut) return;
+        clearTimeout(timer);
+        var latencyMs = performance.now() - start;
+        if (res.statusCode >= 400) {
+          resolve({ error: "HTTP " + res.statusCode, latencyMs: latencyMs, ttftMs: ttft, body: fullBody.slice(0, 500), statusCode: res.statusCode });
+        } else {
+          resolve({ error: null, latencyMs: latencyMs, ttftMs: ttft, body: fullBody, statusCode: res.statusCode });
+        }
+      });
+    });
+
+    req.on("error", function(e) {
+      if (timedOut) return;
+      clearTimeout(timer);
+      var errMsg = e.message || String(e);
+      if (errMsg.indexOf("ENOTFOUND") >= 0) errMsg = "DNS_FAIL";
+      else if (errMsg.indexOf("ECONNREFUSED") >= 0) errMsg = "CONN_REFUSED";
+      resolve({ error: errMsg, latencyMs: performance.now() - start, ttftMs: null, body: "", statusCode: 0 });
+    });
+
+    req.write(data);
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Response Parsing (OpenAI, Anthropic, Responses API)
+// ---------------------------------------------------------------------------
+
+function extractResponse(body) {
+  try {
+    var d = JSON.parse(body);
+    if (d.choices && d.choices[0]) {
+      var c = d.choices[0];
+      var text = (c.message && c.message.content) || c.text || (c.delta && c.delta.content) || "";
+      var usage = d.usage || {};
+      return {
+        text: text.trim().slice(0, 500),
+        promptTokens: usage.prompt_tokens || 0,
+        completionTokens: usage.completion_tokens || 0,
+        totalTokens: usage.total_tokens || 0,
+      };
+    }
+    if (d.content && d.content[0]) {
+      return {
+        text: (d.content[0].text || "").trim().slice(0, 500),
+        promptTokens: (d.usage && d.usage.input_tokens) || 0,
+        completionTokens: (d.usage && d.usage.output_tokens) || 0,
+        totalTokens: ((d.usage && d.usage.input_tokens) || 0) + ((d.usage && d.usage.output_tokens) || 0),
+      };
+    }
+    if (d.output && Array.isArray(d.output)) {
+      var msg = d.output.find(function(o) { return o.type === "message"; });
+      if (msg && msg.content) {
+        var t = msg.content.map(function(cc) { return cc.text || ""; }).join("");
+        return { text: t.trim().slice(0, 500), promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      }
+    }
+    return { text: JSON.stringify(d).slice(0, 200), promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+  } catch (_e) {
+    return { text: (body || "").slice(0, 200), promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single Test Execution (with 429 retry)
+// ---------------------------------------------------------------------------
+
+function sleep(ms) {
+  return new Promise(function(resolve) { setTimeout(resolve, ms); });
+}
+
+async function runSingleTest(model, test, timeoutMs) {
+  var url = model.baseUrl.replace(/\/+$/, "") + "/chat/completions";
+  var body = {
+    model: model.id,
+    messages: [{ role: "user", content: test.prompt }],
+    max_tokens: test.maxTokens || 64,
+    temperature: test.temperature != null ? test.temperature : 0,
+    stream: false,
+  };
+
+  var res = await httpRequest(url, body, model.apiKey, timeoutMs);
+
+  // Retry once on HTTP 429 (rate limited)
+  if (res.statusCode === 429) {
+    await sleep(RETRY_DELAY_MS);
+    res = await httpRequest(url, body, model.apiKey, timeoutMs);
+  }
+
+  if (res.error) {
+    return {
+      name: test.name,
+      status: res.error === "TIMEOUT" ? "timeout" : "error",
+      latencyMs: Math.round(res.latencyMs),
+      ttftMs: res.ttftMs != null ? Math.round(res.ttftMs) : null,
+      response: "",
+      completionTokens: 0,
+      httpStatus: res.statusCode || 0,
+      error: res.error,
+    };
+  }
+
+  var parsed = extractResponse(res.body);
+  return {
+    name: test.name,
+    status: "ok",
+    latencyMs: Math.round(res.latencyMs),
+    ttftMs: res.ttftMs != null ? Math.round(res.ttftMs) : Math.round(res.latencyMs),
+    response: parsed.text,
+    completionTokens: parsed.completionTokens,
+    httpStatus: res.statusCode,
+    error: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Model Benchmark (run all 3 tests in parallel for one model)
+// ---------------------------------------------------------------------------
+
+async function benchmarkModel(model, timeoutMs) {
+  var testPromises = TEST_SUITE.map(function(test) {
+    return runSingleTest(model, test, timeoutMs);
+  });
+
+  var tests = await Promise.all(testPromises);
+
+  return {
+    provider: model.provider,
+    modelId: model.provider + "/" + model.id,
+    modelName: model.name,
+    free: model.free !== false,
+    tests: tests,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Parallel Benchmark with Semaphore (across models)
+// ---------------------------------------------------------------------------
+
+async function benchmarkAll(models, timeoutMs, maxConcurrent, quiet) {
+  var results = [];
+  var idx = 0;
+  var total = models.length;
+
+  async function worker() {
+    while (idx < total) {
+      var i = idx++;
+      var model = models[i];
+      if (!quiet) {
+        process.stdout.write("\r  Benchmarking [" + (i + 1) + "/" + total + "] " + model.provider + "/" + model.id + "...          ");
+      }
+      results[i] = await benchmarkModel(model, timeoutMs);
+    }
+  }
+
+  var workerCount = Math.min(maxConcurrent, total);
+  var workers = [];
+  for (var w = 0; w < workerCount; w++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+
+  if (!quiet) {
+    process.stdout.write("\r" + " ".repeat(80) + "\r");
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Config Management
+// ---------------------------------------------------------------------------
+
+function loadConfig() {
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
+}
+
+function createBackup() {
+  var now = new Date();
+  var ts = now.getFullYear().toString() +
+    String(now.getMonth() + 1).padStart(2, "0") +
+    String(now.getDate()).padStart(2, "0") + "-" +
+    String(now.getHours()).padStart(2, "0") +
+    String(now.getMinutes()).padStart(2, "0") +
+    String(now.getSeconds()).padStart(2, "0");
+  var backupPath = CONFIG_PATH + ".backup-" + ts;
+  fs.copyFileSync(CONFIG_PATH, backupPath);
+  return backupPath;
+}
+
+function atomicWriteConfig(cfg) {
+  var tmpPath = CONFIG_PATH + ".tmp";
+  var data = JSON.stringify(cfg, null, 2);
+  JSON.parse(data); // validate JSON before writing
+  fs.writeFileSync(tmpPath, data);
+  fs.renameSync(tmpPath, CONFIG_PATH);
+}
+
+function reloadGateway(quiet) {
+  try {
+    // Only signal PID 1 if we're in Docker (check /proc/1/cmdline)
+    var isDocker = false;
+    try {
+      var cmdline = fs.readFileSync("/proc/1/cmdline", "utf8");
+      isDocker = cmdline.indexOf("node") >= 0 || cmdline.indexOf("openclaw") >= 0;
+    } catch (_) {
+      // /proc not available (Windows, macOS) — not in Docker
+    }
+    if (!isDocker) {
+      if (!quiet) console.log("  Skipping gateway reload (not running in Docker container).");
+      return;
+    }
+    process.kill(1, "SIGUSR1");
+    if (!quiet) console.log("  Gateway reload signal sent (SIGUSR1).");
+  } catch (e) {
+    if (!quiet) console.log("  Warning: Could not send SIGUSR1 to PID 1: " + e.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fallback Selection
+// ---------------------------------------------------------------------------
+
+function buildFallbacks(rankedModels, primaryModelId) {
+  var candidates = rankedModels.filter(function(m) {
+    return m.composite > 0 && m.modelId !== primaryModelId;
+  });
+
+  // Stable sort: by score descending, then free first
+  candidates.sort(function(a, b) {
+    if (b.composite !== a.composite) return b.composite - a.composite;
+    if (a.free && !b.free) return -1;
+    if (!a.free && b.free) return 1;
+    return 0;
+  });
+
+  return candidates.slice(0, MAX_FALLBACKS).map(function(m) { return m.modelId; });
+}
+
+// ---------------------------------------------------------------------------
+// Human-Readable Output
+// ---------------------------------------------------------------------------
+
+function formatTable(rankedModels, failures, opts) {
+  console.log("");
+  console.log("  #  Score  Provider       Model                         Latency  TTFT     Tok/s  Tests  Free");
+  console.log("  -- -----  -------------- ----------------------------- -------- -------- ------ ------ ----");
+
+  for (var i = 0; i < rankedModels.length; i++) {
+    var r = rankedModels[i];
+    var testsPassed = r.successCount + "/" + r.totalTests;
+    var freeStr = r.free ? "YES" : "NO";
+    var latStr = r.avgLatencyMs != null ? r.avgLatencyMs + "ms" : "?";
+    var ttftStr = r.avgTtftMs != null ? r.avgTtftMs + "ms" : "?";
+    var tpsStr = r.tokPerSec != null ? String(r.tokPerSec) : "?";
+
+    console.log(
+      "  " + String(r.rank).padStart(2) +
+      "  " + String(r.composite).padStart(5) +
+      "  " + r.provider.padEnd(14) +
+      " " + (r.modelName || r.modelId).slice(0, 29).padEnd(29) +
+      " " + latStr.padEnd(8) +
+      " " + ttftStr.padEnd(8) +
+      " " + tpsStr.padEnd(6) +
+      " " + testsPassed.padEnd(6) +
+      " " + freeStr
+    );
+  }
+
+  if (opts.verbose) {
+    for (var j = 0; j < rankedModels.length; j++) {
+      var m = rankedModels[j];
+      console.log("\n  " + m.modelId + ":");
+      console.log("    Latency:      " + m.latencyScore + "/100 (avg TTFT: " + (m.avgTtftMs || "?") + "ms)");
+      console.log("    Throughput:   " + m.throughputScore + "/100 (" + (m.tokPerSec || "?") + " tok/s)");
+      console.log("    Correctness:  " + m.correctnessScore + "/100 (" + JSON.stringify(m.tests) + ")");
+      console.log("    Availability: " + m.availabilityScore + "/100 (" + m.successCount + "/" + m.totalTests + ")");
+      console.log("    COMPOSITE:    " + m.composite + "/100");
+    }
+  }
+
+  if (failures.length > 0) {
+    console.log("\n  FAILED MODELS (" + failures.length + "):");
+    for (var k = 0; k < failures.length; k++) {
+      var f = failures[k];
+      console.log("    x " + f.modelId + " (score: " + f.composite + ")");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON Result Builder
+// ---------------------------------------------------------------------------
+
+function buildResultJSON(ranked, failures, rawResults, rotated, reason, backupPath, currentPrimary, newPrimary, fallbacks, elapsed) {
+  return {
+    timestamp: new Date().toISOString(),
+    version: VERSION,
+    elapsedMs: elapsed,
+    totalModels: rawResults.length,
+    testedModels: rawResults.length,
+    workingModels: ranked.length,
+    failedModels: failures.length,
+    primary: {
+      provider: ranked.length > 0 ? ranked[0].provider : null,
+      modelId: newPrimary,
+      score: ranked.length > 0 ? ranked[0].composite : 0,
+      latencyMs: ranked.length > 0 ? ranked[0].avgLatencyMs : null,
+      tokPerSec: ranked.length > 0 ? ranked[0].tokPerSec : null,
+    },
+    fallbacks: fallbacks,
+    rotated: rotated,
+    rotationReason: reason,
+    configBackup: backupPath || null,
+    rankings: ranked.map(function(r) {
+      return {
+        rank: r.rank,
+        provider: r.provider,
+        modelId: r.modelId,
+        modelName: r.modelName,
+        free: r.free,
+        composite: r.composite,
+        latencyScore: r.latencyScore,
+        throughputScore: r.throughputScore,
+        correctnessScore: r.correctnessScore,
+        availabilityScore: r.availabilityScore,
+        avgLatencyMs: r.avgLatencyMs,
+        avgTtftMs: r.avgTtftMs,
+        tokPerSec: r.tokPerSec,
+        tests: r.tests,
+      };
+    }),
+    failures: failures.map(function(f) {
+      return {
+        provider: f.provider,
+        modelId: f.modelId,
+        error: "All tests failed or scored 0",
+      };
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  var opts = parseArgs();
+
+  if (opts.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  // Load config
+  var cfg = loadConfig();
+  var currentPrimaryId = "";
+  if (cfg.agents && cfg.agents.defaults && cfg.agents.defaults.model) {
+    currentPrimaryId = cfg.agents.defaults.model.primary || "";
+  }
+
+  // Build testable model list
+  var envKeys = null;
+  if (opts.discover) {
+    envKeys = {};
+    var known = registry.getKnownProviders();
+    for (var p = 0; p < known.length; p++) {
+      var envKey = process.env[known[p].envVar];
+      if (envKey) envKeys[known[p].name] = envKey;
+    }
+  }
+
+  var models = registry.getTestableModels(cfg, envKeys);
+
+  // Filter by provider
+  if (opts.providers) {
+    models = models.filter(function(m) { return opts.providers.indexOf(m.provider) >= 0; });
+  }
+
+  // Filter out models without API keys
+  models = models.filter(function(m) { return m.apiKey; });
+
+  if (models.length === 0) {
+    if (!opts.json) console.error("No models available to benchmark. Check config or set provider API keys.");
+    process.exit(1);
+  }
+
+  if (!opts.json) {
+    console.log("\n=== OpenClaw Model Auto-Optimizer v" + VERSION + " ===");
+    console.log("  Models: " + models.length + " | Timeout: " + opts.timeout + "ms | Concurrency: " + opts.concurrency);
+    console.log("  Current primary: " + (currentPrimaryId || "(none)"));
+    console.log("  Tests per model: " + TEST_SUITE.length + " (" + TEST_SUITE.map(function(t) { return t.name; }).join(", ") + ")");
+    console.log("");
+  }
+
+  // Run benchmarks (parallel with semaphore)
+  var startTime = Date.now();
+  var rawResults = await benchmarkAll(models, opts.timeout, opts.concurrency, opts.json);
+  var elapsed = Date.now() - startTime;
+
+  // Score all results using the multi-test scoring engine
+  var scoredResults = rawResults.map(function(raw) {
+    return scoring.scoreModel(raw, opts.weights);
+  });
+
+  // Rank working models and separate failures
+  var ranked = scoring.rankModels(scoredResults.filter(function(r) { return r.composite > 0; }));
+  var failures = scoredResults.filter(function(r) { return r.composite <= 0; });
+
+  // Display results
+  if (!opts.json) {
+    console.log("  Benchmarked " + models.length + " models in " + (elapsed / 1000).toFixed(1) + "s");
+    console.log("  Working: " + ranked.length + " | Failed: " + failures.length);
+    formatTable(ranked, failures, opts);
+  }
+
+  // Rotation decision
+  var newPrimaryId = currentPrimaryId;
+  var fallbackIds = [];
+  if (cfg.agents && cfg.agents.defaults && cfg.agents.defaults.model) {
+    fallbackIds = cfg.agents.defaults.model.fallbacks || [];
+  }
+  var rotated = false;
+  var rotationReason = "No rotation needed";
+  var backupPath = null;
+
+  if (ranked.length > 0) {
+    var newBest = ranked[0];
+    var currentScored = ranked.find(function(r) { return r.modelId === currentPrimaryId; }) || null;
+    var decision = scoring.shouldRotate(currentScored, newBest, opts.threshold);
+
+    if (!opts.json) {
+      console.log("\n  ROTATION DECISION:");
+      console.log("    Best model:    " + newBest.modelId + " (score: " + newBest.composite + ")");
+      console.log("    Current model: " + (currentPrimaryId || "(none)") + " (score: " + (currentScored ? currentScored.composite : 0) + ")");
+      console.log("    Decision:      " + (decision.rotate ? "ROTATE" : "KEEP") + " - " + decision.reason);
+    }
+
+    var newFallbacks = buildFallbacks(ranked, decision.rotate ? newBest.modelId : currentPrimaryId);
+
+    if (decision.rotate && !opts.dryRun && opts.auto) {
+      // Create backup FIRST (safety invariant)
+      try {
+        backupPath = createBackup();
+      } catch (e) {
+        if (!opts.json) console.error("  CRITICAL: Backup failed (" + e.message + "). Aborting rotation.");
+        rotationReason = "Backup failed: " + e.message;
+        var abortResult = buildResultJSON(ranked, failures, rawResults, false, rotationReason, null, currentPrimaryId, currentPrimaryId, fallbackIds, elapsed);
+        try { fs.writeFileSync(RESULTS_LATEST, JSON.stringify(abortResult, null, 2)); } catch (_e) {}
+        if (opts.json) console.log(JSON.stringify(abortResult, null, 2));
+        process.exit(1);
+      }
+
+      // Update config
+      newPrimaryId = newBest.modelId;
+      fallbackIds = newFallbacks;
+      rotated = true;
+      rotationReason = decision.reason;
+
+      if (!cfg.agents) cfg.agents = {};
+      if (!cfg.agents.defaults) cfg.agents.defaults = {};
+      cfg.agents.defaults.model = {
+        primary: newPrimaryId,
+        fallbacks: fallbackIds,
+      };
+
+      try {
+        atomicWriteConfig(cfg);
+        if (!opts.json) {
+          console.log("\n  CONFIG UPDATED:");
+          console.log("    Backup: " + backupPath);
+          console.log("    Primary: " + newPrimaryId);
+          console.log("    Fallbacks: " + fallbackIds.join(", "));
+        }
+        reloadGateway(opts.json);
+      } catch (e) {
+        if (!opts.json) console.error("  ERROR writing config: " + e.message);
+        rotated = false;
+        rotationReason = "Config write failed: " + e.message;
+      }
+    } else if (decision.rotate && opts.dryRun) {
+      rotationReason = "DRY RUN - would rotate: " + decision.reason;
+      newPrimaryId = newBest.modelId;
+      fallbackIds = newFallbacks;
+      if (!opts.json) {
+        console.log("\n  DRY RUN - would update to:");
+        console.log("    Primary: " + newBest.modelId);
+        console.log("    Fallbacks: " + newFallbacks.join(", "));
+      }
+    } else {
+      rotationReason = decision.reason;
+      // Still update fallback order if changed (non-disruptive reorder)
+      if (!opts.dryRun && newFallbacks.length >= MIN_FALLBACKS) {
+        var currentFallbacks = [];
+        if (cfg.agents && cfg.agents.defaults && cfg.agents.defaults.model) {
+          currentFallbacks = cfg.agents.defaults.model.fallbacks || [];
+        }
+        var fallbacksChanged = JSON.stringify(newFallbacks) !== JSON.stringify(currentFallbacks);
+        if (fallbacksChanged) {
+          fallbackIds = newFallbacks;
+          if (!cfg.agents) cfg.agents = {};
+          if (!cfg.agents.defaults) cfg.agents.defaults = {};
+          if (!cfg.agents.defaults.model) cfg.agents.defaults.model = {};
+          cfg.agents.defaults.model.fallbacks = newFallbacks;
+          try {
+            backupPath = createBackup();
+            atomicWriteConfig(cfg);
+            if (!opts.json) console.log("\n  Fallback order updated (primary unchanged).");
+          } catch (e) {
+            if (!opts.json) console.log("  Warning: Could not update fallback order: " + e.message);
+          }
+        }
+      }
+    }
+  } else {
+    rotationReason = "No working models found. Config unchanged.";
+    if (!opts.json) console.log("\n  WARNING: No working models found. Config unchanged.");
+  }
+
+  // Build and persist results
+  var resultJSON = buildResultJSON(ranked, failures, rawResults, rotated, rotationReason, backupPath, currentPrimaryId, newPrimaryId, fallbackIds, elapsed);
+
+  try { fs.writeFileSync(RESULTS_LATEST, JSON.stringify(resultJSON, null, 2)); } catch (_e) {}
+  try { fs.appendFileSync(RESULTS_HISTORY, JSON.stringify(resultJSON) + "\n"); } catch (_e) {}
+
+  if (opts.json) {
+    console.log(JSON.stringify(resultJSON, null, 2));
+  } else {
+    console.log("\n  Results saved to " + RESULTS_LATEST);
+    console.log("  History appended to " + RESULTS_HISTORY);
+    console.log("");
+  }
+}
+
+main().catch(function(e) {
+  console.error("Model optimizer error: " + (e.message || e));
+  process.exit(1);
+});

--- a/scripts/provider-db.cjs
+++ b/scripts/provider-db.cjs
@@ -1,0 +1,671 @@
+#!/usr/bin/env node
+/**
+ * provider-db.cjs - SQLite database layer for dynamic provider management.
+ *
+ * Provides CRUD operations for providers and models backed by SQLite (WAL mode).
+ * Uses Node.js built-in node:sqlite (DatabaseSync) - no native addons needed.
+ * Seeds builtin providers from provider-registry.cjs on first use.
+ * Merges DB providers with config to produce testable model lists.
+ *
+ * Key functions:
+ *  - initDB(dbPath)                    - Open/create database with schema
+ *  - seedBuiltinProviders(db)          - Seed KNOWN_PROVIDERS (idempotent)
+ *  - getProviders(db, opts)            - List providers with optional filters
+ *  - getProvider(db, name)             - Single provider with models
+ *  - addProvider(db, data)             - Add new provider + models
+ *  - updateProvider(db, name, updates) - Update provider fields
+ *  - removeProvider(db, name, force)   - Remove (builtin requires force)
+ *  - addModel(db, providerName, data)  - Add model to provider
+ *  - removeModel(db, providerName, id) - Remove model
+ *  - toggleProvider(db, name, enabled) - Enable/disable provider
+ *  - toggleModel(db, prov, id, on)     - Enable/disable model
+ *  - getTestableModelsFromDB(db, cfg, envKeys) - Flat deduped list for benchmarks
+ *  - closeDB(db)                       - Safe close
+ */
+"use strict";
+
+var path = require("path");
+var fs = require("fs");
+
+var DEFAULT_DB_PATH = path.join(
+  process.env.HOME || process.env.USERPROFILE || "/home/node",
+  ".openclaw",
+  "providers.db"
+);
+
+// Lazy-loaded to avoid circular dependency with provider-registry.cjs
+var _registry = null;
+function getRegistry() {
+  if (!_registry) _registry = require("./provider-registry.cjs");
+  return _registry;
+}
+
+// ---------------------------------------------------------------------------
+// Database Initialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialize the provider database.
+ * Creates tables if they don't exist. Uses node:sqlite DatabaseSync.
+ * @param {string} [dbPath] - path to SQLite file (default: ~/.openclaw/providers.db)
+ * @returns {Object} DatabaseSync instance
+ */
+function initDB(dbPath) {
+  var sqlite = require("node:sqlite");
+  var resolvedPath = dbPath || process.env.OPENCLAW_PROVIDERS_DB || DEFAULT_DB_PATH;
+
+  // Ensure directory exists (skip for :memory:)
+  if (resolvedPath !== ":memory:") {
+    var dir = path.dirname(resolvedPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  }
+
+  var db = new sqlite.DatabaseSync(resolvedPath);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS providers (" +
+    "  name TEXT PRIMARY KEY," +
+    "  display_name TEXT NOT NULL," +
+    "  base_url TEXT NOT NULL," +
+    "  api TEXT NOT NULL DEFAULT 'openai-completions'," +
+    "  auth_type TEXT NOT NULL DEFAULT 'bearer'," +
+    "  requires_key INTEGER NOT NULL DEFAULT 1," +
+    "  env_var TEXT," +
+    "  rate_limit_rpm INTEGER DEFAULT 30," +
+    "  rate_limit_tpm INTEGER DEFAULT 100000," +
+    "  signup_url TEXT," +
+    "  enabled INTEGER NOT NULL DEFAULT 1," +
+    "  is_builtin INTEGER NOT NULL DEFAULT 0," +
+    "  created_at TEXT DEFAULT (datetime('now'))," +
+    "  updated_at TEXT DEFAULT (datetime('now'))" +
+    ")"
+  );
+
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS models (" +
+    "  id TEXT NOT NULL," +
+    "  provider_name TEXT NOT NULL," +
+    "  name TEXT NOT NULL," +
+    "  free INTEGER NOT NULL DEFAULT 1," +
+    "  context_window INTEGER DEFAULT 131072," +
+    "  max_tokens INTEGER DEFAULT 8192," +
+    "  reasoning INTEGER DEFAULT 0," +
+    "  input TEXT DEFAULT '[\"text\"]'," +
+    "  cost_input REAL DEFAULT 0," +
+    "  cost_output REAL DEFAULT 0," +
+    "  enabled INTEGER NOT NULL DEFAULT 1," +
+    "  is_builtin INTEGER NOT NULL DEFAULT 0," +
+    "  created_at TEXT DEFAULT (datetime('now'))," +
+    "  updated_at TEXT DEFAULT (datetime('now'))," +
+    "  PRIMARY KEY (id, provider_name)," +
+    "  FOREIGN KEY (provider_name) REFERENCES providers(name) ON DELETE CASCADE" +
+    ")"
+  );
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Seeding
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed builtin providers from KNOWN_PROVIDERS. Idempotent (INSERT OR IGNORE).
+ * Wraps all inserts in a single transaction for performance.
+ * @param {Object} db - DatabaseSync instance
+ */
+function seedBuiltinProviders(db) {
+  var known = getRegistry().KNOWN_PROVIDERS;
+
+  var insertProvider = db.prepare(
+    "INSERT OR IGNORE INTO providers " +
+    "(name, display_name, base_url, api, auth_type, requires_key, env_var, " +
+    "rate_limit_rpm, rate_limit_tpm, signup_url, is_builtin) " +
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)"
+  );
+
+  var insertModel = db.prepare(
+    "INSERT OR IGNORE INTO models " +
+    "(id, provider_name, name, free, context_window, max_tokens, reasoning, " +
+    "input, cost_input, cost_output, is_builtin) " +
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)"
+  );
+
+  db.exec("BEGIN");
+  try {
+    for (var i = 0; i < known.length; i++) {
+      var p = known[i];
+      insertProvider.run(
+        p.name,
+        p.displayName,
+        p.baseUrl,
+        p.api,
+        p.authType,
+        p.requiresKey ? 1 : 0,
+        p.envVar || null,
+        (p.rateLimit && p.rateLimit.requestsPerMinute) || 30,
+        (p.rateLimit && p.rateLimit.tokensPerMinute) || 100000,
+        p.signupUrl || null
+      );
+      for (var j = 0; j < p.models.length; j++) {
+        var m = p.models[j];
+        insertModel.run(
+          m.id,
+          p.name,
+          m.name,
+          m.free ? 1 : 0,
+          m.contextWindow || 131072,
+          m.maxTokens || 8192,
+          m.reasoning ? 1 : 0,
+          JSON.stringify(m.input || ["text"])
+        );
+      }
+    }
+    db.exec("COMMIT");
+  } catch (e) {
+    db.exec("ROLLBACK");
+    throw e;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a raw provider row to the JS object shape.
+ * @param {Object} r - raw row from providers table
+ * @returns {Object}
+ */
+function mapProviderRow(r) {
+  return {
+    name: r.name,
+    displayName: r.display_name,
+    baseUrl: r.base_url,
+    api: r.api,
+    authType: r.auth_type,
+    requiresKey: r.requires_key === 1,
+    envVar: r.env_var,
+    rateLimit: {
+      requestsPerMinute: r.rate_limit_rpm,
+      tokensPerMinute: r.rate_limit_tpm,
+    },
+    signupUrl: r.signup_url,
+    enabled: r.enabled === 1,
+    isBuiltin: r.is_builtin === 1,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+/**
+ * Map a raw model row to the JS object shape.
+ * @param {Object} m - raw row from models table
+ * @returns {Object}
+ */
+function mapModelRow(m) {
+  var inputArr;
+  try { inputArr = JSON.parse(m.input); } catch (_) { inputArr = ["text"]; }
+  return {
+    id: m.id,
+    name: m.name,
+    free: m.free === 1,
+    contextWindow: m.context_window,
+    maxTokens: m.max_tokens,
+    reasoning: m.reasoning === 1,
+    input: inputArr,
+    cost: { input: m.cost_input, output: m.cost_output },
+    enabled: m.enabled === 1,
+    isBuiltin: m.is_builtin === 1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Provider CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * List providers, optionally filtered.
+ * @param {Object} db
+ * @param {Object} [opts] - { enabled: true|false, builtin: true|false }
+ * @returns {Array<Object>}
+ */
+function getProviders(db, opts) {
+  var where = [];
+
+  if (opts) {
+    if (opts.enabled === true) {
+      where.push("enabled = 1");
+    } else if (opts.enabled === false) {
+      where.push("enabled = 0");
+    }
+    if (opts.builtin === true) {
+      where.push("is_builtin = 1");
+    } else if (opts.builtin === false) {
+      where.push("is_builtin = 0");
+    }
+  }
+
+  var sql = "SELECT * FROM providers";
+  if (where.length > 0) sql += " WHERE " + where.join(" AND ");
+  sql += " ORDER BY name";
+
+  var rows = db.prepare(sql).all();
+  return rows.map(mapProviderRow);
+}
+
+/**
+ * Get a single provider with its models.
+ * @param {Object} db
+ * @param {string} name - provider name
+ * @returns {Object|null}
+ */
+function getProvider(db, name) {
+  var row = db.prepare("SELECT * FROM providers WHERE name = ?").get(name);
+  if (!row) return null;
+
+  var modelRows = db.prepare(
+    "SELECT * FROM models WHERE provider_name = ? ORDER BY id"
+  ).all(name);
+
+  var result = mapProviderRow(row);
+  result.models = modelRows.map(mapModelRow);
+  return result;
+}
+
+/**
+ * Add a new provider with optional models. Uses a transaction.
+ * @param {Object} db
+ * @param {Object} data - { name, displayName, baseUrl, api?, authType?, requiresKey?,
+ *                          envVar?, rateLimit?, signupUrl?, models?[] }
+ * @returns {Object} the created provider (with models)
+ */
+function addProvider(db, data) {
+  if (!data || !data.name || !data.displayName || !data.baseUrl) {
+    throw new Error("addProvider requires name, displayName, and baseUrl");
+  }
+
+  var existing = db.prepare("SELECT name FROM providers WHERE name = ?").get(data.name);
+  if (existing) {
+    throw new Error("Provider '" + data.name + "' already exists");
+  }
+
+  var insertProv = db.prepare(
+    "INSERT INTO providers " +
+    "(name, display_name, base_url, api, auth_type, requires_key, env_var, " +
+    "rate_limit_rpm, rate_limit_tpm, signup_url, enabled, is_builtin) " +
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0)"
+  );
+
+  var insertModel = db.prepare(
+    "INSERT INTO models " +
+    "(id, provider_name, name, free, context_window, max_tokens, reasoning, " +
+    "input, cost_input, cost_output, enabled, is_builtin) " +
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0)"
+  );
+
+  var rl = data.rateLimit || {};
+
+  db.exec("BEGIN");
+  try {
+    insertProv.run(
+      data.name,
+      data.displayName,
+      data.baseUrl,
+      data.api || "openai-completions",
+      data.authType || "bearer",
+      data.requiresKey !== false ? 1 : 0,
+      data.envVar || null,
+      rl.requestsPerMinute || 30,
+      rl.tokensPerMinute || 100000,
+      data.signupUrl || null
+    );
+
+    var models = data.models || [];
+    for (var i = 0; i < models.length; i++) {
+      var m = models[i];
+      if (!m.id || !m.name) continue;
+      var cost = m.cost || {};
+      insertModel.run(
+        m.id,
+        data.name,
+        m.name,
+        m.free !== false ? 1 : 0,
+        m.contextWindow || 131072,
+        m.maxTokens || 8192,
+        m.reasoning ? 1 : 0,
+        JSON.stringify(m.input || ["text"]),
+        cost.input || 0,
+        cost.output || 0
+      );
+    }
+    db.exec("COMMIT");
+  } catch (e) {
+    db.exec("ROLLBACK");
+    throw e;
+  }
+
+  return getProvider(db, data.name);
+}
+
+/**
+ * Update provider fields. Only provided fields are updated.
+ * @param {Object} db
+ * @param {string} name - provider name
+ * @param {Object} updates - { displayName?, baseUrl?, api?, authType?, requiresKey?,
+ *                             envVar?, rateLimit?, signupUrl?, enabled? }
+ * @returns {Object|null} updated provider or null if not found
+ */
+function updateProvider(db, name, updates) {
+  var existing = db.prepare("SELECT name FROM providers WHERE name = ?").get(name);
+  if (!existing) return null;
+
+  var sets = [];
+  var params = [];
+
+  if (updates.displayName !== undefined) {
+    sets.push("display_name = ?");
+    params.push(updates.displayName);
+  }
+  if (updates.baseUrl !== undefined) {
+    sets.push("base_url = ?");
+    params.push(updates.baseUrl);
+  }
+  if (updates.api !== undefined) {
+    sets.push("api = ?");
+    params.push(updates.api);
+  }
+  if (updates.authType !== undefined) {
+    sets.push("auth_type = ?");
+    params.push(updates.authType);
+  }
+  if (updates.requiresKey !== undefined) {
+    sets.push("requires_key = ?");
+    params.push(updates.requiresKey ? 1 : 0);
+  }
+  if (updates.envVar !== undefined) {
+    sets.push("env_var = ?");
+    params.push(updates.envVar);
+  }
+  if (updates.rateLimit) {
+    if (updates.rateLimit.requestsPerMinute !== undefined) {
+      sets.push("rate_limit_rpm = ?");
+      params.push(updates.rateLimit.requestsPerMinute);
+    }
+    if (updates.rateLimit.tokensPerMinute !== undefined) {
+      sets.push("rate_limit_tpm = ?");
+      params.push(updates.rateLimit.tokensPerMinute);
+    }
+  }
+  if (updates.signupUrl !== undefined) {
+    sets.push("signup_url = ?");
+    params.push(updates.signupUrl);
+  }
+  if (updates.enabled !== undefined) {
+    sets.push("enabled = ?");
+    params.push(updates.enabled ? 1 : 0);
+  }
+
+  if (sets.length === 0) return getProvider(db, name);
+
+  sets.push("updated_at = datetime('now')");
+  params.push(name);
+
+  var sql = "UPDATE providers SET " + sets.join(", ") + " WHERE name = ?";
+  var stmt = db.prepare(sql);
+  stmt.run.apply(stmt, params);
+
+  return getProvider(db, name);
+}
+
+/**
+ * Remove a provider and its models (CASCADE).
+ * Builtin providers cannot be removed unless force=true.
+ * @param {Object} db
+ * @param {string} name
+ * @param {boolean} [force=false] - allow removing builtins
+ * @returns {boolean} true if removed
+ */
+function removeProvider(db, name, force) {
+  var row = db.prepare("SELECT name, is_builtin FROM providers WHERE name = ?").get(name);
+  if (!row) return false;
+
+  if (row.is_builtin === 1 && !force) {
+    throw new Error(
+      "Cannot remove builtin provider '" + name + "'. Use force=true to override."
+    );
+  }
+
+  // Manually delete models first since ON DELETE CASCADE requires foreign_keys pragma
+  db.prepare("DELETE FROM models WHERE provider_name = ?").run(name);
+  db.prepare("DELETE FROM providers WHERE name = ?").run(name);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Model CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a model to an existing provider.
+ * @param {Object} db
+ * @param {string} providerName
+ * @param {Object} data - { id, name, free?, contextWindow?, maxTokens?, reasoning?,
+ *                          input?, cost? }
+ * @returns {Object} the provider with updated models
+ */
+function addModel(db, providerName, data) {
+  if (!data || !data.id || !data.name) {
+    throw new Error("addModel requires id and name");
+  }
+
+  var prov = db.prepare("SELECT name FROM providers WHERE name = ?").get(providerName);
+  if (!prov) {
+    throw new Error("Provider '" + providerName + "' not found");
+  }
+
+  var existingModel = db.prepare(
+    "SELECT id FROM models WHERE id = ? AND provider_name = ?"
+  ).get(data.id, providerName);
+  if (existingModel) {
+    throw new Error("Model '" + data.id + "' already exists for provider '" + providerName + "'");
+  }
+
+  var cost = data.cost || {};
+  db.prepare(
+    "INSERT INTO models " +
+    "(id, provider_name, name, free, context_window, max_tokens, reasoning, " +
+    "input, cost_input, cost_output, enabled, is_builtin) " +
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0)"
+  ).run(
+    data.id,
+    providerName,
+    data.name,
+    data.free !== false ? 1 : 0,
+    data.contextWindow || 131072,
+    data.maxTokens || 8192,
+    data.reasoning ? 1 : 0,
+    JSON.stringify(data.input || ["text"]),
+    cost.input || 0,
+    cost.output || 0
+  );
+
+  return getProvider(db, providerName);
+}
+
+/**
+ * Remove a model from a provider.
+ * @param {Object} db
+ * @param {string} providerName
+ * @param {string} modelId
+ * @returns {boolean} true if removed
+ */
+function removeModel(db, providerName, modelId) {
+  var result = db.prepare(
+    "DELETE FROM models WHERE id = ? AND provider_name = ?"
+  ).run(modelId, providerName);
+  return result.changes > 0;
+}
+
+/**
+ * Enable or disable a provider.
+ * @param {Object} db
+ * @param {string} name
+ * @param {boolean} enabled
+ * @returns {Object|null} updated provider or null
+ */
+function toggleProvider(db, name, enabled) {
+  var result = db.prepare(
+    "UPDATE providers SET enabled = ?, updated_at = datetime('now') WHERE name = ?"
+  ).run(enabled ? 1 : 0, name);
+  if (result.changes === 0) return null;
+  return getProvider(db, name);
+}
+
+/**
+ * Enable or disable a model.
+ * @param {Object} db
+ * @param {string} providerName
+ * @param {string} modelId
+ * @param {boolean} enabled
+ * @returns {boolean} true if updated
+ */
+function toggleModel(db, providerName, modelId, enabled) {
+  var result = db.prepare(
+    "UPDATE models SET enabled = ?, updated_at = datetime('now') " +
+    "WHERE id = ? AND provider_name = ?"
+  ).run(enabled ? 1 : 0, modelId, providerName);
+  return result.changes > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Testable Model List (DB-aware)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build flat testable model list from DB, merging with config (same dedup
+ * logic as registry.getTestableModels but loads from DB first).
+ *
+ * Priority: config providers > DB providers (DB fills gaps, config wins on dupes).
+ *
+ * @param {Object} db
+ * @param {Object} cfg - full openclaw.json config
+ * @param {Object} [envKeys] - { providerName: apiKey } overrides
+ * @returns {Array<Object>} flat model list with connection details
+ */
+function getTestableModelsFromDB(db, cfg, envKeys) {
+  var dbProviders = getProviders(db, { enabled: true });
+  var models = [];
+  var seen = new Set();
+
+  // Config providers take priority over DB
+  var configProviders = (cfg && cfg.models && cfg.models.providers) || {};
+  var configNames = Object.keys(configProviders);
+  for (var i = 0; i < configNames.length; i++) {
+    var provName = configNames[i];
+    var prov = configProviders[provName];
+    if (!prov.baseUrl) continue;
+
+    var provModels = prov.models || [];
+    for (var j = 0; j < provModels.length; j++) {
+      var m = provModels[j];
+      var key = provName + "/" + m.id;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      models.push({
+        provider: provName,
+        id: m.id,
+        name: m.name || m.id,
+        baseUrl: prov.baseUrl,
+        apiKey: prov.apiKey || "",
+        api: prov.api || "openai-completions",
+        free: getRegistry().isModelFree(m),
+        cost: m.cost || { input: 0, output: 0 },
+        contextWindow: m.contextWindow || 0,
+        maxTokens: m.maxTokens || 0,
+        reasoning: m.reasoning || false,
+      });
+    }
+  }
+
+  // Add DB providers that are not already covered by config
+  for (var k = 0; k < dbProviders.length; k++) {
+    var dbProv = dbProviders[k];
+    var apiKey = (envKeys && envKeys[dbProv.name]) || "";
+    if (!apiKey && dbProv.envVar) {
+      apiKey = process.env[dbProv.envVar] || "";
+    }
+
+    // Skip if no key available and key is required
+    if (!apiKey && dbProv.requiresKey && dbProv.authType !== "none") continue;
+
+    // Get enabled models for this provider
+    var dbModels = db.prepare(
+      "SELECT * FROM models WHERE provider_name = ? AND enabled = 1 ORDER BY id"
+    ).all(dbProv.name);
+
+    for (var l = 0; l < dbModels.length; l++) {
+      var dm = dbModels[l];
+      var dkey = dbProv.name + "/" + dm.id;
+      if (seen.has(dkey)) continue;
+      seen.add(dkey);
+
+      models.push({
+        provider: dbProv.name,
+        id: dm.id,
+        name: dm.name || dm.id,
+        baseUrl: dbProv.baseUrl,
+        apiKey: apiKey,
+        api: dbProv.api || "openai-completions",
+        free: dm.free === 1,
+        cost: { input: dm.cost_input || 0, output: dm.cost_output || 0 },
+        contextWindow: dm.context_window || 0,
+        maxTokens: dm.max_tokens || 0,
+        reasoning: dm.reasoning === 1,
+      });
+    }
+  }
+
+  return models;
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely close the database connection.
+ * @param {Object} db
+ */
+function closeDB(db) {
+  if (!db) return;
+  try {
+    db.close();
+  } catch (_) {
+    // Already closed or invalid - ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  DEFAULT_DB_PATH: DEFAULT_DB_PATH,
+  initDB: initDB,
+  seedBuiltinProviders: seedBuiltinProviders,
+  getProviders: getProviders,
+  getProvider: getProvider,
+  addProvider: addProvider,
+  updateProvider: updateProvider,
+  removeProvider: removeProvider,
+  addModel: addModel,
+  removeModel: removeModel,
+  toggleProvider: toggleProvider,
+  toggleModel: toggleModel,
+  getTestableModelsFromDB: getTestableModelsFromDB,
+  closeDB: closeDB,
+};

--- a/scripts/provider-registry.cjs
+++ b/scripts/provider-registry.cjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+/**
+ * provider-registry.cjs - Registry of free LLM API providers.
+ *
+ * Defines all known free providers with their API details, models, and auth.
+ * Merges with existing openclaw.json config to build a flat testable model list.
+ *
+ * Key functions:
+ *  - getKnownProviders()      - All hardcoded free providers
+ *  - mergeWithConfig(cfg)     - Merge known providers with config
+ *  - getTestableModels(cfg)   - Flat deduped model list ready for benchmarking
+ *  - isModelFree(model)       - Check if a model has zero cost
+ *  - generateProviderConfig() - Generate config snippet for new providers
+ */
+"use strict";
+
+/**
+ * Known free model providers.
+ * Each entry follows the architecture spec schema.
+ */
+var KNOWN_PROVIDERS = [
+  {
+    name: "nvidia",
+    displayName: "NVIDIA NIM",
+    baseUrl: "https://integrate.api.nvidia.com/v1",
+    api: "openai-completions",
+    authType: "bearer",
+    requiresKey: true,
+    envVar: "NVIDIA_API_KEY",
+    rateLimit: { requestsPerMinute: 5, tokensPerMinute: 100000 },
+    signupUrl: "https://build.nvidia.com/explore/discover",
+    models: [
+      { id: "nvidia/llama-3.3-nemotron-super-49b-v1", name: "Nemotron Super 49B", free: true, contextWindow: 131072, maxTokens: 16384, reasoning: true, input: ["text"] },
+      { id: "stepfun-ai/step-3.5-flash", name: "Step 3.5 Flash", free: true, contextWindow: 262144, maxTokens: 16384, reasoning: false, input: ["text"] },
+      { id: "nvidia/nemotron-3-nano-30b-a3b", name: "Nemotron Nano 30B", free: true, contextWindow: 1048576, maxTokens: 16384, reasoning: false, input: ["text"] },
+      { id: "minimaxai/minimax-m2", name: "MiniMax M2", free: true, contextWindow: 262144, maxTokens: 16384, reasoning: false, input: ["text"] },
+      { id: "deepseek-ai/deepseek-v3.2", name: "DeepSeek V3.2", free: true, contextWindow: 131072, maxTokens: 16384, reasoning: false, input: ["text"] },
+      { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5", free: true, contextWindow: 262000, maxTokens: 16384, reasoning: true, input: ["text", "image"] },
+      { id: "qwen/qwen3-coder-480b-a35b-instruct", name: "Qwen3 Coder 480B", free: true, contextWindow: 262144, maxTokens: 16384, reasoning: false, input: ["text"] },
+      { id: "qwen/qwen3.5-397b-a17b", name: "Qwen 3.5 397B", free: true, contextWindow: 131072, maxTokens: 16384, reasoning: false, input: ["text"] },
+    ],
+  },
+  {
+    name: "groq",
+    displayName: "Groq",
+    baseUrl: "https://api.groq.com/openai/v1",
+    api: "openai-completions",
+    authType: "bearer",
+    requiresKey: true,
+    envVar: "GROQ_API_KEY",
+    rateLimit: { requestsPerMinute: 30, tokensPerMinute: 100000 },
+    signupUrl: "https://console.groq.com/keys",
+    models: [
+      { id: "llama-3.3-70b-versatile", name: "Llama 3.3 70B", free: true, contextWindow: 131072, maxTokens: 32768 },
+      { id: "llama-3.1-8b-instant", name: "Llama 3.1 8B Instant", free: true, contextWindow: 131072, maxTokens: 8192 },
+      { id: "gemma2-9b-it", name: "Gemma2 9B IT", free: true, contextWindow: 8192, maxTokens: 8192 },
+      { id: "mixtral-8x7b-32768", name: "Mixtral 8x7B", free: true, contextWindow: 32768, maxTokens: 32768 },
+    ],
+  },
+  {
+    name: "cerebras",
+    displayName: "Cerebras",
+    baseUrl: "https://api.cerebras.ai/v1",
+    api: "openai-completions",
+    authType: "bearer",
+    requiresKey: true,
+    envVar: "CEREBRAS_API_KEY",
+    rateLimit: { requestsPerMinute: 30, tokensPerMinute: 1000000 },
+    signupUrl: "https://cloud.cerebras.ai/",
+    models: [
+      { id: "llama-3.3-70b", name: "Llama 3.3 70B (Cerebras)", free: true, contextWindow: 131072, maxTokens: 8192 },
+      { id: "llama-3.1-8b", name: "Llama 3.1 8B (Cerebras)", free: true, contextWindow: 131072, maxTokens: 8192 },
+    ],
+  },
+  {
+    name: "sambanova",
+    displayName: "SambaNova",
+    baseUrl: "https://api.sambanova.ai/v1",
+    api: "openai-completions",
+    authType: "bearer",
+    requiresKey: true,
+    envVar: "SAMBANOVA_API_KEY",
+    rateLimit: { requestsPerMinute: 10, tokensPerMinute: 100000 },
+    signupUrl: "https://cloud.sambanova.ai/",
+    models: [
+      { id: "Meta-Llama-3.3-70B-Instruct", name: "Llama 3.3 70B (SambaNova)", free: true, contextWindow: 131072, maxTokens: 8192 },
+      { id: "DeepSeek-R1-Distill-Llama-70B", name: "DeepSeek R1 Distill 70B", free: true, contextWindow: 131072, maxTokens: 8192 },
+    ],
+  },
+  {
+    name: "together",
+    displayName: "Together.ai",
+    baseUrl: "https://api.together.xyz/v1",
+    api: "openai-completions",
+    authType: "bearer",
+    requiresKey: true,
+    envVar: "TOGETHER_API_KEY",
+    rateLimit: { requestsPerMinute: 60, tokensPerMinute: 100000 },
+    signupUrl: "https://api.together.xyz/",
+    models: [
+      { id: "meta-llama/Llama-3.3-70B-Instruct-Turbo", name: "Llama 3.3 70B Turbo", free: true, contextWindow: 131072, maxTokens: 8192 },
+      { id: "Qwen/Qwen2.5-72B-Instruct-Turbo", name: "Qwen 2.5 72B Turbo", free: true, contextWindow: 131072, maxTokens: 8192 },
+    ],
+  },
+  {
+    name: "huggingface",
+    displayName: "HuggingFace",
+    baseUrl: "https://router.huggingface.co/v1",
+    api: "openai-completions",
+    authType: "bearer",
+    requiresKey: true,
+    envVar: "HF_TOKEN",
+    rateLimit: { requestsPerMinute: 30, tokensPerMinute: 100000 },
+    signupUrl: "https://huggingface.co/settings/tokens",
+    models: [
+      { id: "meta-llama/Llama-3.3-70B-Instruct", name: "Llama 3.3 70B (HF)", free: true, contextWindow: 131072, maxTokens: 8192 },
+      { id: "Qwen/Qwen2.5-72B-Instruct", name: "Qwen 2.5 72B (HF)", free: true, contextWindow: 131072, maxTokens: 8192 },
+    ],
+  },
+  {
+    name: "github_models",
+    displayName: "GitHub Models",
+    baseUrl: "https://models.inference.ai.azure.com",
+    api: "openai-completions",
+    authType: "bearer",
+    requiresKey: true,
+    envVar: "GITHUB_TOKEN",
+    rateLimit: { requestsPerMinute: 15, tokensPerMinute: 150000 },
+    signupUrl: "https://github.com/marketplace/models",
+    models: [
+      { id: "gpt-4o-mini", name: "GPT-4o Mini (GitHub)", free: true, contextWindow: 128000, maxTokens: 16384 },
+      { id: "Meta-Llama-3.1-405B-Instruct", name: "Llama 3.1 405B (GitHub)", free: true, contextWindow: 131072, maxTokens: 8192 },
+    ],
+  },
+];
+
+/**
+ * Get all known free providers.
+ * @returns {Array<Object>}
+ */
+function getKnownProviders() {
+  return KNOWN_PROVIDERS;
+}
+
+/**
+ * Check if a model has zero cost.
+ * @param {Object} model - model with cost field
+ * @returns {boolean}
+ */
+function isModelFree(model) {
+  if (!model) return false;
+  if (model.free === true) return true;
+  if (model.free === false) return false;
+  var cost = model.cost;
+  if (!cost) return false; // no cost info = assume paid (safer default)
+  return (cost.input || 0) === 0 && (cost.output || 0) === 0;
+}
+
+/**
+ * Merge known providers with existing openclaw.json config.
+ * - If a known provider exists in config: use config's apiKey, merge new models
+ * - If a known provider is NOT in config: add if env var is set or authType is "none"
+ * - Config providers not in known list are kept as-is
+ *
+ * @param {Object} cfg - full openclaw.json config
+ * @param {Object} [envKeys] - { providerName: apiKey } overrides
+ * @returns {Object} merged providers map keyed by name
+ */
+function mergeWithConfig(cfg, envKeys) {
+  var configProviders = (cfg && cfg.models && cfg.models.providers) || {};
+  var merged = {};
+
+  // Copy all config providers first
+  var configNames = Object.keys(configProviders);
+  for (var i = 0; i < configNames.length; i++) {
+    var name = configNames[i];
+    merged[name] = JSON.parse(JSON.stringify(configProviders[name]));
+  }
+
+  // Merge in known providers
+  for (var j = 0; j < KNOWN_PROVIDERS.length; j++) {
+    var kp = KNOWN_PROVIDERS[j];
+    var apiKey = (envKeys && envKeys[kp.name]) || process.env[kp.envVar] || "";
+
+    if (merged[kp.name]) {
+      // Provider exists in config - merge any new models not already listed
+      var existing = merged[kp.name];
+      var existingIds = new Set((existing.models || []).map(function(m) { return m.id; }));
+
+      for (var k = 0; k < kp.models.length; k++) {
+        if (!existingIds.has(kp.models[k].id)) {
+          if (!existing.models) existing.models = [];
+          existing.models.push({
+            id: kp.models[k].id,
+            name: kp.models[k].name,
+            reasoning: kp.models[k].reasoning || false,
+            input: kp.models[k].input || ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: kp.models[k].contextWindow || 131072,
+            maxTokens: kp.models[k].maxTokens || 8192,
+          });
+        }
+      }
+    } else if (apiKey || kp.authType === "none") {
+      // New provider - add it
+      merged[kp.name] = {
+        baseUrl: kp.baseUrl,
+        apiKey: apiKey,
+        api: kp.api,
+        models: kp.models.map(function(m) {
+          return {
+            id: m.id,
+            name: m.name,
+            reasoning: m.reasoning || false,
+            input: m.input || ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: m.contextWindow || 131072,
+            maxTokens: m.maxTokens || 8192,
+          };
+        }),
+      };
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Get flat list of testable models from config, deduplicating by provider/model.id.
+ * @param {Object} cfg - full openclaw.json config
+ * @param {Object} [envKeys] - optional key overrides
+ * @returns {Array<Object>} flat model list with connection details
+ */
+function getTestableModels(cfg, envKeys) {
+  var providers = mergeWithConfig(cfg, envKeys);
+  var models = [];
+  var seen = new Set();
+
+  var names = Object.keys(providers);
+  for (var i = 0; i < names.length; i++) {
+    var provName = names[i];
+    var prov = providers[provName];
+    if (!prov.baseUrl) continue;
+
+    var provModels = prov.models || [];
+    for (var j = 0; j < provModels.length; j++) {
+      var m = provModels[j];
+      var key = provName + "/" + m.id;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      models.push({
+        provider: provName,
+        id: m.id,
+        name: m.name || m.id,
+        baseUrl: prov.baseUrl,
+        apiKey: prov.apiKey || "",
+        api: prov.api || "openai-completions",
+        free: isModelFree(m),
+        cost: m.cost || { input: 0, output: 0 },
+        contextWindow: m.contextWindow || 0,
+        maxTokens: m.maxTokens || 0,
+        reasoning: m.reasoning || false,
+      });
+    }
+  }
+
+  return models;
+}
+
+/**
+ * Generate config snippet for a newly discovered provider.
+ * @param {string} providerName
+ * @param {string} apiKey
+ * @returns {Object|null}
+ */
+function generateProviderConfig(providerName, apiKey) {
+  var prov = null;
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    if (KNOWN_PROVIDERS[i].name === providerName) {
+      prov = KNOWN_PROVIDERS[i];
+      break;
+    }
+  }
+  if (!prov) return null;
+
+  return {
+    baseUrl: prov.baseUrl,
+    apiKey: apiKey,
+    api: prov.api,
+    models: prov.models.map(function(m) {
+      return {
+        id: m.id,
+        name: m.name,
+        reasoning: m.reasoning || false,
+        input: m.input || ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: m.contextWindow || 131072,
+        maxTokens: m.maxTokens || 8192,
+      };
+    }),
+  };
+}
+
+/**
+ * Get all known providers as a map keyed by name (legacy compat).
+ * @returns {Object}
+ */
+function getAllProviders() {
+  var map = {};
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    map[KNOWN_PROVIDERS[i].name] = KNOWN_PROVIDERS[i];
+  }
+  return map;
+}
+
+module.exports = {
+  KNOWN_PROVIDERS: KNOWN_PROVIDERS,
+  getKnownProviders: getKnownProviders,
+  mergeWithConfig: mergeWithConfig,
+  getTestableModels: getTestableModels,
+  isModelFree: isModelFree,
+  generateProviderConfig: generateProviderConfig,
+  getAllProviders: getAllProviders,
+};

--- a/scripts/scoring.cjs
+++ b/scripts/scoring.cjs
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+/**
+ * scoring.cjs - Quality scoring engine for model benchmarks.
+ *
+ * Converts raw benchmark results into composite scores (0-100)
+ * using weighted criteria: latency (40%), throughput (25%),
+ * correctness (20%), availability (15%).
+ *
+ * Supports both single-prompt scoring (legacy bench-models.cjs compat)
+ * and multi-test scoring (model-optimizer 3-test suite).
+ */
+"use strict";
+
+const DEFAULT_WEIGHTS = {
+  latency: 0.40,
+  throughput: 0.25,
+  correctness: 0.20,
+  availability: 0.15,
+};
+
+// ---------------------------------------------------------------------------
+// Latency scoring (TTFT in ms, lower is better)
+// ---------------------------------------------------------------------------
+
+const LATENCY_BANDS = [
+  { max: 500, score: 100 },
+  { max: 1000, score: 90 },
+  { max: 2000, score: 75 },
+  { max: 5000, score: 50 },
+  { max: 10000, score: 25 },
+  { max: Infinity, score: 10 },
+];
+
+function lerp(value, lo, hi, loScore, hiScore) {
+  if (hi <= lo) return loScore;
+  const t = (value - lo) / (hi - lo);
+  return loScore - t * (loScore - hiScore);
+}
+
+/**
+ * Score latency (TTFT) on 0-100 scale with linear interpolation.
+ * @param {number|null} ttftMs
+ * @returns {number}
+ */
+function latencyScore(ttftMs) {
+  if (ttftMs === null || ttftMs === undefined || !Number.isFinite(ttftMs) || ttftMs < 0) return 0;
+
+  let prevMax = 0;
+  let prevScore = 100;
+  for (const band of LATENCY_BANDS) {
+    if (ttftMs <= band.max) {
+      const hi = band.max === Infinity ? 20000 : band.max;
+      return Math.max(10, Math.round(lerp(ttftMs, prevMax, hi, prevScore, band.score) * 10) / 10);
+    }
+    prevMax = band.max;
+    prevScore = band.score;
+  }
+  return 10;
+}
+
+// ---------------------------------------------------------------------------
+// Throughput scoring (tokens/sec, higher is better)
+// ---------------------------------------------------------------------------
+
+const THROUGHPUT_BANDS = [
+  { min: 100, score: 100 },
+  { min: 50, score: 90 },
+  { min: 20, score: 75 },
+  { min: 10, score: 50 },
+  { min: 5, score: 25 },
+  { min: 0, score: 10 },
+];
+
+const THROUGHPUT_UNKNOWN = 30;
+
+/**
+ * Score throughput (tok/s) on 0-100 scale with linear interpolation.
+ * Returns 30 for unknown throughput (benefit of doubt).
+ * @param {number|null} tokPerSec
+ * @returns {number}
+ */
+function throughputScore(tokPerSec) {
+  if (tokPerSec === null || tokPerSec === undefined) return THROUGHPUT_UNKNOWN;
+  if (!Number.isFinite(tokPerSec) || tokPerSec <= 0) return 10;
+
+  let prevMin = Infinity;
+  let prevScore = 100;
+  for (const band of THROUGHPUT_BANDS) {
+    if (tokPerSec >= band.min) {
+      if (prevMin === Infinity) return 100;
+      return Math.round(lerp(tokPerSec, band.min, prevMin, band.score, prevScore) * 10) / 10;
+    }
+    prevMin = band.min;
+    prevScore = band.score;
+  }
+  return 10;
+}
+
+// ---------------------------------------------------------------------------
+// Correctness scoring (test validation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate math test: response should contain "4".
+ * @param {string} response
+ * @returns {boolean}
+ */
+function validateMath(response) {
+  if (!response) return false;
+  return /\b4\b/.test(response) || /\bfour\b/i.test(response);
+}
+
+/**
+ * Validate instruction test: response should have ~3 lines each being a color.
+ * @param {string} response
+ * @returns {boolean}
+ */
+function validateInstruction(response) {
+  if (!response) return false;
+  const lines = response.trim().split(/\n/).map(function(l) { return l.trim(); }).filter(Boolean);
+  if (lines.length < 2 || lines.length > 8) return false;
+  var colorRe = /^[\d.)\-*\s]*(red|blue|green|yellow|orange|purple|pink|white|black|brown|gray|grey|violet|indigo|cyan|magenta|teal|gold|silver|crimson|scarlet|navy|lime|olive|maroon|coral|turquoise|lavender|beige|tan|amber|aqua|ivory|salmon|ruby|emerald|sapphire|rose|sky|mint|peach|plum|cherry|copper|bronze|khaki|cream|charcoal|burgundy|fuchsia|periwinkle|mauve|taupe|rust)/i;
+  var colorCount = lines.filter(function(l) { return colorRe.test(l); }).length;
+  return colorCount >= 2;
+}
+
+/**
+ * Validate availability test: any non-empty response is a pass.
+ * @param {string} response
+ * @returns {boolean}
+ */
+function validateAvailability(response) {
+  return typeof response === "string" && response.trim().length > 0;
+}
+
+var TEST_VALIDATORS = {
+  math: validateMath,
+  instruction: validateInstruction,
+  availability: validateAvailability,
+};
+
+/**
+ * Score correctness from multi-test results.
+ * @param {Array<{name: string, status: string, response: string}>} tests
+ * @returns {{score: number, details: Object}}
+ */
+function correctnessScoreMulti(tests) {
+  var passed = 0;
+  var details = {};
+  var total = 0;
+
+  for (var i = 0; i < tests.length; i++) {
+    var test = tests[i];
+    var validator = TEST_VALIDATORS[test.name];
+    if (!validator) continue;
+    total++;
+    if (test.status === "ok" || test.status === "OK") {
+      var valid = validator(test.response || "");
+      details[test.name] = valid ? "pass" : "fail";
+      if (valid) passed++;
+    } else {
+      details[test.name] = "error";
+    }
+  }
+
+  var score = total > 0 ? Math.round((passed / total) * 100) : 0;
+  return { score: score, details: details };
+}
+
+/**
+ * Score correctness from a single response (legacy compat for bench-models.cjs).
+ * @param {string} response
+ * @param {string} [expected="4"]
+ * @returns {number} 0-100
+ */
+function correctnessScoreSingle(response, expected) {
+  if (!response || typeof response !== "string") return 0;
+  if (typeof expected !== "string") expected = "4";
+
+  var clean = response.toLowerCase().trim().replace(/[.,!?;:'"]/g, "").trim();
+  var exp = expected.toLowerCase().trim();
+
+  if (clean === exp) return 100;
+  if (exp === "4" && (clean === "four" || clean === "4")) return 100;
+  if (/\b4\b/.test(clean) || /\bfour\b/.test(clean)) return 80;
+  if (clean.includes(exp)) return 85;
+  if (clean.length > 0) return 15;
+  return 0;
+}
+
+/**
+ * Unified correctness scorer.
+ * Accepts either an array of tests (multi-test) or (response, expected) args (single-test).
+ * @param {Array|string} testsOrResponse
+ * @param {string} [expected]
+ * @returns {{score: number, details: Object}|number}
+ */
+function correctnessScore(testsOrResponse, expected) {
+  if (Array.isArray(testsOrResponse)) {
+    return correctnessScoreMulti(testsOrResponse);
+  }
+  return correctnessScoreSingle(testsOrResponse, expected);
+}
+
+/**
+ * Score availability based on test success count.
+ * Accepts either (tests[]) or (successes, attempts).
+ * @param {Array|number} testsOrSuccesses
+ * @param {number} [attempts]
+ * @returns {number} 0-100
+ */
+function availabilityScore(testsOrSuccesses, attempts) {
+  if (Array.isArray(testsOrSuccesses)) {
+    var tests = testsOrSuccesses;
+    if (tests.length === 0) return 0;
+    var succeeded = tests.filter(function(t) {
+      return t.status === "ok" || t.status === "OK";
+    }).length;
+    return Math.round((succeeded / tests.length) * 100);
+  }
+  // Legacy (successes, attempts) signature
+  var successes = testsOrSuccesses;
+  if (!Number.isFinite(successes) || !Number.isFinite(attempts) || attempts <= 0) return 0;
+  return Math.round((successes / attempts) * 100);
+}
+
+// ---------------------------------------------------------------------------
+// Throughput estimation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate token count from response text when provider doesn't report usage.
+ * Rough heuristic: ~4 chars per token.
+ * @param {string} text
+ * @returns {number}
+ */
+function estimateTokens(text) {
+  if (!text) return 0;
+  return Math.max(1, Math.round(text.length / 4));
+}
+
+/**
+ * Calculate tok/s for a single test result.
+ * @param {{completionTokens?: number, response?: string, latencyMs: number}} test
+ * @returns {number|null}
+ */
+function calcThroughput(test) {
+  if (!test || !test.latencyMs || test.latencyMs <= 0) return null;
+  var tokens = test.completionTokens;
+  if (!tokens || tokens <= 0) {
+    tokens = estimateTokens(test.response);
+    if (tokens <= 0) return null;
+  }
+  return tokens / (test.latencyMs / 1000);
+}
+
+// ---------------------------------------------------------------------------
+// Composite scoring for the full model-optimizer pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Score a single model from its raw benchmark results (multi-test format).
+ * @param {Object} rawResult - { provider, modelId, modelName, free, tests[], timestamp }
+ * @param {Object} [weights] - custom weights
+ * @returns {Object} scored result
+ */
+function scoreModel(rawResult, weights) {
+  var w = Object.assign({}, DEFAULT_WEIGHTS, weights || {});
+  var tests = rawResult.tests || [];
+
+  // Compute averages from successful tests
+  var successfulTests = tests.filter(function(t) {
+    return t.status === "ok" || t.status === "OK";
+  });
+
+  var avgTtft = null;
+  var avgLatency = null;
+  if (successfulTests.length > 0) {
+    var ttfts = successfulTests.filter(function(t) { return t.ttftMs != null; }).map(function(t) { return t.ttftMs; });
+    avgTtft = ttfts.length > 0 ? ttfts.reduce(function(a, b) { return a + b; }, 0) / ttfts.length : null;
+    avgLatency = successfulTests.reduce(function(a, t) { return a + t.latencyMs; }, 0) / successfulTests.length;
+  }
+
+  // Throughput average
+  var avgTokPerSec = null;
+  if (successfulTests.length > 0) {
+    var throughputs = successfulTests.map(calcThroughput).filter(function(t) { return t !== null; });
+    if (throughputs.length > 0) {
+      avgTokPerSec = throughputs.reduce(function(a, b) { return a + b; }, 0) / throughputs.length;
+    }
+  }
+
+  var latScore = latencyScore(avgTtft);
+  var tpScore = throughputScore(avgTokPerSec);
+  var corr = correctnessScoreMulti(tests);
+  var availScore = availabilityScore(tests);
+
+  var composite = Math.round(
+    (latScore * w.latency + tpScore * w.throughput + corr.score * w.correctness + availScore * w.availability) * 10
+  ) / 10;
+
+  return {
+    provider: rawResult.provider,
+    modelId: rawResult.modelId,
+    modelName: rawResult.modelName,
+    free: rawResult.free !== false,
+    composite: composite,
+    latencyScore: latScore,
+    throughputScore: tpScore,
+    correctnessScore: corr.score,
+    availabilityScore: availScore,
+    avgLatencyMs: avgLatency !== null ? Math.round(avgLatency) : null,
+    avgTtftMs: avgTtft !== null ? Math.round(avgTtft) : null,
+    tokPerSec: avgTokPerSec !== null ? Math.round(avgTokPerSec * 10) / 10 : null,
+    tests: corr.details,
+    successCount: successfulTests.length,
+    totalTests: tests.length,
+  };
+}
+
+/**
+ * Rank scored results by composite score (highest first).
+ * @param {Array<Object>} scoredResults
+ * @returns {Array<Object>} sorted with rank field
+ */
+function rankModels(scoredResults) {
+  var sorted = scoredResults.slice().sort(function(a, b) { return b.composite - a.composite; });
+  return sorted.map(function(r, i) { return Object.assign({}, r, { rank: i + 1 }); });
+}
+
+/**
+ * Decide whether to rotate the primary model.
+ * @param {Object|null} currentPrimary - scored result for current primary
+ * @param {Object} newBest - highest-scoring model
+ * @param {number} [threshold=10] - % improvement required
+ * @returns {{rotate: boolean, reason: string}}
+ */
+function shouldRotate(currentPrimary, newBest, threshold) {
+  if (threshold == null) threshold = 10;
+
+  if (!newBest || newBest.composite <= 0) {
+    return { rotate: false, reason: "No working models found in benchmark" };
+  }
+
+  if (!currentPrimary || currentPrimary.composite <= 0) {
+    return {
+      rotate: true,
+      reason: "Current primary failed all tests; rotating to " + newBest.modelId,
+    };
+  }
+
+  if (currentPrimary.modelId === newBest.modelId) {
+    return { rotate: false, reason: "Current primary is already the best model" };
+  }
+
+  var improvementPct =
+    ((newBest.composite - currentPrimary.composite) / currentPrimary.composite) * 100;
+
+  if (improvementPct > threshold) {
+    return {
+      rotate: true,
+      reason:
+        "New best (" + newBest.modelId + ") scores " +
+        Math.round(improvementPct) + "% higher than current (" +
+        currentPrimary.modelId + ")",
+    };
+  }
+
+  if (!currentPrimary.free && newBest.free && newBest.composite >= 50) {
+    return {
+      rotate: true,
+      reason:
+        "Free alternative (" + newBest.modelId +
+        ") scores adequately (" + newBest.composite +
+        ") vs paid current",
+    };
+  }
+
+  return {
+    rotate: false,
+    reason:
+      "Current primary performing adequately (within " + threshold +
+      "% of best, improvement: " + (Math.round(improvementPct * 10) / 10) + "%)",
+  };
+}
+
+/**
+ * Legacy composite score from individual scores object.
+ * @param {Object} scores - { latency, throughput, correctness, availability }
+ * @param {Object} [weights]
+ * @returns {number} 0-100
+ */
+function compositeScore(scores, weights) {
+  var w = Object.assign({}, DEFAULT_WEIGHTS, weights || {});
+  var lat = Number(scores.latency) || 0;
+  var thr = Number(scores.throughput) || 0;
+  var cor = Number(scores.correctness) || 0;
+  var avl = Number(scores.availability) || 0;
+  return Math.round(lat * w.latency + thr * w.throughput + cor * w.correctness + avl * w.availability);
+}
+
+/**
+ * Grade label from composite score.
+ * @param {number} score
+ * @returns {string}
+ */
+function gradeLabel(score) {
+  if (score >= 90) return "Excellent";
+  if (score >= 75) return "Good";
+  if (score >= 55) return "Fair";
+  if (score >= 30) return "Poor";
+  return "Unusable";
+}
+
+module.exports = {
+  // Core individual scorers
+  latencyScore: latencyScore,
+  throughputScore: throughputScore,
+  correctnessScore: correctnessScore,
+  availabilityScore: availabilityScore,
+  compositeScore: compositeScore,
+  gradeLabel: gradeLabel,
+  DEFAULT_WEIGHTS: DEFAULT_WEIGHTS,
+  // Multi-test pipeline (model-optimizer)
+  scoreModel: scoreModel,
+  rankModels: rankModels,
+  shouldRotate: shouldRotate,
+  estimateTokens: estimateTokens,
+  calcThroughput: calcThroughput,
+  // Test validators (exported for testing)
+  validateMath: validateMath,
+  validateInstruction: validateInstruction,
+  validateAvailability: validateAvailability,
+};

--- a/skills/model-optimizer/SKILL.md
+++ b/skills/model-optimizer/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: model-optimizer
+description: >
+  Benchmark, score, and auto-rotate LLM models for optimal performance.
+  Use when asked to: optimize models, benchmark models, check model health,
+  run model tests, find the best model, compare model performance,
+  check which models are working, rotate models, update model config,
+  schedule periodic model benchmarks, discover free providers, or
+  troubleshoot slow/broken model responses.
+---
+
+# Model Auto-Optimizer
+
+Benchmark all configured (and optionally discovered) AI models with a 3-test suite, score them on a composite metric, and auto-configure OpenClaw to use the best model.
+
+## Quick Start
+
+Run a full benchmark with auto-rotation:
+
+```bash
+node {baseDir}/scripts/run.cjs --auto
+```
+
+Dry run (score and rank without changing config):
+
+```bash
+node {baseDir}/scripts/run.cjs --dry-run --verbose
+```
+
+JSON output for scripting:
+
+```bash
+node {baseDir}/scripts/run.cjs --json
+```
+
+## Test Suite
+
+Each model is tested with 3 prompts (run in parallel):
+
+| Test | Prompt | Validates |
+|------|--------|-----------|
+| Math | "What is 2+2? Reply with only the number." | Correctness (response contains "4") |
+| Instruction | "List exactly 3 colors, one per line." | Instruction following (3 color lines) |
+| Availability | "Say hello." | Basic availability (non-empty response) |
+
+## Scoring Criteria
+
+Composite score (0-100) with linear interpolation within bands:
+
+| Criterion | Weight | Excellent | Good | Fair | Poor |
+|-----------|--------|-----------|------|------|------|
+| Latency (TTFT) | 40% | <500ms (100) | <2s (75) | <5s (50) | <10s (25) |
+| Throughput | 25% | >100 tok/s (100) | >20 (75) | >10 (50) | >5 (25) |
+| Correctness | 20% | 3/3 pass (100) | 2/3 (66) | 1/3 (33) | 0/3 (0) |
+| Availability | 15% | 3/3 succeed (100) | 2/3 (66) | 1/3 (33) | 0/3 (0) |
+
+## CLI Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--auto` | Benchmark and auto-rotate if improvement found | off |
+| `--dry-run` | Score without config changes | off |
+| `--discover` | Test registry providers with env keys | off |
+| `--json` | JSON-only output | off |
+| `--verbose` | Show per-test score breakdown | off |
+| `--timeout N` | Per-request timeout (ms) | 30000 |
+| `--concurrency N` | Max parallel model tests | 10 |
+| `--threshold N` | Min % improvement to rotate | 10 |
+| `--providers X` | Comma-separated provider filter | all |
+| `--weights JSON` | Custom scoring weights | default |
+
+## Auto-Rotation Safety
+
+- Only rotates if new best scores **>10%** better than current primary
+- If current primary fails all tests, rotates immediately
+- Prefers free models over paid when scores are adequate
+- Always keeps **3-6 fallbacks** ordered by composite score
+- Creates **timestamped backup** before any config change
+- Uses **atomic write** (write .tmp then rename) to prevent corruption
+- Sends **SIGUSR1** for gateway hot-reload
+- Never removes a working model -- only reorders
+
+## Provider Discovery
+
+Pass `--discover` to test free models from known providers. Set the env var to enable:
+
+| Provider | Env Var | Signup |
+|----------|---------|--------|
+| NVIDIA NIM | `NVIDIA_API_KEY` | build.nvidia.com |
+| Groq | `GROQ_API_KEY` | console.groq.com |
+| Cerebras | `CEREBRAS_API_KEY` | cloud.cerebras.ai |
+| SambaNova | `SAMBANOVA_API_KEY` | cloud.sambanova.ai |
+| Together.ai | `TOGETHER_API_KEY` | api.together.xyz |
+| HuggingFace | `HF_TOKEN` | huggingface.co |
+| GitHub Models | `GITHUB_TOKEN` | github.com/marketplace/models |
+
+Discovered providers are automatically added to OpenClaw config.
+
+For provider API details, rate limits, and model lists, see `references/providers.md`.
+
+## Cron Scheduling
+
+Daily benchmark at 6 AM UTC:
+
+```bash
+openclaw cron add --name "model-optimizer:benchmark" \
+  --schedule "0 6 * * *" \
+  --command "node /host/home/openclaw/skills/model-optimizer/scripts/run.cjs --auto"
+```
+
+Weekly full benchmark with discovery (Sunday midnight):
+
+```bash
+openclaw cron add --name "model-optimizer:full-benchmark" \
+  --schedule "0 0 * * 0" \
+  --command "node /host/home/openclaw/skills/model-optimizer/scripts/run.cjs --auto --discover"
+```
+
+Check or update cron:
+
+```bash
+openclaw cron list
+```
+
+## Results
+
+- `/tmp/model-optimizer-latest.json` - Most recent run (overwritten)
+- `/tmp/model-optimizer-history.jsonl` - Append-only history (one JSON line per run)
+
+Each result includes: timestamp, per-model scores, rankings, rotation decision with reason, backup path.
+
+## Troubleshooting
+
+- **All models fail**: Check network, API keys, provider status pages
+- **No rotation despite better model**: Threshold not met (use `--threshold 0` to force)
+- **Gateway doesn't reload**: Run `kill -USR1 1` manually
+- **Slow benchmarks**: Reduce `--timeout` or filter with `--providers nvidia`
+- **Rate limited**: Lower `--concurrency` or wait between runs

--- a/skills/model-optimizer/references/providers.md
+++ b/skills/model-optimizer/references/providers.md
@@ -1,0 +1,50 @@
+# Free Model Providers Reference
+
+## NVIDIA NIM (Primary)
+- **Base URL**: `https://integrate.api.nvidia.com/v1`
+- **Auth**: API key (nvapi-xxx)
+- **Free tier**: 5 req/min per model, unlimited daily
+- **Best models**: Nemotron Super 49B (fastest), Step 3.5 Flash, DeepSeek V3.2
+- **Signup**: https://build.nvidia.com/explore/discover
+
+## Groq
+- **Base URL**: `https://api.groq.com/openai/v1`
+- **Auth**: API key
+- **Free tier**: 30 req/min, 14400 req/day
+- **Best models**: Llama 3.3 70B, Llama 3.1 8B Instant (ultra-fast)
+- **Signup**: https://console.groq.com/keys
+
+## Cerebras
+- **Base URL**: `https://api.cerebras.ai/v1`
+- **Auth**: API key
+- **Free tier**: 30 req/min, 1M tokens/day
+- **Best models**: Llama 3.3 70B (extremely fast inference)
+- **Signup**: https://cloud.cerebras.ai/
+
+## SambaNova
+- **Base URL**: `https://api.sambanova.ai/v1`
+- **Auth**: API key
+- **Free tier**: 10 req/min
+- **Best models**: Llama 3.3 70B, DeepSeek R1 Distill 70B
+- **Signup**: https://cloud.sambanova.ai/
+
+## Together.ai
+- **Base URL**: `https://api.together.xyz/v1`
+- **Auth**: API key
+- **Free tier**: $1 free credit on signup
+- **Best models**: Llama 3.3 70B Turbo, Qwen 2.5 72B Turbo
+- **Signup**: https://api.together.xyz/
+
+## HuggingFace
+- **Base URL**: `https://router.huggingface.co/v1`
+- **Auth**: API key (HF token)
+- **Free tier**: 30 req/min, varies by model
+- **Best models**: Llama 3.3 70B, Qwen 2.5 72B
+- **Signup**: https://huggingface.co/settings/tokens
+
+## GitHub Models
+- **Base URL**: `https://models.inference.ai.azure.com`
+- **Auth**: GitHub personal access token
+- **Free tier**: 15 req/min, 150 req/day
+- **Best models**: GPT-4o Mini, Llama 3.1 405B
+- **Signup**: https://github.com/marketplace/models

--- a/skills/model-optimizer/scripts/run.cjs
+++ b/skills/model-optimizer/scripts/run.cjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * run.cjs - Skill runner for model-optimizer.
+ * Thin wrapper that invokes the core engine from the skill context.
+ * Called by OpenClaw when the skill triggers.
+ *
+ * The core engine lives at /host/home/openclaw/scripts/model-optimizer.cjs
+ * (or relative to this file at ../../../scripts/model-optimizer.cjs).
+ *
+ * If no flags are passed, defaults to --auto (benchmark + rotate).
+ */
+"use strict";
+
+var childProcess = require("child_process");
+var path = require("path");
+
+// Resolve engine path (works both in container and locally)
+var enginePath = path.resolve(__dirname, "..", "..", "..", "scripts", "model-optimizer.cjs");
+
+// Forward all CLI args; default to --auto if no args given
+var args = process.argv.slice(2);
+if (args.length === 0) {
+  args.push("--auto");
+}
+
+var cmd = "node";
+var cmdArgs = [enginePath].concat(args);
+
+try {
+  var result = childProcess.spawnSync(cmd, cmdArgs, {
+    stdio: "inherit",
+    timeout: 300000, // 5 minute max
+    env: process.env,
+  });
+
+  if (result.error) {
+    console.error("Skill runner error: " + result.error.message);
+    process.exit(1);
+  }
+
+  process.exit(result.status || 0);
+} catch (e) {
+  console.error("Skill runner error: " + (e.message || e));
+  process.exit(1);
+}

--- a/tests/model-optimizer/run-all-tests.cjs
+++ b/tests/model-optimizer/run-all-tests.cjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * run-all-tests.cjs - Runs all model-optimizer test suites in order.
+ *
+ * Run inside Docker:
+ *   MSYS_NO_PATHCONV=1 docker exec openclaw-openclaw-gateway-1 \
+ *     node /host/home/openclaw/tests/model-optimizer/run-all-tests.cjs
+ */
+'use strict';
+
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const TEST_DIR = '/host/home/openclaw/tests/model-optimizer';
+const REPORT_PATH = '/host/home/openclaw/.workshop/test-results.md';
+
+const TESTS = [
+  { file: 'test-scoring.cjs',           name: 'Scoring (Unit)',             type: 'unit' },
+  { file: 'test-provider-registry.cjs', name: 'Provider Registry (Unit)',   type: 'unit' },
+  { file: 'test-live-benchmark.cjs',    name: 'Live Benchmark (Integration)', type: 'integration' },
+  { file: 'test-config-update.cjs',     name: 'Config Update (Integration)',  type: 'integration' },
+  { file: 'test-e2e.cjs',              name: 'End-to-End',                 type: 'e2e' },
+];
+
+const results = [];
+let totalPassed = 0;
+let totalFailed = 0;
+let totalSkipped = 0;
+
+console.log('=================================================');
+console.log('  Model Optimizer Test Suite');
+console.log('  ' + new Date().toISOString());
+console.log('=================================================\n');
+
+for (const t of TESTS) {
+  const filePath = path.join(TEST_DIR, t.file);
+  console.log('--- Running: ' + t.name + ' (' + t.file + ') ---\n');
+
+  if (!fs.existsSync(filePath)) {
+    console.log('  [ERROR] File not found: ' + filePath);
+    results.push({ name: t.name, file: t.file, type: t.type, status: 'MISSING', output: '', exitCode: -1 });
+    continue;
+  }
+
+  let output = '';
+  let exitCode = 0;
+  const start = performance.now();
+
+  try {
+    output = execSync('node ' + filePath, {
+      timeout: 180000, // 3 min per suite
+      encoding: 'utf8',
+      env: process.env,
+    });
+    console.log(output);
+  } catch (e) {
+    exitCode = e.status || 1;
+    output = (e.stdout || '') + (e.stderr || '');
+    console.log(output);
+  }
+
+  const elapsed = Math.round(performance.now() - start);
+
+  // Parse summary from output
+  const passMatch = output.match(/Passed:\s*(\d+)/);
+  const failMatch = output.match(/Failed:\s*(\d+)/);
+  const skipMatch = output.match(/Skipped:\s*(\d+)/);
+
+  const p = passMatch ? parseInt(passMatch[1], 10) : 0;
+  const f = failMatch ? parseInt(failMatch[1], 10) : 0;
+  const s = skipMatch ? parseInt(skipMatch[1], 10) : 0;
+
+  totalPassed += p;
+  totalFailed += f;
+  totalSkipped += s;
+
+  results.push({
+    name: t.name,
+    file: t.file,
+    type: t.type,
+    status: exitCode === 0 ? 'PASS' : 'FAIL',
+    passed: p,
+    failed: f,
+    skipped: s,
+    elapsed: elapsed,
+    output: output,
+    exitCode: exitCode,
+  });
+
+  console.log('');
+}
+
+// ===========================================================================
+// GRAND SUMMARY
+// ===========================================================================
+console.log('=================================================');
+console.log('  GRAND SUMMARY');
+console.log('=================================================\n');
+
+for (const r of results) {
+  const icon = r.status === 'PASS' ? 'OK' : r.status === 'MISSING' ? '??' : 'XX';
+  console.log('  [' + icon + '] ' + r.name.padEnd(35) + ' P:' + (r.passed || 0) + ' F:' + (r.failed || 0) + ' S:' + (r.skipped || 0) + ' (' + (r.elapsed || 0) + 'ms)');
+}
+
+console.log('\n  Total: ' + totalPassed + ' passed, ' + totalFailed + ' failed, ' + totalSkipped + ' skipped');
+console.log('  Overall: ' + (totalFailed === 0 ? 'ALL PASS' : 'FAILURES DETECTED'));
+console.log('');
+
+// ===========================================================================
+// WRITE REPORT
+// ===========================================================================
+const reportDir = path.dirname(REPORT_PATH);
+if (!fs.existsSync(reportDir)) {
+  fs.mkdirSync(reportDir, { recursive: true });
+}
+
+let report = '# Model Optimizer Test Results\n\n';
+report += '**Date**: ' + new Date().toISOString() + '\n';
+report += '**Overall**: ' + (totalFailed === 0 ? 'ALL PASS' : 'FAILURES DETECTED') + '\n';
+report += '**Totals**: ' + totalPassed + ' passed, ' + totalFailed + ' failed, ' + totalSkipped + ' skipped\n\n';
+report += '## Suite Results\n\n';
+report += '| Suite | Type | Status | Pass | Fail | Skip | Time |\n';
+report += '|-------|------|--------|------|------|------|------|\n';
+
+for (const r of results) {
+  report += '| ' + r.name + ' | ' + r.type + ' | ' + r.status + ' | ' + (r.passed || 0) + ' | ' + (r.failed || 0) + ' | ' + (r.skipped || 0) + ' | ' + (r.elapsed || 0) + 'ms |\n';
+}
+
+if (totalFailed > 0) {
+  report += '\n## Failures\n\n';
+  for (const r of results) {
+    if (r.status === 'FAIL') {
+      report += '### ' + r.name + '\n\n';
+      // Extract failure lines
+      const failLines = r.output.split('\n').filter(l => l.includes('FAIL:'));
+      for (const l of failLines) {
+        report += '- ' + l.trim() + '\n';
+      }
+      report += '\n';
+    }
+  }
+}
+
+report += '\n## Full Output\n\n';
+for (const r of results) {
+  report += '### ' + r.name + '\n\n```\n' + (r.output || '(no output)').slice(0, 3000) + '\n```\n\n';
+}
+
+fs.writeFileSync(REPORT_PATH, report);
+console.log('Report saved to: ' + REPORT_PATH);
+
+process.exit(totalFailed > 0 ? 1 : 0);

--- a/tests/model-optimizer/test-config-update.cjs
+++ b/tests/model-optimizer/test-config-update.cjs
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+/**
+ * test-config-update.cjs - Integration tests for config backup and update.
+ *
+ * Tests: backup creation, primary model update, fallback ordering,
+ * dry-run mode (--dry-run flag), rollback from backup.
+ *
+ * Run inside Docker:
+ *   MSYS_NO_PATHCONV=1 docker exec openclaw-openclaw-gateway-1 \
+ *     node /host/home/openclaw/tests/model-optimizer/test-config-update.cjs
+ */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const CONFIG_PATH = '/home/node/.openclaw/openclaw.json';
+const BACKUP_PATH = CONFIG_PATH + '.optimizer-backup';
+const TEST_BACKUP_DIR = '/tmp/model-optimizer-test-backups';
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+var passed = 0;
+var failed = 0;
+var skipped = 0;
+var failures = [];
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log('  PASS: ' + name);
+  } catch (e) {
+    failed++;
+    failures.push({ name: name, error: e.message });
+    console.log('  FAIL: ' + name + ' -- ' + e.message);
+  }
+}
+
+function skip(name, reason) {
+  skipped++;
+  console.log('  SKIP: ' + name + ' -- ' + reason);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function readConfig() {
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+}
+
+function writeConfig(cfg) {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+}
+
+// ===========================================================================
+// SETUP: Snapshot original config
+// ===========================================================================
+var originalConfigStr = fs.readFileSync(CONFIG_PATH, 'utf8');
+var originalConfig = JSON.parse(originalConfigStr);
+var originalPrimary = originalConfig.agents &&
+  originalConfig.agents.defaults &&
+  originalConfig.agents.defaults.model ?
+  originalConfig.agents.defaults.model.primary : null;
+var originalFallbacks = originalConfig.agents &&
+  originalConfig.agents.defaults &&
+  originalConfig.agents.defaults.model ?
+  (originalConfig.agents.defaults.model.fallbacks || []) : [];
+
+console.log('\nOriginal primary: ' + originalPrimary);
+console.log('Original fallbacks: ' + JSON.stringify(originalFallbacks));
+
+if (!fs.existsSync(TEST_BACKUP_DIR)) {
+  fs.mkdirSync(TEST_BACKUP_DIR, { recursive: true });
+}
+
+// Save a test-level backup
+var testBackupPath = path.join(TEST_BACKUP_DIR, 'test-safety-backup.json');
+fs.copyFileSync(CONFIG_PATH, testBackupPath);
+
+// ===========================================================================
+// TESTS: Config Backup Creation
+// ===========================================================================
+console.log('\n=== Config Backup Creation ===\n');
+
+test('Can create a config backup file', function() {
+  var backupPath = path.join(TEST_BACKUP_DIR, 'test-backup-' + Date.now() + '.json');
+  fs.copyFileSync(CONFIG_PATH, backupPath);
+
+  assert.ok(fs.existsSync(backupPath), 'Backup file should exist');
+  var backup = JSON.parse(fs.readFileSync(backupPath, 'utf8'));
+  assert.ok(backup.models, 'Backup should contain models section');
+  fs.unlinkSync(backupPath);
+});
+
+test('Backup is a valid JSON copy of original config', function() {
+  var backupPath = path.join(TEST_BACKUP_DIR, 'test-valid-' + Date.now() + '.json');
+  fs.copyFileSync(CONFIG_PATH, backupPath);
+  var backup = JSON.parse(fs.readFileSync(backupPath, 'utf8'));
+  var current = readConfig();
+  assert.deepStrictEqual(backup.models, current.models);
+  fs.unlinkSync(backupPath);
+});
+
+test('model-optimizer creates backup at expected path', function() {
+  // The model-optimizer.cjs creates backup at CONFIG_PATH + '.optimizer-backup'
+  // We test that the backup path convention is correct
+  var expectedPath = CONFIG_PATH + '.optimizer-backup';
+  assert.ok(typeof expectedPath === 'string');
+  assert.ok(expectedPath.endsWith('.optimizer-backup'));
+});
+
+test('Multiple backups do not conflict', function() {
+  var b1 = path.join(TEST_BACKUP_DIR, 'b1-' + Date.now() + '.json');
+  var b2 = path.join(TEST_BACKUP_DIR, 'b2-' + Date.now() + '.json');
+  fs.copyFileSync(CONFIG_PATH, b1);
+  fs.copyFileSync(CONFIG_PATH, b2);
+  assert.ok(fs.existsSync(b1) && fs.existsSync(b2));
+  fs.unlinkSync(b1);
+  fs.unlinkSync(b2);
+});
+
+// ===========================================================================
+// TESTS: Primary Model Update
+// ===========================================================================
+console.log('\n=== Primary Model Update ===\n');
+
+test('Can update primary model in config', function() {
+  var testPrimary = 'nvidia/test-model-update-primary';
+  var cfg = readConfig();
+  cfg.agents.defaults.model.primary = testPrimary;
+  writeConfig(cfg);
+
+  var verify = readConfig();
+  assert.strictEqual(verify.agents.defaults.model.primary, testPrimary);
+
+  // Restore
+  cfg.agents.defaults.model.primary = originalPrimary;
+  writeConfig(cfg);
+});
+
+test('Updated config remains valid JSON', function() {
+  var cfg = readConfig();
+  var saved = cfg.agents.defaults.model.primary;
+  cfg.agents.defaults.model.primary = 'nvidia/json-validity-test';
+  writeConfig(cfg);
+
+  var reRead;
+  try {
+    reRead = readConfig();
+  } catch (e) {
+    cfg.agents.defaults.model.primary = saved;
+    writeConfig(cfg);
+    assert.fail('Config invalid after update: ' + e.message);
+  }
+  assert.strictEqual(reRead.agents.defaults.model.primary, 'nvidia/json-validity-test');
+
+  cfg.agents.defaults.model.primary = saved;
+  writeConfig(cfg);
+});
+
+test('Config preserves other sections after model update', function() {
+  var before = readConfig();
+  var providersBefore = JSON.stringify(before.models.providers);
+
+  var cfg = readConfig();
+  cfg.agents.defaults.model.primary = 'nvidia/preserve-test';
+  writeConfig(cfg);
+
+  var after = readConfig();
+  assert.strictEqual(JSON.stringify(after.models.providers), providersBefore,
+    'providers section should be unchanged');
+
+  cfg.agents.defaults.model.primary = originalPrimary;
+  writeConfig(cfg);
+});
+
+// ===========================================================================
+// TESTS: Fallback Ordering
+// ===========================================================================
+console.log('\n=== Fallback Ordering ===\n');
+
+test('Can set ordered fallback list', function() {
+  var testFallbacks = ['provider/model-a', 'provider/model-b', 'provider/model-c'];
+  var cfg = readConfig();
+  var saved = cfg.agents.defaults.model.fallbacks;
+  cfg.agents.defaults.model.fallbacks = testFallbacks;
+  writeConfig(cfg);
+
+  var verify = readConfig();
+  assert.deepStrictEqual(verify.agents.defaults.model.fallbacks, testFallbacks);
+
+  cfg.agents.defaults.model.fallbacks = saved;
+  writeConfig(cfg);
+});
+
+test('Fallback order is preserved exactly', function() {
+  var testFallbacks = ['z-model', 'a-model', 'm-model'];
+  var cfg = readConfig();
+  var saved = cfg.agents.defaults.model.fallbacks;
+  cfg.agents.defaults.model.fallbacks = testFallbacks;
+  writeConfig(cfg);
+
+  var verify = readConfig();
+  for (var i = 0; i < testFallbacks.length; i++) {
+    assert.strictEqual(verify.agents.defaults.model.fallbacks[i], testFallbacks[i],
+      'Fallback at index ' + i + ' should be ' + testFallbacks[i]);
+  }
+
+  cfg.agents.defaults.model.fallbacks = saved;
+  writeConfig(cfg);
+});
+
+test('Empty fallback list is valid', function() {
+  var cfg = readConfig();
+  var saved = cfg.agents.defaults.model.fallbacks;
+  cfg.agents.defaults.model.fallbacks = [];
+  writeConfig(cfg);
+
+  var verify = readConfig();
+  assert.deepStrictEqual(verify.agents.defaults.model.fallbacks, []);
+
+  cfg.agents.defaults.model.fallbacks = saved;
+  writeConfig(cfg);
+});
+
+// ===========================================================================
+// TESTS: Dry-Run Mode
+// ===========================================================================
+console.log('\n=== Dry-Run Mode ===\n');
+
+test('--dry-run flag does not modify config', function() {
+  var before = readConfig();
+  var beforePrimary = before.agents.defaults.model.primary;
+  var beforeFallbacksStr = JSON.stringify(before.agents.defaults.model.fallbacks);
+
+  // Run optimizer with --dry-run
+  try {
+    execSync('node /host/home/openclaw/scripts/model-optimizer.cjs --dry-run --timeout 10000', {
+      timeout: 120000,
+      encoding: 'utf8',
+    });
+  } catch (e) {
+    // Exit code 0 or 1 both ok for dry-run
+    if (!e.stdout && !e.stderr) {
+      skip('dry-run execution', 'optimizer not available');
+      return;
+    }
+  }
+
+  var after = readConfig();
+  assert.strictEqual(after.agents.defaults.model.primary, beforePrimary,
+    'Primary should be unchanged after --dry-run');
+  assert.strictEqual(JSON.stringify(after.agents.defaults.model.fallbacks), beforeFallbacksStr,
+    'Fallbacks should be unchanged after --dry-run');
+});
+
+// ===========================================================================
+// TESTS: Rollback on Error
+// ===========================================================================
+console.log('\n=== Rollback on Error ===\n');
+
+test('Config can be restored from backup after bad write', function() {
+  // Ensure config exists (prior test may have replaced it via atomic write)
+  if (!fs.existsSync(CONFIG_PATH)) fs.copyFileSync(testBackupPath, CONFIG_PATH);
+  var backupPath = path.join(TEST_BACKUP_DIR, 'rollback-' + Date.now() + '.json');
+  fs.copyFileSync(CONFIG_PATH, backupPath);
+
+  var cfg = readConfig();
+  var saved = cfg.agents.defaults.model.primary;
+  cfg.agents.defaults.model.primary = 'BROKEN/nonexistent-model';
+  writeConfig(cfg);
+
+  var corrupted = readConfig();
+  assert.strictEqual(corrupted.agents.defaults.model.primary, 'BROKEN/nonexistent-model');
+
+  // Rollback
+  fs.copyFileSync(backupPath, CONFIG_PATH);
+  var restored = readConfig();
+  assert.strictEqual(restored.agents.defaults.model.primary, saved);
+
+  fs.unlinkSync(backupPath);
+});
+
+test('Rollback preserves all config sections', function() {
+  if (!fs.existsSync(CONFIG_PATH)) fs.copyFileSync(testBackupPath, CONFIG_PATH);
+  var backupPath = path.join(TEST_BACKUP_DIR, 'rollback-full-' + Date.now() + '.json');
+  fs.copyFileSync(CONFIG_PATH, backupPath);
+
+  var cfg = readConfig();
+  cfg.agents.defaults.model.primary = 'ROLLBACK/test';
+  writeConfig(cfg);
+
+  fs.copyFileSync(backupPath, CONFIG_PATH);
+  var restored = readConfig();
+
+  assert.ok(restored.models, 'models section should exist');
+  assert.ok(restored.agents, 'agents section should exist');
+  assert.ok(restored.models.providers, 'providers should exist');
+
+  fs.unlinkSync(backupPath);
+});
+
+test('Optimizer backup path convention works for rollback', function() {
+  // Simulate what the optimizer does: backup to .optimizer-backup
+  var simulatedBackup = CONFIG_PATH + '.test-optimizer-backup';
+  fs.copyFileSync(CONFIG_PATH, simulatedBackup);
+
+  var cfg = readConfig();
+  cfg.agents.defaults.model.primary = 'SIMULATED/bad-update';
+  writeConfig(cfg);
+
+  // Rollback using the backup
+  fs.copyFileSync(simulatedBackup, CONFIG_PATH);
+  var restored = readConfig();
+  assert.strictEqual(restored.agents.defaults.model.primary, originalPrimary);
+
+  fs.unlinkSync(simulatedBackup);
+});
+
+// ===========================================================================
+// FINAL RESTORE
+// ===========================================================================
+console.log('\n=== Final Config Restoration ===\n');
+
+test('Config is restored to original state after all tests', function() {
+  // Restore from our safety backup (ensure backup still exists)
+  assert.ok(fs.existsSync(testBackupPath), 'Safety backup should exist at ' + testBackupPath);
+  fs.writeFileSync(CONFIG_PATH, fs.readFileSync(testBackupPath, 'utf8'));
+  var final_ = readConfig();
+  assert.strictEqual(final_.agents.defaults.model.primary, originalPrimary);
+  assert.deepStrictEqual(final_.agents.defaults.model.fallbacks, originalFallbacks);
+});
+
+// Cleanup
+try {
+  var files = fs.readdirSync(TEST_BACKUP_DIR);
+  for (var f of files) {
+    fs.unlinkSync(path.join(TEST_BACKUP_DIR, f));
+  }
+  fs.rmdirSync(TEST_BACKUP_DIR);
+} catch (e) { /* best effort */ }
+
+// ===========================================================================
+// Summary
+// ===========================================================================
+console.log('\n=== CONFIG UPDATE TEST SUMMARY ===');
+console.log('  Passed: ' + passed);
+console.log('  Failed: ' + failed);
+console.log('  Skipped: ' + skipped);
+if (failures.length > 0) {
+  console.log('\n  Failures:');
+  failures.forEach(function(f) { console.log('    - ' + f.name + ': ' + f.error); });
+}
+console.log('');
+
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/model-optimizer/test-e2e.cjs
+++ b/tests/model-optimizer/test-e2e.cjs
@@ -1,0 +1,369 @@
+#!/usr/bin/env node
+/**
+ * test-e2e.cjs - End-to-end test for the model auto-optimizer.
+ *
+ * Tests: full benchmark cycle, config update verification,
+ * gateway reload capability, results JSON validation.
+ *
+ * Run inside Docker:
+ *   MSYS_NO_PATHCONV=1 docker exec openclaw-openclaw-gateway-1 \
+ *     node /host/home/openclaw/tests/model-optimizer/test-e2e.cjs
+ */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const CONFIG_PATH = '/home/node/.openclaw/openclaw.json';
+const RESULTS_PATH = '/tmp/model-optimizer-latest.json';
+const BACKUP_DIR = '/tmp/model-optimizer-e2e-backup';
+const ENGINE_PATH = '/host/home/openclaw/scripts/model-optimizer.cjs';
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+var passed = 0;
+var failed = 0;
+var skipped = 0;
+var failures = [];
+
+function test(name, fn) {
+  if (fn.constructor.name === 'AsyncFunction') {
+    return fn().then(function() {
+      passed++;
+      console.log('  PASS: ' + name);
+    }).catch(function(e) {
+      failed++;
+      failures.push({ name: name, error: e.message });
+      console.log('  FAIL: ' + name + ' -- ' + e.message);
+    });
+  }
+  try {
+    fn();
+    passed++;
+    console.log('  PASS: ' + name);
+  } catch (e) {
+    failed++;
+    failures.push({ name: name, error: e.message });
+    console.log('  FAIL: ' + name + ' -- ' + e.message);
+  }
+  return Promise.resolve();
+}
+
+function skip(name, reason) {
+  skipped++;
+  console.log('  SKIP: ' + name + ' -- ' + reason);
+  return Promise.resolve();
+}
+
+// ===========================================================================
+// SETUP: Backup current config
+// ===========================================================================
+if (!fs.existsSync(BACKUP_DIR)) {
+  fs.mkdirSync(BACKUP_DIR, { recursive: true });
+}
+
+var backupPath = path.join(BACKUP_DIR, 'pre-e2e-config.json');
+fs.copyFileSync(CONFIG_PATH, backupPath);
+var originalConfig = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+console.log('\nE2E backup saved to: ' + backupPath);
+console.log('Engine: ' + ENGINE_PATH + ' (exists: ' + fs.existsSync(ENGINE_PATH) + ')');
+
+// ===========================================================================
+// RUN TESTS
+// ===========================================================================
+async function runTests() {
+
+  // =========================================================================
+  // TESTS: Engine Script Availability
+  // =========================================================================
+  console.log('\n=== Engine Availability ===\n');
+
+  await test('model-optimizer.cjs exists', function() {
+    assert.ok(fs.existsSync(ENGINE_PATH), 'Engine script should exist at ' + ENGINE_PATH);
+  });
+
+  await test('scoring.cjs exists and is loadable', function() {
+    var scoringPath = '/host/home/openclaw/scripts/scoring.cjs';
+    assert.ok(fs.existsSync(scoringPath), 'scoring.cjs should exist');
+    var m = require(scoringPath);
+    assert.ok(typeof m.latencyScore === 'function');
+    assert.ok(typeof m.compositeScore === 'function');
+  });
+
+  await test('provider-registry.cjs exists and is loadable', function() {
+    var regPath = '/host/home/openclaw/scripts/provider-registry.cjs';
+    assert.ok(fs.existsSync(regPath), 'provider-registry.cjs should exist');
+    var m = require(regPath);
+    assert.ok(Array.isArray(m.KNOWN_PROVIDERS), 'KNOWN_PROVIDERS should be array');
+    assert.ok(typeof m.getTestableModels === 'function', 'getTestableModels should be function');
+  });
+
+  // =========================================================================
+  // TESTS: Full Benchmark Cycle (dry-run for safety)
+  // =========================================================================
+  console.log('\n=== Full Benchmark Cycle (dry-run) ===\n');
+
+  if (!fs.existsSync(ENGINE_PATH)) {
+    await skip('Full benchmark cycle', 'Engine not found');
+  } else {
+    var engineOutput = '';
+
+    await test('Engine runs with --dry-run --json without crashing', async function() {
+      try {
+        engineOutput = execSync('node ' + ENGINE_PATH + ' --dry-run --json --timeout 15000', {
+          timeout: 180000,
+          encoding: 'utf8',
+        });
+        console.log('    (Output length: ' + engineOutput.length + ' chars)');
+        assert.ok(engineOutput.length > 0, 'Should produce output');
+      } catch (e) {
+        engineOutput = e.stdout || '';
+        if (engineOutput.length > 0) {
+          console.log('    (Got output despite exit code ' + e.status + ')');
+        } else {
+          assert.fail('Engine crashed: ' + (e.stderr || e.message).slice(0, 300));
+        }
+      }
+    });
+
+    await test('Engine JSON output is parseable', async function() {
+      if (!engineOutput) { skip('JSON parse', 'no output'); return; }
+      var parsed;
+      try {
+        parsed = JSON.parse(engineOutput);
+      } catch (e) {
+        assert.fail('Output is not valid JSON: ' + e.message);
+      }
+      assert.ok(typeof parsed === 'object');
+    });
+
+    await test('Engine JSON has required fields', async function() {
+      if (!engineOutput) return;
+      var results;
+      try { results = JSON.parse(engineOutput); } catch (e) { return; }
+
+      assert.ok(results.timestamp, 'Should have timestamp');
+      assert.ok(typeof results.totalModels === 'number', 'Should have totalModels');
+      assert.ok(typeof results.workingModels === 'number', 'Should have workingModels count');
+      assert.ok(typeof results.failedModels === 'number', 'Should have failedModels count');
+      assert.ok(typeof results.primary === 'object', 'Should have primary object');
+      assert.ok(typeof results.primary.modelId === 'string', 'Should have primary.modelId');
+      assert.ok(typeof results.primary.score === 'number', 'Should have primary.score');
+      assert.ok(typeof results.rotated === 'boolean', 'Should have rotated flag');
+      assert.ok(Array.isArray(results.rankings), 'Should have rankings array');
+    });
+
+    await test('Engine produces results file', async function() {
+      if (!fs.existsSync(RESULTS_PATH)) {
+        console.log('    [INFO] Results file not at ' + RESULTS_PATH + ', running engine...');
+        try {
+          execSync('node ' + ENGINE_PATH + ' --dry-run --timeout 15000', {
+            timeout: 180000,
+            encoding: 'utf8',
+          });
+        } catch (e) { /* ok */ }
+      }
+
+      assert.ok(fs.existsSync(RESULTS_PATH),
+        'Results file should exist at ' + RESULTS_PATH);
+    });
+  }
+
+  // =========================================================================
+  // TESTS: Results JSON Validation
+  // =========================================================================
+  console.log('\n=== Results JSON Validation ===\n');
+
+  if (!fs.existsSync(RESULTS_PATH)) {
+    await skip('Results JSON tests', 'No results file');
+  } else {
+    await test('Results JSON is valid and parseable', function() {
+      var content = fs.readFileSync(RESULTS_PATH, 'utf8');
+      JSON.parse(content); // Throws if invalid
+    });
+
+    await test('Results has timestamp as valid ISO date', function() {
+      var results = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+      assert.ok(results.timestamp);
+      var d = new Date(results.timestamp);
+      assert.ok(!isNaN(d.getTime()), 'Invalid date: ' + results.timestamp);
+    });
+
+    await test('Results workingModels + failedModels = totalModels', function() {
+      var results = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+      assert.strictEqual(results.workingModels + results.failedModels, results.totalModels,
+        'workingModels(' + results.workingModels + ') + failedModels(' + results.failedModels + ') != totalModels(' + results.totalModels + ')');
+    });
+
+    await test('Each ranking entry has required fields', function() {
+      var results = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+      for (var r of results.rankings) {
+        assert.ok(typeof r.provider === 'string', 'provider');
+        assert.ok(typeof r.modelId === 'string', 'modelId');
+        assert.ok(typeof r.rank === 'number', 'rank');
+        assert.ok(typeof r.composite === 'number', 'composite');
+        assert.ok(typeof r.latencyScore === 'number', 'latencyScore');
+        assert.ok(typeof r.throughputScore === 'number', 'throughputScore');
+        assert.ok(typeof r.correctnessScore === 'number', 'correctnessScore');
+        assert.ok(typeof r.availabilityScore === 'number', 'availabilityScore');
+      }
+    });
+
+    await test('Result scores are in 0-100 range', function() {
+      var results = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+      for (var r of results.rankings) {
+        assert.ok(r.latencyScore >= 0 && r.latencyScore <= 100,
+          r.modelId + ' latencyScore: ' + r.latencyScore);
+        assert.ok(r.throughputScore >= 0 && r.throughputScore <= 100,
+          r.modelId + ' throughputScore: ' + r.throughputScore);
+        assert.ok(r.correctnessScore >= 0 && r.correctnessScore <= 100,
+          r.modelId + ' correctnessScore: ' + r.correctnessScore);
+        assert.ok(r.composite >= 0 && r.composite <= 100,
+          r.modelId + ' composite: ' + r.composite);
+      }
+    });
+
+    await test('At least one model succeeded', function() {
+      var results = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+      assert.ok(results.workingModels > 0,
+        'At least one model should succeed, workingModels=' + results.workingModels);
+    });
+
+    await test('primary.modelId is among ranked models', function() {
+      var results = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+      var primaryId = results.primary.modelId;
+      var found = results.rankings.some(function(r) {
+        return r.modelId === primaryId;
+      });
+      assert.ok(found, 'primary.modelId "' + primaryId + '" should be among rankings');
+    });
+
+    await test('primary.score matches top-ranked composite', function() {
+      var results = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+      if (results.rankings.length > 0) {
+        assert.strictEqual(results.primary.score, results.rankings[0].composite,
+          'primary.score (' + results.primary.score + ') should match top ranking (' + results.rankings[0].composite + ')');
+      }
+    });
+
+    await test('dry-run flag means rotated is false', function() {
+      var results = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+      // We ran with --dry-run, so rotated should be false
+      assert.strictEqual(results.rotated, false, 'dry-run should not rotate');
+    });
+  }
+
+  // =========================================================================
+  // TESTS: Config Integrity
+  // =========================================================================
+  console.log('\n=== Config Integrity ===\n');
+
+  await test('Config has a primary model set', function() {
+    var cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    var primary = cfg.agents && cfg.agents.defaults && cfg.agents.defaults.model
+      ? cfg.agents.defaults.model.primary : null;
+    assert.ok(primary && typeof primary === 'string' && primary.length > 0,
+      'Primary should be set');
+  });
+
+  await test('Config has fallback models array', function() {
+    var cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    var fallbacks = cfg.agents && cfg.agents.defaults && cfg.agents.defaults.model
+      ? cfg.agents.defaults.model.fallbacks : null;
+    assert.ok(Array.isArray(fallbacks), 'Fallbacks should be an array');
+  });
+
+  await test('Config is valid JSON that gateway can parse', function() {
+    var cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    assert.ok(cfg.models, 'Should have models section');
+    assert.ok(cfg.agents, 'Should have agents section');
+    assert.ok(cfg.agents.defaults, 'Should have agents.defaults');
+    assert.ok(cfg.agents.defaults.model, 'Should have agents.defaults.model');
+  });
+
+  // =========================================================================
+  // TESTS: Gateway Reload
+  // =========================================================================
+  console.log('\n=== Gateway Reload Capability ===\n');
+
+  await test('PID 1 is the gateway process', function() {
+    try {
+      var cmdline = execSync('cat /proc/1/cmdline', { encoding: 'utf8' });
+      console.log('    (PID 1: ' + cmdline.replace(/\0/g, ' ').trim().slice(0, 80) + ')');
+      assert.ok(cmdline.length > 0);
+    } catch (e) {
+      console.log('    [INFO] Could not read PID 1');
+    }
+  });
+
+  await test('Config file is readable', function() {
+    fs.accessSync(CONFIG_PATH, fs.constants.R_OK);
+  });
+
+  await test('Config file is writable', function() {
+    fs.accessSync(CONFIG_PATH, fs.constants.W_OK);
+  });
+
+  // =========================================================================
+  // TESTS: Config unchanged after dry-run e2e
+  // =========================================================================
+  console.log('\n=== Config Unchanged After Dry-Run ===\n');
+
+  await test('Config unchanged after dry-run cycle', function() {
+    var current = readConfig();
+    assert.strictEqual(
+      current.agents.defaults.model.primary,
+      originalConfig.agents.defaults.model.primary,
+      'Primary should be unchanged after dry-run e2e'
+    );
+  });
+
+  // =========================================================================
+  // TEARDOWN
+  // =========================================================================
+  console.log('\n=== Teardown ===\n');
+
+  await test('Restore original config from backup', function() {
+    fs.copyFileSync(backupPath, CONFIG_PATH);
+    var restored = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    assert.strictEqual(
+      restored.agents.defaults.model.primary,
+      originalConfig.agents.defaults.model.primary
+    );
+  });
+
+  // Cleanup
+  try {
+    fs.unlinkSync(backupPath);
+    fs.rmdirSync(BACKUP_DIR);
+  } catch (e) { /* best effort */ }
+
+  // =========================================================================
+  // Summary
+  // =========================================================================
+  console.log('\n=== E2E TEST SUMMARY ===');
+  console.log('  Passed: ' + passed);
+  console.log('  Failed: ' + failed);
+  console.log('  Skipped: ' + skipped);
+  if (failures.length > 0) {
+    console.log('\n  Failures:');
+    failures.forEach(function(f) { console.log('    - ' + f.name + ': ' + f.error); });
+  }
+  console.log('');
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+function readConfig() {
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+}
+
+runTests().catch(function(e) {
+  // Restore on crash
+  try { fs.copyFileSync(backupPath, CONFIG_PATH); } catch (e2) { /* */ }
+  console.error('E2E test runner error: ' + e.message);
+  process.exit(1);
+});

--- a/tests/model-optimizer/test-live-benchmark.cjs
+++ b/tests/model-optimizer/test-live-benchmark.cjs
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+/**
+ * test-live-benchmark.cjs - Integration tests with live NVIDIA API calls.
+ *
+ * Tests: response format parsing, score validity (0-100), timeout handling,
+ * concurrent execution.
+ *
+ * Run inside Docker:
+ *   MSYS_NO_PATHCONV=1 docker exec openclaw-openclaw-gateway-1 \
+ *     node /host/home/openclaw/tests/model-optimizer/test-live-benchmark.cjs
+ */
+'use strict';
+
+const assert = require('assert');
+const https = require('https');
+const http = require('http');
+const fs = require('fs');
+
+const scoring = require('/host/home/openclaw/scripts/scoring.cjs');
+
+const CONFIG_PATH = '/home/node/.openclaw/openclaw.json';
+const PROMPT = 'What is 2+2? Answer with just the number.';
+const EXPECTED_ANSWER = '4';
+const MAX_TOKENS = 32;
+const TIMEOUT_MS = 30000;
+const SHORT_TIMEOUT_MS = 50;
+
+// ---------------------------------------------------------------------------
+// Load config and extract NVIDIA provider
+// ---------------------------------------------------------------------------
+var cfg, nvidiaProvider;
+try {
+  cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+  var providers = cfg.models && cfg.models.providers ? cfg.models.providers : {};
+  nvidiaProvider = providers.nvidia;
+} catch (e) {
+  console.log('[ERROR] Cannot load config: ' + e.message);
+  process.exit(1);
+}
+
+if (!nvidiaProvider || !nvidiaProvider.apiKey) {
+  console.log('[ERROR] NVIDIA provider not configured or missing API key');
+  process.exit(1);
+}
+
+var NVIDIA_URL = nvidiaProvider.baseUrl.replace(/\/+$/, '') + '/chat/completions';
+var NVIDIA_KEY = nvidiaProvider.apiKey;
+var NVIDIA_MODELS = (nvidiaProvider.models || []).map(function(m) { return m.id; });
+
+console.log('NVIDIA endpoint: ' + NVIDIA_URL);
+console.log('Models to test: ' + NVIDIA_MODELS.length);
+
+// ---------------------------------------------------------------------------
+// HTTP helper
+// ---------------------------------------------------------------------------
+function makeRequest(url, body, apiKey, timeoutMs) {
+  return new Promise(function(resolve) {
+    var u = new URL(url);
+    var mod = u.protocol === 'https:' ? https : http;
+    var headers = { 'Content-Type': 'application/json' };
+    if (apiKey) headers['Authorization'] = 'Bearer ' + apiKey;
+    var data = JSON.stringify(body);
+    headers['Content-Length'] = Buffer.byteLength(data);
+
+    var start = performance.now();
+    var ttft = null;
+    var fullBody = '';
+    var timedOut = false;
+
+    var timer = setTimeout(function() {
+      timedOut = true;
+      req.destroy();
+      resolve({ error: 'TIMEOUT', latencyMs: timeoutMs, ttftMs: null, body: '' });
+    }, timeoutMs);
+
+    var req = mod.request(u, { method: 'POST', headers: headers }, function(res) {
+      res.on('data', function(chunk) {
+        if (ttft === null) ttft = performance.now() - start;
+        fullBody += chunk;
+      });
+      res.on('end', function() {
+        if (timedOut) return;
+        clearTimeout(timer);
+        var latencyMs = performance.now() - start;
+        if (res.statusCode >= 400) {
+          resolve({ error: 'HTTP ' + res.statusCode, latencyMs: latencyMs, ttftMs: ttft, body: fullBody.slice(0, 500) });
+        } else {
+          resolve({ error: null, latencyMs: latencyMs, ttftMs: ttft, body: fullBody });
+        }
+      });
+    });
+
+    req.on('error', function(e) {
+      if (timedOut) return;
+      clearTimeout(timer);
+      resolve({ error: e.message, latencyMs: performance.now() - start, ttftMs: null, body: '' });
+    });
+
+    req.write(data);
+    req.end();
+  });
+}
+
+function extractText(body) {
+  try {
+    var d = JSON.parse(body);
+    if (d.choices && d.choices[0]) {
+      var c = d.choices[0];
+      return (c.message && c.message.content) || c.text || '';
+    }
+    return '';
+  } catch (e) {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+var passed = 0;
+var failed = 0;
+var skipped = 0;
+var failures = [];
+
+function test(name, fn) {
+  return fn().then(function() {
+    passed++;
+    console.log('  PASS: ' + name);
+  }).catch(function(e) {
+    failed++;
+    failures.push({ name: name, error: e.message });
+    console.log('  FAIL: ' + name + ' -- ' + e.message);
+  });
+}
+
+function assertInRange(val, min, max, msg) {
+  assert.ok(typeof val === 'number', msg + ' (expected number, got ' + typeof val + ')');
+  assert.ok(val >= min && val <= max, msg + ' (expected ' + min + '-' + max + ', got ' + val + ')');
+}
+
+// ===========================================================================
+// RUN TESTS
+// ===========================================================================
+async function runTests() {
+
+  var testModelId = NVIDIA_MODELS[0] || 'nvidia/llama-3.3-nemotron-super-49b-v1';
+  var testBody = {
+    model: testModelId,
+    messages: [{ role: 'user', content: PROMPT }],
+    max_tokens: MAX_TOKENS,
+    temperature: 0,
+    stream: false,
+  };
+
+  // =========================================================================
+  // TESTS: Response Format Parsing
+  // =========================================================================
+  console.log('\n=== Response Format Parsing (Live) ===\n');
+
+  await test('NVIDIA API returns valid JSON with choices array', async function() {
+    var res = await makeRequest(NVIDIA_URL, testBody, NVIDIA_KEY, TIMEOUT_MS);
+    if (res.error) {
+      console.log('    [INFO] Model unavailable: ' + res.error);
+      return;
+    }
+    var parsed = JSON.parse(res.body);
+    assert.ok(parsed.choices, 'Response should have choices array');
+    assert.ok(Array.isArray(parsed.choices), 'choices should be an array');
+    assert.ok(parsed.choices.length > 0, 'choices should not be empty');
+  });
+
+  await test('Response contains message.content text', async function() {
+    // Try multiple models until one responds (some may be rate-limited)
+    var tried = 0;
+    for (var mi = 0; mi < NVIDIA_MODELS.length && mi < 5; mi++) {
+      var body = {
+        model: NVIDIA_MODELS[mi],
+        messages: [{ role: 'user', content: PROMPT }],
+        max_tokens: MAX_TOKENS,
+        temperature: 0,
+        stream: false,
+      };
+      var res = await makeRequest(NVIDIA_URL, body, NVIDIA_KEY, TIMEOUT_MS);
+      tried++;
+      if (res.error) continue;
+      var text = extractText(res.body);
+      if (text.length > 0) {
+        console.log('    (model: ' + NVIDIA_MODELS[mi] + ', text: "' + text.slice(0, 50) + '")');
+        return; // pass
+      }
+    }
+    assert.fail('No model returned non-empty text after trying ' + tried + ' models');
+  });
+
+  await test('Response text contains expected answer "4"', async function() {
+    // Try multiple models until one responds correctly
+    for (var mi = 0; mi < NVIDIA_MODELS.length && mi < 5; mi++) {
+      var body = {
+        model: NVIDIA_MODELS[mi],
+        messages: [{ role: 'user', content: PROMPT }],
+        max_tokens: MAX_TOKENS,
+        temperature: 0,
+        stream: false,
+      };
+      var res = await makeRequest(NVIDIA_URL, body, NVIDIA_KEY, TIMEOUT_MS);
+      if (res.error) continue;
+      var text = extractText(res.body);
+      if (text.includes('4') || text.toLowerCase().includes('four')) {
+        console.log('    (model: ' + NVIDIA_MODELS[mi] + ', answer: "' + text.slice(0, 50) + '")');
+        return; // pass
+      }
+    }
+    assert.fail('No model returned "4" in response');
+  });
+
+  // =========================================================================
+  // TESTS: Scoring with Live Data
+  // =========================================================================
+  console.log('\n=== Scoring Validation (Live) ===\n');
+
+  await test('latencyScore from live request is in 0-100 range', async function() {
+    var res = await makeRequest(NVIDIA_URL, testBody, NVIDIA_KEY, TIMEOUT_MS);
+    if (res.error) return;
+    var ls = scoring.latencyScore(res.latencyMs);
+    assertInRange(ls, 0, 100, 'latencyScore');
+    console.log('    (latency: ' + Math.round(res.latencyMs) + 'ms -> score: ' + ls + ')');
+  });
+
+  await test('throughputScore from live request is in 0-100 range', async function() {
+    var res = await makeRequest(NVIDIA_URL, testBody, NVIDIA_KEY, TIMEOUT_MS);
+    if (res.error) return;
+    var parsed;
+    try { parsed = JSON.parse(res.body); } catch (e) { return; }
+    var usage = parsed.usage || {};
+    var completionTokens = usage.completion_tokens || 0;
+    var tokPerSec = completionTokens > 0 ? completionTokens / (res.latencyMs / 1000) : null;
+    var ts = scoring.throughputScore(tokPerSec);
+    assertInRange(ts, 0, 100, 'throughputScore');
+    console.log('    (throughput: ' + (tokPerSec ? tokPerSec.toFixed(1) : 'unknown') + ' tok/s -> score: ' + ts + ')');
+  });
+
+  await test('correctnessScore from live request is in 0-100 range', async function() {
+    var res = await makeRequest(NVIDIA_URL, testBody, NVIDIA_KEY, TIMEOUT_MS);
+    if (res.error) return;
+    var text = extractText(res.body);
+    var cs = scoring.correctnessScore(text, EXPECTED_ANSWER);
+    assertInRange(cs, 0, 100, 'correctnessScore');
+    console.log('    (response: "' + text.slice(0, 50) + '" -> score: ' + cs + ')');
+  });
+
+  await test('compositeScore from live request is in 0-100 range', async function() {
+    var res = await makeRequest(NVIDIA_URL, testBody, NVIDIA_KEY, TIMEOUT_MS);
+    if (res.error) return;
+    var text = extractText(res.body);
+    var parsed;
+    try { parsed = JSON.parse(res.body); } catch (e) { return; }
+    var usage = parsed.usage || {};
+    var completionTokens = usage.completion_tokens || 0;
+    var tokPerSec = completionTokens > 0 ? completionTokens / (res.latencyMs / 1000) : null;
+
+    var scores = {
+      latency: scoring.latencyScore(res.latencyMs),
+      throughput: scoring.throughputScore(tokPerSec),
+      correctness: scoring.correctnessScore(text, EXPECTED_ANSWER),
+      availability: scoring.availabilityScore(1, 1),
+    };
+    var composite = scoring.compositeScore(scores);
+    assertInRange(composite, 0, 100, 'compositeScore');
+    console.log('    (composite: ' + composite + ' L=' + scores.latency + ' T=' + scores.throughput + ' C=' + scores.correctness + ' A=' + scores.availability + ')');
+  });
+
+  // =========================================================================
+  // TESTS: Timeout Handling
+  // =========================================================================
+  console.log('\n=== Timeout Handling ===\n');
+
+  await test('Very short timeout (50ms) returns TIMEOUT error', async function() {
+    var res = await makeRequest(NVIDIA_URL, testBody, NVIDIA_KEY, SHORT_TIMEOUT_MS);
+    assert.strictEqual(res.error, 'TIMEOUT', 'Should timeout with 50ms limit');
+  });
+
+  await test('Timeout latency is approximately the timeout value', async function() {
+    var res = await makeRequest(NVIDIA_URL, testBody, NVIDIA_KEY, SHORT_TIMEOUT_MS);
+    if (res.error !== 'TIMEOUT') return;
+    assert.ok(res.latencyMs >= SHORT_TIMEOUT_MS - 10,
+      'Latency should be >= timeout-10ms');
+    assert.ok(res.latencyMs <= SHORT_TIMEOUT_MS + 500,
+      'Latency should be <= timeout+500ms');
+  });
+
+  // =========================================================================
+  // TESTS: Concurrent Execution
+  // =========================================================================
+  console.log('\n=== Concurrent Execution ===\n');
+
+  await test('Can run 3 models concurrently without errors', async function() {
+    var modelsToTest = NVIDIA_MODELS.slice(0, 3);
+    if (modelsToTest.length < 2) {
+      console.log('    [INFO] Only ' + modelsToTest.length + ' models available');
+      return;
+    }
+
+    var start = performance.now();
+    var promises = modelsToTest.map(function(modelId) {
+      return makeRequest(NVIDIA_URL, {
+        model: modelId,
+        messages: [{ role: 'user', content: PROMPT }],
+        max_tokens: MAX_TOKENS,
+        temperature: 0,
+        stream: false,
+      }, NVIDIA_KEY, TIMEOUT_MS);
+    });
+
+    var results = await Promise.all(promises);
+    var elapsed = performance.now() - start;
+    var successes = results.filter(function(r) { return !r.error; });
+    console.log('    (' + successes.length + '/' + results.length + ' succeeded in ' + Math.round(elapsed) + 'ms)');
+
+    for (var i = 0; i < results.length; i++) {
+      assert.ok(results[i].latencyMs > 0, 'Result ' + i + ' should have positive latency');
+    }
+  });
+
+  await test('Concurrent execution is faster than sum of latencies', async function() {
+    var modelsToTest = NVIDIA_MODELS.slice(0, 2);
+    if (modelsToTest.length < 2) return;
+
+    var concStart = performance.now();
+    var concResults = await Promise.all(modelsToTest.map(function(modelId) {
+      return makeRequest(NVIDIA_URL, {
+        model: modelId,
+        messages: [{ role: 'user', content: PROMPT }],
+        max_tokens: MAX_TOKENS,
+        temperature: 0,
+        stream: false,
+      }, NVIDIA_KEY, TIMEOUT_MS);
+    }));
+    var concElapsed = performance.now() - concStart;
+    var sumLatencies = concResults.reduce(function(s, r) { return s + r.latencyMs; }, 0);
+
+    console.log('    (concurrent: ' + Math.round(concElapsed) + 'ms, sum: ' + Math.round(sumLatencies) + 'ms)');
+
+    var allFailed = concResults.every(function(r) { return r.error; });
+    if (!allFailed) {
+      assert.ok(concElapsed < sumLatencies * 1.1,
+        'Concurrent should be faster than sequential sum');
+    }
+  });
+
+  // =========================================================================
+  // TESTS: Benchmark Each NVIDIA Model
+  // =========================================================================
+  console.log('\n=== Benchmark All NVIDIA Models ===\n');
+
+  for (var mi = 0; mi < NVIDIA_MODELS.length; mi++) {
+    var modelId = NVIDIA_MODELS[mi];
+    await test('Model ' + modelId + ' responds or fails gracefully', async function() {
+      var body = {
+        model: modelId,
+        messages: [{ role: 'user', content: PROMPT }],
+        max_tokens: MAX_TOKENS,
+        temperature: 0,
+        stream: false,
+      };
+      var res = await makeRequest(NVIDIA_URL, body, NVIDIA_KEY, TIMEOUT_MS);
+
+      if (res.error) {
+        assert.ok(typeof res.error === 'string');
+        assert.ok(res.latencyMs > 0);
+        console.log('    (' + modelId + ': ' + res.error + ' in ' + Math.round(res.latencyMs) + 'ms)');
+      } else {
+        var text = extractText(res.body);
+        assert.ok(typeof text === 'string');
+        console.log('    (' + modelId + ': OK in ' + Math.round(res.latencyMs) + 'ms, "' + text.slice(0, 40) + '")');
+      }
+    });
+  }
+
+  // =========================================================================
+  // Summary
+  // =========================================================================
+  console.log('\n=== LIVE BENCHMARK TEST SUMMARY ===');
+  console.log('  Passed: ' + passed);
+  console.log('  Failed: ' + failed);
+  console.log('  Skipped: ' + skipped);
+  if (failures.length > 0) {
+    console.log('\n  Failures:');
+    failures.forEach(function(f) { console.log('    - ' + f.name + ': ' + f.error); });
+  }
+  console.log('');
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch(function(e) {
+  console.error('Test runner error: ' + e.message);
+  process.exit(1);
+});

--- a/tests/model-optimizer/test-provider-db.cjs
+++ b/tests/model-optimizer/test-provider-db.cjs
@@ -1,0 +1,850 @@
+#!/usr/bin/env node
+/**
+ * test-provider-db.cjs - Unit tests for scripts/provider-db.cjs
+ *
+ * Tests: Database init, seed builtins, CRUD providers, CRUD models,
+ * getTestableModelsFromDB, and edge cases.
+ *
+ * All tests use :memory: SQLite databases to avoid file system side effects.
+ *
+ * Run inside Docker:
+ *   MSYS_NO_PATHCONV=1 docker exec openclaw-openclaw-gateway-1 \
+ *     node /host/home/openclaw/tests/model-optimizer/test-provider-db.cjs
+ */
+'use strict';
+
+var assert = require('assert');
+
+// ---------------------------------------------------------------------------
+// Load the module under test
+// ---------------------------------------------------------------------------
+var providerDb;
+try {
+  providerDb = require('/host/home/openclaw/scripts/provider-db.cjs');
+} catch (e) {
+  console.error('FATAL: Cannot load provider-db.cjs - ' + e.message);
+  console.error('Make sure the file exists at /host/home/openclaw/scripts/provider-db.cjs');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Test infrastructure (matches project pattern)
+// ---------------------------------------------------------------------------
+var passed = 0;
+var failed = 0;
+var skipped = 0;
+var failures = [];
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log('  PASS: ' + name);
+  } catch (e) {
+    failed++;
+    failures.push({ name: name, error: e.message });
+    console.log('  FAIL: ' + name + ' -- ' + e.message);
+  }
+}
+
+function skip(name, reason) {
+  skipped++;
+  console.log('  SKIP: ' + name + ' -- ' + reason);
+}
+
+// ---------------------------------------------------------------------------
+// Detect API surface and adapt tests accordingly
+// ---------------------------------------------------------------------------
+var hasInitDB = typeof providerDb.initDB === 'function';
+var hasSeedBuiltins = typeof providerDb.seedBuiltinProviders === 'function';
+var hasAddProvider = typeof providerDb.addProvider === 'function';
+var hasGetProvider = typeof providerDb.getProvider === 'function';
+var hasGetProviders = typeof providerDb.getProviders === 'function';
+var hasUpdateProvider = typeof providerDb.updateProvider === 'function';
+var hasRemoveProvider = typeof providerDb.removeProvider === 'function';
+var hasAddModel = typeof providerDb.addModel === 'function';
+var hasRemoveModel = typeof providerDb.removeModel === 'function';
+var hasToggleModel = typeof providerDb.toggleModel === 'function';
+var hasGetTestableModelsFromDB = typeof providerDb.getTestableModelsFromDB === 'function';
+var hasCloseDB = typeof providerDb.closeDB === 'function';
+
+console.log('\n=== provider-db.cjs API Surface ===\n');
+console.log('  initDB:                  ' + hasInitDB);
+console.log('  seedBuiltinProviders:    ' + hasSeedBuiltins);
+console.log('  addProvider:             ' + hasAddProvider);
+console.log('  getProvider:             ' + hasGetProvider);
+console.log('  getProviders:            ' + hasGetProviders);
+console.log('  updateProvider:          ' + hasUpdateProvider);
+console.log('  removeProvider:          ' + hasRemoveProvider);
+console.log('  addModel:                ' + hasAddModel);
+console.log('  removeModel:             ' + hasRemoveModel);
+console.log('  toggleModel:             ' + hasToggleModel);
+console.log('  getTestableModelsFromDB: ' + hasGetTestableModelsFromDB);
+console.log('  closeDB:                 ' + hasCloseDB);
+
+// ===========================================================================
+// TESTS: Database Initialization (5 tests)
+// ===========================================================================
+console.log('\n=== Database Initialization ===\n');
+
+test('initDB creates tables and returns db handle', function() {
+  if (!hasInitDB) throw new Error('initDB not exported');
+  var db = providerDb.initDB(':memory:');
+  assert.ok(db, 'initDB should return a db handle');
+  // Verify tables exist by querying sqlite_master
+  var tables;
+  if (typeof db.prepare === 'function') {
+    tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all();
+  } else if (db.tables) {
+    tables = db.tables;
+  }
+  assert.ok(tables, 'should be able to query tables');
+  if (typeof db.close === 'function') db.close();
+  else if (hasCloseDB) providerDb.closeDB(db);
+});
+
+test('Re-init is idempotent (no error on second call)', function() {
+  if (!hasInitDB) throw new Error('initDB not exported');
+  var db = providerDb.initDB(':memory:');
+  // Call init again on the same :memory: db -- should not throw
+  // For :memory:, each call creates a new db, so just verify two calls succeed
+  var db2 = providerDb.initDB(':memory:');
+  assert.ok(db2, 'second initDB should succeed');
+  if (typeof db.close === 'function') db.close();
+  if (typeof db2.close === 'function') db2.close();
+});
+
+test('WAL mode is enabled', function() {
+  if (!hasInitDB) throw new Error('initDB not exported');
+  var db = providerDb.initDB(':memory:');
+  if (typeof db.pragma === 'function') {
+    var mode = db.pragma('journal_mode', { simple: true });
+    // :memory: may report 'memory' instead of 'wal', both are acceptable
+    assert.ok(mode === 'wal' || mode === 'memory',
+      'journal_mode should be wal or memory, got: ' + mode);
+  } else {
+    // If not better-sqlite3 direct API, just verify db works
+    assert.ok(db, 'db should be valid');
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+test('Foreign keys are enabled', function() {
+  if (!hasInitDB) throw new Error('initDB not exported');
+  var db = providerDb.initDB(':memory:');
+  if (typeof db.pragma === 'function') {
+    var fk = db.pragma('foreign_keys', { simple: true });
+    assert.strictEqual(fk, 1, 'foreign_keys should be enabled (1)');
+  } else {
+    assert.ok(db, 'db should be valid');
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+test('In-memory DB works (no file created)', function() {
+  if (!hasInitDB) throw new Error('initDB not exported');
+  var db = providerDb.initDB(':memory:');
+  assert.ok(db, ':memory: db should be valid');
+  // Should be able to do basic operations
+  if (typeof db.prepare === 'function') {
+    var row = db.prepare('SELECT 1 as val').get();
+    assert.strictEqual(row.val, 1);
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+// ===========================================================================
+// TESTS: Seed Builtins (5 tests)
+// ===========================================================================
+console.log('\n=== Seed Builtins ===\n');
+
+test('seedBuiltins seeds all KNOWN_PROVIDERS', function() {
+  if (!hasInitDB || !hasSeedBuiltins) throw new Error('initDB or seedBuiltins not exported');
+  var db = providerDb.initDB(':memory:');
+  providerDb.seedBuiltinProviders(db);
+  if (hasGetProviders) {
+    var providers = providerDb.getProviders(db);
+    assert.ok(providers.length >= 5,
+      'Should have at least 5 providers after seeding, got ' + providers.length);
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+test('Seeded providers have correct total model count (22+)', function() {
+  if (!hasInitDB || !hasSeedBuiltins) throw new Error('initDB or seedBuiltins not exported');
+  var db = providerDb.initDB(':memory:');
+  providerDb.seedBuiltinProviders(db);
+  // Count models via direct query or API
+  var modelCount = 0;
+  if (typeof db.prepare === 'function') {
+    var row = db.prepare('SELECT COUNT(*) as cnt FROM models').get();
+    modelCount = row.cnt;
+  } else if (hasGetProviders) {
+    var providers = providerDb.getProviders(db);
+    for (var i = 0; i < providers.length; i++) {
+      var p = providers[i];
+      modelCount += (p.models ? p.models.length : 0);
+    }
+  }
+  assert.ok(modelCount >= 22,
+    'Should have at least 22 models after seeding, got ' + modelCount);
+  if (typeof db.close === 'function') db.close();
+});
+
+test('All seeded providers have is_builtin=1', function() {
+  if (!hasInitDB || !hasSeedBuiltins) throw new Error('initDB or seedBuiltins not exported');
+  var db = providerDb.initDB(':memory:');
+  providerDb.seedBuiltinProviders(db);
+  if (typeof db.prepare === 'function') {
+    var nonBuiltin = db.prepare('SELECT COUNT(*) as cnt FROM providers WHERE is_builtin = 0').get();
+    assert.strictEqual(nonBuiltin.cnt, 0, 'All seeded providers should be builtin');
+  } else if (hasGetProviders) {
+    var providers = providerDb.getProviders(db);
+    for (var i = 0; i < providers.length; i++) {
+      assert.ok(providers[i].is_builtin === 1 || providers[i].isBuiltin === true,
+        'Provider ' + providers[i].name + ' should be builtin');
+    }
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+test('Re-seed is idempotent (no duplicates)', function() {
+  if (!hasInitDB || !hasSeedBuiltins) throw new Error('initDB or seedBuiltins not exported');
+  var db = providerDb.initDB(':memory:');
+  providerDb.seedBuiltinProviders(db);
+  var countBefore = 0;
+  if (typeof db.prepare === 'function') {
+    countBefore = db.prepare('SELECT COUNT(*) as cnt FROM providers').get().cnt;
+  }
+  // Seed again
+  providerDb.seedBuiltinProviders(db);
+  var countAfter = 0;
+  if (typeof db.prepare === 'function') {
+    countAfter = db.prepare('SELECT COUNT(*) as cnt FROM providers').get().cnt;
+  }
+  assert.strictEqual(countAfter, countBefore,
+    'Re-seed should not create duplicates: before=' + countBefore + ' after=' + countAfter);
+  if (typeof db.close === 'function') db.close();
+});
+
+test('Providers have all required fields (name, displayName, baseUrl)', function() {
+  if (!hasInitDB || !hasSeedBuiltins || !hasGetProviders) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.seedBuiltinProviders(db);
+  var providers = providerDb.getProviders(db);
+  for (var i = 0; i < providers.length; i++) {
+    var p = providers[i];
+    assert.ok(p.name && typeof p.name === 'string',
+      'Provider at index ' + i + ' must have name');
+    assert.ok(p.display_name || p.displayName,
+      'Provider ' + p.name + ' must have displayName');
+    assert.ok(p.base_url || p.baseUrl,
+      'Provider ' + p.name + ' must have baseUrl');
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+// ===========================================================================
+// TESTS: CRUD Providers (8 tests)
+// ===========================================================================
+console.log('\n=== CRUD Providers ===\n');
+
+test('addProvider with valid data', function() {
+  if (!hasInitDB || !hasAddProvider) throw new Error('Required functions not exported');
+  var db = providerDb.initDB(':memory:');
+  var result = providerDb.addProvider(db, {
+    name: 'test-provider',
+    displayName: 'Test Provider',
+    baseUrl: 'https://api.test.com/v1',
+    api: 'openai-completions',
+    envVar: 'TEST_API_KEY',
+    signupUrl: 'https://test.com/signup',
+  });
+  assert.ok(result, 'addProvider should return truthy result');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('addProvider validates required fields (name, displayName, baseUrl)', function() {
+  if (!hasInitDB || !hasAddProvider) throw new Error('Required functions not exported');
+  var db = providerDb.initDB(':memory:');
+  var threw = false;
+  try {
+    providerDb.addProvider(db, { name: 'incomplete' });
+  } catch (e) {
+    threw = true;
+  }
+  assert.ok(threw, 'addProvider should throw/reject for missing required fields');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('getProvider returns provider with models', function() {
+  if (!hasInitDB || !hasAddProvider || !hasGetProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'get-test',
+    displayName: 'Get Test Provider',
+    baseUrl: 'https://api.gettest.com/v1',
+    api: 'openai-completions',
+    envVar: 'GET_TEST_KEY',
+    signupUrl: 'https://gettest.com',
+  });
+  if (hasAddModel) {
+    providerDb.addModel(db, 'get-test', {
+      id: 'test-model-1',
+      name: 'Test Model 1',
+      contextWindow: 8192,
+      maxTokens: 4096,
+      free: true,
+    });
+  }
+  var provider = providerDb.getProvider(db, 'get-test');
+  assert.ok(provider, 'getProvider should return the provider');
+  assert.strictEqual(provider.name, 'get-test');
+  if (hasAddModel) {
+    assert.ok(Array.isArray(provider.models), 'provider should have models array');
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+test('getProviders lists all providers', function() {
+  if (!hasInitDB || !hasAddProvider || !hasGetProviders) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'list-a',
+    displayName: 'List A',
+    baseUrl: 'https://a.com/v1',
+    api: 'openai-completions',
+    envVar: 'A_KEY',
+    signupUrl: 'https://a.com',
+  });
+  providerDb.addProvider(db, {
+    name: 'list-b',
+    displayName: 'List B',
+    baseUrl: 'https://b.com/v1',
+    api: 'openai-completions',
+    envVar: 'B_KEY',
+    signupUrl: 'https://b.com',
+  });
+  var all = providerDb.getProviders(db);
+  assert.ok(Array.isArray(all), 'getProviders should return array');
+  assert.ok(all.length >= 2, 'should have at least 2 providers, got ' + all.length);
+  if (typeof db.close === 'function') db.close();
+});
+
+test('getProviders filters by enabled', function() {
+  if (!hasInitDB || !hasAddProvider || !hasGetProviders || !hasUpdateProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'enabled-prov',
+    displayName: 'Enabled',
+    baseUrl: 'https://enabled.com/v1',
+    api: 'openai-completions',
+    envVar: 'EN_KEY',
+    signupUrl: 'https://enabled.com',
+  });
+  providerDb.addProvider(db, {
+    name: 'disabled-prov',
+    displayName: 'Disabled',
+    baseUrl: 'https://disabled.com/v1',
+    api: 'openai-completions',
+    envVar: 'DIS_KEY',
+    signupUrl: 'https://disabled.com',
+  });
+  // Disable one
+  providerDb.updateProvider(db, 'disabled-prov', { enabled: false });
+  // Filter by enabled
+  var enabledOnly;
+  try {
+    enabledOnly = providerDb.getProviders(db, { enabled: true });
+  } catch (e) {
+    // May use different filter syntax
+    enabledOnly = providerDb.getProviders(db, true);
+  }
+  if (enabledOnly) {
+    var hasDisabled = enabledOnly.some(function(p) { return p.name === 'disabled-prov'; });
+    assert.ok(!hasDisabled, 'disabled provider should not appear in enabled-only list');
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+test('updateProvider changes fields', function() {
+  if (!hasInitDB || !hasAddProvider || !hasUpdateProvider || !hasGetProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'update-test',
+    displayName: 'Before Update',
+    baseUrl: 'https://old.com/v1',
+    api: 'openai-completions',
+    envVar: 'UPD_KEY',
+    signupUrl: 'https://old.com',
+  });
+  providerDb.updateProvider(db, 'update-test', {
+    displayName: 'After Update',
+    baseUrl: 'https://new.com/v1',
+  });
+  var updated = providerDb.getProvider(db, 'update-test');
+  var dn = updated.display_name || updated.displayName;
+  var bu = updated.base_url || updated.baseUrl;
+  assert.ok(dn === 'After Update', 'displayName should be updated, got: ' + dn);
+  assert.ok(bu === 'https://new.com/v1', 'baseUrl should be updated, got: ' + bu);
+  if (typeof db.close === 'function') db.close();
+});
+
+test('removeProvider removes non-builtin provider', function() {
+  if (!hasInitDB || !hasAddProvider || !hasRemoveProvider || !hasGetProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'removable',
+    displayName: 'Removable',
+    baseUrl: 'https://removable.com/v1',
+    api: 'openai-completions',
+    envVar: 'RM_KEY',
+    signupUrl: 'https://removable.com',
+  });
+  providerDb.removeProvider(db, 'removable');
+  var removed = providerDb.getProvider(db, 'removable');
+  assert.ok(!removed, 'removed provider should not be found');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('removeProvider refuses builtin (without force)', function() {
+  if (!hasInitDB || !hasSeedBuiltins || !hasRemoveProvider || !hasGetProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.seedBuiltinProviders(db);
+  // Try to remove a builtin provider (nvidia should be builtin)
+  var threw = false;
+  try {
+    providerDb.removeProvider(db, 'nvidia');
+  } catch (e) {
+    threw = true;
+  }
+  // It should have thrown for builtin removal
+  assert.ok(threw, 'removeProvider should throw for builtin provider without force');
+  // Verify nvidia still exists
+  var nvidia = providerDb.getProvider(db, 'nvidia');
+  assert.ok(nvidia, 'nvidia should still exist after failed removal');
+  if (typeof db.close === 'function') db.close();
+});
+
+// ===========================================================================
+// TESTS: CRUD Models (6 tests)
+// ===========================================================================
+console.log('\n=== CRUD Models ===\n');
+
+test('addModel to existing provider', function() {
+  if (!hasInitDB || !hasAddProvider || !hasAddModel || !hasGetProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'model-host',
+    displayName: 'Model Host',
+    baseUrl: 'https://models.com/v1',
+    api: 'openai-completions',
+    envVar: 'MH_KEY',
+    signupUrl: 'https://models.com',
+  });
+  providerDb.addModel(db, 'model-host', {
+    id: 'fast-model',
+    name: 'Fast Model',
+    contextWindow: 32768,
+    maxTokens: 8192,
+    free: true,
+  });
+  var provider = providerDb.getProvider(db, 'model-host');
+  assert.ok(provider.models && provider.models.length >= 1,
+    'provider should have at least 1 model after addModel');
+  var model = provider.models.find(function(m) {
+    return m.id === 'fast-model' || m.model_id === 'fast-model';
+  });
+  assert.ok(model, 'should find the added model');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('addModel validates provider exists', function() {
+  if (!hasInitDB || !hasAddModel) throw new Error('Required functions not exported');
+  var db = providerDb.initDB(':memory:');
+  var threw = false;
+  try {
+    providerDb.addModel(db, 'nonexistent-provider', {
+      id: 'orphan-model',
+      name: 'Orphan',
+      contextWindow: 8192,
+      maxTokens: 4096,
+      free: true,
+    });
+  } catch (e) {
+    threw = true;
+  }
+  assert.ok(threw, 'addModel should throw for nonexistent provider');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('removeModel works', function() {
+  if (!hasInitDB || !hasAddProvider || !hasAddModel || !hasRemoveModel || !hasGetProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'rm-model-host',
+    displayName: 'RM Model Host',
+    baseUrl: 'https://rm-models.com/v1',
+    api: 'openai-completions',
+    envVar: 'RM_MH_KEY',
+    signupUrl: 'https://rm-models.com',
+  });
+  providerDb.addModel(db, 'rm-model-host', {
+    id: 'to-remove',
+    name: 'Remove Me',
+    contextWindow: 8192,
+    maxTokens: 4096,
+    free: true,
+  });
+  providerDb.removeModel(db, 'rm-model-host', 'to-remove');
+  var provider = providerDb.getProvider(db, 'rm-model-host');
+  var found = (provider.models || []).find(function(m) {
+    return m.id === 'to-remove' || m.model_id === 'to-remove';
+  });
+  assert.ok(!found, 'removed model should not be found');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('toggleModel enabled/disabled', function() {
+  if (!hasInitDB || !hasAddProvider || !hasAddModel || !hasToggleModel || !hasGetProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'toggle-host',
+    displayName: 'Toggle Host',
+    baseUrl: 'https://toggle.com/v1',
+    api: 'openai-completions',
+    envVar: 'TG_KEY',
+    signupUrl: 'https://toggle.com',
+  });
+  providerDb.addModel(db, 'toggle-host', {
+    id: 'toggle-me',
+    name: 'Toggle Me',
+    contextWindow: 8192,
+    maxTokens: 4096,
+    free: true,
+  });
+  // Toggle off
+  providerDb.toggleModel(db, 'toggle-host', 'toggle-me', false);
+  var provider = providerDb.getProvider(db, 'toggle-host');
+  var model = (provider.models || []).find(function(m) {
+    return m.id === 'toggle-me' || m.model_id === 'toggle-me';
+  });
+  if (model) {
+    var isEnabled = model.enabled !== undefined ? model.enabled : model.is_enabled;
+    assert.ok(isEnabled === false || isEnabled === 0, 'model should be disabled');
+  }
+  // Toggle back on
+  providerDb.toggleModel(db, 'toggle-host', 'toggle-me', true);
+  provider = providerDb.getProvider(db, 'toggle-host');
+  model = (provider.models || []).find(function(m) {
+    return m.id === 'toggle-me' || m.model_id === 'toggle-me';
+  });
+  if (model) {
+    var isEnabled2 = model.enabled !== undefined ? model.enabled : model.is_enabled;
+    assert.ok(isEnabled2 === true || isEnabled2 === 1, 'model should be re-enabled');
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+test('Models cascade delete with provider', function() {
+  if (!hasInitDB || !hasAddProvider || !hasAddModel || !hasRemoveProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'cascade-host',
+    displayName: 'Cascade Host',
+    baseUrl: 'https://cascade.com/v1',
+    api: 'openai-completions',
+    envVar: 'CC_KEY',
+    signupUrl: 'https://cascade.com',
+  });
+  providerDb.addModel(db, 'cascade-host', {
+    id: 'model-a',
+    name: 'Model A',
+    contextWindow: 8192,
+    maxTokens: 4096,
+    free: true,
+  });
+  providerDb.addModel(db, 'cascade-host', {
+    id: 'model-b',
+    name: 'Model B',
+    contextWindow: 16384,
+    maxTokens: 8192,
+    free: false,
+  });
+  providerDb.removeProvider(db, 'cascade-host');
+  // Verify models are gone too
+  if (typeof db.prepare === 'function') {
+    var orphans = db.prepare(
+      "SELECT COUNT(*) as cnt FROM models WHERE provider_name = 'cascade-host'"
+    ).get();
+    assert.strictEqual(orphans.cnt, 0, 'models should be cascade-deleted');
+  } else if (hasGetProvider) {
+    var provider = providerDb.getProvider(db, 'cascade-host');
+    assert.ok(!provider, 'provider should be gone');
+  }
+  if (typeof db.close === 'function') db.close();
+});
+
+test('No duplicate models (same provider + model id)', function() {
+  if (!hasInitDB || !hasAddProvider || !hasAddModel || !hasGetProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'dup-host',
+    displayName: 'Dup Host',
+    baseUrl: 'https://dup.com/v1',
+    api: 'openai-completions',
+    envVar: 'DUP_KEY',
+    signupUrl: 'https://dup.com',
+  });
+  providerDb.addModel(db, 'dup-host', {
+    id: 'same-model',
+    name: 'Same Model',
+    contextWindow: 8192,
+    maxTokens: 4096,
+    free: true,
+  });
+  // Try adding duplicate - should either throw or be ignored
+  var threw = false;
+  try {
+    providerDb.addModel(db, 'dup-host', {
+      id: 'same-model',
+      name: 'Same Model Duplicate',
+      contextWindow: 8192,
+      maxTokens: 4096,
+      free: true,
+    });
+  } catch (e) {
+    threw = true;
+  }
+  var provider = providerDb.getProvider(db, 'dup-host');
+  var matching = (provider.models || []).filter(function(m) {
+    return m.id === 'same-model' || m.model_id === 'same-model';
+  });
+  assert.ok(threw || matching.length === 1,
+    'should not have duplicate models (threw=' + threw + ', count=' + matching.length + ')');
+  if (typeof db.close === 'function') db.close();
+});
+
+// ===========================================================================
+// TESTS: getTestableModelsFromDB (5 tests)
+// ===========================================================================
+console.log('\n=== getTestableModelsFromDB ===\n');
+
+test('getTestableModelsFromDB returns flat array with connection details', function() {
+  if (!hasInitDB || !hasSeedBuiltins || !hasGetTestableModelsFromDB) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.seedBuiltinProviders(db);
+  // Provide env keys so providers pass the requiresKey check
+  var envKeys = { nvidia: 'test-key', groq: 'test-key', cerebras: 'test-key' };
+  var models = providerDb.getTestableModelsFromDB(db, {}, envKeys);
+  assert.ok(Array.isArray(models), 'should return array');
+  assert.ok(models.length > 0, 'should have models (got ' + models.length + ')');
+  // Check first model has connection details
+  var m = models[0];
+  assert.ok(typeof m.provider === 'string', 'model should have provider');
+  assert.ok(typeof m.id === 'string', 'model should have id');
+  assert.ok(typeof m.name === 'string', 'model should have name');
+  assert.ok(typeof m.baseUrl === 'string' || typeof m.base_url === 'string',
+    'model should have baseUrl');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('getTestableModelsFromDB includes all DB providers', function() {
+  if (!hasInitDB || !hasSeedBuiltins || !hasAddProvider || !hasAddModel || !hasGetTestableModelsFromDB) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.seedBuiltinProviders(db);
+  // Add a custom provider with envKeys so it passes the requiresKey check
+  providerDb.addProvider(db, {
+    name: 'custom-for-test',
+    displayName: 'Custom',
+    baseUrl: 'https://custom.com/v1',
+    api: 'openai-completions',
+    envVar: 'CUSTOM_KEY',
+    signupUrl: 'https://custom.com',
+  });
+  providerDb.addModel(db, 'custom-for-test', {
+    id: 'custom-model',
+    name: 'Custom Model',
+    contextWindow: 8192,
+    maxTokens: 4096,
+    free: true,
+  });
+  var envKeys = { 'custom-for-test': 'test-key', nvidia: 'test-key' };
+  var models = providerDb.getTestableModelsFromDB(db, {}, envKeys);
+  var customModels = models.filter(function(m) { return m.provider === 'custom-for-test'; });
+  assert.ok(customModels.length >= 1,
+    'should include custom provider models, found ' + customModels.length);
+  if (typeof db.close === 'function') db.close();
+});
+
+test('getTestableModelsFromDB merges with config when provided', function() {
+  if (!hasInitDB || !hasGetTestableModelsFromDB) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  // Try calling with a config object (may or may not be supported)
+  var fakeCfg = {
+    models: {
+      providers: {
+        'config-only-prov': {
+          baseUrl: 'https://config-only.com/v1',
+          apiKey: 'test-key',
+          api: 'openai-completions',
+          models: [{ id: 'cfg-model', name: 'Config Model' }],
+        },
+      },
+    },
+  };
+  try {
+    var models = providerDb.getTestableModelsFromDB(db, fakeCfg);
+    if (Array.isArray(models)) {
+      // If it accepts config, config-only models might be merged in
+      console.log('    (returned ' + models.length + ' models with config merge)');
+    }
+  } catch (e) {
+    // Might not accept config arg - that's OK
+    console.log('    (config merge not supported: ' + e.message.slice(0, 60) + ')');
+  }
+  assert.ok(true, 'should not crash');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('getTestableModelsFromDB deduplicates by provider/id', function() {
+  if (!hasInitDB || !hasSeedBuiltins || !hasGetTestableModelsFromDB) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.seedBuiltinProviders(db);
+  var envKeys = { nvidia: 'test-key', groq: 'test-key', cerebras: 'test-key',
+    sambanova: 'test-key', together: 'test-key', huggingface: 'test-key', github_models: 'test-key' };
+  var models = providerDb.getTestableModelsFromDB(db, {}, envKeys);
+  var keys = models.map(function(m) { return m.provider + '/' + m.id; });
+  var unique = new Set(keys);
+  assert.strictEqual(keys.length, unique.size,
+    'should have no duplicate provider/id pairs (total=' + keys.length + ' unique=' + unique.size + ')');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('getTestableModelsFromDB falls back gracefully without DB data', function() {
+  if (!hasInitDB || !hasGetTestableModelsFromDB) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  // Don't seed - empty DB
+  var models = providerDb.getTestableModelsFromDB(db);
+  assert.ok(Array.isArray(models), 'should return array even with empty DB');
+  // May return empty array or fall back to config
+  console.log('    (returned ' + models.length + ' models from empty DB)');
+  if (typeof db.close === 'function') db.close();
+});
+
+// ===========================================================================
+// TESTS: Edge Cases (4 tests)
+// ===========================================================================
+console.log('\n=== Edge Cases ===\n');
+
+test('Empty DB returns empty array from getProviders', function() {
+  if (!hasInitDB || !hasGetProviders) throw new Error('Required functions not exported');
+  var db = providerDb.initDB(':memory:');
+  var providers = providerDb.getProviders(db);
+  assert.ok(Array.isArray(providers), 'should return array');
+  assert.strictEqual(providers.length, 0, 'empty DB should have 0 providers');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('Provider with no models returns empty models array', function() {
+  if (!hasInitDB || !hasAddProvider || !hasGetProvider) {
+    throw new Error('Required functions not exported');
+  }
+  var db = providerDb.initDB(':memory:');
+  providerDb.addProvider(db, {
+    name: 'empty-provider',
+    displayName: 'Empty',
+    baseUrl: 'https://empty.com/v1',
+    api: 'openai-completions',
+    envVar: 'EMPTY_KEY',
+    signupUrl: 'https://empty.com',
+  });
+  var provider = providerDb.getProvider(db, 'empty-provider');
+  assert.ok(provider, 'provider should exist');
+  assert.ok(Array.isArray(provider.models), 'should have models array');
+  assert.strictEqual(provider.models.length, 0, 'should have 0 models');
+  if (typeof db.close === 'function') db.close();
+});
+
+test('closeDB is safe to call twice', function() {
+  if (!hasInitDB || !hasCloseDB) throw new Error('Required functions not exported');
+  var db = providerDb.initDB(':memory:');
+  providerDb.closeDB(db);
+  // Second close should not throw
+  var threw = false;
+  try {
+    providerDb.closeDB(db);
+  } catch (e) {
+    threw = true;
+  }
+  assert.ok(!threw, 'closeDB should be safe to call twice');
+});
+
+test('Invalid provider data throws', function() {
+  if (!hasInitDB || !hasAddProvider) throw new Error('Required functions not exported');
+  var db = providerDb.initDB(':memory:');
+  var threw = false;
+  try {
+    providerDb.addProvider(db, null);
+  } catch (e) {
+    threw = true;
+  }
+  if (!threw) {
+    try {
+      providerDb.addProvider(db, {});
+    } catch (e) {
+      threw = true;
+    }
+  }
+  assert.ok(threw, 'invalid data should throw');
+  if (typeof db.close === 'function') db.close();
+});
+
+// ===========================================================================
+// Summary
+// ===========================================================================
+console.log('\n=== PROVIDER DB TEST SUMMARY ===');
+console.log('  Passed: ' + passed);
+console.log('  Failed: ' + failed);
+console.log('  Skipped: ' + skipped);
+if (failures.length > 0) {
+  console.log('\n  Failures:');
+  failures.forEach(function(f) { console.log('    - ' + f.name + ': ' + f.error); });
+}
+console.log('');
+
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/model-optimizer/test-provider-registry.cjs
+++ b/tests/model-optimizer/test-provider-registry.cjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+/**
+ * test-provider-registry.cjs - Unit tests for scripts/provider-registry.cjs
+ *
+ * Tests: KNOWN_PROVIDERS structure, model entries, API format validation,
+ * provider filtering, getTestableModels, mergeWithConfig, generateProviderConfig.
+ *
+ * Run inside Docker:
+ *   MSYS_NO_PATHCONV=1 docker exec openclaw-openclaw-gateway-1 \
+ *     node /host/home/openclaw/tests/model-optimizer/test-provider-registry.cjs
+ */
+'use strict';
+
+var assert = require('assert');
+var fs = require('fs');
+
+var registry = require('/host/home/openclaw/scripts/provider-registry.cjs');
+
+var CONFIG_PATH = '/home/node/.openclaw/openclaw.json';
+var cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+var passedCount = 0;
+var failedCount = 0;
+var skippedCount = 0;
+var failureList = [];
+
+function test(name, fn) {
+  try {
+    fn();
+    passedCount++;
+    console.log('  PASS: ' + name);
+  } catch (e) {
+    failedCount++;
+    failureList.push({ name: name, error: e.message });
+    console.log('  FAIL: ' + name + ' -- ' + e.message);
+  }
+}
+
+function skip(name, reason) {
+  skippedCount++;
+  console.log('  SKIP: ' + name + ' -- ' + reason);
+}
+
+// ===========================================================================
+// TESTS: KNOWN_PROVIDERS Structure
+// ===========================================================================
+console.log('\n=== KNOWN_PROVIDERS Structure ===\n');
+
+var KNOWN_PROVIDERS = registry.KNOWN_PROVIDERS;
+
+test('KNOWN_PROVIDERS is an array', function() {
+  assert.ok(Array.isArray(KNOWN_PROVIDERS), 'should be array');
+});
+
+test('KNOWN_PROVIDERS has at least 5 providers', function() {
+  assert.ok(KNOWN_PROVIDERS.length >= 5,
+    'Expected 5+ providers, got ' + KNOWN_PROVIDERS.length);
+});
+
+test('All providers have "name" field (non-empty string)', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    assert.ok(typeof p.name === 'string' && p.name.length > 0,
+      'Provider at index ' + i + ' must have non-empty name');
+  }
+});
+
+test('All providers have "displayName" field', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    assert.ok(typeof p.displayName === 'string' && p.displayName.length > 0,
+      'Provider ' + p.name + ' must have displayName');
+  }
+});
+
+test('All providers have "baseUrl" field (valid HTTPS URL)', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    assert.ok(typeof p.baseUrl === 'string' && p.baseUrl.startsWith('https://'),
+      'Provider ' + p.name + ' baseUrl must be HTTPS, got: ' + p.baseUrl);
+    new URL(p.baseUrl); // validates URL format
+  }
+});
+
+test('All providers have "api" field', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    assert.ok(typeof p.api === 'string' && p.api.length > 0,
+      'Provider ' + p.name + ' must have api format');
+  }
+});
+
+test('All providers have "envVar" field', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    assert.ok(typeof p.envVar === 'string' && p.envVar.length > 0,
+      'Provider ' + p.name + ' must have envVar');
+  }
+});
+
+test('All providers have "signupUrl" (valid URL)', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    assert.ok(typeof p.signupUrl === 'string' && p.signupUrl.startsWith('https://'),
+      'Provider ' + p.name + ' must have HTTPS signupUrl');
+  }
+});
+
+test('All providers have "models" array with at least 1 entry', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    assert.ok(Array.isArray(p.models), 'Provider ' + p.name + ' must have models array');
+    assert.ok(p.models.length >= 1, 'Provider ' + p.name + ' must have at least 1 model');
+  }
+});
+
+test('All providers have "rateLimit" object', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    assert.ok(typeof p.rateLimit === 'object' && p.rateLimit !== null,
+      'Provider ' + p.name + ' must have rateLimit');
+  }
+});
+
+test('No duplicate provider names', function() {
+  var names = KNOWN_PROVIDERS.map(function(p) { return p.name; });
+  var unique = new Set(names);
+  assert.strictEqual(names.length, unique.size, 'Duplicate names: ' +
+    names.filter(function(n, i) { return names.indexOf(n) !== i; }).join(', '));
+});
+
+// ===========================================================================
+// TESTS: Model Entry Validation
+// ===========================================================================
+console.log('\n=== Model Entry Validation ===\n');
+
+test('All model entries have "id" (non-empty string)', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    for (var j = 0; j < p.models.length; j++) {
+      var m = p.models[j];
+      assert.ok(typeof m.id === 'string' && m.id.length > 0,
+        'Model in ' + p.name + ' at index ' + j + ' must have id');
+    }
+  }
+});
+
+test('All model entries have "name" (non-empty string)', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    for (var j = 0; j < p.models.length; j++) {
+      var m = p.models[j];
+      assert.ok(typeof m.name === 'string' && m.name.length > 0,
+        'Model ' + m.id + ' in ' + p.name + ' must have name');
+    }
+  }
+});
+
+test('All model entries have "contextWindow" (positive number)', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    for (var j = 0; j < p.models.length; j++) {
+      var m = p.models[j];
+      assert.ok(typeof m.contextWindow === 'number' && m.contextWindow > 0,
+        'Model ' + m.id + ' in ' + p.name + ' must have positive contextWindow');
+    }
+  }
+});
+
+test('All model entries have "maxTokens" (positive number)', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    for (var j = 0; j < p.models.length; j++) {
+      var m = p.models[j];
+      assert.ok(typeof m.maxTokens === 'number' && m.maxTokens > 0,
+        'Model ' + m.id + ' in ' + p.name + ' must have positive maxTokens');
+    }
+  }
+});
+
+test('All model entries have "free" boolean', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    for (var j = 0; j < p.models.length; j++) {
+      var m = p.models[j];
+      assert.ok(typeof m.free === 'boolean',
+        'Model ' + m.id + ' in ' + p.name + ' must have boolean free flag');
+    }
+  }
+});
+
+test('No duplicate model IDs within a provider', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    var ids = p.models.map(function(m) { return m.id; });
+    var unique = new Set(ids);
+    assert.strictEqual(ids.length, unique.size,
+      'Provider ' + p.name + ' has duplicate model IDs');
+  }
+});
+
+// ===========================================================================
+// TESTS: API Format Validation
+// ===========================================================================
+console.log('\n=== API Format Validation ===\n');
+
+test('NVIDIA uses openai-completions', function() {
+  var nvidia = KNOWN_PROVIDERS.find(function(p) { return p.name === 'nvidia'; });
+  assert.ok(nvidia, 'nvidia should exist');
+  assert.strictEqual(nvidia.api, 'openai-completions');
+});
+
+test('Groq uses openai-completions', function() {
+  var groq = KNOWN_PROVIDERS.find(function(p) { return p.name === 'groq'; });
+  assert.ok(groq, 'groq should exist');
+  assert.strictEqual(groq.api, 'openai-completions');
+});
+
+test('All provider URLs are valid', function() {
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    var p = KNOWN_PROVIDERS[i];
+    try {
+      new URL(p.baseUrl);
+    } catch (e) {
+      assert.fail('Provider ' + p.name + ' has invalid URL: ' + p.baseUrl);
+    }
+  }
+});
+
+// ===========================================================================
+// TESTS: getKnownProviders()
+// ===========================================================================
+console.log('\n=== getKnownProviders ===\n');
+
+test('getKnownProviders returns array of providers', function() {
+  var kp = registry.getKnownProviders();
+  assert.ok(Array.isArray(kp));
+  assert.ok(kp.length >= 5);
+});
+
+test('getKnownProviders includes nvidia', function() {
+  var kp = registry.getKnownProviders();
+  var nvidia = kp.find(function(p) { return p.name === 'nvidia'; });
+  assert.ok(nvidia, 'should include nvidia');
+});
+
+// ===========================================================================
+// TESTS: getAllProviders()
+// ===========================================================================
+console.log('\n=== getAllProviders ===\n');
+
+test('getAllProviders returns object keyed by provider name', function() {
+  var all = registry.getAllProviders();
+  assert.ok(typeof all === 'object' && all !== null);
+  assert.ok('nvidia' in all, 'should have nvidia key');
+});
+
+test('getAllProviders has expected providers', function() {
+  var all = registry.getAllProviders();
+  var keys = Object.keys(all);
+  assert.ok(keys.includes('nvidia'));
+  assert.ok(keys.includes('groq'));
+  console.log('    (providers: ' + keys.join(', ') + ')');
+});
+
+// ===========================================================================
+// TESTS: getTestableModels(cfg)
+// ===========================================================================
+console.log('\n=== getTestableModels ===\n');
+
+test('getTestableModels returns array', function() {
+  var models = registry.getTestableModels(cfg);
+  assert.ok(Array.isArray(models));
+});
+
+test('getTestableModels includes config models', function() {
+  var models = registry.getTestableModels(cfg);
+  assert.ok(models.length >= 1, 'should include at least config models');
+  console.log('    (total testable models: ' + models.length + ')');
+});
+
+test('getTestableModels entries have required fields', function() {
+  var models = registry.getTestableModels(cfg);
+  if (models.length === 0) { skip('model fields', 'no models'); return; }
+  var m = models[0];
+  assert.ok(typeof m.provider === 'string', 'should have provider');
+  assert.ok(typeof m.id === 'string', 'should have id');
+  assert.ok(typeof m.name === 'string', 'should have name');
+  assert.ok(typeof m.baseUrl === 'string', 'should have baseUrl');
+});
+
+test('getTestableModels does not contain duplicates', function() {
+  var models = registry.getTestableModels(cfg);
+  var keys = models.map(function(m) { return m.provider + '/' + m.id; });
+  var unique = new Set(keys);
+  assert.strictEqual(keys.length, unique.size, 'should have no duplicate models');
+});
+
+// ===========================================================================
+// TESTS: mergeWithConfig(cfg)
+// ===========================================================================
+console.log('\n=== mergeWithConfig ===\n');
+
+test('mergeWithConfig returns object with config providers', function() {
+  var merged = registry.mergeWithConfig(cfg);
+  assert.ok(typeof merged === 'object');
+  // Should include existing config providers
+  var configProviders = Object.keys(cfg.models && cfg.models.providers ? cfg.models.providers : {});
+  for (var cp of configProviders) {
+    assert.ok(cp in merged, 'merged should include config provider: ' + cp);
+  }
+});
+
+// ===========================================================================
+// TESTS: isModelFree
+// ===========================================================================
+console.log('\n=== isModelFree ===\n');
+
+test('isModelFree returns true for zero-cost model', function() {
+  assert.strictEqual(registry.isModelFree({ cost: { input: 0, output: 0 } }), true);
+});
+
+test('isModelFree returns false for non-zero cost model', function() {
+  assert.strictEqual(registry.isModelFree({ cost: { input: 1, output: 0 } }), false);
+  assert.strictEqual(registry.isModelFree({ cost: { input: 0, output: 0.5 } }), false);
+});
+
+test('isModelFree handles model with free flag', function() {
+  var result = registry.isModelFree({ free: true, cost: { input: 0, output: 0 } });
+  assert.strictEqual(result, true);
+});
+
+// ===========================================================================
+// TESTS: generateProviderConfig
+// ===========================================================================
+console.log('\n=== generateProviderConfig ===\n');
+
+test('generateProviderConfig returns config for nvidia', function() {
+  var config = registry.generateProviderConfig('nvidia', 'test-key');
+  assert.ok(config, 'should return config');
+  assert.ok(config.baseUrl, 'should have baseUrl');
+  assert.ok(config.apiKey === 'test-key' || config.api, 'should have apiKey or api');
+  assert.ok(Array.isArray(config.models), 'should have models array');
+});
+
+test('generateProviderConfig models have required fields', function() {
+  var config = registry.generateProviderConfig('nvidia', 'key');
+  if (!config || !config.models) { skip('model fields', 'no config'); return; }
+  for (var m of config.models) {
+    assert.ok(typeof m.id === 'string', 'model should have id');
+    assert.ok(typeof m.name === 'string', 'model should have name');
+  }
+});
+
+test('generateProviderConfig returns null for unknown provider', function() {
+  var config = registry.generateProviderConfig('nonexistent_xyz_provider', 'key');
+  assert.strictEqual(config, null);
+});
+
+// ===========================================================================
+// TESTS: Known Provider Counts
+// ===========================================================================
+console.log('\n=== Known Provider Counts ===\n');
+
+test('NVIDIA has at least 7 free models', function() {
+  var nvidia = KNOWN_PROVIDERS.find(function(p) { return p.name === 'nvidia'; });
+  assert.ok(nvidia.models.length >= 7,
+    'Expected 7+ nvidia models, got ' + nvidia.models.length);
+});
+
+test('Total free models across all providers is substantial', function() {
+  var total = 0;
+  for (var i = 0; i < KNOWN_PROVIDERS.length; i++) {
+    total += KNOWN_PROVIDERS[i].models.length;
+  }
+  assert.ok(total >= 15, 'Expected 15+ total free models, got ' + total);
+  console.log('    (Total models: ' + total + ' across ' + KNOWN_PROVIDERS.length + ' providers)');
+});
+
+// ===========================================================================
+// Summary
+// ===========================================================================
+console.log('\n=== PROVIDER REGISTRY TEST SUMMARY ===');
+console.log('  Passed: ' + passedCount);
+console.log('  Failed: ' + failedCount);
+console.log('  Skipped: ' + skippedCount);
+if (failureList.length > 0) {
+  console.log('\n  Failures:');
+  failureList.forEach(function(f) { console.log('    - ' + f.name + ': ' + f.error); });
+}
+console.log('');
+
+process.exit(failedCount > 0 ? 1 : 0);

--- a/tests/model-optimizer/test-scoring.cjs
+++ b/tests/model-optimizer/test-scoring.cjs
@@ -1,0 +1,644 @@
+#!/usr/bin/env node
+/**
+ * test-scoring.cjs - Unit tests for scripts/scoring.cjs
+ *
+ * Tests latencyScore, throughputScore, correctnessScore, compositeScore,
+ * availabilityScore, gradeLabel, scoreModel, rankModels, shouldRotate,
+ * and all edge cases.
+ *
+ * Run inside Docker:
+ *   MSYS_NO_PATHCONV=1 docker exec openclaw-openclaw-gateway-1 \
+ *     node /host/home/openclaw/tests/model-optimizer/test-scoring.cjs
+ */
+'use strict';
+
+const assert = require('assert');
+
+// Load the actual scoring module
+const scoring = require('/host/home/openclaw/scripts/scoring.cjs');
+
+const {
+  latencyScore,
+  throughputScore,
+  correctnessScore,
+  availabilityScore,
+  compositeScore,
+  gradeLabel,
+  scoreModel,
+  rankModels,
+  shouldRotate,
+  estimateTokens,
+  calcThroughput,
+  validateMath,
+  validateInstruction,
+  validateAvailability,
+  DEFAULT_WEIGHTS,
+} = scoring;
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+const failures = [];
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log('  PASS: ' + name);
+  } catch (e) {
+    failed++;
+    failures.push({ name, error: e.message });
+    console.log('  FAIL: ' + name + ' -- ' + e.message);
+  }
+}
+
+function skip(name, reason) {
+  skipped++;
+  console.log('  SKIP: ' + name + ' -- ' + reason);
+}
+
+function assertInRange(val, min, max, msg) {
+  assert.ok(typeof val === 'number', msg + ' (expected number, got ' + typeof val + ')');
+  assert.ok(val >= min && val <= max, msg + ' (expected ' + min + '-' + max + ', got ' + val + ')');
+}
+
+// ===========================================================================
+// TESTS: latencyScore - band-based interpolation
+// ===========================================================================
+console.log('\n=== latencyScore ===\n');
+
+test('latencyScore(100) returns high score (>80)', function() {
+  assertInRange(latencyScore(100), 80, 100, '100ms');
+});
+
+test('latencyScore(500) returns top band boundary (100)', function() {
+  // 500ms is the boundary of the first band
+  assert.strictEqual(latencyScore(500), 100);
+});
+
+test('latencyScore(2000) returns moderate score (>=50)', function() {
+  assertInRange(latencyScore(2000), 50, 100, '2000ms');
+});
+
+test('latencyScore(5000) returns band score around 50', function() {
+  assertInRange(latencyScore(5000), 25, 75, '5000ms');
+});
+
+test('latencyScore(15000) returns low score (<=25)', function() {
+  assertInRange(latencyScore(15000), 0, 30, '15000ms');
+});
+
+test('latencyScore(30000) returns floor score of 10', function() {
+  // Values beyond 20000ms hit the Infinity band. The lerp extrapolation
+  // would produce a negative value, but Math.max(10, ...) clamps it.
+  var score = latencyScore(30000);
+  assert.strictEqual(score, 10, 'should be clamped to floor score of 10');
+});
+
+test('latencyScore monotonically decreasing', function() {
+  var values = [0, 100, 500, 2000, 5000, 15000, 30000];
+  var scores = values.map(function(v) { return latencyScore(v); });
+  for (var i = 1; i < scores.length; i++) {
+    assert.ok(scores[i] <= scores[i - 1],
+      values[i] + 'ms (' + scores[i] + ') should be <= ' + values[i-1] + 'ms (' + scores[i-1] + ')');
+  }
+});
+
+test('latencyScore(0) returns 100', function() {
+  assert.strictEqual(latencyScore(0), 100);
+});
+
+// Edge cases: non-finite and invalid inputs return 0
+test('latencyScore(-1) returns 0', function() {
+  assert.strictEqual(latencyScore(-1), 0);
+});
+
+test('latencyScore(NaN) returns 0', function() {
+  assert.strictEqual(latencyScore(NaN), 0);
+});
+
+test('latencyScore(Infinity) returns 0', function() {
+  assert.strictEqual(latencyScore(Infinity), 0);
+});
+
+test('latencyScore(-Infinity) returns 0', function() {
+  assert.strictEqual(latencyScore(-Infinity), 0);
+});
+
+test('latencyScore(null) returns 0', function() {
+  assert.strictEqual(latencyScore(null), 0);
+});
+
+test('latencyScore(undefined) returns 0', function() {
+  assert.strictEqual(latencyScore(undefined), 0);
+});
+
+test('latencyScore("string") returns 0', function() {
+  assert.strictEqual(latencyScore("fast"), 0);
+});
+
+// ===========================================================================
+// TESTS: throughputScore - band-based interpolation
+// ===========================================================================
+console.log('\n=== throughputScore ===\n');
+
+test('throughputScore(100) returns 100 (top band)', function() {
+  assert.strictEqual(throughputScore(100), 100);
+});
+
+test('throughputScore(50) returns high score (>=80)', function() {
+  assertInRange(throughputScore(50), 80, 100, '50 tok/s');
+});
+
+test('throughputScore(10) returns moderate score (>=40)', function() {
+  assertInRange(throughputScore(10), 40, 60, '10 tok/s');
+});
+
+test('throughputScore(5) returns low band score (>=20)', function() {
+  assertInRange(throughputScore(5), 20, 30, '5 tok/s');
+});
+
+test('throughputScore(1) returns near-floor score (10-25)', function() {
+  assertInRange(throughputScore(1), 10, 25, '1 tok/s');
+});
+
+test('throughputScore(0) returns 10 (floor for zero throughput)', function() {
+  assert.strictEqual(throughputScore(0), 10);
+});
+
+test('throughputScore monotonically increasing', function() {
+  var values = [0, 1, 5, 10, 50, 100];
+  var scores = values.map(function(v) { return throughputScore(v); });
+  for (var i = 1; i < scores.length; i++) {
+    assert.ok(scores[i] >= scores[i - 1],
+      values[i] + ' tok/s (' + scores[i] + ') should be >= ' + values[i-1] + ' tok/s (' + scores[i-1] + ')');
+  }
+});
+
+// Edge cases: null returns benefit-of-doubt (30), non-finite returns 10
+test('throughputScore(null) returns 30 (benefit of doubt)', function() {
+  assert.strictEqual(throughputScore(null), 30);
+});
+
+test('throughputScore(undefined) returns 30 (benefit of doubt)', function() {
+  assert.strictEqual(throughputScore(undefined), 30);
+});
+
+test('throughputScore(-1) returns 10 (floor)', function() {
+  assert.strictEqual(throughputScore(-1), 10);
+});
+
+test('throughputScore(NaN) returns 10 (floor for non-finite)', function() {
+  assert.strictEqual(throughputScore(NaN), 10);
+});
+
+test('throughputScore(Infinity) returns 10 (floor for non-finite)', function() {
+  assert.strictEqual(throughputScore(Infinity), 10);
+});
+
+// ===========================================================================
+// TESTS: correctnessScore (single-test mode)
+// ===========================================================================
+console.log('\n=== correctnessScore (single) ===\n');
+
+test('correctnessScore("4", "4") returns 100 (exact match)', function() {
+  assert.strictEqual(correctnessScore("4", "4"), 100);
+});
+
+test('correctnessScore("four", "4") returns 100 (word match)', function() {
+  assert.strictEqual(correctnessScore("four", "4"), 100);
+});
+
+test('correctnessScore("The answer is 4", "4") returns 80 (contains match)', function() {
+  assert.strictEqual(correctnessScore("The answer is 4", "4"), 80);
+});
+
+test('correctnessScore("FOUR", "4") returns 100 (case-insensitive word)', function() {
+  assert.strictEqual(correctnessScore("FOUR", "4"), 100);
+});
+
+test('correctnessScore("The answer is 5", "4") returns 15 (non-empty wrong)', function() {
+  assert.strictEqual(correctnessScore("The answer is 5", "4"), 15);
+});
+
+test('correctnessScore with empty string returns 0', function() {
+  assert.strictEqual(correctnessScore("", "4"), 0);
+});
+
+test('correctnessScore with null returns 0', function() {
+  assert.strictEqual(correctnessScore(null, "4"), 0);
+});
+
+test('correctnessScore with undefined returns 0', function() {
+  assert.strictEqual(correctnessScore(undefined, "4"), 0);
+});
+
+test('correctnessScore with no expected defaults to "4"', function() {
+  // When expected is undefined, the implementation defaults to "4"
+  var s = correctnessScore("4");
+  assert.strictEqual(s, 100);
+});
+
+// ===========================================================================
+// TESTS: correctnessScore (multi-test mode)
+// ===========================================================================
+console.log('\n=== correctnessScore (multi) ===\n');
+
+test('correctnessScore with all-pass tests returns 100', function() {
+  var tests = [
+    { name: 'math', status: 'OK', response: 'The answer is 4' },
+    { name: 'availability', status: 'OK', response: 'Hello world' },
+  ];
+  var result = correctnessScore(tests);
+  assert.ok(typeof result === 'object', 'multi-test returns object');
+  assert.strictEqual(result.score, 100);
+});
+
+test('correctnessScore with all-fail tests returns 0', function() {
+  var tests = [
+    { name: 'math', status: 'FAIL', response: '' },
+    { name: 'availability', status: 'FAIL', response: '' },
+  ];
+  var result = correctnessScore(tests);
+  assert.strictEqual(result.score, 0);
+});
+
+test('correctnessScore with mixed results', function() {
+  var tests = [
+    { name: 'math', status: 'OK', response: 'The answer is 4' },
+    { name: 'availability', status: 'FAIL', response: '' },
+  ];
+  var result = correctnessScore(tests);
+  assert.strictEqual(result.score, 50);
+});
+
+test('correctnessScore with empty test array returns 0', function() {
+  var result = correctnessScore([]);
+  assert.ok(typeof result === 'object');
+  assert.strictEqual(result.score, 0);
+});
+
+// ===========================================================================
+// TESTS: availabilityScore
+// ===========================================================================
+console.log('\n=== availabilityScore ===\n');
+
+test('availabilityScore(1, 1) returns 100', function() {
+  assert.strictEqual(availabilityScore(1, 1), 100);
+});
+
+test('availabilityScore(0, 1) returns 0', function() {
+  assert.strictEqual(availabilityScore(0, 1), 0);
+});
+
+test('availabilityScore(1, 2) returns 50', function() {
+  assert.strictEqual(availabilityScore(1, 2), 50);
+});
+
+test('availabilityScore with test array: all OK', function() {
+  var tests = [
+    { status: 'OK' },
+    { status: 'OK' },
+  ];
+  assert.strictEqual(availabilityScore(tests), 100);
+});
+
+test('availabilityScore with test array: half OK', function() {
+  var tests = [
+    { status: 'OK' },
+    { status: 'FAIL' },
+  ];
+  assert.strictEqual(availabilityScore(tests), 50);
+});
+
+test('availabilityScore with empty array returns 0', function() {
+  assert.strictEqual(availabilityScore([]), 0);
+});
+
+test('availabilityScore with invalid args returns 0', function() {
+  assert.strictEqual(availabilityScore(NaN, NaN), 0);
+  assert.strictEqual(availabilityScore(0, 0), 0);
+});
+
+// ===========================================================================
+// TESTS: compositeScore
+// ===========================================================================
+console.log('\n=== compositeScore ===\n');
+
+test('compositeScore with all 100s returns weighted sum', function() {
+  // Default weights: latency=0.4, throughput=0.25, correctness=0.2, availability=0.15
+  // 100*0.4 + 100*0.25 + 100*0.2 + 100*0.15 = 40+25+20+15 = 100
+  var s = compositeScore({ latency: 100, throughput: 100, correctness: 100, availability: 100 });
+  assert.strictEqual(s, 100);
+});
+
+test('compositeScore with all 0s returns 0', function() {
+  var s = compositeScore({ latency: 0, throughput: 0, correctness: 0, availability: 0 });
+  assert.strictEqual(s, 0);
+});
+
+test('compositeScore with default weights (4 components)', function() {
+  var s = compositeScore({ latency: 80, throughput: 60, correctness: 90, availability: 100 });
+  // 80*0.4 + 60*0.25 + 90*0.2 + 100*0.15 = 32 + 15 + 18 + 15 = 80
+  assert.strictEqual(s, 80);
+});
+
+test('compositeScore with custom weights', function() {
+  var s = compositeScore(
+    { latency: 100, throughput: 0, correctness: 0, availability: 0 },
+    { latency: 1.0, throughput: 0, correctness: 0, availability: 0 }
+  );
+  assert.strictEqual(s, 100);
+});
+
+test('compositeScore with missing fields defaults to 0', function() {
+  // Only correctness=100 * 0.2 = 20
+  var s = compositeScore({ correctness: 100 });
+  assert.strictEqual(s, 20);
+});
+
+test('compositeScore returns integer', function() {
+  var s = compositeScore({ latency: 33, throughput: 33, correctness: 33, availability: 33 });
+  assert.strictEqual(s, Math.round(s));
+});
+
+// ===========================================================================
+// TESTS: gradeLabel
+// ===========================================================================
+console.log('\n=== gradeLabel ===\n');
+
+test('gradeLabel(95) returns "Excellent"', function() {
+  assert.strictEqual(gradeLabel(95), 'Excellent');
+});
+
+test('gradeLabel(90) returns "Excellent"', function() {
+  assert.strictEqual(gradeLabel(90), 'Excellent');
+});
+
+test('gradeLabel(80) returns "Good"', function() {
+  assert.strictEqual(gradeLabel(80), 'Good');
+});
+
+test('gradeLabel(60) returns "Fair"', function() {
+  assert.strictEqual(gradeLabel(60), 'Fair');
+});
+
+test('gradeLabel(40) returns "Poor"', function() {
+  assert.strictEqual(gradeLabel(40), 'Poor');
+});
+
+test('gradeLabel(10) returns "Unusable"', function() {
+  assert.strictEqual(gradeLabel(10), 'Unusable');
+});
+
+// ===========================================================================
+// TESTS: DEFAULT_WEIGHTS
+// ===========================================================================
+console.log('\n=== DEFAULT_WEIGHTS ===\n');
+
+test('DEFAULT_WEIGHTS sums to 1.0', function() {
+  var sum = DEFAULT_WEIGHTS.latency + DEFAULT_WEIGHTS.throughput +
+            DEFAULT_WEIGHTS.correctness + DEFAULT_WEIGHTS.availability;
+  assert.ok(Math.abs(sum - 1.0) < 0.001, 'Weights sum should be 1.0, got ' + sum);
+});
+
+test('DEFAULT_WEIGHTS has all 4 components', function() {
+  assert.ok(typeof DEFAULT_WEIGHTS.latency === 'number');
+  assert.ok(typeof DEFAULT_WEIGHTS.throughput === 'number');
+  assert.ok(typeof DEFAULT_WEIGHTS.correctness === 'number');
+  assert.ok(typeof DEFAULT_WEIGHTS.availability === 'number');
+});
+
+// ===========================================================================
+// TESTS: validateMath
+// ===========================================================================
+console.log('\n=== validateMath ===\n');
+
+test('validateMath("4") returns true', function() {
+  assert.strictEqual(validateMath("4"), true);
+});
+
+test('validateMath("four") returns true', function() {
+  assert.strictEqual(validateMath("four"), true);
+});
+
+test('validateMath("The answer is 4.") returns true', function() {
+  assert.strictEqual(validateMath("The answer is 4."), true);
+});
+
+test('validateMath("5") returns false', function() {
+  assert.strictEqual(validateMath("5"), false);
+});
+
+test('validateMath("") returns false', function() {
+  assert.strictEqual(validateMath(""), false);
+});
+
+test('validateMath(null) returns false', function() {
+  assert.strictEqual(validateMath(null), false);
+});
+
+// ===========================================================================
+// TESTS: validateAvailability
+// ===========================================================================
+console.log('\n=== validateAvailability ===\n');
+
+test('validateAvailability("Hello") returns true', function() {
+  assert.strictEqual(validateAvailability("Hello"), true);
+});
+
+test('validateAvailability("") returns false', function() {
+  assert.strictEqual(validateAvailability(""), false);
+});
+
+test('validateAvailability("   ") returns false', function() {
+  assert.strictEqual(validateAvailability("   "), false);
+});
+
+test('validateAvailability(null) returns false', function() {
+  assert.strictEqual(validateAvailability(null), false);
+});
+
+// ===========================================================================
+// TESTS: estimateTokens
+// ===========================================================================
+console.log('\n=== estimateTokens ===\n');
+
+test('estimateTokens("hello world") returns > 0', function() {
+  assert.ok(estimateTokens("hello world") > 0);
+});
+
+test('estimateTokens("") returns 0', function() {
+  assert.strictEqual(estimateTokens(""), 0);
+});
+
+test('estimateTokens(null) returns 0', function() {
+  assert.strictEqual(estimateTokens(null), 0);
+});
+
+test('estimateTokens estimates ~4 chars per token', function() {
+  var text = "a".repeat(100);
+  var tokens = estimateTokens(text);
+  assert.strictEqual(tokens, 25); // 100/4 = 25
+});
+
+// ===========================================================================
+// TESTS: calcThroughput
+// ===========================================================================
+console.log('\n=== calcThroughput ===\n');
+
+test('calcThroughput with completionTokens and latencyMs', function() {
+  var result = calcThroughput({ completionTokens: 100, latencyMs: 1000 });
+  assert.strictEqual(result, 100); // 100 tokens / 1 second
+});
+
+test('calcThroughput estimates from response text', function() {
+  var result = calcThroughput({ response: "a".repeat(40), latencyMs: 1000 });
+  assert.ok(result > 0, 'should estimate throughput from response');
+});
+
+test('calcThroughput returns null for zero latency', function() {
+  assert.strictEqual(calcThroughput({ completionTokens: 10, latencyMs: 0 }), null);
+});
+
+test('calcThroughput returns null for null input', function() {
+  assert.strictEqual(calcThroughput(null), null);
+});
+
+// ===========================================================================
+// TESTS: scoreModel
+// ===========================================================================
+console.log('\n=== scoreModel ===\n');
+
+test('scoreModel produces valid composite score', function() {
+  var raw = {
+    provider: 'nvidia',
+    modelId: 'test-model',
+    modelName: 'Test Model',
+    free: true,
+    tests: [
+      { name: 'math', status: 'OK', response: '4', latencyMs: 300, ttftMs: 200, completionTokens: 5 },
+      { name: 'availability', status: 'OK', response: 'Hello', latencyMs: 250, ttftMs: 150, completionTokens: 3 },
+    ],
+  };
+  var result = scoreModel(raw);
+  assert.ok(typeof result.composite === 'number');
+  assertInRange(result.composite, 0, 100, 'composite');
+  assert.strictEqual(result.provider, 'nvidia');
+  assert.strictEqual(result.modelId, 'test-model');
+  assert.ok(result.free === true);
+});
+
+test('scoreModel with all-failed tests returns low score', function() {
+  var raw = {
+    provider: 'test',
+    modelId: 'fail-model',
+    modelName: 'Fail Model',
+    tests: [
+      { name: 'math', status: 'FAIL', response: '', latencyMs: 0, ttftMs: null },
+    ],
+  };
+  var result = scoreModel(raw);
+  assert.ok(result.composite <= 20, 'all-fail should score low');
+});
+
+// ===========================================================================
+// TESTS: rankModels
+// ===========================================================================
+console.log('\n=== rankModels ===\n');
+
+test('rankModels sorts by composite score descending', function() {
+  var models = [
+    { composite: 50, modelId: 'B' },
+    { composite: 90, modelId: 'A' },
+    { composite: 70, modelId: 'C' },
+  ];
+  var ranked = rankModels(models);
+  assert.strictEqual(ranked[0].modelId, 'A');
+  assert.strictEqual(ranked[1].modelId, 'C');
+  assert.strictEqual(ranked[2].modelId, 'B');
+});
+
+test('rankModels assigns rank numbers starting at 1', function() {
+  var models = [
+    { composite: 80 },
+    { composite: 60 },
+  ];
+  var ranked = rankModels(models);
+  assert.strictEqual(ranked[0].rank, 1);
+  assert.strictEqual(ranked[1].rank, 2);
+});
+
+test('rankModels does not mutate input array', function() {
+  var models = [
+    { composite: 50 },
+    { composite: 90 },
+  ];
+  var ranked = rankModels(models);
+  assert.strictEqual(models[0].composite, 50); // original unchanged
+  assert.ok(!models[0].rank); // no rank added to original
+});
+
+// ===========================================================================
+// TESTS: shouldRotate
+// ===========================================================================
+console.log('\n=== shouldRotate ===\n');
+
+test('shouldRotate when new best is significantly better', function() {
+  var current = { composite: 50, modelId: 'old' };
+  var best = { composite: 80, modelId: 'new' };
+  var result = shouldRotate(current, best, 10);
+  assert.strictEqual(result.rotate, true);
+});
+
+test('shouldRotate false when improvement is below threshold', function() {
+  var current = { composite: 80, modelId: 'old' };
+  var best = { composite: 82, modelId: 'new' };
+  var result = shouldRotate(current, best, 10);
+  assert.strictEqual(result.rotate, false);
+});
+
+test('shouldRotate true when current is null (failed)', function() {
+  var best = { composite: 70, modelId: 'new' };
+  var result = shouldRotate(null, best, 10);
+  assert.strictEqual(result.rotate, true);
+});
+
+test('shouldRotate false when same model is best', function() {
+  var current = { composite: 80, modelId: 'same' };
+  var best = { composite: 80, modelId: 'same' };
+  var result = shouldRotate(current, best, 10);
+  assert.strictEqual(result.rotate, false);
+});
+
+test('shouldRotate false when no working models', function() {
+  var current = { composite: 80, modelId: 'old' };
+  var result = shouldRotate(current, null, 10);
+  assert.strictEqual(result.rotate, false);
+});
+
+test('shouldRotate true when free alternative is adequate', function() {
+  var current = { composite: 60, modelId: 'paid', free: false };
+  var best = { composite: 55, modelId: 'free', free: true };
+  var result = shouldRotate(current, best, 10);
+  assert.strictEqual(result.rotate, true);
+  assert.ok(result.reason.includes('Free'), 'reason should mention free');
+});
+
+// ===========================================================================
+// Summary
+// ===========================================================================
+console.log('\n=== SCORING TEST SUMMARY ===');
+console.log('  Passed: ' + passed);
+console.log('  Failed: ' + failed);
+console.log('  Skipped: ' + skipped);
+if (failures.length > 0) {
+  console.log('\n  Failures:');
+  failures.forEach(function(f) { console.log('    - ' + f.name + ': ' + f.error); });
+}
+console.log('');
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Fix isModelFree to default to paid when cost data missing
- Fix latencyScore(30000) test to assert correct floor score of 10
- Add PID 1 validation before SIGUSR1 in reloadGateway
- Add --config CLI flag and OPENCLAW_CONFIG_PATH env var
- Add _config-fix.json to .gitignore

## Test plan
- [x] All 142 existing tests pass (90 scoring + 37 registry + 15 config)
- [x] latencyScore(30000) correctly returns 10
- [x] isModelFree({}) returns false

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements code review improvements for the model-optimizer feature, addressing test accuracy and adding safety validations.

**Key Changes:**
- Fixed `isModelFree` in `scripts/provider-registry.cjs` to default to `false` when cost data is missing (safer default for paid models)
- Fixed `latencyScore(30000)` test in `tests/model-optimizer/test-scoring.cjs` to correctly assert floor score of 10
- Added PID 1 validation in `reloadGateway` function before sending SIGUSR1 signal (checks `/proc/1/cmdline` to confirm Docker environment)
- Added `--config` CLI flag and `OPENCLAW_CONFIG_PATH` environment variable support for custom config paths
- Added `_config-fix*.json` patterns to `.gitignore` to prevent committing test fixtures with credentials

**Test Coverage:**
All 142 existing tests pass (90 scoring + 37 registry + 15 config), confirming the changes maintain backward compatibility while fixing the identified issues.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are defensive improvements (safer defaults, better validation) with comprehensive test coverage. The PID 1 check prevents signaling errors outside Docker, the isModelFree fix prevents misclassifying paid models as free, and the config path flexibility improves testability. No breaking changes or risky logic modifications.
- No files require special attention

<sub>Last reviewed commit: 7e1a932</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->