### PR TITLE
fix: guard against undefined fileOps properties in compaction safeguard

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -129,8 +129,8 @@ function computeFileLists(fileOps: FileOperations): {
   readFiles: string[];
   modifiedFiles: string[];
 } {
-  const modified = new Set([...fileOps.edited, ...fileOps.written]);
-  const readFiles = [...fileOps.read].filter((f) => !modified.has(f)).toSorted();
+  const modified = new Set([...(fileOps.edited ?? []), ...(fileOps.written ?? [])]);
+  const readFiles = [...(fileOps.read ?? [])].filter((f) => !modified.has(f)).toSorted();
   const modifiedFiles = [...modified].toSorted();
   return { readFiles, modifiedFiles };
 }


### PR DESCRIPTION
## Summary
- Adds nullish coalescing (`?? []`) fallbacks for `fileOps.read`, `.edited`, and `.written` in `computeFileLists()` to prevent `TypeError: Cannot read properties of undefined (reading 'filter')` when any of these properties are undefined

Without this guard, compaction crashes and falls back to summarization instead of producing real summaries.

Fixes #7190

## Local Validation
- [x] Verified the fix handles all three properties (`read`, `edited`, `written`)
- [x] Spread + `?? []` pattern is safe for both arrays and undefined values

## Scope
XS — 1-line change (2 lines reformatted) in one file

## Author
@miloudbelarebia

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds nullish coalescing guards (`?? []`) to prevent `TypeError` when `fileOps.read`, `fileOps.edited`, or `fileOps.written` are undefined. Without these guards, the spread operators would throw runtime errors, causing compaction to fail and fall back to basic truncation instead of generating proper summaries.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - defensive guard that prevents runtime errors
- Minimal defensive fix that adds proper undefined handling without changing logic. Uses idiomatic TypeScript pattern and matches the PR description's stated intent.
- No files require special attention

<sub>Last reviewed commit: fa31e1f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->