### PR TITLE
fix(signal): guard JSON.parse of Signal RPC response with try-catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Signal/RPC: guard malformed Signal RPC JSON responses with a clear status-scoped error and add regression coverage for invalid JSON responses. (#22995) Thanks @adhitShet.
 - Gateway/Subagents: guard gateway and subagent session-key/message trim paths against undefined inputs to prevent early `Cannot read properties of undefined (reading 'trim')` crashes during subagent spawn and wait flows.
 - Agents/Workspace: guard `resolveUserPath` against undefined/null input to prevent `Cannot read properties of undefined (reading 'trim')` crashes when workspace paths are missing in embedded runner flows.
 - Auth/Profiles: keep active `cooldownUntil`/`disabledUntil` windows immutable across retries so mid-window failures cannot extend recovery indefinitely; only recompute a backoff window after the previous deadline has expired. This resolves cron/inbound retry loops that could trap gateways until manual `usageStats` cleanup. (#23516, #23536) Thanks @arosstale.

--- a/src/signal/client.test.ts
+++ b/src/signal/client.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithTimeoutMock = vi.fn();
+const resolveFetchMock = vi.fn();
+
+vi.mock("../infra/fetch.js", () => ({
+  resolveFetch: (...args: unknown[]) => resolveFetchMock(...args),
+}));
+
+vi.mock("../infra/secure-random.js", () => ({
+  generateSecureUuid: () => "test-id",
+}));
+
+vi.mock("../utils/fetch-timeout.js", () => ({
+  fetchWithTimeout: (...args: unknown[]) => fetchWithTimeoutMock(...args),
+}));
+
+import { signalRpcRequest } from "./client.js";
+
+type ErrorWithCause = Error & { cause?: unknown };
+
+describe("signalRpcRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveFetchMock.mockReturnValue(vi.fn());
+  });
+
+  it("returns parsed RPC result", async () => {
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", result: { version: "0.13.22" }, id: "test-id" }),
+        {
+          status: 200,
+        },
+      ),
+    );
+
+    const result = await signalRpcRequest<{ version: string }>("version", undefined, {
+      baseUrl: "http://127.0.0.1:8080",
+    });
+
+    expect(result).toEqual({ version: "0.13.22" });
+  });
+
+  it("throws a wrapped error when RPC response JSON is malformed", async () => {
+    fetchWithTimeoutMock.mockResolvedValueOnce(new Response("not-json", { status: 502 }));
+
+    const err = (await signalRpcRequest("version", undefined, {
+      baseUrl: "http://127.0.0.1:8080",
+    }).catch((error: unknown) => error)) as ErrorWithCause;
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("Signal RPC returned malformed JSON (status 502)");
+    expect(err.cause).toBeInstanceOf(SyntaxError);
+  });
+});

--- a/src/signal/client.ts
+++ b/src/signal/client.ts
@@ -77,7 +77,12 @@ export async function signalRpcRequest<T = unknown>(
   if (!text) {
     throw new Error(`Signal RPC empty response (status ${res.status})`);
   }
-  const parsed = JSON.parse(text) as SignalRpcResponse<T>;
+  let parsed: SignalRpcResponse<T>;
+  try {
+    parsed = JSON.parse(text) as SignalRpcResponse<T>;
+  } catch (err) {
+    throw new Error(`Signal RPC returned malformed JSON (status ${res.status})`, { cause: err });
+  }
   if (parsed.error) {
     const code = parsed.error.code ?? "unknown";
     const msg = parsed.error.message ?? "Signal RPC error";


### PR DESCRIPTION
## Summary

`signalRpcRequest` parses the daemon's HTTP response body with an
unguarded `JSON.parse`. If the response is malformed (network truncation,
proxy interference, daemon crash mid-write), callers receive a raw
`SyntaxError` with no diagnostic context — no status code, no endpoint,
no hint that it was a Signal RPC call.

## Bug

```ts
// src/signal/client.ts, line 80
const parsed = JSON.parse(text) as SignalRpcResponse<T>;  // unguarded
```

The function already guards against an empty response (line 77–78:
`if (!text) throw …`), so response validation was clearly intended —
the JSON parse step was simply missed.

Callers like `send.ts:183` (`sendMessageSignal`) and
`send-reactions.ts:122` (`sendReaction`) do not wrap the call in
try-catch, so a raw `SyntaxError` propagates up with zero context.

## Fix

Wrap `JSON.parse` in try-catch and rethrow with the HTTP status code
for diagnostic context:

```ts
let parsed: SignalRpcResponse<T>;
try {
  parsed = JSON.parse(text) as SignalRpcResponse<T>;
} catch (err) {
  throw new Error(`Signal RPC returned malformed JSON (status ${res.status})`, { cause: err });
}
```

The original `SyntaxError` is preserved as `cause` for stack-trace
inspection.

## Test plan

- [x] `npx oxfmt --check src/signal/client.ts` — pass
- [x] `npx oxlint src/signal/client.ts` — 0 warnings, 0 errors
- [x] `npx vitest run src/signal/ --config vitest.unit.config.ts` — 86 tests pass (10 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wrapped `JSON.parse` in try-catch to prevent raw `SyntaxError` from propagating when Signal daemon returns malformed JSON due to network truncation or daemon crashes. The fix adds diagnostic context (HTTP status code) and preserves the original error as `cause` for debugging.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused defensive improvement to error handling that adds proper try-catch around JSON.parse, includes diagnostic context (HTTP status), preserves the original error as cause, follows existing validation patterns in the codebase, and passed all 86 unit tests. The fix is minimal, well-documented, and addresses a real production scenario without introducing new dependencies or changing the API surface.
- No files require special attention

<sub>Last reviewed commit: 1ad1152</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->