### PR TITLE
WhatsApp: add lifecycle status reactions

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -340,6 +340,15 @@ Behavior notes:
 - group mode `mentions` reacts on mention-triggered turns; group activation `always` acts as bypass for this check
 - WhatsApp uses `channels.whatsapp.ackReaction` (legacy `messages.ackReaction` is not used here)
 
+### Lifecycle status reactions
+
+WhatsApp also supports lifecycle status reactions (`queued → thinking → tool → done/error`) when `messages.statusReactions.enabled=true`.
+
+- uses the same trigger message and updates the reaction in place as the run progresses
+- the initial queued state uses `channels.whatsapp.ackReaction.emoji`
+- final state is kept (no post-reply reaction cleanup)
+- in broadcast groups, only the deterministic owner agent (first valid configured agent) writes lifecycle reactions
+
 ## Multi-account and credentials
 
 <AccordionGroup>

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1465,11 +1465,11 @@ export const FIELD_HELP: Record<string, string> = {
   "messages.statusReactions":
     "Lifecycle status reactions that update the emoji on the trigger message as the agent progresses (queued → thinking → tool → done/error).",
   "messages.statusReactions.enabled":
-    "Enable lifecycle status reactions for Telegram. When enabled, the ack reaction becomes the initial 'queued' state and progresses through thinking, tool, done/error automatically. Default: false.",
+    "Enable lifecycle status reactions for channels that respect this toggle (currently Telegram and WhatsApp). When enabled, the ack reaction becomes the initial 'queued' state and progresses through thinking, tool, done/error automatically. Default: false.",
   "messages.statusReactions.emojis":
-    "Override default status reaction emojis. Keys: thinking, tool, coding, web, done, error, stallSoft, stallHard. Must be valid Telegram reaction emojis.",
+    "Override default status reaction emojis. Keys: thinking, tool, coding, web, done, error, stallSoft, stallHard. Must be valid reaction emojis for the target channel.",
   "messages.statusReactions.timing":
-    "Override default timing. Keys: debounceMs (700), stallSoftMs (25000), stallHardMs (60000), doneHoldMs (1500), errorHoldMs (2500).",
+    "Override default timing. Keys: debounceMs (700), stallSoftMs (10000), stallHardMs (30000), doneHoldMs (1500), errorHoldMs (2500).",
   "messages.inbound.debounceMs":
     "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
   "channels.telegram.dmPolicy":

--- a/src/web/auto-reply.broadcast-groups.combined.test.ts
+++ b/src/web/auto-reply.broadcast-groups.combined.test.ts
@@ -12,6 +12,7 @@ import {
   sendWebGroupInboundMessage,
   setLoadConfigMock,
 } from "./auto-reply.test-harness.js";
+import { maybeBroadcastMessage } from "./auto-reply/monitor/broadcast.js";
 
 installWebAutoReplyTestHomeHooks();
 
@@ -190,5 +191,69 @@ describe("broadcast groups", () => {
 
     expect(resolver).toHaveBeenCalledTimes(2);
     resetLoadConfigMock();
+  });
+
+  it("passes a deterministic lifecycle owner to every broadcasted agent", async () => {
+    const lifecycleOwners: string[] = [];
+    const emittedBy: string[] = [];
+
+    const processMessage = vi.fn(
+      async (
+        _msg: import("./auto-reply/types.js").WebInboundMsg,
+        route: ReturnType<typeof import("../routing/resolve-route.js").resolveAgentRoute>,
+        _groupHistoryKey: string,
+        opts?: { lifecycleOwnerAgentId?: string },
+      ) => {
+        if (opts?.lifecycleOwnerAgentId) {
+          lifecycleOwners.push(opts.lifecycleOwnerAgentId);
+          if (route.agentId === opts.lifecycleOwnerAgentId) {
+            emittedBy.push(route.agentId);
+          }
+        }
+        return true;
+      },
+    );
+
+    const didBroadcast = await maybeBroadcastMessage({
+      cfg: {
+        agents: {
+          list: [{ id: "alfred" }, { id: "baerbel" }],
+        },
+        broadcast: {
+          strategy: "parallel",
+          "+1000": ["unknown", "baerbel", "alfred"],
+        },
+      } as OpenClawConfig,
+      msg: {
+        id: "m1",
+        from: "+1000",
+        conversationId: "+1000",
+        to: "+2000",
+        accountId: "default",
+        body: "hello",
+        timestamp: Date.now(),
+        chatType: "direct",
+        chatId: "direct:+1000",
+        sendComposing: vi.fn(async () => {}),
+        reply: vi.fn(async () => {}),
+        sendMedia: vi.fn(async () => {}),
+      } as import("./auto-reply/types.js").WebInboundMsg,
+      peerId: "+1000",
+      route: {
+        agentId: "main",
+        accountId: "default",
+        sessionKey: "agent:main:main",
+        mainSessionKey: "agent:main:main",
+      } as ReturnType<typeof import("../routing/resolve-route.js").resolveAgentRoute>,
+      groupHistoryKey: "agent:main:main",
+      groupHistories: new Map(),
+      processMessage,
+    });
+
+    expect(didBroadcast).toBe(true);
+    expect(processMessage).toHaveBeenCalledTimes(2);
+    expect(lifecycleOwners.length).toBeGreaterThan(0);
+    expect(new Set(lifecycleOwners)).toEqual(new Set(["baerbel"]));
+    expect(emittedBy).toEqual(["baerbel"]);
   });
 });

