### PR TITLE
Onboard: persist env-backed API keys as secret refs

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -7,6 +7,7 @@ import type {
   GatewayAuthChoice,
   GatewayBind,
   NodeManagerChoice,
+  SecretInputMode,
   TailscaleMode,
 } from "../../commands/onboard-types.js";
 import { onboardCommand } from "../../commands/onboard.js";
@@ -74,6 +75,10 @@ export function registerOnboardCommand(program: Command) {
       "Auth profile id (non-interactive; default: <provider>:manual)",
     )
     .option("--token-expires-in <duration>", "Optional token expiry duration (e.g. 365d, 12h)")
+    .option(
+      "--secret-input-mode <mode>",
+      "API key persistence mode: plaintext|ref (default: plaintext)",
+    )
     .option("--cloudflare-ai-gateway-account-id <id>", "Cloudflare Account ID")
     .option("--cloudflare-ai-gateway-gateway-id <id>", "Cloudflare AI Gateway ID");
 
@@ -129,6 +134,7 @@ export function registerOnboardCommand(program: Command) {
           token: opts.token as string | undefined,
           tokenProfileId: opts.tokenProfileId as string | undefined,
           tokenExpiresIn: opts.tokenExpiresIn as string | undefined,
+          secretInputMode: opts.secretInputMode as SecretInputMode | undefined,
           anthropicApiKey: opts.anthropicApiKey as string | undefined,
           openaiApiKey: opts.openaiApiKey as string | undefined,
           mistralApiKey: opts.mistralApiKey as string | undefined,

--- a/src/commands/auth-choice.apply-helpers.test.ts
+++ b/src/commands/auth-choice.apply-helpers.test.ts
@@ -90,7 +90,7 @@ describe("maybeApplyApiKeyFromOption", () => {
     });
 
     expect(result).toBe("opt-key");
-    expect(setCredential).toHaveBeenCalledWith("opt-key");
+    expect(setCredential).toHaveBeenCalledWith("opt-key", undefined);
   });
 
   it("matches provider with whitespace/case normalization", async () => {
@@ -105,7 +105,7 @@ describe("maybeApplyApiKeyFromOption", () => {
     });
 
     expect(result).toBe("opt-key");
-    expect(setCredential).toHaveBeenCalledWith("opt-key");
+    expect(setCredential).toHaveBeenCalledWith("opt-key", undefined);
   });
 
   it("skips when provider does not match", async () => {
@@ -132,7 +132,7 @@ describe("ensureApiKeyFromEnvOrPrompt", () => {
     });
 
     expect(result).toBe("env-key");
-    expect(setCredential).toHaveBeenCalledWith("env-key");
+    expect(setCredential).toHaveBeenCalledWith("env-key", "plaintext");
     expect(text).not.toHaveBeenCalled();
   });
 
@@ -143,7 +143,7 @@ describe("ensureApiKeyFromEnvOrPrompt", () => {
     });
 
     expect(result).toBe("prompted-key");
-    expect(setCredential).toHaveBeenCalledWith("prompted-key");
+    expect(setCredential).toHaveBeenCalledWith("prompted-key", undefined);
     expect(text).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "Enter key",
@@ -176,7 +176,7 @@ describe("ensureApiKeyFromOptionEnvOrPrompt", () => {
     });
 
     expect(result).toBe("opts-key");
-    expect(setCredential).toHaveBeenCalledWith("opts-key");
+    expect(setCredential).toHaveBeenCalledWith("opts-key", undefined);
     expect(note).not.toHaveBeenCalled();
     expect(confirm).not.toHaveBeenCalled();
     expect(text).not.toHaveBeenCalled();
@@ -211,6 +211,6 @@ describe("ensureApiKeyFromOptionEnvOrPrompt", () => {
     expect(note).toHaveBeenCalledWith("MiniMax note", "MiniMax");
     expect(confirm).toHaveBeenCalled();
     expect(text).not.toHaveBeenCalled();
-    expect(setCredential).toHaveBeenCalledWith("env-key");
+    expect(setCredential).toHaveBeenCalledWith("env-key", "plaintext");
   });
 });

