### PR TITLE
Fix NODE_EXTRA_CA_CERTS missing from LaunchAgent environment on macOS

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -309,6 +309,26 @@ describe("buildServiceEnvironment", () => {
       expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.work");
     }
   });
+
+  it("defaults NODE_EXTRA_CA_CERTS to system cert bundle on macOS", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+    });
+    if (process.platform === "darwin") {
+      expect(env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/cert.pem");
+    } else {
+      expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    }
+  });
+
+  it("respects user-provided NODE_EXTRA_CA_CERTS over the default", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user", NODE_EXTRA_CA_CERTS: "/custom/certs/ca.pem" },
+      port: 18789,
+    });
+    expect(env.NODE_EXTRA_CA_CERTS).toBe("/custom/certs/ca.pem");
+  });
 });
 
 describe("buildNodeServiceEnvironment", () => {
@@ -331,6 +351,24 @@ describe("buildNodeServiceEnvironment", () => {
       env: { HOME: "/home/user" },
     });
     expect(env.TMPDIR).toBe(os.tmpdir());
+  });
+
+  it("defaults NODE_EXTRA_CA_CERTS to system cert bundle on macOS for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user" },
+    });
+    if (process.platform === "darwin") {
+      expect(env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/cert.pem");
+    } else {
+      expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    }
+  });
+
+  it("respects user-provided NODE_EXTRA_CA_CERTS for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", NODE_EXTRA_CA_CERTS: "/custom/certs/ca.pem" },
+    });
+    expect(env.NODE_EXTRA_CA_CERTS).toBe("/custom/certs/ca.pem");
   });
 });
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -215,10 +215,16 @@ export function buildServiceEnvironment(params: {
   const configPath = env.OPENCLAW_CONFIG_PATH;
   // Keep a usable temp directory for supervised services even when the host env omits TMPDIR.
   const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
+  // On macOS, launchd services don't inherit the shell environment, so Node's undici/fetch
+  // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
+  // works correctly when running as a LaunchAgent without extra user configuration.
+  const nodeCaCerts =
+    env.NODE_EXTRA_CA_CERTS ?? (process.platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,
     PATH: buildMinimalServicePath({ env }),
+    NODE_EXTRA_CA_CERTS: nodeCaCerts,
     OPENCLAW_PROFILE: profile,
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,
@@ -239,10 +245,16 @@ export function buildNodeServiceEnvironment(params: {
   const stateDir = env.OPENCLAW_STATE_DIR;
   const configPath = env.OPENCLAW_CONFIG_PATH;
   const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
+  // On macOS, launchd services don't inherit the shell environment, so Node's undici/fetch
+  // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
+  // works correctly when running as a LaunchAgent without extra user configuration.
+  const nodeCaCerts =
+    env.NODE_EXTRA_CA_CERTS ?? (process.platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,
     PATH: buildMinimalServicePath({ env }),
+    NODE_EXTRA_CA_CERTS: nodeCaCerts,
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,
     OPENCLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),


### PR DESCRIPTION
## Problem

When OpenClaw runs as a macOS LaunchAgent (installed via `openclaw gateway install`), Node's `undici`/`fetch` cannot locate the system CA bundle because `launchd` does not inherit the shell environment. This causes TLS verification failures for all HTTPS connections (Telegram, webhooks, etc.), while the same gateway works fine in a foreground terminal session.

Root cause: `buildServiceEnvironment` and `buildNodeServiceEnvironment` in `service-env.ts` did not include `NODE_EXTRA_CA_CERTS` in the generated plist environment.

Fixes #22856.

## Fix

Set `NODE_EXTRA_CA_CERTS` to `/etc/ssl/cert.pem` (the macOS system CA bundle) by default when building the service environment on macOS. A user-supplied `NODE_EXTRA_CA_CERTS` in the host environment always takes precedence.

The same default is applied to both `buildServiceEnvironment` (gateway) and `buildNodeServiceEnvironment` (node service) since both run under launchd on macOS.

## Changes

- `src/daemon/service-env.ts`: add `NODE_EXTRA_CA_CERTS` to the service environment on macOS, falling back to `/etc/ssl/cert.pem` when not set by the user
- `src/daemon/service-env.test.ts`: add 4 tests covering the default and user-override cases for both environment builders

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes TLS verification failures for HTTPS connections when OpenClaw runs as a macOS LaunchAgent by setting `NODE_EXTRA_CA_CERTS` to the macOS system CA bundle path (`/etc/ssl/cert.pem`). The issue occurs because launchd services don't inherit the shell environment, preventing Node's undici/fetch from locating system certificates.

- Adds `NODE_EXTRA_CA_CERTS` environment variable to both `buildServiceEnvironment` and `buildNodeServiceEnvironment` functions
- Defaults to `/etc/ssl/cert.pem` on macOS (Darwin platform only)
- Respects user-provided `NODE_EXTRA_CA_CERTS` values as overrides
- Includes comprehensive test coverage for both default behavior and user override scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and narrowly scoped. It adds a single environment variable that only affects macOS LaunchAgent environments, uses the correct system CA bundle path, properly respects user overrides, and includes comprehensive test coverage for all scenarios. The fix directly addresses a documented issue without introducing any breaking changes or side effects.
- No files require special attention

<sub>Last reviewed commit: 35c5a8e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->