### PR TITLE
docs(android): note that app is not publicly released yet

### DIFF
--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -9,6 +9,8 @@ title: "Android App"
 
 # Android App (Node)
 
+> **Note:** The Android app has not been publicly released yet. The source code is available in the [OpenClaw repository](https://github.com/openclaw/openclaw) under `apps/android`. You can build it yourself using Java 17 and the Android SDK (`./gradlew :app:assembleDebug`). See [apps/android/README.md](https://github.com/openclaw/openclaw/blob/main/apps/android/README.md) for build instructions.
+
 ## Support snapshot
 
 - Role: companion node app (Android does not host the Gateway).


### PR DESCRIPTION
The Android docs describe the companion app in detail but give no download link, leaving users confused. This adds a brief note clarifying that the app hasn't been publicly released yet and pointing to the source code and build instructions in the repo.

Fixes the gap noticed in [#9443](https://github.com/openclaw/openclaw/issues/9443).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a brief note to the Android platform documentation clarifying that the app hasn't been publicly released yet, with pointers to the source code and build instructions. This addresses user confusion about the missing download link mentioned in issue #9443.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks - it only adds documentation.
- Documentation-only change that adds a helpful clarification. All links are valid, build command matches the README, Java version requirement is accurate (verified in build.gradle.kts), and formatting is correct.
- No files require special attention

<sub>Last reviewed commit: 2292f82</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->