### PR TITLE
fix(exec): guard onUpdate callback type in runtime

### DIFF
--- a/src/agents/bash-tools.exec-runtime.on-update-guard.test.ts
+++ b/src/agents/bash-tools.exec-runtime.on-update-guard.test.ts
@@ -1,0 +1,63 @@
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { afterEach, expect, test, vi } from "vitest";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.js";
+import { runExecProcess } from "./bash-tools.exec-runtime.js";
+
+const { supervisorSpawnMock } = vi.hoisted(() => ({
+  supervisorSpawnMock: vi.fn(),
+}));
+
+vi.mock("../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => ({
+    spawn: (...args: unknown[]) => supervisorSpawnMock(...args),
+    cancel: vi.fn(),
+    cancelScope: vi.fn(),
+    reconcileOrphans: vi.fn(),
+    getRecord: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+  vi.clearAllMocks();
+});
+
+test("runExecProcess ignores truthy non-function onUpdate values", async () => {
+  supervisorSpawnMock.mockImplementation(async (input: { onStdout?: (chunk: string) => void }) => {
+    input.onStdout?.("streamed output");
+    return {
+      runId: "run-1",
+      pid: 1234,
+      startedAtMs: Date.now(),
+      wait: async () => ({
+        reason: "exit" as const,
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 1,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+      cancel: vi.fn(),
+    };
+  });
+
+  const handle = await runExecProcess({
+    command: "echo ok",
+    workdir: "/tmp",
+    env: {},
+    usePty: false,
+    warnings: [],
+    maxOutput: 200_000,
+    pendingMaxOutput: 30_000,
+    notifyOnExit: false,
+    timeoutSec: 5,
+    onUpdate: true as unknown as (partialResult: AgentToolResult<ExecToolDetails>) => void,
+  });
+
+  const outcome = await handle.promise;
+  expect(outcome.status).toBe("completed");
+  expect(outcome.aggregated).toContain("streamed output");
+});

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -1,16 +1,16 @@
-import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
+import path from "node:path";
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
-import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
-import { mergePathPrepend } from "../infra/path-prepend.js";
-import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
+import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
+import { mergePathPrepend } from "../infra/path-prepend.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
 export { applyPathPrepend, normalizePathPrepend } from "../infra/path-prepend.js";
-import { logWarn } from "../logger.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
+import { logWarn } from "../logger.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import {
   addSession,
@@ -332,7 +332,7 @@ export async function runExecProcess(opts: {
   addSession(session);
 
   const emitUpdate = () => {
-    if (!opts.onUpdate) {
+    if (typeof opts.onUpdate !== "function") {
       return;
     }
     const tailText = session.tail || session.aggregated;


### PR DESCRIPTION
## Summary
- fix a crash path in `runExecProcess` by guarding `opts.onUpdate` with a strict function check
- previously, truthy non-function values could pass the falsy guard and throw `TypeError: opts.onUpdate is not a function`
- add a regression test that simulates a truthy non-function `onUpdate` value while stdout updates are emitted

## Testing
- `pnpm vitest run src/agents/bash-tools.exec-runtime.on-update-guard.test.ts`

## AI Transparency
- [x] AI-assisted
- [x] Lightly tested (targeted test)

Fixes #22206

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a crash path in `runExecProcess` by adding a strict type check for the `opts.onUpdate` callback. Previously, the code used a falsy check (`if (!opts.onUpdate)`) which would allow truthy non-function values (like `true`, `1`, objects, etc.) to pass through, resulting in a `TypeError: opts.onUpdate is not a function` when invoked. The fix implements `typeof opts.onUpdate !== "function"` guard, which aligns with the codebase's existing pattern for callback validation and prevents runtime errors.

**Changes:**
- Updated callback guard in `emitUpdate` function from falsy check to explicit function type check
- Added regression test that verifies truthy non-function `onUpdate` values are safely ignored
- Import order changes (auto-formatted by oxfmt)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a defensive bug fix with proper test coverage.
- The change is a focused, defensive fix that prevents a specific crash scenario. The fix uses a well-established pattern (`typeof !== "function"`) that appears throughout the codebase (20+ occurrences). The regression test adequately simulates the failure case, and the change doesn't affect any other logic paths.
- No files require special attention

<sub>Last reviewed commit: f704f20</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->