### PR TITLE
Gateway: add manual secrets reload command

### DIFF
--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -8,7 +8,6 @@ import { ensureAuthProfileStore } from "./auth-profiles.js";
 import { resolvePiCredentialMapFromStore, type PiCredentialMap } from "./pi-auth-credentials.js";
 
 export { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
-
 function createAuthStorage(AuthStorageLike: unknown, path: string, creds: PiCredentialMap) {
   const withInMemory = AuthStorageLike as { inMemory?: (data?: unknown) => unknown };
   if (typeof withInMemory.inMemory === "function") {

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -261,6 +261,15 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "secrets",
+    description: "Secrets runtime reload controls",
+    hasSubcommands: true,
+    register: async (program) => {
+      const mod = await import("../secrets-cli.js");
+      mod.registerSecretsCli(program);
+    },
+  },
+  {
     name: "skills",
     description: "List and inspect available skills",
     hasSubcommands: true,

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -1,0 +1,53 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCliRuntimeCapture } from "./test-runtime-capture.js";
+
+const callGatewayFromCli = vi.fn();
+
+const { defaultRuntime, runtimeLogs, runtimeErrors, resetRuntimeCapture } =
+  createCliRuntimeCapture();
+
+vi.mock("./gateway-rpc.js", () => ({
+  addGatewayClientOptions: (cmd: Command) => cmd,
+  callGatewayFromCli: (method: string, opts: unknown, params?: unknown, extra?: unknown) =>
+    callGatewayFromCli(method, opts, params, extra),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime,
+}));
+
+const { registerSecretsCli } = await import("./secrets-cli.js");
+
+describe("secrets CLI", () => {
+  const createProgram = () => {
+    const program = new Command();
+    program.exitOverride();
+    registerSecretsCli(program);
+    return program;
+  };
+
+  beforeEach(() => {
+    resetRuntimeCapture();
+    callGatewayFromCli.mockReset();
+  });
+
+  it("calls secrets.reload and prints human output", async () => {
+    callGatewayFromCli.mockResolvedValue({ ok: true, warningCount: 1 });
+    await createProgram().parseAsync(["secrets", "reload"], { from: "user" });
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "secrets.reload",
+      expect.anything(),
+      undefined,
+      expect.objectContaining({ expectFinal: false }),
+    );
+    expect(runtimeLogs.at(-1)).toBe("Secrets reloaded with 1 warning(s).");
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("prints JSON when requested", async () => {
+    callGatewayFromCli.mockResolvedValue({ ok: true, warningCount: 0 });
+    await createProgram().parseAsync(["secrets", "reload", "--json"], { from: "user" });
+    expect(runtimeLogs.at(-1)).toContain('"ok": true');
+  });
+});

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -1,0 +1,47 @@
+import type { Command } from "commander";
+import { danger } from "../globals.js";
+import { defaultRuntime } from "../runtime.js";
+import { formatDocsLink } from "../terminal/links.js";
+import { theme } from "../terminal/theme.js";
+import { addGatewayClientOptions, callGatewayFromCli, type GatewayRpcOpts } from "./gateway-rpc.js";
+
+type SecretsReloadOptions = GatewayRpcOpts & { json?: boolean };
+
+export function registerSecretsCli(program: Command) {
+  const secrets = program
+    .command("secrets")
+    .description("Secrets runtime controls")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/gateway/security", "docs.openclaw.ai/gateway/security")}\n`,
+    );
+
+  addGatewayClientOptions(
+    secrets
+      .command("reload")
+      .description("Re-resolve secret references and atomically swap runtime snapshot")
+      .option("--json", "Output JSON", false),
+  ).action(async (opts: SecretsReloadOptions) => {
+    try {
+      const result = await callGatewayFromCli("secrets.reload", opts, undefined, {
+        expectFinal: false,
+      });
+      if (opts.json) {
+        defaultRuntime.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      const warningCount = Number(
+        (result as { warningCount?: unknown } | undefined)?.warningCount ?? 0,
+      );
+      if (Number.isFinite(warningCount) && warningCount > 0) {
+        defaultRuntime.log(`Secrets reloaded with ${warningCount} warning(s).`);
+        return;
+      }
+      defaultRuntime.log("Secrets reloaded.");
+    } catch (err) {
+      defaultRuntime.error(danger(String(err)));
+      defaultRuntime.exit(1);
+    }
+  });
+}

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -101,6 +101,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "agents.delete",
     "skills.install",
     "skills.update",
+    "secrets.reload",
     "cron.add",
     "cron.update",
     "cron.remove",

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -50,6 +50,7 @@ const BASE_METHODS = [
   "update.run",
   "voicewake.get",
   "voicewake.set",
+  "secrets.reload",
   "sessions.list",
   "sessions.preview",
   "sessions.patch",

--- a/src/gateway/server-methods/secrets.test.ts
+++ b/src/gateway/server-methods/secrets.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSecretsHandlers } from "./secrets.js";
+
+describe("secrets handlers", () => {
+  it("responds with warning count on successful reload", async () => {
+    const handlers = createSecretsHandlers({
+      reloadSecrets: vi.fn().mockResolvedValue({ warningCount: 2 }),
+    });
+    const respond = vi.fn();
+    await handlers["secrets.reload"]({
+      req: { type: "req", id: "1", method: "secrets.reload" },
+      params: {},
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, warningCount: 2 });
+  });
+
+  it("returns unavailable when reload fails", async () => {
+    const handlers = createSecretsHandlers({
+      reloadSecrets: vi.fn().mockRejectedValue(new Error("reload failed")),
+    });
+    const respond = vi.fn();
+    await handlers["secrets.reload"]({
+      req: { type: "req", id: "1", method: "secrets.reload" },
+      params: {},
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: "Error: reload failed",
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/secrets.ts
+++ b/src/gateway/server-methods/secrets.ts
@@ -1,0 +1,17 @@
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+export function createSecretsHandlers(params: {
+  reloadSecrets: () => Promise<{ warningCount: number }>;
+}): GatewayRequestHandlers {
+  return {
+    "secrets.reload": async ({ respond }) => {
+      try {
+        const result = await params.reloadSecrets();
+        respond(true, { ok: true, warningCount: result.warningCount });
+      } catch (err) {
+        respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+      }
+    },
+  };
+}

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -255,49 +255,59 @@ export async function startGatewayServer(
       contextKey: code,
     });
   };
+  let secretsActivationTail: Promise<void> = Promise.resolve();
+  const runWithSecretsActivationLock = async <T>(operation: () => Promise<T>): Promise<T> => {
+    const run = secretsActivationTail.then(operation, operation);
+    secretsActivationTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await run;
+  };
   const activateRuntimeSecrets = async (
     config: OpenClawConfig,
     params: { reason: "startup" | "reload" | "restart-check"; activate: boolean },
-  ) => {
-    try {
-      const prepared = await prepareSecretsRuntimeSnapshot({ config });
-      if (params.activate) {
-        activateSecretsRuntimeSnapshot(prepared);
-      }
-      for (const warning of prepared.warnings) {
-        logSecrets.warn(`[${warning.code}] ${warning.message}`);
-      }
-      if (secretsDegraded) {
-        const recoveredMessage =
-          "Secret resolution recovered; runtime remained on last-known-good during the outage.";
-        logSecrets.info(`[SECRETS_RELOADER_RECOVERED] ${recoveredMessage}`);
-        emitSecretsStateEvent("SECRETS_RELOADER_RECOVERED", recoveredMessage, prepared.config);
-      }
-      secretsDegraded = false;
-      return prepared;
-    } catch (err) {
-      const details = String(err);
-      if (!secretsDegraded) {
-        logSecrets.error(`[SECRETS_RELOADER_DEGRADED] ${details}`);
-        if (params.reason !== "startup") {
-          emitSecretsStateEvent(
-            "SECRETS_RELOADER_DEGRADED",
-            `Secret resolution failed; runtime remains on last-known-good snapshot. ${details}`,
-            config,
-          );
+  ) =>
+    await runWithSecretsActivationLock(async () => {
+      try {
+        const prepared = await prepareSecretsRuntimeSnapshot({ config });
+        if (params.activate) {
+          activateSecretsRuntimeSnapshot(prepared);
         }
-      } else {
-        logSecrets.warn(`[SECRETS_RELOADER_DEGRADED] ${details}`);
+        for (const warning of prepared.warnings) {
+          logSecrets.warn(`[${warning.code}] ${warning.message}`);
+        }
+        if (secretsDegraded) {
+          const recoveredMessage =
+            "Secret resolution recovered; runtime remained on last-known-good during the outage.";
+          logSecrets.info(`[SECRETS_RELOADER_RECOVERED] ${recoveredMessage}`);
+          emitSecretsStateEvent("SECRETS_RELOADER_RECOVERED", recoveredMessage, prepared.config);
+        }
+        secretsDegraded = false;
+        return prepared;
+      } catch (err) {
+        const details = String(err);
+        if (!secretsDegraded) {
+          logSecrets.error(`[SECRETS_RELOADER_DEGRADED] ${details}`);
+          if (params.reason !== "startup") {
+            emitSecretsStateEvent(
+              "SECRETS_RELOADER_DEGRADED",
+              `Secret resolution failed; runtime remains on last-known-good snapshot. ${details}`,
+              config,
+            );
+          }
+        } else {
+          logSecrets.warn(`[SECRETS_RELOADER_DEGRADED] ${details}`);
+        }
+        secretsDegraded = true;
+        if (params.reason === "startup") {
+          throw new Error(`Startup failed: required secrets are unavailable. ${details}`, {
+            cause: err,
+          });
+        }
+        throw err;
       }
-      secretsDegraded = true;
-      if (params.reason === "startup") {
-        throw new Error(`Startup failed: required secrets are unavailable. ${details}`, {
-          cause: err,
-        });
-      }
-      throw err;
-    }
-  };
+    });
 
   // Fail fast before startup if required refs are unresolved.
   let cfgAtStart: OpenClawConfig;


### PR DESCRIPTION
## Summary
- add `secrets.reload` gateway RPC to re-resolve refs from the active unresolved config snapshot
- add `openclaw secrets reload` CLI command to trigger runtime secret re-activation
- classify/list the new method in gateway method metadata and add tests

## Validation
- pnpm check
- pnpm vitest src/gateway/server-methods/secrets.test.ts src/cli/secrets-cli.test.ts src/secrets/runtime.test.ts
- pnpm vitest src/gateway/method-scopes.test.ts src/gateway/server-methods.control-plane-rate-limit.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `secrets.reload` RPC method to manually re-resolve secret references from the active snapshot's source config. The implementation reuses the existing `activateRuntimeSecrets` helper to prepare and activate a new snapshot from `sourceConfig`, preserving the unresolved configuration for subsequent reloads. The CLI command properly handles both human-readable and JSON output formats, with appropriate error handling and permission scoping to `operator.admin`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns, includes comprehensive unit tests for both gateway handlers and CLI commands, properly handles error cases, and correctly integrates with the existing secrets runtime system. The addition of `sourceConfig` to the snapshot structure enables the reload functionality without breaking changes.
- No files require special attention

<sub>Last reviewed commit: 3b463cb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->