### PR TITLE
fix(whatsapp): detect LID JID in implicit reply-to-bot mention check

### DIFF
--- a/src/web/auto-reply/monitor/group-gating.ts
+++ b/src/web/auto-reply/monitor/group-gating.ts
@@ -124,9 +124,11 @@ export function applyGroupGating(params: {
   const replySenderE164 = params.msg.replyToSenderE164
     ? normalizeE164(params.msg.replyToSenderE164)
     : null;
+  const selfLid = params.msg.selfLid?.replace(/:\d+/, "");
   const implicitMention = Boolean(
     (selfJid && replySenderJid && selfJid === replySenderJid) ||
-    (selfE164 && replySenderE164 && selfE164 === replySenderE164),
+    (selfE164 && replySenderE164 && selfE164 === replySenderE164) ||
+    (selfLid && replySenderJid && selfLid === replySenderJid),
   );
   const mentionGate = resolveMentionGating({
     requireMention,

--- a/src/web/auto-reply/web-auto-reply-monitor.test.ts
+++ b/src/web/auto-reply/web-auto-reply-monitor.test.ts
@@ -114,6 +114,50 @@ describe("applyGroupGating", () => {
     expect(result.shouldProcess).toBe(true);
   });
 
+  it("treats reply-to-bot as implicit mention when replyToSenderJid uses LID format", () => {
+    const cfg = makeConfig({});
+    const { result } = runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "m-lid",
+        to: "+15550000",
+        accountId: "default",
+        body: "hello",
+        timestamp: Date.now(),
+        selfJid: "15551234567@s.whatsapp.net",
+        selfE164: "+15551234567",
+        selfLid: "98765432@lid",
+        replyToId: "m0",
+        replyToBody: "bot said hi",
+        replyToSenderJid: "98765432@lid",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(true);
+  });
+
+  it("does not treat reply as implicit mention when LID does not match", () => {
+    const cfg = makeConfig({});
+    const { result } = runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "m-lid-no",
+        to: "+15550000",
+        accountId: "default",
+        body: "hello",
+        timestamp: Date.now(),
+        selfJid: "15551234567@s.whatsapp.net",
+        selfE164: "+15551234567",
+        selfLid: "98765432@lid",
+        replyToId: "m0",
+        replyToBody: "someone else said hi",
+        replyToSenderJid: "11111111@lid",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(false);
+  });
+
   it("bypasses mention gating for owner /new in group chats", () => {
     const cfg = makeConfig({
       channels: {

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -67,6 +67,7 @@ export async function monitorWebInbox(options: {
 
   const selfJid = sock.user?.id;
   const selfE164 = selfJid ? jidToE164(selfJid) : null;
+  const selfLid = sock.user?.lid ?? null;
   const debouncer = createInboundDebouncer<WebInboundMessage>({
     debounceMs: options.debounceMs ?? 0,
     buildKey: (msg) => {
@@ -323,6 +324,7 @@ export async function monitorWebInbox(options: {
         mentionedJids: mentionedJids ?? undefined,
         selfJid,
         selfE164,
+        selfLid,
         location: location ?? undefined,
         sendComposing,
         reply,

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -31,6 +31,7 @@ export type WebInboundMessage = {
   mentionedJids?: string[];
   selfJid?: string | null;
   selfE164?: string | null;
+  selfLid?: string | null;
   location?: NormalizedLocation;
   sendComposing: () => Promise<void>;
   reply: (text: string) => Promise<void>;


### PR DESCRIPTION
Fixes #23029.

When someone swipe-replies to a bot message in a WhatsApp group, the reply's `participant` field sometimes comes back as `XXXX@lid` instead of `XXXX@s.whatsapp.net`. This is WhatsApp's LID (Linked Identity Device) format, and it's becoming more common as WhatsApp migrates to it.

The `implicitMention` check in `applyGroupGating` only compares against `selfJid` (regular JID) and `selfE164` (phone number). When the reply sender shows up as a LID, both comparisons fail silently and the reply is dropped as "no mention detected."

The bot's own LID is available at `sock.user?.lid`, but it was never extracted or threaded through to the gating check.

## What changed

Three small changes:

1. `types.ts` — added `selfLid?: string | null` to `WebInboundMessage`
2. `monitor.ts` — extracted `selfLid = sock.user?.lid ?? null` and passed it into the inbound message object
3. `group-gating.ts` — added a third condition to `implicitMention`: `(selfLid && replySenderJid && selfLid === replySenderJid)`

The device-suffix stripping (`.replace(/:\d+/, "")`) already handles `"98765432:1@lid"` → `"98765432@lid"` correctly, so no extra logic needed there.

## Relationship to #16655

PR #16655 resolves LID JIDs to E.164 via `lidLookup` when a mapping file exists. This handles the fallback case where that mapping is unavailable. Both fixes work together.

## Tests

- New: reply with matching LID triggers implicit mention → `shouldProcess: true`
- New: reply with non-matching LID does not trigger → `shouldProcess: false`
- Existing 15 group gating tests unchanged

Closes #23029

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where swipe-replies to bot messages in WhatsApp groups were silently dropped when the reply's `participant` field used WhatsApp's LID (Linked Identity Device) format (`XXXX@lid`) instead of the standard JID format (`XXXX@s.whatsapp.net`).

- Adds `selfLid` (from `sock.user?.lid`) to the `WebInboundMessage` type and threads it through from the inbound monitor to the group gating logic
- Extends the `implicitMention` check in `applyGroupGating` with a third condition comparing the bot's own LID against the reply sender's JID, so LID-format replies are correctly recognized as replies to the bot
- Complements PR #16655's `lidLookup` approach by handling the fallback case where no LID-to-E164 mapping is available
- Adds two focused tests covering the matching and non-matching LID scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a narrowly scoped fallback check with no impact on existing behavior.
- The change is minimal and well-contained: one new optional field on a type, one new line extracting a value from an existing API, and one additional OR condition in a Boolean expression. The existing 15 group gating tests are unaffected, and two new tests specifically cover the LID matching logic. The device-suffix stripping regex is consistent with existing patterns. No security, performance, or correctness concerns.
- No files require special attention.

<sub>Last reviewed commit: 4615437</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->