### PR TITLE
feat: forward session key as X-Session-Key header to providers

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -373,3 +373,24 @@ export function applyExtraParamsToAgent(
   // server-side conversation state is preserved.
   agent.streamFn = createOpenAIResponsesStoreWrapper(agent.streamFn);
 }
+
+/**
+ * Create a streamFn wrapper that injects an X-Session-Key header on all
+ * outgoing provider requests. This allows reverse proxies to implement
+ * session-affine (sticky) routing so multi-turn conversations stay on the
+ * same upstream credential.
+ */
+export function createSessionKeyHeaderWrapper(
+  baseStreamFn: StreamFn | undefined,
+  sessionKey: string,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) =>
+    underlying(model, context, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        "X-Session-Key": sessionKey,
+      },
+    });
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -76,7 +76,7 @@ import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
 import { buildEmbeddedExtensionFactories } from "../extensions.js";
-import { applyExtraParamsToAgent } from "../extra-params.js";
+import { applyExtraParamsToAgent, createSessionKeyHeaderWrapper } from "../extra-params.js";
 import {
   logToolSchemasForGoogle,
   sanitizeAntigravityThinkingBlocks,
@@ -668,6 +668,16 @@ export async function runEmbeddedAttempt(
         params.modelId,
         params.streamParams,
       );
+
+      // Inject X-Session-Key header so upstream reverse proxies can implement
+      // session-affine (sticky) routing for multi-turn conversations.
+      const effectiveSessionKey = params.sessionKey?.trim() || params.sessionId;
+      if (effectiveSessionKey) {
+        activeSession.agent.streamFn = createSessionKeyHeaderWrapper(
+          activeSession.agent.streamFn,
+          effectiveSessionKey,
+        );
+      }
 
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {


### PR DESCRIPTION
## Summary

- Adds `createSessionKeyHeaderWrapper` in `extra-params.ts` that wraps the `StreamFn` to inject an `X-Session-Key` HTTP header on all outgoing AI provider requests
- Applies the wrapper in `attempt.ts` after `applyExtraParamsToAgent()`, using the resolved session key (or session ID as fallback)
- Enables reverse proxies to implement session-affine (sticky) routing, keeping multi-turn conversations on the same upstream credential

## Motivation

When OpenClaw is used behind a credential-rotating reverse proxy, requests from the same conversation get scattered across different upstream accounts (round-robin). This is detectable by providers and breaks conversation continuity. By forwarding the already-computed session key as a header, proxies can route all requests from the same conversation to the same account.

Related: #22885

## Test plan

- [ ] Verify `X-Session-Key` header appears in outgoing provider requests via network inspection
- [ ] Verify the header value matches the session key from `session-key.ts`
- [ ] Verify existing functionality (Anthropic betas, OpenRouter headers, etc.) is not affected
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `X-Session-Key` header to all outgoing AI provider requests to enable session-affine routing in reverse proxies. The implementation follows the existing header wrapper pattern used by `createOpenRouterHeadersWrapper` and `createAnthropicBetaHeadersWrapper`. The wrapper is correctly applied after `applyExtraParamsToAgent()` and uses the session key (or session ID as fallback) that's already computed elsewhere in the codebase.

**Key changes:**
- New `createSessionKeyHeaderWrapper()` function in `extra-params.ts` that wraps the `StreamFn` to inject the header
- Applied in `attempt.ts` after existing extra params processing
- Uses `params.sessionKey?.trim() || params.sessionId` as the header value, consistent with the existing pattern used for sandbox session keys elsewhere in the same file (line 238)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase (similar to OpenRouter and Anthropic beta header wrappers), uses the same fallback pattern for session keys that's already used elsewhere in the file, and doesn't modify any existing functionality. The wrapper is correctly placed in the chain after `applyExtraParamsToAgent()` and properly spreads existing headers to avoid conflicts.
- No files require special attention

<sub>Last reviewed commit: b4e00c9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->