### PR TITLE
fix(whatsapp): resolve LID JIDs for reply-to-bot implicit mention detection

### DIFF
--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -317,7 +317,9 @@ export async function monitorWebInbox(options: {
         replyToBody: replyContext?.body,
         replyToSender: replyContext?.sender,
         replyToSenderJid: replyContext?.senderJid,
-        replyToSenderE164: replyContext?.senderE164,
+        replyToSenderE164: replyContext?.senderJid?.endsWith("@lid")
+          ? (await resolveInboundJid(replyContext.senderJid)) ?? replyContext?.senderE164
+          : replyContext?.senderE164,
         groupSubject,
         groupParticipants,
         mentionedJids: mentionedJids ?? undefined,

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -318,7 +318,7 @@ export async function monitorWebInbox(options: {
         replyToSender: replyContext?.sender,
         replyToSenderJid: replyContext?.senderJid,
         replyToSenderE164: replyContext?.senderJid?.endsWith("@lid")
-          ? (await resolveInboundJid(replyContext.senderJid)) ?? replyContext?.senderE164
+          ? ((await resolveInboundJid(replyContext.senderJid)) ?? replyContext?.senderE164)
           : replyContext?.senderE164,
         groupSubject,
         groupParticipants,


### PR DESCRIPTION
## Problem

WhatsApp has migrated group participants to use **LID (Linked ID) format** (`@lid`) instead of regular JIDs (`@s.whatsapp.net`). When a user replies to a bot message in a WhatsApp group, the quoted participant's JID comes back as a LID (e.g. `151320958894225@lid`), which fails the implicit mention comparison against the bot's own regular JID (`6285174386822@s.whatsapp.net`).

This means **reply-to-bot does not trigger a response** in WhatsApp groups, even though the docs state it should work as an implicit mention.

### Debug output showing the mismatch:

```json
{
  "selfJid": "6285174386822@s.whatsapp.net",
  "replySenderJid": "151320958894225@lid",
  "selfE164": "+6285174386822",
  "replySenderE164": "+151320958894225",
  "implicitMention": false
}
```

`replySenderE164` is incorrectly derived from the LID number instead of being resolved to the actual phone number.

## Fix

Resolve LID JIDs to E164 using the existing `resolveInboundJid` helper (which leverages Baileys' `lidMapping`) before populating `replyToSenderE164` on the inbound message. This allows the implicit mention check in `group-gating.ts` to correctly match the reply sender against the bot's own E164.

## Change

`src/web/inbound/monitor.ts`: When building the inbound message, if `replyContext.senderJid` ends with `@lid`, resolve it via `resolveInboundJid` before setting `replyToSenderE164`.

## Testing

- Tested on OpenClaw 2026.2.21-2 with WhatsApp Web (Baileys)
- Before fix: replying to bot message in group → `implicitMention: false` → no response
- After fix: replying to bot message in group → `implicitMention: true` → bot responds correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes reply-to-bot implicit mention detection in WhatsApp groups by resolving LID (Linked ID) JIDs to E.164 phone numbers before comparing against the bot's own E.164.

**Key changes:**
- When `replyContext.senderJid` ends with `@lid`, resolve it via `resolveInboundJid` (which uses Baileys' `lidMapping`) before setting `replyToSenderE164`
- Fallback to the original `replyContext.senderE164` if LID resolution fails
- This allows the E.164-based comparison in `group-gating.ts:129` to correctly match when users reply to bot messages

**Impact:**
- Restores expected reply-to-bot behavior in WhatsApp groups after WhatsApp's migration to LID format for group participants

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a targeted fix that properly handles LID resolution with appropriate fallbacks
- The change is minimal, well-scoped, and follows existing patterns in the codebase. It reuses the existing `resolveInboundJid` helper (already used on lines 181 and 187 for similar purposes), includes proper null safety with optional chaining and nullish coalescing, and has appropriate fallback behavior. The PR description includes clear before/after testing evidence.
- No files require special attention

<sub>Last reviewed commit: f1d5a0d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->