### PR TITLE
feat(model-usage): merge basic observability modes (errors/overview)

### DIFF
--- a/skills/model-usage/SKILL.md
+++ b/skills/model-usage/SKILL.md
@@ -1,69 +1,58 @@
 ---
 name: model-usage
-description: Use CodexBar CLI local cost usage to summarize per-model usage for Codex or Claude, including the current (most recent) model or a full model breakdown. Trigger when asked for model-level usage/cost data from codexbar, or when you need a scriptable per-model summary from codexbar cost JSON.
+description: Summarize model-level cost usage and basic observability for OpenClaw. Use when you need CodexBar per-model cost (current/all), recent failed or aborted sessions, or a combined overview report for cost + errors.
 metadata:
   {
     "openclaw":
       {
         "emoji": "📊",
-        "os": ["darwin"],
-        "requires": { "bins": ["codexbar"] },
-        "install":
-          [
-            {
-              "id": "brew-cask",
-              "kind": "brew",
-              "formula": "steipete/tap/codexbar",
-              "bins": ["codexbar"],
-              "label": "Install CodexBar (brew cask)",
-            },
-          ],
+        "os": ["darwin", "linux"],
+        "requires": { "bins": ["codexbar", "openclaw"] },
       },
   }
 ---
 
-# Model usage
+# Model usage + observability
 
 ## Overview
 
-Get per-model usage cost from CodexBar's local cost logs. Supports "current model" (most recent daily entry) or "all models" summaries for Codex or Claude.
+统一脚本，支持两类能力：
 
-TODO: add Linux CLI support guidance once CodexBar CLI install path is documented for Linux.
+1. 成本：基于 CodexBar 的 per-model cost 汇总
+2. 可观测：基于 OpenClaw sessions 的失败会话扫描 + 网关日志提示
 
-## Quick start
-
-1. Fetch cost JSON via CodexBar CLI or pass a JSON file.
-2. Use the bundled script to summarize by model.
+## Usage
 
 ```bash
+# 成本：当前模型
 python {baseDir}/scripts/model_usage.py --provider codex --mode current
-python {baseDir}/scripts/model_usage.py --provider codex --mode all
-python {baseDir}/scripts/model_usage.py --provider claude --mode all --format json --pretty
+
+# 成本：全部模型
+python {baseDir}/scripts/model_usage.py --provider codex --mode all --days 7
+
+# 错误观测：最近失败/中止会话
+python {baseDir}/scripts/model_usage.py --mode errors --error-limit 50
+
+# 总览：成本 + 错误
+python {baseDir}/scripts/model_usage.py --provider codex --mode overview --days 7 --error-limit 50
+
+# JSON 输出
+python {baseDir}/scripts/model_usage.py --mode overview --format json --pretty
 ```
 
-## Current model logic
+## Modes
 
-- Uses the most recent daily row with `modelBreakdowns`.
-- Picks the model with the highest cost in that row.
-- Falls back to the last entry in `modelsUsed` when breakdowns are missing.
-- Override with `--model <name>` when you need a specific model.
+- `current`: 当前模型成本摘要
+- `all`: 全模型成本汇总
+- `errors`: 最近失败/中止会话 + 日志提示
+- `overview`: 成本与错误合并输出
 
-## Inputs
+## Notes
 
-- Default: runs `codexbar cost --format json --provider <codex|claude>`.
-- File or stdin:
-
-```bash
-codexbar cost --provider codex --format json > /tmp/cost.json
-python {baseDir}/scripts/model_usage.py --input /tmp/cost.json --mode all
-cat /tmp/cost.json | python {baseDir}/scripts/model_usage.py --input - --mode current
-```
-
-## Output
-
-- Text (default) or JSON (`--format json --pretty`).
-- Values are cost-only per model; tokens are not split by model in CodexBar output.
+- `current/all/overview` 需要 `codexbar`。
+- `errors/overview` 需要 `openclaw`。
+- 日志读取优先 `journalctl`（Linux/systemd）；在 macOS 会尝试 `~/.openclaw/logs/gateway.log`。
 
 ## References
 
-- Read `references/codexbar-cli.md` for CLI flags and cost JSON fields.
+- `references/codexbar-cli.md`

--- a/skills/model-usage/SKILL.md
+++ b/skills/model-usage/SKILL.md
@@ -16,42 +16,42 @@ metadata:
 
 ## Overview
 
-统一脚本，支持两类能力：
+A unified script that provides two capabilities:
 
-1. 成本：基于 CodexBar 的 per-model cost 汇总
-2. 可观测：基于 OpenClaw sessions 的失败会话扫描 + 网关日志提示
+1. Cost: per-model cost aggregation via CodexBar
+2. Observability: failed/aborted session scan via OpenClaw sessions + gateway log hints
 
 ## Usage
 
 ```bash
-# 成本：当前模型
+# Cost: current model
 python {baseDir}/scripts/model_usage.py --provider codex --mode current
 
-# 成本：全部模型
+# Cost: all models
 python {baseDir}/scripts/model_usage.py --provider codex --mode all --days 7
 
-# 错误观测：最近失败/中止会话
+# Errors: recent failed/aborted sessions
 python {baseDir}/scripts/model_usage.py --mode errors --error-limit 50
 
-# 总览：成本 + 错误
+# Overview: cost + errors
 python {baseDir}/scripts/model_usage.py --provider codex --mode overview --days 7 --error-limit 50
 
-# JSON 输出
+# JSON output
 python {baseDir}/scripts/model_usage.py --mode overview --format json --pretty
 ```
 
 ## Modes
 
