### PR TITLE
fix: make replyToMode 'off' actually prevent threading in Slack

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -241,7 +241,7 @@ Manual reply tags are supported:
 - `[[reply_to_current]]`
 - `[[reply_to:<id>]]`
 
-Note: `replyToMode="off"` disables implicit reply threading. Explicit `[[reply_to_*]]` tags are still honored.
+Note: `replyToMode="off"` disables **all** reply threading in Slack, including explicit `[[reply_to_*]]` tags. This differs from Telegram, where explicit tags are still honored in `"off"` mode. The difference reflects the platform threading models: Slack threads hide messages from the channel, while Telegram replies remain visible in the main chat flow.
 
 ## Media, chunking, and delivery
 

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -177,7 +177,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   threading: {
     resolveReplyToMode: ({ cfg, accountId, chatType }) =>
       resolveSlackReplyToMode(resolveSlackAccount({ cfg, accountId }), chatType),
-    allowExplicitReplyTagsWhenOff: true,
+    allowExplicitReplyTagsWhenOff: false,
     buildToolContext: (params) => buildSlackThreadingToolContext(params),
   },
   messaging: {

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -206,7 +206,7 @@ describe("applyReplyThreading auto-threading", () => {
     expect(result[0].replyToId).toBeUndefined();
   });
 
-  it("keeps explicit tags for Slack when off mode allows tags", () => {
+  it("strips explicit tags for Slack when off mode disallows tags", () => {
     const result = applyReplyThreading({
       payloads: [{ text: "[[reply_to_current]]A" }],
       replyToMode: "off",
@@ -215,8 +215,7 @@ describe("applyReplyThreading auto-threading", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].replyToId).toBe("42");
-    expect(result[0].replyToTag).toBe(true);
+    expect(result[0].replyToId).toBeUndefined();
   });
 
   it("keeps explicit tags for Telegram when off mode is enabled", () => {

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -473,7 +473,7 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     threading: {
       resolveReplyToMode: ({ cfg, accountId, chatType }) =>
         resolveSlackReplyToMode(resolveSlackAccount({ cfg, accountId }), chatType),
-      allowExplicitReplyTagsWhenOff: true,
+      allowExplicitReplyTagsWhenOff: false,
       buildToolContext: (params) => buildSlackThreadingToolContext(params),
     },
   },

--- a/src/slack/monitor.tool-result.test.ts
+++ b/src/slack/monitor.tool-result.test.ts
@@ -300,6 +300,7 @@ describe("monitorSlackProvider tool results", () => {
       return { text: "final reply" };
     });
 
+    setDirectMessageReplyMode("all");
     await runSlackMessageOnce(monitorSlackProvider, {
       event: makeSlackMessageEvent(),
     });

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -117,7 +117,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
   const reactionMode = slackCfg.reactionNotifications ?? "own";
   const reactionAllowlist = slackCfg.reactionAllowlist ?? [];
-  const replyToMode = slackCfg.replyToMode ?? "all";
+  const replyToMode = slackCfg.replyToMode ?? "off";
   const threadHistoryScope = slackCfg.thread?.historyScope ?? "thread";
   const threadInheritParent = slackCfg.thread?.inheritParent ?? false;
   const slashCommand = resolveSlackSlashCommandConfig(opts.slashCommand ?? slackCfg.slashCommand);

--- a/src/slack/threading.test.ts
+++ b/src/slack/threading.test.ts
@@ -31,7 +31,7 @@ describe("resolveSlackThreadTargets", () => {
     expect(statusThreadTs).toBe("123");
   });
 
-  it("keeps status threading even when reply threading is off", () => {
+  it("does not thread status indicator when reply threading is off", () => {
     const { replyThreadTs, statusThreadTs } = resolveSlackThreadTargets({
       replyToMode: "off",
       message: {
@@ -42,7 +42,7 @@ describe("resolveSlackThreadTargets", () => {
     });
 
     expect(replyThreadTs).toBeUndefined();
-    expect(statusThreadTs).toBe("123");
+    expect(statusThreadTs).toBeUndefined();
   });
 
   it("sets messageThreadId for top-level messages when replyToMode is all", () => {

--- a/src/slack/threading.ts
+++ b/src/slack/threading.ts
@@ -40,6 +40,6 @@ export function resolveSlackThreadTargets(params: {
 }) {
   const { incomingThreadTs, messageTs } = resolveSlackThreadContext(params);
   const replyThreadTs = incomingThreadTs ?? (params.replyToMode === "all" ? messageTs : undefined);
-  const statusThreadTs = replyThreadTs ?? messageTs;
+  const statusThreadTs = replyThreadTs;
   return { replyThreadTs, statusThreadTs };
 }


### PR DESCRIPTION
## Summary
Three fixes that make `replyToMode: "off"` work correctly for Slack.

### Changes
1. **`src/slack/threading.ts`** — Remove `messageTs` fallback on `statusThreadTs`. When no thread exists, the status thread timestamp should not fall back to the message timestamp, which creates a new thread. (Fixes #16868)

2. **`src/channels/dock.ts`** — Set `allowExplicitReplyTagsWhenOff: false` for Slack. System prompt `[[reply_to_current]]` tags were bypassing `replyToMode: "off"`, creating threads. This is intentionally different from Telegram — see docs update below. (Fixes #16080)

3. **`src/slack/monitor/provider.ts`** — Default `replyToMode` from `"all"` to `"off"`. The provider had `"all"` while `accounts.ts` had `"off"`, contradicting documentation which states `"off"` is the default. (Fixes #20827)

4. **`docs/channels/slack.md`** — Updated to note that Slack strips explicit reply tags in `"off"` mode and why this differs from Telegram (Slack threads hide messages from channels; Telegram replies remain in the main chat flow).

### Migration Note
Existing installs that relied on the implicit `"all"` default (replies always auto-threaded) should add `channels.slack.replyToMode: "all"` to their config to maintain previous behavior. This aligns the runtime default with the documented default (`"off"`).

### Testing
- All 966 test files pass
- 3 test files updated to match new behavior
- Verified on production deployment

### Code Review Discussion

The following findings were raised during automated code review (Codex CLI) and reviewed by humans:

**Finding 1 (Medium): Default behavior change for unconfigured installs.**
The `provider.ts` change from `"all"` to `"off"` is a user-visible behavioral change. Existing installs that never set `replyToMode` will stop auto-threading.

*Decision: Intentional.* The docs already document `"off"` as the default. The `"all"` fallback contradicted both docs and `accounts.ts`. Migration path is simple: add `replyToMode: "all"` to config.

**Finding 2 (Low): Status thread target lost for `replyToMode: "first"`.**
`statusThreadTs` now equals `replyThreadTs`, which is `undefined` for `"first"` mode before the first reply.

*Decision: Not a real issue.* The thread does not exist yet before the first reply — the old `messageTs` fallback was a no-op on a non-existent thread.

**Finding 3 (Low): Docs conflict — explicit reply tags stripped in "off" mode.**
`allowExplicitReplyTagsWhenOff: false` conflicts with docs saying explicit tags are honored.

*Decision: Updated docs.* Slack threads hide messages from channels, so `"off"` should mean truly off. Telegram correctly keeps tags honored in `"off"` mode because replies stay visible in the main chat. The docs update explains this distinction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three bugs that prevented `replyToMode: "off"` from actually disabling threading in Slack:

1. **`threading.ts`** - removed `messageTs` fallback for `statusThreadTs`, preventing unwanted thread creation when `replyToMode` is `"off"`
2. **`dock.ts`** - set `allowExplicitReplyTagsWhenOff: false` for Slack to strip `[[reply_to_*]]` tags in `"off"` mode (different from Telegram which keeps them)
3. **`provider.ts`** - changed default `replyToMode` from `"all"` to `"off"` to align with documented default and `accounts.ts`

The changes are well-tested with 3 test files updated to match the new behavior. The distinction between Slack (threads hide messages) and Telegram (replies stay visible) is clearly documented.

**Minor issue:** The extension file at `extensions/slack/src/channel.ts:180` still has `allowExplicitReplyTagsWhenOff: true`, though it's not actively used since the core implementation takes precedence. Updating it would keep the codebase consistent.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-reasoned, thoroughly tested (all 966 tests pass, 3 test files updated), and fix documented bugs. The logic is sound: `statusThreadTs` is now properly tied to `replyThreadTs`, and the `setSlackThreadStatus` function already handles undefined values gracefully. The default change aligns with existing documentation. The only minor issue is a cosmetic inconsistency in the extension file that doesn't affect runtime behavior.
- No files require special attention beyond the minor style suggestion in `extensions/slack/src/channel.ts`

<sub>Last reviewed commit: 21038d1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->