### PR TITLE
fix(discord): pass accountId to ack reaction handlers

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -133,11 +133,13 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
         rest: client.rest as never,
+        accountId,
       });
     },
     removeReaction: async (emoji) => {
       await removeReactionDiscord(messageChannelId, message.id, emoji, {
         rest: client.rest as never,
+        accountId,
       });
     },
   };


### PR DESCRIPTION
## Summary
- Passes the already-available `accountId` to `reactMessageDiscord()` and `removeReactionDiscord()` in the status reaction adapter
- Without `accountId`, `createDiscordClient` falls back to `"default"`, which fails when only named accounts are configured (e.g. `channels.discord.accounts.coach_claw`)
- The failure was completely silent at debug log level — only visible with `--verbose`

Fixes #22938

## Local Validation
- [x] `accountId` is already destructured from params (line 62) and used elsewhere in the same function
- [x] `DiscordReactOpts` type already accepts `accountId?: string`
- [x] No other reaction call sites in the same handler need updating

## Scope
XS — 2-line addition in one file (adding `accountId` to two opts objects)

## Author
@miloudbelarebia

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Discord reaction failures when using named accounts by passing `accountId` to reaction handlers. Without this parameter, the Discord client falls back to `"default"` account lookup, which fails silently when only named accounts (e.g., `channels.discord.accounts.coach_claw`) are configured. The `accountId` is already available in scope and the types already support it - this change ensures named Discord accounts work correctly with status reactions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal (2 lines), passes a parameter that's already in scope to functions that already accept it. The change follows existing patterns in the codebase (other call sites already pass accountId when available), fixes a real bug where named Discord accounts fail silently, and has no edge cases or potential side effects.
- No files require special attention

<sub>Last reviewed commit: 991c2d9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->