### PR TITLE
fix(skills): fallback to npm for summarize skill on non-darwin systems

### DIFF
--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -13,9 +13,17 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin"],
               "formula": "steipete/tap/summarize",
               "bins": ["summarize"],
               "label": "Install summarize (brew)",
+            },
+            {
+              "id": "npm",
+              "kind": "node",
+              "package": "@steipete/summarize",
+              "bins": ["summarize"],
+              "label": "Install summarize (npm)",
             },
           ],
       },


### PR DESCRIPTION
# Pull Request Draft: Fix summarize skill installation on Linux/Docker

**Title:** fix(skills): fallback to npm for summarize skill on non-darwin systems (#<issue-number>)

**Description:**

Fixes #<issue-number>

### The Issue
When running OpenClaw in a user-scoped Docker container (like WSL2), the `summarize` skill fails to install with an `EACCES` permission denied error (exit 243). 

This happens because the `SKILL.md` strictly specified the `steipete/tap/summarize` Homebrew formula over the npm method. The formula is restricted to `arm64` Apple Silicon, causing the runtime installer to fail on `x86_64` Linux/Docker environments. Furthermore, even if it falls back to NPM, a raw global `npm install -g` attempt without proper prefixing causes `EACCES` errors when running as an unprivileged `node` user in Docker containers.

### The Fix
This PR restricts the `brew` installation method in `SKILL.md` explicitly to `"os": ["darwin"]`. 

By doing this, the OpenClaw runtime correctly skips `brew` entirely on Linux/Docker environments and safely falls back to the Node.js installation method (`@steipete/summarize`), matching the behavior of other Node-based skills like `mcporter`.

### Note for Docker Users
To prevent the `EACCES` error during global Node.js skill installation at runtime, Docker setups running under an unprivileged user (like the `node` user) should set a user-owned global NPM prefix in their Dockerfile or Compose environment:

```dockerfile
# Configure npm global prefix for the node user to avoid EACCES errors
ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
ENV PATH="/home/node/.npm-global/bin:${PATH}"
```

### AI Assistance
- [x] Marked as AI-assisted (Generated with Gemini Antigravity)
- [x] Tested locally in a Linux WSL2 Docker container
- [x] Confirmed the code changes are understood and safe for macOS `arm64` users

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `summarize` skill installation on non-macOS platforms (Linux/Docker) by making two changes to `skills/summarize/SKILL.md`:

1. **Restricts the Homebrew install spec to macOS** by adding `"os": ["darwin"]` — the `steipete/tap/summarize` formula only works on Apple Silicon anyway, so the runtime now correctly skips it on Linux.
2. **Adds an npm fallback install spec** with `"kind": "node"` and `"package": "@steipete/summarize"` — this provides a universal installation path that works on all platforms.

Both changes follow established patterns in the codebase: the `sherpa-onnx-tts` skill already uses per-spec `"os"` filtering, and `mcporter` uses the same `"kind": "node"` install structure. The runtime's `normalizeInstallOptions()` in `skills-status.ts` correctly filters install specs by OS before presenting them, and `selectPreferredInstallSpec()` has built-in logic to prefer node over an unavailable brew spec.

- No issues or bugs found in this change.
- The JSON5 structure is valid and consistent with other SKILL.md files.
- On macOS, both brew and npm options will remain available; the preference logic correctly handles selection.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal metadata-only change to a SKILL.md file with no code logic modifications.
- The change is confined to a single declarative metadata file (SKILL.md). It follows established patterns used by other skills in the repository (sherpa-onnx-tts for OS filtering, mcporter for node install specs). The runtime already supports all the fields used. No new code logic is introduced, and the existing platform filtering and preference selection mechanisms handle the new configuration correctly.
- No files require special attention.

<sub>Last reviewed commit: 4dd9fe0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->