### PR TITLE
fix: P0 cron delivery threading + suppress no-change progress checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/.env
+**/.env.local
 node_modules
 **/node_modules/
 .env
@@ -99,3 +101,5 @@ package-lock.json
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
+
+apps/web/.next/cache/

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -124,6 +124,19 @@ function resolveAnnounceOrigin(
   // requesterOrigin, captured at spawn time, reflects the channel the user is
   // actually on and must take priority over the session entry, which may carry
   // stale lastChannel / lastTo values from a previous channel interaction.
+  //
+  // When requesterOrigin specifies a full delivery target (channel + to) but
+  // omits threadId, the caller intentionally wants a standalone channel post
+  // (e.g. cron announce with stripSessionThreadId). Do NOT fall back to the
+  // session entry's threadId, which may be stale from a recent thread interaction.
+  if (normalizedRequester?.channel && normalizedRequester?.to && !normalizedRequester.threadId) {
+    return mergeDeliveryContext(
+      // Spread channel/to/accountId from requester but explicitly omit threadId
+      // so the fallback's stale threadId doesn't leak through.
+      normalizedRequester,
+      normalizedEntry ? { ...normalizedEntry, threadId: undefined } : undefined,
+    );
+  }
   return mergeDeliveryContext(normalizedRequester, normalizedEntry);
 }
 

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -215,6 +215,27 @@ describe("resolveDeliveryTarget", () => {
     expect(result.threadId).toBe("thread-2");
   });
 
+  it("strips session-derived threadId when stripSessionThreadId is true", async () => {
+    setMainSessionEntry({
+      sessionId: "sess-strip-1",
+      updatedAt: 1000,
+      lastChannel: "telegram",
+      lastTo: "123456",
+      lastThreadId: "thread-stale",
+    });
+
+    const cfg = makeCfg({ bindings: [] });
+    const result = await resolveDeliveryTarget(cfg, AGENT_ID, {
+      channel: "telegram",
+      to: "123456",
+      stripSessionThreadId: true,
+    });
+
+    expect(result.channel).toBe("telegram");
+    expect(result.to).toBe("123456");
+    expect(result.threadId).toBeUndefined();
+  });
+
   it("falls back to default channel when selection probe fails", async () => {
     setMainSessionEntry(undefined);
     vi.mocked(resolveMessageChannelSelection).mockRejectedValueOnce(new Error("no selection"));

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -364,6 +364,11 @@ export async function runCronIsolatedAgentTurn(params: {
     channel: deliveryPlan.channel ?? "last",
     to: deliveryPlan.to,
     sessionKey: params.job.sessionKey,
+    // Cron announce deliveries should post as standalone channel messages,
+    // never threading into whatever conversation was last active in the
+    // agent's main session. Only explicitly-configured threadIds (e.g.
+    // Telegram :topic: syntax in delivery.to) are preserved.
+    stripSessionThreadId: deliveryRequested,
   });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);


### PR DESCRIPTION
## Summary

Three P0 fixes from Xavier's root cause analysis of dropped instructions (2026-02-21):

### Fix 1: Suppress no-change progress checks
- Updated Tim's workq Progress Check cron to respond HEARTBEAT_OK when board is unchanged
- Eliminates ~17 identical 'fully green' messages per 4 hours

### Fix 2: Fix cron delivery threading (code change)
- Added stripSessionThreadId to cron delivery target resolution
- Cron announce deliveries now always post as standalone channel messages
- Session-inherited threadIds no longer leak into cron output
- Also fixed resolveAnnounceOrigin() re-introducing stale threadId from session entry

### Fix 3: Instruction triage cron
- New cron: runs every 5 min, scans #cb-inbox for unprocessed David messages
- Routes to appropriate agent via sessions_send
- delivery.mode=none — zero channel noise

## Files Changed
- src/cron/isolated-agent/delivery-target.ts
- src/cron/isolated-agent/run.ts
- src/cron/isolated-agent/delivery-target.test.ts
- src/cron/isolated-agent.delivery-target-thread-session.test.ts
- src/agents/subagent-announce.ts

## Tests
3 new tests added, all 326 related tests pass.

Priority: P0 | Author: xavier

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements three P0 fixes for cron delivery threading issues. The changes add a `stripSessionThreadId` flag to prevent cron announce deliveries from threading into active conversations, ensuring they always post as standalone channel messages unless explicitly configured otherwise. The implementation correctly handles explicit `:topic:` syntax and prevents stale threadIds from leaking across different delivery contexts.

Key changes:
- Added `stripSessionThreadId` parameter to `resolveDeliveryTarget()` that strips session-derived threadIds while preserving explicitly-set ones
- Updated cron delivery logic in `run.ts` to enable `stripSessionThreadId` for announce deliveries
- Modified `resolveAnnounceOrigin()` to prevent stale threadIds from leaking when requester omits threadId
- Added comprehensive test coverage for the new behavior
- Updated `.gitignore` with additional patterns for environment files and Next.js cache

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with good test coverage and clear logic, though one implementation detail could be simplified
- The changes are well-tested with 3 new test cases covering the main scenarios. The logic for stripping session-derived threadIds is sound and addresses a real issue with cron deliveries threading into stale conversations. However, there's a minor redundancy in the `resolveAnnounceOrigin()` implementation that could be simplified without changing behavior
- No files require special attention - the implementation is straightforward and well-tested

<sub>Last reviewed commit: f97260d</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->