### PR TITLE
feat(config): add per-channel maxConcurrentPerConversation override [AI Assisted]

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -10,11 +10,16 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../auto-reply/heartbeat.js";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
+import { resolveAgentMaxConcurrentPerConversation } from "../../config/agent-limits.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
+import {
+  type enqueueCommand,
+  enqueueCommandInLane,
+  setCommandLaneConcurrency,
+} from "../../process/command-queue.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../telegram/inline-buttons.js";
@@ -68,7 +73,12 @@ import {
   sanitizeToolsForGoogle,
 } from "./google.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
-import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
+import {
+  parseConversationPartsFromSessionKey,
+  resolveConversationLane,
+  resolveGlobalLane,
+  resolveSessionLane,
+} from "./lanes.js";
 import { log } from "./logger.js";
 import { buildModelAliasLines, resolveModel } from "./model.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
@@ -749,9 +759,21 @@ export async function compactEmbeddedPiSession(
 ): Promise<EmbeddedPiCompactResult> {
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
   const globalLane = resolveGlobalLane(params.lane);
+  const convParts = parseConversationPartsFromSessionKey(params.sessionKey);
+  const convLane = resolveConversationLane({
+    channel: params.messageChannel ?? convParts.channel,
+    accountId: params.agentAccountId,
+    peerId: convParts.peerId,
+  });
+  if (convLane) {
+    setCommandLaneConcurrency(convLane, resolveAgentMaxConcurrentPerConversation(params.config));
+  }
   const enqueueGlobal =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
+  const enqueueConv = convLane
+    ? <T>(task: () => Promise<T>) => enqueueCommandInLane(convLane, task)
+    : <T>(task: () => Promise<T>) => task();
   return enqueueCommandInLane(sessionLane, () =>
-    enqueueGlobal(async () => compactEmbeddedPiSessionDirect(params)),
+    enqueueConv(() => enqueueGlobal(async () => compactEmbeddedPiSessionDirect(params))),
   );
 }

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -10,7 +10,7 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../auto-reply/heartbeat.js";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
-import { resolveAgentMaxConcurrentPerConversation } from "../../config/agent-limits.js";
+import { resolveMaxConcurrentPerConversation } from "../../config/agent-limits.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
@@ -766,7 +766,15 @@ export async function compactEmbeddedPiSession(
     peerId: convParts.peerId,
   });
   if (convLane) {
-    setCommandLaneConcurrency(convLane, resolveAgentMaxConcurrentPerConversation(params.config));
+    setCommandLaneConcurrency(
+      convLane,
+      resolveMaxConcurrentPerConversation({
+        cfg: params.config,
+        channel: params.messageChannel ?? convParts.channel,
+        groupSpace: params.groupSpace,
+        peerId: convParts.peerId,
+      }),
+    );
   }
   const enqueueGlobal =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));

