### PR TITLE
fix(slack): exclude archived channels from startup channel resolution

### DIFF
--- a/src/slack/resolve-channels.ts
+++ b/src/slack/resolve-channels.ts
@@ -51,7 +51,7 @@ async function listSlackChannels(client: WebClient): Promise<SlackChannelLookup[
   do {
     const res = (await client.conversations.list({
       types: "public_channel,private_channel",
-      exclude_archived: false,
+      exclude_archived: true,
       limit: 1000,
       cursor,
     })) as SlackListResponse;


### PR DESCRIPTION
## Summary

`listSlackChannels()` in `resolve-channels.ts` calls `conversations.list` with `exclude_archived: false`, which paginates through **every** channel in the workspace including archived ones.

For workspaces with thousands of archived channels (e.g., a 10-year-old Slack install), this:
- Burns through Slack's rate limit on every gateway startup
- Causes `rate_limit_exceeded` warnings with 30-second retry delays
- Compounds when the gateway restarts multiple times (each restart re-fetches the full list)

## Fix

One-line change: `exclude_archived: false` → `exclude_archived: true`

This is safe because `resolveByName()` already prefers active channels over archived ones (line 89), and channels referenced by ID don't need the list at all — they're matched directly.

Supersedes #19870 (closed due to stale branch).

## Test plan

- [x] Verified channel resolution still works when channels are referenced by ID (e.g., `C02LFRN0V`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `exclude_archived` from `false` to `true` in `listSlackChannels()` to prevent fetching thousands of archived channels during gateway startup, avoiding Slack API rate limits.

- Resolves rate limit warnings for workspaces with large numbers of archived channels
- Name-based resolution already prefers active channels (resolve-channels.ts:89)
- ID-based channel references continue to work (resolved as `true` even if channel metadata is missing from the list)
- The `archived` field is only used for logging, so missing metadata for archived channels referenced by ID has no functional impact

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple one-line fix that addresses a real performance issue without breaking existing functionality. The change is well-justified and the code already handles the edge case where archived channels might be referenced by ID
- No files require special attention

<sub>Last reviewed commit: 7c4858b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->