### PR TITLE
fix(webchat): strip reply directive tags from finalized messages

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -25,6 +25,31 @@ describe("extractTextCached", () => {
   });
 });
 
+describe("extractText strips reply tags", () => {
+  it("strips [[reply_to_current]] from assistant string content", () => {
+    const message = { role: "assistant", content: "[[reply_to_current]] Hello" };
+    expect(extractText(message)).toBe("Hello");
+  });
+
+  it("strips [[reply_to:<id>]] from assistant array content", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "[[reply_to:msg-123]] Hello" }],
+    };
+    expect(extractText(message)).toBe("Hello");
+  });
+
+  it("does not strip reply tags from user messages", () => {
+    const message = { role: "user", content: "[[reply_to_current]] Hello" };
+    expect(extractText(message)).toContain("[[reply_to_current]]");
+  });
+
+  it("strips [[reply_to_current]] from assistant text field", () => {
+    const message = { role: "assistant", text: "[[reply_to_current]] World" };
+    expect(extractText(message)).toBe("World");
+  });
+});
+
 describe("extractThinkingCached", () => {
   it("matches extractThinking output", () => {
     const message = {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,5 +1,6 @@
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
+import { parseInlineDirectives } from "../../../../src/utils/directive-tags.js";
 import { stripThinkingTags } from "../format.ts";
 
 const textCache = new WeakMap<object, string | null>();
@@ -13,7 +14,7 @@ export function extractText(message: unknown): string | null {
   if (typeof content === "string") {
     const processed =
       role === "assistant"
-        ? stripThinkingTags(content)
+        ? parseInlineDirectives(stripThinkingTags(content)).text
         : shouldStripInboundMetadata
           ? stripInboundMetadata(stripEnvelope(content))
           : stripEnvelope(content);
@@ -33,7 +34,7 @@ export function extractText(message: unknown): string | null {
       const joined = parts.join("\n");
       const processed =
         role === "assistant"
-          ? stripThinkingTags(joined)
+          ? parseInlineDirectives(stripThinkingTags(joined)).text
           : shouldStripInboundMetadata
             ? stripInboundMetadata(stripEnvelope(joined))
             : stripEnvelope(joined);
@@ -43,7 +44,7 @@ export function extractText(message: unknown): string | null {
   if (typeof m.text === "string") {
     const processed =
       role === "assistant"
-        ? stripThinkingTags(m.text)
+        ? parseInlineDirectives(stripThinkingTags(m.text)).text
         : shouldStripInboundMetadata
           ? stripInboundMetadata(stripEnvelope(m.text))
           : stripEnvelope(m.text);


### PR DESCRIPTION
## Summary

- WebChat displays `[[reply_to_current]]` (and `[[reply_to:<id>]]`) tags in chat bubbles after a message finishes streaming, even though the tags are invisible during streaming
- Root cause: during streaming, the Pi agent strips reply directive tags before emitting text to the UI; however, when finalized messages are loaded from chat history, the raw text (with tags intact) is returned, and the UI's `extractText()` only stripped thinking tags — not reply directive tags
- Fix: apply `parseInlineDirectives()` (already used by the backend delivery path in `reply-directives.ts`) to assistant messages inside `extractText()`, so reply tags are stripped regardless of whether the message arrives via streaming or history retrieval

## Changes

| File | What |
|------|------|
| `ui/src/ui/chat/message-extract.ts` | Import `parseInlineDirectives` and chain it after `stripThinkingTags()` in all 3 assistant-message branches of `extractText()` |
| `ui/src/ui/chat/message-extract.test.ts` | Add 4 test cases: string content, array content, `.text` field, and user-message passthrough |

## Test plan

- [x] `pnpm format:check` — passes
- [x] `pnpm tsgo` — type-check passes with zero errors
- [x] `pnpm test -- src/auto-reply/reply/reply-utils.test.ts` — 64 related tests pass
- [ ] Open Control UI WebChat, send a message, verify `[[reply_to_current]]` no longer appears after streaming completes
- [ ] Verify tags are still invisible during streaming (no regression)
- [ ] Verify user messages are unaffected

Closes #23053

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where reply directive tags like `[[reply_to_current]]` and `[[reply_to:<id>]]` were visible in finalized WebChat messages loaded from history, even though they were correctly hidden during streaming.

The root cause was that during streaming, the backend already strips these tags via `parseInlineDirectives()` before emitting text, but when messages are loaded from history, the raw text (with tags intact) is returned and the UI's `extractText()` function only stripped thinking tags.

The fix applies `parseInlineDirectives()` to all three assistant-message branches in `extractText()` (string content, array content, and text field), ensuring reply tags are stripped consistently regardless of whether the message arrives via streaming or history retrieval. User messages are correctly left unchanged.

- Adds proper handling for reply directive tags in `extractText()` by chaining `parseInlineDirectives()` after `stripThinkingTags()`
- Includes 4 test cases covering all message content formats and verifying user messages are not affected
- Aligns UI message processing with backend delivery path behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted, addresses a clear bug in a UI display layer, and follows the existing pattern already used in the backend. The change reuses an existing utility function (`parseInlineDirectives`) that is already being used for the same purpose in `reply-directives.ts`, ensuring consistency. Tests cover all message content formats and verify the fix works correctly. The modification is purely additive (chaining an additional processing step) with no breaking changes.
- No files require special attention

<sub>Last reviewed commit: e1aade3</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->