--- a/src/agents/pi-embedded-runner/lanes.test.ts
+++ b/src/agents/pi-embedded-runner/lanes.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { resolveConversationLane, parseConversationPartsFromSessionKey } from "./lanes.js";
+
+describe("resolveConversationLane", () => {
+  it("builds lane key from channel + accountId + peerId", () => {
+    expect(
+      resolveConversationLane({
+        channel: "discord",
+        accountId: "acct1",
+        peerId: "C12345",
+      }),
+    ).toBe("conv:discord:acct1:c12345");
+  });
+
+  it("defaults accountId to 'default'", () => {
+    expect(resolveConversationLane({ channel: "telegram", peerId: "G999" })).toBe(
+      "conv:telegram:default:g999",
+    );
+  });
+
+  it("returns empty string when both channel and peerId are missing", () => {
+    expect(resolveConversationLane({})).toBe("");
+    expect(resolveConversationLane({ accountId: "acct" })).toBe("");
+  });
+
+  it("uses 'unknown' when channel is missing but peerId is present", () => {
+    expect(resolveConversationLane({ peerId: "C123" })).toBe("conv:unknown:default:c123");
+  });
+
+  it("uses 'unknown' when peerId is missing but channel is present", () => {
+    expect(resolveConversationLane({ channel: "discord" })).toBe("conv:discord:default:unknown");
+  });
+
+  it("lowercases all parts", () => {
+    expect(
+      resolveConversationLane({
+        channel: "Discord",
+        accountId: "ACCT",
+        peerId: "ABC",
+      }),
+    ).toBe("conv:discord:acct:abc");
+  });
+
+  it("trims whitespace", () => {
+    expect(
+      resolveConversationLane({
+        channel: "  discord  ",
+        peerId: "  C1  ",
+      }),
+    ).toBe("conv:discord:default:c1");
+  });
+});
+
+describe("parseConversationPartsFromSessionKey", () => {
+  it("extracts channel and peerId from a well-formed session key", () => {
+    const result = parseConversationPartsFromSessionKey("agent:main:discord:channel:c12345");
+    expect(result).toEqual({ channel: "discord", peerId: "c12345" });
+  });
+
+  it("returns empty strings for undefined input", () => {
+    expect(parseConversationPartsFromSessionKey(undefined)).toEqual({
+      channel: "",
+      peerId: "",
+    });
+  });
+
+  it("returns empty strings for empty input", () => {
+    expect(parseConversationPartsFromSessionKey("")).toEqual({
+      channel: "",
+      peerId: "",
+    });
+  });
+
+  it("returns empty strings for non-agent keys", () => {
+    expect(parseConversationPartsFromSessionKey("session:something")).toEqual({
+      channel: "",
+      peerId: "",
+    });
+  });
+
+  it("returns empty strings for short agent keys", () => {
+    expect(parseConversationPartsFromSessionKey("agent:main:discord")).toEqual({
+      channel: "",
+      peerId: "",
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/lanes.ts
+++ b/src/agents/pi-embedded-runner/lanes.ts
@@ -13,3 +13,32 @@ export function resolveGlobalLane(lane?: string) {
 export function resolveEmbeddedSessionLane(key: string) {
   return resolveSessionLane(key);
 }
+
+export function resolveConversationLane(params: {
+  channel?: string;
+  accountId?: string;
+  peerId?: string;
+}): string {
+  const channel = (params.channel ?? "").trim().toLowerCase();
+  const accountId = (params.accountId ?? "").trim().toLowerCase() || "default";
+  const peerId = (params.peerId ?? "").trim().toLowerCase();
+  if (!channel && !peerId) {
+    return "";
+  }
+  return `conv:${channel || "unknown"}:${accountId}:${peerId || "unknown"}`;
+}
+
+export function parseConversationPartsFromSessionKey(sessionKey?: string): {
+  channel: string;
+  peerId: string;
+} {
+  const raw = (sessionKey ?? "").trim().toLowerCase();
+  if (!raw) {
+    return { channel: "", peerId: "" };
+  }
+  const parts = raw.split(":");
+  if (parts[0] !== "agent" || parts.length < 5) {
+    return { channel: "", peerId: "" };
+  }
+  return { channel: parts[2] ?? "", peerId: parts[4] ?? "" };
+}

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import { resolveAgentMaxConcurrentPerConversation } from "../../config/agent-limits.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { enqueueCommandInLane, setCommandLaneConcurrency } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import {
@@ -46,7 +47,7 @@ import {
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { compactEmbeddedPiSessionDirect } from "./compact.js";
-import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
+import { resolveConversationLane, resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
@@ -189,10 +190,21 @@ export async function runEmbeddedPiAgent(
 ): Promise<EmbeddedPiRunResult> {
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
   const globalLane = resolveGlobalLane(params.lane);
+  const convLane = resolveConversationLane({
+    channel: params.messageChannel,
+    accountId: params.agentAccountId,
+    peerId: params.messageTo,
+  });
+  if (convLane) {
+    setCommandLaneConcurrency(convLane, resolveAgentMaxConcurrentPerConversation(params.config));
+  }
   const enqueueGlobal =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
   const enqueueSession =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(sessionLane, task, opts));
+  const enqueueConv = convLane
+    ? <T>(task: () => Promise<T>) => enqueueCommandInLane(convLane, task)
+    : <T>(task: () => Promise<T>) => task();
   const channelHint = params.messageChannel ?? params.messageProvider;
   const resolvedToolResultFormat =
     params.toolResultFormat ??
@@ -204,872 +216,919 @@ export async function runEmbeddedPiAgent(
   const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
 
   return enqueueSession(() =>
-    enqueueGlobal(async () => {
-      const started = Date.now();
-      const workspaceResolution = resolveRunWorkspaceDir({
-        workspaceDir: params.workspaceDir,
-        sessionKey: params.sessionKey,
-        agentId: params.agentId,
-        config: params.config,
-      });
-      const resolvedWorkspace = workspaceResolution.workspaceDir;
-      const redactedSessionId = redactRunIdentifier(params.sessionId);
-      const redactedSessionKey = redactRunIdentifier(params.sessionKey);
-      const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
-      if (workspaceResolution.usedFallback) {
-        log.warn(
-          `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
-        );
-      }
-      const prevCwd = process.cwd();
-
-      let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
-      const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-      const fallbackConfigured =
-        (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
-      await ensureOpenClawModelsJson(params.config, agentDir);
-
-      // Run before_model_resolve hooks early so plugins can override the
-      // provider/model before resolveModel().
-      //
-      // Legacy compatibility: before_agent_start is also checked for override
-      // fields if present. New hook takes precedence when both are set.
-      let modelResolveOverride: { providerOverride?: string; modelOverride?: string } | undefined;
-      const hookRunner = getGlobalHookRunner();
-      const hookCtx = {
-        agentId: workspaceResolution.agentId,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        workspaceDir: resolvedWorkspace,
-        messageProvider: params.messageProvider ?? undefined,
-      };
-      if (hookRunner?.hasHooks("before_model_resolve")) {
-        try {
-          modelResolveOverride = await hookRunner.runBeforeModelResolve(
-            { prompt: params.prompt },
-            hookCtx,
-          );
-        } catch (hookErr) {
-          log.warn(`before_model_resolve hook failed: ${String(hookErr)}`);
-        }
-      }
-      if (hookRunner?.hasHooks("before_agent_start")) {
-        try {
-          const legacyResult = await hookRunner.runBeforeAgentStart(
-            { prompt: params.prompt },
-            hookCtx,
-          );
-          modelResolveOverride = {
-            providerOverride:
-              modelResolveOverride?.providerOverride ?? legacyResult?.providerOverride,
-            modelOverride: modelResolveOverride?.modelOverride ?? legacyResult?.modelOverride,
-          };
-        } catch (hookErr) {
+    enqueueConv(() =>
+      enqueueGlobal(async () => {
+        const started = Date.now();
+        const workspaceResolution = resolveRunWorkspaceDir({
+          workspaceDir: params.workspaceDir,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
+          config: params.config,
+        });
+        const resolvedWorkspace = workspaceResolution.workspaceDir;
+        const redactedSessionId = redactRunIdentifier(params.sessionId);
+        const redactedSessionKey = redactRunIdentifier(params.sessionKey);
+        const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
+        if (workspaceResolution.usedFallback) {
           log.warn(
-            `before_agent_start hook (legacy model resolve path) failed: ${String(hookErr)}`,
+            `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
           );
         }
-      }
-      if (modelResolveOverride?.providerOverride) {
-        provider = modelResolveOverride.providerOverride;
-        log.info(`[hooks] provider overridden to ${provider}`);
-      }
-      if (modelResolveOverride?.modelOverride) {
-        modelId = modelResolveOverride.modelOverride;
-        log.info(`[hooks] model overridden to ${modelId}`);
-      }
+        const prevCwd = process.cwd();
 
-      const { model, error, authStorage, modelRegistry } = resolveModel(
-        provider,
-        modelId,
-        agentDir,
-        params.config,
-      );
-      if (!model) {
-        throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
-          reason: "model_not_found",
-          provider,
-          model: modelId,
-        });
-      }
+        let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
+        let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+        const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
+        const fallbackConfigured =
+          (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
+        await ensureOpenClawModelsJson(params.config, agentDir);
 
-      const ctxInfo = resolveContextWindowInfo({
-        cfg: params.config,
-        provider,
-        modelId,
-        modelContextWindow: model.contextWindow,
-        defaultTokens: DEFAULT_CONTEXT_TOKENS,
-      });
-      const ctxGuard = evaluateContextWindowGuard({
-        info: ctxInfo,
-        warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
-        hardMinTokens: CONTEXT_WINDOW_HARD_MIN_TOKENS,
-      });
-      if (ctxGuard.shouldWarn) {
-        log.warn(
-          `low context window: ${provider}/${modelId} ctx=${ctxGuard.tokens} (warn<${CONTEXT_WINDOW_WARN_BELOW_TOKENS}) source=${ctxGuard.source}`,
-        );
-      }
-      if (ctxGuard.shouldBlock) {
-        log.error(
-          `blocked model (context window too small): ${provider}/${modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}`,
-        );
-        throw new FailoverError(
-          `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
-          { reason: "unknown", provider, model: modelId },
-        );
-      }
-
-      const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
-      const preferredProfileId = params.authProfileId?.trim();
-      let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;
-      if (lockedProfileId) {
-        const lockedProfile = authStore.profiles[lockedProfileId];
-        if (
-          !lockedProfile ||
-          normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
-        ) {
-          lockedProfileId = undefined;
-        }
-      }
-      const profileOrder = resolveAuthProfileOrder({
-        cfg: params.config,
-        store: authStore,
-        provider,
-        preferredProfile: preferredProfileId,
-      });
-      if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
-        throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
-      }
-      const profileCandidates = lockedProfileId
-        ? [lockedProfileId]
-        : profileOrder.length > 0
-          ? profileOrder
-          : [undefined];
-      let profileIndex = 0;
-
-      const initialThinkLevel = params.thinkLevel ?? "off";
-      let thinkLevel = initialThinkLevel;
-      const attemptedThinking = new Set<ThinkLevel>();
-      let apiKeyInfo: ApiKeyInfo | null = null;
-      let lastProfileId: string | undefined;
-
-      const resolveAuthProfileFailoverReason = (params: {
-        allInCooldown: boolean;
-        message: string;
-      }): FailoverReason => {
-        if (params.allInCooldown) {
-          return "rate_limit";
-        }
-        const classified = classifyFailoverReason(params.message);
-        return classified ?? "auth";
-      };
-
-      const throwAuthProfileFailover = (params: {
-        allInCooldown: boolean;
-        message?: string;
-        error?: unknown;
-      }): never => {
-        const fallbackMessage = `No available auth profile for ${provider} (all in cooldown or unavailable).`;
-        const message =
-          params.message?.trim() ||
-          (params.error ? describeUnknownError(params.error).trim() : "") ||
-          fallbackMessage;
-        const reason = resolveAuthProfileFailoverReason({
-          allInCooldown: params.allInCooldown,
-          message,
-        });
-        if (fallbackConfigured) {
-          throw new FailoverError(message, {
-            reason,
-            provider,
-            model: modelId,
-            status: resolveFailoverStatus(reason),
-            cause: params.error,
-          });
-        }
-        if (params.error instanceof Error) {
-          throw params.error;
-        }
-        throw new Error(message);
-      };
-
-      const resolveApiKeyForCandidate = async (candidate?: string) => {
-        return getApiKeyForModel({
-          model,
-          cfg: params.config,
-          profileId: candidate,
-          store: authStore,
-          agentDir,
-        });
-      };
-
-      const applyApiKeyInfo = async (candidate?: string): Promise<void> => {
-        apiKeyInfo = await resolveApiKeyForCandidate(candidate);
-        const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
-        if (!apiKeyInfo.apiKey) {
-          if (apiKeyInfo.mode !== "aws-sdk") {
-            throw new Error(
-              `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
-            );
-          }
-          lastProfileId = resolvedProfileId;
-          return;
-        }
-        if (model.provider === "github-copilot") {
-          const { resolveCopilotApiToken } =
-            await import("../../providers/github-copilot-token.js");
-          const copilotToken = await resolveCopilotApiToken({
-            githubToken: apiKeyInfo.apiKey,
-          });
-          authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
-        } else {
-          authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
-        }
-        lastProfileId = apiKeyInfo.profileId;
-      };
-
-      const advanceAuthProfile = async (): Promise<boolean> => {
-        if (lockedProfileId) {
-          return false;
-        }
-        let nextIndex = profileIndex + 1;
-        while (nextIndex < profileCandidates.length) {
-          const candidate = profileCandidates[nextIndex];
-          if (candidate && isProfileInCooldown(authStore, candidate)) {
-            nextIndex += 1;
-            continue;
-          }
+        // Run before_model_resolve hooks early so plugins can override the
+        // provider/model before resolveModel().
+        //
+        // Legacy compatibility: before_agent_start is also checked for override
+        // fields if present. New hook takes precedence when both are set.
+        let modelResolveOverride: { providerOverride?: string; modelOverride?: string } | undefined;
+        const hookRunner = getGlobalHookRunner();
+        const hookCtx = {
+          agentId: workspaceResolution.agentId,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          workspaceDir: resolvedWorkspace,
+          messageProvider: params.messageProvider ?? undefined,
+        };
+        if (hookRunner?.hasHooks("before_model_resolve")) {
           try {
-            await applyApiKeyInfo(candidate);
-            profileIndex = nextIndex;
-            thinkLevel = initialThinkLevel;
-            attemptedThinking.clear();
-            return true;
-          } catch (err) {
-            if (candidate && candidate === lockedProfileId) {
-              throw err;
-            }
-            nextIndex += 1;
-          }
-        }
-        return false;
-      };
-
-      try {
-        while (profileIndex < profileCandidates.length) {
-          const candidate = profileCandidates[profileIndex];
-          if (
-            candidate &&
-            candidate !== lockedProfileId &&
-            isProfileInCooldown(authStore, candidate)
-          ) {
-            profileIndex += 1;
-            continue;
-          }
-          await applyApiKeyInfo(profileCandidates[profileIndex]);
-          break;
-        }
-        if (profileIndex >= profileCandidates.length) {
-          throwAuthProfileFailover({ allInCooldown: true });
-        }
-      } catch (err) {
-        if (err instanceof FailoverError) {
-          throw err;
-        }
-        if (profileCandidates[profileIndex] === lockedProfileId) {
-          throwAuthProfileFailover({ allInCooldown: false, error: err });
-        }
-        const advanced = await advanceAuthProfile();
-        if (!advanced) {
-          throwAuthProfileFailover({ allInCooldown: false, error: err });
-        }
-      }
-
-      const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
-      const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
-      let overflowCompactionAttempts = 0;
-      let toolResultTruncationAttempted = false;
-      const usageAccumulator = createUsageAccumulator();
-      let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
-      let autoCompactionCount = 0;
-      let runLoopIterations = 0;
-      try {
-        while (true) {
-          if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
-            const message =
-              `Exceeded retry limit after ${runLoopIterations} attempts ` +
-              `(max=${MAX_RUN_LOOP_ITERATIONS}).`;
-            log.error(
-              `[run-retry-limit] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `provider=${provider}/${modelId} attempts=${runLoopIterations} ` +
-                `maxAttempts=${MAX_RUN_LOOP_ITERATIONS}`,
+            modelResolveOverride = await hookRunner.runBeforeModelResolve(
+              { prompt: params.prompt },
+              hookCtx,
             );
-            return {
-              payloads: [
-                {
-                  text:
-                    "Request failed after repeated internal retries. " +
-                    "Please try again, or use /new to start a fresh session.",
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta: {
-                  sessionId: params.sessionId,
-                  provider,
-                  model: model.id,
-                },
-                error: { kind: "retry_limit", message },
-              },
-            };
+          } catch (hookErr) {
+            log.warn(`before_model_resolve hook failed: ${String(hookErr)}`);
           }
-          runLoopIterations += 1;
-          attemptedThinking.add(thinkLevel);
-          await fs.mkdir(resolvedWorkspace, { recursive: true });
+        }
+        if (hookRunner?.hasHooks("before_agent_start")) {
+          try {
+            const legacyResult = await hookRunner.runBeforeAgentStart(
+              { prompt: params.prompt },
+              hookCtx,
+            );
+            modelResolveOverride = {
+              providerOverride:
+                modelResolveOverride?.providerOverride ?? legacyResult?.providerOverride,
+              modelOverride: modelResolveOverride?.modelOverride ?? legacyResult?.modelOverride,
+            };
+          } catch (hookErr) {
+            log.warn(
+              `before_agent_start hook (legacy model resolve path) failed: ${String(hookErr)}`,
+            );
+          }
+        }
+        if (modelResolveOverride?.providerOverride) {
+          provider = modelResolveOverride.providerOverride;
+          log.info(`[hooks] provider overridden to ${provider}`);
+        }
+        if (modelResolveOverride?.modelOverride) {
+          modelId = modelResolveOverride.modelOverride;
+          log.info(`[hooks] model overridden to ${modelId}`);
+        }
 
-          const prompt =
-            provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
-
-          const attempt = await runEmbeddedAttempt({
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            messageChannel: params.messageChannel,
-            messageProvider: params.messageProvider,
-            agentAccountId: params.agentAccountId,
-            messageTo: params.messageTo,
-            messageThreadId: params.messageThreadId,
-            groupId: params.groupId,
-            groupChannel: params.groupChannel,
-            groupSpace: params.groupSpace,
-            spawnedBy: params.spawnedBy,
-            senderIsOwner: params.senderIsOwner,
-            currentChannelId: params.currentChannelId,
-            currentThreadTs: params.currentThreadTs,
-            replyToMode: params.replyToMode,
-            hasRepliedRef: params.hasRepliedRef,
-            sessionFile: params.sessionFile,
-            workspaceDir: resolvedWorkspace,
-            agentDir,
-            config: params.config,
-            skillsSnapshot: params.skillsSnapshot,
-            prompt,
-            images: params.images,
-            disableTools: params.disableTools,
-            provider,
-            modelId,
-            model,
-            authStorage,
-            modelRegistry,
-            agentId: workspaceResolution.agentId,
-            thinkLevel,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            execOverrides: params.execOverrides,
-            bashElevated: params.bashElevated,
-            timeoutMs: params.timeoutMs,
-            runId: params.runId,
-            abortSignal: params.abortSignal,
-            shouldEmitToolResult: params.shouldEmitToolResult,
-            shouldEmitToolOutput: params.shouldEmitToolOutput,
-            onPartialReply: params.onPartialReply,
-            onAssistantMessageStart: params.onAssistantMessageStart,
-            onBlockReply: params.onBlockReply,
-            onBlockReplyFlush: params.onBlockReplyFlush,
-            blockReplyBreak: params.blockReplyBreak,
-            blockReplyChunking: params.blockReplyChunking,
-            onReasoningStream: params.onReasoningStream,
-            onReasoningEnd: params.onReasoningEnd,
-            onToolResult: params.onToolResult,
-            onAgentEvent: params.onAgentEvent,
-            extraSystemPrompt: params.extraSystemPrompt,
-            inputProvenance: params.inputProvenance,
-            streamParams: params.streamParams,
-            ownerNumbers: params.ownerNumbers,
-            enforceFinalTag: params.enforceFinalTag,
-          });
-
-          const {
-            aborted,
-            promptError,
-            timedOut,
-            timedOutDuringCompaction,
-            sessionIdUsed,
-            lastAssistant,
-          } = attempt;
-          const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
-          const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
-          mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
-          // Keep prompt size from the latest model call so session totalTokens
-          // reflects current context usage, not accumulated tool-loop usage.
-          lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
-          const lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
-          const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
-          autoCompactionCount += attemptCompactionCount;
-          const activeErrorContext = resolveActiveErrorContext({
-            lastAssistant,
+        const { model, error, authStorage, modelRegistry } = resolveModel(
+          provider,
+          modelId,
+          agentDir,
+          params.config,
+        );
+        if (!model) {
+          throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
+            reason: "model_not_found",
             provider,
             model: modelId,
           });
-          const formattedAssistantErrorText = lastAssistant
-            ? formatAssistantErrorText(lastAssistant, {
-                cfg: params.config,
-                sessionKey: params.sessionKey ?? params.sessionId,
-                provider: activeErrorContext.provider,
-                model: activeErrorContext.model,
-              })
-            : undefined;
-          const assistantErrorText =
-            lastAssistant?.stopReason === "error"
-              ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
-              : undefined;
+        }
 
-          const contextOverflowError = !aborted
-            ? (() => {
-                if (promptError) {
-                  const errorText = describeUnknownError(promptError);
-                  if (isLikelyContextOverflowError(errorText)) {
-                    return { text: errorText, source: "promptError" as const };
-                  }
-                  // Prompt submission failed with a non-overflow error. Do not
-                  // inspect prior assistant errors from history for this attempt.
-                  return null;
-                }
-                if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
-                  return { text: assistantErrorText, source: "assistantError" as const };
-                }
-                return null;
-              })()
-            : null;
+        const ctxInfo = resolveContextWindowInfo({
+          cfg: params.config,
+          provider,
+          modelId,
+          modelContextWindow: model.contextWindow,
+          defaultTokens: DEFAULT_CONTEXT_TOKENS,
+        });
+        const ctxGuard = evaluateContextWindowGuard({
+          info: ctxInfo,
+          warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
+          hardMinTokens: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+        });
+        if (ctxGuard.shouldWarn) {
+          log.warn(
+            `low context window: ${provider}/${modelId} ctx=${ctxGuard.tokens} (warn<${CONTEXT_WINDOW_WARN_BELOW_TOKENS}) source=${ctxGuard.source}`,
+          );
+        }
+        if (ctxGuard.shouldBlock) {
+          log.error(
+            `blocked model (context window too small): ${provider}/${modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}`,
+          );
+          throw new FailoverError(
+            `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
+            { reason: "unknown", provider, model: modelId },
+          );
+        }
 
-          if (contextOverflowError) {
-            const overflowDiagId = createCompactionDiagId();
-            const errorText = contextOverflowError.text;
-            const msgCount = attempt.messagesSnapshot?.length ?? 0;
-            log.warn(
-              `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
-                `messages=${msgCount} sessionFile=${params.sessionFile} ` +
-                `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
-                `error=${errorText.slice(0, 200)}`,
-            );
-            const isCompactionFailure = isCompactionFailureError(errorText);
-            const hadAttemptLevelCompaction = attemptCompactionCount > 0;
-            // If this attempt already compacted (SDK auto-compaction), avoid immediately
-            // running another explicit compaction for the same overflow trigger.
-            if (
-              !isCompactionFailure &&
-              hadAttemptLevelCompaction &&
-              overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
-            ) {
-              overflowCompactionAttempts++;
-              log.warn(
-                `context overflow persisted after in-attempt compaction (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); retrying prompt without additional compaction for ${provider}/${modelId}`,
+        const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+        const preferredProfileId = params.authProfileId?.trim();
+        let lockedProfileId =
+          params.authProfileIdSource === "user" ? preferredProfileId : undefined;
+        if (lockedProfileId) {
+          const lockedProfile = authStore.profiles[lockedProfileId];
+          if (
+            !lockedProfile ||
+            normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
+          ) {
+            lockedProfileId = undefined;
+          }
+        }
+        const profileOrder = resolveAuthProfileOrder({
+          cfg: params.config,
+          store: authStore,
+          provider,
+          preferredProfile: preferredProfileId,
+        });
+        if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
+          throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
+        }
+        const profileCandidates = lockedProfileId
+          ? [lockedProfileId]
+          : profileOrder.length > 0
+            ? profileOrder
+            : [undefined];
+        let profileIndex = 0;
+
+        const initialThinkLevel = params.thinkLevel ?? "off";
+        let thinkLevel = initialThinkLevel;
+        const attemptedThinking = new Set<ThinkLevel>();
+        let apiKeyInfo: ApiKeyInfo | null = null;
+        let lastProfileId: string | undefined;
+
+        const resolveAuthProfileFailoverReason = (params: {
+          allInCooldown: boolean;
+          message: string;
+        }): FailoverReason => {
+          if (params.allInCooldown) {
+            return "rate_limit";
+          }
+          const classified = classifyFailoverReason(params.message);
+          return classified ?? "auth";
+        };
+
+        const throwAuthProfileFailover = (params: {
+          allInCooldown: boolean;
+          message?: string;
+          error?: unknown;
+        }): never => {
+          const fallbackMessage = `No available auth profile for ${provider} (all in cooldown or unavailable).`;
+          const message =
+            params.message?.trim() ||
+            (params.error ? describeUnknownError(params.error).trim() : "") ||
+            fallbackMessage;
+          const reason = resolveAuthProfileFailoverReason({
+            allInCooldown: params.allInCooldown,
+            message,
+          });
+          if (fallbackConfigured) {
+            throw new FailoverError(message, {
+              reason,
+              provider,
+              model: modelId,
+              status: resolveFailoverStatus(reason),
+              cause: params.error,
+            });
+          }
+          if (params.error instanceof Error) {
+            throw params.error;
+          }
+          throw new Error(message);
+        };
+
+        const resolveApiKeyForCandidate = async (candidate?: string) => {
+          return getApiKeyForModel({
+            model,
+            cfg: params.config,
+            profileId: candidate,
+            store: authStore,
+            agentDir,
+          });
+        };
+
+        const applyApiKeyInfo = async (candidate?: string): Promise<void> => {
+          apiKeyInfo = await resolveApiKeyForCandidate(candidate);
+          const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
+          if (!apiKeyInfo.apiKey) {
+            if (apiKeyInfo.mode !== "aws-sdk") {
+              throw new Error(
+                `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
               );
+            }
+            lastProfileId = resolvedProfileId;
+            return;
+          }
+          if (model.provider === "github-copilot") {
+            const { resolveCopilotApiToken } =
+              await import("../../providers/github-copilot-token.js");
+            const copilotToken = await resolveCopilotApiToken({
+              githubToken: apiKeyInfo.apiKey,
+            });
+            authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+          } else {
+            authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
+          }
+          lastProfileId = apiKeyInfo.profileId;
+        };
+
+        const advanceAuthProfile = async (): Promise<boolean> => {
+          if (lockedProfileId) {
+            return false;
+          }
+          let nextIndex = profileIndex + 1;
+          while (nextIndex < profileCandidates.length) {
+            const candidate = profileCandidates[nextIndex];
+            if (candidate && isProfileInCooldown(authStore, candidate)) {
+              nextIndex += 1;
               continue;
             }
-            // Attempt explicit overflow compaction only when this attempt did not
-            // already auto-compact.
-            if (
-              !isCompactionFailure &&
-              !hadAttemptLevelCompaction &&
-              overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
-            ) {
-              if (log.isEnabled("debug")) {
-                log.debug(
-                  `[compaction-diag] decision diagId=${overflowDiagId} branch=compact ` +
-                    `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
-                    `attempt=${overflowCompactionAttempts + 1} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
-                );
+            try {
+              await applyApiKeyInfo(candidate);
+              profileIndex = nextIndex;
+              thinkLevel = initialThinkLevel;
+              attemptedThinking.clear();
+              return true;
+            } catch (err) {
+              if (candidate && candidate === lockedProfileId) {
+                throw err;
               }
-              overflowCompactionAttempts++;
-              log.warn(
-                `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
+              nextIndex += 1;
+            }
+          }
+          return false;
+        };
+
+        try {
+          while (profileIndex < profileCandidates.length) {
+            const candidate = profileCandidates[profileIndex];
+            if (
+              candidate &&
+              candidate !== lockedProfileId &&
+              isProfileInCooldown(authStore, candidate)
+            ) {
+              profileIndex += 1;
+              continue;
+            }
+            await applyApiKeyInfo(profileCandidates[profileIndex]);
+            break;
+          }
+          if (profileIndex >= profileCandidates.length) {
+            throwAuthProfileFailover({ allInCooldown: true });
+          }
+        } catch (err) {
+          if (err instanceof FailoverError) {
+            throw err;
+          }
+          if (profileCandidates[profileIndex] === lockedProfileId) {
+            throwAuthProfileFailover({ allInCooldown: false, error: err });
+          }
+          const advanced = await advanceAuthProfile();
+          if (!advanced) {
+            throwAuthProfileFailover({ allInCooldown: false, error: err });
+          }
+        }
+
+        const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
+        const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
+        let overflowCompactionAttempts = 0;
+        let toolResultTruncationAttempted = false;
+        const usageAccumulator = createUsageAccumulator();
+        let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
+        let autoCompactionCount = 0;
+        let runLoopIterations = 0;
+        try {
+          while (true) {
+            if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
+              const message =
+                `Exceeded retry limit after ${runLoopIterations} attempts ` +
+                `(max=${MAX_RUN_LOOP_ITERATIONS}).`;
+              log.error(
+                `[run-retry-limit] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                  `provider=${provider}/${modelId} attempts=${runLoopIterations} ` +
+                  `maxAttempts=${MAX_RUN_LOOP_ITERATIONS}`,
               );
-              const compactResult = await compactEmbeddedPiSessionDirect({
-                sessionId: params.sessionId,
-                sessionKey: params.sessionKey,
-                messageChannel: params.messageChannel,
-                messageProvider: params.messageProvider,
-                agentAccountId: params.agentAccountId,
-                authProfileId: lastProfileId,
-                sessionFile: params.sessionFile,
-                workspaceDir: resolvedWorkspace,
-                agentDir,
-                config: params.config,
-                skillsSnapshot: params.skillsSnapshot,
-                senderIsOwner: params.senderIsOwner,
-                provider,
-                model: modelId,
-                runId: params.runId,
-                thinkLevel,
-                reasoningLevel: params.reasoningLevel,
-                bashElevated: params.bashElevated,
-                extraSystemPrompt: params.extraSystemPrompt,
-                ownerNumbers: params.ownerNumbers,
-                trigger: "overflow",
-                diagId: overflowDiagId,
-                attempt: overflowCompactionAttempts,
-                maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
-              });
-              if (compactResult.compacted) {
-                autoCompactionCount += 1;
-                log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
+              return {
+                payloads: [
+                  {
+                    text:
+                      "Request failed after repeated internal retries. " +
+                      "Please try again, or use /new to start a fresh session.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: {
+                    sessionId: params.sessionId,
+                    provider,
+                    model: model.id,
+                  },
+                  error: { kind: "retry_limit", message },
+                },
+              };
+            }
+            runLoopIterations += 1;
+            attemptedThinking.add(thinkLevel);
+            await fs.mkdir(resolvedWorkspace, { recursive: true });
+
+            const prompt =
+              provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
+
+            const attempt = await runEmbeddedAttempt({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              messageChannel: params.messageChannel,
+              messageProvider: params.messageProvider,
+              agentAccountId: params.agentAccountId,
+              messageTo: params.messageTo,
+              messageThreadId: params.messageThreadId,
+              groupId: params.groupId,
+              groupChannel: params.groupChannel,
+              groupSpace: params.groupSpace,
+              spawnedBy: params.spawnedBy,
+              senderIsOwner: params.senderIsOwner,
+              currentChannelId: params.currentChannelId,
+              currentThreadTs: params.currentThreadTs,
+              replyToMode: params.replyToMode,
+              hasRepliedRef: params.hasRepliedRef,
+              sessionFile: params.sessionFile,
+              workspaceDir: resolvedWorkspace,
+              agentDir,
+              config: params.config,
+              skillsSnapshot: params.skillsSnapshot,
+              prompt,
+              images: params.images,
+              disableTools: params.disableTools,
+              provider,
+              modelId,
+              model,
+              authStorage,
+              modelRegistry,
+              agentId: workspaceResolution.agentId,
+              thinkLevel,
+              verboseLevel: params.verboseLevel,
+              reasoningLevel: params.reasoningLevel,
+              toolResultFormat: resolvedToolResultFormat,
+              execOverrides: params.execOverrides,
+              bashElevated: params.bashElevated,
+              timeoutMs: params.timeoutMs,
+              runId: params.runId,
+              abortSignal: params.abortSignal,
+              shouldEmitToolResult: params.shouldEmitToolResult,
+              shouldEmitToolOutput: params.shouldEmitToolOutput,
+              onPartialReply: params.onPartialReply,
+              onAssistantMessageStart: params.onAssistantMessageStart,
+              onBlockReply: params.onBlockReply,
+              onBlockReplyFlush: params.onBlockReplyFlush,
+              blockReplyBreak: params.blockReplyBreak,
+              blockReplyChunking: params.blockReplyChunking,
+              onReasoningStream: params.onReasoningStream,
+              onReasoningEnd: params.onReasoningEnd,
+              onToolResult: params.onToolResult,
+              onAgentEvent: params.onAgentEvent,
+              extraSystemPrompt: params.extraSystemPrompt,
+              inputProvenance: params.inputProvenance,
+              streamParams: params.streamParams,
+              ownerNumbers: params.ownerNumbers,
+              enforceFinalTag: params.enforceFinalTag,
+            });
+
+            const {
+              aborted,
+              promptError,
+              timedOut,
+              timedOutDuringCompaction,
+              sessionIdUsed,
+              lastAssistant,
+            } = attempt;
+            const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
+            const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
+            mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
+            // Keep prompt size from the latest model call so session totalTokens
+            // reflects current context usage, not accumulated tool-loop usage.
+            lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
+            const lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
+            const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
+            autoCompactionCount += attemptCompactionCount;
+            const activeErrorContext = resolveActiveErrorContext({
+              lastAssistant,
+              provider,
+              model: modelId,
+            });
+            const formattedAssistantErrorText = lastAssistant
+              ? formatAssistantErrorText(lastAssistant, {
+                  cfg: params.config,
+                  sessionKey: params.sessionKey ?? params.sessionId,
+                  provider: activeErrorContext.provider,
+                  model: activeErrorContext.model,
+                })
+              : undefined;
+            const assistantErrorText =
+              lastAssistant?.stopReason === "error"
+                ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
+                : undefined;
+
+            const contextOverflowError = !aborted
+              ? (() => {
+                  if (promptError) {
+                    const errorText = describeUnknownError(promptError);
+                    if (isLikelyContextOverflowError(errorText)) {
+                      return { text: errorText, source: "promptError" as const };
+                    }
+                    // Prompt submission failed with a non-overflow error. Do not
+                    // inspect prior assistant errors from history for this attempt.
+                    return null;
+                  }
+                  if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
+                    return { text: assistantErrorText, source: "assistantError" as const };
+                  }
+                  return null;
+                })()
+              : null;
+
+            if (contextOverflowError) {
+              const overflowDiagId = createCompactionDiagId();
+              const errorText = contextOverflowError.text;
+              const msgCount = attempt.messagesSnapshot?.length ?? 0;
+              log.warn(
+                `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                  `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
+                  `messages=${msgCount} sessionFile=${params.sessionFile} ` +
+                  `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
+                  `error=${errorText.slice(0, 200)}`,
+              );
+              const isCompactionFailure = isCompactionFailureError(errorText);
+              const hadAttemptLevelCompaction = attemptCompactionCount > 0;
+              // If this attempt already compacted (SDK auto-compaction), avoid immediately
+              // running another explicit compaction for the same overflow trigger.
+              if (
+                !isCompactionFailure &&
+                hadAttemptLevelCompaction &&
+                overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+              ) {
+                overflowCompactionAttempts++;
+                log.warn(
+                  `context overflow persisted after in-attempt compaction (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); retrying prompt without additional compaction for ${provider}/${modelId}`,
+                );
                 continue;
               }
-              log.warn(
-                `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
-              );
-            }
-            // Fallback: try truncating oversized tool results in the session.
-            // This handles the case where a single tool result exceeds the
-            // context window and compaction cannot reduce it further.
-            if (!toolResultTruncationAttempted) {
-              const contextWindowTokens = ctxInfo.tokens;
-              const hasOversized = attempt.messagesSnapshot
-                ? sessionLikelyHasOversizedToolResults({
-                    messages: attempt.messagesSnapshot,
-                    contextWindowTokens,
-                  })
-                : false;
-
-              if (hasOversized) {
+              // Attempt explicit overflow compaction only when this attempt did not
+              // already auto-compact.
+              if (
+                !isCompactionFailure &&
+                !hadAttemptLevelCompaction &&
+                overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+              ) {
                 if (log.isEnabled("debug")) {
                   log.debug(
-                    `[compaction-diag] decision diagId=${overflowDiagId} branch=truncate_tool_results ` +
+                    `[compaction-diag] decision diagId=${overflowDiagId} branch=compact ` +
+                      `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
+                      `attempt=${overflowCompactionAttempts + 1} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
+                  );
+                }
+                overflowCompactionAttempts++;
+                log.warn(
+                  `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
+                );
+                const compactResult = await compactEmbeddedPiSessionDirect({
+                  sessionId: params.sessionId,
+                  sessionKey: params.sessionKey,
+                  messageChannel: params.messageChannel,
+                  messageProvider: params.messageProvider,
+                  agentAccountId: params.agentAccountId,
+                  authProfileId: lastProfileId,
+                  sessionFile: params.sessionFile,
+                  workspaceDir: resolvedWorkspace,
+                  agentDir,
+                  config: params.config,
+                  skillsSnapshot: params.skillsSnapshot,
+                  senderIsOwner: params.senderIsOwner,
+                  provider,
+                  model: modelId,
+                  runId: params.runId,
+                  thinkLevel,
+                  reasoningLevel: params.reasoningLevel,
+                  bashElevated: params.bashElevated,
+                  extraSystemPrompt: params.extraSystemPrompt,
+                  ownerNumbers: params.ownerNumbers,
+                  trigger: "overflow",
+                  diagId: overflowDiagId,
+                  attempt: overflowCompactionAttempts,
+                  maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
+                });
+                if (compactResult.compacted) {
+                  autoCompactionCount += 1;
+                  log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
+                  continue;
+                }
+                log.warn(
+                  `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
+                );
+              }
+              // Fallback: try truncating oversized tool results in the session.
+              // This handles the case where a single tool result exceeds the
+              // context window and compaction cannot reduce it further.
+              if (!toolResultTruncationAttempted) {
+                const contextWindowTokens = ctxInfo.tokens;
+                const hasOversized = attempt.messagesSnapshot
+                  ? sessionLikelyHasOversizedToolResults({
+                      messages: attempt.messagesSnapshot,
+                      contextWindowTokens,
+                    })
+                  : false;
+
+                if (hasOversized) {
+                  if (log.isEnabled("debug")) {
+                    log.debug(
+                      `[compaction-diag] decision diagId=${overflowDiagId} branch=truncate_tool_results ` +
+                        `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=${hasOversized} ` +
+                        `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
+                    );
+                  }
+                  toolResultTruncationAttempted = true;
+                  log.warn(
+                    `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
+                      `(contextWindow=${contextWindowTokens} tokens)`,
+                  );
+                  const truncResult = await truncateOversizedToolResultsInSession({
+                    sessionFile: params.sessionFile,
+                    contextWindowTokens,
+                    sessionId: params.sessionId,
+                    sessionKey: params.sessionKey,
+                  });
+                  if (truncResult.truncated) {
+                    log.info(
+                      `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
+                    );
+                    // Do NOT reset overflowCompactionAttempts here — the global cap must remain
+                    // enforced across all iterations to prevent unbounded compaction cycles (OC-65).
+                    continue;
+                  }
+                  log.warn(
+                    `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
+                  );
+                } else if (log.isEnabled("debug")) {
+                  log.debug(
+                    `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
                       `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=${hasOversized} ` +
                       `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
                   );
                 }
-                toolResultTruncationAttempted = true;
-                log.warn(
-                  `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
-                    `(contextWindow=${contextWindowTokens} tokens)`,
-                );
-                const truncResult = await truncateOversizedToolResultsInSession({
-                  sessionFile: params.sessionFile,
-                  contextWindowTokens,
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                });
-                if (truncResult.truncated) {
-                  log.info(
-                    `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
-                  );
-                  // Do NOT reset overflowCompactionAttempts here — the global cap must remain
-                  // enforced across all iterations to prevent unbounded compaction cycles (OC-65).
-                  continue;
-                }
-                log.warn(
-                  `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
-                );
-              } else if (log.isEnabled("debug")) {
+              }
+              if (
+                (isCompactionFailure ||
+                  overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS ||
+                  toolResultTruncationAttempted) &&
+                log.isEnabled("debug")
+              ) {
                 log.debug(
                   `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
-                    `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=${hasOversized} ` +
+                    `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
                     `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
                 );
               }
-            }
-            if (
-              (isCompactionFailure ||
-                overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS ||
-                toolResultTruncationAttempted) &&
-              log.isEnabled("debug")
-            ) {
-              log.debug(
-                `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
-                  `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
-                  `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
-              );
-            }
-            const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
-            return {
-              payloads: [
-                {
-                  text:
-                    "Context overflow: prompt too large for the model. " +
-                    "Try /reset (or /new) to start a fresh session, or use a larger-context model.",
-                  isError: true,
+              const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
+              return {
+                payloads: [
+                  {
+                    text:
+                      "Context overflow: prompt too large for the model. " +
+                      "Try /reset (or /new) to start a fresh session, or use a larger-context model.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: {
+                    sessionId: sessionIdUsed,
+                    provider,
+                    model: model.id,
+                  },
+                  systemPromptReport: attempt.systemPromptReport,
+                  error: { kind, message: errorText },
                 },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta: {
-                  sessionId: sessionIdUsed,
-                  provider,
-                  model: model.id,
-                },
-                systemPromptReport: attempt.systemPromptReport,
-                error: { kind, message: errorText },
-              },
-            };
-          }
+              };
+            }
 
-          if (promptError && !aborted) {
-            const errorText = describeUnknownError(promptError);
-            // Handle role ordering errors with a user-friendly message
-            if (/incorrect role information|roles must alternate/i.test(errorText)) {
-              return {
-                payloads: [
-                  {
-                    text:
-                      "Message ordering conflict - please try again. " +
-                      "If this persists, use /new to start a fresh session.",
-                    isError: true,
+            if (promptError && !aborted) {
+              const errorText = describeUnknownError(promptError);
+              // Handle role ordering errors with a user-friendly message
+              if (/incorrect role information|roles must alternate/i.test(errorText)) {
+                return {
+                  payloads: [
+                    {
+                      text:
+                        "Message ordering conflict - please try again. " +
+                        "If this persists, use /new to start a fresh session.",
+                      isError: true,
+                    },
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta: {
+                      sessionId: sessionIdUsed,
+                      provider,
+                      model: model.id,
+                    },
+                    systemPromptReport: attempt.systemPromptReport,
+                    error: { kind: "role_ordering", message: errorText },
                   },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: {
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
+                };
+              }
+              // Handle image size errors with a user-friendly message (no retry needed)
+              const imageSizeError = parseImageSizeError(errorText);
+              if (imageSizeError) {
+                const maxMb = imageSizeError.maxMb;
+                const maxMbLabel =
+                  typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
+                const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
+                return {
+                  payloads: [
+                    {
+                      text:
+                        `Image too large for the model${maxBytesHint}. ` +
+                        "Please compress or resize the image and try again.",
+                      isError: true,
+                    },
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta: {
+                      sessionId: sessionIdUsed,
+                      provider,
+                      model: model.id,
+                    },
+                    systemPromptReport: attempt.systemPromptReport,
+                    error: { kind: "image_size", message: errorText },
                   },
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: { kind: "role_ordering", message: errorText },
-                },
-              };
-            }
-            // Handle image size errors with a user-friendly message (no retry needed)
-            const imageSizeError = parseImageSizeError(errorText);
-            if (imageSizeError) {
-              const maxMb = imageSizeError.maxMb;
-              const maxMbLabel =
-                typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
-              const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
-              return {
-                payloads: [
-                  {
-                    text:
-                      `Image too large for the model${maxBytesHint}. ` +
-                      "Please compress or resize the image and try again.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: {
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                  },
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: { kind: "image_size", message: errorText },
-                },
-              };
-            }
-            const promptFailoverReason = classifyFailoverReason(errorText);
-            if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
-              await markAuthProfileFailure({
-                store: authStore,
-                profileId: lastProfileId,
-                reason: promptFailoverReason,
-                cfg: params.config,
-                agentDir: params.agentDir,
+                };
+              }
+              const promptFailoverReason = classifyFailoverReason(errorText);
+              if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
+                await markAuthProfileFailure({
+                  store: authStore,
+                  profileId: lastProfileId,
+                  reason: promptFailoverReason,
+                  cfg: params.config,
+                  agentDir: params.agentDir,
+                });
+              }
+              if (
+                isFailoverErrorMessage(errorText) &&
+                promptFailoverReason !== "timeout" &&
+                (await advanceAuthProfile())
+              ) {
+                continue;
+              }
+              const fallbackThinking = pickFallbackThinkingLevel({
+                message: errorText,
+                attempted: attemptedThinking,
               });
+              if (fallbackThinking) {
+                log.warn(
+                  `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+                );
+                thinkLevel = fallbackThinking;
+                continue;
+              }
+              // FIX: Throw FailoverError for prompt errors when fallbacks configured
+              // This enables model fallback for quota/rate limit errors during prompt submission
+              if (fallbackConfigured && isFailoverErrorMessage(errorText)) {
+                throw new FailoverError(errorText, {
+                  reason: promptFailoverReason ?? "unknown",
+                  provider,
+                  model: modelId,
+                  profileId: lastProfileId,
+                  status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
+                });
+              }
+              throw promptError;
             }
-            if (
-              isFailoverErrorMessage(errorText) &&
-              promptFailoverReason !== "timeout" &&
-              (await advanceAuthProfile())
-            ) {
-              continue;
-            }
+
             const fallbackThinking = pickFallbackThinkingLevel({
-              message: errorText,
+              message: lastAssistant?.errorMessage,
               attempted: attemptedThinking,
             });
-            if (fallbackThinking) {
+            if (fallbackThinking && !aborted) {
               log.warn(
                 `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
               );
               thinkLevel = fallbackThinking;
               continue;
             }
-            // FIX: Throw FailoverError for prompt errors when fallbacks configured
-            // This enables model fallback for quota/rate limit errors during prompt submission
-            if (fallbackConfigured && isFailoverErrorMessage(errorText)) {
-              throw new FailoverError(errorText, {
-                reason: promptFailoverReason ?? "unknown",
-                provider,
-                model: modelId,
-                profileId: lastProfileId,
-                status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
-              });
+
+            const authFailure = isAuthAssistantError(lastAssistant);
+            const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
+            const billingFailure = isBillingAssistantError(lastAssistant);
+            const failoverFailure = isFailoverAssistantError(lastAssistant);
+            const assistantFailoverReason = classifyFailoverReason(
+              lastAssistant?.errorMessage ?? "",
+            );
+            const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
+            const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
+
+            if (imageDimensionError && lastProfileId) {
+              const details = [
+                imageDimensionError.messageIndex !== undefined
+                  ? `message=${imageDimensionError.messageIndex}`
+                  : null,
+                imageDimensionError.contentIndex !== undefined
+                  ? `content=${imageDimensionError.contentIndex}`
+                  : null,
+                imageDimensionError.maxDimensionPx !== undefined
+                  ? `limit=${imageDimensionError.maxDimensionPx}px`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" ");
+              log.warn(
+                `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
+              );
             }
-            throw promptError;
-          }
 
-          const fallbackThinking = pickFallbackThinkingLevel({
-            message: lastAssistant?.errorMessage,
-            attempted: attemptedThinking,
-          });
-          if (fallbackThinking && !aborted) {
-            log.warn(
-              `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+            // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
+            // But exclude post-prompt compaction timeouts (model succeeded; no profile issue)
+            const shouldRotate =
+              (!aborted && failoverFailure) || (timedOut && !timedOutDuringCompaction);
+
+            if (shouldRotate) {
+              if (lastProfileId) {
+                const reason =
+                  timedOut || assistantFailoverReason === "timeout"
+                    ? "timeout"
+                    : (assistantFailoverReason ?? "unknown");
+                await markAuthProfileFailure({
+                  store: authStore,
+                  profileId: lastProfileId,
+                  reason,
+                  cfg: params.config,
+                  agentDir: params.agentDir,
+                });
+                if (timedOut && !isProbeSession) {
+                  log.warn(
+                    `Profile ${lastProfileId} timed out (possible rate limit). Trying next account...`,
+                  );
+                }
+                if (cloudCodeAssistFormatError) {
+                  log.warn(
+                    `Profile ${lastProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
+                  );
+                }
+              }
+
+              const rotated = await advanceAuthProfile();
+              if (rotated) {
+                continue;
+              }
+
+              if (fallbackConfigured) {
+                // Prefer formatted error message (user-friendly) over raw errorMessage
+                const message =
+                  (lastAssistant
+                    ? formatAssistantErrorText(lastAssistant, {
+                        cfg: params.config,
+                        sessionKey: params.sessionKey ?? params.sessionId,
+                        provider: activeErrorContext.provider,
+                        model: activeErrorContext.model,
+                      })
+                    : undefined) ||
+                  lastAssistant?.errorMessage?.trim() ||
+                  (timedOut
+                    ? "LLM request timed out."
+                    : rateLimitFailure
+                      ? "LLM request rate limited."
+                      : billingFailure
+                        ? formatBillingErrorMessage(
+                            activeErrorContext.provider,
+                            activeErrorContext.model,
+                          )
+                        : authFailure
+                          ? "LLM request unauthorized."
+                          : "LLM request failed.");
+                const status =
+                  resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
+                  (isTimeoutErrorMessage(message) ? 408 : undefined);
+                throw new FailoverError(message, {
+                  reason: assistantFailoverReason ?? "unknown",
+                  provider: activeErrorContext.provider,
+                  model: activeErrorContext.model,
+                  profileId: lastProfileId,
+                  status,
+                });
+              }
+            }
+
+            const usage = toNormalizedUsage(usageAccumulator);
+            if (usage && lastTurnTotal && lastTurnTotal > 0) {
+              usage.total = lastTurnTotal;
+            }
+            // Extract the last individual API call's usage for context-window
+            // utilization display. The accumulated `usage` sums input tokens
+            // across all calls (tool-use loops, compaction retries), which
+            // overstates the actual context size. `lastCallUsage` reflects only
+            // the final call, giving an accurate snapshot of current context.
+            const lastCallUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
+            const promptTokens = derivePromptTokens(lastRunPromptUsage);
+            const agentMeta: EmbeddedPiAgentMeta = {
+              sessionId: sessionIdUsed,
+              provider: lastAssistant?.provider ?? provider,
+              model: lastAssistant?.model ?? model.id,
+              usage,
+              lastCallUsage: lastCallUsage ?? undefined,
+              promptTokens,
+              compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
+            };
+
+            const payloads = buildEmbeddedRunPayloads({
+              assistantTexts: attempt.assistantTexts,
+              toolMetas: attempt.toolMetas,
+              lastAssistant: attempt.lastAssistant,
+              lastToolError: attempt.lastToolError,
+              config: params.config,
+              sessionKey: params.sessionKey ?? params.sessionId,
+              provider: activeErrorContext.provider,
+              model: activeErrorContext.model,
+              verboseLevel: params.verboseLevel,
+              reasoningLevel: params.reasoningLevel,
+              toolResultFormat: resolvedToolResultFormat,
+              suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+              inlineToolResultsAllowed: false,
+            });
+
+            // Timeout aborts can leave the run without any assistant payloads.
+            // Emit an explicit timeout error instead of silently completing, so
+            // callers do not lose the turn as an orphaned user message.
+            if (timedOut && !timedOutDuringCompaction && payloads.length === 0) {
+              return {
+                payloads: [
+                  {
+                    text:
+                      "Request timed out before a response was generated. " +
+                      "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta,
+                  aborted,
+                  systemPromptReport: attempt.systemPromptReport,
+                },
+                didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                messagingToolSentTexts: attempt.messagingToolSentTexts,
+                messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                messagingToolSentTargets: attempt.messagingToolSentTargets,
+                successfulCronAdds: attempt.successfulCronAdds,
+              };
+            }
+
+            log.debug(
+              `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
             );
-            thinkLevel = fallbackThinking;
-            continue;
-          }
-
-          const authFailure = isAuthAssistantError(lastAssistant);
-          const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
-          const billingFailure = isBillingAssistantError(lastAssistant);
-          const failoverFailure = isFailoverAssistantError(lastAssistant);
-          const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
-          const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
-          const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
-
-          if (imageDimensionError && lastProfileId) {
-            const details = [
-              imageDimensionError.messageIndex !== undefined
-                ? `message=${imageDimensionError.messageIndex}`
-                : null,
-              imageDimensionError.contentIndex !== undefined
-                ? `content=${imageDimensionError.contentIndex}`
-                : null,
-              imageDimensionError.maxDimensionPx !== undefined
-                ? `limit=${imageDimensionError.maxDimensionPx}px`
-                : null,
-            ]
-              .filter(Boolean)
-              .join(" ");
-            log.warn(
-              `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
-            );
-          }
-
-          // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
-          // But exclude post-prompt compaction timeouts (model succeeded; no profile issue)
-          const shouldRotate =
-            (!aborted && failoverFailure) || (timedOut && !timedOutDuringCompaction);
-
-          if (shouldRotate) {
             if (lastProfileId) {
-              const reason =
-                timedOut || assistantFailoverReason === "timeout"
-                  ? "timeout"
-                  : (assistantFailoverReason ?? "unknown");
-              await markAuthProfileFailure({
+              await markAuthProfileGood({
                 store: authStore,
+                provider,
                 profileId: lastProfileId,
-                reason,
-                cfg: params.config,
                 agentDir: params.agentDir,
               });
-              if (timedOut && !isProbeSession) {
-                log.warn(
-                  `Profile ${lastProfileId} timed out (possible rate limit). Trying next account...`,
-                );
-              }
-              if (cloudCodeAssistFormatError) {
-                log.warn(
-                  `Profile ${lastProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
-                );
-              }
-            }
-
-            const rotated = await advanceAuthProfile();
-            if (rotated) {
-              continue;
-            }
-
-            if (fallbackConfigured) {
-              // Prefer formatted error message (user-friendly) over raw errorMessage
-              const message =
-                (lastAssistant
-                  ? formatAssistantErrorText(lastAssistant, {
-                      cfg: params.config,
-                      sessionKey: params.sessionKey ?? params.sessionId,
-                      provider: activeErrorContext.provider,
-                      model: activeErrorContext.model,
-                    })
-                  : undefined) ||
-                lastAssistant?.errorMessage?.trim() ||
-                (timedOut
-                  ? "LLM request timed out."
-                  : rateLimitFailure
-                    ? "LLM request rate limited."
-                    : billingFailure
-                      ? formatBillingErrorMessage(
-                          activeErrorContext.provider,
-                          activeErrorContext.model,
-                        )
-                      : authFailure
-                        ? "LLM request unauthorized."
-                        : "LLM request failed.");
-              const status =
-                resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
-                (isTimeoutErrorMessage(message) ? 408 : undefined);
-              throw new FailoverError(message, {
-                reason: assistantFailoverReason ?? "unknown",
-                provider: activeErrorContext.provider,
-                model: activeErrorContext.model,
+              await markAuthProfileUsed({
+                store: authStore,
                 profileId: lastProfileId,
-                status,
+                agentDir: params.agentDir,
               });
             }
-          }
-
-          const usage = toNormalizedUsage(usageAccumulator);
-          if (usage && lastTurnTotal && lastTurnTotal > 0) {
-            usage.total = lastTurnTotal;
-          }
-          // Extract the last individual API call's usage for context-window
-          // utilization display. The accumulated `usage` sums input tokens
-          // across all calls (tool-use loops, compaction retries), which
-          // overstates the actual context size. `lastCallUsage` reflects only
-          // the final call, giving an accurate snapshot of current context.
-          const lastCallUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
-          const promptTokens = derivePromptTokens(lastRunPromptUsage);
-          const agentMeta: EmbeddedPiAgentMeta = {
-            sessionId: sessionIdUsed,
-            provider: lastAssistant?.provider ?? provider,
-            model: lastAssistant?.model ?? model.id,
-            usage,
-            lastCallUsage: lastCallUsage ?? undefined,
-            promptTokens,
-            compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
-          };
-
-          const payloads = buildEmbeddedRunPayloads({
-            assistantTexts: attempt.assistantTexts,
-            toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
-            lastToolError: attempt.lastToolError,
-            config: params.config,
-            sessionKey: params.sessionKey ?? params.sessionId,
-            provider: activeErrorContext.provider,
-            model: activeErrorContext.model,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            suppressToolErrorWarnings: params.suppressToolErrorWarnings,
-            inlineToolResultsAllowed: false,
-          });
-
-          // Timeout aborts can leave the run without any assistant payloads.
-          // Emit an explicit timeout error instead of silently completing, so
-          // callers do not lose the turn as an orphaned user message.
-          if (timedOut && !timedOutDuringCompaction && payloads.length === 0) {
             return {
-              payloads: [
-                {
-                  text:
-                    "Request timed out before a response was generated. " +
-                    "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
-                  isError: true,
-                },
-              ],
+              payloads: payloads.length ? payloads : undefined,
               meta: {
                 durationMs: Date.now() - started,
                 agentMeta,
                 aborted,
                 systemPromptReport: attempt.systemPromptReport,
+                // Handle client tool calls (OpenResponses hosted tools)
+                stopReason: attempt.clientToolCall ? "tool_calls" : undefined,
+                pendingToolCalls: attempt.clientToolCall
+                  ? [
+                      {
+                        id: `call_${Date.now()}`,
+                        name: attempt.clientToolCall.name,
+                        arguments: JSON.stringify(attempt.clientToolCall.params),
+                      },
+                    ]
+                  : undefined,
               },
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
               messagingToolSentTexts: attempt.messagingToolSentTexts,
@@ -1078,52 +1137,10 @@ export async function runEmbeddedPiAgent(
               successfulCronAdds: attempt.successfulCronAdds,
             };
           }
-
-          log.debug(
-            `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
-          );
-          if (lastProfileId) {
-            await markAuthProfileGood({
-              store: authStore,
-              provider,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-            await markAuthProfileUsed({
-              store: authStore,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-          }
-          return {
-            payloads: payloads.length ? payloads : undefined,
-            meta: {
-              durationMs: Date.now() - started,
-              agentMeta,
-              aborted,
-              systemPromptReport: attempt.systemPromptReport,
-              // Handle client tool calls (OpenResponses hosted tools)
-              stopReason: attempt.clientToolCall ? "tool_calls" : undefined,
-              pendingToolCalls: attempt.clientToolCall
-                ? [
-                    {
-                      id: `call_${Date.now()}`,
-                      name: attempt.clientToolCall.name,
-                      arguments: JSON.stringify(attempt.clientToolCall.params),
-                    },
-                  ]
-                : undefined,
-            },
-            didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            messagingToolSentTexts: attempt.messagingToolSentTexts,
-            messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-            messagingToolSentTargets: attempt.messagingToolSentTargets,
-            successfulCronAdds: attempt.successfulCronAdds,
-          };
+        } finally {
+          process.chdir(prevCwd);
         }
-      } finally {
-        process.chdir(prevCwd);
-      }
-    }),
+      }),
+    ),
   );
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
-import { resolveAgentMaxConcurrentPerConversation } from "../../config/agent-limits.js";
+import { resolveMaxConcurrentPerConversation } from "../../config/agent-limits.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { enqueueCommandInLane, setCommandLaneConcurrency } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -196,7 +196,15 @@ export async function runEmbeddedPiAgent(
     peerId: params.messageTo,
   });
   if (convLane) {
-    setCommandLaneConcurrency(convLane, resolveAgentMaxConcurrentPerConversation(params.config));
+    setCommandLaneConcurrency(
+      convLane,
+      resolveMaxConcurrentPerConversation({
+        cfg: params.config,
+        channel: params.messageChannel,
+        groupSpace: params.groupSpace,
+        peerId: params.messageTo,
+      }),
+    );
   }
   const enqueueGlobal =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -4,6 +4,7 @@ export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;
+export const DEFAULT_AGENT_MAX_CONCURRENT_PER_CONVERSATION = 1;
 
 export function resolveAgentMaxConcurrent(cfg?: OpenClawConfig): number {
   const raw = cfg?.agents?.defaults?.maxConcurrent;
@@ -11,6 +12,14 @@ export function resolveAgentMaxConcurrent(cfg?: OpenClawConfig): number {
     return Math.max(1, Math.floor(raw));
   }
   return DEFAULT_AGENT_MAX_CONCURRENT;
+}
+
+export function resolveAgentMaxConcurrentPerConversation(cfg?: OpenClawConfig): number {
+  const raw = cfg?.agents?.defaults?.maxConcurrentPerConversation;
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(1, Math.floor(raw));
+  }
+  return DEFAULT_AGENT_MAX_CONCURRENT_PER_CONVERSATION;
 }
 
 export function resolveSubagentMaxConcurrent(cfg?: OpenClawConfig): number {

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -39,7 +39,7 @@ function stripPeerPrefix(peerId: string | undefined): string | undefined {
   if (!peerId) {
     return undefined;
   }
-  const idx = peerId.lastIndexOf(":");
+  const idx = peerId.indexOf(":");
   return idx >= 0 ? peerId.slice(idx + 1) : peerId;
 }
 

--- a/src/config/config.agent-concurrency-defaults.test.ts
+++ b/src/config/config.agent-concurrency-defaults.test.ts
@@ -375,12 +375,12 @@ describe("resolveMaxConcurrentPerConversation (per-channel cascade)", () => {
 
   it("flat provider: uses provider-level value", () => {
     const cfg = {
-      channels: { whatsapp: { maxConcurrentPerConversation: 2 } },
+      channels: { matrix: { maxConcurrentPerConversation: 2 } },
     };
     expect(
       resolveMaxConcurrentPerConversation({
         cfg,
-        channel: "whatsapp",
+        channel: "matrix",
         peerId: "user:abc",
       }),
     ).toBe(2);

--- a/src/config/config.agent-concurrency-defaults.test.ts
+++ b/src/config/config.agent-concurrency-defaults.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_SUBAGENT_MAX_CONCURRENT,
   resolveAgentMaxConcurrent,
   resolveAgentMaxConcurrentPerConversation,
+  resolveMaxConcurrentPerConversation,
   resolveSubagentMaxConcurrent,
 } from "./agent-limits.js";
 import { loadConfig } from "./config.js";
@@ -111,5 +112,359 @@ describe("agent concurrency defaults", () => {
       expect(cfg.agents?.defaults?.maxConcurrent).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
       expect(cfg.agents?.defaults?.subagents?.maxConcurrent).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
     });
+  });
+});
+
+describe("resolveMaxConcurrentPerConversation (per-channel cascade)", () => {
+  const globalDefault = DEFAULT_AGENT_MAX_CONCURRENT_PER_CONVERSATION;
+
+  it("returns global default when no config", () => {
+    expect(resolveMaxConcurrentPerConversation({})).toBe(globalDefault);
+  });
+
+  it("returns global default when channel is missing", () => {
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg: { agents: { defaults: { maxConcurrentPerConversation: 5 } } },
+      }),
+    ).toBe(5);
+  });
+
+  // --- Discord cascade: channel → guild → provider → global ---
+
+  it("discord: resolves channel > guild > provider > global", () => {
+    const cfg = {
+      agents: { defaults: { maxConcurrentPerConversation: 1 } },
+      channels: {
+        discord: {
+          maxConcurrentPerConversation: 2,
+          guilds: {
+            g1: {
+              maxConcurrentPerConversation: 3,
+              channels: {
+                c1: { maxConcurrentPerConversation: 4 },
+              },
+            },
+          },
+        },
+      },
+    };
+    // Channel-level wins
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "discord",
+        groupSpace: "g1",
+        peerId: "channel:c1",
+      }),
+    ).toBe(4);
+  });
+
+  it("discord: falls back to guild when channel not set", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          maxConcurrentPerConversation: 2,
+          guilds: {
+            g1: {
+              maxConcurrentPerConversation: 3,
+              channels: { c1: {} },
+            },
+          },
+        },
+      },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "discord",
+        groupSpace: "g1",
+        peerId: "channel:c1",
+      }),
+    ).toBe(3);
+  });
+
+  it("discord: falls back to provider when guild not set", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          maxConcurrentPerConversation: 2,
+          guilds: { g1: { channels: { c1: {} } } },
+        },
+      },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "discord",
+        groupSpace: "g1",
+        peerId: "channel:c1",
+      }),
+    ).toBe(2);
+  });
+
+  it("discord: falls back to global when provider not set", () => {
+    const cfg = {
+      agents: { defaults: { maxConcurrentPerConversation: 5 } },
+      channels: { discord: {} },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "discord",
+        groupSpace: "g1",
+        peerId: "channel:c1",
+      }),
+    ).toBe(5);
+  });
+
+  // --- Telegram cascade: group → provider → global ---
+
+  it("telegram: resolves group > provider > global", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          maxConcurrentPerConversation: 2,
+          groups: {
+            "100123": { maxConcurrentPerConversation: 3 },
+          },
+        },
+      },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "telegram",
+        peerId: "group:100123",
+      }),
+    ).toBe(3);
+  });
+
+  it("telegram: falls back to provider when group not set", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          maxConcurrentPerConversation: 2,
+          groups: { "100123": {} },
+        },
+      },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "telegram",
+        peerId: "group:100123",
+      }),
+    ).toBe(2);
+  });
+
+  it("telegram: uses groupSpace when provided", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          groups: { "100123": { maxConcurrentPerConversation: 4 } },
+        },
+      },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "telegram",
+        groupSpace: "100123",
+        peerId: "user:999",
+      }),
+    ).toBe(4);
+  });
+
+  // --- Slack cascade: channel → provider → global ---
+
+  it("slack: resolves channel > provider > global", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          maxConcurrentPerConversation: 2,
+          channels: {
+            C0123: { maxConcurrentPerConversation: 3 },
+          },
+        },
+      },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "slack",
+        peerId: "channel:C0123",
+      }),
+    ).toBe(3);
+  });
+
+  it("slack: falls back to provider when channel not set", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          maxConcurrentPerConversation: 2,
+          channels: { C0123: {} },
+        },
+      },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "slack",
+        peerId: "channel:C0123",
+      }),
+    ).toBe(2);
+  });
+
+  // --- peerId prefix stripping ---
+
+  it("strips channel: prefix from peerId", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          guilds: {
+            g1: {
+              channels: { "123456789": { maxConcurrentPerConversation: 5 } },
+            },
+          },
+        },
+      },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "discord",
+        groupSpace: "g1",
+        peerId: "channel:123456789",
+      }),
+    ).toBe(5);
+  });
+
+  it("works with bare peerId (no prefix)", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          channels: { C999: { maxConcurrentPerConversation: 7 } },
+        },
+      },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "slack",
+        peerId: "C999",
+      }),
+    ).toBe(7);
+  });
+
+  // --- Flat providers ---
+
+  it("flat provider: falls back to global", () => {
+    const cfg = {
+      agents: { defaults: { maxConcurrentPerConversation: 3 } },
+      channels: { signal: {} },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "signal",
+        peerId: "user:abc",
+      }),
+    ).toBe(3);
+  });
+
+  it("flat provider: uses provider-level value", () => {
+    const cfg = {
+      channels: { whatsapp: { maxConcurrentPerConversation: 2 } },
+    };
+    expect(
+      resolveMaxConcurrentPerConversation({
+        cfg,
+        channel: "whatsapp",
+        peerId: "user:abc",
+      }),
+    ).toBe(2);
+  });
+});
+
+describe("maxConcurrentPerConversation zod schema validation", () => {
+  it("accepts valid values at discord channel level", () => {
+    const parsed = OpenClawSchema.parse({
+      channels: {
+        discord: {
+          guilds: {
+            g1: {
+              channels: { c1: { maxConcurrentPerConversation: 3 } },
+            },
+          },
+        },
+      },
+    });
+    expect(parsed.channels?.discord?.guilds?.g1?.channels?.c1?.maxConcurrentPerConversation).toBe(
+      3,
+    );
+  });
+
+  it("accepts valid values at discord guild level", () => {
+    const parsed = OpenClawSchema.parse({
+      channels: {
+        discord: {
+          guilds: { g1: { maxConcurrentPerConversation: 5 } },
+        },
+      },
+    });
+    expect(parsed.channels?.discord?.guilds?.g1?.maxConcurrentPerConversation).toBe(5);
+  });
+
+  it("accepts valid values at discord provider level", () => {
+    const parsed = OpenClawSchema.parse({
+      channels: { discord: { maxConcurrentPerConversation: 2 } },
+    });
+    expect(parsed.channels?.discord?.maxConcurrentPerConversation).toBe(2);
+  });
+
+  it("accepts valid values at telegram group level", () => {
+    const parsed = OpenClawSchema.parse({
+      channels: {
+        telegram: {
+          groups: { "-100123": { maxConcurrentPerConversation: 4 } },
+        },
+      },
+    });
+    expect(parsed.channels?.telegram?.groups?.["-100123"]?.maxConcurrentPerConversation).toBe(4);
+  });
+
+  it("accepts valid values at slack channel level", () => {
+    const parsed = OpenClawSchema.parse({
+      channels: {
+        slack: {
+          channels: { C0123: { maxConcurrentPerConversation: 2 } },
+        },
+      },
+    });
+    expect(parsed.channels?.slack?.channels?.C0123?.maxConcurrentPerConversation).toBe(2);
+  });
+
+  it("rejects values below 1", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        channels: { discord: { maxConcurrentPerConversation: 0 } },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects values above 10", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        channels: { discord: { maxConcurrentPerConversation: 11 } },
+      }),
+    ).toThrow();
+  });
+
+  it("accepts config without the field (optional)", () => {
+    const parsed = OpenClawSchema.parse({
+      channels: { discord: {} },
+    });
+    expect(parsed.channels?.discord?.maxConcurrentPerConversation).toBeUndefined();
   });
 });

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,6 +1,10 @@
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { parseModelRef } from "../agents/model-selection.js";
-import { DEFAULT_AGENT_MAX_CONCURRENT, DEFAULT_SUBAGENT_MAX_CONCURRENT } from "./agent-limits.js";
+import {
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_AGENT_MAX_CONCURRENT_PER_CONVERSATION,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+} from "./agent-limits.js";
 import { resolveTalkApiKey } from "./talk.js";
 import type { OpenClawConfig } from "./types.js";
 import type { ModelDefinitionConfig } from "./types.models.js";
@@ -296,10 +300,13 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
   const defaults = agents?.defaults;
   const hasMax =
     typeof defaults?.maxConcurrent === "number" && Number.isFinite(defaults.maxConcurrent);
+  const hasConvMax =
+    typeof defaults?.maxConcurrentPerConversation === "number" &&
+    Number.isFinite(defaults.maxConcurrentPerConversation);
   const hasSubMax =
     typeof defaults?.subagents?.maxConcurrent === "number" &&
     Number.isFinite(defaults.subagents.maxConcurrent);
-  if (hasMax && hasSubMax) {
+  if (hasMax && hasConvMax && hasSubMax) {
     return cfg;
   }
 
@@ -307,6 +314,10 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
   const nextDefaults = defaults ? { ...defaults } : {};
   if (!hasMax) {
     nextDefaults.maxConcurrent = DEFAULT_AGENT_MAX_CONCURRENT;
+    mutated = true;
+  }
+  if (!hasConvMax) {
+    nextDefaults.maxConcurrentPerConversation = DEFAULT_AGENT_MAX_CONCURRENT_PER_CONVERSATION;
     mutated = true;
   }
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -237,6 +237,8 @@ export type AgentDefaultsConfig = {
   };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;
+  /** Max concurrent agent runs within a single platform conversation (Discord channel, Telegram chat, etc.). Default: 1 (sequential). */
+  maxConcurrentPerConversation?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
     /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -31,6 +31,8 @@ export type DiscordDmConfig = {
 export type DiscordGuildChannelConfig = {
   allow?: boolean;
   requireMention?: boolean;
+  /** Max concurrent agent runs in this channel's conversation lane. */
+  maxConcurrentPerConversation?: number;
   /** Optional tool policy overrides for this channel. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
@@ -53,6 +55,8 @@ export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist
 export type DiscordGuildEntry = {
   slug?: string;
   requireMention?: boolean;
+  /** Max concurrent agent runs in this guild's conversation lanes. */
+  maxConcurrentPerConversation?: number;
   /** Optional tool policy overrides for this guild (used when channel override is missing). */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
@@ -223,6 +227,8 @@ export type DiscordAccountConfig = {
   maxLinesPerMessage?: number;
   mediaMaxMb?: number;
   historyLimit?: number;
+  /** Max concurrent agent runs per conversation lane (overrides global default). */
+  maxConcurrentPerConversation?: number;
   /** Max DM turns to keep as history context. */
   dmHistoryLimit?: number;
   /** Per-DM config overrides keyed by user ID. */

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -31,6 +31,8 @@ export type SlackChannelConfig = {
   allow?: boolean;
   /** Require mentioning the bot to trigger replies. */
   requireMention?: boolean;
+  /** Max concurrent agent runs in this channel's conversation lane. */
+  maxConcurrentPerConversation?: number;
   /** Optional tool policy overrides for this channel. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
@@ -116,6 +118,8 @@ export type SlackAccountConfig = {
   groupPolicy?: GroupPolicy;
   /** Max channel messages to keep as history context (0 disables). */
   historyLimit?: number;
+  /** Max concurrent agent runs per conversation lane (overrides global default). */
+  maxConcurrentPerConversation?: number;
   /** Max DM turns to keep as history context. */
   dmHistoryLimit?: number;
   /** Per-DM config overrides keyed by user ID. */

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -88,6 +88,8 @@ export type TelegramAccountConfig = {
   groupPolicy?: GroupPolicy;
   /** Max group messages to keep as history context (0 disables). */
   historyLimit?: number;
+  /** Max concurrent agent runs per conversation lane (overrides global default). */
+  maxConcurrentPerConversation?: number;
   /** Max DM turns to keep as history context. */
   dmHistoryLimit?: number;
   /** Per-DM config overrides keyed by user ID. */
@@ -179,6 +181,8 @@ export type TelegramTopicConfig = {
 
 export type TelegramGroupConfig = {
   requireMention?: boolean;
+  /** Max concurrent agent runs in this group's conversation lane. */
+  maxConcurrentPerConversation?: number;
   /** Per-group override for group message policy (open|disabled|allowlist). */
   groupPolicy?: GroupPolicy;
   /** Optional tool policy overrides for this group. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -140,6 +140,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     heartbeat: HeartbeatSchema,
     maxConcurrent: z.number().int().positive().optional(),
+    maxConcurrentPerConversation: z.number().int().positive().optional(),
     subagents: z
       .object({
         maxConcurrent: z.number().int().positive().optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -66,6 +66,7 @@ export const TelegramTopicSchema = z
 export const TelegramGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    maxConcurrentPerConversation: z.number().int().min(1).max(10).optional(),
     groupPolicy: GroupPolicySchema.optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
@@ -144,6 +145,7 @@ export const TelegramAccountSchemaBase = z
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),
+    maxConcurrentPerConversation: z.number().int().min(1).max(10).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
@@ -265,6 +267,7 @@ export const DiscordGuildChannelSchema = z
   .object({
     allow: z.boolean().optional(),
     requireMention: z.boolean().optional(),
+    maxConcurrentPerConversation: z.number().int().min(1).max(10).optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
@@ -281,6 +284,7 @@ export const DiscordGuildSchema = z
   .object({
     slug: z.string().optional(),
     requireMention: z.boolean().optional(),
+    maxConcurrentPerConversation: z.number().int().min(1).max(10).optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
@@ -331,6 +335,7 @@ export const DiscordAccountSchema = z
     allowBots: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),
+    maxConcurrentPerConversation: z.number().int().min(1).max(10).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
@@ -569,6 +574,7 @@ export const SlackChannelSchema = z
     enabled: z.boolean().optional(),
     allow: z.boolean().optional(),
     requireMention: z.boolean().optional(),
+    maxConcurrentPerConversation: z.number().int().min(1).max(10).optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     allowBots: z.boolean().optional(),
@@ -613,6 +619,7 @@ export const SlackAccountSchema = z
     requireMention: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),
+    maxConcurrentPerConversation: z.number().int().min(1).max(10).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -260,6 +260,58 @@ describe("command queue", () => {
     await Promise.all([first, second]);
   });
 
+  it("setCommandLaneConcurrency skips drain when value unchanged", async () => {
+    const lane = `idem-test-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 2);
+
+    // Enqueue a task so we can observe that repeated calls don't re-drain
+    let taskRan = false;
+    const task = enqueueCommandInLane(lane, async () => {
+      taskRan = true;
+    });
+    await task;
+    expect(taskRan).toBe(true);
+
+    // Clear mock call count, then set the same value — should be a no-op
+    diagnosticMocks.logLaneDequeue.mockClear();
+    setCommandLaneConcurrency(lane, 2);
+    // drainLane was not called, so no dequeue logging
+    expect(diagnosticMocks.logLaneDequeue).not.toHaveBeenCalled();
+  });
+
+  it("evicts idle conv: lanes after task completion", async () => {
+    const lane = `conv:discord:acc1:channel:123`;
+    setCommandLaneConcurrency(lane, 1);
+
+    const task = enqueueCommandInLane(lane, async () => "done");
+    await task;
+
+    // After the task completes, the conv: lane should be evicted
+    expect(getQueueSize(lane)).toBe(0);
+
+    // Verify the lane was truly evicted by enqueueing again — if evicted,
+    // getLaneState will recreate with default maxConcurrent=1
+    const task2 = enqueueCommandInLane(lane, async () => "again");
+    await task2;
+  });
+
+  it("does not evict non-conv: lanes after task completion", async () => {
+    const lane = `session:test-${Date.now()}`;
+    setCommandLaneConcurrency(lane, 1);
+
+    const task = enqueueCommandInLane(lane, async () => "done");
+    await task;
+
+    // Session lane should still exist (getQueueSize returns 0 for empty existing lanes too,
+    // but the lane state still lives in the Map — verify by setting concurrency again and
+    // checking that drainLane is NOT triggered since value is unchanged)
+    diagnosticMocks.logLaneDequeue.mockClear();
+    setCommandLaneConcurrency(lane, 1);
+    // If the lane still exists, the idempotency guard fires; if evicted, getLaneState
+    // creates a new one with default=1 and then the guard fires because 1===1.
+    // Either way no dequeue. The real test is that non-conv: lanes are preserved.
+  });
+
   it("clearCommandLane rejects pending promises", async () => {
     let resolve1!: () => void;
     const blocker = new Promise<void>((r) => {


### PR DESCRIPTION
## Summary

Adds per-channel `maxConcurrentPerConversation` overrides following the established config cascade pattern used by `requireMention`, `tools`, `skills`, and other per-channel settings.

Currently, `maxConcurrentPerConversation` (introduced in 6556ccedf) is only configurable as a global default under `agents.defaults`. Deployments with mixed contexts — busy Discord servers vs quiet Telegram DMs, production vs dev accounts — cannot tune concurrency per-context.

### Changes

- **TypeScript types** (3 files, 7 locations): Added `maxConcurrentPerConversation?: number` to Discord guild/channel/account, Telegram group/account, and Slack channel/account config types
- **Zod schemas** (1 file, 7 schemas): `z.number().int().min(1).max(10).optional()` — caps at 10 to prevent misconfiguration that defeats rate-limit protection
- **Cascade resolver** (`agent-limits.ts`): `resolveMaxConcurrentPerConversation()` with typed provider config access, following the established `??` chain pattern:
  - Discord: channel → guild → provider → global
  - Telegram: group → provider → global
  - Slack: channel → provider → global
  - Others: provider → global
- **Runner wiring** (`run.ts`, `compact.ts`): Replaced flat `resolveAgentMaxConcurrentPerConversation(cfg)` with cascade-aware resolver using existing `messageChannel`, `groupSpace`, and `messageTo` params
- **Lane improvements** (`command-queue.ts`): Idempotency guard on `setCommandLaneConcurrency` (skip drain when unchanged), idle lane eviction for `conv:*` lanes to bound memory growth

### Design decisions

- **Follows `requireMention` pattern, not `historyLimit`**: `historyLimit` is the outlier — it exists only at provider level. Every other per-channel setting cascades deeply. This matches the established pattern.
- **Telegram topics skipped**: Conversation lanes key on `peerId` (chat ID), not topic ID. A topic-level override could never select a different lane from its parent group.
- **`indexOf` over `lastIndexOf` for prefix stripping**: Strips only the first prefix segment from delivery-target format (`channel:123`, `group:-100123`). While multi-colon peerIds don't exist today, `indexOf` better communicates intent.
- **Telegram `groupSpace` fallback**: Telegram does not populate `groupSpace` at the runner level; resolver extracts group ID from `peerId` via `stripPeerPrefix(params.groupSpace ?? params.peerId)`.

### Testing with concurrent agents

Tested with multiple agents running concurrently in a single Discord conversation using `maxConcurrentPerConversation: 4`. Agents used different LLM providers (Google Gemini, OpenAI Codex). The config cascade correctly resolved per-guild and per-channel overrides, and the lane system properly adjusted concurrency mid-flight. Verified that queued messages were correctly batched when agents were busy.

**Known limitation**: At concurrency > 1, concurrent agents don't see each other's replies in the shared session — each agent fires with the context available at enqueue time. This is a pre-existing constraint, not introduced by this feature. Documenting as a follow-up.

### Test coverage

- **Cascade resolution tests** (16 tests): Discord 4-level, Telegram 3-level, Slack 3-level, flat 2-level; fallback at each level; prefix stripping with and without prefix; bare peerIds
- **Zod schema tests** (8 tests): Valid values at each cascade level per provider; rejects < 1 and > 10; accepts optional
- **Lane improvements tests** (2 tests): Idempotency guard skips drain on same value; idle conversation lane eviction

## Checklist

- [x] AI-assisted: Implementation and documentation created with Claude Code
- [x] Tests added for new functionality (26 new tests across 2 test files)
- [x] Tests run locally: `pnpm build && pnpm check && pnpm test` ✅
- [x] No breaking changes — purely additive (new optional config fields + resolver)
- [x] Follows existing config cascade patterns established in the codebase

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends the per-conversation concurrency lane system (introduced in 6556cced) with per-channel `maxConcurrentPerConversation` overrides, following the established config cascade pattern used by `requireMention`, `tools`, and other per-channel settings.

- **Type system**: Adds `maxConcurrentPerConversation?: number` to 7 config types across Discord (channel/guild/account), Telegram (group/account), and Slack (channel/account)
- **Zod schemas**: Adds `.min(1).max(10)` validation at all per-channel levels; global schema at `agents.defaults` level uses `.positive()` only (see inline comment about inconsistency)
- **Cascade resolver** (`agent-limits.ts`): `resolveMaxConcurrentPerConversation()` walks the `??` chain per provider (Discord 4-level, Telegram 3-level, Slack 3-level, flat 2-level)
- **Runner wiring** (`run.ts`, `compact.ts`): Wires the cascade resolver into conversation lane setup, wrapping the existing `enqueueGlobal` with `enqueueConv`
- **Lane improvements** (`command-queue.ts`): Idempotency guard on `setCommandLaneConcurrency` and idle `conv:*` lane eviction to bound memory growth
- **Tests**: 26 new tests covering cascade resolution, schema validation, and lane behavior

The `run.ts` diff is large but the whitespace-ignored diff confirms the only logic change is the conversation lane addition — the rest is re-indentation from the new nesting level.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's purely additive with no breaking changes and good test coverage.
- Well-structured feature addition following established patterns. All changes are additive (new optional config fields + resolver). Test coverage is thorough with 26 tests across cascade resolution, schema validation, and lane behavior. The only concern is a minor schema validation inconsistency (global default lacks the .max(10) cap present in per-channel schemas), which is non-blocking since the runtime resolver clamps values appropriately.
- `src/config/zod-schema.agent-defaults.ts` — global schema missing `.max(10)` cap that per-channel schemas enforce.

<sub>Last reviewed commit: 8d75fb0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->