### PR TITLE
fix(tools): enforce global inline-secret blocking for tool inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ pnpm openclaw onboard --install-daemon
 
 # Dev loop (auto-reload on TS changes)
 pnpm gateway:watch
+
+# Windows (native PowerShell/cmd, no WSL2)
+node scripts/watch-node.mjs gateway run --bind loopback --port 18789 --allow-unconfigured
 ```
 
 Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` produces `dist/` for running via Node / the packaged `openclaw` binary.

--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ pnpm openclaw onboard --install-daemon
 # Dev loop (auto-reload on TS changes)
 pnpm gateway:watch
 
-# Windows (native PowerShell/cmd, no WSL2)
-openclaw gateway stop
-node scripts/watch-node.mjs gateway run --bind loopback --port 18789 --allow-unconfigured
+# Windows (native PowerShell/cmd, no WSL2) uses a compatible fallback automatically.
 ```
 
 Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` produces `dist/` for running via Node / the packaged `openclaw` binary.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ pnpm openclaw onboard --install-daemon
 pnpm gateway:watch
 
 # Windows (native PowerShell/cmd, no WSL2)
+openclaw gateway stop
 node scripts/watch-node.mjs gateway run --bind loopback --port 18789 --allow-unconfigured
 ```
 

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -40,11 +40,14 @@ pnpm gateway:watch
 This maps to:
 
 ```bash
-node --watch-path src --watch-path tsconfig.json --watch-path package.json --watch-preserve-output scripts/run-node.mjs gateway --force
+node scripts/gateway-watch.mjs
 ```
 
 Add any gateway CLI flags after `gateway:watch` and they will be passed through
 on each restart.
+
+On native Windows, `gateway:watch` uses a compatible fallback (`gateway run ... --allow-unconfigured`)
+and runs `openclaw gateway stop` best-effort first to avoid port conflicts with an installed daemon.
 
 ## Dev profile + dev gateway (--dev)
 

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -97,6 +97,7 @@ pnpm gateway:watch
 ```
 
 `gateway:watch` runs the gateway in watch mode and reloads on TypeScript changes.
+On native Windows, it automatically switches to a compatible gateway start path.
 
 ### 2) Point the macOS app at your running Gateway
 

--- a/extensions/feishu/skills/feishu-perm/SKILL.md
+++ b/extensions/feishu/skills/feishu-perm/SKILL.md
@@ -13,7 +13,7 @@ Single tool `feishu_perm` for managing file/document permissions.
 ### List Collaborators
 
 ```json
-{ "action": "list", "token": "ABC123", "type": "docx" }
+{ "action": "list", "file_token": "ABC123", "type": "docx" }
 ```
 
 Returns: members with member_type, member_id, perm, name.
