### PR TITLE
fix(subagents): restore isInternalMessageChannel guard in resolveAnnounceOrigin

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -21,7 +21,7 @@ import {
   mergeDeliveryContext,
   normalizeDeliveryContext,
 } from "../utils/delivery-context.js";
-import { isDeliverableMessageChannel } from "../utils/message-channel.js";
+import { isDeliverableMessageChannel, isInternalMessageChannel } from "../utils/message-channel.js";
 import {
   buildAnnounceIdFromChildRun,
   buildAnnounceIdempotencyKey,
@@ -333,9 +333,12 @@ function resolveAnnounceOrigin(
 ): DeliveryContext | undefined {
   const normalizedRequester = normalizeDeliveryContext(requesterOrigin);
   const normalizedEntry = deliveryContextFromSession(entry);
-  if (normalizedRequester?.channel && !isDeliverableMessageChannel(normalizedRequester.channel)) {
-    // Ignore internal/non-deliverable channel hints (for example webchat)
-    // so a valid persisted route can still be used for outbound delivery.
+  if (normalizedRequester?.channel && isInternalMessageChannel(normalizedRequester.channel)) {
+    // Ignore internal channel hints (webchat) so a valid persisted route
+    // can still be used for outbound delivery. Non-standard channels that
+    // are not in the deliverable list should NOT be stripped here — doing
+    // so causes the session entry's stale lastChannel (often WhatsApp) to
+    // override the actual requester origin, leading to delivery failures.
     return mergeDeliveryContext(
       {
         accountId: normalizedRequester.accountId,


### PR DESCRIPTION
## Summary

Restores the narrower `isInternalMessageChannel()` guard from PR #22223 (fe57bea08) that was inadvertently reverted by f555835b0.

The original `!isDeliverableMessageChannel()` check strips the requester channel from the announce origin whenever the channel is not in the registered deliverable set. This is overly broad: it discards legitimate requester origins for plugin channels whose adapter ID differs from their plugin ID (e.g. `"gmail"` vs `"openclaw-gmail"`), causing the announce system to fall back to stale session routes.

`isInternalMessageChannel()` limits stripping to explicitly internal channels (webchat only), preserving requester origin context for all external channels regardless of their position in the deliverable registry.

## Note

This is a behaviour change for channels not yet in the deliverable list. Acceptable as a no-op if upstream prefers the broader check — the immediate Gmail delivery issue is fixed separately in #23229.

## Related

- #23229 — companion fix: gate `sendAnnounce` delivery hints on channel deliverability, remove `method:send` bypass in `sendSubagentAnnounceDirectly`
- #22223 — original fix (fe57bea08) that introduced `isInternalMessageChannel`
- f555835b0 — commit that inadvertently reverted #22223

## Test plan

- [ ] Spawn a subagent from a Gmail thread — announce origin channel is preserved, not stripped
- [ ] Spawn a subagent from webchat — webchat still stripped as internal (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)