### PR TITLE
fix: continue to fallbacks when first fallback throws unclassified error

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,29 @@
+﻿## Summary
+
+This fix addresses two issues:
+
+### Issue 1: Fallbacks being skipped
+When the primary model fails with a classified error (like rate limit), and the first fallback fails with an unclassified error, OpenClaw was throwing immediately instead of trying the second fallback. This caused the "2nd model blocks 3rd" problem.
+
+### Issue 2: (unknown) in error summaries
+The CLI runner was explicitly setting reason: "unknown" when errors could not be classified, resulting in "(unknown)" appearing in error messages.
+
+## Changes
+
+1. Only fail-fast on primary model (i===0) for unclassified errors - preserves safety semantics
+2. Continue to next fallback for unclassified errors on fallback models (i > 0)
+3. Set reason: undefined instead of "unknown" to avoid (unknown) in summaries
+4. Added regression test for: primary fails with classified error -> fallback #1 fails with unclassified error -> fallback #2 succeeds
+
+## Reviewed by
+Krill (OpenClaw maintainer) - provided feedback on preserving safety semantics
+
+---
+
+Testing:
+- The fix maintains the existing safety behavior (fail-fast on primary model unclassified errors)
+- Added e2e test case for the specific scenario
+
+Files changed:
+- src/agents/model-fallback.ts - core fix
+- src/agents/model-fallback.e2e.test.ts - regression test

--- a/src/agents/model-fallback.e2e.test.ts
+++ b/src/agents/model-fallback.e2e.test.ts
@@ -609,7 +609,6 @@ describe("runWithModelFallback", () => {
     expect(result.provider).toBe("openai");
     expect(result.model).toBe("gpt-4.1-mini");
   });
-});
 
   it("continues to second fallback when first fallback throws unclassified error after primary classified error", async () => {
     // This tests the fix for "2nd model blocks 3rd" - when primary fails with a 


### PR DESCRIPTION
## Summary

This fix addresses two issues:

### Issue 1: Fallbacks being skipped
When the primary model fails with a classified error (like rate limit), and the first fallback fails with an unclassified error, OpenClaw was throwing immediately instead of trying the second fallback. This caused the "2nd model blocks 3rd" problem.

### Issue 2: (unknown) in error summaries
The CLI runner was explicitly setting reason: "unknown" when errors could not be classified, resulting in "(unknown)" appearing in error messages.

## Changes

1. Only fail-fast on primary model (i===0) for unclassified errors - preserves safety semantics
2. Continue to next fallback for unclassified errors on fallback models (i > 0)
3. Set reason: undefined instead of "unknown" to avoid (unknown) in summaries
4. Added regression test for: primary fails with classified error -> fallback #1 fails with unclassified error -> fallback #2 succeeds

## Reviewed by
Krill (OpenClaw maintainer) - provided feedback on preserving safety semantics

---

Testing:
- The fix maintains the existing safety behavior (fail-fast on primary model unclassified errors)
- Added e2e test case for the specific scenario

Files changed:
- src/agents/model-fallback.ts - core fix
- src/agents/model-fallback.e2e.test.ts - regression test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed fallback mechanism to continue trying remaining fallbacks when a non-primary model throws an unclassified error, resolving the "2nd model blocks 3rd" issue.

**Key changes:**
- Modified `src/agents/model-fallback.ts:386-405` to only fail-fast on unclassified errors from the primary model (i===0), preserving safety semantics
- For fallback models (i>0), unclassified errors are now recorded in attempts with `reason: undefined` and execution continues to the next fallback
- Added regression test covering: primary fails (classified) → fallback #1 fails (unclassified) → fallback #2 succeeds

**Issues found:**
- Test structure issue: new test is placed outside the `describe` block and needs to be moved inside

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing test placement - logic is sound but test structure needs correction
- The core logic fix is correct and preserves fail-fast safety for primary model unclassified errors while enabling fallback continuation. However, the test has a structural issue (placed outside describe block) that will cause test runner problems.
- src/agents/model-fallback.e2e.test.ts needs the test moved inside the describe block

<sub>Last reviewed commit: 53c7489</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->