### PR TITLE
fix(cron): every-schedule boundary returns nowMs instead of next slot (#22895)

### DIFF
--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -37,7 +37,12 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
       return anchor;
     }
     const elapsed = nowMs - anchor;
-    const steps = Math.max(1, Math.floor((elapsed + everyMs - 1) / everyMs));
+    // Always return a strictly-future time.  The old ceiling-division
+    // formula `Math.floor((elapsed + everyMs - 1) / everyMs)` returns
+    // `nowMs` itself when `elapsed` is an exact multiple of `everyMs`,
+    // which causes the job to be perpetually "due" and triggers
+    // double-execution on restart (#22895).
+    const steps = Math.floor(elapsed / everyMs) + 1;
     return anchor + steps * everyMs;
   }
 

--- a/src/cron/service.issue-22895-restart-every.test.ts
+++ b/src/cron/service.issue-22895-restart-every.test.ts
@@ -1,0 +1,218 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createCronStoreHarness,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-22895-" });
+installCronTestHooks({
+  logger: noopLogger,
+  baseTimeIso: "2025-12-13T17:00:00.000Z",
+});
+
+describe("CronService restart with every-30m job (#22895)", () => {
+  async function writeStoreJobs(storePath: string, jobs: unknown[]) {
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, JSON.stringify({ version: 1, jobs }, null, 2), "utf-8");
+  }
+
+  function createRestartCronService(params: {
+    storePath: string;
+    enqueueSystemEvent: ReturnType<typeof vi.fn>;
+    requestHeartbeatNow: ReturnType<typeof vi.fn>;
+  }) {
+    return new CronService({
+      storePath: params.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: params.enqueueSystemEvent as never,
+      requestHeartbeatNow: params.requestHeartbeatNow as never,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })) as never,
+    });
+  }
+
+  it("preserves correct nextRunAtMs for every-30m job after restart (last ran 6m ago)", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    const nowMs = Date.parse("2025-12-13T17:00:00.000Z");
+    const everyMs = 30 * 60 * 1000; // 30 min
+    const createdAtMs = Date.parse("2025-12-10T12:00:00.000Z");
+    const lastRunAtMs = nowMs - 6 * 60 * 1000; // 6 min ago
+
+    // Compute what nextRunAtMs should have been after the last run:
+    // anchor = createdAtMs, elapsed = lastRunAtMs - createdAtMs
+    const elapsed = lastRunAtMs - createdAtMs;
+    const steps = Math.max(1, Math.floor((elapsed + everyMs - 1) / everyMs));
+    const correctNextRunAtMs = createdAtMs + steps * everyMs;
+
+    await writeStoreJobs(store.storePath, [
+      {
+        id: "every-30m-job",
+        name: "check-health",
+        enabled: true,
+        createdAtMs,
+        updatedAtMs: lastRunAtMs,
+        schedule: { kind: "every", everyMs, anchorMs: createdAtMs },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "health check" },
+        state: {
+          nextRunAtMs: correctNextRunAtMs,
+          lastRunAtMs,
+          lastStatus: "ok",
+        },
+      },
+    ]);
+
+    const cron = createRestartCronService({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+    });
+
+    await cron.start();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const job = jobs.find((j) => j.id === "every-30m-job");
+
+    // The nextRunAtMs should be at most everyMs (30 min) from now
+    const nextRunAtMs = job?.state.nextRunAtMs ?? 0;
+    const nextInMs = nextRunAtMs - nowMs;
+
+    console.log("correctNextRunAtMs:", new Date(correctNextRunAtMs).toISOString());
+    console.log("actual nextRunAtMs:", new Date(nextRunAtMs).toISOString());
+    console.log("next in:", nextInMs / 60000, "min");
+
+    // Key assertion: next run should be <= 30 min from now, never > everyMs
+    expect(nextInMs).toBeLessThanOrEqual(everyMs);
+    expect(nextInMs).toBeGreaterThan(0);
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("handles restart when every-30m job was running (stale runningAtMs)", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    const nowMs = Date.parse("2025-12-13T17:00:00.000Z");
+    const everyMs = 30 * 60 * 1000;
+    const createdAtMs = Date.parse("2025-12-10T12:00:00.000Z");
+    const lastRunAtMs = nowMs - 6 * 60 * 1000;
+
+    // Job was running when gateway crashed — nextRunAtMs is the OLD (past-due) value
+    const oldNextRunAtMs = lastRunAtMs; // was due when it started running
+
+    await writeStoreJobs(store.storePath, [
+      {
+        id: "every-30m-stale",
+        name: "stale-health",
+        enabled: true,
+        createdAtMs,
+        updatedAtMs: lastRunAtMs,
+        schedule: { kind: "every", everyMs, anchorMs: createdAtMs },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "health check" },
+        state: {
+          nextRunAtMs: oldNextRunAtMs,
+          lastRunAtMs: lastRunAtMs - everyMs, // previous successful run
+          lastStatus: "ok",
+          runningAtMs: lastRunAtMs, // was running when crashed
+        },
+      },
+    ]);
+
+    const cron = createRestartCronService({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+    });
+
+    await cron.start();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const job = jobs.find((j) => j.id === "every-30m-stale");
+
+    const nextRunAtMs = job?.state.nextRunAtMs ?? 0;
+    const nextInMs = nextRunAtMs - nowMs;
+
+    console.log("stale scenario nextRunAtMs:", new Date(nextRunAtMs).toISOString());
+    console.log("stale scenario next in:", nextInMs / 60000, "min");
+
+    // Should be cleared and recomputed correctly
+    expect(job?.state.runningAtMs).toBeUndefined();
+    // Next run should be <= everyMs from now
+    expect(nextInMs).toBeLessThanOrEqual(everyMs);
+    expect(nextInMs).toBeGreaterThan(0);
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("next run never exceeds everyMs from now for various anchor offsets", async () => {
+    const nowMs = Date.parse("2025-12-13T17:00:00.000Z");
+    const everyMs = 30 * 60 * 1000;
+
+    // Test all possible anchor offsets (every minute within a 30-min window)
+    for (let offsetMin = 0; offsetMin < 30; offsetMin++) {
+      const store = await makeStorePath();
+      const createdAtMs = Date.parse("2025-12-10T12:00:00.000Z") + offsetMin * 60 * 1000;
+      const lastRunAtMs = nowMs - 6 * 60 * 1000;
+
+      // Compute persisted nextRunAtMs as applyJobResult would
+      const elapsed = lastRunAtMs - createdAtMs;
+      const steps = Math.max(1, Math.floor((elapsed + everyMs - 1) / everyMs));
+      const persistedNext = createdAtMs + steps * everyMs;
+
+      await writeStoreJobs(store.storePath, [
+        {
+          id: `every-30m-offset-${offsetMin}`,
+          name: `offset-${offsetMin}`,
+          enabled: true,
+          createdAtMs,
+          updatedAtMs: lastRunAtMs,
+          schedule: { kind: "every", everyMs, anchorMs: createdAtMs },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "check" },
+          state: {
+            nextRunAtMs: persistedNext,
+            lastRunAtMs,
+            lastStatus: "ok",
+          },
+        },
+      ]);
+
+      const cron = new CronService({
+        storePath: store.storePath,
+        cronEnabled: true,
+        log: noopLogger,
+        enqueueSystemEvent: vi.fn() as never,
+        requestHeartbeatNow: vi.fn() as never,
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })) as never,
+      });
+
+      await cron.start();
+
+      const jobs = await cron.list({ includeDisabled: true });
+      const job = jobs.find((j) => j.id === `every-30m-offset-${offsetMin}`);
+      const nextRunAtMs = job?.state.nextRunAtMs ?? 0;
+      const nextInMs = nextRunAtMs - nowMs;
+
+      expect(nextInMs).toBeLessThanOrEqual(everyMs);
+      expect(nextInMs).toBeGreaterThanOrEqual(0);
+
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

