### PR TITLE
fix(feishu): download media from quoted messages in group chats (#22872)

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -606,13 +606,19 @@ export async function handleFeishuMessage(params: {
         `feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot, recording to history`,
       );
       if (chatHistories) {
+        // For media messages, record a human-readable placeholder instead of
+        // the raw `{"image_key":"…"}` JSON which is useless to the model (#22872).
+        const mediaHistoryTypes = ["image", "file", "audio", "video", "sticker"];
+        const historyBody = mediaHistoryTypes.includes(ctx.contentType)
+          ? `${ctx.senderName ?? ctx.senderOpenId}: [sent ${ctx.contentType === "image" ? "an" : "a"} ${ctx.contentType}]`
+          : `${ctx.senderName ?? ctx.senderOpenId}: ${ctx.content}`;
         recordPendingHistoryEntryIfEnabled({
           historyMap: chatHistories,
           historyKey: ctx.chatId,
           limit: historyLimit,
           entry: {
             sender: ctx.senderOpenId,
-            body: `${ctx.senderName ?? ctx.senderOpenId}: ${ctx.content}`,
+            body: historyBody,
             timestamp: Date.now(),
             messageId: ctx.messageId,
           },
@@ -770,9 +776,10 @@ export async function handleFeishuMessage(params: {
       log,
       accountId: account.accountId,
     });
-    const mediaPayload = buildAgentMediaPayload(mediaList);
-
-    // Fetch quoted/replied message content if parentId exists
+    // Fetch quoted/replied message content if parentId exists.
+    // For media messages (image, file, audio, video, sticker), download the
+    // actual media so the model can see it — otherwise the agent only receives
+    // a useless `{"image_key":"…"}` JSON string (#22872).
     let quotedContent: string | undefined;
     if (ctx.parentId) {
       try {
@@ -782,15 +789,39 @@ export async function handleFeishuMessage(params: {
           accountId: account.accountId,
         });
         if (quotedMsg) {
-          quotedContent = quotedMsg.content;
-          log(
-            `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
-          );
+          const quotedMediaTypes = ["image", "file", "audio", "video", "sticker", "post"];
+          if (quotedMediaTypes.includes(quotedMsg.contentType)) {
+            const quotedMedia = await resolveFeishuMediaList({
+              cfg,
+              messageId: ctx.parentId,
+              messageType: quotedMsg.contentType,
+              content: quotedMsg.rawContent ?? quotedMsg.content,
+              maxBytes: mediaMaxBytes,
+              log,
+              accountId: account.accountId,
+            });
+            if (quotedMedia.length > 0) {
+              mediaList.push(...quotedMedia);
+              log(
+                `feishu[${account.accountId}]: downloaded ${quotedMedia.length} media from quoted message ${ctx.parentId}`,
+              );
+            } else {
+              quotedContent = quotedMsg.content;
+            }
+          } else {
+            quotedContent = quotedMsg.content;
+            log(
+              `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
+            );
+          }
         }
       } catch (err) {
         log(`feishu[${account.accountId}]: failed to fetch quoted message: ${String(err)}`);
       }
     }
+
+    // Build media payload AFTER quoted media has been appended to mediaList.
+    const mediaPayload = buildAgentMediaPayload(mediaList);
 
     const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -14,6 +14,9 @@ export type FeishuMessageInfo = {
   senderId?: string;
   senderOpenId?: string;
   content: string;
+  /** Raw JSON content from the API before text extraction. Needed by
+   *  `resolveFeishuMediaList` to parse media keys from quoted messages. */
+  rawContent?: string;
   contentType: string;
   createTime?: number;
 };
@@ -67,7 +70,8 @@ export async function getMessageFeishu(params: {
     }
 
     // Parse content based on message type
-    let content = item.body?.content ?? "";
+    const rawContent = item.body?.content ?? "";
+    let content = rawContent;
     try {
       const parsed = JSON.parse(content);
       if (item.msg_type === "text" && parsed.text) {
@@ -83,6 +87,7 @@ export async function getMessageFeishu(params: {
       senderId: item.sender?.id,
       senderOpenId: item.sender?.id_type === "open_id" ? item.sender?.id : undefined,
       content,
+      rawContent,
       contentType: item.msg_type ?? "text",
       createTime: item.create_time ? parseInt(item.create_time, 10) : undefined,
     };


### PR DESCRIPTION
## Problem

In Feishu group chats, image recognition is completely broken. When a user sends an image and then replies to it with @bot, the model receives a raw JSON string like `{"image_key":"img_v3_02v5_xxx"}` instead of the actual image.

This happens because:
1. The quoted-message fetch path (`getMessageFeishu`) only extracts text content and never checks `contentType` for media types
2. History entries record raw `image_key` JSON for image messages

DM image recognition works fine because the message itself is dispatched as an image type and goes through `resolveFeishuMediaList()`.

### Why this matters

Feishu's UI does not allow sending an image and @mentioning the bot in the same message — images are sent immediately on selection. The only natural workflow in group chats is: send image → reply to it with @bot. This means there is **no working path** for image recognition in group chats.

## Changes

### Fix 1: Download media from quoted messages (high priority)

When fetching a quoted message, check its `contentType`. For media types (image, file, audio, video, sticker, post), call `resolveFeishuMediaList()` to download the actual media and append it to the media payload sent to the model.

### Fix 2: Human-readable history entries for media messages

Replace raw `{"image_key":"xxx"}` in history entries with human-readable placeholders like `[sent an image]` so the model gets useful context instead of cryptic JSON strings.

### Supporting change

Add `rawContent` field to `FeishuMessageInfo` so the original JSON content is preserved for media key parsing by `resolveFeishuMediaList()`.

## Files changed

- `extensions/feishu/src/bot.ts` — quoted message media download + history placeholder
- `extensions/feishu/src/send.ts` — `rawContent` field in `FeishuMessageInfo`

Fixes #22872

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Feishu group chat image recognition by downloading media from quoted messages and improving history entries. However, there's a critical bug: `mediaPayload` is created before quoted media is added to `mediaList`, so quoted media won't actually reach the agent.

**Changes made:**
- Added media download for quoted messages (image, file, audio, video, sticker, post)
- Replaced raw JSON in history entries with readable placeholders like `[sent an image]`
- Added `rawContent` field to preserve original JSON for media key parsing

**Critical issue:**
- `mediaPayload` on line 779:779 is built too early—before quoted media is added to `mediaList` on line 806:806. This means the fix won't work as intended.

<h3>Confidence Score: 1/5</h3>

- This PR has a critical logic bug that prevents the main feature from working
- The PR addresses a real problem but contains a critical timing bug where `mediaPayload` is created before quoted media is added to `mediaList`. This means quoted media will be downloaded but never sent to the agent, breaking the intended functionality. The fix is straightforward—move the `buildAgentMediaPayload` call after all media collection is complete.
- extensions/feishu/src/bot.ts requires immediate attention—the `mediaPayload` build timing bug must be fixed

<sub>Last reviewed commit: 7d40875</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->