### PR TITLE
fix: flatten nested anyOf/oneOf in Gemini schema cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Subagents: restore announce-chain delivery to agent injection, defer nested announce output until descendant follow-up content is ready, and prevent descendant deferrals from consuming announce retry budget so deep chains do not drop final completions. (#22223) Thanks @tyler6204.
 - Agents/System Prompt: label allowlisted senders as authorized senders to avoid implying ownership. Thanks @thewilloftheshadow.
 - Agents/Tool display: fix exec cwd suffix inference so `pushd ... && popd ... && <command>` does not keep stale `(in <dir>)` context in summaries. (#21925) Thanks @Lukavyi.
+- Agents/Google: flatten residual nested `anyOf`/`oneOf` unions in Gemini tool-schema cleanup so Cloud Code Assist no longer rejects unsupported union keywords that survive earlier simplification. (#22825) Thanks @Oceanswave.
 - Tools/web_search: handle xAI Responses API payloads that emit top-level `output_text` blocks (without a `message` wrapper) so Grok web_search no longer returns `No response` for those results. (#20508) Thanks @echoVic.
 - Agents/Failover: treat non-default override runs as direct fallback-to-configured-primary (skip configured fallback chain), normalize default-model detection for provider casing/whitespace, and add regression coverage for override/auth error paths. (#18820) Thanks @Glucksberg.
 - Docker/Build: include `ownerDisplay` in `CommandsSchema` object-level defaults so Docker `pnpm build` no longer fails with `TS2769` during plugin SDK d.ts generation. (#22558) Thanks @obviyus.


### PR DESCRIPTION
## Summary

Adds a last-resort `flattenUnionFallback` pass in `cleanSchemaForGeminiWithDefs` to eliminate nested `anyOf`/`oneOf` arrays that survive the existing `simplifyUnionVariants` simplification.

This is the final piece of the google-antigravity schema cleaning fix. The other two pieces — `sanitizeToolsForGoogle` guard and `sanitizeAntigravityThinkingBlocks` text conversion — shipped in v2026.2.21 via PR #19732. This PR addresses the remaining `anyOf`/`oneOf` issue.

## Problem

Google's Cloud Code Assist API validates tool schemas against a restricted JSON Schema subset before forwarding requests to the downstream model (e.g. Anthropic Claude via google-antigravity). This validation rejects `anyOf` and `oneOf` keywords in nested schemas:

```
Cloud Code Assist API error (400): Invalid JSON payload received.
Unknown name "anyOf" at 'request.tools[0].function_declarations[21].parameters.properties[0].value': Cannot find field.
```

Tool index 21 is the **image tool**, whose `content` parameter is a TypeBox union (`Type.Union([Type.String(), Type.Array(Type.String())])`) that compiles to:

```json
{
  "anyOf": [
    { "type": "string" },
    { "type": "array", "items": { "type": "string" } }
  ]
}
```

The existing `simplifyUnionVariants` in `cleanSchemaForGeminiWithDefs` handles two cases:
1. **Literal enum unions** — `tryFlattenLiteralAnyOf` flattens `[{ const: "a" }, { const: "b" }]` into `{ enum: ["a", "b"] }`
2. **Null stripping** — `stripNullVariants` removes `{ type: "null" }` variants and unwraps single-variant results

But non-literal, non-null unions like `string | array<string>` fall through — `anyOf` remains in the cleaned output and Google's API rejects it.

## Solution

After the main cleaning loop (which recursively cleans all nested schemas), check if `cleaned.anyOf` or `cleaned.oneOf` still exist. If so, apply `flattenUnionFallback`:

1. **Single variant** → unwrap it (spread the variant object)
2. **All same type** → collapse to `{ type: commonType }`
3. **Mixed types** → use the first variant's type
4. **No typed variants** → return empty schema with metadata

This is intentionally lossy — it picks a representative type rather than preserving the full union — but the alternative is a hard 400 from Google's API. The LLM can still understand the parameter from its description, and the execute function handles type coercion at runtime.

## Prior art

- **PR #18499** (merged then reverted) — original fix that included this logic plus provider-aware `normalizeToolParameters`. Reverted because the provider-aware approach was incorrect.
- **PR #19732** (merged in v2026.2.21) — fixed `sanitizeToolsForGoogle` to include `google-antigravity` and converted unsigned thinking blocks to text. Did not include `flattenUnionFallback`.
- **PR #20124** — related schema cleaning changes, also did not include `flattenUnionFallback`.

## Changes

Single file: `src/agents/schema/clean-for-gemini.ts`
- Add `flattenUnionFallback()` helper function
- Call it at the end of `cleanSchemaForGeminiWithDefs` for any remaining `anyOf`/`oneOf`

## Test plan

- [x] Verified TypeBox `Type.Union([Type.String(), Type.Array(Type.String())])` is flattened to `{ type: "string" }`
- [x] Verified existing `tryFlattenLiteralAnyOf` behavior unchanged (literal enums still handled before fallback)
- [x] Verified `cleanSchemaForGemini` remains idempotent
- [ ] No regressions for google-gemini-cli provider
- [ ] No regressions for non-Google providers (anyOf/oneOf preserved before `sanitizeToolsForGoogle` strips them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `flattenUnionFallback` function to eliminate nested `anyOf`/`oneOf` arrays that survive the existing simplification logic in `cleanSchemaForGeminiWithDefs`. This prevents 400 errors from Google's Cloud Code Assist API when tool schemas contain union types like `Type.Union([Type.String(), Type.Array(Type.String())])`.

- Added new `flattenUnionFallback()` helper that degrades unions to a single representative type (all same type → common type, mixed types → first variant's type)
- Integrated the fallback after the main cleaning loop to catch any remaining `anyOf`/`oneOf` keywords
- Completes the google-antigravity schema cleaning fix started in PR #19732

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase, addresses a specific API validation issue with a pragmatic fallback approach, and preserves metadata through `copySchemaMeta`. The logic is defensive with multiple checks for edge cases. However, the fallback is intentionally lossy (picks first type from mixed-type unions), which could theoretically cause runtime issues if LLMs pass incompatible types - though the PR description acknowledges this trade-off and notes that execute functions handle type coercion.
- No files require special attention

<sub>Last reviewed commit: 8680bd8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->