### PR TITLE
fix(config): add modelByChannel to allowed channels keys

### DIFF
--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -237,7 +237,7 @@ function validateConfigObjectWithPluginsBase(
     return registryInfo;
   };
 
-  const allowedChannels = new Set<string>(["defaults", ...CHANNEL_IDS]);
+  const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...CHANNEL_IDS]);
 
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {


### PR DESCRIPTION
Fixes #22963

## Summary

- `channels.modelByChannel` was added to the Zod schema and TypeScript types in 2026.2.21 but was not added to the runtime validation whitelist in `src/config/validation.ts`
- Configs using `channels.modelByChannel` are rejected with `unknown channel id: modelByChannel`, even though the feature works at runtime
- Adds `"modelByChannel"` to the `allowedChannels` set alongside `"defaults"`

## Test plan

- [ ] Set `channels.modelByChannel` in config and verify `openclaw doctor` no longer reports invalid config
- [ ] Verify per-channel model overrides still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `modelByChannel` to the runtime validation allowlist in `src/config/validation.ts:240`. The `channels.modelByChannel` feature was added to the Zod schema and TypeScript types in commit f555835b (2026-02-20) but the runtime validation whitelist was not updated, causing configs with this valid key to be rejected with "unknown channel id: modelByChannel" errors.

- Aligns runtime validation with the schema definition in `src/config/zod-schema.providers.ts:34`
- Matches the existing pattern where `defaults` is also a special channel key
- Consistent with usage in `src/commands/doctor-state-integrity.ts:178` which already treats `modelByChannel` as a special case

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line fix that adds a missing validation whitelist entry for an already-implemented feature. The change is necessary, correct, and matches the existing pattern for special channel keys like `defaults`. No logical issues, security concerns, or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 945131e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->