### PR TITLE
Add Gemini 3.1 Pro to Google model normalizer and OpenCode Zen catalog

### DIFF
--- a/src/agents/models-config.normalize-google.test.ts
+++ b/src/agents/models-config.normalize-google.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGoogleModelId } from "./models-config.providers.js";
+
+describe("normalizeGoogleModelId", () => {
+  it("maps gemini-3-pro to gemini-3-pro-preview", () => {
+    expect(normalizeGoogleModelId("gemini-3-pro")).toBe("gemini-3-pro-preview");
+  });
+
+  it("maps gemini-3-flash to gemini-3-flash-preview", () => {
+    expect(normalizeGoogleModelId("gemini-3-flash")).toBe("gemini-3-flash-preview");
+  });
+
+  it("maps gemini-3.1-pro to gemini-3.1-pro-preview", () => {
+    expect(normalizeGoogleModelId("gemini-3.1-pro")).toBe("gemini-3.1-pro-preview");
+  });
+
+  it("passes through already-qualified model ids", () => {
+    expect(normalizeGoogleModelId("gemini-3-pro-preview")).toBe("gemini-3-pro-preview");
+    expect(normalizeGoogleModelId("gemini-3.1-pro-preview")).toBe("gemini-3.1-pro-preview");
+  });
+
+  it("passes through unknown model ids unchanged", () => {
+    expect(normalizeGoogleModelId("gemini-4-ultra")).toBe("gemini-4-ultra");
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -351,6 +351,11 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3-flash") {
     return "gemini-3-flash-preview";
   }
+  // Gemini 3.1 Pro launched 2026-02-19 as "gemini-3.1-pro-preview".
+  // Accept the short alias so users can write "gemini-3.1-pro" in config.
+  if (id === "gemini-3.1-pro") {
+    return "gemini-3.1-pro-preview";
+  }
   return id;
 }
 

--- a/src/agents/opencode-zen-models.e2e.test.ts
+++ b/src/agents/opencode-zen-models.e2e.test.ts
@@ -16,7 +16,7 @@ describe("resolveOpencodeZenAlias", () => {
     expect(resolveOpencodeZenAlias("haiku")).toBe("claude-opus-4-6");
     expect(resolveOpencodeZenAlias("gpt4")).toBe("gpt-5.1");
     expect(resolveOpencodeZenAlias("o1")).toBe("gpt-5.2");
-    expect(resolveOpencodeZenAlias("gemini-2.5")).toBe("gemini-3-pro");
+    expect(resolveOpencodeZenAlias("gemini-2.5")).toBe("gemini-3.1-pro");
   });
 
   it("resolves gpt5 alias", () => {
@@ -24,7 +24,7 @@ describe("resolveOpencodeZenAlias", () => {
   });
 
   it("resolves gemini alias", () => {
-    expect(resolveOpencodeZenAlias("gemini")).toBe("gemini-3-pro");
+    expect(resolveOpencodeZenAlias("gemini")).toBe("gemini-3.1-pro");
   });
 
   it("returns input if no alias exists", () => {
@@ -53,7 +53,7 @@ describe("getOpencodeZenStaticFallbackModels", () => {
   it("returns an array of models", () => {
     const models = getOpencodeZenStaticFallbackModels();
     expect(Array.isArray(models)).toBe(true);
-    expect(models.length).toBe(10);
+    expect(models.length).toBe(11);
   });
 
   it("includes Claude, GPT, Gemini, and GLM models", () => {
@@ -65,6 +65,7 @@ describe("getOpencodeZenStaticFallbackModels", () => {
     expect(ids).toContain("gpt-5.2");
     expect(ids).toContain("gpt-5.1-codex");
     expect(ids).toContain("gemini-3-pro");
+    expect(ids).toContain("gemini-3.1-pro");
     expect(ids).toContain("glm-4.7");
   });
 
@@ -87,7 +88,7 @@ describe("OPENCODE_ZEN_MODEL_ALIASES", () => {
     expect(OPENCODE_ZEN_MODEL_ALIASES.opus).toBe("claude-opus-4-6");
     expect(OPENCODE_ZEN_MODEL_ALIASES.codex).toBe("gpt-5.1-codex");
     expect(OPENCODE_ZEN_MODEL_ALIASES.gpt5).toBe("gpt-5.2");
-    expect(OPENCODE_ZEN_MODEL_ALIASES.gemini).toBe("gemini-3-pro");
+    expect(OPENCODE_ZEN_MODEL_ALIASES.gemini).toBe("gemini-3.1-pro");
     expect(OPENCODE_ZEN_MODEL_ALIASES.glm).toBe("glm-4.7");
     expect(OPENCODE_ZEN_MODEL_ALIASES["opus-4.5"]).toBe("claude-opus-4-5");
 
@@ -96,6 +97,6 @@ describe("OPENCODE_ZEN_MODEL_ALIASES", () => {
     expect(OPENCODE_ZEN_MODEL_ALIASES.haiku).toBe("claude-opus-4-6");
     expect(OPENCODE_ZEN_MODEL_ALIASES.gpt4).toBe("gpt-5.1");
     expect(OPENCODE_ZEN_MODEL_ALIASES.o1).toBe("gpt-5.2");
-    expect(OPENCODE_ZEN_MODEL_ALIASES["gemini-2.5"]).toBe("gemini-3-pro");
+    expect(OPENCODE_ZEN_MODEL_ALIASES["gemini-2.5"]).toBe("gemini-3.1-pro");
   });
 });

--- a/src/agents/opencode-zen-models.ts
+++ b/src/agents/opencode-zen-models.ts
@@ -60,15 +60,17 @@ export const OPENCODE_ZEN_MODEL_ALIASES: Record<string, string> = {
   "codex-max": "gpt-5.1-codex-max",
 
   // Gemini
-  gemini: "gemini-3-pro",
-  "gemini-pro": "gemini-3-pro",
-  "gemini-3": "gemini-3-pro",
+  gemini: "gemini-3.1-pro",
+  "gemini-pro": "gemini-3.1-pro",
+  "gemini-3": "gemini-3.1-pro",
+  "gemini-3.1": "gemini-3.1-pro",
   flash: "gemini-3-flash",
   "gemini-flash": "gemini-3-flash",
 
-  // Legacy Gemini 2.5 aliases (map to the nearest current Gemini tier).
-  "gemini-2.5": "gemini-3-pro",
-  "gemini-2.5-pro": "gemini-3-pro",
+  // Legacy Gemini 3.0/2.5 aliases (map to the nearest current Gemini tier).
+  "gemini-3-pro": "gemini-3.1-pro",
+  "gemini-2.5": "gemini-3.1-pro",
+  "gemini-2.5-pro": "gemini-3.1-pro",
   "gemini-2.5-flash": "gemini-3-flash",
 
   // GLM (free)
@@ -126,6 +128,7 @@ const MODEL_COSTS: Record<
   "claude-opus-4-6": { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   "claude-opus-4-5": { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   "gemini-3-pro": { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0 },
+  "gemini-3.1-pro": { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0 },
   "gpt-5.1-codex-mini": {
     input: 0.25,
     output: 2,
@@ -151,6 +154,7 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "claude-opus-4-6": 1000000,
   "claude-opus-4-5": 200000,
   "gemini-3-pro": 1048576,
+  "gemini-3.1-pro": 1048576,
   "gpt-5.1-codex-mini": 400000,
   "gpt-5.1": 400000,
   "glm-4.7": 204800,
@@ -168,6 +172,7 @@ const MODEL_MAX_TOKENS: Record<string, number> = {
   "claude-opus-4-6": 128000,
   "claude-opus-4-5": 64000,
   "gemini-3-pro": 65536,
+  "gemini-3.1-pro": 65536,
   "gpt-5.1-codex-mini": 128000,
   "gpt-5.1": 128000,
   "glm-4.7": 131072,
@@ -205,6 +210,7 @@ const MODEL_NAMES: Record<string, string> = {
   "claude-opus-4-6": "Claude Opus 4.6",
   "claude-opus-4-5": "Claude Opus 4.5",
   "gemini-3-pro": "Gemini 3 Pro",
+  "gemini-3.1-pro": "Gemini 3.1 Pro",
   "gpt-5.1-codex-mini": "GPT-5.1 Codex Mini",
   "gpt-5.1": "GPT-5.1",
   "glm-4.7": "GLM-4.7",
@@ -233,6 +239,7 @@ export function getOpencodeZenStaticFallbackModels(): ModelDefinitionConfig[] {
     "claude-opus-4-6",
     "claude-opus-4-5",
     "gemini-3-pro",
+    "gemini-3.1-pro",
     "gpt-5.1-codex-mini",
     "gpt-5.1",
     "glm-4.7",


### PR DESCRIPTION
## Problem

Gemini 3.1 Pro (`gemini-3.1-pro-preview`) launched on 2026-02-19 with improved reasoning capabilities. Users who set `gemini-3.1-pro` in their Google provider config or pick it via OpenCode Zen aliases get unknown-model errors because:

1. `normalizeGoogleModelId` only handles `gemini-3-pro` → `gemini-3-pro-preview`, not the 3.1 variant
2. The OpenCode Zen alias table still points `gemini`/`gemini-pro` at the older `gemini-3-pro`
3. The Zen static fallback catalog has no entry for `gemini-3.1-pro`

Existing PRs cover antigravity (#21920, #22899) and gemini-cli (#21181) providers, but the direct Google API key path and OpenCode Zen were not addressed.

## Changes

- **`models-config.providers.ts`**: add `gemini-3.1-pro` → `gemini-3.1-pro-preview` mapping in `normalizeGoogleModelId`
- **`opencode-zen-models.ts`**:
  - Update aliases: `gemini`, `gemini-pro`, `gemini-3` now point to `gemini-3.1-pro`; add `gemini-3.1` alias; keep `gemini-3-pro` as legacy alias
  - Add `gemini-3.1-pro` to cost table ($2/$12 per 1M tokens, same as 3.0), context window (1M), max output (65536), display name, and static fallback list

## Tests

5 new tests in `models-config.normalize-google.test.ts` covering all normalize paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for Gemini 3.1 Pro (`gemini-3.1-pro-preview`) across Google model normalizer and OpenCode Zen catalog. Updates primary aliases (`gemini`, `gemini-pro`, `gemini-3`) to point to the newer 3.1 variant, while keeping `gemini-3-pro` as a legacy alias that now redirects to 3.1. Adds comprehensive test coverage for the Google normalizer function.

**Major changes:**
- `normalizeGoogleModelId`: adds `gemini-3.1-pro` → `gemini-3.1-pro-preview` mapping
- OpenCode Zen aliases: updated `gemini`/`gemini-pro`/`gemini-3` to resolve to `gemini-3.1-pro`; added `gemini-3.1` alias; converted `gemini-3-pro` to legacy alias
- Model catalog: added `gemini-3.1-pro` entries for cost ($2/$12), context window (1M), max output (65536), display name, and static fallback list
- Tests: 5 new test cases for `normalizeGoogleModelId`

**Issues found:**
- Breaking test failures in `opencode-zen-models.e2e.test.ts` - 4 test assertions expect aliases to resolve to `gemini-3-pro` but now resolve to `gemini-3.1-pro` 
- Static fallback model count increased from 10 to 11, breaking length assertion

<h3>Confidence Score: 2/5</h3>

- This PR contains breaking test failures that will prevent CI from passing
- The implementation is clean and comprehensive, with proper test coverage for the new normalizer function. However, the PR modifies alias mappings without updating existing tests in `opencode-zen-models.e2e.test.ts`. Four test assertions (lines 19, 27, 90, 99) expect `gemini-3-pro` but will now receive `gemini-3.1-pro`, and the static fallback model count test (line 56) expects 10 models but will now see 11. These are guaranteed test failures that block merging.
- The test file `src/agents/opencode-zen-models.e2e.test.ts` needs updates to match the new alias mappings and model count

<sub>Last reviewed commit: 383299b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->