### PR TITLE
fix(ports): fall back to ss(8) when lsof fails to resolve listener PIDs

### DIFF
--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -75,6 +75,66 @@ async function resolveUnixUser(pid: number): Promise<string | undefined> {
   return line || undefined;
 }
 
+function parseSsOutput(output: string, port: number): PortListener[] {
+  const listeners: PortListener[] = [];
+  const portToken = `:${port}`;
+  for (const rawLine of output.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || !line.startsWith("LISTEN")) {
+      continue;
+    }
+    if (!line.includes(portToken)) {
+      continue;
+    }
+    // ss -tlnp output: LISTEN  0  511  127.0.0.1:18789  0.0.0.0:*  users:(("node",pid=1234,fd=24))
+    const pidMatch = line.match(/pid=(\d+)/);
+    const pid = pidMatch ? Number.parseInt(pidMatch[1], 10) : NaN;
+    const parts = line.split(/\s+/);
+    const localAddr = parts[3];
+    const listener: PortListener = {};
+    if (Number.isFinite(pid)) {
+      listener.pid = pid;
+    }
+    if (localAddr?.includes(portToken)) {
+      listener.address = localAddr;
+    }
+    listeners.push(listener);
+  }
+  return listeners;
+}
+
+async function readSsListeners(
+  port: number,
+): Promise<{ listeners: PortListener[]; errors: string[] }> {
+  const errors: string[] = [];
+  const res = await runCommandSafe(["ss", "-tlnp", `sport = :${port}`]);
+  if (res.code !== 0) {
+    if (res.error) {
+      errors.push(res.error);
+    }
+    return { listeners: [], errors };
+  }
+  const listeners = parseSsOutput(res.stdout, port);
+  await Promise.all(
+    listeners.map(async (listener) => {
+      if (!listener.pid) {
+        return;
+      }
+      const [commandLine, user] = await Promise.all([
+        resolveUnixCommandLine(listener.pid),
+        resolveUnixUser(listener.pid),
+      ]);
+      if (commandLine) {
+        listener.commandLine = commandLine;
+      }
+      if (user) {
+        listener.user = user;
+      }
+    }),
+  );
+  return { listeners, errors };
+}
+
 async function readUnixListeners(
   port: number,
 ): Promise<{ listeners: PortListener[]; detail?: string; errors: string[] }> {
@@ -102,6 +162,13 @@ async function readUnixListeners(
     );
     return { listeners, detail: res.stdout.trim() || undefined, errors };
   }
