### PR TITLE
fix: enforce strict allowlist by excluding pairing-store entries

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -332,6 +332,7 @@ export async function processMessage(
     allowFrom: account.config.allowFrom,
     groupAllowFrom: account.config.groupAllowFrom,
     storeAllowFrom,
+    dmPolicy,
   });
   const groupAllowEntry = formatGroupAllowlistEntry({
     chatGuid: message.chatGuid,
@@ -1107,6 +1108,7 @@ export async function processReaction(
     allowFrom: account.config.allowFrom,
     groupAllowFrom: account.config.groupAllowFrom,
     storeAllowFrom,
+    dmPolicy,
   });
   const accessDecision = resolveDmGroupAccessDecision({
     isGroup: reaction.isGroup,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -630,7 +630,9 @@ export async function handleFeishuMessage(params: {
       cfg,
     );
     const storeAllowFrom =
-      !isGroup && (dmPolicy !== "open" || shouldComputeCommandAuthorized)
+      !isGroup &&
+      dmPolicy !== "allowlist" &&
+      (dmPolicy !== "open" || shouldComputeCommandAuthorized)
         ? await core.channel.pairing.readAllowFromStore("feishu").catch(() => [])
         : [];
     const effectiveDmAllowFrom = [...configAllowFrom, ...storeAllowFrom];

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -485,7 +485,7 @@ async function processMessageWithPipeline(params: {
   const configAllowFrom = (account.config.dm?.allowFrom ?? []).map((v) => String(v));
   const shouldComputeAuth = core.channel.commands.shouldComputeCommandAuthorized(rawBody, config);
   const storeAllowFrom =
-    !isGroup && (dmPolicy !== "open" || shouldComputeAuth)
+    !isGroup && dmPolicy !== "allowlist" && (dmPolicy !== "open" || shouldComputeAuth)
       ? await core.channel.pairing.readAllowFromStore("googlechat").catch(() => [])
       : [];
   const effectiveAllowFrom = [...configAllowFrom, ...storeAllowFrom];

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -89,7 +89,10 @@ export async function handleIrcInbound(params: {
 
   const configAllowFrom = normalizeIrcAllowlist(account.config.allowFrom);
   const configGroupAllowFrom = normalizeIrcAllowlist(account.config.groupAllowFrom);
-  const storeAllowFrom = await core.channel.pairing.readAllowFromStore(CHANNEL_ID).catch(() => []);
+  const storeAllowFrom =
+    dmPolicy === "allowlist"
+      ? []
+      : await core.channel.pairing.readAllowFromStore(CHANNEL_ID).catch(() => []);
   const storeAllowList = normalizeIrcAllowlist(storeAllowFrom);
 
   const groupMatch = resolveIrcGroupMatch({

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -218,9 +218,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       }
 
       const senderName = await getMemberDisplayName(roomId, senderId);
-      const storeAllowFrom = await core.channel.pairing
-        .readAllowFromStore("matrix")
-        .catch(() => []);
+      const storeAllowFrom =
+        dmPolicy === "allowlist"
+          ? []
+          : await core.channel.pairing.readAllowFromStore("matrix").catch(() => []);
       const effectiveAllowFrom = normalizeMatrixAllowList([...allowFrom, ...storeAllowFrom]);
       const groupAllowFrom = cfg.channels?.matrix?.groupAllowFrom ?? [];
       const effectiveGroupAllowFrom = normalizeMatrixAllowList(groupAllowFrom);

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -380,7 +380,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
     const configGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
     const storeAllowFrom = normalizeAllowList(
-      await core.channel.pairing.readAllowFromStore("mattermost").catch(() => []),
+      dmPolicy === "allowlist"
+        ? []
+        : await core.channel.pairing.readAllowFromStore("mattermost").catch(() => []),
     );
     const effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
     const effectiveGroupAllowFrom = Array.from(
@@ -867,7 +869,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       if (dmPolicy !== "open") {
         const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
         const storeAllowFrom = normalizeAllowList(
-          await core.channel.pairing.readAllowFromStore("mattermost").catch(() => []),
+          dmPolicy === "allowlist"
+            ? []
+            : await core.channel.pairing.readAllowFromStore("mattermost").catch(() => []),
         );
         const effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
         const allowed = isSenderAllowed({
@@ -890,10 +894,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         return;
       }
       if (groupPolicy === "allowlist") {
+        const dmPolicyForStore = account.config.dmPolicy ?? "pairing";
         const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
         const configGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
         const storeAllowFrom = normalizeAllowList(
-          await core.channel.pairing.readAllowFromStore("mattermost").catch(() => []),
+          dmPolicyForStore === "allowlist"
+            ? []
+            : await core.channel.pairing.readAllowFromStore("mattermost").catch(() => []),
         );
         const effectiveGroupAllowFrom = Array.from(
           new Set([

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -124,16 +124,17 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
 
     const senderName = from.name ?? from.id;
     const senderId = from.aadObjectId ?? from.id;
-    const storedAllowFrom = await core.channel.pairing
-      .readAllowFromStore("msteams")
-      .catch(() => []);
+    const dmPolicy = msteamsCfg?.dmPolicy ?? "pairing";
+    const storedAllowFrom =
+      dmPolicy === "allowlist"
+        ? []
+        : await core.channel.pairing.readAllowFromStore("msteams").catch(() => []);
     const useAccessGroups = cfg.commands?.useAccessGroups !== false;
 
     // Check DM policy for direct messages.
     const dmAllowFrom = msteamsCfg?.allowFrom ?? [];
     const effectiveDmAllowFrom = [...dmAllowFrom.map((v) => String(v)), ...storedAllowFrom];
     if (isDirectMessage && msteamsCfg) {
-      const dmPolicy = msteamsCfg.dmPolicy ?? "pairing";
       const allowFrom = dmAllowFrom;
 
       if (dmPolicy === "disabled") {

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -93,7 +93,10 @@ export async function handleNextcloudTalkInbound(params: {
 
   const configAllowFrom = normalizeNextcloudTalkAllowlist(account.config.allowFrom);
   const configGroupAllowFrom = normalizeNextcloudTalkAllowlist(account.config.groupAllowFrom);
-  const storeAllowFrom = await core.channel.pairing.readAllowFromStore(CHANNEL_ID).catch(() => []);
+  const storeAllowFrom =
+    dmPolicy === "allowlist"
+      ? []
+      : await core.channel.pairing.readAllowFromStore(CHANNEL_ID).catch(() => []);
   const storeAllowList = normalizeNextcloudTalkAllowlist(storeAllowFrom);
 
   const roomMatch = resolveNextcloudTalkRoomMatch({

--- a/src/channels/allow-from.test.ts
+++ b/src/channels/allow-from.test.ts
@@ -10,6 +10,26 @@ describe("mergeAllowFromSources", () => {
       }),
     ).toEqual(["line:user:abc", "123", "telegram:456"]);
   });
+
+  it("excludes pairing-store entries when dmPolicy is allowlist", () => {
+    expect(
+      mergeAllowFromSources({
+        allowFrom: ["+1111"],
+        storeAllowFrom: ["+2222", "+3333"],
+        dmPolicy: "allowlist",
+      }),
+    ).toEqual(["+1111"]);
+  });
+
+  it("keeps pairing-store entries for non-allowlist policies", () => {
+    expect(
+      mergeAllowFromSources({
+        allowFrom: ["+1111"],
+        storeAllowFrom: ["+2222"],
+        dmPolicy: "pairing",
+      }),
+    ).toEqual(["+1111", "+2222"]);
+  });
 });
 
 describe("firstDefined", () => {

--- a/src/channels/allow-from.ts
+++ b/src/channels/allow-from.ts
@@ -1,8 +1,10 @@
 export function mergeAllowFromSources(params: {
   allowFrom?: Array<string | number>;
   storeAllowFrom?: string[];
+  dmPolicy?: string;
 }): string[] {
-  return [...(params.allowFrom ?? []), ...(params.storeAllowFrom ?? [])]
+  const storeEntries = params.dmPolicy === "allowlist" ? [] : (params.storeAllowFrom ?? []);
+  return [...(params.allowFrom ?? []), ...storeEntries]
     .map((value) => String(value).trim())
     .filter(Boolean);
 }

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -464,7 +464,8 @@ async function ensureDmComponentAuthorized(params: {
     return true;
   }
 
-  const storeAllowFrom = await readChannelAllowFromStore("discord").catch(() => []);
+  const storeAllowFrom =
+    dmPolicy === "allowlist" ? [] : await readChannelAllowFromStore("discord").catch(() => []);
   const effectiveAllowFrom = [...(ctx.allowFrom ?? []), ...storeAllowFrom];
   const allowList = normalizeDiscordAllowList(effectiveAllowFrom, ["discord:", "user:", "pk:"]);
   const allowMatch = allowList

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -178,7 +178,8 @@ export async function preflightDiscordMessage(
       return null;
     }
     if (dmPolicy !== "open") {
-      const storeAllowFrom = await readChannelAllowFromStore("discord").catch(() => []);
+      const storeAllowFrom =
+        dmPolicy === "allowlist" ? [] : await readChannelAllowFromStore("discord").catch(() => []);
       const effectiveAllowFrom = [...(params.allowFrom ?? []), ...storeAllowFrom];
       const allowList = normalizeDiscordAllowList(effectiveAllowFrom, ["discord:", "user:", "pk:"]);
       const allowMatch = allowList

--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -140,7 +140,7 @@ describe("agent components", () => {
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
   });
 
-  it("allows DM interactions when pairing store allowlist matches", async () => {
+  it("blocks DM interactions when only pairing store entries match in allowlist mode", async () => {
     readAllowFromStoreMock.mockResolvedValue(["123456789"]);
     const button = createAgentComponentButton({
       cfg: createCfg(),
@@ -152,8 +152,9 @@ describe("agent components", () => {
     await button.run(interaction, { componentId: "hello" } as ComponentData);
 
     expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
-    expect(enqueueSystemEventMock).toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({ content: "You are not authorized to use this button." });
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(readAllowFromStoreMock).not.toHaveBeenCalled();
   });
 
   it("matches tag-based allowlist entries for DM select menus", async () => {

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1347,7 +1347,8 @@ async function dispatchDiscordCommandInteraction(params: {
       return;
     }
     if (dmPolicy !== "open") {
-      const storeAllowFrom = await readChannelAllowFromStore("discord").catch(() => []);
+      const storeAllowFrom =
+        dmPolicy === "allowlist" ? [] : await readChannelAllowFromStore("discord").catch(() => []);
       const effectiveAllowFrom = [
         ...(discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? []),
         ...storeAllowFrom,

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -138,7 +138,8 @@ export function resolveIMessageInboundDecision(params: {
   }
 
   const groupId = isGroup ? groupIdCandidate : undefined;
-  const effectiveDmAllowFrom = Array.from(new Set([...params.allowFrom, ...params.storeAllowFrom]))
+  const storeAllowFrom = params.dmPolicy === "allowlist" ? [] : params.storeAllowFrom;
+  const effectiveDmAllowFrom = Array.from(new Set([...params.allowFrom, ...storeAllowFrom]))
     .map((v) => String(v).trim())
     .filter(Boolean);
   // Keep DM pairing-store authorization scoped to DMs; group access must come from explicit group allowlist config.

--- a/src/line/bot-access.ts
+++ b/src/line/bot-access.ts
@@ -30,6 +30,7 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
 export const normalizeAllowFromWithStore = (params: {
   allowFrom?: Array<string | number>;
   storeAllowFrom?: string[];
+  dmPolicy?: string;
 }): NormalizedAllowFrom => normalizeAllowFrom(mergeAllowFromSources(params));
 
 export const isSenderAllowed = (params: {

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -109,11 +109,13 @@ async function shouldProcessLineEvent(
   const { cfg, account } = context;
   const { userId, groupId, roomId, isGroup } = getLineSourceInfo(event.source);
   const senderId = userId ?? "";
+  const dmPolicy = account.config.dmPolicy ?? "pairing";
 
   const storeAllowFrom = await readChannelAllowFromStore("line").catch(() => []);
   const effectiveDmAllow = normalizeAllowFromWithStore({
     allowFrom: account.config.allowFrom,
     storeAllowFrom,
+    dmPolicy,
   });
   const groupConfig = resolveLineGroupConfig({ config: account.config, groupId, roomId });
   const groupAllowOverride = groupConfig?.allowFrom;
@@ -128,8 +130,8 @@ async function shouldProcessLineEvent(
   const effectiveGroupAllow = normalizeAllowFromWithStore({
     allowFrom: groupAllowFrom,
     storeAllowFrom,
+    dmPolicy,
   });
-  const dmPolicy = account.config.dmPolicy ?? "pairing";
   const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
   const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
 

--- a/src/plugin-sdk/command-auth.ts
+++ b/src/plugin-sdk/command-auth.ts
@@ -26,7 +26,9 @@ export async function resolveSenderCommandAuthorization(
 }> {
   const shouldComputeAuth = params.shouldComputeCommandAuthorized(params.rawBody, params.cfg);
   const storeAllowFrom =
-    !params.isGroup && (params.dmPolicy !== "open" || shouldComputeAuth)
+    !params.isGroup &&
+    params.dmPolicy !== "allowlist" &&
+    (params.dmPolicy !== "open" || shouldComputeAuth)
       ? await params.readAllowFromStore().catch(() => [])
       : [];
   const effectiveAllowFrom = [...params.configuredAllowFrom, ...storeAllowFrom];

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -53,6 +53,28 @@ describe("security/dm-policy-shared", () => {
     expect(lists.effectiveGroupAllowFrom).toEqual(["owner", "owner2"]);
   });
 
+  it("excludes storeAllowFrom when dmPolicy is allowlist", () => {
+    const lists = resolveEffectiveAllowFromLists({
+      allowFrom: ["+1111"],
+      groupAllowFrom: ["group:abc"],
+      storeAllowFrom: ["+2222", "+3333"],
+      dmPolicy: "allowlist",
+    });
+    expect(lists.effectiveAllowFrom).toEqual(["+1111"]);
+    expect(lists.effectiveGroupAllowFrom).toEqual(["group:abc"]);
+  });
+
+  it("includes storeAllowFrom when dmPolicy is pairing", () => {
+    const lists = resolveEffectiveAllowFromLists({
+      allowFrom: ["+1111"],
+      groupAllowFrom: [],
+      storeAllowFrom: ["+2222"],
+      dmPolicy: "pairing",
+    });
+    expect(lists.effectiveAllowFrom).toEqual(["+1111", "+2222"]);
+    expect(lists.effectiveGroupAllowFrom).toEqual(["+1111", "+2222"]);
+  });
+
   const channels = [
     "bluebubbles",
     "imessage",

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -6,6 +6,7 @@ export function resolveEffectiveAllowFromLists(params: {
   allowFrom?: Array<string | number> | null;
   groupAllowFrom?: Array<string | number> | null;
   storeAllowFrom?: Array<string | number> | null;
+  dmPolicy?: string | null;
 }): {
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
@@ -16,9 +17,12 @@ export function resolveEffectiveAllowFromLists(params: {
   const configGroupAllowFrom = normalizeStringEntries(
     Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined,
   );
-  const storeAllowFrom = normalizeStringEntries(
-    Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined,
-  );
+  const storeAllowFrom =
+    params.dmPolicy === "allowlist"
+      ? []
+      : normalizeStringEntries(
+          Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined,
+        );
   const effectiveAllowFrom = normalizeStringEntries([...configAllowFrom, ...storeAllowFrom]);
   const groupBase = configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom;
   const effectiveGroupAllowFrom = normalizeStringEntries([...groupBase, ...storeAllowFrom]);

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -441,7 +441,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage.groupInfo?.groupId ?? undefined;
     const groupName = dataMessage.groupInfo?.groupName ?? undefined;
     const isGroup = Boolean(groupId);
-    const storeAllowFrom = await readChannelAllowFromStore("signal").catch(() => []);
+    const storeAllowFrom =
+      deps.dmPolicy === "allowlist"
+        ? []
+        : await readChannelAllowFromStore("signal").catch(() => []);
     const effectiveDmAllow = [...deps.allowFrom, ...storeAllowFrom];
     const effectiveGroupAllow = [...deps.groupAllowFrom, ...storeAllowFrom];
     const dmAllowed =

--- a/src/slack/monitor/auth.ts
+++ b/src/slack/monitor/auth.ts
@@ -3,7 +3,8 @@ import { allowListMatches, normalizeAllowList, normalizeAllowListLower } from ".
 import type { SlackMonitorContext } from "./context.js";
 
 export async function resolveSlackEffectiveAllowFrom(ctx: SlackMonitorContext) {
-  const storeAllowFrom = await readChannelAllowFromStore("slack").catch(() => []);
+  const storeAllowFrom =
+    ctx.dmPolicy === "allowlist" ? [] : await readChannelAllowFromStore("slack").catch(() => []);
   const allowFrom = normalizeAllowList([...ctx.allowFrom, ...storeAllowFrom]);
   const allowFromLower = normalizeAllowListLower(allowFrom);
   return { allowFrom, allowFromLower };

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -350,7 +350,10 @@ export async function registerSlackMonitorSlashCommands(params: {
         return;
       }
 
-      const storeAllowFrom = await readChannelAllowFromStore("slack").catch(() => []);
+      const storeAllowFrom =
+        ctx.dmPolicy === "allowlist"
+          ? []
+          : await readChannelAllowFromStore("slack").catch(() => []);
       const effectiveAllowFrom = normalizeAllowList([...ctx.allowFrom, ...storeAllowFrom]);
       const effectiveAllowFromLower = normalizeAllowListLower(effectiveAllowFrom);
 

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -54,6 +54,7 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
 export const normalizeAllowFromWithStore = (params: {
   allowFrom?: Array<string | number>;
   storeAllowFrom?: string[];
+  dmPolicy?: string;
 }): NormalizedAllowFrom => normalizeAllowFrom(mergeAllowFromSources(params));
 
 export const isSenderAllowed = (params: {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -794,6 +794,7 @@ export const registerTelegramHandlers = ({
       const groupAllowContext = await resolveTelegramGroupAllowFromContext({
         chatId,
         accountId,
+        dmPolicy: telegramCfg.dmPolicy ?? "pairing",
         isForum,
         messageThreadId,
         groupAllowFrom,
@@ -807,11 +808,12 @@ export const registerTelegramHandlers = ({
         effectiveGroupAllow,
         hasGroupAllowOverride,
       } = groupAllowContext;
+      const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
       const effectiveDmAllow = normalizeAllowFromWithStore({
         allowFrom: telegramCfg.allowFrom,
         storeAllowFrom,
+        dmPolicy,
       });
-      const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
       const senderId = callback.from?.id ? String(callback.from.id) : "";
       const senderUsername = callback.from?.username ?? "";
       if (
@@ -1089,6 +1091,7 @@ export const registerTelegramHandlers = ({
       const groupAllowContext = await resolveTelegramGroupAllowFromContext({
         chatId: event.chatId,
         accountId,
+        dmPolicy: telegramCfg.dmPolicy ?? "pairing",
         isForum: event.isForum,
         messageThreadId: event.messageThreadId,
         groupAllowFrom,

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -197,11 +197,12 @@ export const buildTelegramMessageContext = async ({
       : null;
   const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
   const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
-  const effectiveDmAllow = normalizeAllowFromWithStore({ allowFrom, storeAllowFrom });
+  const effectiveDmAllow = normalizeAllowFromWithStore({ allowFrom, storeAllowFrom, dmPolicy });
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   const effectiveGroupAllow = normalizeAllowFromWithStore({
     allowFrom: groupAllowOverride ?? groupAllowFrom,
     storeAllowFrom,
+    dmPolicy,
   });
   const hasGroupAllowOverride = typeof groupAllowOverride !== "undefined";
   const senderId = msg.from?.id ? String(msg.from.id) : "";

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -167,6 +167,7 @@ async function resolveTelegramCommandAuth(params: {
   const groupAllowContext = await resolveTelegramGroupAllowFromContext({
     chatId,
     accountId,
+    dmPolicy: telegramCfg.dmPolicy ?? "pairing",
     isForum,
     messageThreadId,
     groupAllowFrom,
@@ -251,6 +252,7 @@ async function resolveTelegramCommandAuth(params: {
   const dmAllow = normalizeAllowFromWithStore({
     allowFrom: allowFrom,
     storeAllowFrom,
+    dmPolicy: telegramCfg.dmPolicy ?? "pairing",
   });
   const senderAllowed = isSenderAllowed({
     allow: dmAllow,

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -20,6 +20,7 @@ export type TelegramThreadSpec = {
 export async function resolveTelegramGroupAllowFromContext(params: {
   chatId: string | number;
   accountId?: string;
+  dmPolicy?: string;
   isForum?: boolean;
   messageThreadId?: number | null;
   groupAllowFrom?: Array<string | number>;
@@ -53,6 +54,7 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   const effectiveGroupAllow = normalizeAllowFromWithStore({
     allowFrom: groupAllowOverride ?? params.groupAllowFrom,
     storeAllowFrom,
+    dmPolicy: params.dmPolicy,
   });
   const hasGroupAllowOverride = typeof groupAllowOverride !== "undefined";
   return {

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -28,6 +28,7 @@ import { getAgentScopedMediaLocalRoots } from "../../../media/local-roots.js";
 import { readChannelAllowFromStore } from "../../../pairing/pairing-store.js";
 import type { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { jidToE164, normalizeE164 } from "../../../utils.js";
+import { resolveWhatsAppAccount } from "../../accounts.js";
 import { newConnectionId } from "../../reconnect.js";
 import { formatError } from "../../session.js";
 import { deliverWebReply } from "../deliver-reply.js";
@@ -73,10 +74,11 @@ async function resolveWhatsAppCommandAuthorized(params: {
     return false;
   }
 
-  const configuredAllowFrom = params.cfg.channels?.whatsapp?.allowFrom ?? [];
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
+  const dmPolicy = account.dmPolicy ?? "pairing";
+  const configuredAllowFrom = account.allowFrom ?? [];
   const configuredGroupAllowFrom =
-    params.cfg.channels?.whatsapp?.groupAllowFrom ??
-    (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
+    account.groupAllowFrom ?? (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
 
   if (isGroup) {
     if (!configuredGroupAllowFrom || configuredGroupAllowFrom.length === 0) {
@@ -88,11 +90,12 @@ async function resolveWhatsAppCommandAuthorized(params: {
     return normalizeAllowFromE164(configuredGroupAllowFrom).includes(senderE164);
   }
 
-  const storeAllowFrom = await readChannelAllowFromStore(
-    "whatsapp",
-    process.env,
-    params.msg.accountId,
-  ).catch(() => []);
+  const storeAllowFrom =
+    dmPolicy === "allowlist"
+      ? []
+      : await readChannelAllowFromStore("whatsapp", process.env, params.msg.accountId).catch(
+          () => [],
+        );
   const combinedAllowFrom = Array.from(
     new Set([...(configuredAllowFrom ?? []), ...storeAllowFrom]),
   );

--- a/src/web/inbound/access-control.test.ts
+++ b/src/web/inbound/access-control.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  readAllowFromStoreMock,
   sendMessageMock,
   setAccessControlTestConfig,
   setupAccessControlTestHarness,
@@ -107,5 +108,26 @@ describe("WhatsApp dmPolicy precedence", () => {
 
     const result = await checkUnauthorizedWorkDmSender();
     expectSilentlyBlocked(result);
+  });
+
+  it("does not merge persisted pairing approvals in allowlist mode", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          accounts: {
+            work: {
+              allowFrom: ["+15559999999"],
+            },
+          },
+        },
+      },
+    });
+    readAllowFromStoreMock.mockResolvedValue(["+15550001111"]);
+
+    const result = await checkUnauthorizedWorkDmSender();
+
+    expectSilentlyBlocked(result);
+    expect(readAllowFromStoreMock).not.toHaveBeenCalled();
   });
 });

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -40,11 +40,10 @@ export async function checkInboundAccessControl(params: {
   });
   const dmPolicy = account.dmPolicy ?? "pairing";
   const configuredAllowFrom = account.allowFrom;
-  const storeAllowFrom = await readChannelAllowFromStore(
-    "whatsapp",
-    process.env,
-    account.accountId,
-  ).catch(() => []);
+  const storeAllowFrom =
+    dmPolicy === "allowlist"
+      ? []
+      : await readChannelAllowFromStore("whatsapp", process.env, account.accountId).catch(() => []);
   // Without user config, default to self-only DM access so the owner can talk to themselves.
   const combinedAllowFrom = Array.from(
     new Set([...(configuredAllowFrom ?? []), ...storeAllowFrom]),


### PR DESCRIPTION
## Summary
- enforce strict `dmPolicy=allowlist` behavior by excluding persisted pairing-store IDs from effective allowlists
- propagate the rule across core + extension ingress paths (Discord, Slack, WhatsApp, Signal, iMessage, Telegram, LINE, and plugin channels)
- refactor shared helpers so channels using shared auth logic inherit the same policy consistently
- add regressions for shared helpers, plugin SDK auth helper, WhatsApp access-control, and Discord component auth behavior

## Details
- `mergeAllowFromSources` now accepts `dmPolicy` and skips store entries for `allowlist`
- `resolveEffectiveAllowFromLists` now accepts `dmPolicy` and skips store entries for `allowlist`
- `resolveSenderCommandAuthorization` now skips store entries for `allowlist` while preserving open+command-auth behavior
- manual merge sites now gate store reads on `dmPolicy !== "allowlist"`

## Validation
- `pnpm build`
- `pnpm lint`
- `pnpm test src/channels/allow-from.test.ts src/security/dm-policy-shared.test.ts src/plugin-sdk/command-auth.test.ts src/web/inbound/access-control.test.ts`
- `pnpm test src/discord/monitor/message-handler.preflight.test.ts src/slack/monitor/message-handler/prepare.test.ts src/imessage/monitor.gating.test.ts src/telegram/bot-native-commands.test.ts src/telegram/bot-message-context.sender-prefix.test.ts src/signal/monitor/event-handler.inbound-contract.test.ts extensions/feishu/src/bot.test.ts extensions/googlechat/src/monitor.test.ts extensions/matrix/src/matrix/monitor/allowlist.test.ts extensions/irc/src/monitor.test.ts`
- `pnpm test src/discord/monitor/monitor.test.ts src/web/inbound/access-control.test.ts src/plugin-sdk/command-auth.test.ts`

## Notes
- local `pnpm check` currently fails in unrelated pre-existing test-typecheck files (outside this change set)
- local full `pnpm test` run shows one unrelated existing failure in `src/commands/models.list.auth-sync.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enforced strict `dmPolicy=allowlist` behavior by preventing pairing-store entries from being merged into effective allowlists across all messaging channels (Discord, Slack, WhatsApp, Signal, iMessage, Telegram, LINE, and plugin extensions).

Major changes:
- `mergeAllowFromSources` and `resolveEffectiveAllowFromLists` now accept `dmPolicy` parameter and skip store entries when `dmPolicy === "allowlist"`
- `resolveSenderCommandAuthorization` (plugin SDK) updated to gate store reads on `dmPolicy !== "allowlist"`
- Applied consistently across 31 files covering core channels, extensions (MS Teams, Matrix, Feishu, Google Chat, IRC, Mattermost, Nextcloud Talk, BlueBubbles), and web access control
- Comprehensive test coverage added for shared helpers, plugin SDK auth, WhatsApp access-control, and Discord component auth

One issue found:
- `resolveDmAllowState` in `src/security/dm-policy-shared.ts:80` doesn't respect `dmPolicy` when computing statistics for security audits, which could cause misleading audit reports when `dmPolicy=allowlist` but pairing-store entries exist

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor issue to address
- The implementation is comprehensive and consistent across all channels. The core logic change is sound and well-tested. One logic issue exists in `resolveDmAllowState` which could affect security audit accuracy but doesn't impact actual access control enforcement. All access-control paths properly enforce the new behavior.
- Pay attention to `src/security/dm-policy-shared.ts` - the `resolveDmAllowState` function needs updating to respect dmPolicy for accurate security audits

<sub>Last reviewed commit: 44d7556</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->