### PR TITLE
feat(session): add `announceDeliver` option to suppress auto-delivery of subagent results

### DIFF
--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -120,6 +120,14 @@ export type SessionConfig = {
   };
   /** Shared defaults for thread-bound session routing across channels/providers. */
   threadBindings?: SessionThreadBindingsConfig;
+  /**
+   * Whether subagent announce results are auto-delivered to the chat channel.
+   * When `false`, the announce trigger is still injected into the requester
+   * session but the agent's reply is **not** automatically sent — the agent
+   * must use its own tools (e.g. a card API) to deliver user-facing output.
+   * Default: `true` (auto-deliver).
+   */
+  announceDeliver?: boolean;
   /** Automatic session store maintenance (pruning, capping, file rotation). */
   maintenance?: SessionMaintenanceConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -73,6 +73,7 @@ export const SessionSchema = z
       })
       .strict()
       .optional(),
+    announceDeliver: z.boolean().optional(),
     maintenance: z
       .object({
         mode: z.enum(["enforce", "warn"]).optional(),


### PR DESCRIPTION
## Summary

Add `session.announceDeliver` (boolean, default `true`) to let users opt out of automatic delivery of subagent announce replies to the chat channel.

## Motivation

When agents use structured message formats — Feishu interactive cards, Slack Block Kit, Telegram InlineKeyboard, etc. — instead of plain text, the current hardcoded `deliver: true` in the announce flow causes raw text to leak into the chat channel *before* the agent can send a properly formatted message via its own tools.

Today the only workaround is patching `deliver` in the compiled dist files, which breaks on every update. A first-class config option lets users cleanly control this behavior.

Related: #13267

## Changes

**`src/config/types.base.ts`**
- Add `announceDeliver?: boolean` to `SessionConfig` with JSDoc

**`src/config/zod-schema.session.ts`**
- Add `announceDeliver: z.boolean().optional()` to `SessionSchema`

**`src/agents/subagent-announce.ts`**
- `sendAnnounce()` (queue drain path): read `cfg.session.announceDeliver` and pass it to the `deliver` param
- `sendSubagentAnnounceDirectly()` (direct path): same change
- `buildAnnounceReplyInstruction()`: when `announceDeliver === false`, instruct the agent to use its own tools for delivery and reply `NO_REPLY`
- `runSubagentAnnounceFlow()`: thread the config value into `buildAnnounceReplyInstruction()`

## Behavior

| `announceDeliver` | Trigger injected? | LLM reply auto-delivered? | Reply instruction |
|---|---|---|---|
| `true` (default) | ✅ | ✅ | "Convert and send user-facing update now" |
| `false` | ✅ | ❌ | "Use your own tools to deliver; reply NO_REPLY" |

## Usage

```json
{
  "session": {
    "announceDeliver": false
  }
}
```

## Backward compatibility

Fully backward-compatible. The option defaults to `true` when omitted — existing behavior is unchanged.

## Test plan

- [ ] Verify default behavior (no config / `true`): subagent results auto-delivered as before
- [ ] Verify `announceDeliver: false`: trigger injected into session, agent processes result, but LLM reply is NOT auto-sent to channel
- [ ] Verify agent can still deliver via its own tools (e.g. card API) when `announceDeliver: false`
- [ ] Verify nested subagent announces (requesterIsSubagent) are unaffected by this option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `session.announceDeliver` config option (boolean, defaults to `true`) to control whether subagent completion results are automatically delivered to the chat channel. When disabled, the announce trigger is still injected but the LLM's reply is not auto-sent, allowing agents to deliver via structured message tools (Feishu cards, Slack blocks, etc.) instead of leaking raw text.

- Config plumbing: added field to `SessionConfig` type with JSDoc, added to Zod schema validation
- Modified three announce delivery paths (`sendAnnounce`, `sendSubagentAnnounceDirectly`, `runSubagentAnnounceFlow`) to read config and conditionally set `deliver` parameter
- Updated `buildAnnounceReplyInstruction` to provide different instructions when auto-delivery is disabled (instructs agent to use own tools and reply with `NO_REPLY`)

The implementation correctly defaults to `true` (maintaining backward compatibility) and handles the three code paths that control delivery.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style inconsistency
- The implementation is logically correct and backward-compatible. Config schema, type definitions, and all three delivery paths are properly updated. The inconsistency in default value handling (line 1122 passes raw value vs normalized `!== false` in other locations) works correctly but creates maintenance risk if the check in `buildAnnounceReplyInstruction` changes.
- No files require special attention

<sub>Last reviewed commit: 94598c5</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->