### PR TITLE
feat: inject user birthday into system prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ package-lock.json
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
+openclaw-*.log

--- a/src/agents/check-birthday.test.ts
+++ b/src/agents/check-birthday.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { checkBirthday } from "./system-prompt.js";
+
+describe("checkBirthday", () => {
+  const tz = "America/New_York";
+
+  it("returns 'today' when birthday matches", () => {
+    // March 15 in ET
+    const now = new Date("2025-03-15T12:00:00-04:00");
+    expect(checkBirthday("03-15", tz, now)).toBe("today");
+  });
+
+  it("returns 'tomorrow' when birthday is the next day", () => {
+    const now = new Date("2025-03-14T12:00:00-04:00");
+    expect(checkBirthday("03-15", tz, now)).toBe("tomorrow");
+  });
+
+  it("returns null when birthday is neither today nor tomorrow", () => {
+    const now = new Date("2025-06-01T12:00:00-04:00");
+    expect(checkBirthday("03-15", tz, now)).toBeNull();
+  });
+
+  it("handles year boundary (Dec 31 → Jan 1)", () => {
+    const now = new Date("2025-12-31T12:00:00-05:00");
+    expect(checkBirthday("01-01", tz, now)).toBe("tomorrow");
+  });
+
+  it("handles timezone edge case (UTC midnight vs local)", () => {
+    // 11pm HST Dec 31 = Jan 1 UTC, but local is still Dec 31
+    const now = new Date("2026-01-01T09:00:00Z"); // 11pm HST Dec 31
+    expect(checkBirthday("12-31", "Pacific/Honolulu", now)).toBe("today");
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -98,6 +98,7 @@ export function buildSystemPrompt(params: {
     toolNames: params.tools.map((tool) => tool.name),
     modelAliasLines: buildModelAliasLines(params.config),
     userTimezone,
+    userBirthday: params.config?.agents?.defaults?.userBirthday,
     userTime,
     userTimeFormat,
     contextFiles: params.contextFiles,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -504,6 +504,7 @@ export async function compactEmbeddedPiSessionDirect(
       tools,
       modelAliasLines: buildModelAliasLines(params.config),
       userTimezone,
+      userBirthday: params.config?.agents?.defaults?.userBirthday,
       userTime,
       userTimeFormat,
       contextFiles,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -464,6 +464,7 @@ export async function runEmbeddedAttempt(
       tools,
       modelAliasLines: buildModelAliasLines(params.config),
       userTimezone,
+      userBirthday: params.config?.agents?.defaults?.userBirthday,
       userTime,
       userTimeFormat,
       contextFiles,

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -46,6 +46,7 @@ export function buildEmbeddedSystemPrompt(params: {
   tools: AgentTool[];
   modelAliasLines: string[];
   userTimezone: string;
+  userBirthday?: string;
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
   contextFiles?: EmbeddedContextFile[];
@@ -74,6 +75,7 @@ export function buildEmbeddedSystemPrompt(params: {
     toolSummaries: buildToolSummaryMap(params.tools),
     modelAliasLines: params.modelAliasLines,
     userTimezone: params.userTimezone,
+    userBirthday: params.userBirthday,
     userTime: params.userTime,
     userTimeFormat: params.userTimeFormat,
     contextFiles: params.contextFiles,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -140,6 +140,8 @@ export type AgentDefaultsConfig = {
   bootstrapTotalMaxChars?: number;
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
   userTimezone?: string;
+  /** Optional user birthday in MM-DD format (e.g. "03-15"). Adds a note to the system prompt on the day and the day before. */
+  userBirthday?: string;
   /** Time format in system prompt: auto (OS preference), 12-hour, or 24-hour. */
   timeFormat?: "auto" | "12" | "24";
   /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -48,6 +48,10 @@ export const AgentDefaultsSchema = z
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
     userTimezone: z.string().optional(),
+    userBirthday: z
+      .string()
+      .regex(/^\d{2}-\d{2}$/, "Must be MM-DD format (e.g. 03-15)")
+      .optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
     envelopeTimezone: z.string().optional(),
     envelopeTimestamp: z.union([z.literal("on"), z.literal("off")]).optional(),


### PR DESCRIPTION
## Summary

Adds a `userBirthday` config field (MM-DD format) under `agents.defaults`. When the user's birthday is today or tomorrow (in their configured timezone), a note is appended to the `## Current Date & Time` section of the system prompt.

Similar to how holiday taglines work for the CLI banner, but this actually reaches the LLM.

## Config

```yaml
agents:
  defaults:
    userBirthday: '03-15'
```

## Prompt Output

- **On the day:** `🎂 It is the user's birthday today! Feel free to acknowledge it warmly.`
- **Day before:** `🎂 The user's birthday is tomorrow.`

## Changes

- `src/config/types.agent-defaults.ts` — added `userBirthday?: string` field
- `src/config/zod-schema.agent-defaults.ts` — added MM-DD regex validated field
- `src/agents/system-prompt.ts` — added `checkBirthday()` helper and wired into `buildTimeSection`
- `src/agents/pi-embedded-runner/system-prompt.ts` — threaded param
- `src/agents/pi-embedded-runner/run/attempt.ts` — reads from config
- `src/agents/pi-embedded-runner/compact.ts` — reads from config
- `src/agents/cli-runner/helpers.ts` — reads from config
- `src/agents/check-birthday.test.ts` — unit tests for checkBirthday

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds user birthday configuration field and injects birthday acknowledgment into the agent system prompt when the user's birthday is today or tomorrow. The feature follows existing patterns for config fields and timezone handling, and includes unit tests.

- Critical timezone bug in `checkBirthday()` that will cause incorrect detection when system timezone differs from user's configured timezone
- Config validation accepts invalid dates like "13-99" (suggestion: add range validation)
- `.gitignore` change for `openclaw-*.log` is unrelated to this PR

<h3>Confidence Score: 2/5</h3>

- Contains critical timezone bug that will cause incorrect behavior in production
- The timezone conversion logic has a critical flaw that causes dates to be re-interpreted in the system's local timezone instead of the user's configured timezone, leading to incorrect birthday detection. This affects the core functionality. The config validation is also weak but less critical.
- Fix `src/agents/system-prompt.ts` timezone handling before merging

<sub>Last reviewed commit: 8018667</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->