### PR TITLE
Onboard: store OpenAI auth in profiles instead of .env

### DIFF
--- a/src/commands/auth-choice.apply.openai.test.ts
+++ b/src/commands/auth-choice.apply.openai.test.ts
@@ -48,7 +48,9 @@ describe("applyAuthChoiceOpenAI", () => {
       provider: "openai",
       mode: "api_key",
     });
-    expect(result?.config.agents?.defaults?.model?.primary).toBe("openai/gpt-5.1-codex");
+    const defaultModel = result?.config.agents?.defaults?.model;
+    const primaryModel = typeof defaultModel === "string" ? defaultModel : defaultModel?.primary;
+    expect(primaryModel).toBe("openai/gpt-5.1-codex");
     expect(text).not.toHaveBeenCalled();
 
     const parsed = await readAuthProfilesForAgent<{

--- a/src/commands/auth-choice.apply.openai.test.ts
+++ b/src/commands/auth-choice.apply.openai.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
+import {
+  createAuthTestLifecycle,
+  createExitThrowingRuntime,
+  createWizardPrompter,
+  readAuthProfilesForAgent,
+  setupAuthTestEnv,
+} from "./test-wizard-helpers.js";
+
+describe("applyAuthChoiceOpenAI", () => {
+  const lifecycle = createAuthTestLifecycle([
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_AGENT_DIR",
+    "PI_CODING_AGENT_DIR",
+    "OPENAI_API_KEY",
+  ]);
+
+  async function setupTempState() {
+    const env = await setupAuthTestEnv("openclaw-openai-");
+    lifecycle.setStateDir(env.stateDir);
+    return env.agentDir;
+  }
+
+  afterEach(async () => {
+    await lifecycle.cleanup();
+  });
+
+  it("writes env-backed OpenAI key as keyRef in auth profiles", async () => {
+    const agentDir = await setupTempState();
+    process.env.OPENAI_API_KEY = "sk-openai-env";
+
+    const confirm = vi.fn(async () => true);
+    const text = vi.fn(async () => "unused");
+    const prompter = createWizardPrompter({ confirm, text }, { defaultSelect: "" });
+    const runtime = createExitThrowingRuntime();
+
+    const result = await applyAuthChoiceOpenAI({
+      authChoice: "openai-api-key",
+      config: {},
+      prompter,
+      runtime,
+      setDefaultModel: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.config.auth?.profiles?.["openai:default"]).toMatchObject({
+      provider: "openai",
+      mode: "api_key",
+    });
+    expect(result?.config.agents?.defaults?.model?.primary).toBe("openai/gpt-5.1-codex");
+    expect(text).not.toHaveBeenCalled();
+
+    const parsed = await readAuthProfilesForAgent<{
+      profiles?: Record<string, { key?: string; keyRef?: unknown }>;
+    }>(agentDir);
+    expect(parsed.profiles?.["openai:default"]).toMatchObject({
+      keyRef: { source: "env", id: "OPENAI_API_KEY" },
+    });
+    expect(parsed.profiles?.["openai:default"]?.key).toBeUndefined();
+  });
+
+  it("writes explicit token input into openai auth profile", async () => {
+    const agentDir = await setupTempState();
+
+    const prompter = createWizardPrompter({}, { defaultSelect: "" });
+    const runtime = createExitThrowingRuntime();
+
+    const result = await applyAuthChoiceOpenAI({
+      authChoice: "apiKey",
+      config: {},
+      prompter,
+      runtime,
+      setDefaultModel: true,
+      opts: {
+        tokenProvider: "openai",
+        token: "sk-openai-token",
+      },
+    });
+
+    expect(result).not.toBeNull();
+
+    const parsed = await readAuthProfilesForAgent<{
+      profiles?: Record<string, { key?: string; keyRef?: unknown }>;
+    }>(agentDir);
+    expect(parsed.profiles?.["openai:default"]?.key).toBe("sk-openai-token");
+    expect(parsed.profiles?.["openai:default"]?.keyRef).toBeUndefined();
+  });
+});

--- a/src/commands/onboard-auth.credentials.test.ts
+++ b/src/commands/onboard-auth.credentials.test.ts
@@ -106,12 +106,28 @@ describe("onboard auth credentials secret refs", () => {
     expect(parsed.profiles?.["cloudflare-ai-gateway:default"]?.key).toBeUndefined();
   });
 
-  it("stores env-backed openai key as keyRef", async () => {
+  it("keeps env-backed openai key as plaintext by default", async () => {
     const env = await setupAuthTestEnv("openclaw-onboard-auth-credentials-openai-");
     lifecycle.setStateDir(env.stateDir);
     process.env.OPENAI_API_KEY = "sk-openai-env";
 
     await setOpenaiApiKey("sk-openai-env");
+
+    const parsed = await readAuthProfilesForAgent<{
+      profiles?: Record<string, { key?: string; keyRef?: unknown }>;
+    }>(env.agentDir);
+    expect(parsed.profiles?.["openai:default"]).toMatchObject({
+      key: "sk-openai-env",
+    });
+    expect(parsed.profiles?.["openai:default"]?.keyRef).toBeUndefined();
+  });
+
+  it("stores env-backed openai key as keyRef in ref mode", async () => {
+    const env = await setupAuthTestEnv("openclaw-onboard-auth-credentials-openai-ref-");
+    lifecycle.setStateDir(env.stateDir);
+    process.env.OPENAI_API_KEY = "sk-openai-env";
+
+    await setOpenaiApiKey("sk-openai-env", env.agentDir, { secretInputMode: "ref" });
 
     const parsed = await readAuthProfilesForAgent<{
       profiles?: Record<string, { key?: string; keyRef?: unknown }>;

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -206,6 +206,7 @@ export async function setAnthropicApiKey(
   });
 }
 
+<<<<<<< HEAD
 export async function setOpenaiApiKey(
   key: SecretInput,
   agentDir?: string,

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -206,7 +206,6 @@ export async function setAnthropicApiKey(
   });
 }
 
-<<<<<<< HEAD
 export async function setOpenaiApiKey(
   key: SecretInput,
   agentDir?: string,

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -61,6 +61,7 @@ export {
   KILOCODE_DEFAULT_MODEL_REF,
   LITELLM_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
+  setOpenaiApiKey,
   setAnthropicApiKey,
   setCloudflareAiGatewayConfig,
   setQianfanApiKey,

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -42,6 +42,7 @@ import {
   setMistralApiKey,
   setMinimaxApiKey,
   setMoonshotApiKey,
+  setOpenaiApiKey,
   setOpencodeZenApiKey,
   setOpenrouterApiKey,
   setSyntheticApiKey,
@@ -408,15 +409,16 @@ export async function applyNonInteractiveAuthChoice(params: {
       flagName: "--openai-api-key",
       envVar: "OPENAI_API_KEY",
       runtime,
-      allowProfile: false,
     });
     if (!resolved) {
       return null;
     }
-    const key = resolved.key;
-    const result = upsertSharedEnvVar({ key: "OPENAI_API_KEY", value: key });
-    process.env.OPENAI_API_KEY = key;
-    runtime.log(`Saved OPENAI_API_KEY to ${shortenHomePath(result.path)}`);
+    await setOpenaiApiKey(resolved.key);
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "openai:default",
+      provider: "openai",
+      mode: "api_key",
+    });
     return applyOpenAIConfig(nextConfig);
   }
 


### PR DESCRIPTION
## Summary
- migrate OpenAI onboarding auth persistence from shared `.env` writes to auth-profile credentials
- update interactive and non-interactive OpenAI auth-choice paths to call profile persistence (`setOpenaiApiKey`) instead of `upsertSharedEnvVar`
- preserve env-backed security behavior by storing `keyRef: { source: "env", id: "OPENAI_API_KEY" }` when input is env-backed/`${OPENAI_API_KEY}`
- keep plaintext compatibility when users provide a literal key that is not env-backed

## User-visible Behavior
- onboarding no longer writes OpenAI static keys into `~/.openclaw/.env` on these paths
- OpenAI credentials are now managed consistently with other profile-backed providers

## Scope Boundary
- no OAuth token handling changes
- no runtime resolver contract changes

## Validation
- `pnpm check`
- `pnpm vitest run src/commands/onboard-auth.credentials.test.ts src/commands/auth-choice.apply.openai.test.ts`
