### PR TITLE
Gateway: add eager secrets runtime snapshot activation

### DIFF
--- a/src/agents/auth-profiles.readonly-sync.test.ts
+++ b/src/agents/auth-profiles.readonly-sync.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
+
+const mocks = vi.hoisted(() => ({
+  syncExternalCliCredentials: vi.fn((store: AuthProfileStore) => {
+    store.profiles["qwen-portal:default"] = {
+      type: "oauth",
+      provider: "qwen-portal",
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+    };
+    return true;
+  }),
+}));
+
+vi.mock("./auth-profiles/external-cli-sync.js", () => ({
+  syncExternalCliCredentials: mocks.syncExternalCliCredentials,
+}));
+
+const { loadAuthProfileStoreForRuntime } = await import("./auth-profiles.js");
+
+describe("auth profiles read-only external CLI sync", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("syncs external CLI credentials in-memory without writing auth-profiles.json in read-only mode", () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-readonly-sync-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const baseline: AuthProfileStore = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-test",
+          },
+        },
+      };
+      fs.writeFileSync(authPath, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+
+      const loaded = loadAuthProfileStoreForRuntime(agentDir, { readOnly: true });
+
+      expect(mocks.syncExternalCliCredentials).toHaveBeenCalled();
+      expect(loaded.profiles["qwen-portal:default"]).toMatchObject({
+        type: "oauth",
+        provider: "qwen-portal",
+      });
+
+      const persisted = JSON.parse(fs.readFileSync(authPath, "utf8")) as AuthProfileStore;
+      expect(persisted.profiles["qwen-portal:default"]).toBeUndefined();
+      expect(persisted.profiles["openai:default"]).toMatchObject({
+        type: "api_key",
+        provider: "openai",
+        key: "sk-test",
+      });
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -17,7 +17,10 @@ export {
   suggestOAuthProfileIdForLegacyDefault,
 } from "./auth-profiles/repair.js";
 export {
+  clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
+  loadAuthProfileStoreForRuntime,
+  replaceRuntimeAuthProfileStoreSnapshots,
   loadAuthProfileStore,
   saveAuthProfileStore,
 } from "./auth-profiles/store.js";

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -19,6 +19,7 @@ export {
 export {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
+  loadAuthProfileStoreForSecretsRuntime,
   loadAuthProfileStoreForRuntime,
   replaceRuntimeAuthProfileStoreSnapshots,
   loadAuthProfileStore,

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -1,10 +1,12 @@
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { SecretRef } from "../../config/types.secrets.js";
 
 export type ApiKeyCredential = {
   type: "api_key";
   provider: string;
   key?: string;
+  keyRef?: SecretRef;
   email?: string;
   /** Optional provider-specific metadata (e.g., account IDs, gateway IDs). */
   metadata?: Record<string, string>;
@@ -18,6 +20,7 @@ export type TokenCredential = {
   type: "token";
   provider: string;
   token: string;
+  tokenRef?: SecretRef;
   /** Optional expiry timestamp (ms since epoch). */
   expires?: number;
   email?: string;

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyPrimaryModel } from "./model-picker.js";
 import { normalizeAlias } from "./models/shared.js";
@@ -541,7 +542,7 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   const mergedModels = hasModel ? existingModels : [...existingModels, nextModel];
   const { apiKey: existingApiKey, ...existingProviderRest } = existingProvider ?? {};
   const normalizedApiKey =
-    params.apiKey?.trim() || (existingApiKey ? existingApiKey.trim() : undefined);
+    normalizeOptionalSecretInput(params.apiKey) ?? normalizeOptionalSecretInput(existingApiKey);
 
   let config: OpenClawConfig = {
     ...params.config,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,11 +1,14 @@
 export {
   clearConfigCache,
+  clearRuntimeConfigSnapshot,
   createConfigIO,
+  getRuntimeConfigSnapshot,
   loadConfig,
   parseConfigJson5,
   readConfigFileSnapshot,
   readConfigFileSnapshotForWrite,
   resolveConfigSnapshotHash,
+  setRuntimeConfigSnapshot,
   writeConfigFile,
 } from "./io.js";
 export { migrateLegacyConfig } from "./legacy-migrate.js";

--- a/src/config/io.runtime-snapshot-write.test.ts
+++ b/src/config/io.runtime-snapshot-write.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "./home-env.test-harness.js";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+  loadConfig,
+  setRuntimeConfigSnapshot,
+  writeConfigFile,
+} from "./io.js";
+import type { OpenClawConfig } from "./types.js";
+
+describe("runtime config snapshot writes", () => {
+  it("preserves source secret refs when writeConfigFile receives runtime-resolved config", async () => {
+    await withTempHome("openclaw-config-runtime-write-", async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const sourceConfig: OpenClawConfig = {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: { source: "env", id: "OPENAI_API_KEY" },
+              models: [],
+            },
+          },
+        },
+      };
+      const runtimeConfig: OpenClawConfig = {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: "sk-runtime-resolved",
+              models: [],
+            },
+          },
+        },
+      };
+
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, `${JSON.stringify(sourceConfig, null, 2)}\n`, "utf8");
+
+      try {
+        setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+        expect(loadConfig().models?.providers?.openai?.apiKey).toBe("sk-runtime-resolved");
+
+        await writeConfigFile(loadConfig());
+
+        const persisted = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+          models?: { providers?: { openai?: { apiKey?: unknown } } };
+        };
+        expect(persisted.models?.providers?.openai?.apiKey).toEqual({
+          source: "env",
+          id: "OPENAI_API_KEY",
+        });
+      } finally {
+        clearRuntimeConfigSnapshot();
+        clearConfigCache();
+      }
+    });
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1280,6 +1280,7 @@ let configCache: {
   expiresAt: number;
   config: OpenClawConfig;
 } | null = null;
