### PR TITLE
feat(auth): add qwen-agent plugin auth choice support

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -202,15 +202,17 @@ Kimi Coding uses Moonshot AI's Anthropic-compatible endpoint:
 ### Qwen OAuth (free tier)
 
 Qwen provides OAuth access to Qwen Coder + Vision via a device-code flow.
-Enable the bundled plugin, then log in:
+Enable a bundled plugin, then log in:
 
 ```bash
-openclaw plugins enable qwen-portal-auth
-openclaw models auth login --provider qwen-portal --set-default
+openclaw plugins enable qwen-agent-auth
+openclaw models auth login --provider qwen-agent --set-default
 ```
 
 Model refs:
 
+- `qwen-agent/coder-model`
+- `qwen-agent/vision-model`
 - `qwen-portal/coder-model`
 - `qwen-portal/vision-model`
 

--- a/docs/providers/qwen.md
+++ b/docs/providers/qwen.md
@@ -1,20 +1,24 @@
 ---
-summary: "Use Qwen OAuth (free tier) in OpenClaw"
+summary: "Use Qwen OAuth providers in OpenClaw"
 read_when:
   - You want to use Qwen with OpenClaw
-  - You want free-tier OAuth access to Qwen Coder
+  - You want OAuth access to Qwen Coder
 title: "Qwen"
 ---
 
 # Qwen
 
-Qwen provides a free-tier OAuth flow for Qwen Coder and Qwen Vision models
-(2,000 requests/day, subject to Qwen rate limits).
+OpenClaw supports two Qwen OAuth provider plugins:
+
+- `qwen-agent-auth` (provider id: `qwen-agent`)
+- `qwen-portal-auth` (provider id: `qwen-portal`, legacy path)
 
 ## Enable the plugin
 
 ```bash
-openclaw plugins enable qwen-portal-auth
+openclaw plugins enable qwen-agent-auth
+# optional legacy provider:
+# openclaw plugins enable qwen-portal-auth
 ```
 
 Restart the Gateway after enabling.
@@ -22,7 +26,9 @@ Restart the Gateway after enabling.
 ## Authenticate
 
 ```bash
-openclaw models auth login --provider qwen-portal --set-default
+openclaw models auth login --provider qwen-agent --set-default
+# legacy provider:
+# openclaw models auth login --provider qwen-portal --set-default
 ```
 
 This runs the Qwen device-code OAuth flow and writes a provider entry to your
@@ -30,24 +36,27 @@ This runs the Qwen device-code OAuth flow and writes a provider entry to your
 
 ## Model IDs
 
-- `qwen-portal/coder-model`
-- `qwen-portal/vision-model`
+- `qwen-agent/coder-model`
+- `qwen-agent/vision-model`
+- `qwen-portal/coder-model` (legacy)
+- `qwen-portal/vision-model` (legacy)
 
 Switch models with:
 
 ```bash
-openclaw models set qwen-portal/coder-model
+openclaw models set qwen-agent/coder-model
 ```
 
 ## Reuse Qwen Code CLI login
 
 If you already logged in with the Qwen Code CLI, OpenClaw will sync credentials
 from `~/.qwen/oauth_creds.json` when it loads the auth store. You still need a
-`models.providers.qwen-portal` entry (use the login command above to create one).
+provider entry (`models.providers.qwen-agent` or `models.providers.qwen-portal`)
+created by the login command.
 
 ## Notes
 
 - Tokens auto-refresh; re-run the login command if refresh fails or access is revoked.
 - Default base URL: `https://portal.qwen.ai/v1` (override with
-  `models.providers.qwen-portal.baseUrl` if Qwen provides a different endpoint).
+  `models.providers.qwen-agent.baseUrl` or `models.providers.qwen-portal.baseUrl`).
 - See [Model providers](/concepts/model-providers) for provider-wide rules.

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -52,6 +52,7 @@ Looking for third-party listings? See [Community plugins](/plugins/community).
 - [Microsoft Teams](/channels/msteams) — `@openclaw/msteams`
 - Google Antigravity OAuth (provider auth) — bundled as `google-antigravity-auth` (disabled by default)
 - Gemini CLI OAuth (provider auth) — bundled as `google-gemini-cli-auth` (disabled by default)
+- Qwen Agent OAuth (provider auth) — bundled as `qwen-agent-auth` (disabled by default)
 - Qwen OAuth (provider auth) — bundled as `qwen-portal-auth` (disabled by default)
 - Copilot Proxy (provider auth) — local VS Code Copilot Proxy bridge; distinct from built-in `github-copilot` device login (bundled, disabled by default)
 

