### PR TITLE
discord: harden preflight/reply path against slow lookup latency

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -646,7 +646,8 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
     },
     onReplyStart: async () => {
-      await typingCallbacks.onReplyStart();
+      // Typing is UX-only; don't block reply dispatch on Discord REST latency.
+      void typingCallbacks.onReplyStart();
       await statusReactions.setThinking();
     },
   });

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -129,6 +129,7 @@ export async function resolveDiscordThreadParentInfo(params: {
   client: Client;
   threadChannel: DiscordThreadChannel;
   channelInfo: import("./message-utils.js").DiscordChannelInfo | null;
+  channelLookupTimeoutMs?: number;
 }): Promise<DiscordThreadParentInfo> {
   const { threadChannel, channelInfo, client } = params;
   const parentId =
@@ -137,7 +138,9 @@ export async function resolveDiscordThreadParentInfo(params: {
     return {};
   }
   let parentName = threadChannel.parent?.name;
-  const parentInfo = await resolveDiscordChannelInfo(client, parentId);
+  const parentInfo = await resolveDiscordChannelInfo(client, parentId, {
+    timeoutMs: params.channelLookupTimeoutMs,
+  });
   parentName = parentName ?? parentInfo?.name;
   const parentType = parentInfo?.type;
   return { id: parentId, name: parentName, type: parentType };

--- a/src/discord/pluralkit.ts
+++ b/src/discord/pluralkit.ts
@@ -1,6 +1,7 @@
 import { resolveFetch } from "../infra/fetch.js";
 
 const PLURALKIT_API_BASE = "https://api.pluralkit.me/v2";
+const PLURALKIT_LOOKUP_TIMEOUT_MS = 1_500;
 
 export type DiscordPluralKitConfig = {
   enabled?: boolean;
@@ -31,6 +32,7 @@ export async function fetchPluralKitMessageInfo(params: {
   messageId: string;
   config?: DiscordPluralKitConfig;
   fetcher?: typeof fetch;
+  timeoutMs?: number;
 }): Promise<PluralKitMessageInfo | null> {
   if (!params.config?.enabled) {
     return null;
@@ -43,9 +45,30 @@ export async function fetchPluralKitMessageInfo(params: {
   if (params.config.token?.trim()) {
     headers.Authorization = params.config.token.trim();
   }
-  const res = await fetchImpl(`${PLURALKIT_API_BASE}/messages/${params.messageId}`, {
-    headers,
-  });
+  const timeoutMs =
+    typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+      ? Math.max(0, Math.trunc(params.timeoutMs))
+      : PLURALKIT_LOOKUP_TIMEOUT_MS;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const controller =
+    timeoutMs > 0 && typeof AbortController !== "undefined" ? new AbortController() : undefined;
+  if (controller && timeoutMs > 0) {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+    }, timeoutMs);
+    timeoutId.unref?.();
+  }
+  let res: Response;
+  try {
+    res = await fetchImpl(`${PLURALKIT_API_BASE}/messages/${params.messageId}`, {
+      headers,
+      signal: controller?.signal,
+    });
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
   if (res.status === 404) {
     return null;
   }


### PR DESCRIPTION
## Summary
- I fixed Discord preflight/reply stalls tied to slow channel and PluralKit lookups.
- I added bounded timeout/abort handling and guarded retry behavior so monitor flow fails fast instead of hanging.
- I hardened thread-bound routing when Discord payload thread metadata is incomplete.
- I kept scope strictly to Discord monitor/pluralkit paths and related tests.

## Linked Issue
Closes openclaw/openclaw#22378.

## What Changed
- Preflight guild fast path: skip early channel REST lookup for guild traffic.
- Channel lookup timeout support in preflight/thread-parent resolution.
- PluralKit lookup timeout + abort support; bot-path retry only on timeout/abort-like failures.
- Thread binding lookup now consistently uses `channel_id`.
- Bound-thread session detection based on binding/session key presence.
- Reply typing start is non-blocking (`fire-and-forget`) so reply dispatch is not delayed by typing REST latency.

## Scope
Changed files:
- `src/discord/monitor/message-handler.preflight.ts`
- `src/discord/monitor/message-handler.process.ts`
- `src/discord/monitor/message-utils.ts`
- `src/discord/monitor/threading.ts`
- `src/discord/pluralkit.ts`
- Discord test updates only

## Validation
- `pnpm check` passes.
- `pnpm test` passes.
- Targeted Discord suites pass:
  - `src/discord/monitor/message-handler.process.test.ts`
  - `src/discord/monitor/message-utils.test.ts`
  - `src/discord/pluralkit.test.ts`
  - `src/discord/monitor.tool-result.sends-status-replies-responseprefix.test.ts`
  - `src/discord/monitor/message-handler.preflight.test.ts`

## Risk Notes
- No new permissions, auth model changes, or config migrations.
- Network behavior changed only by adding timeout/abort bounds on existing Discord/PluralKit calls.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardened Discord preflight and reply paths against slow external API latency by adding bounded timeouts to channel lookups (2.5s) and PluralKit lookups (1.5s, with 5s retry for bot messages). Guild messages now skip early channel REST lookups via payload metadata, and typing indicators no longer block reply dispatch. Thread binding lookups consistently use `channel_id` for more robust thread-bound session detection.

**Key changes:**
- Added timeout support to `resolveDiscordChannelInfo` and `fetchPluralKitMessageInfo` using AbortController
- PluralKit bot lookup now retries on timeout/abort errors with longer timeout (5s) to handle slow API responses
- Guild messages skip early channel lookup since `guild_id` in payload is sufficient for routing
- Typing start is now fire-and-forget (`void` call) to prevent Discord REST latency from delaying reply dispatch
- Thread binding detection simplified to check for `boundSessionKey` presence rather than requiring both key and thread channel
- Comprehensive test coverage for timeout behavior and non-blocking typing

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - focused changes to add timeout bounds and optimize lookup paths
- The changes are well-scoped to Discord monitor paths with comprehensive test coverage for new timeout behavior. The implementation uses standard AbortController patterns, includes proper error handling, and maintains backward compatibility. No breaking changes to API contracts or auth models.
- No files require special attention - all changes follow existing patterns and include proper test coverage

<sub>Last reviewed commit: 13e72ca</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

## Transparency
- AI-assisted: Yes (Codex).
- Testing level: fully tested (`pnpm build`, `pnpm check`, `pnpm test`, plus targeted Discord suites).
