### PR TITLE
fix(slack): parse generic attachment text for inbound events

### DIFF
--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -453,7 +453,7 @@ describe("resolveSlackAttachmentContent", () => {
     vi.restoreAllMocks();
   });
 
-  it("ignores non-forwarded attachments", async () => {
+  it("extracts text from non-forwarded attachments", async () => {
     const result = await resolveSlackAttachmentContent({
       attachments: [
         {
@@ -466,7 +466,10 @@ describe("resolveSlackAttachmentContent", () => {
       maxBytes: 1024 * 1024,
     });
 
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      text: "[Slack attachment]\nunfurl text",
+      media: [],
+    });
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -484,7 +487,35 @@ describe("resolveSlackAttachmentContent", () => {
     });
 
     expect(result).toEqual({
-      text: "[Forwarded message from Bob]\nPlease review this",
+      text: "[Slack attachment from Bob]\nPlease review this",
+      media: [],
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("extracts pretext/fallback/fields from generic Slack attachments", async () => {
+    const result = await resolveSlackAttachmentContent({
+      attachments: [
+        {
+          title: "Vercel deploy",
+          pretext: "Deployment to Preview - tideflow-app",
+          fallback: "Status: Completed",
+          fields: [{ title: "Commit", value: "e6be351" }, { value: "Environment: Preview" }],
+          is_msg_unfurl: true,
+        },
+      ],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toEqual({
+      text: [
+        "[Slack attachment: Vercel deploy]",
+        "Deployment to Preview - tideflow-app",
+        "Status: Completed",
+        "Commit: e6be351",
+        "Environment: Preview",
+      ].join("\n"),
       media: [],
     });
     expect(mockFetch).not.toHaveBeenCalled();

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -193,10 +193,10 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     expect(prepared).toBeTruthy();
-    expect(prepared!.ctxPayload.RawBody).toContain("[Forwarded message from Bob]\nForwarded hello");
+    expect(prepared!.ctxPayload.RawBody).toContain("[Slack attachment from Bob]\nForwarded hello");
   });
 
-  it("ignores non-forward attachments when no direct text/files are present", async () => {
+  it("includes non-forward attachment text when no direct text/files are present", async () => {
     const prepared = await prepareWithDefaultCtx(
       createSlackMessage({
         text: "",
@@ -205,7 +205,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
       }),
     );
 
-    expect(prepared).toBeNull();
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toContain("[Slack attachment]\nlink unfurl text");
   });
 
   it("keeps channel metadata out of GroupSystemPrompt", async () => {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -344,7 +344,7 @@ export async function prepareSlackMessage(params: {
     maxBytes: ctx.mediaMaxBytes,
   });
 
-  // Resolve forwarded message content (text + media) from Slack attachments
+  // Resolve attachment content (text + media), including forwarded shares
   const attachmentContent = await resolveSlackAttachmentContent({
     attachments: message.attachments,
     token: ctx.botToken,
@@ -363,6 +363,7 @@ export async function prepareSlackMessage(params: {
       .filter(Boolean)
       .join("\n") || "";
   if (!rawBody) {
+    logVerbose("slack: drop message (empty body after attachment/media normalization)");
     return null;
   }
 

--- a/src/slack/types.ts
+++ b/src/slack/types.ts
@@ -12,6 +12,11 @@ export type SlackAttachment = {
   fallback?: string;
   text?: string;
   pretext?: string;
+  title?: string;
+  fields?: Array<{
+    title?: string;
+    value?: string;
+  }>;
   author_name?: string;
   author_id?: string;
   from_url?: string;


### PR DESCRIPTION
## Summary
- parse text from generic Slack attachments (not only `is_share` forwarded payloads)
- include `pretext`, `text`, `fallback`, and `fields` in normalized inbound message body
- keep media download behavior restricted to forwarded/share attachments for safety
- add a verbose drop log when body is empty after attachment/media normalization

## Why
GitHub/Vercel Slack app notifications often arrive as attachment-only bot messages without `is_share=true`. Those messages were being dropped as empty, so automation never saw deployment status updates.

## Validation
- `pnpm vitest run src/slack/monitor/media.test.ts src/slack/monitor/message-handler/prepare.test.ts`
- `pnpm exec oxlint --type-aware src/slack/monitor/media.ts src/slack/monitor/message-handler/prepare.ts src/slack/types.ts src/slack/monitor/media.test.ts src/slack/monitor/message-handler/prepare.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Expands Slack attachment parsing to extract text from generic bot attachments (like GitHub/Vercel notifications), not just forwarded messages. Previously, attachment-only bot messages were dropped as empty, preventing automation from seeing deployment status updates.

**Key changes:**
- Parses `pretext`, `fallback`, `title`, and `fields` from all attachments
- Deduplicates fallback text when it matches pretext/text
- Restricts media downloads to forwarded attachments (`is_share: true`) for safety
- Adds verbose logging when messages are dropped due to empty body
- Updates heading format from "Forwarded message" to "Slack attachment" to reflect broader scope

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-tested (37 passing tests), maintains backward compatibility, and follows defensive coding practices. Media downloads remain restricted to forwarded attachments for security. The deduplication logic correctly prevents duplicate text. All edge cases are covered in tests.
- No files require special attention

<sub>Last reviewed commit: c5c755d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->