### PR TITLE
feat(telegram): add localBotApiUrl for large file downloads via Local Bot API Server

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -115,6 +115,14 @@ export type TelegramAccountConfig = {
   /** @deprecated Legacy key; migrated automatically to `streaming`. */
   streamMode?: "off" | "partial" | "block";
   mediaMaxMb?: number;
+  /**
+   * URL of a local Telegram Bot API server (e.g. "http://localhost:8081").
+   * When set, file downloads use this server instead of the standard Telegram
+   * Bot API, raising the file size limit from 20 MB to 2 GB.
+   * All other API calls (sending messages, polling, etc.) still use the
+   * standard Telegram API.
+   */
+  localBotApiUrl?: string;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;
   /** Retry policy for outbound Telegram API calls. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -155,6 +155,7 @@ export const TelegramAccountSchemaBase = z
     // Legacy key kept for automatic migration to `streaming`.
     streamMode: z.enum(["off", "partial", "block"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
+    localBotApiUrl: z.string().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,
     network: z

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -270,7 +270,7 @@ export const registerTelegramHandlers = ({
 
       const allMedia: TelegramMediaRef[] = [];
       for (const { ctx } of entry.messages) {
-        const media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+        const media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch, telegramCfg.localBotApiUrl);
         if (media) {
           allMedia.push({
             path: media.path,
@@ -661,7 +661,7 @@ export const registerTelegramHandlers = ({
 
     let media: Awaited<ReturnType<typeof resolveMedia>> = null;
     try {
-      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch, telegramCfg.localBotApiUrl);
     } catch (mediaErr) {
       const errMsg = String(mediaErr);
       if (errMsg.includes("exceeds") && errMsg.includes("MB limit")) {


### PR DESCRIPTION
## Summary

Add a new `localBotApiUrl` config option to the Telegram channel that routes **file downloads only** through a self-hosted [Telegram Bot API server](https://github.com/tdlib/telegram-bot-api), raising the file-size limit from 20 MB to 2 GB.

- All other API calls (sending messages, polling updates, etc.) continue to use the standard Telegram Bot API — no behavior change when the option is not set.
- When `localBotApiUrl` is set, both `getFile` and file download requests are routed through the local server, bypassing the 20 MB cloud limit.

### Changes

- **`src/config/types.telegram.ts`** — Add `localBotApiUrl?: string` to `TelegramAccountConfig`
- **`src/config/zod-schema.providers-core.ts`** — Add `localBotApiUrl` to Zod schema
- **`src/telegram/bot/delivery.ts`** — Route `getFile` + file download through local API when configured; introduce `getFilePath()` helper
- **`src/telegram/bot-handlers.ts`** — Pass `telegramCfg.localBotApiUrl` to `resolveMedia()`
- **`src/telegram/bot/delivery.resolve-media-retry.test.ts`** — Add 3 tests for local API routing, standard fallback, and trailing-slash normalization

### Config

```json
{
  "channels": {
    "telegram": {
      "localBotApiUrl": "http://localhost:8081",
      "mediaMaxMb": 2000
    }
  }
}
```

Per-account support works too:

```json
{
  "channels": {
    "telegram": {
      "accounts": {
        "main": {
          "localBotApiUrl": "http://localhost:8081",
          "mediaMaxMb": 2000
        }
      }
    }
  }
}
```

### Motivation

- The standard Telegram Bot API limits file downloads to 20 MB
- The self-hosted [Telegram Bot API server](https://core.telegram.org/bots/api#using-a-local-bot-api-server) supports files up to 2 GB
- Users doing audio/video transcription (e.g., with ASR skills) frequently hit the 20 MB limit
- grammY natively supports `apiRoot`, but changing it would route ALL API calls through the local server; `localBotApiUrl` is a targeted option that only affects file downloads

### Related Issues

- Closes #3037
- Ref #14657 (partial — this PR addresses the file-download use case; full `apiRoot` for all API calls is a separate feature)

## Test plan

- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] Full build succeeds (`pnpm build`)
- [x] All 13 delivery tests pass (10 existing + 3 new)
- [x] Tested against a live `telegram-bot-api` Docker container (port 18995)
- [ ] Verify existing tests pass in CI