### PR TITLE
fix(slack): thread sessions broken — fork gate + history injection

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -260,12 +260,11 @@ export async function runPreparedReply(
   prefixedBodyBase = appendUntrustedContext(prefixedBodyBase, sessionCtx.UntrustedContext);
   const threadStarterBody = ctx.ThreadStarterBody?.trim();
   const threadHistoryBody = ctx.ThreadHistoryBody?.trim();
-  const threadContextNote =
-    isNewSession && threadHistoryBody
-      ? `[Thread history - for context]\n${threadHistoryBody}`
-      : isNewSession && threadStarterBody
-        ? `[Thread starter - for context]\n${threadStarterBody}`
-        : undefined;
+  const threadContextNote = threadHistoryBody
+    ? `[Thread history - for context]\n${threadHistoryBody}`
+    : threadStarterBody
+      ? `[Thread starter - for context]\n${threadStarterBody}`
+      : undefined;
   const skillResult = await ensureSkillSnapshot({
     sessionEntry,
     sessionStore,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -110,6 +110,8 @@ export type SessionEntry = {
   lastThreadId?: string | number;
   skillsSnapshot?: SessionSkillSnapshot;
   systemPromptReport?: SessionSystemPromptReport;
+  /** Set to true after the session has been forked from a parent session (thread inheritance). */
+  forkedFromParent?: boolean;
 };
 
 export function mergeSessionEntry(

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -361,7 +361,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     expect(prepared).toBeTruthy();
     expect(prepared!.ctxPayload.IsFirstThreadTurn).toBeUndefined();
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toBeUndefined();
+    // Thread history is now fetched on every turn (not just the first),
+    // so ThreadHistoryBody is populated when history exists.
+    expect(prepared!.ctxPayload.ThreadHistoryBody).toBeDefined();
   });
 
   it("includes thread_ts and parent_user_id metadata in thread replies", async () => {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -521,7 +521,7 @@ export async function prepareSlackMessage(params: {
       storePath,
       sessionKey, // Thread-specific session key
     });
-    if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
+    if (threadInitialHistoryLimit > 0) {
       const threadHistory = await resolveSlackThreadHistory({
         channelId: message.channel,
         threadTs,


### PR DESCRIPTION
## Problem

Thread sessions in Slack DMs are fundamentally broken. Agents lose all thread context after the first turn, making threaded conversations unusable.

## Root Cause

Three independent gates conspire to break thread sessions:

### 1. Session fork gate (`initSessionState`)
The `forkSessionFromParent` call is gated by `isNewSession`, but the session is always pre-created by the outbound reply handler before `initSessionState` runs. So `isNewSession` is always `false` for thread sessions, and forking never fires.

**Fix:** Track `forkedFromParent` flag on the session entry. Gate on `!alreadyForked` instead of `isNewSession`.

### 2. Thread history fetch gate (`prepare.ts`)
```typescript
if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
```
The `!threadSessionPreviousTimestamp` condition means thread history is only fetched on the very first turn. Once the session exists and has a stored timestamp, this gate blocks all subsequent fetches.

**Fix:** Remove `&& !threadSessionPreviousTimestamp` — always fetch the last N messages.

### 3. Thread history injection gate (`get-reply-run.ts`)
```typescript
const threadContextNote = isNewSession && threadHistoryBody ? ...
```
The `isNewSession &&` condition discards fetched thread history when building the prompt on non-new sessions. Even if history was successfully fetched, it is thrown away.

**Fix:** Remove `isNewSession &&` — always inject thread context when available.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/session/init-session-state.ts` | Add `forkedFromParent` flag, gate fork on `!alreadyForked` instead of `isNewSession`, add error logging |
| `src/slack/monitor/message-handler/prepare.ts` | Remove `!threadSessionPreviousTimestamp` from fetch gate |
| `src/auto-reply/reply/get-reply-run.ts` | Remove `isNewSession &&` from injection gate |

## Testing

Validated on a live OpenClaw instance with monkeypatched dist:
- Thread history now appears on every turn (sliding window of last 20 messages)
- Session forking fires correctly on first thread interaction
- No regressions on non-thread DM sessions