### PR TITLE
Fix prototype pollution in applyMergePatch via blocked key filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Chat/UI: strip inline reply/audio directive tags (`[[reply_to_current]]`, `[[reply_to:<id>]]`, `[[audio_as_voice]]`) from displayed chat history, live chat event output, and session preview snippets so control tags no longer leak into user-visible surfaces.
+- Security/Config: block prototype-key traversal during config merge patch and legacy migration merge helpers (`__proto__`, `constructor`, `prototype`) to prevent prototype pollution during config mutation flows. (#22968) Thanks @Clawborn.
 - Security/Shell env: validate login-shell executable paths for shell-env fallback (`/etc/shells` + trusted prefixes) and block `SHELL` in dangerous env override policy paths so untrusted shell-path injection falls back safely to `/bin/sh`. Thanks @athuljayaram for reporting.
 - Security/Config: make parsed chat allowlist checks fail closed when `allowFrom` is empty, restoring expected DM/pairing gating.
 - Security/Exec: in non-default setups that manually add `sort` to `tools.exec.safeBins`, block `sort --compress-program` so allowlist-mode safe-bin checks cannot bypass approval. Thanks @tdjackey for reporting.

--- a/src/config/legacy.shared.test.ts
+++ b/src/config/legacy.shared.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mergeMissing } from "./legacy.shared.js";
+
+describe("mergeMissing prototype pollution guard", () => {
+  afterEach(() => {
+    delete (Object.prototype as Record<string, unknown>).polluted;
+  });
+
+  it("ignores __proto__ keys without polluting Object.prototype", () => {
+    const target = { safe: { keep: true } } as Record<string, unknown>;
+    const source = JSON.parse('{"safe":{"next":1},"__proto__":{"polluted":true}}') as Record<
+      string,
+      unknown
+    >;
+
+    mergeMissing(target, source);
+
+    expect((target.safe as Record<string, unknown>).keep).toBe(true);
+    expect((target.safe as Record<string, unknown>).next).toBe(1);
+    expect(target.polluted).toBeUndefined();
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/src/config/legacy.shared.ts
+++ b/src/config/legacy.shared.ts
@@ -12,6 +12,7 @@ export type LegacyConfigMigration = {
 
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import { isRecord } from "../utils.js";
+import { isBlockedObjectKey } from "./prototype-keys.js";
 export { isRecord };
 
 export const getRecord = (value: unknown): Record<string, unknown> | null =>
@@ -32,7 +33,7 @@ export const ensureRecord = (
 
 export const mergeMissing = (target: Record<string, unknown>, source: Record<string, unknown>) => {
   for (const [key, value] of Object.entries(source)) {
-    if (value === undefined) {
+    if (value === undefined || isBlockedObjectKey(key)) {
       continue;
     }
     const existing = target[key];

--- a/src/config/merge-patch.proto-pollution.test.ts
+++ b/src/config/merge-patch.proto-pollution.test.ts
@@ -9,6 +9,7 @@ describe("applyMergePatch prototype pollution guard", () => {
     expect(result.b).toBe(2);
     expect(result.a).toBe(1);
     expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(false);
+    expect(result.polluted).toBeUndefined();
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 
@@ -35,6 +36,7 @@ describe("applyMergePatch prototype pollution guard", () => {
     expect(result.nested.y).toBe(2);
     expect(result.nested.x).toBe(1);
     expect(Object.prototype.hasOwnProperty.call(result.nested, "__proto__")).toBe(false);
+    expect(result.nested.polluted).toBeUndefined();
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 });

--- a/src/config/merge-patch.proto-pollution.test.ts
+++ b/src/config/merge-patch.proto-pollution.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { applyMergePatch } from "./merge-patch.js";
+
+describe("applyMergePatch prototype pollution guard", () => {
+  it("ignores __proto__ keys in patch", () => {
+    const base = { a: 1 };
+    const patch = JSON.parse('{"__proto__": {"polluted": true}, "b": 2}');
+    const result = applyMergePatch(base, patch) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(result.a).toBe(1);
+    expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("ignores constructor key in patch", () => {
+    const base = { a: 1 };
+    const patch = { constructor: { polluted: true }, b: 2 };
+    const result = applyMergePatch(base, patch) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(Object.prototype.hasOwnProperty.call(result, "constructor")).toBe(false);
+  });
+
+  it("ignores prototype key in patch", () => {
+    const base = { a: 1 };
+    const patch = { prototype: { polluted: true }, b: 2 };
+    const result = applyMergePatch(base, patch) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(Object.prototype.hasOwnProperty.call(result, "prototype")).toBe(false);
+  });
+
+  it("ignores __proto__ in nested patches", () => {
+    const base = { nested: { x: 1 } };
+    const patch = JSON.parse('{"nested": {"__proto__": {"polluted": true}, "y": 2}}');
+    const result = applyMergePatch(base, patch) as { nested: Record<string, unknown> };
+    expect(result.nested.y).toBe(2);
+    expect(result.nested.x).toBe(1);
+    expect(Object.prototype.hasOwnProperty.call(result.nested, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -1,9 +1,7 @@
 import { isPlainObject } from "../utils.js";
+import { isBlockedObjectKey } from "./prototype-keys.js";
 
 type PlainObject = Record<string, unknown>;
-
-/** Keys that must never be merged to prevent prototype-pollution attacks. */
-const BLOCKED_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 type MergePatchOptions = {
   mergeObjectArraysById?: boolean;
@@ -73,7 +71,7 @@ export function applyMergePatch(
   const result: PlainObject = isPlainObject(base) ? { ...base } : {};
 
   for (const [key, value] of Object.entries(patch)) {
-    if (BLOCKED_KEYS.has(key)) {
+    if (isBlockedObjectKey(key)) {
       continue;
     }
     if (value === null) {

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -2,6 +2,9 @@ import { isPlainObject } from "../utils.js";
 
 type PlainObject = Record<string, unknown>;
 
+/** Keys that must never be merged to prevent prototype-pollution attacks. */
+const BLOCKED_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 type MergePatchOptions = {
   mergeObjectArraysById?: boolean;
 };
@@ -70,6 +73,9 @@ export function applyMergePatch(
   const result: PlainObject = isPlainObject(base) ? { ...base } : {};
 
   for (const [key, value] of Object.entries(patch)) {
+    if (BLOCKED_KEYS.has(key)) {
+      continue;
+    }
     if (value === null) {
       delete result[key];
       continue;


### PR DESCRIPTION
## Problem

`applyMergePatch` in `src/config/merge-patch.ts` iterates `Object.entries(patch)` without filtering dangerous property names. When a caller passes a JSON-parsed object containing a `"__proto__"` key (e.g. `JSON.parse('{"__proto__":{"polluted":true}}')`), the loop executes `result["__proto__"] = value`, which replaces the prototype of `result` and pollutes `Object.prototype` for the entire process. The same applies to `"constructor"` and `"prototype"`.

This function is used by the gateway's `config.patch` path, making it reachable from any caller that can issue a PATCH to the config endpoint.

Note: the sibling `deepMerge` function in `includes.ts` already guards against this via `isBlockedObjectKey` (#8078). `applyMergePatch` had no equivalent protection.

## Fix

Add a `BLOCKED_KEYS` set (`{ "__proto__", "constructor", "prototype" }`) and skip matching keys in the merge loop, consistent with the guard already in `deepMerge`.

## Tests

Four new tests in `src/config/merge-patch.proto-pollution.test.ts`:
- `__proto__` in patch is silently ignored
- `constructor` key in patch is silently ignored
- `prototype` key in patch is silently ignored
- Nested `__proto__` in a recursive patch is ignored

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a critical prototype pollution vulnerability in `applyMergePatch` by blocking dangerous keys (`__proto__`, `constructor`, `prototype`) during merge operations. The fix prevents attackers from polluting `Object.prototype` through the gateway's `config.patch` endpoint.

- Added `BLOCKED_KEYS` set filter to prevent prototype pollution attacks
- Comprehensive test coverage validates protection against all three dangerous keys in both top-level and nested contexts
- Fix aligns with existing protection already present in `deepMerge` function from #8078
- The implementation could be improved by reusing the existing `isBlockedObjectKey` utility instead of duplicating the blocked keys logic

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with only minor code quality improvements recommended
- The fix correctly addresses a critical security vulnerability with proper test coverage. The implementation is sound and follows the same pattern already used in `deepMerge`. Score is 4 (not 5) because the code duplicates existing utility logic instead of reusing `isBlockedObjectKey` from `prototype-keys.ts`, which could lead to maintenance issues if the blocked keys list needs updating in the future
- No files require special attention - the security fix is straightforward and well-tested

<sub>Last reviewed commit: 538c0d1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->