--- a/extensions/qwen-agent-auth/README.md
+++ b/extensions/qwen-agent-auth/README.md
@@ -1,0 +1,24 @@
+# Qwen Agent OAuth (OpenClaw plugin)
+
+OAuth provider plugin for **Qwen Agent**.
+
+## Enable
+
+Bundled plugins are disabled by default. Enable this one:
+
+```bash
+openclaw plugins enable qwen-agent-auth
+```
+
+Restart the Gateway after enabling.
+
+## Authenticate
+
+```bash
+openclaw models auth login --provider qwen-agent --set-default
+```
+
+## Notes
+
+- Qwen Agent OAuth uses a device-code login flow.
+- Tokens auto-refresh; re-run login if refresh fails or access is revoked.

--- a/extensions/qwen-agent-auth/index.ts
+++ b/extensions/qwen-agent-auth/index.ts
@@ -1,0 +1,134 @@
+import {
+  emptyPluginConfigSchema,
+  type OpenClawPluginApi,
+  type ProviderAuthContext,
+} from "openclaw/plugin-sdk";
+import { loginQwenAgentOAuth } from "./oauth.js";
+
+const PROVIDER_ID = "qwen-agent";
+const PROVIDER_LABEL = "Qwen Agent";
+const DEFAULT_MODEL = "qwen-agent/coder-model";
+const DEFAULT_BASE_URL = "https://portal.qwen.ai/v1";
+const DEFAULT_CONTEXT_WINDOW = 128000;
+const DEFAULT_MAX_TOKENS = 8192;
+const OAUTH_PLACEHOLDER = "qwen-agent-oauth";
+
+function normalizeBaseUrl(value: string | undefined): string {
+  const raw = value?.trim() || DEFAULT_BASE_URL;
+  const withProtocol = raw.startsWith("http") ? raw : `https://${raw}`;
+  return withProtocol.endsWith("/v1") ? withProtocol : `${withProtocol.replace(/\/+$/, "")}/v1`;
+}
+
+function buildModelDefinition(params: {
+  id: string;
+  name: string;
+  input: Array<"text" | "image">;
+}) {
+  return {
+    id: params.id,
+    name: params.name,
+    reasoning: false,
+    input: params.input,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+  };
+}
+
+const qwenAgentPlugin = {
+  id: "qwen-agent-auth",
+  name: "Qwen Agent OAuth",
+  description: "OAuth flow for Qwen Agent models",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: PROVIDER_LABEL,
+      docsPath: "/providers/qwen",
+      aliases: ["qwen-agent"],
+      auth: [
+        {
+          id: "device",
+          label: "Qwen Agent OAuth",
+          hint: "Device code login",
+          kind: "device_code",
+          run: async (ctx: ProviderAuthContext) => {
+            const progress = ctx.prompter.progress("Starting Qwen Agent OAuth…");
+            try {
+              const result = await loginQwenAgentOAuth({
+                openUrl: ctx.openUrl,
+                note: ctx.prompter.note,
+                progress,
+              });
+
+              progress.stop("Qwen Agent OAuth complete");
+
+              const profileId = `${PROVIDER_ID}:default`;
+              const baseUrl = normalizeBaseUrl(result.resourceUrl);
+
+              return {
+                profiles: [
+                  {
+                    profileId,
+                    credential: {
+                      type: "oauth",
+                      provider: PROVIDER_ID,
+                      access: result.access,
+                      refresh: result.refresh,
+                      expires: result.expires,
+                    },
+                  },
+                ],
+                configPatch: {
+                  models: {
+                    providers: {
+                      [PROVIDER_ID]: {
+                        baseUrl,
+                        apiKey: OAUTH_PLACEHOLDER,
+                        api: "openai-completions",
+                        models: [
+                          buildModelDefinition({
+                            id: "coder-model",
+                            name: "Qwen Agent Coder",
+                            input: ["text"],
+                          }),
+                          buildModelDefinition({
+                            id: "vision-model",
+                            name: "Qwen Agent Vision",
+                            input: ["text", "image"],
+                          }),
+                        ],
+                      },
+                    },
+                  },
+                  agents: {
+                    defaults: {
+                      models: {
+                        "qwen-agent/coder-model": { alias: "qwen" },
+                        "qwen-agent/vision-model": {},
+                      },
+                    },
+                  },
+                },
+                defaultModel: DEFAULT_MODEL,
+                notes: [
+                  "Qwen OAuth tokens auto-refresh. Re-run login if refresh fails or access is revoked.",
+                  `Base URL defaults to ${DEFAULT_BASE_URL}. Override models.providers.${PROVIDER_ID}.baseUrl if needed.`,
+                ],
+              };
+            } catch (err) {
+              progress.stop("Qwen Agent OAuth failed");
+              await ctx.prompter.note(
+                "If OAuth fails, verify your Qwen account has agent access and try again.",
+                "Qwen Agent OAuth",
+              );
+              throw err;
+            }
+          },
+        },
+      ],
+    });
+  },
+};
+
+export default qwenAgentPlugin;

