### PR TITLE
fix(browser): suggest remote profile when local Chrome is not installed

### DIFF
--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -89,7 +89,13 @@ export const BrowserToolSchema = Type.Object({
   action: stringEnum(BROWSER_TOOL_ACTIONS),
   target: optionalStringEnum(BROWSER_TARGETS),
   node: Type.Optional(Type.String()),
-  profile: Type.Optional(Type.String()),
+  profile: Type.Optional(
+    Type.String({
+      description:
+        "Browser profile name. Omit to use the default profile (recommended). " +
+        "Use action=profiles to list available profiles.",
+    }),
+  ),
   targetUrl: Type.Optional(Type.String()),
   url: Type.Optional(Type.String()),
   targetId: Type.Optional(Type.String()),

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, type ChildProcessWithoutNullStreams, spawn } from "n
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isLoopbackHost } from "../gateway/net.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { rawDataToString } from "../infra/ws.js";
@@ -73,7 +74,9 @@ export type RunningChrome = {
   proc: ChildProcess;
 };
 
-function resolveBrowserExecutable(resolved: ResolvedBrowserConfig): BrowserExecutable | null {
+export function resolveBrowserExecutable(
+  resolved: ResolvedBrowserConfig,
+): BrowserExecutable | null {
   return resolveBrowserExecutableForPlatform(resolved, process.platform);
 }
 
@@ -302,8 +305,26 @@ export async function launchOpenClawChrome(
 
   const exe = resolveBrowserExecutable(resolved);
   if (!exe) {
+    const remoteProfiles = Object.entries(resolved.profiles)
+      .filter(([, p]) => {
+        const url = p.cdpUrl?.trim();
+        if (!url) {
+          return false;
+        }
+        try {
+          return !isLoopbackHost(new URL(url).hostname);
+        } catch {
+          return false;
+        }
+      })
+      .map(([name]) => name);
+    const hint =
+      remoteProfiles.length > 0
+        ? ` A remote browser profile is available: "${remoteProfiles[0]}". ` +
+          `Use profile="${remoteProfiles[0]}" or set browser.defaultProfile to "${remoteProfiles[0]}".`
+        : "";
     throw new Error(
-      "No supported browser found (Chrome/Brave/Edge/Chromium on macOS, Linux, or Windows).",
+      `No supported browser found (Chrome/Brave/Edge/Chromium on macOS, Linux, or Windows).${hint}`,
     );
   }
 

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -15,8 +15,10 @@ import {
   isChromeCdpReady,
   isChromeReachable,
   launchOpenClawChrome,
+  resolveBrowserExecutable,
   stopOpenClawChrome,
 } from "./chrome.js";
+import { resolveProfile } from "./config.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { BrowserProfileUnavailableError } from "./errors.js";
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
@@ -214,6 +216,21 @@ export function createProfileAvailability({
             ? `Remote CDP for profile "${profile.name}" is not reachable at ${profile.cdpUrl}.`
             : `Browser attachOnly is enabled and profile "${profile.name}" is not running.`,
         );
+      }
+      // Before attempting local Chrome launch, check if a browser executable exists.
+      // If not and there's a different remote default profile, suggest using it instead
+      // of failing with "No supported browser found".
+      if (!resolveBrowserExecutable(current.resolved)) {
+        const defaultProfileName = current.resolved.defaultProfile;
+        if (defaultProfileName && defaultProfileName !== profile.name) {
+          const defaultResolved = resolveProfile(current.resolved, defaultProfileName);
+          if (defaultResolved && !defaultResolved.cdpIsLoopback) {
+            throw new Error(
+              `Profile "${profile.name}" requires a local browser but none is installed. ` +
+                `Use the default profile "${defaultProfileName}" instead (remote CDP at ${defaultResolved.cdpUrl}).`,
+            );
+          }
+        }
       }
       const launched = await launchOpenClawChrome(current.resolved, profile);
       attachRunning(launched);

--- a/extensions/browser/src/browser/server-context.chrome-test-harness.ts
+++ b/extensions/browser/src/browser/server-context.chrome-test-harness.ts
@@ -10,6 +10,7 @@ vi.mock("./chrome.js", () => ({
   launchOpenClawChrome: vi.fn(async () => {
     throw new Error("unexpected launch");
   }),
+  resolveBrowserExecutable: vi.fn(() => null),
   resolveOpenClawUserDataDir: vi.fn(() => chromeUserDataDir.dir),
   stopOpenClawChrome: vi.fn(async () => {}),
 }));

--- a/extensions/browser/src/browser/server-context.loopback-fallback-to-remote.test.ts
+++ b/extensions/browser/src/browser/server-context.loopback-fallback-to-remote.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  vi.resetModules();
+});
+
+import "./server-context.chrome-test-harness.js";
+import * as chromeModule from "./chrome.js";
+import type { BrowserServerState } from "./server-context.js";
+import { createBrowserRouteContext } from "./server-context.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Build a BrowserServerState with both a loopback "openclaw" profile and a remote profile.
+ * This simulates a containerized gateway that has a remote browser pod but no local Chrome.
+ */
+function makeStateWithRemoteDefault(): BrowserServerState {
+  return {
+    server: null,
+    port: 0,
+    resolved: {
+      enabled: true,
+      controlPort: 18791,
+      cdpProtocol: "http",
+      cdpHost: "127.0.0.1",
+      cdpIsLoopback: true,
+      remoteCdpTimeoutMs: 1500,
+      remoteCdpHandshakeTimeoutMs: 3000,
+      cdpPortRangeStart: 18800,
+      cdpPortRangeEnd: 18899,
+      evaluateEnabled: false,
+      extraArgs: [],
+      color: "#FF4500",
+      headless: false,
+      noSandbox: false,
+      attachOnly: false,
+      ssrfPolicy: { allowPrivateNetwork: true },
+      defaultProfile: "remote",
+      profiles: {
+        remote: {
+          cdpUrl: "http://openclaw-browser.openclaw.svc.cluster.local:9222",
+          cdpPort: 9222,
+          color: "#0066CC",
+        },
+        openclaw: { cdpPort: 18800, color: "#FF4500" },
+      },
+    },
+    profiles: new Map(),
+  };
+}
+
+describe("ensureBrowserAvailable loopback-to-remote fallback", () => {
+  it("suggests the remote default profile when local Chrome is not installed", async () => {
+    const state = makeStateWithRemoteDefault();
+
+    // Mock: loopback CDP port is not reachable (nothing running locally)
+    vi.mocked(chromeModule.isChromeReachable).mockResolvedValue(false);
+    // No Chrome executable installed
+    vi.mocked(chromeModule.resolveBrowserExecutable).mockReturnValue(null);
+
+    const ctx = createBrowserRouteContext({
+      getState: () => state,
+      refreshConfigFromDisk: false,
+    });
+
+    // Request the "openclaw" loopback profile explicitly (this is what the LLM does)
+    const profileCtx = ctx.forProfile("openclaw");
+
+    await expect(profileCtx.ensureBrowserAvailable()).rejects.toThrow(
+      /Use the default profile "remote" instead/,
+    );
+  });
+
+  it("throws original error when no remote default profile exists", async () => {
+    const state = makeStateWithRemoteDefault();
+    // Make the default profile also loopback
+    state.resolved.defaultProfile = "openclaw";
+
+    vi.mocked(chromeModule.isChromeReachable).mockResolvedValue(false);
+    vi.mocked(chromeModule.resolveBrowserExecutable).mockReturnValue(null);
+
+    const ctx = createBrowserRouteContext({
+      getState: () => state,
+      refreshConfigFromDisk: false,
+    });
+
+    const profileCtx = ctx.forProfile("openclaw");
+
+    // Should fall through to launchOpenClawChrome which throws "unexpected launch" (from harness mock)
+    await expect(profileCtx.ensureBrowserAvailable()).rejects.toThrow("unexpected launch");
+  });
+});

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -277,6 +277,7 @@ vi.mock("./chrome.js", () => ({
       proc,
     };
   }),
