### PR TITLE
Fix #22985: Record session meta from native slash commands

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -10,6 +10,7 @@ import {
   resolveCommandArgMenu,
 } from "../auto-reply/commands-registry.js";
 import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
+import { recordSessionMetaFromInbound, resolveStorePath } from "../config/sessions.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
@@ -593,7 +594,12 @@ export const registerTelegramNativeCommands = ({
             OriginatingChannel: "telegram" as const,
             OriginatingTo: `telegram:${chatId}`,
           });
-
+void recordSessionMetaFromInbound({
+            storePath: resolveStorePath(cfg.session?.store, { agentId: route.agentId }),
+            sessionKey: `telegram:slash:${senderId || chatId}`,
+            ctx: ctxPayload,
+            createIfMissing: true,
+          }).catch(() => {});
           const disableBlockStreaming =
             typeof telegramCfg.blockStreaming === "boolean"
               ? !telegramCfg.blockStreaming


### PR DESCRIPTION
Problem: Telegram slash command handlers called finalizeInboundContext but never called recordSessionMetaFromInbound, so channel metadata was never persisted to the session store.
Why it matters: Without channel metadata, session-aware features like /elevated mode and exec approval gates always fail with channel: (unknown) and allowedByConfig: false, making them completely non-functional via slash commands.
What changed: Added recordSessionMetaFromInbound call after finalizeInboundContext in bot-native-commands.ts, mirroring the pattern used in channels/session.ts and line/bot-message-context.ts.
What did NOT change: No behavior changes to regular message handling, no config changes, no other files modified.
Change Type

 Bug fix

Scope

 Gateway / orchestration
 Auth / tokens

Linked Issue/PR

Closes #22985

User-visible / Behavior Changes
/elevated mode and exec approval gates now function correctly when invoked via Telegram slash commands.
Security Impact

New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No — this restores intended behavior, not new capability
Data access scope changed? No

Repro + Verification
Environment

OS: macOS
Runtime/container: Docker (openclaw:local)
Model/provider: Anthropic Claude / Ollama
Integration/channel: Telegram

Steps

Configure /elevated with tools.elevated.allowFrom.telegram
Send /elevated full via Telegram
Observe channel: (unknown) and allowedByConfig: false

Expected
/elevated activates successfully
Actual (before fix)
channel: (unknown), allowedByConfig: false — elevated mode never activates
Evidence

Verified via openclaw sandbox explain --session telegram:slash:<id> before and after patch
Before: channel: (unknown), allowedByConfig: false
After: /elevated full responds with "Elevated mode set to full (auto-approve)"

Human Verification

Verified /elevated full works via Telegram after patch
Verified regular message handling unaffected
Did not verify Discord/Slack slash command handlers (same pattern likely applies)

Compatibility / Migration

Backward compatible? Yes
Config/env changes? No
Migration needed? No

Failure Recovery

Revert by removing the recordSessionMetaFromInbound call added at line 597
No config to restore
Bad symptom: session store errors in gateway logs

Risks and Mitigations

Risk: recordSessionMetaFromInbound fails silently and logs errors

Mitigation: Uses .catch(() => {}) pattern — failure is non-fatal, consistent with other handlers