### PR TITLE
fix(onboard): error on unknown --auth-choice in non-interactive mode

### DIFF
--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -781,5 +781,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     return null;
   }
 
-  return nextConfig;
+  runtime.error(`Unknown --auth-choice: "${authChoice}". Run "openclaw onboard --help" for valid choices.`);
+  runtime.exit(1);
+  return null;
 }

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -781,6 +781,10 @@ export async function applyNonInteractiveAuthChoice(params: {
     return null;
   }
 
+  if (authChoice === "skip") {
+    return nextConfig;
+  }
+
   runtime.error(`Unknown --auth-choice: "${authChoice}". Run "openclaw onboard --help" for valid choices.`);
   runtime.exit(1);
   return null;


### PR DESCRIPTION
## Summary
- Adds an explicit error message and `exit(1)` when an unrecognized `--auth-choice` value is passed to `openclaw onboard --non-interactive`
- Previously, unknown values silently fell through and returned the config unchanged — no auth was configured and no error was shown

This addresses part 2 of #17191 (unknown auth choices silently skipped). Part 1 (`apiKey` ignoring `--token-provider`) is a separate, larger change.

Fixes #17191

## Local Validation
- [x] Error message includes the invalid value and help hint
- [x] All known auth choices are handled before the new fallback

## Scope
XS — 3-line change in one file

## Author
@miloudbelarebia

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced silent fallthrough with explicit error for unknown `--auth-choice` values in non-interactive mode. Previously, unrecognized auth choices returned the config unchanged without any auth configured and no error shown.

**Critical Issue Found:**
- The `"skip"` auth choice (valid and used as default in `local.ts:53`) will now trigger an error instead of being allowed to pass through
- This breaks the default behavior when no auth choice is specified

**Other Observations:**
- Several valid auth choices (`github-copilot`, `copilot-proxy`, `google-antigravity`, `google-gemini-cli`) are not explicitly handled, but these likely require interactive mode anyway
- The error message format is helpful and consistent with other errors in the function

<h3>Confidence Score: 1/5</h3>

- This PR contains a critical bug that breaks the default auth flow
- The change introduces a logic error that causes `authChoice === "skip"` to error out, breaking the default behavior when no auth choice is specified (as "skip" is used as the fallback value in local.ts:53)
- src/commands/onboard-non-interactive/local/auth-choice.ts requires immediate attention to handle the "skip" case

<sub>Last reviewed commit: e517647</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->