--- a/extensions/qwen-agent-auth/oauth.ts
+++ b/extensions/qwen-agent-auth/oauth.ts
@@ -1,0 +1,190 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+
+const QWEN_OAUTH_BASE_URL = "https://chat.qwen.ai";
+const QWEN_OAUTH_DEVICE_CODE_ENDPOINT = `${QWEN_OAUTH_BASE_URL}/api/v1/oauth2/device/code`;
+const QWEN_OAUTH_TOKEN_ENDPOINT = `${QWEN_OAUTH_BASE_URL}/api/v1/oauth2/token`;
+const QWEN_OAUTH_CLIENT_ID = "f0304373b74a44d2b584a3fb70ca9e56";
+const QWEN_OAUTH_SCOPE = "openid profile email model.completion";
+const QWEN_OAUTH_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+
+export type QwenDeviceAuthorization = {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval?: number;
+};
+
+export type QwenOAuthToken = {
+  access: string;
+  refresh: string;
+  expires: number;
+  resourceUrl?: string;
+};
+
+type TokenPending = { status: "pending"; slowDown?: boolean };
+
+type DeviceTokenResult =
+  | { status: "success"; token: QwenOAuthToken }
+  | TokenPending
+  | { status: "error"; message: string };
+
+function toFormUrlEncoded(data: Record<string, string>): string {
+  return Object.entries(data)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join("&");
+}
+
+function generatePkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+async function requestDeviceCode(params: { challenge: string }): Promise<QwenDeviceAuthorization> {
+  const response = await fetch(QWEN_OAUTH_DEVICE_CODE_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      "x-request-id": randomUUID(),
+    },
+    body: toFormUrlEncoded({
+      client_id: QWEN_OAUTH_CLIENT_ID,
+      scope: QWEN_OAUTH_SCOPE,
+      code_challenge: params.challenge,
+      code_challenge_method: "S256",
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Qwen device authorization failed: ${text || response.statusText}`);
+  }
+
+  const payload = (await response.json()) as QwenDeviceAuthorization & { error?: string };
+  if (!payload.device_code || !payload.user_code || !payload.verification_uri) {
+    throw new Error(
+      payload.error ??
+        "Qwen device authorization returned an incomplete payload (missing user_code or verification_uri).",
+    );
+  }
+  return payload;
+}
+
+async function pollDeviceToken(params: {
+  deviceCode: string;
+  verifier: string;
+}): Promise<DeviceTokenResult> {
+  const response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: toFormUrlEncoded({
+      grant_type: QWEN_OAUTH_GRANT_TYPE,
+      client_id: QWEN_OAUTH_CLIENT_ID,
+      device_code: params.deviceCode,
+      code_verifier: params.verifier,
+    }),
+  });
+
+  if (!response.ok) {
+    let payload: { error?: string; error_description?: string } | undefined;
+    try {
+      payload = (await response.json()) as { error?: string; error_description?: string };
+    } catch {
+      const text = await response.text();
+      return { status: "error", message: text || response.statusText };
+    }
+
+    if (payload?.error === "authorization_pending") {
+      return { status: "pending" };
+    }
+
+    if (payload?.error === "slow_down") {
+      return { status: "pending", slowDown: true };
+    }
+
+    return {
+      status: "error",
+      message: payload?.error_description || payload?.error || response.statusText,
+    };
+  }
+
+  const tokenPayload = (await response.json()) as {
+    access_token?: string | null;
+    refresh_token?: string | null;
+    expires_in?: number | null;
+    token_type?: string;
+    resource_url?: string;
+  };
+
+  if (!tokenPayload.access_token || !tokenPayload.refresh_token || !tokenPayload.expires_in) {
+    return { status: "error", message: "Qwen OAuth returned incomplete token payload." };
+  }
+
+  return {
+    status: "success",
+    token: {
+      access: tokenPayload.access_token,
+      refresh: tokenPayload.refresh_token,
+      expires: Date.now() + tokenPayload.expires_in * 1000,
+      resourceUrl: tokenPayload.resource_url,
+    },
+  };
+}
+
+export async function loginQwenAgentOAuth(params: {
+  openUrl: (url: string) => Promise<void>;
+  note: (message: string, title?: string) => Promise<void>;
+  progress: { update: (message: string) => void; stop: (message?: string) => void };
+}): Promise<QwenOAuthToken> {
+  const { verifier, challenge } = generatePkce();
+  const device = await requestDeviceCode({ challenge });
+  const verificationUrl = device.verification_uri_complete || device.verification_uri;
+
+  await params.note(
+    [
+      `Open ${verificationUrl} to approve access.`,
+      `If prompted, enter the code ${device.user_code}.`,
+    ].join("\n"),
+    "Qwen OAuth",
+  );
+
+  try {
+    await params.openUrl(verificationUrl);
+  } catch {
+    // Fall back to manual copy/paste if browser open fails.
+  }
+
+  const start = Date.now();
+  let pollIntervalMs = device.interval ? device.interval * 1000 : 2000;
+  const timeoutMs = device.expires_in * 1000;
+
+  while (Date.now() - start < timeoutMs) {
+    params.progress.update("Waiting for Qwen OAuth approval…");
+    const result = await pollDeviceToken({
+      deviceCode: device.device_code,
+      verifier,
+    });
+
+    if (result.status === "success") {
+      return result.token;
+    }
+
+    if (result.status === "error") {
+      throw new Error(`Qwen OAuth failed: ${result.message}`);
+    }
+
+    if (result.status === "pending" && result.slowDown) {
+      pollIntervalMs = Math.min(pollIntervalMs * 1.5, 10000);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  throw new Error("Qwen OAuth timed out waiting for authorization.");
+}

--- a/extensions/qwen-agent-auth/openclaw.plugin.json
+++ b/extensions/qwen-agent-auth/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "qwen-agent-auth",
+  "providers": ["qwen-agent"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/qwen-agent-auth/package.json
+++ b/extensions/qwen-agent-auth/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/qwen-agent-auth",
+  "version": "2026.2.22",
+  "private": true,
+  "description": "OpenClaw Qwen Agent OAuth provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/src/commands/auth-choice-options.e2e.test.ts
+++ b/src/commands/auth-choice-options.e2e.test.ts
@@ -41,7 +41,7 @@ describe("buildAuthChoiceOptions", () => {
     ["Together AI auth choice", ["together-api-key"]],
     ["Synthetic auth choice", ["synthetic-api-key"]],
     ["Chutes OAuth auth choice", ["chutes"]],
-    ["Qwen auth choice", ["qwen-portal"]],
+    ["Qwen auth choice", ["qwen-agent", "qwen-portal"]],
     ["xAI auth choice", ["xai-api-key"]],
     ["Volcano Engine auth choice", ["volcengine-api-key"]],
     ["BytePlus auth choice", ["byteplus-api-key"]],

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -92,7 +92,7 @@ const AUTH_CHOICE_GROUP_DEFS: {
     value: "qwen",
     label: "Qwen",
     hint: "OAuth",
-    choices: ["qwen-portal"],
+    choices: ["qwen-agent", "qwen-portal"],
   },
   {
     value: "zai",
@@ -287,6 +287,7 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     label: "MiniMax OAuth",
     hint: "Oauth plugin for MiniMax",
   },
+  { value: "qwen-agent", label: "Qwen Agent OAuth" },
   { value: "qwen-portal", label: "Qwen OAuth" },
   {
     value: "copilot-proxy",

--- a/src/commands/auth-choice.apply.qwen-agent.ts
+++ b/src/commands/auth-choice.apply.qwen-agent.ts
@@ -1,0 +1,14 @@
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import { applyAuthChoicePluginProvider } from "./auth-choice.apply.plugin-provider.js";
+
+export async function applyAuthChoiceQwenAgent(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  return await applyAuthChoicePluginProvider(params, {
+    authChoice: "qwen-agent",
+    pluginId: "qwen-agent-auth",
+    providerId: "qwen-agent",
+    methodId: "device",
+    label: "Qwen Agent",
+  });
+}

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -11,6 +11,7 @@ import { applyAuthChoiceGoogleGeminiCli } from "./auth-choice.apply.google-gemin
 import { applyAuthChoiceMiniMax } from "./auth-choice.apply.minimax.js";
 import { applyAuthChoiceOAuth } from "./auth-choice.apply.oauth.js";
 import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
+import { applyAuthChoiceQwenAgent } from "./auth-choice.apply.qwen-agent.js";
 import { applyAuthChoiceQwenPortal } from "./auth-choice.apply.qwen-portal.js";
 import { applyAuthChoiceVllm } from "./auth-choice.apply.vllm.js";
 import { applyAuthChoiceVolcengine } from "./auth-choice.apply.volcengine.js";
@@ -47,6 +48,7 @@ export async function applyAuthChoice(
     applyAuthChoiceGoogleAntigravity,
     applyAuthChoiceGoogleGeminiCli,
     applyAuthChoiceCopilotProxy,
+    applyAuthChoiceQwenAgent,
     applyAuthChoiceQwenPortal,
     applyAuthChoiceXAI,
     applyAuthChoiceVolcengine,

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -40,6 +40,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "opencode-zen": "opencode",
   "xai-api-key": "xai",
   "litellm-api-key": "litellm",
+  "qwen-agent": "qwen-agent",
   "qwen-portal": "qwen-portal",
   "volcengine-api-key": "volcengine",
   "byteplus-api-key": "byteplus",

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -773,6 +773,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     authChoice === "oauth" ||
     authChoice === "chutes" ||
     authChoice === "openai-codex" ||
+    authChoice === "qwen-agent" ||
     authChoice === "qwen-portal" ||
     authChoice === "minimax-portal"
   ) {

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -43,6 +43,7 @@ export type AuthChoice =
   | "opencode-zen"
   | "github-copilot"
   | "copilot-proxy"
+  | "qwen-agent"
   | "qwen-portal"
   | "xai-api-key"
   | "volcengine-api-key"

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -60,6 +60,24 @@ describe("applyPluginAutoEnable", () => {
     expect(result.config.plugins?.entries?.["google-antigravity-auth"]?.enabled).toBe(true);
   });
 
+  it("auto-enables qwen agent auth plugin when qwen-agent profile exists", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        auth: {
+          profiles: {
+            "qwen-agent:default": {
+              provider: "qwen-agent",
+              mode: "oauth",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(result.config.plugins?.entries?.["qwen-agent-auth"]?.enabled).toBe(true);
+  });
+
   it("skips when plugins are globally disabled", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -33,6 +33,7 @@ const CHANNEL_PLUGIN_IDS = Array.from(
 const PROVIDER_PLUGIN_IDS: Array<{ pluginId: string; providerId: string }> = [
   { pluginId: "google-antigravity-auth", providerId: "google-antigravity" },
   { pluginId: "google-gemini-cli-auth", providerId: "google-gemini-cli" },
+  { pluginId: "qwen-agent-auth", providerId: "qwen-agent" },
   { pluginId: "qwen-portal-auth", providerId: "qwen-portal" },
   { pluginId: "copilot-proxy", providerId: "copilot-proxy" },
   { pluginId: "minimax-portal-auth", providerId: "minimax-portal" },


### PR DESCRIPTION
## Summary
- add bundled `qwen-agent-auth` plugin package (device OAuth flow + provider metadata)
- wire new `qwen-agent` auth choice into onboarding/auth-choice flows
- auto-enable `qwen-agent-auth` when a qwen-agent profile exists
- update docs to show qwen-agent as primary Qwen OAuth path while preserving qwen-portal as legacy
- add e2e/unit coverage for auth choice routing and plugin auto-enable behavior

## Validation
- `pnpm test src/config/plugin-auto-enable.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/commands/auth-choice-options.e2e.test.ts src/commands/auth-choice.e2e.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added bundled `qwen-agent-auth` plugin package with device OAuth flow and provider metadata, wired the new `qwen-agent` auth choice into onboarding and auth-choice flows, configured auto-enable when a `qwen-agent` profile exists, and updated docs to show `qwen-agent` as the primary Qwen OAuth path while preserving `qwen-portal` as legacy.

- Added new plugin under `extensions/qwen-agent-auth/` with device code OAuth flow implementation
- Integrated `qwen-agent` auth choice across all auth routing surfaces (auth-choice.apply.ts, auth-choice-options.ts, preferred-provider mapping, onboard types)
- Added plugin auto-enable mapping for `qwen-agent-auth` when `qwen-agent` provider is configured
- Updated documentation to position `qwen-agent` as primary with `qwen-portal` as legacy alternative
- Added comprehensive test coverage (76 new test cases) for auth choice routing and plugin auto-enable behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns exactly (mirrors qwen-portal-auth, google-antigravity-auth, and minimax-portal-auth), has comprehensive test coverage with 76 new test cases passing, maintains backward compatibility by preserving qwen-portal as legacy, uses standard OAuth2 device code flow, and updates all necessary integration points (auth routing, plugin auto-enable, docs) consistently
- No files require special attention

<sub>Last reviewed commit: 40eb382</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->