### PR TITLE
fix: subagent announce fails with pairing required due to missing operator.write scope

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -9,6 +9,21 @@ import {
   resolveStorePath,
 } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
+import {
+  ADMIN_SCOPE,
+  READ_SCOPE,
+  WRITE_SCOPE,
+  type OperatorScope,
+} from "../gateway/method-scopes.js";
+
+/**
+ * Scopes required by the subagent announce flow.  These are passed explicitly
+ * to every `callGateway` call so the connection is not rejected with a
+ * "pairing required" scope-upgrade error when the device identity was
+ * originally paired without `operator.write`.
+ */
+const ANNOUNCE_SCOPES: OperatorScope[] = [ADMIN_SCOPE, READ_SCOPE, WRITE_SCOPE];
+
 import { createBoundDeliveryRouter } from "../infra/outbound/bound-delivery-router.js";
 import type { ConversationRef } from "../infra/outbound/session-binding-service.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -201,6 +216,7 @@ async function readLatestSubagentOutput(sessionKey: string): Promise<string | un
   const history = await callGateway<{ messages?: Array<unknown> }>({
     method: "chat.history",
     params: { sessionKey, limit: 50 },
+    scopes: ANNOUNCE_SCOPES,
   });
   const messages = Array.isArray(history?.messages) ? history.messages : [];
   for (let i = messages.length - 1; i >= 0; i -= 1) {
@@ -487,6 +503,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
       deliver: !requesterIsSubagent,
       idempotencyKey,
     },
+    scopes: ANNOUNCE_SCOPES,
     timeoutMs: 15_000,
   });
 }
@@ -674,6 +691,7 @@ async function sendSubagentAnnounceDirectly(params: {
             message: params.completionMessage,
             idempotencyKey: params.directIdempotencyKey,
           },
+          scopes: ANNOUNCE_SCOPES,
           timeoutMs: 15_000,
         });
 
@@ -701,6 +719,7 @@ async function sendSubagentAnnounceDirectly(params: {
         threadId: params.requesterIsSubagent ? undefined : threadId,
         idempotencyKey: params.directIdempotencyKey,
       },
+      scopes: ANNOUNCE_SCOPES,
       expectFinal: true,
       timeoutMs: 15_000,
     });
@@ -970,6 +989,7 @@ export async function runSubagentAnnounceFlow(params: {
           runId: params.childRunId,
           timeoutMs: waitMs,
         },
+        scopes: ANNOUNCE_SCOPES,
         timeoutMs: waitMs + 2000,
       });
       const waitError = typeof wait?.error === "string" ? wait.error : undefined;
@@ -1204,6 +1224,7 @@ export async function runSubagentAnnounceFlow(params: {
         await callGateway({
           method: "sessions.patch",
           params: { key: params.childSessionKey, label: params.label },
+          scopes: ANNOUNCE_SCOPES,
           timeoutMs: 10_000,
         });
       } catch {
@@ -1219,6 +1240,7 @@ export async function runSubagentAnnounceFlow(params: {
             deleteTranscript: true,
             emitLifecycleHooks: false,
           },
+          scopes: ANNOUNCE_SCOPES,
           timeoutMs: 10_000,
         });
       } catch {


### PR DESCRIPTION
## Problem

When a sub-agent completes, `runSubagentAnnounceFlow` calls `callGateway()` for methods like `agent`, `send`, `chat.history`, etc. Without explicit scopes, `callGateway` resolves to least-privilege scopes per method (e.g., `operator.write` for `agent`).

If the device identity was originally paired with `[operator.admin, operator.approvals, operator.pairing]` but not `operator.write`, the gateway detects a scope-upgrade and rejects with "pairing required" (code 1008).

## Fix

Explicitly pass `ANNOUNCE_SCOPES` (`[operator.admin, operator.read, operator.write]`) to all `callGateway` calls in `src/agents/subagent-announce.ts`. This ensures the announce flow — which is an internal process running on the same machine — requests all needed scopes upfront rather than relying on least-privilege resolution that may trigger scope-upgrade rejection.

## Changes

- Added `ANNOUNCE_SCOPES` constant with admin + read + write scopes
- Added `scopes: ANNOUNCE_SCOPES` to all 7 `callGateway` calls in the announce flow
- No behavioral change for devices that already have all scopes paired

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds explicit scope declarations (`ANNOUNCE_SCOPES = [operator.admin, operator.read, operator.write]`) to all 7 `callGateway` calls in the subagent announce flow. This prevents "pairing required" errors when device identity was paired without `operator.write` scope, since the announce flow previously relied on least-privilege scope resolution that would trigger scope-upgrade rejection.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is narrowly scoped to a single file, addresses a specific authentication issue with a well-documented solution, and all modified `callGateway` calls legitimately require the scopes being requested. The approach of explicitly passing scopes for internal operations is sound and follows security best practices.
- No files require special attention

<sub>Last reviewed commit: 49b20a6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->