### PR TITLE
Agents: inject pi auth storage from runtime profiles

### DIFF
--- a/src/agents/auth-profiles.runtime-snapshot-save.test.ts
+++ b/src/agents/auth-profiles.runtime-snapshot-save.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  activateSecretsRuntimeSnapshot,
+  clearSecretsRuntimeSnapshot,
+  prepareSecretsRuntimeSnapshot,
+} from "../secrets/runtime.js";
+import { ensureAuthProfileStore, markAuthProfileUsed } from "./auth-profiles.js";
+
+describe("auth profile runtime snapshot persistence", () => {
+  it("does not write resolved plaintext keys during usage updates", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-runtime-save-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const authPath = path.join(agentDir, "auth-profiles.json");
+    try {
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        authPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "openai:default": {
+                type: "api_key",
+                provider: "openai",
+                keyRef: { source: "env", id: "OPENAI_API_KEY" },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const snapshot = await prepareSecretsRuntimeSnapshot({
+        config: {},
+        env: { OPENAI_API_KEY: "sk-runtime-openai" },
+        agentDirs: [agentDir],
+      });
+      activateSecretsRuntimeSnapshot(snapshot);
+
+      const runtimeStore = ensureAuthProfileStore(agentDir);
+      expect(runtimeStore.profiles["openai:default"]).toMatchObject({
+        type: "api_key",
+        key: "sk-runtime-openai",
+        keyRef: { source: "env", id: "OPENAI_API_KEY" },
+      });
+
+      await markAuthProfileUsed({
+        store: runtimeStore,
+        profileId: "openai:default",
+        agentDir,
+      });
+
+      const persisted = JSON.parse(await fs.readFile(authPath, "utf8")) as {
+        profiles: Record<string, { key?: string; keyRef?: unknown }>;
+      };
+      expect(persisted.profiles["openai:default"]?.key).toBeUndefined();
+      expect(persisted.profiles["openai:default"]?.keyRef).toEqual({
+        source: "env",
+        id: "OPENAI_API_KEY",
+      });
+    } finally {
+      clearSecretsRuntimeSnapshot();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveAuthStorePath } from "./auth-profiles/paths.js";
+import { saveAuthProfileStore } from "./auth-profiles/store.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
+
+describe("saveAuthProfileStore", () => {
+  it("strips plaintext when keyRef/tokenRef are present", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-save-"));
+    try {
+      const store: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-runtime-value",
+            keyRef: { source: "env", id: "OPENAI_API_KEY" },
+          },
+          "github-copilot:default": {
+            type: "token",
+            provider: "github-copilot",
+            token: "gh-runtime-token",
+            tokenRef: { source: "env", id: "GITHUB_TOKEN" },
+          },
+          "anthropic:default": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "sk-anthropic-plain",
+          },
+        },
+      };
+
+      saveAuthProfileStore(store, agentDir);
+
+      const parsed = JSON.parse(await fs.readFile(resolveAuthStorePath(agentDir), "utf8")) as {
+        profiles: Record<
+          string,
+          { key?: string; keyRef?: unknown; token?: string; tokenRef?: unknown }
+        >;
+      };
+
+      expect(parsed.profiles["openai:default"]?.key).toBeUndefined();
+      expect(parsed.profiles["openai:default"]?.keyRef).toEqual({
+        source: "env",
+        id: "OPENAI_API_KEY",
+      });
+
+      expect(parsed.profiles["github-copilot:default"]?.token).toBeUndefined();
+      expect(parsed.profiles["github-copilot:default"]?.tokenRef).toEqual({
+        source: "env",
+        id: "GITHUB_TOKEN",
+      });
+
+      expect(parsed.profiles["anthropic:default"]?.key).toBe("sk-anthropic-plain");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -425,9 +425,24 @@ export function ensureAuthProfileStore(
 
 export function saveAuthProfileStore(store: AuthProfileStore, agentDir?: string): void {
   const authPath = resolveAuthStorePath(agentDir);
+  const profiles = Object.fromEntries(
+    Object.entries(store.profiles).map(([profileId, credential]) => {
+      if (credential.type === "api_key" && credential.keyRef && credential.key !== undefined) {
+        const sanitized = { ...credential } as Record<string, unknown>;
+        delete sanitized.key;
+        return [profileId, sanitized];
+      }
+      if (credential.type === "token" && credential.tokenRef && credential.token !== undefined) {
+        const sanitized = { ...credential } as Record<string, unknown>;
+        delete sanitized.token;
+        return [profileId, sanitized];
+      }
+      return [profileId, credential];
+    }),
+  ) as AuthProfileStore["profiles"];
   const payload = {
     version: AUTH_STORE_VERSION,
-    profiles: store.profiles,
+    profiles,
     order: store.order ?? undefined,
     lastGood: store.lastGood ?? undefined,
     usageStats: store.usageStats ?? undefined,

--- a/src/agents/model-auth-label.test.ts
+++ b/src/agents/model-auth-label.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ensureAuthProfileStoreMock = vi.hoisted(() => vi.fn());
+const resolveAuthProfileOrderMock = vi.hoisted(() => vi.fn());
+const resolveAuthProfileDisplayLabelMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./auth-profiles.js", () => ({
+  ensureAuthProfileStore: (...args: unknown[]) => ensureAuthProfileStoreMock(...args),
+  resolveAuthProfileOrder: (...args: unknown[]) => resolveAuthProfileOrderMock(...args),
+  resolveAuthProfileDisplayLabel: (...args: unknown[]) =>
+    resolveAuthProfileDisplayLabelMock(...args),
+}));
+
+vi.mock("./model-auth.js", () => ({
+  getCustomProviderApiKey: () => undefined,
+  resolveEnvApiKey: () => null,
+}));
+
+const { resolveModelAuthLabel } = await import("./model-auth-label.js");
+
+describe("resolveModelAuthLabel", () => {
+  beforeEach(() => {
+    ensureAuthProfileStoreMock.mockReset();
+    resolveAuthProfileOrderMock.mockReset();
+    resolveAuthProfileDisplayLabelMock.mockReset();
+  });
+
+  it("does not throw when token profile only has tokenRef", () => {
+    ensureAuthProfileStoreMock.mockReturnValue({
+      version: 1,
+      profiles: {
+        "github-copilot:default": {
+          type: "token",
+          provider: "github-copilot",
+          tokenRef: { source: "env", id: "GITHUB_TOKEN" },
+        },
+      },
+    } as never);
+    resolveAuthProfileOrderMock.mockReturnValue(["github-copilot:default"]);
+    resolveAuthProfileDisplayLabelMock.mockReturnValue("github-copilot:default");
+
+    const label = resolveModelAuthLabel({
+      provider: "github-copilot",
+      cfg: {},
+      sessionEntry: { authProfileOverride: "github-copilot:default" } as never,
+    });
+
+    expect(label).toContain("token ref(env:GITHUB_TOKEN)");
+  });
+});

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -19,6 +19,20 @@ function formatApiKeySnippet(apiKey: string): string {
   return `${head}…${tail}`;
 }
 
+function formatCredentialSnippet(params: {
+  value: string | undefined;
+  ref: { source: string; id: string } | undefined;
+}): string {
+  const value = typeof params.value === "string" ? params.value.trim() : "";
+  if (value) {
+    return formatApiKeySnippet(value);
+  }
+  if (params.ref) {
+    return `ref(${params.ref.source}:${params.ref.id})`;
+  }
+  return "unknown";
+}
+
 export function resolveModelAuthLabel(params: {
   provider?: string;
   cfg?: OpenClawConfig;
@@ -57,9 +71,13 @@ export function resolveModelAuthLabel(params: {
       return `oauth${label ? ` (${label})` : ""}`;
     }
     if (profile.type === "token") {
-      return `token ${formatApiKeySnippet(profile.token)}${label ? ` (${label})` : ""}`;
+      return `token ${formatCredentialSnippet({ value: profile.token, ref: profile.tokenRef })}${
+        label ? ` (${label})` : ""
+      }`;
     }
-    return `api-key ${formatApiKeySnippet(profile.key ?? "")}${label ? ` (${label})` : ""}`;
+    return `api-key ${formatCredentialSnippet({ value: profile.key, ref: profile.keyRef })}${
+      label ? ` (${label})` : ""
+    }`;
   }
 
   const envKey = resolveEnvApiKey(providerKey);

--- a/src/agents/model-catalog.test-harness.ts
+++ b/src/agents/model-catalog.test-harness.ts
@@ -31,6 +31,7 @@ export function mockCatalogImportFailThenRecover() {
       throw new Error("boom");
     }
     return {
+      discoverAuthStorage: () => ({}),
       AuthStorage: class {},
       ModelRegistry: class {
         getAll() {

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -38,6 +38,7 @@ describe("loadModelCatalog", () => {
       __setModelCatalogImportForTest(
         async () =>
           ({
+            discoverAuthStorage: () => ({}),
             AuthStorage: class {},
             ModelRegistry: class {
               getAll() {
@@ -69,6 +70,7 @@ describe("loadModelCatalog", () => {
     __setModelCatalogImportForTest(
       async () =>
         ({
+          discoverAuthStorage: () => ({}),
           AuthStorage: class {},
           ModelRegistry: class {
             getAll() {

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -110,6 +110,7 @@ describe("loadModelCatalog", () => {
     __setModelCatalogImportForTest(
       async () =>
         ({
+          discoverAuthStorage: () => ({}),
           AuthStorage: class {},
           ModelRegistry: class {
             getAll() {
@@ -156,6 +157,7 @@ describe("loadModelCatalog", () => {
     __setModelCatalogImportForTest(
       async () =>
         ({
+          discoverAuthStorage: () => ({}),
           AuthStorage: class {},
           ModelRegistry: class {
             getAll() {
@@ -198,6 +200,7 @@ describe("loadModelCatalog", () => {
     __setModelCatalogImportForTest(
       async () =>
         ({
+          discoverAuthStorage: () => ({}),
           AuthStorage: class {},
           ModelRegistry: class {
             getAll() {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -1034,17 +1034,8 @@ export async function resolveImplicitCopilotProvider(params: {
     }
   }
 
-  // pi-coding-agent's ModelRegistry marks a model "available" only if its
-  // `AuthStorage` has auth configured for that provider (via auth.json/env/etc).
-  // Our Copilot auth lives in OpenClaw's auth-profiles store instead, so we also
-  // write a runtime-only auth.json entry for pi-coding-agent to pick up.
-  //
-  // This is safe because it's (1) within OpenClaw's agent dir, (2) contains the
-  // GitHub token (not the exchanged Copilot token), and (3) matches existing
-  // patterns for OAuth-like providers in pi-coding-agent.
-  // Note: we deliberately do not write pi-coding-agent's `auth.json` here.
-  // OpenClaw uses its own auth store and exchanges tokens at runtime.
-  // `models list` uses OpenClaw's auth heuristics for availability.
+  // We deliberately do not write pi-coding-agent auth.json here.
+  // OpenClaw keeps auth in auth-profiles and resolves runtime availability from that store.
 
   // We intentionally do NOT define custom models for Copilot in models.json.
   // pi-coding-agent treats providers with models as replacements requiring apiKey.

--- a/src/agents/pi-auth-credentials.ts
+++ b/src/agents/pi-auth-credentials.ts
@@ -1,0 +1,88 @@
+import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles.js";
+import { normalizeProviderId } from "./model-selection.js";
+
+export type PiApiKeyCredential = { type: "api_key"; key: string };
+export type PiOAuthCredential = {
+  type: "oauth";
+  access: string;
+  refresh: string;
+  expires: number;
+};
+
+export type PiCredential = PiApiKeyCredential | PiOAuthCredential;
+export type PiCredentialMap = Record<string, PiCredential>;
+
+export function convertAuthProfileCredentialToPi(cred: AuthProfileCredential): PiCredential | null {
+  if (cred.type === "api_key") {
+    const key = typeof cred.key === "string" ? cred.key.trim() : "";
+    if (!key) {
+      return null;
+    }
+    return { type: "api_key", key };
+  }
+
+  if (cred.type === "token") {
+    const token = typeof cred.token === "string" ? cred.token.trim() : "";
+    if (!token) {
+      return null;
+    }
+    if (
+      typeof cred.expires === "number" &&
+      Number.isFinite(cred.expires) &&
+      Date.now() >= cred.expires
+    ) {
+      return null;
+    }
+    return { type: "api_key", key: token };
+  }
+
+  if (cred.type === "oauth") {
+    const access = typeof cred.access === "string" ? cred.access.trim() : "";
+    const refresh = typeof cred.refresh === "string" ? cred.refresh.trim() : "";
+    if (!access || !refresh || !Number.isFinite(cred.expires) || cred.expires <= 0) {
+      return null;
+    }
+    return {
+      type: "oauth",
+      access,
+      refresh,
+      expires: cred.expires,
+    };
+  }
+
+  return null;
+}
+
+export function resolvePiCredentialMapFromStore(store: AuthProfileStore): PiCredentialMap {
+  const credentials: PiCredentialMap = {};
+  for (const credential of Object.values(store.profiles)) {
+    const provider = normalizeProviderId(String(credential.provider ?? "")).trim();
+    if (!provider || credentials[provider]) {
+      continue;
+    }
+    const converted = convertAuthProfileCredentialToPi(credential);
+    if (converted) {
+      credentials[provider] = converted;
+    }
+  }
+  return credentials;
+}
+
+export function piCredentialsEqual(a: PiCredential | undefined, b: PiCredential): boolean {
+  if (!a || typeof a !== "object") {
+    return false;
+  }
+  if (a.type !== b.type) {
+    return false;
+  }
+
+  if (a.type === "api_key" && b.type === "api_key") {
+    return a.key === b.key;
+  }
+
+  if (a.type === "oauth" && b.type === "oauth") {
+    return a.access === b.access && a.refresh === b.refresh && a.expires === b.expires;
+  }
+
+  return false;
+}

--- a/src/agents/pi-auth-json.ts
+++ b/src/agents/pi-auth-json.ts
@@ -4,6 +4,10 @@ import { ensureAuthProfileStore } from "./auth-profiles.js";
 import type { AuthProfileCredential } from "./auth-profiles/types.js";
 import { normalizeProviderId } from "./model-selection.js";
 
+/**
+ * @deprecated Legacy bridge for older flows that still expect `agentDir/auth.json`.
+ * Runtime auth resolution uses auth-profiles directly and should not depend on this module.
+ */
 type AuthJsonCredential =
   | {
       type: "api_key";
@@ -110,6 +114,8 @@ function credentialsEqual(a: AuthJsonCredential | undefined, b: AuthJsonCredenti
  * registry/catalog output.
  *
  * Syncs all credential types: api_key, token (as api_key), and oauth.
+ *
+ * @deprecated Runtime auth now comes from OpenClaw auth-profiles snapshots.
  */
 export async function ensurePiAuthJsonFromAuthProfiles(agentDir: string): Promise<{
   wrote: boolean;

--- a/src/agents/pi-auth-json.ts
+++ b/src/agents/pi-auth-json.ts
@@ -1,25 +1,17 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ensureAuthProfileStore } from "./auth-profiles.js";
-import type { AuthProfileCredential } from "./auth-profiles/types.js";
-import { normalizeProviderId } from "./model-selection.js";
+import {
+  piCredentialsEqual,
+  resolvePiCredentialMapFromStore,
+  type PiCredential,
+} from "./pi-auth-credentials.js";
 
 /**
  * @deprecated Legacy bridge for older flows that still expect `agentDir/auth.json`.
  * Runtime auth resolution uses auth-profiles directly and should not depend on this module.
  */
-type AuthJsonCredential =
-  | {
-      type: "api_key";
-      key: string;
-    }
-  | {
-      type: "oauth";
-      access: string;
-      refresh: string;
-      expires: number;
-      [key: string]: unknown;
-    };
+type AuthJsonCredential = PiCredential;
 
 type AuthJsonShape = Record<string, AuthJsonCredential>;
 
@@ -34,75 +26,6 @@ async function readAuthJson(filePath: string): Promise<AuthJsonShape> {
   } catch {
     return {};
   }
-}
-
-/**
- * Convert an OpenClaw auth-profiles credential to pi-coding-agent auth.json format.
- * Returns null if the credential cannot be converted.
- */
-function convertCredential(cred: AuthProfileCredential): AuthJsonCredential | null {
-  if (cred.type === "api_key") {
-    const key = typeof cred.key === "string" ? cred.key.trim() : "";
-    if (!key) {
-      return null;
-    }
-    return { type: "api_key", key };
-  }
-
-  if (cred.type === "token") {
-    // pi-coding-agent treats static tokens as api_key type
-    const token = typeof cred.token === "string" ? cred.token.trim() : "";
-    if (!token) {
-      return null;
-    }
-    const expires =
-      typeof (cred as { expires?: unknown }).expires === "number"
-        ? (cred as { expires: number }).expires
-        : Number.NaN;
-    if (Number.isFinite(expires) && expires > 0 && Date.now() >= expires) {
-      return null;
-    }
-    return { type: "api_key", key: token };
-  }
-
-  if (cred.type === "oauth") {
-    const accessRaw = (cred as { access?: unknown }).access;
-    const refreshRaw = (cred as { refresh?: unknown }).refresh;
-    const expiresRaw = (cred as { expires?: unknown }).expires;
-
-    const access = typeof accessRaw === "string" ? accessRaw.trim() : "";
-    const refresh = typeof refreshRaw === "string" ? refreshRaw.trim() : "";
-    const expires = typeof expiresRaw === "number" ? expiresRaw : Number.NaN;
-
-    if (!access || !refresh || !Number.isFinite(expires) || expires <= 0) {
-      return null;
-    }
-    return { type: "oauth", access, refresh, expires };
-  }
-
-  return null;
-}
-
-/**
- * Check if two auth.json credentials are equivalent.
- */
-function credentialsEqual(a: AuthJsonCredential | undefined, b: AuthJsonCredential): boolean {
-  if (!a || typeof a !== "object") {
-    return false;
-  }
-  if (a.type !== b.type) {
-    return false;
-  }
-
-  if (a.type === "api_key" && b.type === "api_key") {
-    return a.key === b.key;
-  }
-
-  if (a.type === "oauth" && b.type === "oauth") {
-    return a.access === b.access && a.refresh === b.refresh && a.expires === b.expires;
-  }
-
-  return false;
 }
 
 /**
@@ -123,31 +46,16 @@ export async function ensurePiAuthJsonFromAuthProfiles(agentDir: string): Promis
 }> {
   const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
   const authPath = path.join(agentDir, "auth.json");
-
-  // Group profiles by provider, taking the first valid profile for each
-  const providerCredentials = new Map<string, AuthJsonCredential>();
-
-  for (const [, cred] of Object.entries(store.profiles)) {
-    const provider = normalizeProviderId(String(cred.provider ?? "")).trim();
-    if (!provider || providerCredentials.has(provider)) {
-      continue;
-    }
-
-    const converted = convertCredential(cred);
-    if (converted) {
-      providerCredentials.set(provider, converted);
-    }
-  }
-
-  if (providerCredentials.size === 0) {
+  const providerCredentials = resolvePiCredentialMapFromStore(store);
+  if (Object.keys(providerCredentials).length === 0) {
     return { wrote: false, authPath };
   }
 
   const existing = await readAuthJson(authPath);
   let changed = false;
 
-  for (const [provider, cred] of providerCredentials) {
-    if (!credentialsEqual(existing[provider], cred)) {
+  for (const [provider, cred] of Object.entries(providerCredentials)) {
+    if (!piCredentialsEqual(existing[provider], cred)) {
       existing[provider] = cred;
       changed = true;
     }

--- a/src/agents/pi-model-discovery.auth.test.ts
+++ b/src/agents/pi-model-discovery.auth.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { saveAuthProfileStore } from "./auth-profiles.js";
+import { discoverAuthStorage } from "./pi-model-discovery.js";
+
+async function createAgentDir(): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-auth-storage-"));
+}
+
+async function pathExists(pathname: string): Promise<boolean> {
+  try {
+    await fs.stat(pathname);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("discoverAuthStorage", () => {
+  it("loads runtime credentials from auth-profiles without writing auth.json", async () => {
+    const agentDir = await createAgentDir();
+    try {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "openrouter:default": {
+              type: "api_key",
+              provider: "openrouter",
+              key: "sk-or-v1-runtime",
+            },
+            "anthropic:default": {
+              type: "token",
+              provider: "anthropic",
+              token: "sk-ant-runtime",
+            },
+            "openai-codex:default": {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "oauth-access",
+              refresh: "oauth-refresh",
+              expires: Date.now() + 60_000,
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const authStorage = discoverAuthStorage(agentDir);
+
+      expect(authStorage.hasAuth("openrouter")).toBe(true);
+      expect(authStorage.hasAuth("anthropic")).toBe(true);
+      expect(authStorage.hasAuth("openai-codex")).toBe(true);
+      await expect(authStorage.getApiKey("openrouter")).resolves.toBe("sk-or-v1-runtime");
+      await expect(authStorage.getApiKey("anthropic")).resolves.toBe("sk-ant-runtime");
+      expect(authStorage.get("openai-codex")).toMatchObject({
+        type: "oauth",
+        access: "oauth-access",
+      });
+
+      expect(await pathExists(path.join(agentDir, "auth.json"))).toBe(false);
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -1,19 +1,125 @@
 import path from "node:path";
-import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
+import {
+  AuthStorage,
+  InMemoryAuthStorageBackend,
+  ModelRegistry,
+} from "@mariozechner/pi-coding-agent";
+import { ensureAuthProfileStore } from "./auth-profiles.js";
+import type { AuthProfileCredential } from "./auth-profiles.js";
+import { normalizeProviderId } from "./model-selection.js";
 
 export { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 
-function createAuthStorage(AuthStorageLike: unknown, path: string) {
-  const withFactory = AuthStorageLike as { create?: (path: string) => unknown };
-  if (typeof withFactory.create === "function") {
-    return withFactory.create(path) as AuthStorage;
+type PiApiKeyCredential = { type: "api_key"; key: string };
+type PiOAuthCredential = {
+  type: "oauth";
+  access: string;
+  refresh: string;
+  expires: number;
+};
+
+type PiCredential = PiApiKeyCredential | PiOAuthCredential;
+type PiCredentialMap = Record<string, PiCredential>;
+
+function createAuthStorage(AuthStorageLike: unknown, path: string, creds: PiCredentialMap) {
+  const withInMemory = AuthStorageLike as { inMemory?: (data?: unknown) => unknown };
+  if (typeof withInMemory.inMemory === "function") {
+    return withInMemory.inMemory(creds) as AuthStorage;
   }
-  return new (AuthStorageLike as { new (path: string): unknown })(path) as AuthStorage;
+
+  const withFromStorage = AuthStorageLike as {
+    fromStorage?: (storage: unknown) => unknown;
+  };
+  if (typeof withFromStorage.fromStorage === "function") {
+    const backend = new InMemoryAuthStorageBackend();
+    backend.withLock(() => ({
+      result: undefined,
+      next: JSON.stringify(creds, null, 2),
+    }));
+    return withFromStorage.fromStorage(backend) as AuthStorage;
+  }
+
+  const withFactory = AuthStorageLike as { create?: (path: string) => unknown };
+  const withRuntimeOverride = (
+    typeof withFactory.create === "function"
+      ? withFactory.create(path)
+      : new (AuthStorageLike as { new (path: string): unknown })(path)
+  ) as AuthStorage & {
+    setRuntimeApiKey?: (provider: string, apiKey: string) => void;
+  };
+  if (typeof withRuntimeOverride.setRuntimeApiKey === "function") {
+    for (const [provider, credential] of Object.entries(creds)) {
+      if (credential.type === "api_key") {
+        withRuntimeOverride.setRuntimeApiKey(provider, credential.key);
+        continue;
+      }
+      withRuntimeOverride.setRuntimeApiKey(provider, credential.access);
+    }
+  }
+  return withRuntimeOverride;
+}
+
+function convertAuthProfileCredential(cred: AuthProfileCredential): PiCredential | null {
+  if (cred.type === "api_key") {
+    const key = typeof cred.key === "string" ? cred.key.trim() : "";
+    if (!key) {
+      return null;
+    }
+    return { type: "api_key", key };
+  }
+
+  if (cred.type === "token") {
+    const token = typeof cred.token === "string" ? cred.token.trim() : "";
+    if (!token) {
+      return null;
+    }
+    if (
+      typeof cred.expires === "number" &&
+      Number.isFinite(cred.expires) &&
+      Date.now() >= cred.expires
+    ) {
+      return null;
+    }
+    return { type: "api_key", key: token };
+  }
+
+  if (cred.type === "oauth") {
+    const access = typeof cred.access === "string" ? cred.access.trim() : "";
+    const refresh = typeof cred.refresh === "string" ? cred.refresh.trim() : "";
+    if (!access || !refresh || !Number.isFinite(cred.expires) || cred.expires <= 0) {
+      return null;
+    }
+    return {
+      type: "oauth",
+      access,
+      refresh,
+      expires: cred.expires,
+    };
+  }
+
+  return null;
+}
+
+function resolvePiCredentials(agentDir: string): PiCredentialMap {
+  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const credentials: PiCredentialMap = {};
+  for (const credential of Object.values(store.profiles)) {
+    const provider = normalizeProviderId(String(credential.provider ?? "")).trim();
+    if (!provider || credentials[provider]) {
+      continue;
+    }
+    const converted = convertAuthProfileCredential(credential);
+    if (converted) {
+      credentials[provider] = converted;
+    }
+  }
+  return credentials;
 }
 
 // Compatibility helpers for pi-coding-agent 0.50+ (discover* helpers removed).
 export function discoverAuthStorage(agentDir: string): AuthStorage {
-  return createAuthStorage(AuthStorage, path.join(agentDir, "auth.json"));
+  const credentials = resolvePiCredentials(agentDir);
+  return createAuthStorage(AuthStorage, path.join(agentDir, "auth.json"), credentials);
 }
 
 export function discoverModels(authStorage: AuthStorage, agentDir: string): ModelRegistry {

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -5,21 +5,9 @@ import {
   ModelRegistry,
 } from "@mariozechner/pi-coding-agent";
 import { ensureAuthProfileStore } from "./auth-profiles.js";
-import type { AuthProfileCredential } from "./auth-profiles.js";
-import { normalizeProviderId } from "./model-selection.js";
+import { resolvePiCredentialMapFromStore, type PiCredentialMap } from "./pi-auth-credentials.js";
 
 export { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
-
-type PiApiKeyCredential = { type: "api_key"; key: string };
-type PiOAuthCredential = {
-  type: "oauth";
-  access: string;
-  refresh: string;
-  expires: number;
-};
-
-type PiCredential = PiApiKeyCredential | PiOAuthCredential;
-type PiCredentialMap = Record<string, PiCredential>;
 
 function createAuthStorage(AuthStorageLike: unknown, path: string, creds: PiCredentialMap) {
   const withInMemory = AuthStorageLike as { inMemory?: (data?: unknown) => unknown };
@@ -59,61 +47,9 @@ function createAuthStorage(AuthStorageLike: unknown, path: string, creds: PiCred
   return withRuntimeOverride;
 }
 
-function convertAuthProfileCredential(cred: AuthProfileCredential): PiCredential | null {
-  if (cred.type === "api_key") {
-    const key = typeof cred.key === "string" ? cred.key.trim() : "";
-    if (!key) {
-      return null;
-    }
-    return { type: "api_key", key };
-  }
-
-  if (cred.type === "token") {
-    const token = typeof cred.token === "string" ? cred.token.trim() : "";
-    if (!token) {
-      return null;
-    }
-    if (
-      typeof cred.expires === "number" &&
-      Number.isFinite(cred.expires) &&
-      Date.now() >= cred.expires
-    ) {
-      return null;
-    }
-    return { type: "api_key", key: token };
-  }
-
-  if (cred.type === "oauth") {
-    const access = typeof cred.access === "string" ? cred.access.trim() : "";
-    const refresh = typeof cred.refresh === "string" ? cred.refresh.trim() : "";
-    if (!access || !refresh || !Number.isFinite(cred.expires) || cred.expires <= 0) {
-      return null;
-    }
-    return {
-      type: "oauth",
-      access,
-      refresh,
-      expires: cred.expires,
-    };
-  }
-
-  return null;
-}
-
 function resolvePiCredentials(agentDir: string): PiCredentialMap {
   const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
-  const credentials: PiCredentialMap = {};
-  for (const credential of Object.values(store.profiles)) {
-    const provider = normalizeProviderId(String(credential.provider ?? "")).trim();
-    if (!provider || credentials[provider]) {
-      continue;
-    }
-    const converted = convertAuthProfileCredential(credential);
-    if (converted) {
-      credentials[provider] = converted;
-    }
-  }
-  return credentials;
+  return resolvePiCredentialMapFromStore(store);
 }
 
 // Compatibility helpers for pi-coding-agent 0.50+ (discover* helpers removed).

--- a/src/commands/models.list.auth-sync.test.ts
+++ b/src/commands/models.list.auth-sync.test.ts
@@ -100,7 +100,7 @@ describe("models list auth-profile sync", () => {
 
       const openrouter = await runModelsListAndGetProvider("openrouter/");
       expect(openrouter?.available).toBe(true);
-      expect(await pathExists(authPath)).toBe(true);
+      expect(await pathExists(authPath)).toBe(false);
     });
   });
 

--- a/src/commands/models.list.test.ts
+++ b/src/commands/models.list.test.ts
@@ -6,9 +6,6 @@ let toModelRow: typeof import("./models/list.registry.js").toModelRow;
 
 const loadConfig = vi.fn();
 const ensureOpenClawModelsJson = vi.fn().mockResolvedValue(undefined);
-const ensurePiAuthJsonFromAuthProfiles = vi
-  .fn()
-  .mockResolvedValue({ wrote: false, authPath: "/tmp/openclaw-agent/auth.json" });
 const resolveOpenClawAgentDir = vi.fn().mockReturnValue("/tmp/openclaw-agent");
 const ensureAuthProfileStore = vi.fn().mockReturnValue({ version: 1, profiles: {} });
 const listProfilesForProvider = vi.fn().mockReturnValue([]);
@@ -36,10 +33,6 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("../agents/models-config.js", () => ({
   ensureOpenClawModelsJson,
-}));
-
-vi.mock("../agents/pi-auth-json.js", () => ({
-  ensurePiAuthJsonFromAuthProfiles,
 }));
 
 vi.mock("../agents/agent-paths.js", () => ({
@@ -121,7 +114,6 @@ beforeEach(() => {
   modelRegistryState.getAllError = undefined;
   modelRegistryState.getAvailableError = undefined;
   listProfilesForProvider.mockReturnValue([]);
-  ensurePiAuthJsonFromAuthProfiles.mockClear();
 });
 
 afterEach(() => {
@@ -223,13 +215,12 @@ describe("models list/status", () => {
     ({ loadModelRegistry, toModelRow } = await import("./models/list.registry.js"));
   });
 
-  it("models list syncs auth-profiles into auth.json before availability checks", async () => {
+  it("models list runs model discovery without auth.json sync", async () => {
     setDefaultZaiRegistry();
     const runtime = makeRuntime();
 
     await modelsListCommand({ all: true, json: true }, runtime);
-
-    expect(ensurePiAuthJsonFromAuthProfiles).toHaveBeenCalledWith("/tmp/openclaw-agent");
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it("models list outputs canonical zai key for configured z.ai model", async () => {

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveProviderAuthOverview } from "./list.auth-overview.js";
+
+describe("resolveProviderAuthOverview", () => {
+  it("does not throw when token profile only has tokenRef", () => {
+    const overview = resolveProviderAuthOverview({
+      provider: "github-copilot",
+      cfg: {},
+      store: {
+        version: 1,
+        profiles: {
+          "github-copilot:default": {
+            type: "token",
+            provider: "github-copilot",
+            tokenRef: { source: "env", id: "GITHUB_TOKEN" },
+          },
+        },
+      } as never,
+      modelsPath: "/tmp/models.json",
+    });
+
+    expect(overview.profiles.labels[0]).toContain("token:ref(env:GITHUB_TOKEN)");
+  });
+});

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -8,7 +8,6 @@ import {
   resolveEnvApiKey,
 } from "../../agents/model-auth.js";
 import { ensureOpenClawModelsJson } from "../../agents/models-config.js";
-import { ensurePiAuthJsonFromAuthProfiles } from "../../agents/pi-auth-json.js";
 import type { ModelRegistry } from "../../agents/pi-model-discovery.js";
 import { discoverAuthStorage, discoverModels } from "../../agents/pi-model-discovery.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -98,7 +97,6 @@ function loadAvailableModels(registry: ModelRegistry): Model<Api>[] {
 export async function loadModelRegistry(cfg: OpenClawConfig) {
   await ensureOpenClawModelsJson(cfg);
   const agentDir = resolveOpenClawAgentDir();
-  await ensurePiAuthJsonFromAuthProfiles(agentDir);
   const authStorage = discoverAuthStorage(agentDir);
   const registry = discoverModels(authStorage, agentDir);
   const models = registry.getAll();


### PR DESCRIPTION
## Summary
- stop syncing auth-profiles into plaintext `auth.json` for model discovery paths
- build pi `AuthStorage` from in-memory runtime auth profile credentials
- update model catalog/models list discovery paths and tests to use runtime auth injection

## Validation
- pnpm check
- pnpm vitest src/agents/model-catalog.test.ts src/commands/models.list.test.ts src/commands/models.list.auth-sync.test.ts src/agents/pi-model-discovery.auth.test.ts src/agents/pi-embedded-runner/model.test.ts src/agents/pi-embedded-runner/model.e2e.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates the plaintext `auth.json` file from the model discovery path by building Pi `AuthStorage` directly from in-memory runtime auth profile credentials. Previously, `ensurePiAuthJsonFromAuthProfiles()` would sync credentials from `auth-profiles.json` into `auth.json` on disk before each model discovery call. Now, `discoverAuthStorage()` reads auth profiles in-memory and constructs the `AuthStorage` without any disk write.

- **`pi-model-discovery.ts`**: Added `resolvePiCredentials()` and `convertAuthProfileCredential()` to convert auth profiles to Pi credential format in-memory. The `createAuthStorage()` function now has a 3-tier SDK compatibility fallback: `inMemory()` → `fromStorage()` with `InMemoryAuthStorageBackend` → legacy `create()`/`new` with `setRuntimeApiKey()`.
- **`model-catalog.ts`**: Removed the `createAuthStorage` helper and the `ensurePiAuthJsonFromAuthProfiles` call. Now delegates to `piSdk.discoverAuthStorage(agentDir)`.
- **`list.registry.ts`**: Removed `ensurePiAuthJsonFromAuthProfiles` import and call, simplifying the model registry loading path.
- **Tests updated**: All test mocks now include the `discoverAuthStorage` function. The auth-sync integration test now asserts that `auth.json` is **not** created. A new `pi-model-discovery.auth.test.ts` validates the end-to-end in-memory credential flow.
- The old `pi-auth-json.ts` module is now effectively dead code (only referenced by its own tests) but was intentionally left in place to keep this PR focused.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — it replaces disk-based credential syncing with in-memory injection while maintaining backward compatibility through a well-structured fallback chain.
- The changes are well-structured with clean separation of concerns. The credential conversion logic is a faithful port from the existing pi-auth-json.ts. The multi-tier SDK compatibility fallback covers current and future API shapes. All existing callers of discoverAuthStorage benefit automatically without changes. Test coverage includes a new integration test and updated mocks. The only minor concern is the InMemoryAuthStorageBackend.withLock() call whose return value is not awaited, but this appears to be intentional given the in-memory nature of the backend.
- `src/agents/pi-model-discovery.ts` deserves the most attention as it contains all the new credential conversion and SDK compatibility logic.

<sub>Last reviewed commit: b40faee</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->