### PR TITLE
feat: configurable announce mode for sub-agent completions

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -21,6 +21,7 @@ export type SubagentRunRecord = {
   cleanup: "delete" | "keep";
   label?: string;
   model?: string;
+  announceMode?: "full" | "notify" | "silent";
   runTimeoutSeconds?: number;
   createdAt: number;
   startedAt?: number;
@@ -110,6 +111,7 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     endedAt: entry.endedAt,
     label: entry.label,
     outcome: entry.outcome,
+    announceMode: entry.announceMode,
   }).then((didAnnounce) => {
     finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
   });
@@ -514,6 +516,7 @@ export function registerSubagentRun(params: {
   cleanup: "delete" | "keep";
   label?: string;
   model?: string;
+  announceMode?: "full" | "notify" | "silent";
   runTimeoutSeconds?: number;
   expectsCompletionMessage?: boolean;
 }) {
@@ -535,6 +538,7 @@ export function registerSubagentRun(params: {
     expectsCompletionMessage: params.expectsCompletionMessage,
     label: params.label,
     model: params.model,
+    announceMode: params.announceMode,
     runTimeoutSeconds,
     createdAt: now,
     startedAt: now,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -173,6 +173,10 @@ export async function spawnSubagentDirect(
     }
     thinkingOverride = normalized;
   }
+  const announceMode =
+    readStringParam(targetAgentConfig?.subagents ?? {}, "announce") ??
+    readStringParam(cfg.agents?.defaults?.subagents ?? {}, "announce") ??
+    "notify";
   try {
     await callGateway({
       method: "sessions.patch",
@@ -291,6 +295,7 @@ export async function spawnSubagentDirect(
     cleanup,
     label: label || undefined,
     model: resolvedModel,
+    announceMode: announceMode as "full" | "notify" | "silent",
     runTimeoutSeconds,
     expectsCompletionMessage: params.expectsCompletionMessage === true,
   });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -251,6 +251,8 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Announce mode for sub-agent completions: "full" (current behavior), "notify" (one-liner), "silent" (no announce). */
+    announce?: "full" | "notify" | "silent";
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -164,6 +164,7 @@ export const AgentDefaultsSchema = z
         archiveAfterMinutes: z.number().int().positive().optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
+        announce: z.enum(["full", "notify", "silent"]).optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -609,6 +609,7 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        announce: z.enum(["full", "notify", "silent"]).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Sub-agent announce-backs inject the **full findings** into the parent session context on every completion. For long-running or research-heavy sub-agents, this can consume thousands of input tokens — tokens the parent never asked for and often doesn't need.

This PR adds a `subagents.announce` config option with three modes:

- **`"full"`** — Current behavior, unchanged. Full sub-agent output is injected into the parent session.
- **`"notify"`** — One-liner system message: `[System] Task "X" completed. Session: <key>. Use sessions_history to read details.` Parent can retrieve full output on demand.
- **`"silent"`** — No announce at all. Cleanup still runs normally.

### Configuration

Global default:
```yaml
agents:
  defaults:
    subagents:
      announce: "notify"  # or "full" or "silent"
```

Per-agent override:
```yaml
agents:
  list:
    - id: researcher
      subagents:
        announce: "full"  # override for this agent
```

Resolution order: per-agent → global default → `"notify"` (hardcoded fallback).

### Why "notify" as the spawn default?

Most parent sessions don't need the full sub-agent output inline — they just need to know the task completed. The full transcript is always available via `sessions_history`. This reduces token waste by default while preserving full control for users who want it.

### Files changed

| File | Change |
|------|--------|
| `zod-schema.agent-defaults.ts` | Added `announce` enum to `subagents` schema |
| `zod-schema.agent-runtime.ts` | Added `announce` to per-agent `subagents` override |
| `types.agent-defaults.ts` | Added `announce` to TypeScript type |
| `subagent-spawn.ts` | Resolves announce mode from config chain, passes to registry |
| `subagent-registry.ts` | Stores `announceMode` on run record, passes to announce flow |
| `subagent-announce.ts` | Branches on mode before delivery |

## Test plan

- [ ] Start gateway, spawn sub-agent with default config → verify parent gets one-liner (notify mode)
- [ ] Set `announce: "full"` in config → verify full announce (backward compatible)
- [ ] Set `announce: "silent"` → verify no announce, cleanup still runs
- [ ] Per-agent override takes precedence over global default
- [ ] `openclaw doctor` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a configurable `announce` mode for sub-agent completions to reduce token waste when sub-agents inject their full output into parent session contexts. The implementation adds three modes: `full` (current behavior), `notify` (one-liner system message), and `silent` (no announce). The configuration follows the existing pattern with global defaults and per-agent overrides, with `notify` as the hardcoded fallback. The change correctly modifies only the `triggerMessage` that gets injected into parent sessions in `notify` mode, while preserving the full `completionMessage` for manual spawns where users explicitly requested the task and expect full results. The implementation properly threads the `announceMode` through the spawn → registry → announce flow and branches the delivery logic appropriately.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, follows existing patterns, correctly threads configuration through the system, and appropriately branches the announce logic without breaking backward compatibility. The changes are well-scoped to configuration schema, type definitions, and the announce flow with proper fallback defaults.
- No files require special attention

<sub>Last reviewed commit: 95d8877</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->