### PR TITLE
fix: await onBlockReplyFlush before tool execution to preserve message ordering

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -134,9 +134,11 @@ export async function handleToolExecutionStart(
   evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
 ) {
   // Flush pending block replies to preserve message boundaries before tool execution.
+  // Await the flush to ensure block replies are delivered before tool-initiated sends
+  // (e.g., message tool sending a file), preventing out-of-order delivery on Telegram.
   ctx.flushBlockReplyBuffer();
   if (ctx.params.onBlockReplyFlush) {
-    void ctx.params.onBlockReplyFlush();
+    await ctx.params.onBlockReplyFlush();
   }
 
   const rawToolName = String(evt.toolName);


### PR DESCRIPTION
## Problem

When `shouldRouteToOriginating` is true (e.g., agent routing from webchat → telegram), block replies bypass the dispatcher's `sendChain` and go directly through `routeReply` → `sendMessageTelegram`.

In `handleToolExecutionStart`, `onBlockReplyFlush()` was called with `void` (fire-and-forget). This meant tool-initiated sends (e.g., message tool sending a PDF) could race block replies through the async chain and reach the per-chat serializer first, causing **out-of-order delivery** on Telegram.

Example: agent streams reasoning text, then sends a PDF via message tool → PDF arrives before the reasoning text.

## Fix

`void` → `await` on `ctx.params.onBlockReplyFlush()` in `handleToolExecutionStart`. This ensures all pending block reply deliveries complete before tool execution proceeds.

One-line change, the function is already `async`.

## Testing

- Verified build compiles cleanly
- Existing e2e test (`calls-onblockreplyflush-before-tool-execution-start-preserve`) still passes (mock returns void, `await undefined` is a no-op)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes `void` to `await` on `ctx.params.onBlockReplyFlush()` call in `handleToolExecutionStart` (line 141). This ensures pending block replies complete delivery before tool execution proceeds, preventing race conditions where tool-initiated sends could arrive before streamed reasoning text when routing through Telegram.

- The function signature already returns `void | Promise<void>`, so awaiting is safe
- Existing test passes (mock returns void, `await undefined` is a no-op)
- Fixes out-of-order message delivery in agent routing scenarios (webchat → telegram)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal (one keyword change from `void` to `await`), the function is already async, the type signature supports both sync and async returns, and existing tests verify the behavior. The fix addresses a real race condition without introducing new complexity or breaking changes.
- No files require special attention

<sub>Last reviewed commit: e1cf374</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->