--- a/src/web/auto-reply/monitor/ack-reaction.test.ts
+++ b/src/web/auto-reply/monitor/ack-reaction.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendReactionWhatsAppMock = vi.fn(async (..._args: unknown[]) => {});
+const resolveGroupActivationForMock = vi.fn(() => null as "always" | "mentions" | null);
+
+vi.mock("../../outbound.js", () => ({
+  sendReactionWhatsApp: (
+    chatJid: string,
+    messageId: string,
+    emoji: string,
+    options: {
+      verbose: boolean;
+      fromMe?: boolean;
+      participant?: string;
+      accountId?: string;
+    },
+  ) => sendReactionWhatsAppMock(chatJid, messageId, emoji, options),
+}));
+
+vi.mock("./group-activation.js", () => ({
+  resolveGroupActivationFor: () => resolveGroupActivationForMock(),
+}));
+
+import { maybeSendAckReaction, resolveWhatsAppAckReactionDecision } from "./ack-reaction.js";
+
+type Config = ReturnType<typeof import("../../../config/config.js").loadConfig>;
+
+function makeCfg(overrides?: {
+  emoji?: string;
+  direct?: boolean;
+  group?: "always" | "mentions" | "never";
+}): Config {
+  return {
+    channels: {
+      whatsapp: {
+        ackReaction: {
+          emoji: overrides?.emoji ?? "👀",
+          direct: overrides?.direct ?? true,
+          group: overrides?.group ?? "mentions",
+        },
+      },
+    },
+  } as unknown as Config;
+}
+
+function makeDirectMsg(overrides?: Partial<import("../types.js").WebInboundMsg>) {
+  return {
+    id: "msg-1",
+    from: "+15550001",
+    conversationId: "+15550001",
+    to: "+15550002",
+    accountId: "default",
+    body: "hello",
+    chatType: "direct",
+    chatId: "direct:+15550001",
+    sendComposing: vi.fn(async () => {}),
+    reply: vi.fn(async () => {}),
+    sendMedia: vi.fn(async () => {}),
+    ...overrides,
+  } as import("../types.js").WebInboundMsg;
+}
+
+function makeGroupMsg(overrides?: Partial<import("../types.js").WebInboundMsg>) {
+  return {
+    id: "group-msg-1",
+    from: "123@g.us",
+    conversationId: "123@g.us",
+    to: "+15550002",
+    accountId: "default",
+    body: "@bot hello",
+    chatType: "group",
+    chatId: "123@g.us",
+    senderJid: "15550001@s.whatsapp.net",
+    senderE164: "+15550001",
+    wasMentioned: false,
+    sendComposing: vi.fn(async () => {}),
+    reply: vi.fn(async () => {}),
+    sendMedia: vi.fn(async () => {}),
+    ...overrides,
+  } as import("../types.js").WebInboundMsg;
+}
+
+describe("resolveWhatsAppAckReactionDecision", () => {
+  beforeEach(() => {
+    sendReactionWhatsAppMock.mockClear();
+    resolveGroupActivationForMock.mockReset();
+    resolveGroupActivationForMock.mockReturnValue(null);
+  });
+
+  it("enables direct reaction when direct ack is enabled", () => {
+    const decision = resolveWhatsAppAckReactionDecision({
+      cfg: makeCfg({ direct: true }),
+      msg: makeDirectMsg(),
+      agentId: "main",
+      sessionKey: "agent:main:whatsapp:direct:+15550001",
+      conversationId: "+15550001",
+      accountId: "default",
+    });
+
+    expect(decision.shouldReact).toBe(true);
+    expect(decision.emoji).toBe("👀");
+    expect(decision.target).toMatchObject({
+      chatId: "direct:+15550001",
+      messageId: "msg-1",
+      accountId: "default",
+    });
+  });
+
+  it("disables direct reaction when direct ack is disabled", () => {
+    const decision = resolveWhatsAppAckReactionDecision({
+      cfg: makeCfg({ direct: false }),
+      msg: makeDirectMsg(),
+      agentId: "main",
+      sessionKey: "agent:main:whatsapp:direct:+15550001",
+      conversationId: "+15550001",
+      accountId: "default",
+    });
+
+    expect(decision.shouldReact).toBe(false);
+    expect(decision.target).toBeNull();
+  });
+
+  it("honors group=always and group=never", () => {
+    const always = resolveWhatsAppAckReactionDecision({
+      cfg: makeCfg({ group: "always" }),
+      msg: makeGroupMsg({ wasMentioned: false }),
+      agentId: "main",
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      conversationId: "123@g.us",
+      accountId: "default",
+    });
+    const never = resolveWhatsAppAckReactionDecision({
+      cfg: makeCfg({ group: "never" }),
+      msg: makeGroupMsg({ wasMentioned: true }),
+      agentId: "main",
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      conversationId: "123@g.us",
+      accountId: "default",
+    });
+
+    expect(always.shouldReact).toBe(true);
+    expect(never.shouldReact).toBe(false);
+  });
+
+  it("allows mention-mode reaction via group activation bypass", () => {
+    resolveGroupActivationForMock.mockReturnValue("always");
+    const decision = resolveWhatsAppAckReactionDecision({
+      cfg: makeCfg({ group: "mentions" }),
+      msg: makeGroupMsg({ wasMentioned: false }),
+      agentId: "main",
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      conversationId: "123@g.us",
+      accountId: "default",
+    });
+
+    expect(decision.shouldReact).toBe(true);
+    expect(decision.target?.chatId).toBe("123@g.us");
+  });
+
+  it("returns no reaction when inbound message id is missing", () => {
+    const decision = resolveWhatsAppAckReactionDecision({
+      cfg: makeCfg(),
+      msg: makeDirectMsg({ id: undefined }),
+      agentId: "main",
+      sessionKey: "agent:main:whatsapp:direct:+15550001",
+      conversationId: "+15550001",
+      accountId: "default",
+    });
+
+    expect(decision.shouldReact).toBe(false);
+    expect(decision.target).toBeNull();
+  });
+});
+
+describe("maybeSendAckReaction", () => {
+  beforeEach(() => {
+    sendReactionWhatsAppMock.mockClear();
+    resolveGroupActivationForMock.mockReset();
+    resolveGroupActivationForMock.mockReturnValue(null);
+  });
+
+  it("sends one-shot reaction using resolved decision", async () => {
+    const warn = vi.fn();
+    maybeSendAckReaction({
+      cfg: makeCfg(),
+      msg: makeDirectMsg(),
+      agentId: "main",
+      sessionKey: "agent:main:whatsapp:direct:+15550001",
+      conversationId: "+15550001",
+      verbose: false,
+      accountId: "default",
+      info: () => {},
+      warn,
+    });
+
+    await Promise.resolve();
+
+    expect(sendReactionWhatsAppMock).toHaveBeenCalledTimes(1);
+    expect(sendReactionWhatsAppMock).toHaveBeenCalledWith(
+      "direct:+15550001",
+      "msg-1",
+      "👀",
+      expect.objectContaining({
+        accountId: "default",
+        fromMe: false,
+      }),
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/auto-reply/monitor/ack-reaction.ts
+++ b/src/web/auto-reply/monitor/ack-reaction.ts
@@ -6,6 +6,73 @@ import { formatError } from "../../session.js";
 import type { WebInboundMsg } from "../types.js";
 import { resolveGroupActivationFor } from "./group-activation.js";
 
+export type WhatsAppAckReactionTarget = {
+  chatId: string;
+  messageId: string;
+  participant?: string;
+  accountId?: string;
+};
+
+export type WhatsAppAckReactionDecision = {
+  shouldReact: boolean;
+  emoji: string;
+  target: WhatsAppAckReactionTarget | null;
+};
+
+export function resolveWhatsAppAckReactionDecision(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  msg: WebInboundMsg;
+  agentId: string;
+  sessionKey: string;
+  conversationId: string;
+  accountId?: string;
+}): WhatsAppAckReactionDecision {
+  if (!params.msg.id) {
+    return { shouldReact: false, emoji: "", target: null };
+  }
+
+  const ackConfig = params.cfg.channels?.whatsapp?.ackReaction;
+  const emoji = (ackConfig?.emoji ?? "").trim();
+  const directEnabled = ackConfig?.direct ?? true;
+  const groupMode = ackConfig?.group ?? "mentions";
+  const conversationIdForCheck =
+    params.msg.conversationId ?? params.conversationId ?? params.msg.from;
+
+  const activation =
+    params.msg.chatType === "group"
+      ? resolveGroupActivationFor({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          conversationId: conversationIdForCheck,
+        })
+      : null;
+  const shouldReact = shouldAckReactionForWhatsApp({
+    emoji,
+    isDirect: params.msg.chatType === "direct",
+    isGroup: params.msg.chatType === "group",
+    directEnabled,
+    groupMode,
+    wasMentioned: params.msg.wasMentioned === true,
+    groupActivated: activation === "always",
+  });
+
+  if (!shouldReact) {
+    return { shouldReact: false, emoji, target: null };
+  }
+
+  return {
+    shouldReact: true,
+    emoji,
+    target: {
+      chatId: params.msg.chatId,
+      messageId: params.msg.id,
+      participant: params.msg.senderJid,
+      accountId: params.accountId,
+    },
+  };
+}
+
 export function maybeSendAckReaction(params: {
   cfg: ReturnType<typeof loadConfig>;
   msg: WebInboundMsg;
@@ -17,58 +84,41 @@ export function maybeSendAckReaction(params: {
   info: (obj: unknown, msg: string) => void;
   warn: (obj: unknown, msg: string) => void;
 }) {
-  if (!params.msg.id) {
+  const decision = resolveWhatsAppAckReactionDecision({
+    cfg: params.cfg,
+    msg: params.msg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    conversationId: params.conversationId,
+    accountId: params.accountId,
+  });
+  if (!decision.shouldReact || !decision.target) {
     return;
   }
-
-  const ackConfig = params.cfg.channels?.whatsapp?.ackReaction;
-  const emoji = (ackConfig?.emoji ?? "").trim();
-  const directEnabled = ackConfig?.direct ?? true;
-  const groupMode = ackConfig?.group ?? "mentions";
-  const conversationIdForCheck = params.msg.conversationId ?? params.msg.from;
-
-  const activation =
-    params.msg.chatType === "group"
-      ? resolveGroupActivationFor({
-          cfg: params.cfg,
-          agentId: params.agentId,
-          sessionKey: params.sessionKey,
-          conversationId: conversationIdForCheck,
-        })
-      : null;
-  const shouldSendReaction = () =>
-    shouldAckReactionForWhatsApp({
-      emoji,
-      isDirect: params.msg.chatType === "direct",
-      isGroup: params.msg.chatType === "group",
-      directEnabled,
-      groupMode,
-      wasMentioned: params.msg.wasMentioned === true,
-      groupActivated: activation === "always",
-    });
-
-  if (!shouldSendReaction()) {
-    return;
-  }
+  const target = decision.target;
 
   params.info(
-    { chatId: params.msg.chatId, messageId: params.msg.id, emoji },
+    {
+      chatId: target.chatId,
+      messageId: target.messageId,
+      emoji: decision.emoji,
+    },
     "sending ack reaction",
   );
-  sendReactionWhatsApp(params.msg.chatId, params.msg.id, emoji, {
+  sendReactionWhatsApp(target.chatId, target.messageId, decision.emoji, {
     verbose: params.verbose,
     fromMe: false,
-    participant: params.msg.senderJid,
-    accountId: params.accountId,
+    participant: target.participant,
+    accountId: target.accountId,
   }).catch((err) => {
     params.warn(
       {
         error: formatError(err),
-        chatId: params.msg.chatId,
-        messageId: params.msg.id,
+        chatId: target.chatId,
+        messageId: target.messageId,
       },
       "failed to send ack reaction",
     );
-    logVerbose(`WhatsApp ack reaction failed for chat ${params.msg.chatId}: ${formatError(err)}`);
+    logVerbose(`WhatsApp ack reaction failed for chat ${target.chatId}: ${formatError(err)}`);
   });
 }

--- a/src/web/auto-reply/monitor/broadcast.ts
+++ b/src/web/auto-reply/monitor/broadcast.ts
@@ -58,6 +58,7 @@ export async function maybeBroadcastMessage(params: {
     opts?: {
       groupHistory?: GroupHistoryEntry[];
       suppressGroupHistoryClear?: boolean;
+      lifecycleOwnerAgentId?: string;
     },
   ) => Promise<boolean>;
 }) {
@@ -74,6 +75,12 @@ export async function maybeBroadcastMessage(params: {
 
   const agentIds = params.cfg.agents?.list?.map((agent) => normalizeAgentId(agent.id));
   const hasKnownAgents = (agentIds?.length ?? 0) > 0;
+  const knownAgents = new Set(agentIds ?? []);
+  const normalizedBroadcastAgents = broadcastAgents.map((agentId) => normalizeAgentId(agentId));
+  const validBroadcastAgents = normalizedBroadcastAgents.filter((agentId) =>
+    hasKnownAgents ? knownAgents.has(agentId) : true,
+  );
+  const lifecycleOwnerAgentId = validBroadcastAgents[0];
   const groupHistorySnapshot =
     params.msg.chatType === "group"
       ? (params.groupHistories.get(params.groupHistoryKey) ?? [])
@@ -102,6 +109,7 @@ export async function maybeBroadcastMessage(params: {
       return await params.processMessage(params.msg, agentRoute, params.groupHistoryKey, {
         groupHistory: groupHistorySnapshot,
         suppressGroupHistoryClear: true,
+        lifecycleOwnerAgentId,
       });
     } catch (err) {
       whatsappInboundLog.error(`Broadcast agent ${agentId} failed: ${formatError(err)}`);

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -37,6 +37,7 @@ export function createWebOnMessageHandler(params: {
     opts?: {
       groupHistory?: GroupHistoryEntry[];
       suppressGroupHistoryClear?: boolean;
+      lifecycleOwnerAgentId?: string;
     },
   ) =>
     processMessage({
@@ -58,6 +59,7 @@ export function createWebOnMessageHandler(params: {
       buildCombinedEchoKey: params.echoTracker.buildCombinedKey,
       groupHistory: opts?.groupHistory,
       suppressGroupHistoryClear: opts?.suppressGroupHistoryClear,
+      lifecycleOwnerAgentId: opts?.lifecycleOwnerAgentId,
     });
 
   return async (msg: WebInboundMsg) => {

--- a/src/web/auto-reply/monitor/process-message.test.ts
+++ b/src/web/auto-reply/monitor/process-message.test.ts
@@ -1,0 +1,243 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendReactionWhatsAppMock = vi.fn(async (..._args: unknown[]) => {});
+const maybeSendAckReactionMock = vi.fn();
+const resolveWhatsAppAckReactionDecisionMock = vi.fn();
+
+let dispatchImpl: (params: {
+  dispatcherOptions: {
+    onReplyStart?: () => Promise<void>;
+    onError?: (err: unknown, info: { kind: "tool" | "block" | "final" }) => void;
+  };
+  replyOptions?: {
+    onReasoningStream?: (payload: { text?: string }) => Promise<void>;
+    onToolStart?: (payload: { name?: string }) => Promise<void>;
+  };
+}) => Promise<{ queuedFinal: boolean }>;
+
+vi.mock("../../outbound.js", () => ({
+  sendReactionWhatsApp: (
+    chatJid: string,
+    messageId: string,
+    emoji: string,
+    options: {
+      verbose: boolean;
+      fromMe?: boolean;
+      participant?: string;
+      accountId?: string;
+    },
+  ) => sendReactionWhatsAppMock(chatJid, messageId, emoji, options),
+}));
+
+vi.mock("./ack-reaction.js", () => ({
+  maybeSendAckReaction: (params: unknown) => maybeSendAckReactionMock(params),
+  resolveWhatsAppAckReactionDecision: (params: unknown) =>
+    resolveWhatsAppAckReactionDecisionMock(params),
+}));
+
+vi.mock("../../../auto-reply/reply/provider-dispatcher.js", () => ({
+  dispatchReplyWithBufferedBlockDispatcher: (params: unknown) => dispatchImpl(params as never),
+}));
+
+vi.mock("./last-route.js", () => ({
+  trackBackgroundTask: (tasks: Set<Promise<unknown>>, task: Promise<unknown>) => {
+    tasks.add(task);
+    void task.finally(() => tasks.delete(task));
+  },
+  updateLastRouteInBackground: vi.fn(),
+}));
+
+import { processMessage } from "./process-message.js";
+
+type Config = ReturnType<typeof import("../../../config/config.js").loadConfig>;
+
+let sessionDir: string | undefined;
+let sessionStorePath: string;
+let backgroundTasks: Set<Promise<unknown>>;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function makeProcessMessageArgs(overrides?: {
+  cfg?: Config;
+  route?: Partial<ReturnType<typeof import("../../../routing/resolve-route.js").resolveAgentRoute>>;
+  lifecycleOwnerAgentId?: string;
+}) {
+  return {
+    cfg:
+      overrides?.cfg ??
+      ({
+        channels: {
+          whatsapp: {
+            ackReaction: {
+              emoji: "👀",
+              direct: true,
+              group: "mentions",
+            },
+          },
+        },
+        messages: {
+          statusReactions: {
+            enabled: true,
+            timing: { debounceMs: 0, stallSoftMs: 60_000, stallHardMs: 120_000 },
+          },
+        },
+        session: { store: sessionStorePath },
+      } as unknown as Config),
+    msg: {
+      id: "msg-1",
+      from: "+15550001",
+      conversationId: "+15550001",
+      to: "+15550002",
+      accountId: "default",
+      body: "hello",
+      chatType: "direct",
+      chatId: "direct:+15550001",
+      senderJid: "15550001@s.whatsapp.net",
+      senderE164: "+15550001",
+      sendComposing: vi.fn(async () => {}),
+      reply: vi.fn(async () => {}),
+      sendMedia: vi.fn(async () => {}),
+    } as import("../types.js").WebInboundMsg,
+    route: {
+      agentId: "alfred",
+      accountId: "default",
+      sessionKey: "agent:alfred:whatsapp:direct:+15550001",
+      mainSessionKey: "agent:alfred:main",
+      ...overrides?.route,
+    } as ReturnType<typeof import("../../../routing/resolve-route.js").resolveAgentRoute>,
+    groupHistoryKey: "agent:alfred:whatsapp:direct:+15550001",
+    groupHistories: new Map<string, Array<{ sender: string; body: string }>>(),
+    groupMemberNames: new Map<string, Map<string, string>>(),
+    connectionId: "conn",
+    verbose: false,
+    maxMediaBytes: 1,
+    replyResolver: (async () =>
+      undefined) as unknown as typeof import("../../../auto-reply/reply.js").getReplyFromConfig,
+    replyLogger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    } as unknown as ReturnType<(typeof import("../../../logging.js"))["getChildLogger"]>,
+    backgroundTasks,
+    rememberSentText: (_text: string | undefined, _opts: unknown) => {},
+    echoHas: () => false,
+    echoForget: () => {},
+    buildCombinedEchoKey: () => "echo-key",
+    lifecycleOwnerAgentId: overrides?.lifecycleOwnerAgentId,
+  } as Parameters<typeof processMessage>[0];
+}
+
+describe("web processMessage lifecycle status reactions", () => {
+  beforeEach(async () => {
+    sendReactionWhatsAppMock.mockReset();
+    maybeSendAckReactionMock.mockReset();
+    resolveWhatsAppAckReactionDecisionMock.mockReset();
+    resolveWhatsAppAckReactionDecisionMock.mockReturnValue({
+      shouldReact: true,
+      emoji: "👀",
+      target: {
+        chatId: "direct:+15550001",
+        messageId: "msg-1",
+        participant: "15550001@s.whatsapp.net",
+        accountId: "default",
+      },
+    });
+    dispatchImpl = async () => ({ queuedFinal: true });
+    backgroundTasks = new Set();
+    sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-process-message-status-"));
+    sessionStorePath = path.join(sessionDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    await Promise.allSettled(Array.from(backgroundTasks));
+    if (sessionDir) {
+      await fs.rm(sessionDir, { recursive: true, force: true });
+      sessionDir = undefined;
+    }
+  });
+
+  it("updates queued -> thinking -> tool -> done and skips one-shot ack when lifecycle is enabled", async () => {
+    dispatchImpl = async (params) => {
+      await params.dispatcherOptions.onReplyStart?.();
+      await params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\n_step_" });
+      await sleep(0);
+      await params.replyOptions?.onToolStart?.({ name: "web_search" });
+      await sleep(0);
+      return { queuedFinal: true };
+    };
+
+    await processMessage(makeProcessMessageArgs());
+
+    const emojis = sendReactionWhatsAppMock.mock.calls.map((call) => String(call[2]));
+    expect(emojis).toContain("👀");
+    expect(emojis).toContain("🤔");
+    expect(emojis).toContain("⚡");
+    expect(emojis.at(-1)).toBe("👍");
+    expect(maybeSendAckReactionMock).not.toHaveBeenCalled();
+  });
+
+  it("sets error lifecycle reaction when dispatch throws", async () => {
+    dispatchImpl = async (params) => {
+      await params.dispatcherOptions.onReplyStart?.();
+      throw new Error("dispatch failed");
+    };
+
+    await expect(processMessage(makeProcessMessageArgs())).rejects.toThrow("dispatch failed");
+    const emojis = sendReactionWhatsAppMock.mock.calls.map((call) => String(call[2]));
+    expect(emojis).toContain("😱");
+    expect(emojis.at(-1)).toBe("😱");
+  });
+
+  it("sets error lifecycle reaction when final delivery fails", async () => {
+    dispatchImpl = async (params) => {
+      await params.dispatcherOptions.onReplyStart?.();
+      params.dispatcherOptions.onError?.(new Error("final failed"), { kind: "final" });
+      return { queuedFinal: true };
+    };
+
+    await processMessage(makeProcessMessageArgs());
+
+    const emojis = sendReactionWhatsAppMock.mock.calls.map((call) => String(call[2]));
+    expect(emojis).toContain("😱");
+    expect(emojis.at(-1)).toBe("😱");
+  });
+
+  it("still terminalizes to done when no final reply was queued", async () => {
+    dispatchImpl = async (params) => {
+      await params.dispatcherOptions.onReplyStart?.();
+      return { queuedFinal: false };
+    };
+
+    const didSend = await processMessage(makeProcessMessageArgs());
+
+    expect(didSend).toBe(false);
+    const emojis = sendReactionWhatsAppMock.mock.calls.map((call) => String(call[2]));
+    expect(emojis.at(-1)).toBe("👍");
+  });
+
+  it("suppresses all reaction writes for non-owner broadcast agents in lifecycle mode", async () => {
+    dispatchImpl = async (params) => {
+      await params.dispatcherOptions.onReplyStart?.();
+      await params.replyOptions?.onToolStart?.({ name: "web_search" });
+      return { queuedFinal: true };
+    };
+
+    await processMessage(
+      makeProcessMessageArgs({
+        route: { agentId: "baerbel" },
+        lifecycleOwnerAgentId: "alfred",
+      }),
+    );
+
+    expect(sendReactionWhatsAppMock).not.toHaveBeenCalled();
+    expect(maybeSendAckReactionMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -13,6 +13,7 @@ import type { ReplyPayload } from "../../../auto-reply/types.js";
 import { toLocationContext } from "../../../channels/location.js";
 import { createReplyPrefixOptions } from "../../../channels/reply-prefix.js";
 import { resolveInboundSessionEnvelopeContext } from "../../../channels/session-envelope.js";
+import { createStatusReactionController } from "../../../channels/status-reactions.js";
 import type { loadConfig } from "../../../config/config.js";
 import { resolveMarkdownTableMode } from "../../../config/markdown-tables.js";
 import { recordSessionMetaFromInbound } from "../../../config/sessions.js";
@@ -30,13 +31,14 @@ import {
 } from "../../../security/dm-policy-shared.js";
 import { jidToE164, normalizeE164 } from "../../../utils.js";
 import { resolveWhatsAppAccount } from "../../accounts.js";
+import { sendReactionWhatsApp } from "../../outbound.js";
 import { newConnectionId } from "../../reconnect.js";
 import { formatError } from "../../session.js";
 import { deliverWebReply } from "../deliver-reply.js";
 import { whatsappInboundLog, whatsappOutboundLog } from "../loggers.js";
 import type { WebInboundMsg } from "../types.js";
 import { elide } from "../util.js";
-import { maybeSendAckReaction } from "./ack-reaction.js";
+import { maybeSendAckReaction, resolveWhatsAppAckReactionDecision } from "./ack-reaction.js";
 import { formatGroupMembers } from "./group-members.js";
 import { trackBackgroundTask, updateLastRouteInBackground } from "./last-route.js";
 import { buildInboundLine } from "./message-line.js";
@@ -150,6 +152,7 @@ export async function processMessage(params: {
   maxMediaTextChunkLimit?: number;
   groupHistory?: GroupHistoryEntry[];
   suppressGroupHistoryClear?: boolean;
+  lifecycleOwnerAgentId?: string;
 }) {
   const conversationId = params.msg.conversationId ?? params.msg.from;
   const { storePath, envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
@@ -205,18 +208,72 @@ export async function processMessage(params: {
     return false;
   }
 
-  // Send ack reaction immediately upon message receipt (post-gating)
-  maybeSendAckReaction({
+  const statusReactionsConfig = params.cfg.messages?.statusReactions;
+  const statusReactionsModeEnabled = statusReactionsConfig?.enabled === true;
+  const ackDecision = resolveWhatsAppAckReactionDecision({
     cfg: params.cfg,
     msg: params.msg,
     agentId: params.route.agentId,
     sessionKey: params.route.sessionKey,
     conversationId,
-    verbose: params.verbose,
     accountId: params.route.accountId,
-    info: params.replyLogger.info.bind(params.replyLogger),
-    warn: params.replyLogger.warn.bind(params.replyLogger),
   });
+  const ackTarget = ackDecision.target;
+  const isLifecycleOwner =
+    !params.lifecycleOwnerAgentId || params.lifecycleOwnerAgentId === params.route.agentId;
+  const statusReactionsEnabled =
+    statusReactionsModeEnabled && ackDecision.shouldReact && Boolean(ackTarget) && isLifecycleOwner;
+
+  const statusReactionController =
+    statusReactionsEnabled && ackTarget
+      ? createStatusReactionController({
+          enabled: true,
+          adapter: {
+            setReaction: async (emoji) => {
+              await sendReactionWhatsApp(ackTarget.chatId, ackTarget.messageId, emoji, {
+                verbose: params.verbose,
+                fromMe: false,
+                participant: ackTarget.participant,
+                accountId: ackTarget.accountId,
+              });
+            },
+          },
+          initialEmoji: ackDecision.emoji,
+          emojis: statusReactionsConfig?.emojis,
+          timing: statusReactionsConfig?.timing,
+          onError: (err) => {
+            params.replyLogger.warn(
+              {
+                error: formatError(err),
+                chatId: ackTarget.chatId,
+                messageId: ackTarget.messageId,
+              },
+              "failed to update lifecycle status reaction",
+            );
+          },
+        })
+      : null;
+
+  if (statusReactionController) {
+    void statusReactionController.setQueued();
+  } else if (!statusReactionsModeEnabled) {
+    // Send one-shot ack reaction when lifecycle mode is disabled.
+    maybeSendAckReaction({
+      cfg: params.cfg,
+      msg: params.msg,
+      agentId: params.route.agentId,
+      sessionKey: params.route.sessionKey,
+      conversationId,
+      verbose: params.verbose,
+      accountId: params.route.accountId,
+      info: params.replyLogger.info.bind(params.replyLogger),
+      warn: params.replyLogger.warn.bind(params.replyLogger),
+    });
+  } else if (ackDecision.shouldReact && !isLifecycleOwner) {
+    logVerbose(
+      `Skipping lifecycle status reactions for non-owner broadcast agent ${params.route.agentId}`,
+    );
+  }
 
   const correlationId = params.msg.id ?? newConnectionId();
   params.replyLogger.info(
@@ -388,74 +445,106 @@ export async function processMessage(params: {
   });
   trackBackgroundTask(params.backgroundTasks, metaTask);
 
-  const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
-    ctx: ctxPayload,
-    cfg: params.cfg,
-    replyResolver: params.replyResolver,
-    dispatcherOptions: {
-      ...prefixOptions,
-      responsePrefix,
-      onHeartbeatStrip: () => {
-        if (!didLogHeartbeatStrip) {
-          didLogHeartbeatStrip = true;
-          logVerbose("Stripped stray HEARTBEAT_OK token from web reply");
-        }
+  let queuedFinal = false;
+  let dispatchError = false;
+  let finalDeliveryError = false;
+  try {
+    ({ queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
+      ctx: ctxPayload,
+      cfg: params.cfg,
+      replyResolver: params.replyResolver,
+      dispatcherOptions: {
+        ...prefixOptions,
+        responsePrefix,
+        onHeartbeatStrip: () => {
+          if (!didLogHeartbeatStrip) {
+            didLogHeartbeatStrip = true;
+            logVerbose("Stripped stray HEARTBEAT_OK token from web reply");
+          }
+        },
+        deliver: async (payload: ReplyPayload, info) => {
+          if (info.kind !== "final") {
+            // Only deliver final replies to external messaging channels (WhatsApp).
+            // Block (reasoning/thinking) and tool updates are meant for the internal
+            // web UI only; sending them here leaks chain-of-thought to end users.
+            return;
+          }
+          await deliverWebReply({
+            replyResult: payload,
+            msg: params.msg,
+            mediaLocalRoots,
+            maxMediaBytes: params.maxMediaBytes,
+            textLimit,
+            chunkMode,
+            replyLogger: params.replyLogger,
+            connectionId: params.connectionId,
+            skipLog: false,
+            tableMode,
+          });
+          didSendReply = true;
+          const shouldLog = payload.text ? true : undefined;
+          params.rememberSentText(payload.text, {
+            combinedBody,
+            combinedBodySessionKey: params.route.sessionKey,
+            logVerboseMessage: shouldLog,
+          });
+          const fromDisplay =
+            params.msg.chatType === "group" ? conversationId : (params.msg.from ?? "unknown");
+          const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
+          whatsappOutboundLog.info(`Auto-replied to ${fromDisplay}${hasMedia ? " (media)" : ""}`);
+          if (shouldLogVerbose()) {
+            const preview = payload.text != null ? elide(payload.text, 400) : "<media>";
+            whatsappOutboundLog.debug(`Reply body: ${preview}${hasMedia ? " (media)" : ""}`);
+          }
+        },
+        onError: (err, info) => {
+          const label =
+            info.kind === "tool"
+              ? "tool update"
+              : info.kind === "block"
+                ? "block update"
+                : "auto-reply";
+          if (info.kind === "final") {
+            finalDeliveryError = true;
+          }
+          whatsappOutboundLog.error(
+            `Failed sending web ${label} to ${params.msg.from ?? conversationId}: ${formatError(err)}`,
+          );
+        },
+        onReplyStart: async () => {
+          await params.msg.sendComposing();
+          await statusReactionController?.setThinking();
+        },
       },
-      deliver: async (payload: ReplyPayload, info) => {
-        if (info.kind !== "final") {
-          // Only deliver final replies to external messaging channels (WhatsApp).
-          // Block (reasoning/thinking) and tool updates are meant for the internal
-          // web UI only; sending them here leaks chain-of-thought to end users.
-          return;
-        }
-        await deliverWebReply({
-          replyResult: payload,
-          msg: params.msg,
-          mediaLocalRoots,
-          maxMediaBytes: params.maxMediaBytes,
-          textLimit,
-          chunkMode,
-          replyLogger: params.replyLogger,
-          connectionId: params.connectionId,
-          skipLog: false,
-          tableMode,
-        });
-        didSendReply = true;
-        const shouldLog = payload.text ? true : undefined;
-        params.rememberSentText(payload.text, {
-          combinedBody,
-          combinedBodySessionKey: params.route.sessionKey,
-          logVerboseMessage: shouldLog,
-        });
-        const fromDisplay =
-          params.msg.chatType === "group" ? conversationId : (params.msg.from ?? "unknown");
-        const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
-        whatsappOutboundLog.info(`Auto-replied to ${fromDisplay}${hasMedia ? " (media)" : ""}`);
-        if (shouldLogVerbose()) {
-          const preview = payload.text != null ? elide(payload.text, 400) : "<media>";
-          whatsappOutboundLog.debug(`Reply body: ${preview}${hasMedia ? " (media)" : ""}`);
-        }
+      replyOptions: {
+        // WhatsApp delivery intentionally suppresses non-final payloads.
+        // Keep block streaming disabled so final replies are still produced.
+        disableBlockStreaming: true,
+        onReasoningStream: statusReactionController
+          ? async () => {
+              await statusReactionController.setThinking();
+            }
+          : undefined,
+        onToolStart: statusReactionController
+          ? async (payload) => {
+              await statusReactionController.setTool(payload.name);
+            }
+          : undefined,
+        onModelSelected,
       },
-      onError: (err, info) => {
-        const label =
-          info.kind === "tool"
-            ? "tool update"
-            : info.kind === "block"
-              ? "block update"
-              : "auto-reply";
-        whatsappOutboundLog.error(
-          `Failed sending web ${label} to ${params.msg.from ?? conversationId}: ${formatError(err)}`,
-        );
-      },
-      onReplyStart: params.msg.sendComposing,
-    },
-    replyOptions: {
-      // WhatsApp delivery intentionally suppresses non-final payloads.
-      // Keep block streaming disabled so final replies are still produced.
-      disableBlockStreaming: true,
-      onModelSelected,
-    },
-  });
+    }));
+  } catch (err) {
+    dispatchError = true;
+    throw err;
+  } finally {
+    if (statusReactionController) {
+      if (dispatchError || finalDeliveryError) {
+        await statusReactionController.setError();
+      } else {
+        await statusReactionController.setDone();
+      }
+    }
+  }
 
   if (!queuedFinal) {
     if (shouldClearGroupHistory) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp only sent a one-shot ack reaction and did not reflect run lifecycle state.
- Why it matters: Users could not see queued/thinking/tool/done/error progression like Telegram/Discord, and broadcast runs could race reaction updates.
- What changed: Added lifecycle status reactions for WhatsApp behind `messages.statusReactions.enabled`, reused shared status reaction controller, introduced deterministic single-owner lifecycle updates for broadcast groups, and added dedicated tests/docs/help updates.
- What did NOT change (scope boundary): No Slack lifecycle implementation changes, no new config keys, and default behavior remains unchanged unless lifecycle mode is enabled.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: None
- Related: #21893
- Related: #6790
- Related: #22190
- Related: #23288

## User-visible / Behavior Changes

- WhatsApp now supports lifecycle auto-updating reactions (`queued -> thinking -> tool -> done/error`) when `messages.statusReactions.enabled=true`.
- One-shot ack reaction is skipped in lifecycle mode to avoid duplicate writes.
- In broadcast groups, lifecycle reactions are emitted by only the deterministic owner agent (first valid configured broadcast agent).
- Final lifecycle reaction is kept on WhatsApp (no post-reply cleanup).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A
- Integration/channel (if any): WhatsApp (web monitor path)
- Relevant config (redacted): `channels.whatsapp.ackReaction.*`, `messages.statusReactions.enabled`

### Steps

1. Enable `channels.whatsapp.ackReaction` and set `messages.statusReactions.enabled=true`.
2. Send inbound WhatsApp message and trigger response flow (including reasoning/tool activity).
3. Observe reaction progression and broadcast behavior with multiple agents configured.

### Expected

- Lifecycle reaction transitions on a single trigger message; non-owner broadcast agents do not emit lifecycle updates.

### Actual

- Matches expected in unit tests and targeted monitor/broadcast test suites.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: lifecycle queued/thinking/tool/done path, dispatch error path, final delivery error path, silent/no-final terminalization, one-shot ack suppression in lifecycle mode, broadcast owner-only lifecycle updates.
- Edge cases checked: missing message id in ack decision resolver; mention bypass via group activation; deterministic owner selection when first configured agent is invalid.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `messages.statusReactions.enabled=false`.
- Files/config to restore: WhatsApp monitor reaction paths under `src/web/auto-reply/monitor/*` and help/docs updates.
- Known bad symptoms reviewers should watch for: duplicate initial reactions, non-owner reaction updates in broadcast groups, missing terminal reaction state.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Merge conflicts with active WhatsApp monitor PRs touching `process-message.ts` / ack logic.
  - Mitigation: Isolated ack decision helper, explicit lifecycle gating, and targeted tests around lifecycle and broadcast ownership.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added lifecycle status reactions for WhatsApp that reuse the shared status reaction controller. The implementation introduces deterministic single-owner lifecycle updates for broadcast groups where only the first valid configured broadcast agent emits reactions.

- Refactored `maybeSendAckReaction` to extract decision logic into `resolveWhatsAppAckReactionDecision` for reuse
- One-shot ack reaction is now skipped when lifecycle mode is enabled to avoid duplicate initial reactions
- Broadcast groups pass `lifecycleOwnerAgentId` through the call chain, and non-owner agents suppress all lifecycle reactions
- Final lifecycle reaction is kept on WhatsApp (no post-reply cleanup like some other channels)
- Tests cover lifecycle progression, error handling, broadcast ownership, and silent terminalization scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns from Telegram/Discord, reuses the shared status reaction controller without modifications, includes comprehensive tests covering edge cases (broadcast ownership, error paths, silent terminalization), and maintains backward compatibility with proper feature gating
- No files require special attention

<sub>Last reviewed commit: 44f36ac</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

