### PR TITLE
test(nodes-camera): guard optional response in invalid-url cases

### DIFF
--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -172,7 +172,7 @@ describe("nodes camera helpers", () => {
     ] as const;
 
     for (const testCase of cases) {
-      if (testCase.response) {
+      if ("response" in testCase && testCase.response) {
         stubFetchResponse(testCase.response);
       }
       await expect(writeUrlToFile("/tmp/ignored", testCase.url), testCase.name).rejects.toThrow(


### PR DESCRIPTION
## Summary
`pnpm tsgo` currently fails on `origin/main` due to a TypeScript union narrowing error in `src/cli/nodes-camera.test.ts`:

- `TS2339: Property 'response' does not exist on type ...`

This blocks the autonomous quality gate at the baseline step.

## Fix
- Narrow the case object before reading `response`:
  - from: `if (testCase.response) { ... }`
  - to: `if ("response" in testCase && testCase.response) { ... }`

This keeps behavior unchanged while satisfying TypeScript's discriminated-union safety.

## Validation
Ran full quality gate in a fresh `origin/main` worktree after the fix:

- `pnpm build` ✅
- `pnpm format:check` ✅ (advisory)
- `pnpm tsgo` ✅
- `pnpm lint` ✅
- `pnpm test` ✅

Log: `.openclaw-artifacts/quality-gates/gate-20260221-174132.log`

## AI-assisted disclosure
This change was prepared with assistance from the OpenClaw autonomous contributor loop.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes TypeScript discriminated union narrowing error in `src/cli/nodes-camera.test.ts:175` by adding explicit property check before accessing optional `response` field. The test table includes cases where `response` is optional (e.g., the "non-https url" case doesn't need a mock response), so TypeScript requires narrowing the union type before property access.

The fix changes from `if (testCase.response)` to `if ("response" in testCase && testCase.response)` which properly narrows the type using a property existence check before the truthy check. This is the standard pattern for discriminated unions with optional properties and maintains identical runtime behavior while satisfying TypeScript's type safety requirements.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a minimal, type-safe fix that addresses a TypeScript compiler error without altering runtime behavior. The author validated the fix through the full quality gate pipeline (build, format, tsgo, lint, test), and the change follows TypeScript best practices for discriminated union narrowing. The fix is localized to a single test file and uses the standard `"property" in object` pattern for type guards.
- No files require special attention

<sub>Last reviewed commit: 1f11978</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->