### PR TITLE
feat(web-search): add Google Custom Search Engine provider

### DIFF
--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -389,8 +389,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", or "grok"). */
-      provider?: "brave" | "perplexity" | "grok";
+      /** Search provider ("brave", "perplexity", "grok", or "google"). */
+      provider?: "brave" | "perplexity" | "grok" | "google";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -416,6 +416,13 @@ export type ToolsConfig = {
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */
         inlineCitations?: boolean;
+      };
+      /** Google Custom Search configuration (used when provider="google"). */
+      google?: {
+        /** API key for Google Custom Search (defaults to GOOGLE_API_KEY env var). */
+        apiKey?: string;
+        /** Custom Search Engine ID (cx parameter; defaults to GOOGLE_SEARCH_ENGINE_ID env var). */
+        searchEngineId?: string;
       };
     };
     fetch?: {


### PR DESCRIPTION
## Summary

Add Google Custom Search Engine (CSE) as a new web search provider option alongside brave, perplexity, and grok.

## Changes

- Added `google` to `SEARCH_PROVIDERS` array
- Added `GoogleConfig`, `GoogleSearchItem`, `GoogleSearchResponse` types
- Added config resolvers: `resolveGoogleConfig`, `resolveGoogleApiKey`, `resolveGoogleSearchEngineId`
- Added `runGoogleSearch` function using Google Custom Search API
- Updated `createWebSearchTool` with Google-specific description and error handling
- Updated config types to support `tools.web.search.google.apiKey` and `tools.web.search.google.searchEngineId`

## Configuration

Users can configure the Google provider via:

1. **Config file:**
   ```yaml
   tools:
     web:
       search:
         provider: google
         google:
           apiKey: YOUR_API_KEY
           searchEngineId: YOUR_SEARCH_ENGINE_ID
   ```

2. **Environment variables:**
   - `GOOGLE_API_KEY` - Google API key
   - `GOOGLE_SEARCH_ENGINE_ID` - Custom Search Engine ID (cx parameter)

## Usage

Once configured, the web_search tool will use Google CSE:

```
web_search({ query: "hello world", count: 5 })
```

Returns results with `title`, `url`, and `description` fields.

## Requirements

Users need:
- A Google Cloud project with Custom Search API enabled
- An API key from Google Cloud Console
- A Programmable Search Engine (https://programmablesearchengine.google.com/) with its ID

## Testing

- Build passes successfully
- Follows the same patterns as existing providers (brave, perplexity, grok)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Google Custom Search Engine as a new web search provider option. The implementation follows the established patterns from existing providers (brave, perplexity, grok) and includes proper type definitions, config resolvers, error handling, and external content wrapping for security. The Google provider returns structured results with titles, URLs, and snippets similar to Brave Search.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, follows established patterns from existing providers, includes proper error handling and security measures (wrapWebContent), and is well-typed. No logical errors or security vulnerabilities were found.
- No files require special attention

<sub>Last reviewed commit: c96c813</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->