+let runtimeConfigSnapshot: OpenClawConfig | null = null;
 
 function resolveConfigCacheMs(env: NodeJS.ProcessEnv): number {
   const raw = env.OPENCLAW_CONFIG_CACHE_MS?.trim();
@@ -1307,7 +1308,24 @@ export function clearConfigCache(): void {
   configCache = null;
 }
 
+export function setRuntimeConfigSnapshot(config: OpenClawConfig): void {
+  runtimeConfigSnapshot = config;
+  clearConfigCache();
+}
+
+export function clearRuntimeConfigSnapshot(): void {
+  runtimeConfigSnapshot = null;
+  clearConfigCache();
+}
+
+export function getRuntimeConfigSnapshot(): OpenClawConfig | null {
+  return runtimeConfigSnapshot;
+}
+
 export function loadConfig(): OpenClawConfig {
+  if (runtimeConfigSnapshot) {
+    return runtimeConfigSnapshot;
+  }
   const io = createConfigIO();
   const configPath = io.configPath;
   const now = Date.now();

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -1,3 +1,5 @@
+import type { SecretInput } from "./types.secrets.js";
+
 export type ModelApi =
   | "openai-completions"
   | "openai-responses"
@@ -43,7 +45,7 @@ export type ModelDefinitionConfig = {
 
 export type ModelProviderConfig = {
   baseUrl: string;
-  apiKey?: string;
+  apiKey?: SecretInput;
   auth?: ModelProviderAuthMode;
   api?: ModelApi;
   headers?: Record<string, string>;

--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -13,6 +13,24 @@ export type SecretRef = {
 
 export type SecretInput = string | SecretRef;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isSecretRef(value: unknown): value is SecretRef {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (Object.keys(value).length !== 2) {
+    return false;
+  }
+  return (
+    (value.source === "env" || value.source === "file") &&
+    typeof value.id === "string" &&
+    value.id.trim().length > 0
+  );
+}
+
 export type EnvSecretSourceConfig = {
   type?: "env";
 };

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -255,7 +255,7 @@ export function startGatewayConfigReloader(opts: {
   initialConfig: OpenClawConfig;
   readSnapshot: () => Promise<ConfigFileSnapshot>;
   onHotReload: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => Promise<void>;
-  onRestart: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void;
+  onRestart: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
   log: {
     info: (msg: string) => void;
     warn: (msg: string) => void;

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -291,7 +291,7 @@ export function startGatewayConfigReloader(opts: {
       return;
     }
     restartQueued = true;
-    opts.onRestart(plan, nextConfig);
+    void opts.onRestart(plan, nextConfig);
   };
 
   const handleMissingSnapshot = (snapshot: ConfigFileSnapshot): boolean => {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -291,11 +291,10 @@ export async function startGatewayServer(
           : "Unknown validation issue.";
       throw new Error(`Invalid config at ${freshSnapshot.path}.\n${issues}`);
     }
-    const prepared = await activateRuntimeSecrets(freshSnapshot.config, {
+    await activateRuntimeSecrets(freshSnapshot.config, {
       reason: "startup",
-      activate: true,
+      activate: false,
     });
-    cfgAtStart = prepared.config;
   }
 
   cfgAtStart = loadConfig();

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -11,6 +11,7 @@ import { createDefaultDeps } from "../cli/deps.js";
 import { isRestartEnabled } from "../config/commands.js";
 import {
   CONFIG_PATH,
+  type OpenClawConfig,
   isNixMode,
   loadConfig,
   migrateLegacyConfig,
@@ -45,6 +46,12 @@ import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
 import type { RuntimeEnv } from "../runtime.js";
+import {
+  activateSecretsRuntimeSnapshot,
+  clearSecretsRuntimeSnapshot,
+  getActiveSecretsRuntimeSnapshot,
+  prepareSecretsRuntimeSnapshot,
+} from "../secrets/runtime.js";
 import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
@@ -107,6 +114,7 @@ const logReload = log.child("reload");
 const logHooks = log.child("hooks");
 const logPlugins = log.child("plugins");
 const logWsControl = log.child("ws");
+const logSecrets = log.child("secrets");
 const gatewayRuntime = runtimeForLogger(log);
 const canvasRuntime = runtimeForLogger(logCanvas);
 
@@ -233,7 +241,64 @@ export async function startGatewayServer(
     }
   }
 
-  let cfgAtStart = loadConfig();
+  let secretsDegraded = false;
+  const activateRuntimeSecrets = async (
+    config: OpenClawConfig,
+    params: { reason: "startup" | "reload" | "restart-check"; activate: boolean },
+  ) => {
+    try {
+      const prepared = await prepareSecretsRuntimeSnapshot({ config });
+      if (params.activate) {
+        activateSecretsRuntimeSnapshot(prepared);
+      }
+      for (const warning of prepared.warnings) {
+        logSecrets.warn(`[${warning.code}] ${warning.message}`);
+      }
+      if (secretsDegraded) {
+        logSecrets.info(
+          "[SECRETS_RELOADER_RECOVERED] Secret resolution recovered; runtime remained on last-known-good during the outage.",
+        );
+      }
+      secretsDegraded = false;
+      return prepared;
+    } catch (err) {
+      const details = String(err);
+      if (!secretsDegraded) {
+        logSecrets.error(`[SECRETS_RELOADER_DEGRADED] ${details}`);
+      } else {
+        logSecrets.warn(`[SECRETS_RELOADER_DEGRADED] ${details}`);
+      }
+      secretsDegraded = true;
+      if (params.reason === "startup") {
+        throw new Error(`Startup failed: required secrets are unavailable. ${details}`, {
+          cause: err,
+        });
+      }
+      throw err;
+    }
+  };
+
+  // Fail fast before startup if required refs are unresolved.
+  let cfgAtStart: OpenClawConfig;
+  {
+    const freshSnapshot = await readConfigFileSnapshot();
+    if (!freshSnapshot.valid) {
+      const issues =
+        freshSnapshot.issues.length > 0
+          ? freshSnapshot.issues
+              .map((issue) => `${issue.path || "<root>"}: ${issue.message}`)
+              .join("\n")
+          : "Unknown validation issue.";
+      throw new Error(`Invalid config at ${freshSnapshot.path}.\n${issues}`);
+    }
+    const prepared = await activateRuntimeSecrets(freshSnapshot.config, {
+      reason: "startup",
+      activate: true,
+    });
+    cfgAtStart = prepared.config;
+  }
+
+  cfgAtStart = loadConfig();
   const authBootstrap = await ensureGatewayStartupAuth({
     cfg: cfgAtStart,
     env: process.env,
@@ -253,6 +318,12 @@ export async function startGatewayServer(
       );
     }
   }
+  cfgAtStart = (
+    await activateRuntimeSecrets(cfgAtStart, {
+      reason: "startup",
+      activate: true,
+    })
+  ).config;
   const diagnosticsEnabled = isDiagnosticsEnabled(cfgAtStart);
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat();
@@ -723,8 +794,27 @@ export async function startGatewayServer(
         return startGatewayConfigReloader({
           initialConfig: cfgAtStart,
           readSnapshot: readConfigFileSnapshot,
-          onHotReload: applyHotReload,
-          onRestart: requestGatewayRestart,
+          onHotReload: async (plan, nextConfig) => {
+            const previousSnapshot = getActiveSecretsRuntimeSnapshot();
+            const prepared = await activateRuntimeSecrets(nextConfig, {
+              reason: "reload",
+              activate: true,
+            });
+            try {
+              await applyHotReload(plan, prepared.config);
+            } catch (err) {
+              if (previousSnapshot) {
+                activateSecretsRuntimeSnapshot(previousSnapshot);
+              } else {
+                clearSecretsRuntimeSnapshot();
+              }
+              throw err;
+            }
+          },
+          onRestart: async (plan, nextConfig) => {
+            await activateRuntimeSecrets(nextConfig, { reason: "restart-check", activate: false });
+            requestGatewayRestart(plan, nextConfig);
+          },
           log: {
             info: (msg) => logReload.info(msg),
             warn: (msg) => logReload.warn(msg),
@@ -778,6 +868,7 @@ export async function startGatewayServer(
       skillsChangeUnsub();
       authRateLimiter?.dispose();
       channelHealthMonitor?.stop();
+      clearSecretsRuntimeSnapshot();
       await close(opts);
     },
   };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -19,6 +19,7 @@ import {
   writeConfigFile,
 } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -38,6 +39,7 @@ import {
   refreshRemoteBinsForConnectedNodes,
   setSkillsRemoteRegistry,
 } from "../infra/skills-remote.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
@@ -242,6 +244,16 @@ export async function startGatewayServer(
   }
 
   let secretsDegraded = false;
+  const emitSecretsStateEvent = (
+    code: "SECRETS_RELOADER_DEGRADED" | "SECRETS_RELOADER_RECOVERED",
+    message: string,
+    cfg: OpenClawConfig,
+  ) => {
+    enqueueSystemEvent(`[${code}] ${message}`, {
+      sessionKey: resolveMainSessionKey(cfg),
+      contextKey: code,
+    });
+  };
   const activateRuntimeSecrets = async (
     config: OpenClawConfig,
     params: { reason: "startup" | "reload" | "restart-check"; activate: boolean },
@@ -255,9 +267,10 @@ export async function startGatewayServer(
         logSecrets.warn(`[${warning.code}] ${warning.message}`);
       }
       if (secretsDegraded) {
-        logSecrets.info(
-          "[SECRETS_RELOADER_RECOVERED] Secret resolution recovered; runtime remained on last-known-good during the outage.",
-        );
+        const recoveredMessage =
+          "Secret resolution recovered; runtime remained on last-known-good during the outage.";
+        logSecrets.info(`[SECRETS_RELOADER_RECOVERED] ${recoveredMessage}`);
+        emitSecretsStateEvent("SECRETS_RELOADER_RECOVERED", recoveredMessage, prepared.config);
       }
       secretsDegraded = false;
       return prepared;
@@ -265,6 +278,13 @@ export async function startGatewayServer(
       const details = String(err);
       if (!secretsDegraded) {
         logSecrets.error(`[SECRETS_RELOADER_DEGRADED] ${details}`);
+        if (params.reason !== "startup") {
+          emitSecretsStateEvent(
+            "SECRETS_RELOADER_DEGRADED",
+            `Secret resolution failed; runtime remains on last-known-good snapshot. ${details}`,
+            config,
+          );
+        }
       } else {
         logSecrets.warn(`[SECRETS_RELOADER_DEGRADED] ${details}`);
       }

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -281,7 +281,7 @@ describe("gateway hot reload", () => {
       const signalSpy = vi.fn();
       process.once("SIGUSR1", signalSpy);
 
-      onRestart?.(
+      const restartResult = onRestart?.(
         {
           changedPaths: ["gateway.port"],
           restartGateway: true,
@@ -297,6 +297,7 @@ describe("gateway hot reload", () => {
         },
         {},
       );
+      await Promise.resolve(restartResult);
 
       expect(signalSpy).toHaveBeenCalledTimes(1);
     });

--- a/src/secrets/json-pointer.ts
+++ b/src/secrets/json-pointer.ts
@@ -1,0 +1,94 @@
+function failOrUndefined(params: { onMissing: "throw" | "undefined"; message: string }): undefined {
+  if (params.onMissing === "throw") {
+    throw new Error(params.message);
+  }
+  return undefined;
+}
+
+export function decodeJsonPointerToken(token: string): string {
+  return token.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+export function encodeJsonPointerToken(token: string): string {
+  return token.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+export function readJsonPointer(
+  root: unknown,
+  pointer: string,
+  options: { onMissing?: "throw" | "undefined" } = {},
+): unknown {
+  const onMissing = options.onMissing ?? "throw";
+  if (!pointer.startsWith("/")) {
+    return failOrUndefined({
+      onMissing,
+      message:
+        'File-backed secret ids must be absolute JSON pointers (for example: "/providers/openai/apiKey").',
+    });
+  }
+
+  const tokens = pointer
+    .slice(1)
+    .split("/")
+    .map((token) => decodeJsonPointerToken(token));
+
+  let current: unknown = root;
+  for (const token of tokens) {
+    if (Array.isArray(current)) {
+      const index = Number.parseInt(token, 10);
+      if (!Number.isFinite(index) || index < 0 || index >= current.length) {
+        return failOrUndefined({
+          onMissing,
+          message: `JSON pointer segment "${token}" is out of bounds.`,
+        });
+      }
+      current = current[index];
+      continue;
+    }
+    if (typeof current !== "object" || current === null || Array.isArray(current)) {
+      return failOrUndefined({
+        onMissing,
+        message: `JSON pointer segment "${token}" does not exist.`,
+      });
+    }
+    const record = current as Record<string, unknown>;
+    if (!Object.hasOwn(record, token)) {
+      return failOrUndefined({
+        onMissing,
+        message: `JSON pointer segment "${token}" does not exist.`,
+      });
+    }
+    current = record[token];
+  }
+  return current;
+}
+
+export function setJsonPointer(
+  root: Record<string, unknown>,
+  pointer: string,
+  value: unknown,
+): void {
+  if (!pointer.startsWith("/")) {
+    throw new Error(`Invalid JSON pointer "${pointer}".`);
+  }
+
+  const tokens = pointer
+    .slice(1)
+    .split("/")
+    .map((token) => decodeJsonPointerToken(token));
+
+  let current: Record<string, unknown> = root;
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    const isLast = index === tokens.length - 1;
+    if (isLast) {
+      current[token] = value;
+      return;
+    }
+    const child = current[token];
+    if (typeof child !== "object" || child === null || Array.isArray(child)) {
+      current[token] = {};
+    }
+    current = current[token] as Record<string, unknown>;
+  }
+}

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -1,0 +1,28 @@
+export const PROVIDER_ENV_VARS: Record<string, readonly string[]> = {
+  openai: ["OPENAI_API_KEY"],
+  anthropic: ["ANTHROPIC_API_KEY"],
+  google: ["GEMINI_API_KEY"],
+  minimax: ["MINIMAX_API_KEY"],
+  "minimax-cn": ["MINIMAX_API_KEY"],
+  moonshot: ["MOONSHOT_API_KEY"],
+  "kimi-coding": ["KIMI_API_KEY", "KIMICODE_API_KEY"],
+  synthetic: ["SYNTHETIC_API_KEY"],
+  venice: ["VENICE_API_KEY"],
+  zai: ["ZAI_API_KEY", "Z_AI_API_KEY"],
+  xiaomi: ["XIAOMI_API_KEY"],
+  openrouter: ["OPENROUTER_API_KEY"],
+  "cloudflare-ai-gateway": ["CLOUDFLARE_AI_GATEWAY_API_KEY"],
+  litellm: ["LITELLM_API_KEY"],
+  "vercel-ai-gateway": ["AI_GATEWAY_API_KEY"],
+  opencode: ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"],
+  together: ["TOGETHER_API_KEY"],
+  huggingface: ["HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"],
+  qianfan: ["QIANFAN_API_KEY"],
+  xai: ["XAI_API_KEY"],
+  volcengine: ["VOLCANO_ENGINE_API_KEY"],
+  byteplus: ["BYTEPLUS_API_KEY"],
+};
+
+export function listKnownSecretEnvVarNames(): string[] {
+  return [...new Set(Object.values(PROVIDER_ENV_VARS).flatMap((keys) => keys))];
+}

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -1,0 +1,85 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { SecretRef } from "../config/types.secrets.js";
+import { resolveUserPath } from "../utils.js";
+import { readJsonPointer } from "./json-pointer.js";
+import { isNonEmptyString, normalizePositiveInt } from "./shared.js";
+import { decryptSopsJsonFile, DEFAULT_SOPS_TIMEOUT_MS } from "./sops.js";
+
+export type SecretRefResolveCache = {
+  fileSecretsPromise?: Promise<unknown> | null;
+};
+
+type ResolveSecretRefOptions = {
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  cache?: SecretRefResolveCache;
+  missingBinaryMessage?: string;
+};
+
+const DEFAULT_SOPS_MISSING_BINARY_MESSAGE =
+  "sops binary not found in PATH. Install sops >= 3.9.0 or disable secrets.sources.file.";
+
+async function resolveFileSecretPayload(options: ResolveSecretRefOptions): Promise<unknown> {
+  const fileSource = options.config.secrets?.sources?.file;
+  if (!fileSource) {
+    throw new Error(
+      'Secret reference source "file" is not configured. Configure secrets.sources.file first.',
+    );
+  }
+  if (fileSource.type !== "sops") {
+    throw new Error(`Unsupported secrets.sources.file.type "${String(fileSource.type)}".`);
+  }
+
+  const cache = options.cache;
+  if (cache?.fileSecretsPromise) {
+    return await cache.fileSecretsPromise;
+  }
+
+  const promise = decryptSopsJsonFile({
+    path: resolveUserPath(fileSource.path),
+    timeoutMs: normalizePositiveInt(fileSource.timeoutMs, DEFAULT_SOPS_TIMEOUT_MS),
+    missingBinaryMessage: options.missingBinaryMessage ?? DEFAULT_SOPS_MISSING_BINARY_MESSAGE,
+  });
+  if (cache) {
+    cache.fileSecretsPromise = promise;
+  }
+  return await promise;
+}
+
+export async function resolveSecretRefValue(
+  ref: SecretRef,
+  options: ResolveSecretRefOptions,
+): Promise<unknown> {
+  const id = ref.id.trim();
+  if (!id) {
+    throw new Error("Secret reference id is empty.");
+  }
+
+  if (ref.source === "env") {
+    const envValue = options.env?.[id] ?? process.env[id];
+    if (!isNonEmptyString(envValue)) {
+      throw new Error(`Environment variable "${id}" is missing or empty.`);
+    }
+    return envValue;
+  }
+
+  if (ref.source === "file") {
+    const payload = await resolveFileSecretPayload(options);
+    return readJsonPointer(payload, id, { onMissing: "throw" });
+  }
+
+  throw new Error(`Unsupported secret source "${String((ref as { source?: unknown }).source)}".`);
+}
+
+export async function resolveSecretRefString(
+  ref: SecretRef,
+  options: ResolveSecretRefOptions,
+): Promise<string> {
+  const resolved = await resolveSecretRefValue(ref, options);
+  if (!isNonEmptyString(resolved)) {
+    throw new Error(
+      `Secret reference "${ref.source}:${ref.id}" resolved to a non-string or empty value.`,
+    );
+  }
+  return resolved;
+}

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
+import { loadConfig, type OpenClawConfig } from "../config/config.js";
+import {
+  activateSecretsRuntimeSnapshot,
+  clearSecretsRuntimeSnapshot,
+  prepareSecretsRuntimeSnapshot,
+} from "./runtime.js";
+
+const runExecMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../process/exec.js", () => ({
+  runExec: runExecMock,
+}));
+
+describe("secrets runtime snapshot", () => {
+  afterEach(() => {
+    runExecMock.mockReset();
+    clearSecretsRuntimeSnapshot();
+  });
+
+  it("resolves env refs for config and auth profiles", async () => {
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: { source: "env", id: "OPENAI_API_KEY" },
+            models: [],
+          },
+        },
+      },
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env: {
+        OPENAI_API_KEY: "sk-env-openai",
+        GITHUB_TOKEN: "ghp-env-token",
+      },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => ({
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "old-openai",
+            keyRef: { source: "env", id: "OPENAI_API_KEY" },
+          },
+          "github-copilot:default": {
+            type: "token",
+            provider: "github-copilot",
+            token: "old-gh",
+            tokenRef: { source: "env", id: "GITHUB_TOKEN" },
+          },
+        },
+      }),
+    });
+
+    expect(snapshot.config.models?.providers?.openai?.apiKey).toBe("sk-env-openai");
+    expect(snapshot.warnings).toHaveLength(2);
+    expect(snapshot.authStores[0]?.store.profiles["openai:default"]).toMatchObject({
+      type: "api_key",
+      key: "sk-env-openai",
+    });
+    expect(snapshot.authStores[0]?.store.profiles["github-copilot:default"]).toMatchObject({
+      type: "token",
+      token: "ghp-env-token",
+    });
+  });
+
+  it("resolves file refs via sops json payload", async () => {
+    runExecMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        providers: {
+          openai: {
+            apiKey: "sk-from-sops",
+          },
+        },
+      }),
+      stderr: "",
+    });
+
+    const config: OpenClawConfig = {
+      secrets: {
+        sources: {
+          file: {
+            type: "sops",
+            path: "~/.openclaw/secrets.enc.json",
+            timeoutMs: 7000,
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: { source: "file", id: "/providers/openai/apiKey" },
+            models: [],
+          },
+        },
+      },
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+
+    expect(snapshot.config.models?.providers?.openai?.apiKey).toBe("sk-from-sops");
+    expect(runExecMock).toHaveBeenCalledWith(
+      "sops",
+      ["--decrypt", "--output-type", "json", expect.stringContaining("secrets.enc.json")],
+      {
+        timeoutMs: 7000,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+  });
+
+  it("activates runtime snapshots for loadConfig and ensureAuthProfileStore", async () => {
+    const prepared = await prepareSecretsRuntimeSnapshot({
+      config: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: { source: "env", id: "OPENAI_API_KEY" },
+              models: [],
+            },
+          },
+        },
+      },
+      env: { OPENAI_API_KEY: "sk-runtime" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => ({
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", id: "OPENAI_API_KEY" },
+          },
+        },
+      }),
+    });
+
+    activateSecretsRuntimeSnapshot(prepared);
+
+    expect(loadConfig().models?.providers?.openai?.apiKey).toBe("sk-runtime");
+    const store = ensureAuthProfileStore("/tmp/openclaw-agent-main");
+    expect(store.profiles["openai:default"]).toMatchObject({
+      type: "api_key",
+      key: "sk-runtime",
+    });
+  });
+});

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -1,0 +1,385 @@
+import { resolveOpenClawAgentDir } from "../agents/agent-paths.js";
+import { listAgentIds, resolveAgentDir } from "../agents/agent-scope.js";
+import type { AuthProfileCredential, AuthProfileStore } from "../agents/auth-profiles.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  loadAuthProfileStoreForRuntime,
+  replaceRuntimeAuthProfileStoreSnapshots,
+} from "../agents/auth-profiles.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+  type SecretRef,
+} from "../config/config.js";
+import { runExec } from "../process/exec.js";
+import { resolveUserPath } from "../utils.js";
+
+const DEFAULT_SOPS_TIMEOUT_MS = 5_000;
+const MAX_SOPS_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+type SecretResolverWarningCode = "SECRETS_REF_OVERRIDES_PLAINTEXT";
+
+export type SecretResolverWarning = {
+  code: SecretResolverWarningCode;
+  path: string;
+  message: string;
+};
+
+export type PreparedSecretsRuntimeSnapshot = {
+  config: OpenClawConfig;
+  authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
+  warnings: SecretResolverWarning[];
+};
+
+type ResolverContext = {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  fileSecretsPromise: Promise<unknown> | null;
+};
+
+type ProviderLike = {
+  apiKey?: unknown;
+};
+
+type GoogleChatAccountLike = {
+  serviceAccount?: unknown;
+  serviceAccountRef?: unknown;
+  accounts?: Record<string, unknown>;
+};
+
+type ApiKeyCredentialLike = AuthProfileCredential & {
+  type: "api_key";
+  key?: string;
+  keyRef?: unknown;
+};
+
+type TokenCredentialLike = AuthProfileCredential & {
+  type: "token";
+  token?: string;
+  tokenRef?: unknown;
+};
+
+let activeSnapshot: PreparedSecretsRuntimeSnapshot | null = null;
+
+function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecretsRuntimeSnapshot {
+  return {
+    config: structuredClone(snapshot.config),
+    authStores: snapshot.authStores.map((entry) => ({
+      agentDir: entry.agentDir,
+      store: structuredClone(entry.store),
+    })),
+    warnings: snapshot.warnings.map((warning) => ({ ...warning })),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSecretRef(value: unknown): value is SecretRef {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (Object.keys(value).length !== 2) {
+    return false;
+  }
+  return (
+    (value.source === "env" || value.source === "file") &&
+    typeof value.id === "string" &&
+    value.id.trim().length > 0
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function decodeJsonPointerToken(token: string): string {
+  return token.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+function readJsonPointer(root: unknown, pointer: string): unknown {
+  if (!pointer.startsWith("/")) {
+    throw new Error(
+      `File-backed secret ids must be absolute JSON pointers (for example: /providers/openai/apiKey).`,
+    );
+  }
+
+  const tokens = pointer
+    .slice(1)
+    .split("/")
+    .map((token) => decodeJsonPointerToken(token));
+
+  let current: unknown = root;
+  for (const token of tokens) {
+    if (Array.isArray(current)) {
+      const index = Number.parseInt(token, 10);
+      if (!Number.isFinite(index) || index < 0 || index >= current.length) {
+        throw new Error(`JSON pointer segment "${token}" is out of bounds.`);
+      }
+      current = current[index];
+      continue;
+    }
+    if (!isRecord(current)) {
+      throw new Error(`JSON pointer segment "${token}" does not exist.`);
+    }
+    if (!Object.hasOwn(current, token)) {
+      throw new Error(`JSON pointer segment "${token}" does not exist.`);
+    }
+    current = current[token];
+  }
+  return current;
+}
+
+async function decryptSopsFile(config: OpenClawConfig): Promise<unknown> {
+  const fileSource = config.secrets?.sources?.file;
+  if (!fileSource) {
+    throw new Error(
+      `Secret reference source "file" is not configured. Configure secrets.sources.file first.`,
+    );
+  }
+  if (fileSource.type !== "sops") {
+    throw new Error(`Unsupported secrets.sources.file.type "${String(fileSource.type)}".`);
+  }
+
+  const resolvedPath = resolveUserPath(fileSource.path);
+  const timeoutMs =
+    typeof fileSource.timeoutMs === "number" && Number.isFinite(fileSource.timeoutMs)
+      ? Math.max(1, Math.floor(fileSource.timeoutMs))
+      : DEFAULT_SOPS_TIMEOUT_MS;
+
+  try {
+    const { stdout } = await runExec("sops", ["--decrypt", "--output-type", "json", resolvedPath], {
+      timeoutMs,
+      maxBuffer: MAX_SOPS_OUTPUT_BYTES,
+    });
+    return JSON.parse(stdout) as unknown;
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException & { message?: string };
+    if (error.code === "ENOENT") {
+      throw new Error(
+        `sops binary not found in PATH. Install sops >= 3.9.0 or disable secrets.sources.file.`,
+        { cause: err },
+      );
+    }
+    if (typeof error.message === "string" && error.message.toLowerCase().includes("timed out")) {
+      throw new Error(`sops decrypt timed out after ${timeoutMs}ms for ${resolvedPath}.`, {
+        cause: err,
+      });
+    }
+    throw new Error(`sops decrypt failed for ${resolvedPath}: ${String(error.message ?? err)}`, {
+      cause: err,
+    });
+  }
+}
+
+async function resolveSecretRefValue(ref: SecretRef, context: ResolverContext): Promise<unknown> {
+  const id = ref.id.trim();
+  if (!id) {
+    throw new Error(`Secret reference id is empty.`);
+  }
+
+  if (ref.source === "env") {
+    const envValue = context.env[id];
+    if (!isNonEmptyString(envValue)) {
+      throw new Error(`Environment variable "${id}" is missing or empty.`);
+    }
+    return envValue;
+  }
+
+  if (ref.source === "file") {
+    context.fileSecretsPromise ??= decryptSopsFile(context.config);
+    const payload = await context.fileSecretsPromise;
+    return readJsonPointer(payload, id);
+  }
+
+  throw new Error(`Unsupported secret source "${String((ref as { source?: unknown }).source)}".`);
+}
+
+async function resolveGoogleChatServiceAccount(
+  target: GoogleChatAccountLike,
+  path: string,
+  context: ResolverContext,
+  warnings: SecretResolverWarning[],
+): Promise<void> {
+  const explicitRef = isSecretRef(target.serviceAccountRef) ? target.serviceAccountRef : null;
+  const inlineRef = isSecretRef(target.serviceAccount) ? target.serviceAccount : null;
+  const ref = explicitRef ?? inlineRef;
+  if (!ref) {
+    return;
+  }
+  if (explicitRef && target.serviceAccount !== undefined && !isSecretRef(target.serviceAccount)) {
+    warnings.push({
+      code: "SECRETS_REF_OVERRIDES_PLAINTEXT",
+      path,
+      message: `${path}: serviceAccountRef is set; runtime will ignore plaintext serviceAccount.`,
+    });
+  }
+  target.serviceAccount = await resolveSecretRefValue(ref, context);
+}
+
+async function resolveConfigSecretRefs(params: {
+  config: OpenClawConfig;
+  context: ResolverContext;
+  warnings: SecretResolverWarning[];
+}): Promise<OpenClawConfig> {
+  const resolved = structuredClone(params.config);
+  const providers = resolved.models?.providers as Record<string, ProviderLike> | undefined;
+  if (providers) {
+    for (const [providerId, provider] of Object.entries(providers)) {
+      if (!isSecretRef(provider.apiKey)) {
+        continue;
+      }
+      const resolvedValue = await resolveSecretRefValue(provider.apiKey, params.context);
+      if (!isNonEmptyString(resolvedValue)) {
+        throw new Error(
+          `models.providers.${providerId}.apiKey resolved to a non-string or empty value.`,
+        );
+      }
+      provider.apiKey = resolvedValue;
+    }
+  }
+
+  const googleChat = resolved.channels?.googlechat as GoogleChatAccountLike | undefined;
+  if (googleChat) {
+    await resolveGoogleChatServiceAccount(
+      googleChat,
+      "channels.googlechat",
+      params.context,
+      params.warnings,
+    );
+    if (isRecord(googleChat.accounts)) {
+      for (const [accountId, account] of Object.entries(googleChat.accounts)) {
+        if (!isRecord(account)) {
+          continue;
+        }
+        await resolveGoogleChatServiceAccount(
+          account as GoogleChatAccountLike,
+          `channels.googlechat.accounts.${accountId}`,
+          params.context,
+          params.warnings,
+        );
+      }
+    }
+  }
+
+  return resolved;
+}
+
+async function resolveAuthStoreSecretRefs(params: {
+  store: AuthProfileStore;
+  context: ResolverContext;
+  warnings: SecretResolverWarning[];
+  agentDir: string;
+}): Promise<AuthProfileStore> {
+  const resolvedStore = structuredClone(params.store);
+  for (const [profileId, profile] of Object.entries(resolvedStore.profiles)) {
+    if (profile.type === "api_key") {
+      const apiProfile = profile as ApiKeyCredentialLike;
+      const keyRef = isSecretRef(apiProfile.keyRef) ? apiProfile.keyRef : null;
+      if (keyRef && isNonEmptyString(apiProfile.key)) {
+        params.warnings.push({
+          code: "SECRETS_REF_OVERRIDES_PLAINTEXT",
+          path: `${params.agentDir}.auth-profiles.${profileId}.key`,
+          message: `auth-profiles ${profileId}: keyRef is set; runtime will ignore plaintext key.`,
+        });
+      }
+      if (keyRef) {
+        const resolvedValue = await resolveSecretRefValue(keyRef, params.context);
+        if (!isNonEmptyString(resolvedValue)) {
+          throw new Error(`auth profile "${profileId}" keyRef resolved to an empty value.`);
+        }
+        apiProfile.key = resolvedValue;
+      }
+      continue;
+    }
+
+    if (profile.type === "token") {
+      const tokenProfile = profile as TokenCredentialLike;
+      const tokenRef = isSecretRef(tokenProfile.tokenRef) ? tokenProfile.tokenRef : null;
+      if (tokenRef && isNonEmptyString(tokenProfile.token)) {
+        params.warnings.push({
+          code: "SECRETS_REF_OVERRIDES_PLAINTEXT",
+          path: `${params.agentDir}.auth-profiles.${profileId}.token`,
+          message: `auth-profiles ${profileId}: tokenRef is set; runtime will ignore plaintext token.`,
+        });
+      }
+      if (tokenRef) {
+        const resolvedValue = await resolveSecretRefValue(tokenRef, params.context);
+        if (!isNonEmptyString(resolvedValue)) {
+          throw new Error(`auth profile "${profileId}" tokenRef resolved to an empty value.`);
+        }
+        tokenProfile.token = resolvedValue;
+      }
+    }
+  }
+  return resolvedStore;
+}
+
+function collectCandidateAgentDirs(config: OpenClawConfig): string[] {
+  const dirs = new Set<string>();
+  dirs.add(resolveUserPath(resolveOpenClawAgentDir()));
+  for (const agentId of listAgentIds(config)) {
+    dirs.add(resolveUserPath(resolveAgentDir(config, agentId)));
+  }
+  return [...dirs];
+}
+
+export async function prepareSecretsRuntimeSnapshot(params: {
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  agentDirs?: string[];
+  loadAuthStore?: (agentDir?: string) => AuthProfileStore;
+}): Promise<PreparedSecretsRuntimeSnapshot> {
+  const warnings: SecretResolverWarning[] = [];
+  const context: ResolverContext = {
+    config: params.config,
+    env: params.env ?? process.env,
+    fileSecretsPromise: null,
+  };
+  const resolvedConfig = await resolveConfigSecretRefs({
+    config: params.config,
+    context,
+    warnings,
+  });
+
+  const loadAuthStore = params.loadAuthStore ?? loadAuthProfileStoreForRuntime;
+  const candidateDirs = params.agentDirs?.length
+    ? [...new Set(params.agentDirs.map((entry) => resolveUserPath(entry)))]
+    : collectCandidateAgentDirs(resolvedConfig);
+  const authStores: Array<{ agentDir: string; store: AuthProfileStore }> = [];
+  for (const agentDir of candidateDirs) {
+    const rawStore = loadAuthStore(agentDir);
+    const resolvedStore = await resolveAuthStoreSecretRefs({
+      store: rawStore,
+      context,
+      warnings,
+      agentDir,
+    });
+    authStores.push({ agentDir, store: resolvedStore });
+  }
+
+  return {
+    config: resolvedConfig,
+    authStores,
+    warnings,
+  };
+}
+
+export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): void {
+  const next = cloneSnapshot(snapshot);
+  setRuntimeConfigSnapshot(next.config);
+  replaceRuntimeAuthProfileStoreSnapshots(next.authStores);
+  activeSnapshot = next;
+}
+
+export function getActiveSecretsRuntimeSnapshot(): PreparedSecretsRuntimeSnapshot | null {
+  return activeSnapshot ? cloneSnapshot(activeSnapshot) : null;
+}
+
+export function clearSecretsRuntimeSnapshot(): void {
+  activeSnapshot = null;
+  clearRuntimeConfigSnapshot();
+  clearRuntimeAuthProfileStoreSnapshots();
+}

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -25,6 +25,7 @@ export type SecretResolverWarning = {
 };
 
 export type PreparedSecretsRuntimeSnapshot = {
+  sourceConfig: OpenClawConfig;
   config: OpenClawConfig;
   authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
   warnings: SecretResolverWarning[];
@@ -62,6 +63,7 @@ let activeSnapshot: PreparedSecretsRuntimeSnapshot | null = null;
 
 function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecretsRuntimeSnapshot {
   return {
+    sourceConfig: structuredClone(snapshot.sourceConfig),
     config: structuredClone(snapshot.config),
     authStores: snapshot.authStores.map((entry) => ({
       agentDir: entry.agentDir,
@@ -290,6 +292,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
   }
 
   return {
+    sourceConfig: structuredClone(params.config),
     config: resolvedConfig,
     authStores,
     warnings,

--- a/src/secrets/shared.ts
+++ b/src/secrets/shared.ts
@@ -1,0 +1,14 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function normalizePositiveInt(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(1, Math.floor(value));
+  }
+  return Math.max(1, Math.floor(fallback));
+}

--- a/src/secrets/sops.ts
+++ b/src/secrets/sops.ts
@@ -2,15 +2,13 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { runExec } from "../process/exec.js";
+import { normalizePositiveInt } from "./shared.js";
 
 export const DEFAULT_SOPS_TIMEOUT_MS = 5_000;
 const MAX_SOPS_OUTPUT_BYTES = 10 * 1024 * 1024;
 
 function normalizeTimeoutMs(value: number | undefined): number {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return Math.max(1, Math.floor(value));
-  }
-  return DEFAULT_SOPS_TIMEOUT_MS;
+  return normalizePositiveInt(value, DEFAULT_SOPS_TIMEOUT_MS);
 }
 
 function isTimeoutError(message: string | undefined): boolean {

--- a/src/secrets/sops.ts
+++ b/src/secrets/sops.ts
@@ -1,0 +1,120 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { runExec } from "../process/exec.js";
+
+export const DEFAULT_SOPS_TIMEOUT_MS = 5_000;
+const MAX_SOPS_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+function normalizeTimeoutMs(value: number | undefined): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(1, Math.floor(value));
+  }
+  return DEFAULT_SOPS_TIMEOUT_MS;
+}
+
+function isTimeoutError(message: string | undefined): boolean {
+  return typeof message === "string" && message.toLowerCase().includes("timed out");
+}
+
+type SopsErrorContext = {
+  missingBinaryMessage: string;
+  operationLabel: string;
+};
+
+function toSopsError(err: unknown, params: SopsErrorContext): Error {
+  const error = err as NodeJS.ErrnoException & { message?: string };
+  if (error.code === "ENOENT") {
+    return new Error(params.missingBinaryMessage, { cause: err });
+  }
+  return new Error(`${params.operationLabel}: ${String(error.message ?? err)}`, {
+    cause: err,
+  });
+}
+
+function ensureDirForFile(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+}
+
+export async function decryptSopsJsonFile(params: {
+  path: string;
+  timeoutMs?: number;
+  missingBinaryMessage: string;
+}): Promise<unknown> {
+  const timeoutMs = normalizeTimeoutMs(params.timeoutMs);
+  try {
+    const { stdout } = await runExec("sops", ["--decrypt", "--output-type", "json", params.path], {
+      timeoutMs,
+      maxBuffer: MAX_SOPS_OUTPUT_BYTES,
+    });
+    return JSON.parse(stdout) as unknown;
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException & { message?: string };
+    if (isTimeoutError(error.message)) {
+      throw new Error(`sops decrypt timed out after ${timeoutMs}ms for ${params.path}.`, {
+        cause: err,
+      });
+    }
+    throw toSopsError(err, {
+      missingBinaryMessage: params.missingBinaryMessage,
+      operationLabel: `sops decrypt failed for ${params.path}`,
+    });
+  }
+}
+
+export async function encryptSopsJsonFile(params: {
+  path: string;
+  payload: Record<string, unknown>;
+  timeoutMs?: number;
+  missingBinaryMessage: string;
+}): Promise<void> {
+  ensureDirForFile(params.path);
+  const timeoutMs = normalizeTimeoutMs(params.timeoutMs);
+  const tmpPlain = path.join(
+    path.dirname(params.path),
+    `${path.basename(params.path)}.${process.pid}.${crypto.randomUUID()}.plain.tmp`,
+  );
+  const tmpEncrypted = path.join(
+    path.dirname(params.path),
+    `${path.basename(params.path)}.${process.pid}.${crypto.randomUUID()}.enc.tmp`,
+  );
+
+  fs.writeFileSync(tmpPlain, `${JSON.stringify(params.payload, null, 2)}\n`, "utf8");
+  fs.chmodSync(tmpPlain, 0o600);
+
+  try {
+    await runExec(
+      "sops",
+      [
+        "--encrypt",
+        "--input-type",
+        "json",
+        "--output-type",
+        "json",
+        "--output",
+        tmpEncrypted,
+        tmpPlain,
+      ],
+      {
+        timeoutMs,
+        maxBuffer: MAX_SOPS_OUTPUT_BYTES,
+      },
+    );
+    fs.renameSync(tmpEncrypted, params.path);
+    fs.chmodSync(params.path, 0o600);
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException & { message?: string };
+    if (isTimeoutError(error.message)) {
+      throw new Error(`sops encrypt timed out after ${timeoutMs}ms for ${params.path}.`, {
+        cause: err,
+      });
+    }
+    throw toSopsError(err, {
+      missingBinaryMessage: params.missingBinaryMessage,
+      operationLabel: `sops encrypt failed for ${params.path}`,
+    });
+  } finally {
+    fs.rmSync(tmpPlain, { force: true });
+    fs.rmSync(tmpEncrypted, { force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- add a new secrets runtime snapshot service that eagerly resolves `${ENV}` and `file+sops` SecretRefs
- activate resolved secrets at gateway startup (fail-fast) and on config reload with last-known-good rollback on apply failures
- add runtime in-memory snapshots for config + auth profiles so hot paths read resolved secrets without disk/sops/env provider calls
- add auth-profile value-level refs (`keyRef`/`tokenRef`) with ref-over-plaintext precedence warnings

## What changed
- new `src/secrets/runtime.ts` resolver/activation module
- gateway startup/reload wiring in `src/gateway/server.impl.ts`
- reload sequencing improvements in `src/gateway/config-reload.ts` (don’t advance current config on hot-reload failures)
- runtime config snapshot hooks in `src/config/io.ts` (+ exports)
- runtime auth-profile snapshot hooks in `src/agents/auth-profiles/store.ts` (+ exports)
- model provider `apiKey` type widened to `SecretInput` and related call-sites adjusted
- tests: `src/secrets/runtime.test.ts`

## Validation
- `pnpm lint`
- `pnpm vitest src/secrets/runtime.test.ts src/gateway/config-reload.test.ts src/agents/pi-auth-json.test.ts`
- `pnpm vitest src/config/config.secrets-schema.test.ts`
- `pnpm tsgo` (fails on pre-existing repo issues in `src/agents/google-gemini-switch.live.test.ts` and `src/discord/voice/manager.ts`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces eager secrets resolution with runtime snapshots for `${ENV}` and `file+sops` SecretRefs. The implementation activates resolved secrets at gateway startup with fail-fast validation, and on config reload with last-known-good rollback on failures. Auth-profile value-level refs (`keyRef`/`tokenRef`) are added with ref-over-plaintext precedence warnings. Config reload sequencing now advances `currentConfig` only after successful hot-reload application, preventing partial state updates on failures.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk.
- The implementation is well-structured with comprehensive error handling, fail-fast validation, and rollback mechanisms. The double activation issue from the previous thread has been fixed. Test coverage validates the core functionality. Minor risk remains around edge cases in JSON pointer handling and sops timeout scenarios.
- No files require special attention

<sub>Last reviewed commit: f814a5b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->