### PR TITLE
feat(discord): make thread session isolation configurable

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -260,6 +260,12 @@ export type DiscordAccountConfig = {
   slashCommand?: DiscordSlashCommandConfig;
   /** Thread binding lifecycle settings (focus/subagent thread sessions). */
   threadBindings?: DiscordThreadBindingsConfig;
+  /**
+   * Append `:thread:<threadId>` suffix to session keys for thread messages,
+   * giving each thread its own isolated session. Default: false (threads
+   * share the parent channel's session).
+   */
+  threadSessionSuffix?: boolean;
   /** Privileged Gateway Intents (must also be enabled in Discord Developer Portal). */
   intents?: DiscordIntentsConfig;
   /** Voice channel conversation settings. */

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -278,7 +278,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     baseSessionKey,
     threadId: threadChannel ? messageChannelId : undefined,
     parentSessionKey,
-    useSuffix: false,
+    useSuffix: discordConfig?.threadSessionSuffix ?? false,
   });
   const replyPlan = await resolveDiscordAutoThreadReplyPlan({
     client,


### PR DESCRIPTION
## Summary

- Adds `threadSessionSuffix` boolean to `DiscordAccountConfig`
- When `true`, thread messages get a `:thread:<threadId>` suffix on their session key, giving each thread its own isolated conversation session
- Defaults to `false` (existing behavior — threads share the parent channel's session)

### Motivation

Without this, all threads under a parent channel share the same session. This means conversation context from one thread bleeds into another — the bot may reference messages from a different thread, confusing users. With `threadSessionSuffix: true`, each thread gets its own session and the bot maintains separate conversation context per thread.

Note: `resolveThreadSessionKeys()` already supports the `useSuffix` parameter and defaults to `true` internally — this PR simply exposes the choice to operators via config rather than hardcoding `false`.

### Config

```json
{
  "channels": {
    "discord": {
      "threadSessionSuffix": true
    }
  }
}
```

## Test plan

- [ ] With `threadSessionSuffix: false` (default): verify threads share parent session (existing behavior unchanged)
- [ ] With `threadSessionSuffix: true`: verify each thread gets its own session key (`:thread:<id>` suffix)
- [ ] Verify no impact on DM sessions
- [ ] Verify no impact on forum channel sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds configurable thread session isolation for Discord via `threadSessionSuffix` boolean (defaults to `false` for backward compatibility). When enabled, each thread gets its own session key with `:thread:<threadId>` suffix, preventing conversation context from bleeding across threads.

**Key changes:**
- New `threadSessionSuffix?: boolean` field in `DiscordAccountConfig` 
- Inbound message handler now respects config via `useSuffix: discordConfig?.threadSessionSuffix ?? false`
- Exposes existing `resolveThreadSessionKeys()` behavior that was previously hardcoded

**Issue found:**
- Outbound session resolution (`src/infra/outbound/outbound-session.ts:277`) still hardcodes `useSuffix: false`, creating a session key mismatch when the new config is enabled — inbound and outbound messages for the same thread would use different session keys, breaking conversation continuity

<h3>Confidence Score: 2/5</h3>

- This PR has a logic issue that breaks the feature when enabled
- Score reflects incomplete implementation — the inbound path correctly reads the new config, but the outbound path still hardcodes the old behavior, causing session key mismatches that would break conversation state when `threadSessionSuffix: true` is configured
- Pay close attention to `src/infra/outbound/outbound-session.ts` — needs updating to respect the new config

<sub>Last reviewed commit: 2fc51d1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->