### PR TITLE
fix(browser): add --ozone-platform=wayland for Wayland-only Linux desktops

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -212,6 +212,9 @@ export async function launchOpenClawChrome(
     }
     if (process.platform === "linux") {
       args.push("--disable-dev-shm-usage");
+      if (process.env.WAYLAND_DISPLAY && !process.env.DISPLAY) {
+        args.push("--ozone-platform=wayland");
+      }
     }
 
     // Stealth: hide navigator.webdriver from automation detection (#80)


### PR DESCRIPTION
## Summary
- Adds `--ozone-platform=wayland` to Chrome launch args when `WAYLAND_DISPLAY` is set but `DISPLAY` is not (pure Wayland desktop)
- Prevents Chrome from falling back to XWayland, which causes rendering issues or fails if XWayland is not installed

The flag is only added when `DISPLAY` is absent, so setups with both X11 and Wayland available are unaffected.

Fixes #14080

## Local Validation
- [x] Verified the condition correctly targets Wayland-only setups
- [x] Flag is placed in the existing Linux-specific block alongside `--disable-dev-shm-usage`

## Scope
XS — 3-line addition in one file

## Author
@miloudbelarebia

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `--ozone-platform=wayland` flag to Chrome launch args when `WAYLAND_DISPLAY` is set but `DISPLAY` is not, which correctly targets pure Wayland environments. This prevents Chrome from attempting to use XWayland (which causes rendering failures on systems without XWayland installed). The logic matches the existing pattern in `src/commands/oauth-env.ts` where both environment variables are already used for environment detection.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted 3-line fix with clear conditional logic that only affects Linux systems in pure Wayland environments. The environment variable check pattern is already established in the codebase, and the flag is placed appropriately within the existing Linux-specific configuration block. No behavioral changes occur for systems with X11 or hybrid setups.
- No files require special attention

<sub>Last reviewed commit: 9f67e26</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->