+  // lsof failed or returned no results — fall back to ss(8) which is available
+  // on virtually all Linux systems and can resolve PIDs for same-user processes
+  // without elevated privileges.
+  const ssFallback = await readSsListeners(port);
+  if (ssFallback.listeners.length > 0) {
+    return { listeners: ssFallback.listeners, detail: undefined, errors };
+  }
   const stderr = res.stderr.trim();
   if (res.code === 1 && !res.error && !stderr) {
     return { listeners: [], detail: undefined, errors };
@@ -109,6 +176,7 @@ async function readUnixListeners(
   if (res.error) {
     errors.push(res.error);
   }
+  errors.push(...ssFallback.errors);
   const detail = [stderr, res.stdout.trim()].filter(Boolean).join("\n");
   if (detail) {
     errors.push(detail);

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -98,7 +98,9 @@ function parseSsOutput(output: string, port: number): PortListener[] {
     if (localAddr?.includes(portToken)) {
       listener.address = localAddr;
     }
-    listeners.push(listener);
+    if (listener.pid || listener.address) {
+      listeners.push(listener);
+    }
   }
   return listeners;
 }

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -111,4 +111,79 @@ describeUnix("inspectPortUsage", () => {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
+
+  it("falls back to ss when lsof fails and resolves PIDs", async () => {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    const pid = process.pid;
+
+    // lsof fails
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "lsof: permission denied",
+      code: 1,
+    });
+
+    // ss succeeds with PID info
+    const ssOutput = `State   Recv-Q  Send-Q  Local Address:Port  Peer Address:Port  Process\nLISTEN  0       511     127.0.0.1:${port}  0.0.0.0:*  users:(("node",pid=${pid},fd=24))`;
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: ssOutput,
+      stderr: "",
+      code: 0,
+    });
+
+    // ps -o command= for commandLine
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "node /some/openclaw/dist/entry.js gateway\n",
+      stderr: "",
+      code: 0,
+    });
+
+    // ps -o user= for user
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "testuser\n",
+      stderr: "",
+      code: 0,
+    });
+
+    try {
+      const result = await inspectPortUsage(port);
+      expect(result.status).toBe("busy");
+      expect(result.listeners.length).toBeGreaterThan(0);
+      expect(result.listeners[0].pid).toBe(pid);
+      expect(result.listeners[0].commandLine).toContain("openclaw");
+      expect(result.listeners[0].user).toBe("testuser");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("reports busy with empty listeners when both lsof and ss fail", async () => {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+
+    // lsof fails
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "lsof: error",
+      code: 1,
+    });
+
+    // ss also fails
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "ss: error",
+      code: 1,
+    });
+
+    try {
+      const result = await inspectPortUsage(port);
+      expect(result.status).toBe("busy");
+      expect(result.listeners).toHaveLength(0);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
 });

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -102,6 +102,10 @@ describeUnix("inspectPortUsage", () => {
     runCommandWithTimeoutMock.mockRejectedValueOnce(
       Object.assign(new Error("spawn lsof ENOENT"), { code: "ENOENT" }),
     );
+    // ss fallback also fails (not installed)
+    runCommandWithTimeoutMock.mockRejectedValueOnce(
+      Object.assign(new Error("spawn ss ENOENT"), { code: "ENOENT" }),
+    );
 
     try {
       const result = await inspectPortUsage(port);


### PR DESCRIPTION
## What is the problem that this solves?

After running `openclaw --update`, the gateway service crash-loops with "Port is already in use" because a stale gateway process from the update survives and holds the port.

The existing stale PID cleanup in `terminateStaleGatewayPids()` never fires because `inspectPortUsage()` returns `status: "busy"` with an **empty `listeners` array**. Without listener PIDs, there's nothing to kill — the cleanup is dead code in this scenario.

This happens because `readUnixListeners()` relies exclusively on `lsof`, which returns no results when:
- The stale process is owned by a different user (e.g. `sudo openclaw --update` leaves a root-owned gateway, and the user-level health check can't see it via `lsof`)
- `lsof` is not installed
- `lsof` lacks permissions to inspect the process

The result: `staleGatewayPids` is always empty → cleanup is skipped → the systemd service restart finds the port occupied → crash-loop until manual intervention (`fuser -k <port>/tcp`).

**Reproduction:** Run `openclaw --update` on a system where the gateway is managed by systemd. The restart after update leaves an orphan process on the gateway port. `systemctl --user status openclaw-gateway.service` shows repeated "Port is already in use" failures.

## How is the problem solved?

Add `ss -tlnp` as a fallback in `readUnixListeners()` when `lsof` fails to return any listeners. `ss` is part of `iproute2` and available on virtually all Linux systems. It can resolve PIDs for same-user processes without elevated privileges, which is exactly the gap `lsof` leaves.

The fallback only activates when `lsof` returns no results (non-zero exit or empty output). If `ss` also fails, behavior is unchanged — the existing "Port is in use but process details are unavailable" hint still appears.

With this fix, `inspectGatewayRestart()` populates `staleGatewayPids` correctly, and `terminateStaleGatewayPids()` can SIGTERM/SIGKILL the orphan before the service restart.

## Change Type

- [x] Bug fix

## Scope

- [x] Daemon / gateway lifecycle
- [x] Infrastructure (ports)

## Testing

- [x] `pnpm vitest run src/infra/ports.test.ts` — all 8 tests pass
- [x] Added: "falls back to ss when lsof fails and resolves PIDs" — verifies ss fallback returns correct PID, commandLine, and user
- [x] Added: "reports busy with empty listeners when both lsof and ss fail" — verifies graceful degradation
- [x] Manually verified on Ubuntu 24.04 (Hetzner VPS, arm64) where the bug was originally hit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `ss(8)` as a fallback in `readUnixListeners()` when `lsof` fails to resolve listener PIDs — fixing a real crash-loop bug where `terminateStaleGatewayPids()` couldn't clean up orphan gateway processes after `openclaw --update` because the `listeners` array was empty.

- `parseSsOutput` correctly parses `ss -tlnp` output to extract PIDs, and `readSsListeners` enriches listeners with command-line and user info via `ps`
- The fallback only activates when `lsof` returns non-zero, preserving existing behavior on systems where `lsof` works
- Error accumulation is handled properly — `ss` errors are merged into the existing error array when both tools fail
- Two new tests cover the happy path (ss resolves PIDs) and graceful degradation (both fail)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a well-scoped fallback that only activates when the existing lsof path fails, with no changes to the happy path.
- The change is narrowly scoped to Linux port inspection fallback logic, with proper error handling and two new tests. The ss command is invoked safely (array args, numeric port). The only concerns are minor: the existing ENOENT test should ideally mock the new ss call, and `parseSsOutput` could guard against pushing empty listeners. Neither issue affects runtime correctness.
- No files require special attention.

<sub>Last reviewed commit: 96b8e5d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->