### PR TITLE
Upgrade default Google model to Gemini 3.1 Pro and add Venice catalog entry

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -223,6 +223,15 @@ export const VENICE_MODEL_CATALOG = [
 
   // Google (via Venice)
   {
+    id: "gemini-3.1-pro-preview",
+    name: "Gemini 3.1 Pro (via Venice)",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    privacy: "anonymized",
+  },
+  {
     id: "gemini-3-pro-preview",
     name: "Gemini 3 Pro (via Venice)",
     reasoning: true,

--- a/src/commands/google-gemini-model-default.ts
+++ b/src/commands/google-gemini-model-default.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { applyAgentDefaultPrimaryModel } from "./model-default.js";
 
-export const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3-pro-preview";
+export const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3.1-pro-preview";
 
 export function applyGoogleGeminiModelDefault(cfg: OpenClawConfig): {
   next: OpenClawConfig;

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -21,7 +21,7 @@ const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   "gpt-mini": "openai/gpt-5-mini",
 
   // Google Gemini (3.x are preview ids in the catalog)
-  gemini: "google/gemini-3-pro-preview",
+  gemini: "google/gemini-3.1-pro-preview",
   "gemini-flash": "google/gemini-3-flash-preview",
 };
 


### PR DESCRIPTION
## Context

Gemini 3.1 Pro (`gemini-3.1-pro-preview`) launched on 2026-02-19 with improved reasoning capabilities. The default model references in OpenClaw still point to `gemini-3-pro-preview`, meaning new installations and users who haven't pinned a specific model don't get the latest model.

## Changes

- **`src/config/defaults.ts`**: update `gemini` alias from `google/gemini-3-pro-preview` to `google/gemini-3.1-pro-preview`
- **`src/commands/google-gemini-model-default.ts`**: update `GOOGLE_GEMINI_DEFAULT_MODEL` to `google/gemini-3.1-pro-preview`
- **`src/agents/venice-models.ts`**: add `gemini-3.1-pro-preview` entry to the Venice catalog with 1M context window and 65K max output tokens

## What's NOT changed

- Users with explicit model config are unaffected
- `gemini-flash` defaults remain on `gemini-3-flash-preview` (no 3.1 Flash released yet)
- No changes to `normalizeGoogleModelId` (covered separately in #23034)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates default Gemini model references from `gemini-3-pro-preview` to the newly released `gemini-3.1-pro-preview` (launched 2026-02-19) across config defaults and command defaults. Adds the new model to the Venice catalog with 1M context window and 65K max output tokens.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward model identifier updates across three files with consistent string replacements. The Venice catalog entry follows the exact pattern of the existing `gemini-3-pro-preview` entry. Tests already cover both model IDs, and the PR description clearly documents that users with explicit config are unaffected.
- No files require special attention

<sub>Last reviewed commit: 8a0fc13</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

🤖 **AI-assisted PR** (Claude, via OpenClaw agent)
- Testing: Fully tested locally with vitest; all relevant test suites pass
- The contributor understands what this code does