### PR TITLE
feat: add tools.nodes.notifyOnExit config flag

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -82,6 +82,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.loopDetection.detectors.pingPong": "Enable ping-pong loop detection (default: true).",
   "tools.exec.notifyOnExit":
     "When true (default), backgrounded exec sessions enqueue a system event and request a heartbeat on exit.",
+  "tools.nodes.notifyOnExit":
+    "When true (default), node exec events (started/finished/denied) enqueue system events and trigger heartbeats. Set to false to suppress duplicate notifications when results are already received inline from nodes.run.",
   "tools.exec.notifyOnExitEmptySuccess":
     "When true, successful backgrounded exec exits with empty output still enqueue a completion system event (default: false).",
   "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -84,6 +84,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.fs.workspaceOnly": "Workspace-only FS tools",
   "tools.sessions.visibility": "Session Tools Visibility",
   "tools.exec.notifyOnExit": "Exec Notify On Exit",
+  "tools.nodes.notifyOnExit": "Node Exec Notify On Exit",
   "tools.exec.notifyOnExitEmptySuccess": "Exec Notify On Empty Success",
   "tools.exec.approvalRunningNoticeMs": "Exec Approval Running Notice (ms)",
   "tools.exec.host": "Exec Host",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -257,6 +257,10 @@ export type AgentToolsConfig = {
   };
   /** Exec tool defaults for this agent. */
   exec?: ExecToolConfig;
+  nodes?: {
+    /** Emit system events and heartbeats for node exec events (started/finished/denied). Default: true. */
+    notifyOnExit?: boolean;
+  };
   /** Filesystem tool path guards. */
   fs?: FsToolsConfig;
   /** Runtime loop detection for repetitive/ stuck tool-call patterns. */
@@ -519,6 +523,10 @@ export type ToolsConfig = {
   };
   /** Exec tool defaults. */
   exec?: ExecToolConfig;