@@ -23,7 +23,7 @@ Returns: members with member_type, member_id, perm, name.
 ```json
 {
   "action": "add",
-  "token": "ABC123",
+  "file_token": "ABC123",
   "type": "docx",
   "member_type": "email",
   "member_id": "user@example.com",
@@ -36,7 +36,7 @@ Returns: members with member_type, member_id, perm, name.
 ```json
 {
   "action": "remove",
-  "token": "ABC123",
+  "file_token": "ABC123",
   "type": "docx",
   "member_type": "email",
   "member_id": "user@example.com"
@@ -82,7 +82,7 @@ Share document with email:
 ```json
 {
   "action": "add",
-  "token": "doxcnXXX",
+  "file_token": "doxcnXXX",
   "type": "docx",
   "member_type": "email",
   "member_id": "alice@company.com",
@@ -95,7 +95,7 @@ Share folder with group:
 ```json
 {
   "action": "add",
-  "token": "fldcnXXX",
+  "file_token": "fldcnXXX",
   "type": "folder",
   "member_type": "openchat",
   "member_id": "oc_xxx",

--- a/extensions/feishu/src/perm-schema.ts
+++ b/extensions/feishu/src/perm-schema.ts
@@ -29,12 +29,12 @@ const Permission = Type.Union([
 export const FeishuPermSchema = Type.Union([
   Type.Object({
     action: Type.Literal("list"),
-    token: Type.String({ description: "File token" }),
+    file_token: Type.String({ description: "File token" }),
     type: TokenType,
   }),
   Type.Object({
     action: Type.Literal("add"),
-    token: Type.String({ description: "File token" }),
+    file_token: Type.String({ description: "File token" }),
     type: TokenType,
     member_type: MemberType,
     member_id: Type.String({ description: "Member ID (email, open_id, user_id, etc.)" }),
@@ -42,7 +42,7 @@ export const FeishuPermSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("remove"),
-    token: Type.String({ description: "File token" }),
+    file_token: Type.String({ description: "File token" }),
     type: TokenType,
     member_type: MemberType,
     member_id: Type.String({ description: "Member ID to remove" }),

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -154,14 +154,14 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
             });
             switch (p.action) {
               case "list":
-                return json(await listMembers(client, p.token, p.type));
+                return json(await listMembers(client, p.file_token, p.type));
               case "add":
                 return json(
-                  await addMember(client, p.token, p.type, p.member_type, p.member_id, p.perm),
+                  await addMember(client, p.file_token, p.type, p.member_type, p.member_id, p.perm),
                 );
               case "remove":
                 return json(
-                  await removeMember(client, p.token, p.type, p.member_type, p.member_id),
+                  await removeMember(client, p.file_token, p.type, p.member_type, p.member_id),
                 );
               default:
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -6,8 +6,14 @@ import { registerFeishuPermTools } from "./perm.js";
 import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 import { registerFeishuWikiTools } from "./wiki.js";
 
+const permissionMemberListMock = vi.fn(async () => ({ code: 0, data: { items: [] } }));
 const createFeishuClientMock = vi.fn((account: { appId?: string } | undefined) => ({
   __appId: account?.appId,
+  drive: {
+    permissionMember: {
+      list: permissionMemberListMock,
+    },
+  },
 }));
 
 vi.mock("./client.js", () => ({
@@ -113,6 +119,27 @@ describe("feishu tool account routing", () => {
     await tool.execute("call", { action: "unknown_action" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
+
+  test("perm list action maps file_token to Feishu path token", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { perm: true },
+      }),
+    );
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm", { agentAccountId: "a" });
+    await tool.execute("call", {
+      action: "list",
+      file_token: "file_token_123",
+      type: "docx",
+    });
+
+    expect(permissionMemberListMock).toHaveBeenCalledWith({
+      path: { token: "file_token_123" },
+      params: { type: "docx" },
+    });
   });
 
   test("bitable tool routes to agentAccountId and allows explicit accountId override", async () => {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "format:swift": "swiftformat --lint --config .swiftformat apps/macos/Sources apps/ios/Sources apps/shared/OpenClawKit/Sources",
     "gateway:dev": "OPENCLAW_SKIP_CHANNELS=1 CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway",
     "gateway:dev:reset": "OPENCLAW_SKIP_CHANNELS=1 CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --reset",
-    "gateway:watch": "node scripts/watch-node.mjs gateway --force",
+    "gateway:watch": "node scripts/gateway-watch.mjs",
     "gen:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --write",
     "ghsa:patch": "node scripts/ghsa-patch.mjs",
     "ios:build": "bash -lc './scripts/ios-configure-signing.sh && cd apps/ios && xcodegen generate && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination \"${IOS_DEST:-platform=iOS Simulator,name=iPhone 17}\" -configuration Debug build'",

--- a/scripts/gateway-watch.mjs
+++ b/scripts/gateway-watch.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const WATCH_SCRIPT = "scripts/watch-node.mjs";
+const RUN_SCRIPT = "scripts/run-node.mjs";
+const WINDOWS_WATCH_ARGS = [
+  "gateway",
+  "run",
+  "--bind",
+  "loopback",
+  "--port",
+  "18789",
+  "--allow-unconfigured",
+];
+const DEFAULT_WATCH_ARGS = ["gateway", "--force"];
+
+function runNode(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: "inherit",
+    });
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        resolve(1);
+        return;
+      }
+      resolve(code ?? 1);
+    });
+    child.once("error", () => {
+      resolve(1);
+    });
+  });
+}
+
+async function main() {
+  const passthroughArgs = process.argv.slice(2);
+  const isWindows = process.platform === "win32";
+
+  if (isWindows) {
+    // Windows developer flow commonly has a scheduled daemon running.
+    // Stop it best-effort to avoid port conflicts in watch mode.
+    await runNode([RUN_SCRIPT, "gateway", "stop"]);
+  }
+
+  const baseArgs = isWindows ? WINDOWS_WATCH_ARGS : DEFAULT_WATCH_ARGS;
+  const exitCode = await runNode([WATCH_SCRIPT, ...baseArgs, ...passthroughArgs]);
+  process.exit(exitCode);
+}
+
+void main();

--- a/scripts/gateway-watch.mjs
+++ b/scripts/gateway-watch.mjs
@@ -9,8 +9,6 @@ const WINDOWS_WATCH_ARGS = [
   "run",
   "--bind",
   "loopback",
-  "--port",
-  "18789",
   "--allow-unconfigured",
 ];
 const DEFAULT_WATCH_ARGS = ["gateway", "--force"];

--- a/scripts/gateway-watch.mjs
+++ b/scripts/gateway-watch.mjs
@@ -4,13 +4,7 @@ import process from "node:process";
 
 const WATCH_SCRIPT = "scripts/watch-node.mjs";
 const RUN_SCRIPT = "scripts/run-node.mjs";
-const WINDOWS_WATCH_ARGS = [
-  "gateway",
-  "run",
-  "--bind",
-  "loopback",
-  "--allow-unconfigured",
-];
+const WINDOWS_WATCH_ARGS = ["gateway", "run", "--bind", "loopback", "--allow-unconfigured"];
 const DEFAULT_WATCH_ARGS = ["gateway", "--force"];
 
 function runNode(args) {

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -183,6 +183,27 @@ describe("before_tool_call hook integration", () => {
     });
     expect(consumeAdjustedParamsForToolCall(sharedToolCallId, "run-a")).toBeUndefined();
   });
+
+  it("blocks inline secret-like parameters before hook dispatch", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithBeforeToolCallHook({ name: "gateway", execute } as any);
+    const extensionContext = {} as Parameters<typeof tool.execute>[3];
+
+    await expect(
+      tool.execute(
+        "call-inline-secret",
+        {
+          apiKey: "sk-live-123",
+        },
+        undefined,
+        extensionContext,
+      ),
+    ).rejects.toThrow(/Inline secret-like tool parameter "apiKey" is not allowed/);
+    expect(execute).not.toHaveBeenCalled();
+    expect(hookRunner.runBeforeToolCall).not.toHaveBeenCalled();
+  });
 });
 
 describe("before_tool_call hook deduplication (#15502)", () => {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -3,6 +3,7 @@ import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { isPlainObject } from "../utils.js";
+import { findInlineToolSecretViolation } from "./tool-inline-secret-policy.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -89,6 +90,15 @@ export async function runBeforeToolCallHook(args: {
 }): Promise<HookOutcome> {
   const toolName = normalizeToolName(args.toolName || "tool");
   const params = args.params;
+  const inlineSecretViolation = findInlineToolSecretViolation(params);
+  if (inlineSecretViolation) {
+    return {
+      blocked: true,
+      reason:
+        `Inline secret-like tool parameter "${inlineSecretViolation.path}" is not allowed. ` +
+        "Move credentials to config/env/auth profiles or plugin config.",
+    };
+  }
 
   if (args.ctx?.sessionKey) {
     const { getDiagnosticSessionState } = await import("../logging/diagnostic-session-state.js");

--- a/src/agents/tool-inline-secret-policy.test.ts
+++ b/src/agents/tool-inline-secret-policy.test.ts
@@ -24,6 +24,15 @@ describe("tool inline secret policy", () => {
     expect(violation).toBeNull();
   });
 
+  it("does not flag generic key params used by non-secret tools", () => {
+    const violation = findInlineToolSecretViolation({
+      request: {
+        key: "Enter",
+      },
+    });
+    expect(violation).toBeNull();
+  });
+
   it("supports emergency bypass env flag", () => {
     process.env.OPENCLAW_ALLOW_INLINE_TOOL_SECRETS = "1";
     try {

--- a/src/agents/tool-inline-secret-policy.test.ts
+++ b/src/agents/tool-inline-secret-policy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { findInlineToolSecretViolation } from "./tool-inline-secret-policy.js";
+
+describe("tool inline secret policy", () => {
+  it("flags apiKey fields", () => {
+    const violation = findInlineToolSecretViolation({ apiKey: "sk_live_123" });
+    expect(violation).toEqual({ key: "apiKey", path: "apiKey" });
+  });
+
+  it("flags nested oauth credential fields", () => {
+    const violation = findInlineToolSecretViolation({
+      oauth: {
+        refreshToken: "r1",
+      },
+    });
+    expect(violation).toEqual({ key: "refreshToken", path: "oauth.refreshToken" });
+  });
+
+  it("does not flag non-secret resource tokens", () => {
+    const violation = findInlineToolSecretViolation({
+      file_token: "filecnAABBCCDDEE",
+      folder_token: "fldrAABBCCDDEE",
+    });
+    expect(violation).toBeNull();
+  });
+
+  it("supports emergency bypass env flag", () => {
+    process.env.OPENCLAW_ALLOW_INLINE_TOOL_SECRETS = "1";
+    try {
+      const violation = findInlineToolSecretViolation({ password: "secret" });
+      expect(violation).toBeNull();
+    } finally {
+      delete process.env.OPENCLAW_ALLOW_INLINE_TOOL_SECRETS;
+    }
+  });
+});

--- a/src/agents/tool-inline-secret-policy.test.ts
+++ b/src/agents/tool-inline-secret-policy.test.ts
@@ -33,6 +33,27 @@ describe("tool inline secret policy", () => {
     expect(violation).toBeNull();
   });
 
+  it("does not flag bare token handles", () => {
+    const violation = findInlineToolSecretViolation({
+      token: "resume-handle-123",
+    });
+    expect(violation).toBeNull();
+  });
+
+  it("does not flag app_token resource identifiers", () => {
+    const violation = findInlineToolSecretViolation({
+      app_token: "bascnAABBCCDDEE",
+    });
+    expect(violation).toBeNull();
+  });
+
+  it("still flags access_token credentials", () => {
+    const violation = findInlineToolSecretViolation({
+      access_token: "ya29.secret",
+    });
+    expect(violation).toEqual({ key: "access_token", path: "access_token" });
+  });
+
   it("supports emergency bypass env flag", () => {
     process.env.OPENCLAW_ALLOW_INLINE_TOOL_SECRETS = "1";
     try {

--- a/src/agents/tool-inline-secret-policy.ts
+++ b/src/agents/tool-inline-secret-policy.ts
@@ -12,7 +12,6 @@ const SENSITIVE_KEY_NAMES = new Set([
   "authtoken",
   "bearertoken",
   "apikey",
-  "key",
   "secret",
   "clientsecret",
   "password",

--- a/src/agents/tool-inline-secret-policy.ts
+++ b/src/agents/tool-inline-secret-policy.ts
@@ -1,0 +1,102 @@
+export type InlineToolSecretViolation = {
+  key: string;
+  path: string;
+};
+
+const SENSITIVE_KEY_NAMES = new Set([
+  "token",
+  "accesstoken",
+  "refreshtoken",
+  "idtoken",
+  "apitoken",
+  "authtoken",
+  "bearertoken",
+  "apikey",
+  "key",
+  "secret",
+  "clientsecret",
+  "password",
+  "passwd",
+  "privatekey",
+]);
+
+// These keys represent opaque resource identifiers, not credentials.
+const NON_SECRET_TOKEN_KEYS = new Set([
+  "filetoken",
+  "foldertoken",
+  "doctoken",
+  "nodetoken",
+  "parentnodetoken",
+  "targetparenttoken",
+  "nextpagetoken",
+  "pagetoken",
+  "cursor",
+]);
+
+function normalizeKey(input: string): string {
+  return input.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function shouldInspectKey(key: string): boolean {
+  const normalized = normalizeKey(key);
+  if (!normalized) {
+    return false;
+  }
+  if (NON_SECRET_TOKEN_KEYS.has(normalized)) {
+    return false;
+  }
+  if (SENSITIVE_KEY_NAMES.has(normalized)) {
+    return true;
+  }
+  return (
+    normalized.includes("password") ||
+    normalized.includes("secret") ||
+    normalized.includes("apikey") ||
+    normalized.includes("accesstoken") ||
+    normalized.includes("refreshtoken") ||
+    normalized.endsWith("token")
+  );
+}
+
+function findViolationInValue(
+  value: unknown,
+  path: string[],
+  seen: WeakSet<object>,
+): InlineToolSecretViolation | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  if (seen.has(value)) {
+    return null;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      const nested = findViolationInValue(value[i], [...path, `[${i}]`], seen);
+      if (nested) {
+        return nested;
+      }
+    }
+    return null;
+  }
+
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string" && raw.trim() && shouldInspectKey(key)) {
+      const fullPath = path.length > 0 ? `${path.join(".")}.${key}` : key;
+      return { key, path: fullPath };
+    }
+    const nested = findViolationInValue(raw, [...path, key], seen);
+    if (nested) {
+      return nested;
+    }
+  }
+  return null;
+}
+
+export function findInlineToolSecretViolation(params: unknown): InlineToolSecretViolation | null {
+  if (process.env.OPENCLAW_ALLOW_INLINE_TOOL_SECRETS === "1") {
+    return null;
+  }
+  return findViolationInValue(params, [], new WeakSet<object>());
+}

--- a/src/agents/tool-inline-secret-policy.ts
+++ b/src/agents/tool-inline-secret-policy.ts
@@ -4,7 +4,6 @@ export type InlineToolSecretViolation = {
 };
 
 const SENSITIVE_KEY_NAMES = new Set([
-  "token",
   "accesstoken",
   "refreshtoken",
   "idtoken",
@@ -21,6 +20,8 @@ const SENSITIVE_KEY_NAMES = new Set([
 
 // These keys represent opaque resource identifiers, not credentials.
 const NON_SECRET_TOKEN_KEYS = new Set([
+  "token",
+  "apptoken",
   "filetoken",
   "foldertoken",
   "doctoken",
@@ -52,8 +53,7 @@ function shouldInspectKey(key: string): boolean {
     normalized.includes("secret") ||
     normalized.includes("apikey") ||
     normalized.includes("accesstoken") ||
-    normalized.includes("refreshtoken") ||
-    normalized.endsWith("token")
+    normalized.includes("refreshtoken")
   );
 }
 

--- a/src/gateway/server-methods-consistency.test.ts
+++ b/src/gateway/server-methods-consistency.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
+import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { CORE_GATEWAY_METHODS, listGatewayMethods } from "./server-methods-list.js";
+import { coreGatewayHandlers } from "./server-methods.js";
+import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
+
+const INTERNAL_ONLY_METHODS = new Set([
+  "connect",
+  "chat.inject",
+  "web.login.start",
+  "web.login.wait",
+  "sessions.resolve",
+  "push.test",
+  "poll",
+  "sessions.usage",
+  "sessions.usage.timeseries",
+  "sessions.usage.logs",
+]);
+
+describe("gateway method catalog consistency", () => {
+  let previousRegistry = getActivePluginRegistry();
+
+  beforeEach(() => {
+    previousRegistry = getActivePluginRegistry();
+  });
+
+  afterEach(() => {
+    if (previousRegistry) {
+      setActivePluginRegistry(previousRegistry);
+      return;
+    }
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("matches listed public methods to implemented handlers", () => {
+    const supplementalHandlers = createExecApprovalHandlers(new ExecApprovalManager());
+    const implementedHandlers = new Set([
+      ...Object.keys(coreGatewayHandlers),
+      ...Object.keys(supplementalHandlers),
+    ]);
+
+    const missingPublicMethods = CORE_GATEWAY_METHODS.filter(
+      (method) => !implementedHandlers.has(method),
+    );
+    expect(missingPublicMethods).toEqual([]);
+
+    const unexpectedPublicMethods = Array.from(implementedHandlers).filter(
+      (method) => !CORE_GATEWAY_METHODS.includes(method) && !INTERNAL_ONLY_METHODS.has(method),
+    );
+    expect(unexpectedPublicMethods).toEqual([]);
+  });
+
+  it("returns only core catalog methods when no channel plugins register extras", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    expect(listGatewayMethods()).toEqual(CORE_GATEWAY_METHODS);
+  });
+});

--- a/src/gateway/server-methods-consistency.test.ts
+++ b/src/gateway/server-methods-consistency.test.ts
@@ -5,6 +5,7 @@ import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { CORE_GATEWAY_METHODS, listGatewayMethods } from "./server-methods-list.js";
 import { coreGatewayHandlers } from "./server-methods.js";
 import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
+import { createSecretsHandlers } from "./server-methods/secrets.js";
 
 const INTERNAL_ONLY_METHODS = new Set([
   "connect",
@@ -36,9 +37,13 @@ describe("gateway method catalog consistency", () => {
 
   it("matches listed public methods to implemented handlers", () => {
     const supplementalHandlers = createExecApprovalHandlers(new ExecApprovalManager());
+    const secretsHandlers = createSecretsHandlers({
+      reloadSecrets: async () => ({ warningCount: 0 }),
+    });
     const implementedHandlers = new Set([
       ...Object.keys(coreGatewayHandlers),
       ...Object.keys(supplementalHandlers),
+      ...Object.keys(secretsHandlers),
     ]);
 
     const missingPublicMethods = CORE_GATEWAY_METHODS.filter(

--- a/src/gateway/server-methods-consistency.test.ts
+++ b/src/gateway/server-methods-consistency.test.ts
@@ -39,6 +39,11 @@ describe("gateway method catalog consistency", () => {
     const supplementalHandlers = createExecApprovalHandlers(new ExecApprovalManager());
     const secretsHandlers = createSecretsHandlers({
       reloadSecrets: async () => ({ warningCount: 0 }),
+      resolveSecrets: async () => ({
+        assignments: [],
+        diagnostics: [],
+        inactiveRefPaths: [],
+      }),
     });
     const implementedHandlers = new Set([
       ...Object.keys(coreGatewayHandlers),

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -1,7 +1,7 @@
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 
-const BASE_METHODS = [
+export const CORE_GATEWAY_METHODS = [
   "health",
   "doctor.memory.status",
   "logs.tail",
@@ -101,7 +101,7 @@ const BASE_METHODS = [
 
 export function listGatewayMethods(): string[] {
   const channelMethods = listChannelPlugins().flatMap((plugin) => plugin.gatewayMethods ?? []);
-  return Array.from(new Set([...BASE_METHODS, ...channelMethods]));
+  return Array.from(new Set([...CORE_GATEWAY_METHODS, ...channelMethods]));
 }
 
 export const GATEWAY_EVENTS = [

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -594,4 +594,27 @@ describe("POST /tools/invoke", () => {
     expect(body.result?.observedFormat).toBe("pdf");
     expect(body.result?.observedFileFormat).toBeUndefined();
   });
+
+  it("rejects inline secret-like tool args globally", async () => {
+    cfg = {
+      ...cfg,
+      agents: {
+        list: [{ id: "main", default: true, tools: { allow: ["tools_invoke_test"] } }],
+      },
+    };
+
+    const res = await invokeToolAuthed({
+      tool: "tools_invoke_test",
+      args: { mode: "ok", apiKey: "sk-live-123" },
+      sessionKey: "main",
+    });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error?.type).toBe("tool_error");
+    expect(body.error?.message).toContain(
+      'Inline secret-like tool parameter "apiKey" is not allowed',
+    );
+  });
 });

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -2466,9 +2466,9 @@ description: test skill
     const includePath = path.join(stateDir, "extra.json5");
     await fs.writeFile(includePath, "{ logging: { redactSensitive: 'off' } }\n", "utf-8");
     if (isWindows) {
-      // Grant "Everyone" write access to trigger the perms_writable check on Windows
+      // Use the well-known SID for Everyone so this works on non-English Windows locales too.
       const { execSync } = await import("node:child_process");
-      execSync(`icacls "${includePath}" /grant Everyone:W`, { stdio: "ignore" });
+      execSync(`icacls "${includePath}" /grant *S-1-1-0:(W)`, { stdio: "ignore" });
     } else {
       await fs.chmod(includePath, 0o644);
     }


### PR DESCRIPTION
## Summary

- Problem: tools could receive inline credential-like params (`apiKey`, `password`, `accessToken`, etc.) from model/user calls.
- Why it matters: inline secrets increase leakage risk and bypass config/env/auth-profile boundaries.
- What changed:
  - Added global detector: `src/agents/tool-inline-secret-policy.ts`.
  - Enforced in runtime hook gate: `src/agents/pi-tools.before-tool-call.ts`.
  - Enforced in HTTP gateway path: `src/gateway/tools-invoke-http.ts`.
  - Added tests for detector, hook blocking, and gateway rejection.
- Scope boundary: no provider/plugin credential storage changes; this is execution-time input enforcement.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [x] Skills / tool execution
- [x] API / contracts
- [ ] Gateway / orchestration
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (Yes)
- New/changed network calls? (No)
- Command/tool execution surface changed? (Yes)
- Data access scope changed? (No)

If any Yes, explain risk + mitigation:
- Runtime now blocks inline secret-like args and returns explicit errors to force safer credential sources.

## Repro + Verification

Steps:
1. Call a tool with inline secret-like args (e.g. `{ "apiKey": "..." }`).
2. Observe tool call is blocked before execution.

Expected:
- 400/tool_error in HTTP path and blocked execution in runtime path.

Actual:
- Inline secret-like params are rejected with a clear remediation message.

Evidence:
- `pnpm vitest run src/agents/tool-inline-secret-policy.test.ts src/gateway/tools-invoke-http.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/pi-tools.before-tool-call.e2e.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds global inline-secret blocking for tool inputs to prevent credential leakage risks. The implementation introduces a new detector (`tool-inline-secret-policy.ts`) that scans tool parameters for sensitive keys like `apiKey`, `password`, `token`, etc., and enforces blocking at two critical execution points:

- **Runtime hook path**: enforced in `pi-tools.before-tool-call.ts` via `wrapToolWithBeforeToolCallHook`
- **HTTP gateway path**: enforced in `tools-invoke-http.ts` before tool execution

The detector uses a comprehensive heuristic approach with case-insensitive normalized key matching, recursive traversal of nested objects/arrays, and circular reference protection. It includes an allowlist for non-secret resource identifiers (e.g., `fileToken`, `pageToken`) and an emergency bypass via environment variable.

The PR also includes a clean refactor that extracts gateway startup config logic into `startup-config.ts` and adds a method catalog consistency test to ensure all gateway handlers are properly tracked.

Test coverage is thorough with unit tests for the detector, E2E tests for runtime hook blocking, and HTTP integration tests for gateway rejection.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with dual enforcement paths (runtime hook + HTTP gateway), comprehensive test coverage, and defensive coding patterns. The detector logic is sound with proper circular reference handling, and the refactor cleanly extracts startup config without changing behavior. No bypass paths exist, and the emergency escape hatch is properly gated.
- No files require special attention

<sub>Last reviewed commit: 520f616</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->