--- a/src/commands/auth-choice.apply.huggingface.ts
+++ b/src/commands/auth-choice.apply.huggingface.ts
@@ -6,6 +6,7 @@ import { normalizeApiKeyInput, validateApiKeyInput } from "./auth-choice.api-key
 import {
   createAuthChoiceAgentModelNoter,
   ensureApiKeyFromOptionEnvOrPrompt,
+  normalizeSecretInputModeInput,
 } from "./auth-choice.apply-helpers.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
@@ -27,10 +28,12 @@ export async function applyAuthChoiceHuggingface(
   let nextConfig = params.config;
   let agentModelOverride: string | undefined;
   const noteAgentModel = createAuthChoiceAgentModelNoter(params);
+  const requestedSecretInputMode = normalizeSecretInputModeInput(params.opts?.secretInputMode);
 
   const hfKey = await ensureApiKeyFromOptionEnvOrPrompt({
     token: params.opts?.token,
     tokenProvider: params.opts?.tokenProvider,
+    secretInputMode: requestedSecretInputMode,
     expectedProviders: ["huggingface"],
     provider: "huggingface",
     envLabel: "Hugging Face token",
@@ -38,7 +41,8 @@ export async function applyAuthChoiceHuggingface(
     normalize: normalizeApiKeyInput,
     validate: validateApiKeyInput,
     prompter: params.prompter,
-    setCredential: async (apiKey) => setHuggingfaceApiKey(apiKey, params.agentDir),
+    setCredential: async (apiKey, mode) =>
+      setHuggingfaceApiKey(apiKey, params.agentDir, { secretInputMode: mode }),
     noteMessage: [
       "Hugging Face Inference Providers offer OpenAI-compatible chat completions.",
       "Create a token at: https://huggingface.co/settings/tokens (fine-grained, 'Make calls to Inference Providers').",

--- a/src/commands/auth-choice.apply.minimax.test.ts
+++ b/src/commands/auth-choice.apply.minimax.test.ts
@@ -44,7 +44,7 @@ describe("applyAuthChoiceMiniMax", () => {
 
   async function readAuthProfiles(agentDir: string) {
     return await readAuthProfilesForAgent<{
-      profiles?: Record<string, { key?: string }>;
+      profiles?: Record<string, { key?: string; keyRef?: { source: string; id: string } }>;
     }>(agentDir);
   }
 
@@ -154,7 +154,10 @@ describe("applyAuthChoiceMiniMax", () => {
     expect(confirm).toHaveBeenCalled();
 
     const parsed = await readAuthProfiles(agentDir);
-    expect(parsed.profiles?.["minimax-cn:default"]?.key).toBe("mm-env-token");
+    expect(parsed.profiles?.["minimax-cn:default"]?.keyRef).toEqual({
+      source: "env",
+      id: "MINIMAX_API_KEY",
+    });
   });
 
   it("uses minimax-api-lightning default model", async () => {

--- a/src/commands/auth-choice.apply.minimax.test.ts
+++ b/src/commands/auth-choice.apply.minimax.test.ts
@@ -126,7 +126,7 @@ describe("applyAuthChoiceMiniMax", () => {
     },
   );
 
-  it("uses env token for minimax-api-key-cn when confirmed", async () => {
+  it("uses env token for minimax-api-key-cn as plaintext by default", async () => {
     const agentDir = await setupTempState();
     process.env.MINIMAX_API_KEY = "mm-env-token";
     delete process.env.MINIMAX_OAUTH_TOKEN;
@@ -154,10 +154,36 @@ describe("applyAuthChoiceMiniMax", () => {
     expect(confirm).toHaveBeenCalled();
 
     const parsed = await readAuthProfiles(agentDir);
+    expect(parsed.profiles?.["minimax-cn:default"]?.key).toBe("mm-env-token");
+    expect(parsed.profiles?.["minimax-cn:default"]?.keyRef).toBeUndefined();
+  });
+
+  it("uses env token for minimax-api-key-cn as keyRef in ref mode", async () => {
+    const agentDir = await setupTempState();
+    process.env.MINIMAX_API_KEY = "mm-env-token";
+    delete process.env.MINIMAX_OAUTH_TOKEN;
+
+    const text = vi.fn(async () => "should-not-be-used");
+    const confirm = vi.fn(async () => true);
+
+    const result = await applyAuthChoiceMiniMax({
+      authChoice: "minimax-api-key-cn",
+      config: {},
+      prompter: createMinimaxPrompter({ text, confirm }),
+      runtime: createExitThrowingRuntime(),
+      setDefaultModel: true,
+      opts: {
+        secretInputMode: "ref",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    const parsed = await readAuthProfiles(agentDir);
     expect(parsed.profiles?.["minimax-cn:default"]?.keyRef).toEqual({
       source: "env",
       id: "MINIMAX_API_KEY",
     });
+    expect(parsed.profiles?.["minimax-cn:default"]?.key).toBeUndefined();
   });
 
   it("uses minimax-api-lightning default model", async () => {

--- a/src/commands/auth-choice.apply.minimax.ts
+++ b/src/commands/auth-choice.apply.minimax.ts
@@ -3,6 +3,7 @@ import {
   createAuthChoiceDefaultModelApplier,
   createAuthChoiceModelStateBridge,
   ensureApiKeyFromOptionEnvOrPrompt,
+  normalizeSecretInputModeInput,
 } from "./auth-choice.apply-helpers.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyAuthChoicePluginProvider } from "./auth-choice.apply.plugin-provider.js";
@@ -31,6 +32,7 @@ export async function applyAuthChoiceMiniMax(
       setAgentModelOverride: (model) => (agentModelOverride = model),
     }),
   );
+  const requestedSecretInputMode = normalizeSecretInputModeInput(params.opts?.secretInputMode);
   const ensureMinimaxApiKey = async (opts: {
     profileId: string;
     promptMessage: string;
@@ -38,6 +40,7 @@ export async function applyAuthChoiceMiniMax(
     await ensureApiKeyFromOptionEnvOrPrompt({
       token: params.opts?.token,
       tokenProvider: params.opts?.tokenProvider,
+      secretInputMode: requestedSecretInputMode,
       expectedProviders: ["minimax", "minimax-cn"],
       provider: "minimax",
       envLabel: "MINIMAX_API_KEY",
@@ -45,7 +48,8 @@ export async function applyAuthChoiceMiniMax(
       normalize: normalizeApiKeyInput,
       validate: validateApiKeyInput,
       prompter: params.prompter,
-      setCredential: async (apiKey) => setMinimaxApiKey(apiKey, params.agentDir, opts.profileId),
+      setCredential: async (apiKey, mode) =>
+        setMinimaxApiKey(apiKey, params.agentDir, opts.profileId, { secretInputMode: mode }),
     });
   };
   const applyMinimaxApiVariant = async (opts: {

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -8,6 +8,7 @@ import { isSecretRef, type SecretInput, type SecretRef } from "../config/types.s
 import { KILOCODE_DEFAULT_MODEL_REF } from "../providers/kilocode-shared.js";
 import { PROVIDER_ENV_VARS } from "../secrets/provider-env-vars.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+import type { SecretInputMode } from "./onboard-types.js";
 export { CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF } from "../agents/cloudflare-ai-gateway.js";
 export { MISTRAL_DEFAULT_MODEL_REF, XAI_DEFAULT_MODEL_REF } from "./onboard-auth.models.js";
 export { KILOCODE_DEFAULT_MODEL_REF };
@@ -15,6 +16,11 @@ export { KILOCODE_DEFAULT_MODEL_REF };
 const resolveAuthAgentDir = (agentDir?: string) => agentDir ?? resolveOpenClawAgentDir();
 
 const ENV_REF_PATTERN = /^\$\{([A-Z][A-Z0-9_]*)\}$/;
+
+export type ApiKeyStorageOptions = {
+  secretInputMode?: SecretInputMode;
+};
+
 function buildEnvSecretRef(id: string): SecretRef {
   return { source: "env", id };
 }
@@ -27,21 +33,22 @@ function parseEnvSecretRef(value: string): SecretRef | null {
   return buildEnvSecretRef(match[1]);
 }
 
-function inferProviderEnvSecretRef(provider: string, value: string): SecretRef | null {
+function resolveProviderDefaultEnvSecretRef(provider: string): SecretRef {
   const envVars = PROVIDER_ENV_VARS[provider];
-  if (!envVars || value.length === 0) {
-    return null;
+  const envVar = envVars?.find((candidate) => candidate.trim().length > 0);
+  if (!envVar) {
+    throw new Error(
+      `Provider "${provider}" does not have a default env var mapping for secret-input-mode=ref.`,
+    );
   }
-  for (const envVar of envVars) {
-    const envValue = normalizeSecretInput(process.env[envVar] ?? "");
-    if (envValue && envValue === value) {
-      return buildEnvSecretRef(envVar);
-    }
-  }
-  return null;
+  return buildEnvSecretRef(envVar);
 }
 
-function resolveApiKeySecretInput(provider: string, input: SecretInput): SecretInput {
+function resolveApiKeySecretInput(
+  provider: string,
+  input: SecretInput,
+  options?: ApiKeyStorageOptions,
+): SecretInput {
   if (isSecretRef(input)) {
     return input;
   }
@@ -50,9 +57,8 @@ function resolveApiKeySecretInput(provider: string, input: SecretInput): SecretI
   if (inlineEnvRef) {
     return inlineEnvRef;
   }
-  const inferredEnvRef = inferProviderEnvSecretRef(provider, normalized);
-  if (inferredEnvRef) {
-    return inferredEnvRef;
+  if (options?.secretInputMode === "ref") {
+    return resolveProviderDefaultEnvSecretRef(provider);
   }
   return normalized;
 }
@@ -61,6 +67,7 @@ function buildApiKeyCredential(
   provider: string,
   input: SecretInput,
   metadata?: Record<string, string>,
+  options?: ApiKeyStorageOptions,
 ): {
   type: "api_key";
   provider: string;
@@ -68,7 +75,7 @@ function buildApiKeyCredential(
   keyRef?: SecretRef;
   metadata?: Record<string, string>;
 } {
-  const secretInput = resolveApiKeySecretInput(provider, input);
+  const secretInput = resolveApiKeySecretInput(provider, input, options);
   if (typeof secretInput === "string") {
     return {
       type: "api_key",
@@ -186,20 +193,40 @@ export async function writeOAuthCredentials(
   return profileId;
 }
 
-export async function setAnthropicApiKey(key: SecretInput, agentDir?: string) {
+export async function setAnthropicApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId: "anthropic:default",
-    credential: buildApiKeyCredential("anthropic", key),
+    credential: buildApiKeyCredential("anthropic", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setGeminiApiKey(key: SecretInput, agentDir?: string) {
+export async function setOpenaiApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
+  upsertAuthProfile({
+    profileId: "openai:default",
+    credential: buildApiKeyCredential("openai", key, undefined, options),
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
+export async function setGeminiApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId: "google:default",
-    credential: buildApiKeyCredential("google", key),
+    credential: buildApiKeyCredential("google", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
@@ -208,48 +235,89 @@ export async function setMinimaxApiKey(
   key: SecretInput,
   agentDir?: string,
   profileId: string = "minimax:default",
+  options?: ApiKeyStorageOptions,
 ) {
   const provider = profileId.split(":")[0] ?? "minimax";
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId,
-    credential: buildApiKeyCredential(provider, key),
+    credential: buildApiKeyCredential(provider, key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setMoonshotApiKey(key: SecretInput, agentDir?: string) {
+export async function setMoonshotApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId: "moonshot:default",
-    credential: buildApiKeyCredential("moonshot", key),
+    credential: buildApiKeyCredential("moonshot", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setKimiCodingApiKey(key: SecretInput, agentDir?: string) {
+export async function setKimiCodingApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId: "kimi-coding:default",
-    credential: buildApiKeyCredential("kimi-coding", key),
+    credential: buildApiKeyCredential("kimi-coding", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setSyntheticApiKey(key: SecretInput, agentDir?: string) {
+export async function setVolcengineApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
+  upsertAuthProfile({
+    profileId: "volcengine:default",
+    credential: buildApiKeyCredential("volcengine", key, undefined, options),
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
+export async function setByteplusApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
+  upsertAuthProfile({
+    profileId: "byteplus:default",
+    credential: buildApiKeyCredential("byteplus", key, undefined, options),
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
+export async function setSyntheticApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId: "synthetic:default",
-    credential: buildApiKeyCredential("synthetic", key),
+    credential: buildApiKeyCredential("synthetic", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setVeniceApiKey(key: SecretInput, agentDir?: string) {
+export async function setVeniceApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId: "venice:default",
-    credential: buildApiKeyCredential("venice", key),
+    credential: buildApiKeyCredential("venice", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
@@ -262,29 +330,41 @@ export const TOGETHER_DEFAULT_MODEL_REF = "together/moonshotai/Kimi-K2.5";
 export const LITELLM_DEFAULT_MODEL_REF = "litellm/claude-opus-4-6";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.6";
 
-export async function setZaiApiKey(key: SecretInput, agentDir?: string) {
+export async function setZaiApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId: "zai:default",
-    credential: buildApiKeyCredential("zai", key),
+    credential: buildApiKeyCredential("zai", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setXiaomiApiKey(key: SecretInput, agentDir?: string) {
+export async function setXiaomiApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   upsertAuthProfile({
     profileId: "xiaomi:default",
-    credential: buildApiKeyCredential("xiaomi", key),
+    credential: buildApiKeyCredential("xiaomi", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setOpenrouterApiKey(key: SecretInput, agentDir?: string) {
+export async function setOpenrouterApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   // Never persist the literal "undefined" (e.g. when prompt returns undefined and caller used String(key)).
   const safeKey = typeof key === "string" && key === "undefined" ? "" : key;
   upsertAuthProfile({
     profileId: "openrouter:default",
-    credential: buildApiKeyCredential("openrouter", safeKey),
+    credential: buildApiKeyCredential("openrouter", safeKey, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
@@ -294,95 +374,125 @@ export async function setCloudflareAiGatewayConfig(
   gatewayId: string,
   apiKey: SecretInput,
   agentDir?: string,
+  options?: ApiKeyStorageOptions,
 ) {
   const normalizedAccountId = accountId.trim();
   const normalizedGatewayId = gatewayId.trim();
   upsertAuthProfile({
     profileId: "cloudflare-ai-gateway:default",
-    credential: buildApiKeyCredential("cloudflare-ai-gateway", apiKey, {
-      accountId: normalizedAccountId,
-      gatewayId: normalizedGatewayId,
-    }),
+    credential: buildApiKeyCredential(
+      "cloudflare-ai-gateway",
+      apiKey,
+      {
+        accountId: normalizedAccountId,
+        gatewayId: normalizedGatewayId,
+      },
+      options,
+    ),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setLitellmApiKey(key: SecretInput, agentDir?: string) {
+export async function setLitellmApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   upsertAuthProfile({
     profileId: "litellm:default",
-    credential: buildApiKeyCredential("litellm", key),
+    credential: buildApiKeyCredential("litellm", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setVercelAiGatewayApiKey(key: SecretInput, agentDir?: string) {
+export async function setVercelAiGatewayApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   upsertAuthProfile({
     profileId: "vercel-ai-gateway:default",
-    credential: buildApiKeyCredential("vercel-ai-gateway", key),
+    credential: buildApiKeyCredential("vercel-ai-gateway", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setOpencodeZenApiKey(key: SecretInput, agentDir?: string) {
+export async function setOpencodeZenApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   upsertAuthProfile({
     profileId: "opencode:default",
-    credential: buildApiKeyCredential("opencode", key),
+    credential: buildApiKeyCredential("opencode", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setTogetherApiKey(key: SecretInput, agentDir?: string) {
+export async function setTogetherApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   upsertAuthProfile({
     profileId: "together:default",
-    credential: buildApiKeyCredential("together", key),
+    credential: buildApiKeyCredential("together", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setHuggingfaceApiKey(key: SecretInput, agentDir?: string) {
+export async function setHuggingfaceApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   upsertAuthProfile({
     profileId: "huggingface:default",
-    credential: buildApiKeyCredential("huggingface", key),
+    credential: buildApiKeyCredential("huggingface", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export function setQianfanApiKey(key: SecretInput, agentDir?: string) {
+export function setQianfanApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   upsertAuthProfile({
     profileId: "qianfan:default",
-    credential: buildApiKeyCredential("qianfan", key),
+    credential: buildApiKeyCredential("qianfan", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export function setXaiApiKey(key: SecretInput, agentDir?: string) {
+export function setXaiApiKey(key: SecretInput, agentDir?: string, options?: ApiKeyStorageOptions) {
   upsertAuthProfile({
     profileId: "xai:default",
-    credential: buildApiKeyCredential("xai", key),
+    credential: buildApiKeyCredential("xai", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setMistralApiKey(key: string, agentDir?: string) {
+export async function setMistralApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   upsertAuthProfile({
     profileId: "mistral:default",
-    credential: {
-      type: "api_key",
-      provider: "mistral",
-      key,
-    },
+    credential: buildApiKeyCredential("mistral", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
 
-export async function setKilocodeApiKey(key: string, agentDir?: string) {
+export async function setKilocodeApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
   upsertAuthProfile({
     profileId: "kilocode:default",
-    credential: {
-      type: "api_key",
-      provider: "kilocode",
-      key,
-    },
+    credential: buildApiKeyCredential("kilocode", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -3,9 +3,10 @@ import path from "node:path";
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { resolveOpenClawAgentDir } from "../agents/agent-paths.js";
 import { upsertAuthProfile } from "../agents/auth-profiles.js";
-import type { SecretInput, SecretRef } from "../config/types.secrets.js";
 import { resolveStateDir } from "../config/paths.js";
+import { isSecretRef, type SecretInput, type SecretRef } from "../config/types.secrets.js";
 import { KILOCODE_DEFAULT_MODEL_REF } from "../providers/kilocode-shared.js";
+import { PROVIDER_ENV_VARS } from "../secrets/provider-env-vars.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 export { CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF } from "../agents/cloudflare-ai-gateway.js";
 export { MISTRAL_DEFAULT_MODEL_REF, XAI_DEFAULT_MODEL_REF } from "./onboard-auth.models.js";
@@ -14,40 +15,6 @@ export { KILOCODE_DEFAULT_MODEL_REF };
 const resolveAuthAgentDir = (agentDir?: string) => agentDir ?? resolveOpenClawAgentDir();
 
 const ENV_REF_PATTERN = /^\$\{([A-Z][A-Z0-9_]*)\}$/;
-
-const PROVIDER_ENV_VARS: Record<string, readonly string[]> = {
-  anthropic: ["ANTHROPIC_API_KEY"],
-  google: ["GEMINI_API_KEY"],
-  minimax: ["MINIMAX_API_KEY"],
-  "minimax-cn": ["MINIMAX_API_KEY"],
-  moonshot: ["MOONSHOT_API_KEY"],
-  "kimi-coding": ["KIMI_API_KEY", "KIMICODE_API_KEY"],
-  synthetic: ["SYNTHETIC_API_KEY"],
-  venice: ["VENICE_API_KEY"],
-  zai: ["ZAI_API_KEY", "Z_AI_API_KEY"],
-  xiaomi: ["XIAOMI_API_KEY"],
-  openrouter: ["OPENROUTER_API_KEY"],
-  "cloudflare-ai-gateway": ["CLOUDFLARE_AI_GATEWAY_API_KEY"],
-  litellm: ["LITELLM_API_KEY"],
-  "vercel-ai-gateway": ["AI_GATEWAY_API_KEY"],
-  opencode: ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"],
-  together: ["TOGETHER_API_KEY"],
-  huggingface: ["HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"],
-  qianfan: ["QIANFAN_API_KEY"],
-  xai: ["XAI_API_KEY"],
-};
-
-function isSecretRef(value: unknown): value is SecretRef {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as SecretRef).source !== undefined &&
-    (value as SecretRef).id !== undefined &&
-    ((value as SecretRef).source === "env" || (value as SecretRef).source === "file") &&
-    typeof (value as SecretRef).id === "string"
-  );
-}
-
 function buildEnvSecretRef(id: string): SecretRef {
   return { source: "env", id };
 }

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -87,6 +87,7 @@ export type NodeManagerChoice = "npm" | "pnpm" | "bun";
 export type ChannelChoice = ChannelId;
 // Legacy alias (pre-rename).
 export type ProviderChoice = ChannelChoice;
+export type SecretInputMode = "plaintext" | "ref";
 
 export type OnboardOptions = {
   mode?: OnboardMode;
@@ -106,6 +107,8 @@ export type OnboardOptions = {
   tokenProfileId?: string;
   /** Used when `authChoice=token` in non-interactive mode. */
   tokenExpiresIn?: string;
+  /** API key persistence mode for onboarding flows (default: plaintext). */
+  secretInputMode?: SecretInputMode;
   anthropicApiKey?: string;
   openaiApiKey?: string;
   mistralApiKey?: string;

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  runInteractiveOnboarding: vi.fn(async () => {}),
+  runNonInteractiveOnboarding: vi.fn(async () => {}),
+}));
+
+vi.mock("./onboard-interactive.js", () => ({
+  runInteractiveOnboarding: mocks.runInteractiveOnboarding,
+}));
+
+vi.mock("./onboard-non-interactive.js", () => ({
+  runNonInteractiveOnboarding: mocks.runNonInteractiveOnboarding,
+}));
+
+const { onboardCommand } = await import("./onboard.js");
+
+function makeRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn() as unknown as RuntimeEnv["exit"],
+  };
+}
+
+describe("onboardCommand", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails fast for invalid secret-input-mode before onboarding starts", async () => {
+    const runtime = makeRuntime();
+
+    await onboardCommand(
+      {
+        secretInputMode: "invalid" as never,
+      },
+      runtime,
+    );
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      'Invalid --secret-input-mode. Use "plaintext" or "ref".',
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.runInteractiveOnboarding).not.toHaveBeenCalled();
+    expect(mocks.runNonInteractiveOnboarding).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -35,6 +35,15 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
     normalizedAuthChoice === opts.authChoice && flow === opts.flow
       ? opts
       : { ...opts, authChoice: normalizedAuthChoice, flow };
+  if (
+    normalizedOpts.secretInputMode &&
+    normalizedOpts.secretInputMode !== "plaintext" &&
+    normalizedOpts.secretInputMode !== "ref"
+  ) {
+    runtime.error('Invalid --secret-input-mode. Use "plaintext" or "ref".');
+    runtime.exit(1);
+    return;
+  }
 
   if (normalizedOpts.nonInteractive && normalizedOpts.acceptRisk !== true) {
     runtime.error(

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -19,6 +19,8 @@ export const PROVIDER_ENV_VARS: Record<string, readonly string[]> = {
   huggingface: ["HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"],
   qianfan: ["QIANFAN_API_KEY"],
   xai: ["XAI_API_KEY"],
+  mistral: ["MISTRAL_API_KEY"],
+  kilocode: ["KILOCODE_API_KEY"],
   volcengine: ["VOLCANO_ENGINE_API_KEY"],
   byteplus: ["BYTEPLUS_API_KEY"],
 };


### PR DESCRIPTION
## Summary
- route onboarding API-key persistence through shared credential builders that can emit either plaintext `key` or `keyRef`
- add env-ref detection for API key inputs via:
  - explicit `${ENV_VAR}` syntax
  - value match against provider-known env vars (for example `OPENAI_API_KEY`)
- when an env-backed value is detected, persist `keyRef: { source: "env", id: "ENV_VAR" }` instead of plaintext in auth profiles
- keep backward compatibility: if no env match/ref is found, onboarding keeps writing plaintext keys exactly as before

## Scope Boundary
- no runtime resolution behavior changes in this PR (activation/failover remains in earlier stack PRs)
- no provider-specific onboarding flow migration in this PR (handled in follow-up PRs)

## Validation
- `pnpm check`
- `pnpm vitest run src/commands/onboard-auth.credentials.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Routes API key persistence through a unified credential builder that detects environment-backed values and persists them as `keyRef` instead of plaintext. Supports both explicit `${ENV_VAR}` syntax and automatic detection via value matching against provider-specific environment variables. Maintains backward compatibility by falling back to plaintext storage when no environment reference applies.

- refactored 18 provider-specific API key setters to use shared `buildApiKeyCredential` helper
- added `resolveApiKeySecretInput` to detect and convert env-backed values to `SecretRef` objects
- added provider-to-env-var mapping for 17 providers (anthropic, google, moonshot, etc.)
- added comprehensive test coverage for env reference detection, explicit `${ENV}` syntax, plaintext fallback, and metadata preservation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured refactoring with comprehensive test coverage, proper type safety, secure handling of secret references, and maintained backward compatibility. No logical errors or security issues identified.
- No files require special attention

<sub>Last reviewed commit: cc60609</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->