### PR TITLE
fix(discord): reject thread creation in thread/voice/stage channels

### DIFF
--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -119,6 +119,18 @@ export async function createThreadDiscord(
       channelType = undefined;
     }
   }
+  // Reject thread creation in thread/voice/stage channels
+  if (
+    channelType === ChannelType.PublicThread ||
+    channelType === ChannelType.PrivateThread ||
+    channelType === ChannelType.AnnouncementThread ||
+    channelType === ChannelType.GuildVoice ||
+    channelType === ChannelType.GuildStageVoice
+  ) {
+    throw new Error(
+      `Cannot create a thread inside a ${ChannelType[channelType]} channel (${channelId}). Threads can only be created in text, announcement, or forum channels.`,
+    );
+  }
   const isForumLike =
     channelType === ChannelType.GuildForum || channelType === ChannelType.GuildMedia;
   if (isForumLike) {


### PR DESCRIPTION
## Summary

- Adds a type guard in `createThreadDiscord()` that rejects thread creation when the target channel is a thread, voice, or stage channel
- Discord returns an opaque "Cannot execute action on this channel type" error in these cases — this gives the agent a clear, actionable error message instead

The existing channel type detection (added for forum channel support) already fetches the channel type. This builds on that by checking for unsupported types before proceeding.

Closes #20613

## Test plan

- [ ] Verify thread creation still works normally in text channels
- [ ] Verify thread creation still works in forum/media channels
- [ ] Verify attempting to create a thread in a thread returns a clear error message
- [ ] Verify attempting to create a thread in a voice channel returns a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds validation to prevent thread creation in unsupported Discord channel types (threads, voice, and stage channels) before making the API call. When these channel types are detected, the function now throws a descriptive error message instead of letting Discord return an opaque "Cannot execute action on this channel type" error.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change adds defensive validation that improves error messaging without changing existing behavior. It uses the same channel type detection pattern already present in the code and follows existing code patterns in the codebase for similar validation. The error is thrown before any API calls are made, preventing unnecessary Discord API requests.
- No files require special attention

<sub>Last reviewed commit: 4a20819</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->