### PR TITLE
feat(line): add push-only deliveryMode

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -41,6 +41,13 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
     ...meta,
     quickstartAllowFrom: true,
   },
+  // LINE tends to receive short bursts ("??" / follow-ups). Debounce helps coalesce
+  // and reduces queued-message meta spam when the agent is briefly busy.
+  defaults: {
+    queue: {
+      debounceMs: 1200,
+    },
+  },
   pairing: {
     idLabel: "lineUserId",
     normalizeAllowEntry: (entry) => {

--- a/src/line/config-schema.ts
+++ b/src/line/config-schema.ts
@@ -13,6 +13,8 @@ const LineGroupConfigSchema = z
   })
   .strict();
 
+const DeliveryModeSchema = z.enum(["auto", "push"]);
+
 const LineAccountConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -27,6 +29,7 @@ const LineAccountConfigSchema = z
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     mediaMaxMb: z.number().optional(),
     webhookPath: z.string().optional(),
+    deliveryMode: DeliveryModeSchema.optional().default("auto"),
     groups: z.record(z.string(), LineGroupConfigSchema.optional()).optional(),
   })
   .strict();
@@ -45,6 +48,7 @@ export const LineConfigSchema = z
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     mediaMaxMb: z.number().optional(),
     webhookPath: z.string().optional(),
+    deliveryMode: DeliveryModeSchema.optional().default("auto"),
     accounts: z.record(z.string(), LineAccountConfigSchema.optional()).optional(),
     groups: z.record(z.string(), LineGroupConfigSchema.optional()).optional(),
   })

--- a/src/line/types.ts
+++ b/src/line/types.ts
@@ -10,6 +10,8 @@ import type {
 
 export type LineTokenSource = "config" | "env" | "file" | "none";
 
+export type LineDeliveryMode = "auto" | "push";
+
 export interface LineConfig {
   enabled?: boolean;
   channelAccessToken?: string;
@@ -23,6 +25,7 @@ export interface LineConfig {
   groupPolicy?: "open" | "allowlist" | "disabled";
   mediaMaxMb?: number;
   webhookPath?: string;
+  deliveryMode?: LineDeliveryMode;
   accounts?: Record<string, LineAccountConfig>;
   groups?: Record<string, LineGroupConfig>;
 }
@@ -40,6 +43,7 @@ export interface LineAccountConfig {
   groupPolicy?: "open" | "allowlist" | "disabled";
   mediaMaxMb?: number;
   webhookPath?: string;
+  deliveryMode?: LineDeliveryMode;
   groups?: Record<string, LineGroupConfig>;
 }
 


### PR DESCRIPTION
### What
Add `channels.line.deliveryMode` config option ("auto" | "push").

- `auto` (default): current behavior (reply token when possible, fallback to push)
- `push`: disable reply-token usage and always push (reduces failures due to reply token expiry / queued delays)

Also ensure push target uses raw `ctx.userId` when available to avoid LINE push 404 caused by prefixed addresses.

### Tests
- Add unit test to ensure when `replyToken` is undefined, `deliverLineAutoReply` never calls `replyMessageLine` and uses push path.

### Why
Improve reliability on LINE where reply tokens expire quickly (~1 minute) and long/queued agent work can cause reply failures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds configurable `deliveryMode` option for LINE channel to support push-only delivery, avoiding reply token expiry issues. When set to `"push"`, the system bypasses reply tokens entirely and uses push API for all messages. The change correctly uses raw `userId` for push targets (avoiding the `line:` prefix that exists in `ctxPayload.From`), includes proper error handling for push-only mode, and adds test coverage for the new behavior.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-implemented feature with proper defaults and test coverage
- The implementation is clean, maintains backward compatibility with `"auto"` as the default, includes comprehensive test coverage, and follows the repository's existing patterns. The logic correctly differentiates between reply token and push delivery paths.
- No files require special attention

<sub>Last reviewed commit: 1fecf20</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->