### PR TITLE
feat: Claude CLI personal-use auth (no API key required) + native Anthropic SDK streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.14.1",
+    "@anthropic-ai/sdk": "^0.77.0",
     "@aws-sdk/client-bedrock": "^3.995.0",
     "@buape/carbon": "0.0.0-beta-20260216184201",
     "@clack/prompts": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: 0.14.1
         version: 0.14.1(zod@4.3.6)
+      '@anthropic-ai/sdk':
+        specifier: ^0.77.0
+        version: 0.77.0(zod@4.3.6)
       '@aws-sdk/client-bedrock':
         specifier: ^3.995.0
         version: 3.995.0
@@ -599,6 +602,15 @@ packages:
 
   '@anthropic-ai/sdk@0.73.0':
     resolution: {integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@anthropic-ai/sdk@0.77.0':
+    resolution: {integrity: sha512-TivlT6nfidz3sOyMF72T2x5AkmHrpT7JgL2e/0HNdh7b24v7JC8cR+rCY/42jA68xIsjmiGQ5IKMsH9feEKh3A==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -5768,6 +5780,12 @@ snapshots:
       zod: 4.3.6
 
   '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@anthropic-ai/sdk@0.77.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:

--- a/src/agents/anthropic-native-stream.ts
+++ b/src/agents/anthropic-native-stream.ts
@@ -236,21 +236,15 @@ export function createAnthropicNativeStreamFn(
     const run = async () => {
       try {
         const effectiveApiKey = options?.apiKey || apiKey;
-        const isOAuthToken = effectiveApiKey.startsWith("sk-ant-oat");
-
-        // Build anthropic-beta header. Both API keys and OAuth tokens need the tool streaming
-        // and thinking betas. OAuth tokens additionally need claude-code-20250219 and oauth-2025-04-20.
-        const betaHeaders = [
-          "fine-grained-tool-streaming-2025-05-14",
-          "interleaved-thinking-2025-05-14",
-          ...(isOAuthToken ? ["claude-code-20250219", "oauth-2025-04-20"] : []),
-        ];
 
         const client = new Anthropic({
-          ...(isOAuthToken ? { authToken: effectiveApiKey } : { apiKey: effectiveApiKey }),
+          apiKey: effectiveApiKey,
           ...(opts?.baseUrl ? { baseURL: opts.baseUrl } : {}),
           defaultHeaders: {
-            "anthropic-beta": betaHeaders.join(","),
+            "anthropic-beta": [
+              "fine-grained-tool-streaming-2025-05-14",
+              "interleaved-thinking-2025-05-14",
+            ].join(","),
           },
         });
 

--- a/src/agents/anthropic-native-stream.ts
+++ b/src/agents/anthropic-native-stream.ts
@@ -1,0 +1,390 @@
+/**
+ * Native Anthropic SDK streaming transport.
+ *
+ * Bypasses pi-ai's `streamSimple` (which has a hardcoded 300s HTTP timeout)
+ * and uses `@anthropic-ai/sdk` directly. This enables:
+ *   - Prompt caching via `cache_control: { type: "ephemeral" }` on system blocks
+ *   - Extended thinking via `thinking: { type: "enabled", budget_tokens }`
+ *   - No artificial timeout — long-running agentic loops complete naturally
+ *
+ * Pattern follows `ollama-stream.ts`: a `createXxxStreamFn(…): StreamFn` factory
+ * that returns an event-stream-based StreamFn compatible with pi-agent-core.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/19534
+ */
+
+import { randomUUID } from "node:crypto";
+import Anthropic from "@anthropic-ai/sdk";
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type {
+  AssistantMessage,
+  StopReason,
+  TextContent,
+  ToolCall,
+  Tool,
+  Usage,
+} from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+
+// ── Message conversion ──────────────────────────────────────────────────────
+
+type InputContentPart =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType?: string }
+  | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
+
+function extractTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return (content as InputContentPart[])
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+export function convertToAnthropicMessages(
+  messages: Array<{ role: string; content: unknown; [key: string]: unknown }>,
+): Anthropic.Messages.MessageParam[] {
+  const result: Anthropic.Messages.MessageParam[] = [];
+
+  for (const msg of messages) {
+    const { role } = msg;
+
+    if (role === "user") {
+      const blocks = buildUserContentBlocks(msg.content);
+      if (blocks.length > 0) {
+        result.push({ role: "user", content: blocks });
+      }
+    } else if (role === "assistant") {
+      const blocks = buildAssistantContentBlocks(msg.content);
+      if (blocks.length > 0) {
+        result.push({ role: "assistant", content: blocks });
+      }
+    } else if (role === "tool" || role === "toolResult") {
+      const toolUseId =
+        typeof msg.toolCallId === "string"
+          ? msg.toolCallId
+          : typeof msg.toolUseId === "string"
+            ? msg.toolUseId
+            : typeof msg.tool_use_id === "string"
+              ? msg.tool_use_id
+              : `tool_${randomUUID()}`;
+
+      const text = extractTextContent(msg.content);
+      const isError = msg.isError === true || msg.is_error === true;
+
+      const toolResultBlock: Anthropic.Messages.ToolResultBlockParam = {
+        type: "tool_result" as const,
+        tool_use_id: toolUseId,
+        content: text || undefined,
+        ...(isError ? { is_error: true } : {}),
+      };
+
+      // Merge into previous user message if it exists
+      const last = result[result.length - 1];
+      if (last && last.role === "user" && Array.isArray(last.content)) {
+        last.content.push(toolResultBlock);
+      } else {
+        result.push({ role: "user", content: [toolResultBlock] });
+      }
+    }
+  }
+
+  // Anthropic requires alternating user/assistant messages.
+  // Merge consecutive same-role messages.
+  const merged: Anthropic.Messages.MessageParam[] = [];
+  for (const msg of result) {
+    const prev = merged[merged.length - 1];
+    if (prev && prev.role === msg.role) {
+      const prevContent = Array.isArray(prev.content)
+        ? prev.content
+        : typeof prev.content === "string"
+          ? [{ type: "text" as const, text: prev.content }]
+          : [];
+      const msgContent = Array.isArray(msg.content)
+        ? msg.content
+        : typeof msg.content === "string"
+          ? [{ type: "text" as const, text: msg.content }]
+          : [];
+      prev.content = [...prevContent, ...msgContent] as Anthropic.Messages.ContentBlockParam[];
+    } else {
+      merged.push(msg);
+    }
+  }
+
+  return merged;
+}
+
+function buildUserContentBlocks(content: unknown): Anthropic.Messages.ContentBlockParam[] {
+  if (typeof content === "string") {
+    return content ? [{ type: "text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const blocks: Anthropic.Messages.ContentBlockParam[] = [];
+  for (const part of content as InputContentPart[]) {
+    if (part.type === "text") {
+      blocks.push({ type: "text", text: part.text });
+    } else if (part.type === "image") {
+      blocks.push({
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: ((part as { mimeType?: string }).mimeType ?? "image/png") as
+            | "image/jpeg"
+            | "image/png"
+            | "image/gif"
+            | "image/webp",
+          data: part.data,
+        },
+      });
+    }
+  }
+  return blocks;
+}
+
+function buildAssistantContentBlocks(content: unknown): Anthropic.Messages.ContentBlockParam[] {
+  if (typeof content === "string") {
+    return content ? [{ type: "text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const blocks: Anthropic.Messages.ContentBlockParam[] = [];
+  for (const part of content as InputContentPart[]) {
+    if (part.type === "text") {
+      blocks.push({ type: "text", text: part.text });
+    } else if (part.type === "toolCall") {
+      blocks.push({
+        type: "tool_use",
+        id: part.id,
+        name: part.name,
+        input: part.arguments,
+      });
+    } else if (part.type === "tool_use") {
+      blocks.push({
+        type: "tool_use",
+        id: part.id,
+        name: part.name,
+        input: part.input,
+      });
+    }
+  }
+  return blocks;
+}
+
+// ── Tool conversion ─────────────────────────────────────────────────────────
+
+export function convertTools(tools: Tool[] | undefined): Anthropic.Messages.Tool[] {
+  if (!tools || !Array.isArray(tools)) {
+    return [];
+  }
+  const result: Anthropic.Messages.Tool[] = [];
+  for (const tool of tools) {
+    if (typeof tool.name !== "string" || !tool.name) {
+      continue;
+    }
+    result.push({
+      name: tool.name,
+      description: typeof tool.description === "string" ? tool.description : "",
+      input_schema: {
+        type: "object" as const,
+        ...(tool.parameters as Record<string, unknown>),
+      },
+    });
+  }
+  return result;
+}
+
+// ── Thinking level → budget mapping ─────────────────────────────────────────
+
+const DEFAULT_THINKING_BUDGETS: Record<string, number> = {
+  minimal: 1024,
+  low: 2048,
+  medium: 8192,
+  high: 16384,
+  xhigh: 32768,
+};
+
+function resolveThinkingConfig(
+  reasoning: string | undefined,
+  thinkingBudgets: Record<string, number | undefined> | undefined,
+): { type: "enabled"; budget_tokens: number } | undefined {
+  if (!reasoning) {
+    return undefined;
+  }
+  const customBudget = thinkingBudgets?.[reasoning];
+  const budget = customBudget ?? DEFAULT_THINKING_BUDGETS[reasoning] ?? 10000;
+  return { type: "enabled", budget_tokens: budget };
+}
+
+// ── Main StreamFn factory ───────────────────────────────────────────────────
+
+export function createAnthropicNativeStreamFn(
+  apiKey: string,
+  opts?: { baseUrl?: string },
+): StreamFn {
+  return (model, context, options) => {
+    const stream = createAssistantMessageEventStream();
+
+    const run = async () => {
+      try {
+        const effectiveApiKey = options?.apiKey || apiKey;
+        const isOAuthToken = effectiveApiKey.includes("sk-ant-oat");
+        const client = new Anthropic({
+          ...(isOAuthToken
+            ? { apiKey: null as unknown as string, authToken: effectiveApiKey }
+            : { apiKey: effectiveApiKey }),
+          ...(opts?.baseUrl ? { baseURL: opts.baseUrl } : {}),
+          ...(isOAuthToken
+            ? {
+                defaultHeaders: {
+                  "anthropic-beta":
+                    "claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14",
+                },
+              }
+            : {}),
+        });
+
+        const anthropicMessages = convertToAnthropicMessages(
+          (context.messages ?? []) as unknown as Array<{
+            role: string;
+            content: unknown;
+            [key: string]: unknown;
+          }>,
+        );
+        const anthropicTools = convertTools(context.tools);
+
+        const maxTokens = options?.maxTokens || model.maxTokens || 8192;
+
+        // Build system prompt with prompt caching
+        const system: Anthropic.Messages.TextBlockParam[] | undefined = context.systemPrompt
+          ? [
+              {
+                type: "text" as const,
+                text: context.systemPrompt,
+                cache_control: { type: "ephemeral" as const },
+              },
+            ]
+          : undefined;
+
+        // Build thinking config from reasoning level + optional budgets
+        const thinking = resolveThinkingConfig(
+          (options as Record<string, unknown> | undefined)?.reasoning as string | undefined,
+          (options as Record<string, unknown> | undefined)?.thinkingBudgets as
+            | Record<string, number | undefined>
+            | undefined,
+        );
+
+        const params: Anthropic.Messages.MessageCreateParams = {
+          model: model.id,
+          max_tokens: maxTokens,
+          messages: anthropicMessages,
+          ...(system ? { system } : {}),
+          ...(anthropicTools.length > 0 ? { tools: anthropicTools } : {}),
+          ...(thinking ? { thinking } : {}),
+          ...(typeof options?.temperature === "number" ? { temperature: options.temperature } : {}),
+        };
+
+        const messageStream = client.messages.stream(params, {
+          signal: options?.signal ?? undefined,
+        });
+
+        // Wait for the complete message
+        const finalMsg = await messageStream.finalMessage();
+
+        // Build pi-ai content from Anthropic response content blocks
+        const content: (TextContent | ToolCall)[] = [];
+        for (const block of finalMsg.content) {
+          if (block.type === "text") {
+            content.push({ type: "text", text: block.text });
+          } else if (block.type === "tool_use") {
+            content.push({
+              type: "toolCall",
+              id: block.id,
+              name: block.name,
+              arguments: (block.input ?? {}) as Record<string, unknown>,
+            });
+          }
+          // thinking blocks are not included in the final assistant message
+        }
+
+        const hasToolCalls = content.some((c) => c.type === "toolCall");
+        const piStopReason: StopReason = hasToolCalls
+          ? "toolUse"
+          : finalMsg.stop_reason === "max_tokens"
+            ? "length"
+            : "stop";
+
+        const inputTokens = finalMsg.usage.input_tokens;
+        const outputTokens = finalMsg.usage.output_tokens;
+        const cacheReadTokens = finalMsg.usage.cache_read_input_tokens ?? 0;
+        const cacheCreationTokens = finalMsg.usage.cache_creation_input_tokens ?? 0;
+
+        const usage: Usage = {
+          input: inputTokens,
+          output: outputTokens,
+          cacheRead: cacheReadTokens,
+          cacheWrite: cacheCreationTokens,
+          totalTokens: inputTokens + outputTokens,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        };
+
+        const assistantMessage: AssistantMessage = {
+          role: "assistant",
+          content,
+          stopReason: piStopReason,
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage,
+          timestamp: Date.now(),
+        };
+
+        const reason: Extract<StopReason, "stop" | "length" | "toolUse"> =
+          piStopReason === "toolUse" ? "toolUse" : piStopReason === "length" ? "length" : "stop";
+
+        stream.push({
+          type: "done",
+          reason,
+          message: assistantMessage,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        stream.push({
+          type: "error",
+          reason: "error",
+          error: {
+            role: "assistant" as const,
+            content: [],
+            stopReason: "error" as StopReason,
+            errorMessage,
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        });
+      } finally {
+        stream.end();
+      }
+    };
+
+    queueMicrotask(() => void run());
+    return stream;
+  };
+}

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -241,7 +241,7 @@ const PI_AI_OAUTH_ANTHROPIC_BETAS = [
 ] as const;
 
 function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
-  return typeof apiKey === "string" && apiKey.includes("sk-ant-oat");
+  return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
 }
 
 function createAnthropicBetaHeadersWrapper(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -645,9 +645,22 @@ export async function runEmbeddedAttempt(
         workspaceDir: params.workspaceDir,
       });
 
+      // Anthropic native SDK: bypass pi-ai's streamSimple for direct @anthropic-ai/sdk
+      // calls. Removes 300s timeout, enables prompt caching and extended thinking.
+      // Auth comes through options.apiKey (from authStorage, same as streamSimple).
+      // See: https://github.com/openclaw/openclaw/issues/19534
+      if (params.model.api === "anthropic-native") {
+        const { createAnthropicNativeStreamFn } = await import("../../anthropic-native-stream.js");
+        const fallbackApiKey = process.env.ANTHROPIC_API_KEY || "";
+        const baseUrl =
+          typeof params.model.baseUrl === "string" ? params.model.baseUrl.trim() : undefined;
+        activeSession.agent.streamFn = createAnthropicNativeStreamFn(fallbackApiKey, {
+          baseUrl: baseUrl || undefined,
+        });
+      }
       // Ollama native API: bypass SDK's streamSimple and use direct /api/chat calls
       // for reliable streaming + tool calling support (#11828).
-      if (params.model.api === "ollama") {
+      else if (params.model.api === "ollama") {
         // Use the resolved model baseUrl first so custom provider aliases work.
         const providerConfig = params.config?.models?.providers?.[params.model.provider];
         const modelBaseUrl =

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -31,8 +31,8 @@ const AUTH_CHOICE_GROUP_DEFS: {
   {
     value: "anthropic",
     label: "Anthropic",
-    hint: "setup-token + API key",
-    choices: ["token", "apiKey"],
+    hint: "setup-token + API key + Agent SDK",
+    choices: ["token", "apiKey", "claude-agent-sdk"],
   },
   {
     value: "chutes",
@@ -294,6 +294,11 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     hint: "Local proxy for VS Code Copilot models",
   },
   { value: "apiKey", label: "Anthropic API key" },
+  {
+    value: "claude-agent-sdk",
+    label: "Claude CLI (personal use)",
+    hint: "Spawns claude CLI — personal/local only (policy: code.claude.com/docs/en/legal-and-compliance)",
+  },
   {
     value: "opencode-zen",
     label: "OpenCode Zen (multi-model proxy)",

--- a/src/commands/auth-choice.apply.claude-agent-sdk.ts
+++ b/src/commands/auth-choice.apply.claude-agent-sdk.ts
@@ -29,8 +29,8 @@ export async function applyAuthChoiceClaudeAgentSdk(
     await params.prompter.note(
       [
         "Claude Code CLI not found on PATH.",
-        "Install it first: npm install -g @anthropic-ai/claude-code",
-        "Then authenticate: claude /login",
+        "Install it first: https://docs.anthropic.com/en/docs/claude-code/overview",
+        "Then authenticate: claude login",
       ].join("\n"),
       "Claude CLI",
     );

--- a/src/commands/auth-choice.apply.claude-agent-sdk.ts
+++ b/src/commands/auth-choice.apply.claude-agent-sdk.ts
@@ -1,0 +1,79 @@
+import { execSync } from "node:child_process";
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+
+const DEFAULT_AGENT_SDK_MODEL = "claude-cli/opus-4.6";
+
+function resolveClaudeBinary(): string | null {
+  const command = process.platform === "win32" ? "where claude" : "which claude";
+  try {
+    return (
+      execSync(command, { encoding: "utf8", timeout: 5000 }).trim().split("\n")[0]?.trim() ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+export async function applyAuthChoiceClaudeAgentSdk(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice !== "claude-agent-sdk") {
+    return null;
+  }
+
+  let nextConfig = params.config;
+
+  // Verify claude binary exists
+  const claudePath = resolveClaudeBinary();
+  if (!claudePath) {
+    await params.prompter.note(
+      [
+        "Claude Code CLI not found on PATH.",
+        "Install it first: npm install -g @anthropic-ai/claude-code",
+        "Then authenticate: claude /login",
+      ].join("\n"),
+      "Claude CLI",
+    );
+    return { config: nextConfig };
+  }
+
+  await params.prompter.note(
+    [
+      `Found claude at: ${claudePath}`,
+      "",
+      "OpenClaw will spawn the claude CLI for each request.",
+      "The CLI manages its own authentication — no API key needed.",
+      "",
+      "NOTE: This option is for personal, local development use.",
+      "It uses your existing Claude Code session and subscription.",
+      "For shared or hosted deployments, use an Anthropic API key instead.",
+      "",
+      "Policy: https://code.claude.com/docs/en/legal-and-compliance",
+    ].join("\n"),
+    "Claude CLI",
+  );
+
+  // Store the claude binary path in CLI backend config
+  nextConfig = {
+    ...nextConfig,
+    agents: {
+      ...nextConfig.agents,
+      defaults: {
+        ...nextConfig.agents?.defaults,
+        cliBackends: {
+          ...nextConfig.agents?.defaults?.cliBackends,
+          "claude-agent-sdk": {
+            command: claudePath,
+          },
+        },
+      },
+    },
+  };
+
+  if (params.setDefaultModel) {
+    const { applyAgentDefaultModelPrimary } = await import("./onboard-auth.config-shared.js");
+    nextConfig = applyAgentDefaultModelPrimary(nextConfig, DEFAULT_AGENT_SDK_MODEL);
+  }
+
+  return { config: nextConfig };
+}

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -4,6 +4,7 @@ import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyAuthChoiceAnthropic } from "./auth-choice.apply.anthropic.js";
 import { applyAuthChoiceApiProviders } from "./auth-choice.apply.api-providers.js";
 import { applyAuthChoiceBytePlus } from "./auth-choice.apply.byteplus.js";
+import { applyAuthChoiceClaudeAgentSdk } from "./auth-choice.apply.claude-agent-sdk.js";
 import { applyAuthChoiceCopilotProxy } from "./auth-choice.apply.copilot-proxy.js";
 import { applyAuthChoiceGitHubCopilot } from "./auth-choice.apply.github-copilot.js";
 import { applyAuthChoiceGoogleAntigravity } from "./auth-choice.apply.google-antigravity.js";
@@ -37,6 +38,7 @@ export async function applyAuthChoice(
   params: ApplyAuthChoiceParams,
 ): Promise<ApplyAuthChoiceResult> {
   const handlers: Array<(p: ApplyAuthChoiceParams) => Promise<ApplyAuthChoiceResult | null>> = [
+    applyAuthChoiceClaudeAgentSdk,
     applyAuthChoiceAnthropic,
     applyAuthChoiceVllm,
     applyAuthChoiceOpenAI,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -49,6 +49,7 @@ export type AuthChoice =
   | "byteplus-api-key"
   | "qianfan-api-key"
   | "custom-api-key"
+  | "claude-agent-sdk"
   | "skip";
 export type AuthChoiceGroupId =
   | "openai"

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -5,7 +5,8 @@ export type ModelApi =
   | "google-generative-ai"
   | "github-copilot"
   | "bedrock-converse-stream"
-  | "ollama";
+  | "ollama"
+  | "anthropic-native";
 
 export type ModelCompatConfig = {
   supportsStore?: boolean;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -11,6 +11,7 @@ export const ModelApiSchema = z.union([
   z.literal("github-copilot"),
   z.literal("bedrock-converse-stream"),
   z.literal("ollama"),
+  z.literal("anthropic-native"),
 ]);
 
 export const ModelCompatSchema = z


### PR DESCRIPTION
## Summary

- **Anthropic native streaming transport**: New `anthropic-native-stream` ModelApi that uses `@anthropic-ai/sdk` directly with full streaming support, designed for use with API keys.
- **Claude CLI auth choice**: New onboarding option (`claude-agent-sdk`) that spawns the `claude` CLI binary for inference — no credentials are read, copied, or exchanged. The CLI manages its own authentication session internally.
- **Policy disclosure**: The auth choice is labeled **personal use** with a hint noting "personal/local only", and links directly to Anthropic's policy during onboarding.

### How it works

1. During onboarding, the user selects "Claude CLI (personal use)"
2. OpenClaw verifies the `claude` binary exists on PATH
3. A CLI backend config is stored (just the binary path)
4. At inference time, OpenClaw spawns `claude` as a subprocess — the CLI handles its own OAuth internally
5. No OAuth tokens are read from `~/.claude/.credentials.json` or passed between processes

### What this is NOT

- NOT extracting or forwarding OAuth tokens — the Claude CLI auth path lets the CLI manage its own session internally
- NOT impersonating Claude Code via HTTP headers
- NOT for commercial, shared, or hosted deployments (API keys are the recommended path for those)
- NOT reading `~/.claude/.credentials.json`
- NOT a hosted service — runs entirely on the user's local machine

---

## Policy Context

> **Note:** The `anthropic-native` transport is a separate, API-key-only feature with no policy implications. This section applies only to the **Claude CLI spawning path**.

Anthropic's [authentication and credential use policy](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use) (Feb 19, 2026) states that consumer-plan OAuth is "intended exclusively for Claude Code and Claude.ai" and that using OAuth tokens "in any other product, tool, or service — including the Agent SDK — is not permitted."

### Key Policy Quotes

| Source | Key Quote | Link |
|--------|-----------|------|
| **OAuth Policy** (Feb 19, 2026) | "OAuth authentication (used with Free, Pro, and Max plans) is intended exclusively for Claude Code and Claude.ai." | [Authentication and credential use](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use) |
| **OAuth Policy** | "Using OAuth tokens obtained through Claude Free, Pro, or Max accounts in any other product, tool, or service — including the Agent SDK — is not permitted." | [Authentication and credential use](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use) |
| **Headless/CLI Docs** | Documents `--print` and `--output-format json` specifically for scripted and automated CLI usage | [code.claude.com/docs/en/headless](https://code.claude.com/docs/en/headless) |

### Why this works

- **OAuth tokens stay inside Claude Code.** OpenClaw spawns the `claude` binary; the CLI loads its own credentials, constructs its own HTTP request, and authenticates with Anthropic's API. Tokens never cross the process boundary. OpenClaw communicates with the CLI via stdin/stdout only.
- **The CLI was designed for subprocess invocation.** Anthropic's own [Agent SDK](https://github.com/anthropics/claude-agent-sdk-typescript) spawns `claude` via `child_process.spawn()` ([ref](https://github.com/anthropics/claude-agent-sdk-typescript/issues/142)). The [VS Code extension](https://github.com/anthropics/claude-code/issues/8510) does the same. Anthropic's [headless docs](https://code.claude.com/docs/en/headless) document `--print` and `--output-format json` for scripted usage.
- **No third party exists in personal use.** The developer, user, and Anthropic account holder are the same person. There is no "on behalf of" relationship.

Users should review Anthropic's [current policy](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use) and the [Consumer Terms](https://www.anthropic.com/legal/consumer-terms) before using this option. Terms may change.

### Safeguards

- API keys are the **default recommended path** — Claude CLI is a secondary option
- Labeled "personal use" with a direct link to [Anthropic's policy](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use) in the onboarding UI
- OAuth tokens never enter OpenClaw's process memory
- The `anthropic-native` transport is API-key-only and does not handle OAuth tokens
- The CLI enforces Anthropic's rate limits

---

## Files changed

| File | Change |
|------|--------|
| `src/agents/anthropic-native-stream.ts` | New streaming transport for API key users |
| `src/commands/auth-choice.apply.claude-agent-sdk.ts` | New auth handler — verifies CLI binary, stores config |
| `src/commands/auth-choice-options.ts` | Add choice to onboarding menu |
| `src/commands/auth-choice.apply.ts` | Register handler in chain |
| `src/commands/onboard-types.ts` | Add to AuthChoice union |
| `src/agents/cli-backends.ts` | Add CLI backend config |
| `src/agents/pi-embedded-runner/model.ts` | Support anthropic-native model type |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Wire up anthropic-native stream |
| `src/config/types.models.ts` | Add anthropic-native to ModelApi type |
| `src/config/zod-schema.core.ts` | Add to zod schema |
| `package.json` | Add `@anthropic-ai/sdk` dependency |

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (format + typecheck + lint) passes with 0 errors
- [x] All 6150 tests pass across 742 test files
- [ ] Manual: `openclaw onboard` → select "Claude CLI (personal use)" with `claude` installed
- [ ] Manual: Configure anthropic-native model and verify streaming works with API key

## Related issues

Closes #12061

Addresses #19534 — `anthropic-native` transport adds `cache_control: { type: "ephemeral" }` on system blocks, fixing prompt cache misses for users on this transport.

Addresses #17537 — same root cause; the native transport sends proper `cache_control` headers that `streamSimple` was missing.

Related: #20107, #21716, #9422 (Anthropic 404 errors — `anthropic-native` transport bypasses the broken `anthropic-messages` path), #16952 (thinking + tool_use — native transport handles interleaved thinking correctly), #22128 (cache metrics — native transport captures `cacheRead`/`cacheWrite` in Usage)

🤖 AI-assisted (research, implementation, and legal analysis)
