### PR TITLE
Security/Test: isolate node.invoke approval e2e identity

### DIFF
--- a/src/gateway/server.node-invoke-approval-bypass.e2e.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.e2e.test.ts
@@ -54,6 +54,20 @@ async function requestAllowOnceApproval(ws: WebSocket, command: string): Promise
   return approvalId;
 }
 
+function createEphemeralDeviceIdentity() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+  const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  const publicKeyRaw = publicKeyRawBase64UrlFromPem(publicKeyPem);
+  const deviceId = deriveDeviceIdFromPublicKey(publicKeyRaw);
+  expect(deviceId).toBeTruthy();
+  return {
+    deviceId: deviceId!,
+    publicKeyPem,
+    privateKeyPem,
+  };
+}
+
 describe("node.invoke approval bypass", () => {
   let server: Awaited<ReturnType<typeof startServerWithClient>>["server"];
   let port: number;
@@ -135,6 +149,7 @@ describe("node.invoke approval bypass", () => {
   };
 
   const connectLinuxNode = async (onInvoke: (payload: unknown) => void) => {
+    const nodeIdentity = createEphemeralDeviceIdentity();
     let readyResolve: (() => void) | null = null;
     const ready = new Promise<void>((resolve) => {
       readyResolve = resolve;
@@ -151,6 +166,7 @@ describe("node.invoke approval bypass", () => {
       mode: GATEWAY_CLIENT_MODES.NODE,
       scopes: [],
       commands: ["system.run"],
+      deviceIdentity: nodeIdentity,
       onHelloOk: () => readyResolve?.(),
       onEvent: (evt) => {
         if (evt.event !== "node.invoke.request") {


### PR DESCRIPTION
## Summary
- harden `node.invoke` approval-bypass e2e setup by assigning an ephemeral device identity to the NODE client
- avoid identity collisions with default test client identity in parallel/nearby runs
- keep coverage focused on the authorization boundary under test (`node.invoke.request` path)

## Security context
- Finding ID: `SEC-REGRESSION-NODE-INVOKE-APPROVAL-E2E-IDENTITY`
- Boundary: gateway node-invoke approval mediation
- Scope lock: `src/gateway/server.node-invoke-approval-bypass.e2e.test.ts`
- Non-duplicate rationale: no open PR for this boundary+bug class; historical overlap (`#10129`) is closed and unmerged

## Validation
- `pnpm test:e2e src/gateway/server.node-invoke-approval-bypass.e2e.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardened the `node.invoke` approval-bypass e2e test by assigning an ephemeral device identity to the NODE client, preventing identity collisions with the default test client identity in parallel or nearby test runs. The change introduces a `createEphemeralDeviceIdentity()` helper that generates a unique ed25519 keypair for each test execution and passes it to the `GatewayClient` via the `deviceIdentity` option.

- Added `createEphemeralDeviceIdentity()` function that generates ed25519 keypairs and derives device IDs
- Modified `connectLinuxNode()` to create and use ephemeral node identity instead of the shared test identity from `loadOrCreateDeviceIdentity()`
- Maintains test isolation by ensuring each NODE client has a unique identity, avoiding cross-contamination between test runs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused test isolation improvement that follows established patterns in the codebase. The implementation mirrors the existing `connectOperatorWithNewDevice()` function pattern, uses the same crypto primitives and device identity functions already used throughout the codebase, and only affects test setup without touching production code. The security context indicates this addresses a test regression finding, and the change correctly prevents identity collisions by ensuring each NODE client gets a unique ephemeral identity.
- No files require special attention

<sub>Last reviewed commit: 311ec14</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->