### PR TITLE
fix: guard against NaN reserveTokens in compaction safeguard

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -275,7 +275,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   model,
                   apiKey,
                   signal,
-                  reserveTokens: Math.max(1, Math.floor(preparation.settings.reserveTokens)),
+                  reserveTokens: Math.max(1, Math.floor(preparation.settings.reserveTokens || 0)),
                   maxChunkTokens: droppedMaxChunkTokens,
                   contextWindow: contextWindowTokens,
                   customInstructions,
@@ -297,7 +297,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const allMessages = [...messagesToSummarize, ...turnPrefixMessages];
       const adaptiveRatio = computeAdaptiveChunkRatio(allMessages, contextWindowTokens);
       const maxChunkTokens = Math.max(1, Math.floor(contextWindowTokens * adaptiveRatio));
-      const reserveTokens = Math.max(1, Math.floor(preparation.settings.reserveTokens));
+      const reserveTokens = Math.max(1, Math.floor(preparation.settings.reserveTokens || 0));
 
       // Feed dropped-messages summary as previousSummary so the main summarization
       // incorporates context from pruned messages instead of losing it entirely.


### PR DESCRIPTION
## Summary
- Adds `|| 0` fallback for `preparation.settings.reserveTokens` in both occurrences within `compaction-safeguard.ts`
- When `reserveTokens` is undefined, `Math.floor(undefined)` returns `NaN`, and `Math.max(1, NaN)` also returns `NaN`, causing summarization to fail silently
- With the fallback, `Math.max(1, Math.floor(0))` correctly resolves to `1`

Fixes #9279

## Local Validation
- [x] Both occurrences of `preparation.settings.reserveTokens` are guarded (lines 278 and 300)
- [x] `|| 0` correctly handles `undefined`, `null`, `NaN`, and `0` inputs

## Scope
XS — 2-line change in one file

## Author
@miloudbelarebia

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Minimal 2-line defensive fix in `compaction-safeguard.ts` that guards against `NaN` propagation when `preparation.settings.reserveTokens` is `undefined`. Without the fix, `Math.floor(undefined)` produces `NaN`, and `Math.max(1, NaN)` also returns `NaN`, which would be passed to `summarizeInStages` causing summarization to fail silently. The `|| 0` fallback ensures `Math.max(1, Math.floor(0))` correctly resolves to `1` — a safe minimum.

- Both occurrences of `preparation.settings.reserveTokens` (lines 278 and 300) are now consistently guarded
- The fix correctly handles `undefined`, `null`, `NaN`, and `0` inputs
- No issues found during review

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal defensive fix with no behavioral change when reserveTokens is already a valid number.
- The change is a 2-line fix in a single file, adding a standard JS falsy fallback. The logic is straightforward: `|| 0` guards against `undefined`/`NaN`, and the outer `Math.max(1, ...)` ensures a minimum of 1. Both occurrences are handled consistently. No new code paths, no API changes, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 11e1133</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->