### PR TITLE
Matrix: ensure optional Matrix SDK (incl. crypto) is installed at runtime

### DIFF
--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -2,6 +2,7 @@ import { format } from "node:util";
 import { mergeAllowlist, summarizeMapping, type RuntimeEnv } from "openclaw/plugin-sdk";
 import { resolveMatrixTargets } from "../../resolve-targets.js";
 import { getMatrixRuntime } from "../../runtime.js";
+import { ensureMatrixSdkInstalled } from "../deps.js";
 import type { CoreConfig, ReplyToMode } from "../../types.js";
 import { resolveMatrixAccount } from "../accounts.js";
 import { setActiveMatrixClient } from "../active-client.js";
@@ -52,6 +53,8 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       throw new Error(`exit ${code}`);
     },
   };
+  await ensureMatrixSdkInstalled({ runtime });
+
   const logVerboseMessage = (message: string) => {
     if (!core.logging.shouldLogVerbose()) {
       return;

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -2,7 +2,6 @@ import { format } from "node:util";
 import { mergeAllowlist, summarizeMapping, type RuntimeEnv } from "openclaw/plugin-sdk";
 import { resolveMatrixTargets } from "../../resolve-targets.js";
 import { getMatrixRuntime } from "../../runtime.js";
-import { ensureMatrixSdkInstalled } from "../deps.js";
 import type { CoreConfig, ReplyToMode } from "../../types.js";
 import { resolveMatrixAccount } from "../accounts.js";
 import { setActiveMatrixClient } from "../active-client.js";
@@ -12,6 +11,7 @@ import {
   resolveSharedMatrixClient,
   stopSharedClientForAccount,
 } from "../client.js";
+import { ensureMatrixSdkInstalled } from "../deps.js";
 import { normalizeMatrixUserId } from "./allowlist.js";
 import { registerMatrixAutoJoin } from "./auto-join.js";
 import { createDirectRoomTracker } from "./direct.js";


### PR DESCRIPTION
## Summary
Describe the problem and fix in 2–5 bullets:
- Problem: Matrix channel relies on optional SDK packages that can disappear when `node_modules` is rebuilt (e.g. on update), leaving Matrix (especially E2EE) broken until deps are manually re-installed.
- Why it matters: Matrix may appear enabled in config but fail at runtime with missing SDK/crypto deps, which is subtle and confusing to debug.
- What changed: `monitorMatrixProvider(...)` now calls `ensureMatrixSdkInstalled({ runtime })` so the Matrix provider has a consistent runtime hook to ensure its SDK deps (incl. crypto) are present before client initialization.
- What did NOT change (scope boundary): No changes to Matrix config schema, no changes to other channels, no updater changes, and no new configuration flags or options.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution (Matrix channel plugin)
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Matrix)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #
- Related #

## User-visible / Behavior Changes
List user-visible changes (including defaults/config). If none, write `None`.

- For users with Matrix already configured and working, behavior should be unchanged in normal operation.
- On npm-installed instances where Matrix SDK deps were missing after an update, the Matrix provider now has a runtime hook to ensure deps exist at startup instead of silently failing.
- No new config options; no default changes.

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No (wires existing helper into provider)
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - N/A

## Repro + Verification

### Environment
- OS: Linux (x64)
- Runtime/container: Node 22.x, pnpm workspace
- Model/provider: N/A (Matrix plugin and core tests)
- Integration/channel (if any): Matrix
- Relevant config (redacted): Matrix channel enabled, default account

### Steps
1. Clone repo, checkout `fix/matrix-runtime-deps`.
2. Run:
   - `pnpm install`
   - `pnpm build`
   - `pnpm check`
3. Run tests:
   - `NODE_OPTIONS="--max-old-space-size=8192" pnpm test`
4. On a npm-installed instance, apply the same hook, ensure Matrix deps are installed, restart gateway, and verify Matrix (including encrypted rooms) works.

### Expected
- Build and `pnpm check` succeed.
- Matrix provider invokes `ensureMatrixSdkInstalled({ runtime })` once at startup.
- With Matrix SDK deps present, Matrix continues to work across updates without manual `npm install` fixes.

### Actual
- `pnpm build` and `pnpm check` pass on this branch.
- `pnpm test` passes for the vast majority of suites; remaining failures on this host are environment-specific and pre-existing (Matrix native crypto binding, ACP prompt-prefix path behavior, one Discord Jiti shared-state test), not caused by this change.

## Evidence
Attach at least one:
- [x] Failing test/log before + passing after (build/check + Matrix startup logs)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence:
- Before: Matrix startup after update showed missing crypto deps:
  "Failed to initialize crypto storage, E2EE disabled: Error: Cannot find module '@matrix-org/matrix-sdk-crypto-nodejs' ..."

- After: On the same instance, after applying the runtime hook + restoring deps:
  "MatrixClientLite End-to-end encryption enabled" for @botaccount:matrix.server.domain.

## Human Verification (required)
What you personally verified (not just CI), and how:
- Verified scenarios:
  - Matrix provider builds and type-checks with the `ensureMatrixSdkInstalled` hook wired into `monitorMatrixProvider`.
  - On a npm-installed instance, Matrix works again (including encrypted rooms) after applying this hook and ensuring SDK deps are present.
- Edge cases checked:
  - Matrix disabled in config: provider still exits early without attempting startup.
 - Multi-account Matrix config still passes through unchanged; hook is invoked at provider startup, not per account.
- What you did **not** verify:
  - Full Matrix E2EE flows across all platforms.
  - Behavior in environments where `ensureMatrixSdkInstalled` cannot install deps (read-only `node_modules`, no network, etc.).

## Compatibility / Migration
- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:
  - N/A

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly:
  - Revert the import and `await ensureMatrixSdkInstalled({ runtime })` call in `extensions/matrix/src/matrix/monitor/index.ts`, or temporarily pin to a prior release.
- Files/config to restore:
  - `extensions/matrix/src/matrix/monitor/index.ts`
- Known bad symptoms reviewers should watch for:
  - Matrix provider failing very early with errors from `ensureMatrixSdkInstalled` (e.g. inability to install deps in constrained environments).

## Risks and Mitigations
List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: On environments where `ensureMatrixSdkInstalled` attempts installation into read-only or locked `node_modules`, Matrix startup could fail more clearly instead of half-working.
  - Mitigation: The hook runs at provider startup (not per message), so failures are visible in logs; admins can pre-install deps or disable Matrix if environment cannot support on-demand installation.
- Risk: Slightly longer Matrix startup if deps are missing and must be installed.
  - Mitigation: This is typically a one-time cost per environment; subsequent startups should be fast once deps are present.

AI Assistance:
- This PR was prepared with AI assistance (OpenClaw agent).
- Testing level: lightly tested locally (pnpm build, pnpm check, pnpm test; some suites failing for pre-existing, environment-specific reasons). CI should validate the full test matrix.
- I have reviewed the diff and understand what the code does.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds runtime dependency installation hook for Matrix SDK to prevent silent failures when optional dependencies go missing after updates.

- The change adds `await ensureMatrixSdkInstalled({ runtime })` at extensions/matrix/src/matrix/monitor/index.ts:56, right after the runtime object is created and before any Matrix SDK usage
- This mirrors the existing pattern already used in the onboarding flow (extensions/matrix/src/onboarding.ts:201)
- The hook checks if `@vector-im/matrix-bot-sdk` is available, and if not, runs `pnpm install` or `npm install --omit=dev` to restore missing dependencies
- Placement is correct: SDK installation happens before the first SDK usage, which occurs when `resolveMatrixTargets` → `resolveMatrixAuth` → imports from `config.ts` → imports `MatrixClient` from the SDK
- No new security surface: uses existing `ensureMatrixSdkInstalled` helper with hardcoded commands and plugin-scoped cwd
- Import statement was reorganized (moved after client imports) for logical grouping

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal change with clear benefit and consistent with existing patterns
- The change is a simple two-line addition (one import, one function call) that addresses a real problem with missing optional dependencies. The implementation reuses an existing, well-tested helper function (`ensureMatrixSdkInstalled`) that's already used in the onboarding flow. The placement is correct (after runtime creation, before SDK usage), the security surface is unchanged (no new command execution risks beyond what already exists), and the change is backward compatible. The PR description indicates manual testing was performed and the change aligns with the repository's architectural patterns.
- No files require special attention

<sub>Last reviewed commit: 386b2aa</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->