### PR TITLE
fix(ui): strip reply directive tags from assistant messages in WebChat [AI-assisted]

### DIFF
--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,5 +1,6 @@
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
+import { stripInlineDirectiveTagsForDisplay } from "../../../../src/utils/directive-tags.js";
 import { stripThinkingTags } from "../format.ts";
 
 const textCache = new WeakMap<object, string | null>();
@@ -13,7 +14,7 @@ export function extractText(message: unknown): string | null {
   if (typeof content === "string") {
     const processed =
       role === "assistant"
-        ? stripThinkingTags(content)
+        ? stripInlineDirectiveTagsForDisplay(stripThinkingTags(content)).text
         : shouldStripInboundMetadata
           ? stripInboundMetadata(stripEnvelope(content))
           : stripEnvelope(content);
@@ -33,7 +34,7 @@ export function extractText(message: unknown): string | null {
       const joined = parts.join("\n");
       const processed =
         role === "assistant"
-          ? stripThinkingTags(joined)
+          ? stripInlineDirectiveTagsForDisplay(stripThinkingTags(joined)).text
           : shouldStripInboundMetadata
             ? stripInboundMetadata(stripEnvelope(joined))
             : stripEnvelope(joined);
@@ -43,7 +44,7 @@ export function extractText(message: unknown): string | null {
   if (typeof m.text === "string") {
     const processed =
       role === "assistant"
-        ? stripThinkingTags(m.text)
+        ? stripInlineDirectiveTagsForDisplay(stripThinkingTags(m.text)).text
         : shouldStripInboundMetadata
           ? stripInboundMetadata(stripEnvelope(m.text))
           : stripEnvelope(m.text);


### PR DESCRIPTION
## Summary

Fixes #23053

The `[[reply_to_current]]` tag was appearing in WebChat messages after finalization, even though it was correctly stripped during streaming.

## Root Cause

The frontend's `extractText()` function in `ui/src/ui/chat/message-extract.ts` was only stripping `<thinking>` tags from assistant messages, but NOT directive tags like `[[reply_to_current]]` or `[[audio_inline:...]]`.

While the server-side `chat.history` endpoint correctly strips these tags via `stripInlineDirectiveTagsForDisplay()`, the UI's text extraction was processing messages without this step.

## Fix

Import and apply `stripInlineDirectiveTagsForDisplay()` to assistant message text extraction (3 code paths in `extractText()`).

## Testing

- [x] Verified via tsx import that tags are stripped
- [x] `pnpm check` passes (format + lint)
- [ ] Full test suite (browser tests require display)

## AI Disclosure 🤖

This PR was created with AI assistance (Claude/OpenClaw). The fix was:
- **Identified** by tracing the data flow from server to UI rendering
- **Implemented** by following the existing pattern for tag stripping
- **Tested** via tsx import verification

I understand what the code does: it adds the same tag-stripping function used server-side to the frontend's text extraction for assistant messages, ensuring consistency between streaming and finalized message display.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `stripInlineDirectiveTagsForDisplay()` to frontend's `extractText()` function to remove directive tags like `[[reply_to_current]]` and `[[audio_as_voice]]` from assistant messages. Previously only `<thinking>` tags were stripped on the frontend, while the server-side chat history endpoint correctly removed directive tags, causing inconsistency between streaming and finalized message display.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that adds consistent tag-stripping behavior already used server-side. The implementation correctly applies the same function in all three code paths for assistant messages, follows existing patterns, and addresses a clear display inconsistency issue without introducing new functionality or complexity.
- No files require special attention

<sub>Last reviewed commit: e945350</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->