### PR TITLE
docs: add Onur Solmaz to contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ Welcome to the lobster tank! 🦞
 - **Gustavo Madeira Santana** - Multi-agents, CLI, web UI
   - GitHub: [@gumadeiras](https://github.com/gumadeiras) · X: [@gumadeiras](https://x.com/gumadeiras)
 
+- **Onur Solmaz** - Agents, dev workflows, ACP integrations, MS Teams
+  - GitHub: [@onutc](https://github.com/onutc), [@osolmaz](https://github.com/osolmaz) · X: [@onusoz](https://x.com/onusoz)
+
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!


### PR DESCRIPTION
Adds Onur Solmaz to the Core Team section in CONTRIBUTING.md with GitHub and X links.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Onur Solmaz to the Core Team section in CONTRIBUTING.md with contribution areas (Agents, dev workflows, ACP integrations, MS Teams) and social links. The entry follows the existing maintainer formatting pattern with proper markdown syntax.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change adding a new maintainer entry that follows the existing format exactly, with no code changes or functional impact
- No files require special attention

<sub>Last reviewed commit: f39627c</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->