+  resolveBrowserExecutable: vi.fn(() => ({ kind: "chrome", path: "/fake/chrome" })),
   resolveOpenClawUserDataDir: vi.fn(() => chromeUserDataDir.dir),
   stopOpenClawChrome: vi.fn(async () => {
     state.reachable = false;


### PR DESCRIPTION
## Summary

When deployed in a containerized gateway (no local Chrome), the agent's browser tool fails with "No supported browser found" if the LLM explicitly passes `profile: "openclaw"`. This happens because:

1. `config.ts` auto-creates an "openclaw" loopback profile (`127.0.0.1`) on every instance
2. The `profile` parameter in the tool schema had no description, so the LLM infers "openclaw" as the natural profile name
3. The loopback profile tries to launch a local Chrome that doesn't exist

Meanwhile, omitting the profile parameter works fine — it falls through to the configured `defaultProfile` (e.g., a remote CDP endpoint).

### Changes

- **`browser-tool.schema.ts`**: Add description to `profile` parameter guiding LLMs to omit it (use default)
- **`server-context.ts`**: Pre-launch check — if no Chrome executable and there's a remote default profile, throw a helpful error suggesting the remote profile
- **`chrome.ts`**: Export `resolveBrowserExecutable()` for reuse; improve error message to list available remote profiles

### New test

- `server-context.loopback-fallback-to-remote.test.ts`: Verifies the fallback suggestion and the pass-through when no remote default exists

## Test plan

- [x] All 49 existing browser tests pass (6 test files)
- [x] New test covers both fallback and no-fallback scenarios
- [ ] Manual verification: `POST /start` with no profile → works; `POST /start?profile=openclaw` → helpful error suggesting remote profile

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the browser tool's behavior in containerized environments where local Chrome is not installed. When an LLM explicitly requests a loopback profile (like "openclaw") but no local browser exists and a remote CDP endpoint is available, the error message now suggests using the remote profile instead of failing with a generic "No supported browser found" error.

The changes include:
- Added description to `profile` parameter in browser tool schema to guide LLMs to omit it and use the default
- Pre-launch check in `ensureBrowserAvailable()` that detects missing browser executables and suggests remote default profile
- Enhanced error message in `launchOpenClawChrome()` listing available remote profiles
- Exported `resolveBrowserExecutable()` for reuse across modules
- New test coverage for the fallback suggestion logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, properly tested, and improve error messaging without altering core logic. The new validation check prevents failures earlier in the process with clearer guidance, and all existing tests should continue to pass.
- No files require special attention

<sub>Last reviewed commit: 4aeb4a7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

## Rebase History

| Date | Base | Upstream Commits | Notes |
|------|------|-----------------|-------|
| 2026-03-23 | `d5917d37c54a` (post-v2026.3.23) | 929 | Rebased cleanly, zero conflicts. Fixed CI: switched test from dynamic `await import()` to static `import * as chromeModule` to properly pick up `vi.mock()` harness (dynamic import bypassed mocks, causing real Chrome launch in CI). |
| 2026-03-13 | `330631a0eb39` (v2026.3.12) | | Clean rebase. Upstream added Chrome MCP existing-session support and hardened browser runtime profile handling. No conflicts. Commit: `db0f134faa39`. |
| 2026-03-08 | `eb0758e1722c` (v2026.3.7) | | Minor conflict from upstream extracting CDP helpers out of `chrome.ts`. Resolved by adapting imports to the new module structure. Upstream also added `fix(config): accept "openclaw" as browser profile driver in Zod schema (#39374)` which is complementary to this fix. Commit: `3e312ab30ed7`. |


