### PR TITLE
fix(slash): persist channel metadata from slash command sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 - Telegram/Streaming: preserve archived draft preview mapping after flush and clean superseded reasoning preview bubbles so multi-message preview finals no longer cross-edit or orphan stale messages under send/rotation races. (#23202) Thanks @obviyus.
 - Slack/Slash commands: preserve the Bolt app receiver when registering external select options handlers so monitor startup does not crash on runtimes that require bound `app.options` calls. (#23209) Thanks @0xgaia.
+- Slack/Telegram slash sessions: await session metadata persistence before dispatch so first-turn native slash runs do not race session-origin metadata updates. (#23065) thanks @hydro13.
 - Agents/Ollama: preserve unsafe integer tool-call arguments as exact strings during NDJSON parsing, preventing large numeric IDs from being rounded before tool execution. (#23170) Thanks @BestJoester.
 - Cron/Gateway: keep `cron.list` and `cron.status` responsive during startup catch-up by avoiding a long-held cron lock while missed jobs execute. (#23106) Thanks @jayleekr.
 - Gateway/Config reload: compare array-valued config paths structurally during diffing so unchanged `memory.qmd.paths` and `memory.qmd.scope.rules` no longer trigger false restart-required reloads. (#23185) Thanks @rex05ai.

--- a/src/slack/monitor/slash.test-harness.ts
+++ b/src/slack/monitor/slash.test-harness.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   finalizeInboundContextMock: vi.fn(),
   resolveConversationLabelMock: vi.fn(),
   createReplyPrefixOptionsMock: vi.fn(),
+  recordSessionMetaFromInboundMock: vi.fn(),
+  resolveStorePathMock: vi.fn(),
 }));
 
 vi.mock("../../auto-reply/reply/provider-dispatcher.js", () => ({
@@ -35,6 +37,12 @@ vi.mock("../../channels/reply-prefix.js", () => ({
   createReplyPrefixOptions: (...args: unknown[]) => mocks.createReplyPrefixOptionsMock(...args),
 }));
 
+vi.mock("../../config/sessions.js", () => ({
+  recordSessionMetaFromInbound: (...args: unknown[]) =>
+    mocks.recordSessionMetaFromInboundMock(...args),
+  resolveStorePath: (...args: unknown[]) => mocks.resolveStorePathMock(...args),
+}));
+
 type SlashHarnessMocks = {
   dispatchMock: ReturnType<typeof vi.fn>;
   readAllowFromStoreMock: ReturnType<typeof vi.fn>;
@@ -43,6 +51,8 @@ type SlashHarnessMocks = {
   finalizeInboundContextMock: ReturnType<typeof vi.fn>;
   resolveConversationLabelMock: ReturnType<typeof vi.fn>;
   createReplyPrefixOptionsMock: ReturnType<typeof vi.fn>;
+  recordSessionMetaFromInboundMock: ReturnType<typeof vi.fn>;
+  resolveStorePathMock: ReturnType<typeof vi.fn>;
 };
 
 export function getSlackSlashMocks(): SlashHarnessMocks {
@@ -61,4 +71,6 @@ export function resetSlackSlashMocks() {
   mocks.finalizeInboundContextMock.mockReset().mockImplementation((ctx: unknown) => ctx);
   mocks.resolveConversationLabelMock.mockReset().mockReturnValue(undefined);
   mocks.createReplyPrefixOptionsMock.mockReset().mockReturnValue({ onModelSelected: () => {} });
+  mocks.recordSessionMetaFromInboundMock.mockReset().mockResolvedValue(undefined);
+  mocks.resolveStorePathMock.mockReset().mockReturnValue("/tmp/openclaw-sessions.json");
 }

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -210,6 +210,14 @@ function findFirstActionsBlock(payload: { blocks?: Array<{ type: string }> }) {
     | undefined;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function createArgMenusHarness() {
   const commands = new Map<string, (args: unknown) => Promise<void>>();
   const actions = new Map<string, (args: unknown) => Promise<void>>();
@@ -875,5 +883,31 @@ describe("slack slash command session metadata", () => {
     };
     expect(call.ctx?.OriginatingChannel).toBe("slack");
     expect(call.sessionKey).toBeDefined();
+  });
+
+  it("awaits session metadata persistence before dispatch", async () => {
+    const deferred = createDeferred<void>();
+    recordSessionMetaFromInboundMock.mockReset().mockReturnValue(deferred.promise);
+
+    const harness = createPolicyHarness({ groupPolicy: "open" });
+    await registerCommands(harness.ctx, harness.account);
+
+    const runPromise = runSlashHandler({
+      commands: harness.commands,
+      command: {
+        channel_id: harness.channelId,
+        channel_name: harness.channelName,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(recordSessionMetaFromInboundMock).toHaveBeenCalledTimes(1);
+    });
+    expect(dispatchMock).not.toHaveBeenCalled();
+
+    deferred.resolve();
+    await runPromise;
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -859,3 +859,21 @@ describe("slack slash commands access groups", () => {
     expectUnauthorizedResponse(respond);
   });
 });
+
+describe("slack slash command session metadata", () => {
+  const { recordSessionMetaFromInboundMock } = getSlackSlashMocks();
+
+  it("calls recordSessionMetaFromInbound after dispatching a slash command", async () => {
+    const harness = createPolicyHarness({ groupPolicy: "open" });
+    await registerAndRunPolicySlash({ harness });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(recordSessionMetaFromInboundMock).toHaveBeenCalledTimes(1);
+    const call = recordSessionMetaFromInboundMock.mock.calls[0]?.[0] as {
+      sessionKey?: string;
+      ctx?: { OriginatingChannel?: string };
+    };
+    expect(call.ctx?.OriginatingChannel).toBe("slack");
+    expect(call.sessionKey).toBeDefined();
+  });
+});

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -613,13 +613,15 @@ export async function registerSlackMonitorSlashCommands(params: {
       const storePath = resolveStorePath(cfg.session?.store, {
         agentId: route.agentId,
       });
-      void recordSessionMetaFromInbound({
-        storePath,
-        sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
-        ctx: ctxPayload,
-      }).catch((err) => {
+      try {
+        await recordSessionMetaFromInbound({
+          storePath,
+          sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+          ctx: ctxPayload,
+        });
+      } catch (err) {
         runtime.error?.(danger(`slack slash: failed updating session meta: ${String(err)}`));
-      });
+      }
 
       const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
         cfg,

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -539,9 +539,14 @@ export async function registerSlackMonitorSlashCommands(params: {
           import("../../auto-reply/reply/inbound-context.js"),
           import("../../auto-reply/reply/provider-dispatcher.js"),
         ]);
-      const [{ resolveConversationLabel }, { createReplyPrefixOptions }] = await Promise.all([
+      const [
+        { resolveConversationLabel },
+        { createReplyPrefixOptions },
+        { recordSessionMetaFromInbound, resolveStorePath },
+      ] = await Promise.all([
         import("../../channels/conversation-label.js"),
         import("../../channels/reply-prefix.js"),
+        import("../../config/sessions.js"),
       ]);
 
       const route = resolveAgentRoute({
@@ -603,6 +608,17 @@ export async function registerSlackMonitorSlashCommands(params: {
         CommandAuthorized: commandAuthorized,
         OriginatingChannel: "slack" as const,
         OriginatingTo: `user:${command.user_id}`,
+      });
+
+      const storePath = resolveStorePath(cfg.session?.store, {
+        agentId: route.agentId,
+      });
+      void recordSessionMetaFromInbound({
+        storePath,
+        sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+        ctx: ctxPayload,
+      }).catch((err) => {
+        runtime.error?.(danger(`slack slash: failed updating session meta: ${String(err)}`));
       });
 
       const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { TelegramAccountConfig } from "../config/types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { registerTelegramNativeCommands } from "./bot-native-commands.js";
+
+// All mocks scoped to this file only — does not affect bot-native-commands.test.ts
+
+const sessionMocks = vi.hoisted(() => ({
+  recordSessionMetaFromInbound: vi.fn(),
+  resolveStorePath: vi.fn(),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  recordSessionMetaFromInbound: sessionMocks.recordSessionMetaFromInbound,
+  resolveStorePath: sessionMocks.resolveStorePath,
+}));
+vi.mock("../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: vi.fn(async () => []),
+}));
+vi.mock("../auto-reply/reply/inbound-context.js", () => ({
+  finalizeInboundContext: vi.fn((ctx: unknown) => ctx),
+}));
+vi.mock("../auto-reply/reply/provider-dispatcher.js", () => ({
+  dispatchReplyWithBufferedBlockDispatcher: vi.fn(async () => undefined),
+}));
+vi.mock("../channels/reply-prefix.js", () => ({
+  createReplyPrefixOptions: vi.fn(() => ({ onModelSelected: () => {} })),
+}));
+vi.mock("../auto-reply/skill-commands.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../auto-reply/skill-commands.js")>();
+  return { ...actual, listSkillCommandsForAgents: vi.fn(() => []) };
+});
+vi.mock("../plugins/commands.js", () => ({
+  getPluginCommandSpecs: vi.fn(() => []),
+  matchPluginCommand: vi.fn(() => null),
+  executePluginCommand: vi.fn(async () => ({ text: "ok" })),
+}));
+vi.mock("./bot/delivery.js", () => ({
+  deliverReplies: vi.fn(async () => ({ delivered: true })),
+}));
+
+const buildParams = (cfg: OpenClawConfig, accountId = "default") => ({
+  bot: {
+    api: {
+      setMyCommands: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+    },
+    command: vi.fn(),
+  } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+  cfg,
+  runtime: {} as unknown as RuntimeEnv,
+  accountId,
+  telegramCfg: {} as TelegramAccountConfig,
+  allowFrom: [],
+  groupAllowFrom: [],
+  replyToMode: "off" as const,
+  textLimit: 4096,
+  useAccessGroups: false,
+  nativeEnabled: true,
+  nativeSkillsEnabled: true,
+  nativeDisabledExplicit: false,
+  resolveGroupPolicy: () => ({ allowlistEnabled: false, allowed: true }),
+  resolveTelegramGroupConfig: () => ({
+    groupConfig: undefined,
+    topicConfig: undefined,
+  }),
+  shouldSkipUpdate: () => false,
+  opts: { token: "token" },
+});
+
+describe("registerTelegramNativeCommands — session metadata", () => {
+  it("calls recordSessionMetaFromInbound after a native slash command", async () => {
+    sessionMocks.recordSessionMetaFromInbound.mockReset().mockResolvedValue(undefined);
+    sessionMocks.resolveStorePath.mockReset().mockReturnValue("/tmp/openclaw-sessions.json");
+
+    const commandHandlers = new Map<string, (ctx: unknown) => Promise<void>>();
+    const cfg: OpenClawConfig = {};
+
+    registerTelegramNativeCommands({
+      ...buildParams(cfg),
+      allowFrom: ["*"],
+      bot: {
+        api: {
+          setMyCommands: vi.fn().mockResolvedValue(undefined),
+          sendMessage: vi.fn().mockResolvedValue(undefined),
+        },
+        command: vi.fn((name: string, cb: (ctx: unknown) => Promise<void>) => {
+          commandHandlers.set(name, cb);
+        }),
+      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+    });
+
+    const handler = commandHandlers.get("status");
+    expect(handler).toBeTruthy();
+    await handler?.({
+      match: "",
+      message: {
+        message_id: 1,
+        date: Math.floor(Date.now() / 1000),
+        chat: { id: 100, type: "private" },
+        from: { id: 200, username: "bob" },
+      },
+    });
+
+    expect(sessionMocks.recordSessionMetaFromInbound).toHaveBeenCalledTimes(1);
+    const call = (
+      sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
+        [{ sessionKey?: string; ctx?: { OriginatingChannel?: string } }]
+      >
+    )[0]?.[0];
+    expect(call?.ctx?.OriginatingChannel).toBe("telegram");
+    expect(call?.sessionKey).toBeDefined();
+  });
+});

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -598,13 +598,15 @@ export const registerTelegramNativeCommands = ({
           const storePath = resolveStorePath(cfg.session?.store, {
             agentId: route.agentId,
           });
-          void recordSessionMetaFromInbound({
-            storePath,
-            sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
-            ctx: ctxPayload,
-          }).catch((err) => {
+          try {
+            await recordSessionMetaFromInbound({
+              storePath,
+              sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+              ctx: ctxPayload,
+            });
+          } catch (err) {
             runtime.error?.(danger(`telegram slash: failed updating session meta: ${String(err)}`));
-          });
+          }
 
           const disableBlockStreaming =
             typeof telegramCfg.blockStreaming === "boolean"

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -17,6 +17,7 @@ import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ChannelGroupPolicy } from "../config/group-policy.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
+import { recordSessionMetaFromInbound, resolveStorePath } from "../config/sessions.js";
 import {
   normalizeTelegramCommandName,
   resolveTelegramCustomCommands,
@@ -592,6 +593,17 @@ export const registerTelegramNativeCommands = ({
             // Originating context for sub-agent announce routing
             OriginatingChannel: "telegram" as const,
             OriginatingTo: `telegram:${chatId}`,
+          });
+
+          const storePath = resolveStorePath(cfg.session?.store, {
+            agentId: route.agentId,
+          });
+          void recordSessionMetaFromInbound({
+            storePath,
+            sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+            ctx: ctxPayload,
+          }).catch((err) => {
+            runtime.error?.(danger(`telegram slash: failed updating session meta: ${String(err)}`));
           });
 
           const disableBlockStreaming =


### PR DESCRIPTION
Fixes #22985.

Slash command handlers called `finalizeInboundContext` to build the inbound context payload but never called `recordSessionMetaFromInbound` to persist it. Regular message paths do both. The slash command paths only did the first half.

The missing call means `session.meta.originatingChannel` is never written when a slash command creates a session. Anything that reads it — approval gates, exec policy checks, elevated mode — silently fails or gets stuck.

## What changed

- `src/telegram/bot-native-commands.ts` — resolve `storePath` and call `recordSessionMetaFromInbound` after `finalizeInboundContext`
- `src/slack/monitor/slash.ts` — same, added to the existing dynamic `Promise.all` import block

Both mirror the pattern from `bot-message-context.ts` and `channels/session.ts`.

## Tests

- New test file `bot-native-commands.session-meta.test.ts` — fully isolated mocks, asserts `recordSessionMetaFromInbound` is called with `OriginatingChannel: "telegram"`
- `slash.test-harness.ts` extended with `recordSessionMetaFromInboundMock` — new test in `slash.test.ts` asserts it's called with `OriginatingChannel: "slack"`
- Existing tests unchanged

Closes #22985

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds missing `recordSessionMetaFromInbound` calls to Telegram and Slack slash command handlers after `finalizeInboundContext`, matching the established pattern from regular message handlers (`bot-message-context.ts`, `channels/session.ts`). Without this call, `session.meta.originatingChannel` was never persisted for slash command sessions, causing approval gates, exec policy checks, and elevated mode to silently fail. The fix resolves #22985 by ensuring session metadata is properly recorded for both platforms.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes follow an established pattern from other message handlers, are fully tested with isolated mocks, and add necessary functionality without modifying existing behavior. The error handling matches the existing codebase patterns, and the test coverage verifies the critical assertion that `recordSessionMetaFromInbound` is called with the correct `OriginatingChannel` value.
- No files require special attention

<sub>Last reviewed commit: 47ac822</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->