### PR TITLE
Return clear error when exec cwd is missing instead of spawn ENOENT

### DIFF
--- a/src/node-host/invoke.cwd.test.ts
+++ b/src/node-host/invoke.cwd.test.ts
@@ -1,0 +1,126 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { handleInvoke } from "./invoke.js";
+import type { NodeInvokeRequestPayload } from "./invoke.js";
+import type { GatewayClient } from "../gateway/client.js";
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentConfig: () => undefined,
+}));
+
+vi.mock("../infra/exec-approvals.js", () => ({
+  ensureExecApprovals: () => {},
+  readExecApprovalsSnapshot: () => ({ path: "", exists: false, hash: "", file: {} }),
+  normalizeExecApprovals: (f: unknown) => f,
+  resolveExecApprovals: () => ({
+    agent: { security: "full", ask: "off", autoAllowSkills: false },
+    allowlist: [],
+    file: {},
+    socketPath: "",
+    token: "",
+  }),
+  analyzeArgvCommand: () => ({ ok: true, segments: [], shellCommand: null, cmdText: "whoami" }),
+  evaluateExecAllowlist: () => ({ allowlistMatches: [], allowlistSatisfied: true }),
+  evaluateShellAllowlist: () => ({
+    analysisOk: true,
+    allowlistMatches: [],
+    allowlistSatisfied: true,
+    segments: [],
+  }),
+  requiresExecApproval: () => false,
+  recordAllowlistUse: () => {},
+  addAllowlistEntry: () => {},
+  saveExecApprovals: () => {},
+  resolveExecApprovalsSocketPath: () => "",
+  resolveSafeBins: () => new Set(),
+  normalizeExecApprovals: (f: unknown) => f,
+}));
+
+vi.mock("../infra/system-run-command.js", () => ({
+  validateSystemRunCommandConsistency: () => ({
+    ok: true,
+    shellCommand: null,
+    cmdText: "whoami",
+  }),
+}));
+
+function makeClient(calls: Array<{ method: string; params: unknown }>) {
+  return {
+    request: async (method: string, params: unknown) => {
+      calls.push({ method, params });
+    },
+  } as unknown as GatewayClient;
+}
+
+function makeFrame(paramsJSON: object): NodeInvokeRequestPayload {
+  return {
+    id: "test-id",
+    nodeId: "test-node",
+    command: "system.run",
+    paramsJSON: JSON.stringify(paramsJSON),
+    timeoutMs: null,
+    idempotencyKey: null,
+  };
+}
+
+const skillBins = { current: async () => new Set<string>() };
+
+describe("handleInvoke: cwd validation", () => {
+  it("returns a clear error when cwd does not exist instead of spawn ENOENT", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const client = makeClient(calls);
+    const nonExistentDir = path.join(os.tmpdir(), "openclaw-test-missing-dir-" + Date.now());
+
+    await handleInvoke(
+      makeFrame({
+        command: ["whoami"],
+        cwd: nonExistentDir,
+        approved: true,
+      }),
+      client,
+      skillBins,
+    );
+
+    const resultCall = calls.find((c) => c.method === "node.invoke.result");
+    expect(resultCall).toBeDefined();
+    const result = resultCall?.params as {
+      ok: boolean;
+      error?: { code: string; message: string };
+    };
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("INVALID_REQUEST");
+    expect(result.error?.message).toContain("working directory not found");
+    expect(result.error?.message).toContain(nonExistentDir);
+    // Must NOT mention /bin/sh — that was the old misleading message
+    expect(result.error?.message).not.toContain("/bin/sh");
+  });
+
+  it("proceeds normally when cwd exists", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const client = makeClient(calls);
+
+    await handleInvoke(
+      makeFrame({
+        command: ["echo", "hello"],
+        cwd: os.tmpdir(),
+        approved: true,
+      }),
+      client,
+      skillBins,
+    );
+
+    const resultCall = calls.find((c) => c.method === "node.invoke.result");
+    expect(resultCall).toBeDefined();
+    const result = resultCall?.params as { ok: boolean };
+    // Should succeed (or fail for unrelated reasons, but not cwd-not-found)
+    if (!result.ok) {
+      const err = (resultCall?.params as { error?: { message?: string } }).error;
+      expect(err?.message).not.toContain("working directory not found");
+    }
+  });
+});


### PR DESCRIPTION
## Problem

When a node exec command runs with a `cwd` that doesn't exist on the remote machine (e.g. a freshly registered agent whose workspace directory was never created), Node.js throws:

```
spawn /bin/sh ENOENT
```

This points at the shell binary rather than the real cause, sending users down a rabbit hole checking if `/bin/sh` is missing. The actual issue is that `child_process.spawn()` fails with ENOENT when its `cwd` option refers to a non-existent path.

## Fix

Check `fs.existsSync(cwd)` before calling `runCommand`. If the directory is absent, return a clear error immediately:

```
working directory not found: /home/user/.openclaw/workspace-agent
— create it on the node or check your agent workspace config
```

The check is synchronous (one `stat` call) and only runs when `params.cwd` is set.

## Test

Added `invoke.cwd.test.ts` with two cases:
- missing cwd → `ok: false`, error message contains `working directory not found` and the path, does **not** mention `/bin/sh`
- existing cwd (`os.tmpdir()`) → does not hit the cwd-not-found error path

Closes #22793

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds upfront `cwd` validation to prevent confusing `spawn /bin/sh ENOENT` errors when the working directory doesn't exist. The fix checks `fs.existsSync(cwd)` before spawning and returns a clear error message directing users to create the directory or check their agent workspace config.

**Key changes:**
- Added synchronous cwd existence check at invoke.ts:790-811
- Returns `INVALID_REQUEST` with descriptive error instead of letting spawn fail
- Sends `exec.denied` event with `reason: "cwd-not-found"`
- Comprehensive test coverage in new `invoke.cwd.test.ts`

**Issue found:**
- The validation is placed after the macOS exec host path (lines 578-659), so it won't protect macOS users when the companion app handles execution

<h3>Confidence Score: 3/5</h3>

- Safe to merge with a logical issue that limits effectiveness on macOS
- The PR improves error messaging and adds good test coverage, but the cwd validation is positioned after the macOS execution path, meaning macOS users won't benefit from the clearer error message when using the companion app. The fix is still valuable for other platforms and macOS fallback scenarios, but doesn't fully solve the stated problem across all execution paths.
- `src/node-host/invoke.ts` - the cwd validation should be moved before line 578 to ensure it executes on all platforms

<sub>Last reviewed commit: d0b5cf1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->