+  nodes?: {
+    /** Emit system events and heartbeats for node exec events (started/finished/denied). Default: true. */
+    notifyOnExit?: boolean;
+  };
   /** Filesystem tool path guards. */
   fs?: FsToolsConfig;
   /** Runtime loop detection for repetitive/ stuck tool-call patterns. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -433,6 +433,12 @@ export const AgentToolsSchema = z
       .strict()
       .optional(),
     exec: AgentToolExecSchema,
+    nodes: z
+      .object({
+        notifyOnExit: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     fs: ToolFsSchema,
     loopDetection: ToolLoopDetectionSchema,
     sandbox: z

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -676,6 +676,12 @@ export const ToolsSchema = z
       .strict()
       .optional(),
     exec: ToolExecSchema,
+    nodes: z
+      .object({
+        notifyOnExit: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     fs: ToolFsSchema,
     subagents: z
       .object({

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -31,8 +31,8 @@ vi.mock("./session-utils.js", () => ({
 
 import type { CliDeps } from "../cli/deps.js";
 import { agentCommand } from "../commands/agent.js";
-import { loadConfig } from "../config/config.js";
 import type { HealthSummary } from "../commands/health.js";
+import { loadConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -294,7 +294,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         return;
       }
       const sessionKeyRaw = typeof obj.sessionKey === "string" ? obj.sessionKey.trim() : "";
-      const cfg = loadConfig();
       const rawMainKey = normalizeMainKey(cfg.session?.mainKey);
       const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : rawMainKey;
       const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -522,6 +522,10 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       const timedOut = obj.timedOut === true;
       const output = typeof obj.output === "string" ? obj.output.trim() : "";
       const reason = typeof obj.reason === "string" ? obj.reason.trim() : "";
+      const cfg = loadConfig();
+      if (cfg?.tools?.nodes?.notifyOnExit === false) {
+        return;
+      }
 
       let text = "";
       if (evt.event === "exec.started") {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -274,6 +274,10 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!evt.payloadJSON) {
         return;
       }
+      const cfg = loadConfig();
+      if (cfg?.tools?.nodes?.notifyOnExit === false) {
+        return;
+      }
       let payload: unknown;
       try {
         payload = JSON.parse(evt.payloadJSON) as unknown;
@@ -500,6 +504,10 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!evt.payloadJSON) {
         return;
       }
+      const cfg = loadConfig();
+      if (cfg?.tools?.nodes?.notifyOnExit === false) {
+        return;
+      }
       let payload: unknown;
       try {
         payload = JSON.parse(evt.payloadJSON) as unknown;
@@ -522,10 +530,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       const timedOut = obj.timedOut === true;
       const output = typeof obj.output === "string" ? obj.output.trim() : "";
       const reason = typeof obj.reason === "string" ? obj.reason.trim() : "";
-      const cfg = loadConfig();
-      if (cfg?.tools?.nodes?.notifyOnExit === false) {
-        return;
-      }
 
       let text = "";
       if (evt.event === "exec.started") {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -274,10 +274,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!evt.payloadJSON) {
         return;
       }
-      const cfg = loadConfig();
-      if (cfg?.tools?.nodes?.notifyOnExit === false) {
-        return;
-      }
       let payload: unknown;
       try {
         payload = JSON.parse(evt.payloadJSON) as unknown;
@@ -294,6 +290,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         return;
       }
       const sessionKeyRaw = typeof obj.sessionKey === "string" ? obj.sessionKey.trim() : "";
+      const cfg = loadConfig();
       const rawMainKey = normalizeMainKey(cfg.session?.mainKey);
       const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : rawMainKey;
       const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);


### PR DESCRIPTION
Add a new config option `tools.nodes.notifyOnExit` (default: true) that controls whether node exec events (`exec.started`, `exec.finished`, `exec.denied`) enqueue system events and trigger heartbeats.

When set to `false`, these events are silently dropped. This prevents duplicate notifications when the agent already received results inline from `nodes.run`.

## Problem

Node `exec.finished` events always enqueue a system event + request heartbeat via `server-node-events`, regardless of config. `tools.exec.notifyOnExit: false` exists for gateway-local exec but there was no equivalent for node events.

This causes duplicate token-burning notifications:
1. Agent calls `nodes.run` → gets result inline
2. Node sends `exec.finished` event → gateway enqueues system event
3. Agent responds to both, doubling token usage

## Changes

- **Config schema** (`zod-schema.agent-runtime.ts`): Added `tools.nodes` object with `notifyOnExit` boolean
- **Config types** (`types.tools.ts`): Added `nodes` type with JSDoc
- **Config labels** (`schema.labels.ts`): Added UI label
- **Config help** (`schema.help.ts`): Added help text
- **Event handler** (`server-node-events.ts`): Early return when flag is `false`
- **Tests** (`server-node-events.test.ts`): Added suppression test with mocked config

## Usage

```json
{
  "tools": {
    "nodes": {
      "notifyOnExit": false
    }
  }
}
```

Fixes #22823

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `tools.nodes.notifyOnExit` config flag to prevent duplicate notifications when node exec results are already received inline via `nodes.run`. Implementation correctly handles config schema, types, labels, help text, and event suppression logic in `server-node-events.ts`.

**Key changes:**
- Config flag defaults to `true` (preserves existing behavior)
- Early return in event handler when flag is `false` suppresses both system event enqueueing and heartbeat requests
- Test coverage validates the suppression behavior

**Minor improvements suggested:**
- Moving config check earlier would improve performance when notifications are disabled
- Test could verify both `enqueueSystemEvent` and `requestHeartbeatNow` suppression
- Test coverage could include all three event types (`exec.started`, `exec.finished`, `exec.denied`)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor optimization opportunities
- Implementation is correct and well-tested. Config schema, types, and event handling logic are properly integrated. Suggested improvements are non-critical optimizations (earlier config check, enhanced test assertions) that don't affect correctness
- No files require special attention - all changes follow established patterns

<sub>Last reviewed commit: 7885803</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->