When `elapsed` is an exact multiple of `everyMs` in `computeNextRunAtMs`, the ceiling-division formula `Math.floor((elapsed + everyMs - 1) / everyMs)` returns the **current** slot instead of the next one, producing `nextRunAtMs === nowMs`.

This causes the job to be perpetually "due" after a gateway restart:
1. `recomputeNextRuns` sees `now >= nextRun` → recomputes → gets the same value
2. `runMissedJobs` double-executes the job
3. `applyJobResult` recomputes `nextRunAtMs` from `endedAt`, landing on a later anchor-aligned slot
4. Dashboard shows an incorrect NEXT time (e.g. **56m for a 30m job**)

### Steps to reproduce (from #22895)

1. Create a cron job with `schedule.kind = "every"`, `everyMs = 1800000` (30m)
2. Let it run successfully
3. Restart the gateway
4. Observe NEXT shows ~56m instead of ~24m

## Fix

Replace the ceiling-division with `Math.floor(elapsed / everyMs) + 1` which always returns a **strictly-future** slot. Both formulas produce identical results for non-boundary cases; only the exact-multiple edge case differs.

```diff
- const steps = Math.max(1, Math.floor((elapsed + everyMs - 1) / everyMs));
+ const steps = Math.floor(elapsed / everyMs) + 1;
```

## Testing

- 3 new tests covering the restart scenario, stale `runningAtMs`, and all anchor offsets
- All 178 existing cron tests pass (32 test files, 0 failures)

```
✓ preserves correct nextRunAtMs for every-30m job after restart (last ran 6m ago)
✓ handles restart when every-30m job was running (stale runningAtMs)
✓ next run never exceeds everyMs from now for various anchor offsets
```

Fixes #22895

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a critical boundary condition bug in `every`-schedule cron jobs where `elapsed` being an exact multiple of `everyMs` caused `computeNextRunAtMs` to return `nowMs` instead of a future time. This led to perpetual "due" status after gateway restarts, resulting in double-execution and incorrect dashboard timing displays (e.g., 56m for a 30m job).

**Key changes:**
- Replaced ceiling-division formula with `Math.floor(elapsed / everyMs) + 1` in `src/cron/schedule.ts:45`, which always returns a strictly-future slot
- Removed unnecessary `Math.max(1, ...)` wrapper since new formula guarantees result ≥ 1
- Added comprehensive test coverage for restart scenarios, stale `runningAtMs`, and anchor offset edge cases

**Mathematical correctness:**
- Old formula at boundary: `elapsed = everyMs` → `steps = 1` → `nextRunAtMs = nowMs` (bug)
- New formula at boundary: `elapsed = everyMs` → `steps = 2` → `nextRunAtMs = nowMs + everyMs` (correct)
- All non-boundary cases produce identical results

**Test coverage:**
- 3 new tests specifically for issue #22895 (218 lines total)
- Tests verify restart behavior, stale state handling, and all anchor offsets (0-29 minutes)
- All 178 existing cron tests remain passing

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a well-defined boundary condition bug with thorough test coverage
- The fix is mathematically sound and minimal (single line change), addresses a specific bug with clear reproduction steps, includes comprehensive test coverage (3 new tests covering all edge cases), and all existing tests pass. The change preserves behavior for all non-boundary cases while correctly fixing the exact-multiple edge case. No security or performance concerns.
- No files require special attention

<sub>Last reviewed commit: 629445e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->