### PR TITLE
fix(discord): set IS_COMPONENTS_V2 flag for v2 components in sendDiscordText/Media

### DIFF
--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -8,7 +8,7 @@ import {
 } from "@buape/carbon";
 import { PollLayoutType } from "discord-api-types/payloads/v10";
 import type { RESTAPIPoll } from "discord-api-types/rest/v10";
-import { Routes, type APIEmbed } from "discord-api-types/v10";
+import { MessageFlags, Routes, type APIEmbed } from "discord-api-types/v10";
 import type { ChunkMode } from "../auto-reply/chunk.js";
 import { loadConfig } from "../config/config.js";
 import type { RetryRunner } from "../infra/retry-policy.js";
@@ -316,8 +316,10 @@ export function buildDiscordMessagePayload(params: {
   if (!hasV2 && params.embeds?.length) {
     payload.embeds = params.embeds;
   }
-  if (params.flags !== undefined) {
-    payload.flags = params.flags;
+  const v2Flag = hasV2 ? MessageFlags.IsComponentsV2 : 0;
+  const mergedFlags = (params.flags ?? 0) | v2Flag;
+  if (mergedFlags) {
+    payload.flags = mergedFlags;
   }
   if (params.files?.length) {
     payload.files = params.files;


### PR DESCRIPTION
## Summary
- Merges the `IS_COMPONENTS_V2` message flag (`1 << 15`) into `buildDiscordMessagePayload()` when v2 components (Containers) are detected
- Without this flag, Discord silently drops v2 components from sent messages
- The fix is centralized in `buildDiscordMessagePayload()` which already detects v2 components via `hasV2Components()`, ensuring all send paths benefit

Previously, only the dedicated components send path (`send.components.ts`) set this flag via `buildDiscordComponentMessageFlags()`. The `sendDiscordText` and `sendDiscordMedia` paths never set it.

Fixes #22565

## Local Validation
- [x] Verified `MessageFlags.IsComponentsV2` import from `discord-api-types/v10`
- [x] Flag is only set when v2 components are present (no change for regular messages)
- [x] `SUPPRESS_NOTIFICATIONS_FLAG` is correctly merged with the v2 flag via bitwise OR

## Scope
XS — 5-line change in one file (import + flag merge logic)

## Author
@miloudbelarebia

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Discord v2 components (Containers) were silently dropped from messages sent via `sendDiscordText` and `sendDiscordMedia`. The fix centralizes the `MessageFlags.IsComponentsV2` flag logic in `buildDiscordMessagePayload()`, which already detects v2 components via `hasV2Components()`. The flag is properly merged with any existing flags (like `SUPPRESS_NOTIFICATIONS_FLAG`) using bitwise OR, ensuring all send paths now correctly set the flag when needed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal (5 lines), well-scoped, and follows the existing pattern from `send.components.ts` (line 84-87). The flag merge logic correctly uses bitwise OR with proper null coalescing, and the implementation is consistent with Discord's API requirements for v2 components.
- No files require special attention

<sub>Last reviewed commit: 0668aae</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->