### PR TITLE
test(ui): split baseline browser-test fixes from webchat feature

### DIFF
--- a/ui/src/ui/navigation.test.ts
+++ b/ui/src/ui/navigation.test.ts
@@ -175,10 +175,10 @@ describe("inferBasePathFromPathname", () => {
 describe("TAB_GROUPS", () => {
   it("contains all expected groups", () => {
     const labels = TAB_GROUPS.map((g) => g.label);
-    expect(labels).toContain("Chat");
-    expect(labels).toContain("Control");
-    expect(labels).toContain("Agent");
-    expect(labels).toContain("Settings");
+    expect(labels).toContain("chat");
+    expect(labels).toContain("control");
+    expect(labels).toContain("agent");
+    expect(labels).toContain("settings");
   });
 
   it("all tabs are unique", () => {

--- a/ui/src/ui/test-helpers/app-mount.ts
+++ b/ui/src/ui/test-helpers/app-mount.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach } from "vitest";
-import { OpenClawApp } from "../app.ts";
+import "../app.ts";
+import type { OpenClawApp } from "../app.ts";
 
 export function mountApp(pathname: string) {
   window.history.replaceState({}, "", pathname);


### PR DESCRIPTION
## Summary
Split out baseline UI test fixes that are not specific to the multi-chat feature.

## Changes
- `ui/src/ui/test-helpers/app-mount.ts`
  - ensure app registration side-effects are loaded in browser tests:
    - `import "../app.ts";`
    - `import type { OpenClawApp } from "../app.ts";`
- `ui/src/ui/navigation.test.ts`
  - align expected tab-group labels with current `TAB_GROUPS` values (lowercase labels).

## Why
These failures reproduce on `main` and are unrelated to the webchat multi-session feature itself.

## Validation
- `pnpm -C ui test src/ui/navigation.browser.test.ts src/ui/navigation.test.ts`
- Result: **2 files passed, 40 tests passed**

---
**AI-generated contribution:** This PR was primarily generated with AI assistance and then validated with local tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two pre-existing test failures on `main`:

- **`navigation.test.ts`**: Updates `TAB_GROUPS` label expectations from capitalized (`"Chat"`, `"Control"`, etc.) to lowercase (`"chat"`, `"control"`, etc.), matching the actual values changed in commit `4b17ce7` (i18n feature) where labels were lowercased but tests were not updated.
- **`app-mount.ts`**: Splits the `OpenClawApp` import into a bare side-effect import (`import "../app.ts"`) to ensure the `@customElement("openclaw-app")` decorator registers the custom element, plus a `type`-only import for the type cast. This makes the side-effect dependency explicit rather than relying on a value import to trigger module evaluation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only fixes test expectations and import style with no production code changes.
- Both changes are minimal, test-only fixes that align test expectations with existing source code. The TAB_GROUPS label change is verified against the actual `navigation.ts` source. The import refactor in `app-mount.ts` correctly separates the side-effect import from the type-only import, which is a best practice for custom element registration. No production code is modified.
- No files require special attention.

<sub>Last reviewed commit: a57e2ec</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->