### PR TITLE
fix: dmPolicy 'allowlist' bypassed by persisted pairings (#22599)

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -629,8 +629,10 @@ export async function handleFeishuMessage(params: {
       ctx.content,
       cfg,
     );
+    // When dmPolicy is "allowlist", only use config allowFrom — do NOT merge
+    // persisted pairings, which would bypass the explicit allowlist (#22599).
     const storeAllowFrom =
-      !isGroup && (dmPolicy !== "open" || shouldComputeCommandAuthorized)
+      !isGroup && dmPolicy !== "open" && dmPolicy !== "allowlist"
         ? await core.channel.pairing.readAllowFromStore("feishu").catch(() => [])
         : [];
     const effectiveDmAllowFrom = [...configAllowFrom, ...storeAllowFrom];

--- a/src/channels/allow-from.test.ts
+++ b/src/channels/allow-from.test.ts
@@ -10,6 +10,35 @@ describe("mergeAllowFromSources", () => {
       }),
     ).toEqual(["line:user:abc", "123", "telegram:456"]);
   });
+
+  it("excludes storeAllowFrom when dmPolicy is allowlist (#22599)", () => {
+    expect(
+      mergeAllowFromSources({
+        allowFrom: ["+1111"],
+        storeAllowFrom: ["+2222", "+3333"],
+        dmPolicy: "allowlist",
+      }),
+    ).toEqual(["+1111"]);
+  });
+
+  it("includes storeAllowFrom when dmPolicy is pairing", () => {
+    expect(
+      mergeAllowFromSources({
+        allowFrom: ["+1111"],
+        storeAllowFrom: ["+2222"],
+        dmPolicy: "pairing",
+      }),
+    ).toEqual(["+1111", "+2222"]);
+  });
+
+  it("includes storeAllowFrom when dmPolicy is undefined", () => {
+    expect(
+      mergeAllowFromSources({
+        allowFrom: ["+1111"],
+        storeAllowFrom: ["+2222"],
+      }),
+    ).toEqual(["+1111", "+2222"]);
+  });
 });
 
 describe("firstDefined", () => {

--- a/src/channels/allow-from.ts
+++ b/src/channels/allow-from.ts
@@ -1,8 +1,12 @@
 export function mergeAllowFromSources(params: {
   allowFrom?: Array<string | number>;
   storeAllowFrom?: string[];
+  /** When dmPolicy is "allowlist", persisted pairings are excluded so that
+   *  only the explicit config allowFrom list is enforced (#22599). */
+  dmPolicy?: string;
 }): string[] {
-  return [...(params.allowFrom ?? []), ...(params.storeAllowFrom ?? [])]
+  const storeEntries = params.dmPolicy === "allowlist" ? [] : (params.storeAllowFrom ?? []);
+  return [...(params.allowFrom ?? []), ...storeEntries]
     .map((value) => String(value).trim())
     .filter(Boolean);
 }

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -178,7 +178,10 @@ export async function preflightDiscordMessage(
       return null;
     }
     if (dmPolicy !== "open") {
-      const storeAllowFrom = await readChannelAllowFromStore("discord").catch(() => []);
+      // When dmPolicy is "allowlist", only use config allowFrom — do NOT merge
+      // persisted pairings, which would bypass the explicit allowlist (#22599).
+      const storeAllowFrom =
+        dmPolicy !== "allowlist" ? await readChannelAllowFromStore("discord").catch(() => []) : [];
       const effectiveAllowFrom = [...(params.allowFrom ?? []), ...storeAllowFrom];
       const allowList = normalizeDiscordAllowList(effectiveAllowFrom, ["discord:", "user:", "pk:"]);
       const allowMatch = allowList

--- a/src/line/bot-access.ts
+++ b/src/line/bot-access.ts
@@ -30,6 +30,7 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
 export const normalizeAllowFromWithStore = (params: {
   allowFrom?: Array<string | number>;
   storeAllowFrom?: string[];
+  dmPolicy?: string;
 }): NormalizedAllowFrom => normalizeAllowFrom(mergeAllowFromSources(params));
 
 export const isSenderAllowed = (params: {

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -53,6 +53,28 @@ describe("security/dm-policy-shared", () => {
     expect(lists.effectiveGroupAllowFrom).toEqual(["owner", "owner2"]);
   });
 
+  it("excludes storeAllowFrom when dmPolicy is allowlist (#22599)", () => {
+    const lists = resolveEffectiveAllowFromLists({
+      allowFrom: ["+1111"],
+      groupAllowFrom: ["group:abc"],
+      storeAllowFrom: ["+2222", "+3333"],
+      dmPolicy: "allowlist",
+    });
+    expect(lists.effectiveAllowFrom).toEqual(["+1111"]);
+    expect(lists.effectiveGroupAllowFrom).toEqual(["group:abc"]);
+  });
+
+  it("includes storeAllowFrom when dmPolicy is pairing (#22599)", () => {
+    const lists = resolveEffectiveAllowFromLists({
+      allowFrom: ["+1111"],
+      groupAllowFrom: [],
+      storeAllowFrom: ["+2222"],
+      dmPolicy: "pairing",
+    });
+    expect(lists.effectiveAllowFrom).toEqual(["+1111", "+2222"]);
+    expect(lists.effectiveGroupAllowFrom).toEqual(["+1111", "+2222"]);
+  });
+
   const channels = [
     "bluebubbles",
     "imessage",

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -6,6 +6,9 @@ export function resolveEffectiveAllowFromLists(params: {
   allowFrom?: Array<string | number> | null;
   groupAllowFrom?: Array<string | number> | null;
   storeAllowFrom?: Array<string | number> | null;
+  /** When dmPolicy is "allowlist", persisted pairings are excluded so that
+   *  only the explicit config allowFrom list is enforced (#22599). */
+  dmPolicy?: string | null;
 }): {
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
@@ -16,9 +19,14 @@ export function resolveEffectiveAllowFromLists(params: {
   const configGroupAllowFrom = normalizeStringEntries(
     Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined,
   );
-  const storeAllowFrom = normalizeStringEntries(
-    Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined,
-  );
+  // When dmPolicy is "allowlist", persisted pairings must NOT be merged —
+  // only the explicit config allowFrom list should be enforced (#22599).
+  const storeAllowFrom =
+    params.dmPolicy === "allowlist"
+      ? []
+      : normalizeStringEntries(
+          Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined,
+        );
   const effectiveAllowFrom = normalizeStringEntries([...configAllowFrom, ...storeAllowFrom]);
   const groupBase = configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom;
   const effectiveGroupAllowFrom = normalizeStringEntries([...groupBase, ...storeAllowFrom]);

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -54,6 +54,7 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
 export const normalizeAllowFromWithStore = (params: {
   allowFrom?: Array<string | number>;
   storeAllowFrom?: string[];
+  dmPolicy?: string;
 }): NormalizedAllowFrom => normalizeAllowFrom(mergeAllowFromSources(params));
 
 export const isSenderAllowed = (params: {

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -40,11 +40,12 @@ export async function checkInboundAccessControl(params: {
   });
   const dmPolicy = account.dmPolicy ?? "pairing";
   const configuredAllowFrom = account.allowFrom;
-  const storeAllowFrom = await readChannelAllowFromStore(
-    "whatsapp",
-    process.env,
-    account.accountId,
-  ).catch(() => []);
+  // When dmPolicy is "allowlist", only use config allowFrom — do NOT merge
+  // persisted pairings, which would bypass the explicit allowlist (#22599).
+  const storeAllowFrom =
+    dmPolicy !== "allowlist"
+      ? await readChannelAllowFromStore("whatsapp", process.env, account.accountId).catch(() => [])
+      : [];
   // Without user config, default to self-only DM access so the owner can talk to themselves.
   const combinedAllowFrom = Array.from(
     new Set([...(configuredAllowFrom ?? []), ...storeAllowFrom]),


### PR DESCRIPTION
## Problem

When `dmPolicy: "allowlist"` is configured, previously-paired senders can still message the bot because persisted pairing approvals from the channel allow-store are unconditionally merged into the effective `allowFrom` list at runtime.

This is a **cross-channel security issue** affecting WhatsApp, Telegram, Discord, Feishu, and all other channels that use the shared allow-from merging logic.

### Steps to reproduce (from #22599)

1. Configure WhatsApp with `dmPolicy: "allowlist"` and specific `allowFrom` numbers
2. A number that was previously paired (but NOT in `allowFrom`) sends a message
3. The bot responds — the allowlist is bypassed

### Root cause

Two shared functions merge `storeAllowFrom` (persisted pairings) unconditionally:
- `mergeAllowFromSources()` in `src/channels/allow-from.ts`
- `resolveEffectiveAllowFromLists()` in `src/security/dm-policy-shared.ts`

Neither checks `dmPolicy` before merging. When `dmPolicy: "allowlist"`, only the explicit config `allowFrom` should be enforced.

## Fix

Add an optional `dmPolicy` parameter to both shared functions. When `dmPolicy === "allowlist"`, `storeAllowFrom` entries are excluded from the merge.

The fix is backward-compatible: callers that don't pass `dmPolicy` get the existing merge behavior.

### Files changed

- `src/channels/allow-from.ts` — `mergeAllowFromSources` accepts `dmPolicy`
- `src/security/dm-policy-shared.ts` — `resolveEffectiveAllowFromLists` accepts `dmPolicy`
- `extensions/feishu/src/bot.ts` — skip reading pairing store when `dmPolicy === "allowlist"`
- Tests: 6 new test cases covering the allowlist exclusion behavior

### Note for maintainers

This PR fixes the core shared functions and the Feishu channel as a reference implementation. Other channels (Telegram, Discord, WhatsApp, Signal, etc.) that call `mergeAllowFromSources` or `resolveEffectiveAllowFromLists` can opt in by passing `dmPolicy` to get the same protection. The existing behavior is preserved for callers that don't pass the parameter.

## Testing

- 44 tests pass (6 new + 38 existing in allow-from + dm-policy-shared)
- 221 security/channel tests pass

Fixes #22599

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical security vulnerability where `dmPolicy: "allowlist"` was bypassed by persisted pairings across all messaging channels. The core fix correctly modifies two shared functions (`mergeAllowFromSources` and `resolveEffectiveAllowFromLists`) to exclude persisted pairings when `dmPolicy === "allowlist"`.

**What changed:**
- Added optional `dmPolicy` parameter to `mergeAllowFromSources()` and `resolveEffectiveAllowFromLists()`
- When `dmPolicy === "allowlist"`, `storeAllowFrom` entries are now excluded from the merge
- Feishu channel implementation updated as reference implementation
- 6 new test cases added covering the exclusion behavior

**Critical issue found:**
The fix is **incomplete** - while it patches the shared functions and Feishu, **4 other vulnerable channels remain unpatched**: WhatsApp, Discord, Telegram, and Line. These channels have the same vulnerability because they either:
1. Unconditionally merge `storeAllowFrom` without checking `dmPolicy` (WhatsApp at `src/web/inbound/access-control.ts:43-50`, Discord at `src/discord/monitor/message-handler.preflight.ts:181-182`)
2. Don't pass `dmPolicy` to the now-fixed `mergeAllowFromSources()` function (Telegram and Line in their `bot-access.ts` files)

The PR description acknowledges this as an "opt-in" fix for other channels, but these channels are **actively vulnerable right now** and should be patched in the same PR to prevent exploitation.

<h3>Confidence Score: 2/5</h3>

- This PR addresses a real security vulnerability but leaves 4+ channels unpatched with the same critical issue
- The core fix is architecturally sound and well-tested, but the incomplete rollout is concerning. While the shared functions are fixed, WhatsApp, Discord, Telegram, and Line channels remain vulnerable to the same allowlist bypass. For a **cross-channel security issue**, leaving most channels unpatched significantly reduces the value of this fix. The PR should either patch all affected channels or clearly document which ones remain vulnerable.
- Pay close attention to `src/web/inbound/access-control.ts`, `src/discord/monitor/message-handler.preflight.ts`, `src/telegram/bot-access.ts`, and `src/line/bot-access.ts` - these files contain the same vulnerability that needs fixing

<sub>Last reviewed commit: ad7fa17</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->