### PR TITLE
Fix prototype pollution in mergeConfigSection and add deepMerge coverage

### DIFF
--- a/src/config/includes.deep-merge-proto.test.ts
+++ b/src/config/includes.deep-merge-proto.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { deepMerge } from "./includes.js";
+
+describe("deepMerge prototype pollution guard", () => {
+  it("ignores __proto__ keys in source", () => {
+    const target = { a: 1 };
+    const source = JSON.parse('{"__proto__": {"polluted": true}, "b": 2}');
+    const result = deepMerge(target, source) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(result.a).toBe(1);
+    expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("ignores constructor key in source", () => {
+    const target = { a: 1 };
+    const source = { constructor: { polluted: true }, b: 2 };
+    const result = deepMerge(target, source) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(Object.prototype.hasOwnProperty.call(result, "constructor")).toBe(false);
+  });
+
+  it("ignores __proto__ in nested objects", () => {
+    const target = { nested: { x: 1 } };
+    const source = JSON.parse('{"nested": {"__proto__": {"polluted": true}, "y": 2}}');
+    const result = deepMerge(target, source) as { nested: Record<string, unknown> };
+    expect(result.nested.y).toBe(2);
+    expect(Object.prototype.hasOwnProperty.call(result.nested, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/src/config/merge-config.proto-pollution.test.ts
+++ b/src/config/merge-config.proto-pollution.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { mergeConfigSection } from "./merge-config.js";
+
+describe("mergeConfigSection prototype pollution guard", () => {
+  it("ignores __proto__ keys in patch", () => {
+    const base = { a: "1" } as Record<string, unknown>;
+    const patch = JSON.parse('{"__proto__": {"polluted": true}, "b": "2"}');
+    const result = mergeConfigSection(base, patch);
+    expect(result.b).toBe("2");
+    expect(result.a).toBe("1");
+    expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("ignores constructor key in patch", () => {
+    const base = { a: "1" } as Record<string, unknown>;
+    const patch = { constructor: { polluted: true }, b: "2" } as Record<string, unknown>;
+    const result = mergeConfigSection(base, patch);
+    expect(result.b).toBe("2");
+    expect(Object.prototype.hasOwnProperty.call(result, "constructor")).toBe(false);
+  });
+});

--- a/src/config/merge-config.ts
+++ b/src/config/merge-config.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "./config.js";
 import type { WhatsAppConfig } from "./types.js";
 
+/** Keys that must never be merged to prevent prototype-pollution attacks. */
+const BLOCKED_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 export type MergeSectionOptions<T> = {
   unsetOnUndefined?: Array<keyof T>;
 };
@@ -12,6 +15,9 @@ export function mergeConfigSection<T extends Record<string, unknown>>(
 ): T {
   const next: Record<string, unknown> = { ...(base ?? undefined) };
   for (const [key, value] of Object.entries(patch) as [keyof T, T[keyof T]][]) {
+    if (BLOCKED_KEYS.has(key as string)) {
+      continue;
+    }
     if (value === undefined) {
       if (options.unsetOnUndefined?.includes(key)) {
         delete next[key as string];


### PR DESCRIPTION
## Problem

`mergeConfigSection` in `src/config/merge-config.ts` iterates `Object.entries(patch)` without filtering dangerous property names. A `__proto__` or `constructor` key in a JSON-parsed patch object will be assigned directly (`result["__proto__"] = value`), which can mutate `Object.prototype` for the entire process.

This function is called on every config section merge (e.g. during `gateway config.patch` and runtime config updates), making it reachable through the config write paths.

The sibling functions already have guards:
- `deepMerge` (includes.ts) — guarded via `isBlockedObjectKey` (PR #8078)
- `applyMergePatch` (merge-patch.ts) — guarded in PR #22968

`mergeConfigSection` was the remaining unprotected merge function.

## Fix

Add a `BLOCKED_KEYS` set and skip `__proto__`, `constructor`, and `prototype` keys in the merge loop, consistent with the approach in #22968.

## Tests

- `src/config/merge-config.proto-pollution.test.ts`: 2 tests covering `__proto__` and `constructor` keys in `mergeConfigSection`
- `src/config/includes.deep-merge-proto.test.ts`: 3 tests confirming the existing `isBlockedObjectKey` guard in `deepMerge` holds for `__proto__`, `constructor`, and nested injection (no code change needed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds prototype pollution protection to `mergeConfigSection` by filtering `__proto__`, `constructor`, and `prototype` keys, aligning with the existing protection in `deepMerge`. The fix prevents malicious config patches from mutating Object.prototype during config merges. Comprehensive tests verify both the new protection in `mergeConfigSection` and existing guards in `deepMerge`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - critical security fix with thorough test coverage
- The implementation correctly mirrors the protection pattern used in `deepMerge` (via `isBlockedObjectKey`), uses the exact same set of blocked keys, and includes comprehensive tests that verify both `__proto__` and `constructor` keys are properly filtered. The fix closes a real security vulnerability in a config merge path.
- No files require special attention

<sub>Last reviewed commit: f9f30a4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

🤖 **AI-assisted PR** (Claude, via OpenClaw agent)
- Testing: Fully tested locally with vitest; all relevant test suites pass
- The contributor understands what this code does