-- `current`: 当前模型成本摘要
-- `all`: 全模型成本汇总
-- `errors`: 最近失败/中止会话 + 日志提示
-- `overview`: 成本与错误合并输出
+- `current`: current model cost summary
+- `all`: all-model cost aggregation
+- `errors`: recent failed/aborted sessions + log hints
+- `overview`: combined cost and error report
 
 ## Notes
 
-- `current/all/overview` 需要 `codexbar`。
-- `errors/overview` 需要 `openclaw`。
-- 日志读取优先 `journalctl`（Linux/systemd）；在 macOS 会尝试 `~/.openclaw/logs/gateway.log`。
+- `current/all/overview` require `codexbar`.
+- `errors/overview` require `openclaw`.
+- Logs are read from `journalctl` first (Linux/systemd); on macOS it falls back to `~/.openclaw/logs/gateway.log`.
 
 ## References
 

--- a/skills/model-usage/scripts/model_usage.py
+++ b/skills/model-usage/scripts/model_usage.py
@@ -67,13 +67,14 @@ def load_cost_payload(input_path: Optional[str], provider: str) -> Dict[str, Any
 
 
 def run_openclaw_sessions(limit: int) -> List[Dict[str, Any]]:
-    cmd = ["openclaw", "sessions", "list", "--json", "--limit", str(limit)]
+    # CLI supports `openclaw sessions --json` (no --limit flag).
+    cmd = ["openclaw", "sessions", "--json"]
     try:
         output = subprocess.check_output(cmd, text=True)
     except FileNotFoundError:
         raise RuntimeError("openclaw not found on PATH.")
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(f"openclaw sessions list failed (exit {exc.returncode}).")
+        raise RuntimeError(f"openclaw sessions failed (exit {exc.returncode}).")
 
     try:
         data = json.loads(output)
@@ -81,9 +82,11 @@ def run_openclaw_sessions(limit: int) -> List[Dict[str, Any]]:
         raise RuntimeError(f"Failed to parse openclaw sessions JSON: {exc}")
 
     if isinstance(data, dict) and isinstance(data.get("sessions"), list):
-        return [s for s in data["sessions"] if isinstance(s, dict)]
+        sessions = [s for s in data["sessions"] if isinstance(s, dict)]
+        return sessions[:limit]
     if isinstance(data, list):
-        return [s for s in data if isinstance(s, dict)]
+        sessions = [s for s in data if isinstance(s, dict)]
+        return sessions[:limit]
     return []
 
 


### PR DESCRIPTION
## Summary
This PR extends the `model-usage` skill from cost-only reporting to a combined **cost + observability** utility.

### Added
- New modes:
  - `errors`: scan recent OpenClaw sessions for failed/aborted runs and provide concise diagnostics
  - `overview`: combine cost summary + error summary in one report
- `openclaw` dependency in skill metadata (for session/log inspection paths)
- Basic gateway log hint collection to improve triage context

### Existing behavior preserved
- `current` and `all` cost modes continue to work as before (CodexBar-based)

## Why
Operators often need a quick one-shot view of **model spend + recent failures**.
This reduces context switching between separate scripts/commands when doing routine health checks.

## Validation
- `python3 skills/model-usage/scripts/model_usage.py --help`
- Verified mode flags include: `current | all | errors | overview`

## Scope
Touches only:
- `skills/model-usage/SKILL.md`
- `skills/model-usage/scripts/model_usage.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the `model-usage` skill from cost-only reporting to a combined cost + observability utility. It adds two new modes (`errors` and `overview`) to scan OpenClaw sessions for failed/aborted runs and combines cost summaries with error diagnostics.

**Critical Issue Found:**
- The script calls `openclaw sessions list --limit <num>` but the CLI does not support the `--limit` flag, causing runtime failure. The filtering must be done in Python after fetching all sessions.

**Style Issues:**
- SKILL.md contains Chinese text mixed with English (lines 19-22, 45-48, 52-54), which is inconsistent with repository documentation standards.

**Positive Aspects:**
- Clean code structure with well-organized functions
- Proper error handling for missing dependencies (`codexbar`, `openclaw`)
- Cross-platform log collection (journalctl for Linux, file fallback for macOS)
- Backward compatibility maintained for existing `current` and `all` modes

<h3>Confidence Score: 2/5</h3>

- This PR contains a critical bug that will cause runtime failure in the new error/overview modes
- Score reflects a critical logical error where the code uses a non-existent CLI flag (`--limit`) that will cause the `errors` and `overview` modes to fail at runtime. While the code is well-structured and the existing modes are preserved, the new functionality cannot work without fixing this bug. The Chinese documentation also needs to be translated to English for consistency.
- Pay close attention to `skills/model-usage/scripts/model_usage.py` line 70 - the `--limit` flag must be removed and filtering applied after fetching sessions

<sub>Last reviewed commit: a2e40d6</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->