### PR TITLE
test: clear gateway env vars in beforeEach to prevent leakage

### DIFF
--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -18,6 +18,12 @@ const cdpMocks = getCdpMocks();
 const pwMocks = getPwMocks();
 
 describe("browser control server", () => {
+  beforeEach(() => {
+    // Ensure tests are not affected by environment variables
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+  });
+
   installBrowserControlServerHooks();
 
   it("POST /tabs/open?profile=unknown returns 404", async () => {

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 
 const TRUSTED_PROXY_AUTH = {
@@ -14,6 +14,12 @@ const TOKEN_AUTH = {
 };
 
 describe("resolveGatewayRuntimeConfig", () => {
+  beforeEach(() => {
+    // Ensure tests are not affected by environment variables
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+  });
+
   describe("trusted-proxy auth mode", () => {
     // This test validates BOTH validation layers:
     // 1. CLI validation in src/cli/gateway-cli/run.ts (line 246)


### PR DESCRIPTION
Add beforeEach hooks in these test files to ensure a clean environment:

- src/gateway/server-runtime-config.test.ts
- src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts

This prevents OPENCLAW_GATEWAY_TOKEN and OPENCLAW_GATEWAY_PASSWORD from the outer environment from interfering with auth-related test expectations, making tests deterministic and reliable.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `beforeEach` hooks to clear `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_PASSWORD` environment variables in two test files to prevent environment leakage.

- `src/gateway/server-runtime-config.test.ts`: properly imports `beforeEach` from vitest and clears env vars to ensure auth-related tests run with predictable state
- `src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts`: adds redundant env cleanup in first describe block (already handled by `installBrowserControlServerHooks()`), and the second describe block (`profile CRUD endpoints`) still lacks proper env var cleanup/restoration

<h3>Confidence Score: 3/5</h3>

- safe to merge but with minor issues that should be addressed
- the change properly addresses env var leakage in `server-runtime-config.test.ts`, but has redundant cleanup in one test file and incomplete cleanup in another describe block that could still allow env var leakage
- pay attention to `src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts` - the second describe block needs env var cleanup

<sub>Last reviewed commit: 874a422</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->