### PR TITLE
Docs(changelog): credit nicole-luxe for QMD mcporter work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Memory/QMD: add optional `memory.qmd.mcporter` search routing so QMD `query/search/vsearch` can run through mcporter keep-alive flows (including multi-collection paths) to reduce cold starts, while keeping searches on agent-scoped QMD state for consistent recall. (#19617) Thanks @vignesh07.
+- Memory/QMD: add optional `memory.qmd.mcporter` search routing so QMD `query/search/vsearch` can run through mcporter keep-alive flows (including multi-collection paths) to reduce cold starts, while keeping searches on agent-scoped QMD state for consistent recall. (#19617) Thanks @nicole-luxe and @vignesh07.
 - Chat/UI: strip inline reply/audio directive tags (`[[reply_to_current]]`, `[[reply_to:<id>]]`, `[[audio_as_voice]]`) from displayed chat history, live chat event output, and session preview snippets so control tags no longer leak into user-visible surfaces.
 - BlueBubbles/DM history: restore DM backfill context with account-scoped rolling history, bounded backfill retries, and safer history payload limits. (#20302) Thanks @Ryan-Haines.
 - Security/Config: block prototype-key traversal during config merge patch and legacy migration merge helpers (`__proto__`, `constructor`, `prototype`) to prevent prototype pollution during config mutation flows. (#22968) Thanks @Clawborn.


### PR DESCRIPTION
Adds contributor credit for the QMD mcporter persistent-search work (landed in #19617).

- Update CHANGELOG entry to thank @nicole-luxe alongside @vignesh07.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated CHANGELOG entry for PR #19617 to credit both `@nicole-luxe` and `@vignesh07` for the QMD mcporter persistent-search work. The change follows the repository's established convention of crediting multiple contributors using "Thanks `@user1` and `@user2`" format.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a documentation-only change that adds contributor credit to the CHANGELOG. The change is minimal (single line), follows the repository's established format for crediting multiple contributors, and has no impact on functionality or behavior.
- No files require special attention

<sub>Last reviewed commit: 39b240d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->