### PR TITLE
Pass agentDir through cron and followup embedded runs

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -301,6 +301,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
 
 describe("createFollowupRunner passes agentDir to embedded run", () => {
   it("uses queued run agentDir when invoking runEmbeddedPiAgent", async () => {
+    runEmbeddedPiAgentMock.mockClear();
     const onBlockReply = vi.fn(async () => {});
     const agentDir = path.join("/tmp", "agent-dir");
     const queued = baseQueuedRun();

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -298,3 +298,35 @@ describe("createFollowupRunner messaging tool dedupe", () => {
     expect(store[sessionKey]?.outputTokens).toBe(50);
   });
 });
+
+describe("createFollowupRunner passes agentDir to embedded run", () => {
+  it("uses queued run agentDir when invoking runEmbeddedPiAgent", async () => {
+    const onBlockReply = vi.fn(async () => {});
+    const agentDir = path.join("/tmp", "agent-dir");
+    const queued = baseQueuedRun();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTexts: ["different message"],
+      meta: {},
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+
+    await runner({
+      ...queued,
+      run: {
+        ...queued.run,
+        agentDir,
+      },
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const call = runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0] as { agentDir?: string };
+    expect(call?.agentDir).toBe(agentDir);
+  });
+});

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -154,6 +154,7 @@ export function createFollowupRunner(params: {
               senderE164: queued.run.senderE164,
               senderIsOwner: queued.run.senderIsOwner,
               sessionFile: queued.run.sessionFile,
+              agentDir: queued.run.agentDir,
               workspaceDir: queued.run.workspaceDir,
               config: queued.run.config,
               skillsSnapshot: queued.run.skillsSnapshot,

--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.e2e.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.e2e.test.ts
@@ -298,7 +298,6 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
-
   it("uses model override when provided", async () => {
     await withTempHome(async (home) => {
       const { res } = await runCronTurn(home, {

--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.e2e.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.e2e.test.ts
@@ -251,6 +251,54 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("passes resolved agentDir to runEmbeddedPiAgent", async () => {
+    await withTempHome(async (home) => {
+      const deps = makeDeps();
+      const opsWorkspace = path.join(home, "ops-workspace");
+      const opsAgentDir = path.join(home, ".openclaw", "agents", "ops", "agent");
+      mockEmbeddedOk();
+
+      const cfg = makeCfg(
+        home,
+        path.join(home, ".openclaw", "agents", "{agentId}", "sessions", "sessions.json"),
+        {
+          agents: {
+            defaults: { workspace: path.join(home, "default-workspace") },
+            list: [
+              { id: "main", default: true },
+              { id: "ops", workspace: opsWorkspace, agentDir: opsAgentDir },
+            ],
+          },
+        },
+      );
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg,
+        deps,
+        job: {
+          ...makeJob({
+            kind: "agentTurn",
+            message: DEFAULT_MESSAGE,
+            deliver: false,
+            channel: "last",
+          }),
+          agentId: "ops",
+        },
+        message: DEFAULT_MESSAGE,
+        sessionKey: "cron:job-ops",
+        agentId: "ops",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0] as {
+        agentDir?: string;
+      };
+      expect(call?.agentDir).toBe(opsAgentDir);
+    });
+  });
+
+
   it("uses model override when provided", async () => {
     await withTempHome(async (home) => {
       const { res } = await runCronTurn(home, {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -483,6 +483,7 @@ export async function runCronIsolatedAgentTurn(params: {
           messageChannel,
           agentAccountId: resolvedDelivery.accountId,
           sessionFile,
+          agentDir,
           workspaceDir,
           config: cfgWithAgentDefaults,
           skillsSnapshot,


### PR DESCRIPTION
## Summary
- Pass `agentDir` into `runEmbeddedPiAgent` in cron and follow-up runner execution paths.
- Add focused regression tests for agentDir forwarding.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Scope
- [x] Targeted bugfix (small, non-breaking)
- [ ] Broad behavior change
- [ ] New feature surface

## Changes
- `src/cron/isolated-agent/run.ts`: pass `agentDir` into `runEmbeddedPiAgent` when running cron jobs.
- `src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`: add regression test asserting `agentDir` is forwarded for cron runs.
- `src/auto-reply/reply/followup-runner.ts`: pass `queued.run.agentDir` into `runEmbeddedPiAgent`.
- `src/auto-reply/reply/followup-runner.test.ts`: add regression test for the follow-up path.

## Why
`runEmbeddedPiAgent` resolves provider credentials from `agentDir` and defaults to `main` when missing. In these paths, the directory was not being passed, causing non-default jobs to potentially use the wrong auth store and fail with provider key errors.

## Security impact
- **Low**: The change is additive parameter threading only.
- It reduces cross-agent auth cross-usage risk by explicitly using the job/queue-owned agent directory.

## Verification
Could not run the test suite in this environment because project dependencies are not installed in this container.
- PR scope is limited to auth-path threading plus regression tests.
- Recommended command for maintainers:
  - `pnpm test src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts src/auto-reply/reply/followup-runner.test.ts`

## Human verification
- Confirmed local behavioral expectation by tracing run flow around:
  - `runCronIsolatedAgentTurn` (cron path)
  - `createFollowupRunner` (queued follow-ups)

## Failure recovery
- Revert this PR if any unexpected auth-path behavior is observed; the changes are isolated and can be dropped safely.

## Issue
Closes #22842

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `agentDir` was resolved but not passed through to `runEmbeddedPiAgent` in two code paths: the followup runner (auto-reply) and the cron isolated-agent runner. In both cases, `agentDir` was already being passed to `runWithModelFallback` but was missing from the inner `runEmbeddedPiAgent` call, meaning embedded agent runs would not respect per-agent directory configuration.

- Adds `agentDir: queued.run.agentDir` to the `runEmbeddedPiAgent` call in `src/auto-reply/reply/followup-runner.ts`
- Adds `agentDir` to the `runEmbeddedPiAgent` call in `src/cron/isolated-agent/run.ts`
- Removes unused `formatXHighModelHint` import from `src/cron/isolated-agent/run.ts`
- Adds test coverage for both paths verifying `agentDir` propagation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a missing parameter propagation with proper test coverage.
- The changes are minimal and focused: two one-line additions passing an already-resolved `agentDir` variable through to `runEmbeddedPiAgent`, one unused import removal, and two well-structured tests. The `agentDir` parameter is already typed as optional in `RunEmbeddedPiAgentParams`, the variable is already in scope at both call sites, and both tests verify correct propagation. No logic changes, no new dependencies, no security implications.
- No files require special attention

<sub>Last reviewed commit: 732ebc9</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->