### PR TITLE
fix: Use agent's configured workspace when spawned as subagent

### DIFF
--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -1,0 +1,99 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveRunWorkspaceDir } from "./workspace-run.js";
+
+const PARENT_WORKSPACE = "/home/user/workspace-parent";
+const SDR_WORKSPACE = "/home/user/workspace-sdr";
+const OTHER_WORKSPACE = "/home/user/workspace-other";
+
+const configWithSdrWorkspace = {
+  agents: {
+    list: [
+      { id: "sdr", workspace: SDR_WORKSPACE },
+      { id: "parent", workspace: PARENT_WORKSPACE },
+    ],
+  },
+};
+
+describe("resolveRunWorkspaceDir", () => {
+  describe("subagent workspace isolation", () => {
+    it("uses agent configured workspace instead of inherited parent workspaceDir", () => {
+      // Simulates a subagent (sdr) being spawned by a parent agent whose
+      // workspaceDir gets forwarded as the workspaceDir param.
+      const result = resolveRunWorkspaceDir({
+        workspaceDir: PARENT_WORKSPACE,
+        agentId: "sdr",
+        config: configWithSdrWorkspace,
+      });
+      expect(result.workspaceDir).toBe(path.resolve(SDR_WORKSPACE));
+      expect(result.usedFallback).toBe(false);
+      expect(result.agentId).toBe("sdr");
+    });
+
+    it("uses agent configured workspace even when a different workspaceDir is provided", () => {
+      const result = resolveRunWorkspaceDir({
+        workspaceDir: OTHER_WORKSPACE,
+        agentId: "sdr",
+        config: configWithSdrWorkspace,
+      });
+      expect(result.workspaceDir).toBe(path.resolve(SDR_WORKSPACE));
+      expect(result.usedFallback).toBe(false);
+    });
+  });
+
+  describe("no agent workspace configured", () => {
+    it("uses the provided workspaceDir when agent has no configured workspace", () => {
+      const result = resolveRunWorkspaceDir({
+        workspaceDir: OTHER_WORKSPACE,
+        agentId: "sdr",
+        config: { agents: { list: [{ id: "sdr" }] } },
+      });
+      expect(result.workspaceDir).toBe(path.resolve(OTHER_WORKSPACE));
+      expect(result.usedFallback).toBe(false);
+    });
+
+    it("uses the provided workspaceDir when config has no agents list", () => {
+      const result = resolveRunWorkspaceDir({
+        workspaceDir: OTHER_WORKSPACE,
+      });
+      expect(result.workspaceDir).toBe(path.resolve(OTHER_WORKSPACE));
+      expect(result.usedFallback).toBe(false);
+    });
+  });
+
+  describe("fallback when no workspaceDir provided", () => {
+    it("falls back when workspaceDir is missing, reports reason", () => {
+      const result = resolveRunWorkspaceDir({
+        workspaceDir: undefined,
+        agentId: "sdr",
+        config: configWithSdrWorkspace,
+      });
+      // Falls back to resolveAgentWorkspaceDir which reads the configured workspace
+      expect(result.workspaceDir).toBe(path.resolve(SDR_WORKSPACE));
+      expect(result.usedFallback).toBe(true);
+      expect(result.fallbackReason).toBe("missing");
+    });
+
+    it("falls back when workspaceDir is blank, reports reason", () => {
+      const result = resolveRunWorkspaceDir({
+        workspaceDir: "   ",
+        agentId: "sdr",
+        config: configWithSdrWorkspace,
+      });
+      expect(result.workspaceDir).toBe(path.resolve(SDR_WORKSPACE));
+      expect(result.usedFallback).toBe(true);
+      expect(result.fallbackReason).toBe("blank");
+    });
+
+    it("falls back when workspaceDir is invalid type, reports reason", () => {
+      const result = resolveRunWorkspaceDir({
+        workspaceDir: 42,
+        agentId: "sdr",
+        config: configWithSdrWorkspace,
+      });
+      expect(result.workspaceDir).toBe(path.resolve(SDR_WORKSPACE));
+      expect(result.usedFallback).toBe(true);
+      expect(result.fallbackReason).toBe("invalid_type");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Subagents spawned via `sessions_spawn` inherit the parent agent's `workspaceDir`, which is forwarded as a parameter to `resolveRunWorkspaceDir`
- The function accepted this inherited value without checking whether the child agent has its own workspace configured in `agents.list`
- Result: subagents run in the parent's workspace, missing their own workspace files (skills, AGENTS.md, memory, scripts)

## Problem

In `resolveRunWorkspaceDir`, when a non-empty `workspaceDir` string is provided, it was returned immediately without consulting the agent's configuration. The fallback path (null/undefined workspaceDir) correctly calls `resolveAgentWorkspaceDir` which checks `agents.list`, but the explicit-string path did not.

## Solution

Before accepting a provided `workspaceDir`, check whether the resolved agent has an explicitly configured workspace in `agents.list`. If it does, prefer that over the provided value. This only activates when both conditions are true — the agent has a configured workspace AND a non-empty `workspaceDir` was provided — leaving existing behavior unchanged for all other cases.

## Testing

- Added `src/agents/workspace-run.test.ts` with 7 tests
- Two new tests cover the subagent inheritance scenario (fail without fix, pass with fix)
- Five tests verify existing behavior is preserved (no configured workspace, blank/missing/invalid workspaceDir)
- All tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a workspace inheritance bug where subagents spawned via `sessions_spawn` incorrectly used their parent agent's workspace instead of their own configured workspace. The fix adds a check in `resolveRunWorkspaceDir` to prefer an agent's explicitly configured workspace (from `agents.list`) over any inherited `workspaceDir` parameter.

- Fixed workspace resolution logic to check agent config before accepting provided `workspaceDir`
- Added comprehensive test coverage (7 tests) covering the subagent scenario and existing behavior
- Maintains backward compatibility for agents without configured workspaces
- Applies security hardening via `sanitizeForPromptLiteral` to prevent prompt injection

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted, adds proper test coverage for both the bug scenario and existing behavior, maintains backward compatibility, and follows existing code patterns. The implementation correctly handles all edge cases (missing workspace, blank strings, invalid types) and applies security hardening consistently.
- No files require special attention

<sub>Last reviewed commit: bf68fe3</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->