### PR TITLE
fix(node-host): auto-create cwd before exec spawn to prevent misleading ENOENT

### DIFF
--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -164,6 +164,17 @@ async function runCommand(
     let timedOut = false;
     let settled = false;
 
+    // Auto-create cwd if it doesn't exist to avoid misleading
+    // "spawn /bin/sh ENOENT" errors (Node surfaces missing cwd as ENOENT
+    // on the shell binary rather than the directory).
+    if (cwd) {
+      try {
+        fs.mkdirSync(cwd, { recursive: true });
+      } catch {
+        // Best-effort; let spawn surface the real error if mkdir fails.
+      }
+    }
+
     const child = spawn(argv[0], argv.slice(1), {
       cwd,
       env,


### PR DESCRIPTION
## Problem

When `exec` runs on a node and the agent workspace directory doesn't exist on the remote machine, Node.js throws `spawn /bin/sh ENOENT`. This misleadingly points at the shell binary rather than the real cause: the specified `cwd` directory is missing.

This blocks all exec commands on newly registered agent/node pairs until the user manually creates the workspace directory, and the error message sends users on a wild goose chase debugging shell binary paths.

## Fix

Add a best-effort `fs.mkdirSync(cwd, { recursive: true })` in `runCommand()` before spawning the child process. The `recursive: true` flag is a no-op if the directory already exists. The try/catch ensures that if mkdir fails (e.g. permission denied), the original spawn error still surfaces.

## Changes

- `src/node-host/invoke.ts`: Auto-create `cwd` directory before `spawn()` call

Fixes #22793

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Auto-creates the working directory (`cwd`) before spawning child processes in `runCommand()` to prevent misleading `ENOENT` errors. When the `cwd` doesn't exist, Node.js previously surfaced the error as "spawn /bin/sh ENOENT", incorrectly pointing at the shell binary instead of the missing directory. The fix uses `fs.mkdirSync(cwd, { recursive: true })` in a try/catch block - if directory creation fails, the original spawn error will still surface, ensuring proper error reporting.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, focused, and follows established patterns in the codebase. The fix uses `recursive: true` which is a no-op for existing directories, and the try/catch ensures that failures don't mask underlying issues. The approach matches similar `mkdirSync` patterns used throughout the codebase (found in 100+ locations). No security concerns - the code properly handles errors and doesn't introduce new attack vectors.
- No files require special attention

<sub>Last reviewed commit: 2311143</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->